### PR TITLE
fix(migrations): scope existence checks to schema

### DIFF
--- a/packages/core-backend/src/db/migrations/_patterns.ts
+++ b/packages/core-backend/src/db/migrations/_patterns.ts
@@ -97,7 +97,9 @@ export async function checkColumnExists<DB>(db: Kysely<DB>, tableName: string, c
   const result = await sql<CountResult>`
     SELECT count(*)::int as count
     FROM information_schema.columns
-    WHERE table_name = ${tableName} AND column_name = ${columnName}
+    WHERE table_name = ${tableName}
+      AND column_name = ${columnName}
+      AND table_schema = current_schema()
   `.execute(db)
   return result.rows[0] ? parseInt(String(result.rows[0].count), 10) > 0 : false
 }
@@ -111,6 +113,7 @@ export async function checkTableExists<DB>(db: Kysely<DB>, tableName: string): P
     SELECT count(*)::int as count
     FROM information_schema.tables
     WHERE table_name = ${tableName}
+      AND table_schema = current_schema()
   `.execute(db)
   return result.rows[0] ? parseInt(String(result.rows[0].count), 10) > 0 : false
 }


### PR DESCRIPTION
## Summary
- constrain migration existence checks to current schema to avoid colliding with information_schema views
- prevents create_views_view_states from skipping view creation in CI

## Testing
- not run (migration-only change)