### PR TITLE
fix(ci): correct smoke seed path

### DIFF
--- a/.github/workflows/smoke-verify.yml
+++ b/.github/workflows/smoke-verify.yml
@@ -52,11 +52,6 @@ jobs:
           name: smoke-verify
           retention-days: 14
           path: |
-            artifacts/comments-ui-grid.png
-            artifacts/comments-ui-kanban.png
-            artifacts/editable-demo-grid.png
-            artifacts/editable-demo-kanban.png
-            artifacts/editable-demo-ui-verification.json
             artifacts/smoke/backend.log
             artifacts/smoke/web.log
             artifacts/smoke/smoke-report.json

--- a/scripts/verify-smoke.sh
+++ b/scripts/verify-smoke.sh
@@ -29,7 +29,7 @@ if ! curl -fsS "${API_BASE}/health" >/dev/null 2>&1; then
   echo "[1/4] Preparing database..."
   DATABASE_URL="${SMOKE_DATABASE_URL}" pnpm --filter @metasheet/core-backend migrate >/dev/null
   DATABASE_URL="${SMOKE_DATABASE_URL}" RBAC_ADMIN_USER="${SMOKE_ADMIN_USER}" \
-    pnpm --filter @metasheet/core-backend exec tsx packages/core-backend/scripts/seed-rbac.ts >/dev/null
+    pnpm --filter @metasheet/core-backend exec tsx scripts/seed-rbac.ts >/dev/null
 
   echo "[2/4] Starting backend..."
   PORT="$(python3 - <<'PY'


### PR DESCRIPTION
## Summary
- call seed-rbac from the core-backend package root in smoke script
- simplify smoke workflow artifacts to the files we generate

## Testing
- not run (CI smoke rerun)