### PR TITLE
fix(auth): allow dev token in whitelist

### DIFF
--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -14,6 +14,7 @@ const AUTH_WHITELIST = [
   '/api/auth/register',
   '/api/auth/refresh',
   '/api/auth/refresh-token',
+  '/api/auth/dev-token',
   '/api/plugins',
   '/api/v2/hello',
   '/api/v2/rpc-test',


### PR DESCRIPTION
## Summary
- allow /api/auth/dev-token through JWT whitelist for smoke verification

## Testing
- not run (CI smoke rerun)