### PR TITLE
fix(core): guard workflow init and export data source manager

### DIFF
--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -90,6 +90,10 @@ function getManager(): DataSourceManager {
   return dataSourceManager
 }
 
+export function getDataSourceManager(): DataSourceManager {
+  return getManager()
+}
+
 // Helper to sanitize config for response (remove credentials)
 function sanitizeConfig(config: DataSourceConfig): Omit<DataSourceConfig, 'credentials'> & { hasCredentials: boolean } {
   const { credentials, ...rest } = config

--- a/packages/core-backend/src/routes/workflow.ts
+++ b/packages/core-backend/src/routes/workflow.ts
@@ -25,10 +25,14 @@ const router = Router()
 const logger = new Logger('WorkflowAPI')
 const workflowEngine = new BPMNWorkflowEngine()
 
-// Initialize engine
-workflowEngine.initialize().catch(error => {
-  logger.error('Failed to initialize Workflow Engine:', error)
-})
+// Initialize engine unless explicitly disabled (e.g., CI smoke).
+if (process.env.DISABLE_WORKFLOW === 'true') {
+  logger.warn('Workflow engine disabled (DISABLE_WORKFLOW=true)')
+} else {
+  workflowEngine.initialize().catch(error => {
+    logger.error('Failed to initialize Workflow Engine:', error)
+  })
+}
 
 // Type definitions for database rows
 interface ProcessDefinition {


### PR DESCRIPTION
## Summary
- skip workflow engine initialization when DISABLE_WORKFLOW=true
- export getDataSourceManager for core server wiring

## Testing
- not run (CI smoke rerun)