### PR TITLE
chore(ci): use pnpm 9 for smoke verify

### DIFF
--- a/.github/workflows/smoke-verify.yml
+++ b/.github/workflows/smoke-verify.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Switches smoke-verify workflow to pnpm 9 to match lockfileVersion 9 (prevents frozen-lockfile mismatch).