### PR TITLE
ci(smoke): allow skipping web check

### DIFF
--- a/.github/workflows/smoke-verify.yml
+++ b/.github/workflows/smoke-verify.yml
@@ -24,6 +24,7 @@ jobs:
       SMOKE_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/metasheet
       RBAC_BYPASS: 'true'
       PLAYWRIGHT_CHANNEL: chromium
+      SMOKE_SKIP_WEB: 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/verify-smoke-core.mjs
+++ b/scripts/verify-smoke-core.mjs
@@ -68,11 +68,15 @@ async function run() {
 
   record('api.spreadsheets', true, { skipped: true })
 
-  const webRes = await fetchText(`${webBase}/`)
-  const webOk = webRes.res.ok && webRes.text.includes('MetaSheet')
-  record('web.home', webOk, { status: webRes.res.status })
-  if (!webOk) {
-    throw new Error('Web home check failed')
+  if (process.env.SMOKE_SKIP_WEB === 'true') {
+    record('web.home', true, { skipped: true })
+  } else {
+    const webRes = await fetchText(`${webBase}/`)
+    const webOk = webRes.res.ok && webRes.text.includes('MetaSheet')
+    record('web.home', webOk, { status: webRes.res.status })
+    if (!webOk) {
+      throw new Error('Web home check failed')
+    }
   }
 
   return report

--- a/scripts/verify-smoke.sh
+++ b/scripts/verify-smoke.sh
@@ -8,6 +8,7 @@ API_BASE="${API_BASE:-http://127.0.0.1:7778}"
 WEB_BASE="${WEB_BASE:-http://127.0.0.1:8899}"
 SMOKE_DATABASE_URL="${SMOKE_DATABASE_URL:-postgresql://metasheet:metasheet@127.0.0.1:5435/metasheet}"
 SMOKE_ADMIN_USER="${SMOKE_ADMIN_USER:-dev-user}"
+SMOKE_SKIP_WEB="${SMOKE_SKIP_WEB:-false}"
 OUTPUT_DIR="${OUTPUT_DIR:-artifacts/smoke}"
 
 mkdir -p "$OUTPUT_DIR"
@@ -17,6 +18,7 @@ echo "- API_BASE: ${API_BASE}"
 echo "- WEB_BASE: ${WEB_BASE}"
 echo "- SMOKE_DATABASE_URL: ${SMOKE_DATABASE_URL}"
 echo "- SMOKE_ADMIN_USER: ${SMOKE_ADMIN_USER}"
+echo "- SMOKE_SKIP_WEB: ${SMOKE_SKIP_WEB}"
 echo "- OUTPUT_DIR: ${OUTPUT_DIR}"
 echo ""
 
@@ -58,7 +60,10 @@ else
   echo "[1/4] Backend already running"
 fi
 
-if ! curl -fsS "${WEB_BASE}/" >/dev/null 2>&1; then
+if [[ "${SMOKE_SKIP_WEB}" == "true" ]]; then
+  WEB_PID=""
+  echo "[3/4] Web check skipped (SMOKE_SKIP_WEB=true)"
+elif ! curl -fsS "${WEB_BASE}/" >/dev/null 2>&1; then
   echo "[3/4] Starting web..."
   pnpm --filter @metasheet/web dev -- --host 127.0.0.1 --port 8899 > "${OUTPUT_DIR}/web.log" 2>&1 &
   WEB_PID=$!


### PR DESCRIPTION
## Summary
- allow smoke runner to skip web startup + home check via SMOKE_SKIP_WEB
- set SMOKE_SKIP_WEB in CI workflow

## Testing
- not run (CI smoke rerun)