### PR TITLE
fix(univer): prefer lookup/rollup readonly hints

### DIFF
--- a/apps/web/src/views/MetaFieldsView.vue
+++ b/apps/web/src/views/MetaFieldsView.vue
@@ -1,0 +1,1272 @@
+<template>
+  <div class="meta-fields">
+    <div class="meta-fields__header">
+      <div>
+        <h2 class="meta-fields__title">Meta Fields</h2>
+        <div class="meta-fields__subtitle">
+          sheetId: <span class="meta-fields__mono">{{ sheetId }}</span>
+        </div>
+      </div>
+      <div class="meta-fields__header-actions">
+        <router-link class="meta-fields__btn" to="/sheets">返回 Sheets</router-link>
+        <router-link
+          v-if="sheetId"
+          class="meta-fields__btn"
+          :to="{ path: `/sheets/${encodeURIComponent(sheetId)}/views` }"
+        >
+          Views
+        </router-link>
+        <button type="button" class="meta-fields__btn" :disabled="loading" @click="refresh">
+          {{ loading ? '刷新中…' : '刷新' }}
+        </button>
+      </div>
+    </div>
+
+    <div class="meta-fields__create">
+      <input
+        v-model="createName"
+        class="meta-fields__input"
+        placeholder="新字段名称"
+        @keydown.enter.prevent="createField"
+      />
+      <select v-model="createType" class="meta-fields__select">
+        <option value="string">string</option>
+        <option value="number">number</option>
+        <option value="boolean">boolean</option>
+        <option value="formula">formula</option>
+        <option value="select">select</option>
+        <option value="link">link</option>
+        <option value="lookup">lookup</option>
+        <option value="rollup">rollup</option>
+      </select>
+      <button
+        type="button"
+        class="meta-fields__btn meta-fields__btn--primary"
+        :disabled="createLoading || !createName.trim() || !sheetId"
+        @click="createField"
+      >
+        {{ createLoading ? '创建中…' : '创建' }}
+      </button>
+      <label class="meta-fields__checkbox">
+        <input v-model="createReadonly" type="checkbox" :disabled="createReadonlyForced" />
+        只读
+        <span v-if="createReadonlyForced" class="meta-fields__muted">（lookup/rollup 自动只读）</span>
+      </label>
+      <div v-if="createType === 'select'" class="meta-fields__options">
+        <textarea
+          v-model="createOptionsText"
+          class="meta-fields__textarea"
+          rows="3"
+          placeholder="Select 选项（每行一个；可选颜色：Value|#RRGGBB）"
+        />
+      </div>
+      <div v-if="createType === 'link'" class="meta-fields__options meta-fields__link-options">
+        <input
+          v-model="createLinkForeignSheetId"
+          class="meta-fields__input"
+          placeholder="foreignDatasheetId（关联目标 sheetId，可空=普通字符串 link）"
+        />
+        <input
+          v-model="createLinkDisplayFieldId"
+          class="meta-fields__input"
+          list="link-display-fields-create"
+          placeholder="displayFieldId（显示字段ID，可选）"
+        />
+        <datalist id="link-display-fields-create">
+          <option
+            v-for="field in createLinkForeignFields"
+            :key="field.id"
+            :value="field.id"
+          >
+            {{ field.name }} ({{ field.id }})
+          </option>
+        </datalist>
+        <div v-if="createLinkForeignError" class="meta-fields__muted">
+          外表字段加载失败：{{ createLinkForeignError }}
+        </div>
+        <label class="meta-fields__checkbox">
+          <input v-model="createLinkLimitSingleRecord" type="checkbox" />
+          limitSingleRecord
+        </label>
+      </div>
+      <div v-if="createType === 'lookup'" class="meta-fields__options meta-fields__link-options">
+        <select v-model="createLookupLinkFieldId" class="meta-fields__select">
+          <option value="">选择 Link 字段</option>
+          <option
+            v-for="field in linkFieldOptions"
+            :key="field.id"
+            :value="field.id"
+          >
+            {{ field.name || field.id }} ({{ field.id }}){{ field.foreignSheetId ? '' : ' · 未配置外表' }}
+          </option>
+        </select>
+        <div class="meta-fields__muted">
+          外表 sheetId：{{ createLookupForeignSheetId || '未配置' }}
+        </div>
+        <input
+          v-model="createLookupTargetFieldId"
+          class="meta-fields__input"
+          list="lookup-target-fields-create"
+          placeholder="lookUpTargetFieldId（外表字段ID）"
+        />
+        <datalist id="lookup-target-fields-create">
+          <option
+            v-for="field in createLookupForeignFields"
+            :key="field.id"
+            :value="field.id"
+          >
+            {{ field.name }} ({{ field.id }})
+          </option>
+        </datalist>
+        <div v-if="createLookupForeignError" class="meta-fields__muted">
+          外表字段加载失败：{{ createLookupForeignError }}
+        </div>
+      </div>
+      <div v-if="createType === 'rollup'" class="meta-fields__options meta-fields__link-options">
+        <select v-model="createRollupLinkFieldId" class="meta-fields__select">
+          <option value="">选择 Link 字段</option>
+          <option
+            v-for="field in linkFieldOptions"
+            :key="field.id"
+            :value="field.id"
+          >
+            {{ field.name || field.id }} ({{ field.id }}){{ field.foreignSheetId ? '' : ' · 未配置外表' }}
+          </option>
+        </select>
+        <div class="meta-fields__muted">
+          外表 sheetId：{{ createRollupForeignSheetId || '未配置' }}
+        </div>
+        <input
+          v-model="createRollupTargetFieldId"
+          class="meta-fields__input"
+          list="rollup-target-fields-create"
+          placeholder="targetFieldId（外表字段ID）"
+        />
+        <datalist id="rollup-target-fields-create">
+          <option
+            v-for="field in createRollupForeignFields"
+            :key="field.id"
+            :value="field.id"
+          >
+            {{ field.name }} ({{ field.id }})
+          </option>
+        </datalist>
+        <div v-if="createRollupForeignError" class="meta-fields__muted">
+          外表字段加载失败：{{ createRollupForeignError }}
+        </div>
+        <select v-model="createRollupAgg" class="meta-fields__select">
+          <option value="count">count</option>
+          <option value="sum">sum</option>
+          <option value="avg">avg</option>
+          <option value="min">min</option>
+          <option value="max">max</option>
+        </select>
+        <div class="meta-fields__muted">Rollup 建议选择 number 字段</div>
+      </div>
+      <div v-if="createError" class="meta-fields__error">{{ createError }}</div>
+    </div>
+
+    <div v-if="error" class="meta-fields__error meta-fields__error--block">{{ error }}</div>
+
+    <div v-if="!loading && fields.length === 0" class="meta-fields__empty">
+      暂无字段。可使用上方表单创建第一个字段。
+    </div>
+
+    <table v-else class="meta-fields__table">
+      <thead>
+        <tr>
+          <th style="width: 80px;">顺序</th>
+          <th>名称</th>
+          <th>ID</th>
+          <th style="width: 120px;">类型</th>
+          <th>选项</th>
+          <th style="width: 220px;">只读原因</th>
+          <th style="width: 240px;">操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="field in fields" :key="field.id">
+          <td class="meta-fields__mono">{{ field.order ?? 0 }}</td>
+          <td>
+            <template v-if="editingId === field.id">
+              <input v-model="editName" class="meta-fields__input meta-fields__input--inline" />
+            </template>
+            <template v-else>
+              {{ field.name }}
+            </template>
+          </td>
+          <td class="meta-fields__mono">{{ field.id }}</td>
+          <td>
+            <template v-if="editingId === field.id">
+              <select v-model="editType" class="meta-fields__select meta-fields__select--inline">
+                <option value="string">string</option>
+                <option value="number">number</option>
+                <option value="boolean">boolean</option>
+                <option value="formula">formula</option>
+                <option value="select">select</option>
+                <option value="link">link</option>
+                <option value="lookup">lookup</option>
+                <option value="rollup">rollup</option>
+              </select>
+            </template>
+            <template v-else>
+              <span class="meta-fields__mono">{{ field.type }}</span>
+            </template>
+          </td>
+          <td>
+            <template v-if="editingId === field.id">
+              <textarea
+                v-if="editType === 'select'"
+                v-model="editOptionsText"
+                class="meta-fields__textarea meta-fields__textarea--inline"
+                rows="3"
+                placeholder="Value|#RRGGBB"
+              />
+              <div v-else-if="editType === 'link'" class="meta-fields__link-editor">
+                <input
+                  v-model="editLinkForeignSheetId"
+                  class="meta-fields__input meta-fields__input--inline"
+                  placeholder="foreignDatasheetId"
+                />
+                <input
+                  v-model="editLinkDisplayFieldId"
+                  class="meta-fields__input meta-fields__input--inline"
+                  list="link-display-fields-edit"
+                  placeholder="displayFieldId（显示字段ID）"
+                />
+                <datalist id="link-display-fields-edit">
+                  <option
+                    v-for="field in editLinkForeignFields"
+                    :key="field.id"
+                    :value="field.id"
+                  >
+                    {{ field.name }} ({{ field.id }})
+                  </option>
+                </datalist>
+                <div v-if="editLinkForeignError" class="meta-fields__muted">
+                  外表字段加载失败：{{ editLinkForeignError }}
+                </div>
+                <label class="meta-fields__checkbox">
+                  <input v-model="editLinkLimitSingleRecord" type="checkbox" />
+                  limitSingleRecord
+                </label>
+              </div>
+              <div v-else-if="editType === 'lookup'" class="meta-fields__link-editor">
+                <select v-model="editLookupLinkFieldId" class="meta-fields__select meta-fields__select--inline">
+                  <option value="">选择 Link 字段</option>
+                  <option
+                    v-for="field in linkFieldOptions"
+                    :key="field.id"
+                    :value="field.id"
+                  >
+                    {{ field.name || field.id }} ({{ field.id }}){{ field.foreignSheetId ? '' : ' · 未配置外表' }}
+                  </option>
+                </select>
+                <div class="meta-fields__muted">
+                  外表 sheetId：{{ editLookupForeignSheetId || '未配置' }}
+                </div>
+                <input
+                  v-model="editLookupTargetFieldId"
+                  class="meta-fields__input meta-fields__input--inline"
+                  list="lookup-target-fields-edit"
+                  placeholder="lookUpTargetFieldId"
+                />
+                <datalist id="lookup-target-fields-edit">
+                  <option
+                    v-for="field in editLookupForeignFields"
+                    :key="field.id"
+                    :value="field.id"
+                  >
+                    {{ field.name }} ({{ field.id }})
+                  </option>
+                </datalist>
+                <div v-if="editLookupForeignError" class="meta-fields__muted">
+                  外表字段加载失败：{{ editLookupForeignError }}
+                </div>
+              </div>
+              <div v-else-if="editType === 'rollup'" class="meta-fields__link-editor">
+                <select v-model="editRollupLinkFieldId" class="meta-fields__select meta-fields__select--inline">
+                  <option value="">选择 Link 字段</option>
+                  <option
+                    v-for="field in linkFieldOptions"
+                    :key="field.id"
+                    :value="field.id"
+                  >
+                    {{ field.name || field.id }} ({{ field.id }}){{ field.foreignSheetId ? '' : ' · 未配置外表' }}
+                  </option>
+                </select>
+                <div class="meta-fields__muted">
+                  外表 sheetId：{{ editRollupForeignSheetId || '未配置' }}
+                </div>
+                <input
+                  v-model="editRollupTargetFieldId"
+                  class="meta-fields__input meta-fields__input--inline"
+                  list="rollup-target-fields-edit"
+                  placeholder="targetFieldId"
+                />
+                <datalist id="rollup-target-fields-edit">
+                  <option
+                    v-for="field in editRollupForeignFields"
+                    :key="field.id"
+                    :value="field.id"
+                  >
+                    {{ field.name }} ({{ field.id }})
+                  </option>
+                </datalist>
+                <div v-if="editRollupForeignError" class="meta-fields__muted">
+                  外表字段加载失败：{{ editRollupForeignError }}
+                </div>
+                <select v-model="editRollupAgg" class="meta-fields__select meta-fields__select--inline">
+                  <option value="count">count</option>
+                  <option value="sum">sum</option>
+                  <option value="avg">avg</option>
+                  <option value="min">min</option>
+                  <option value="max">max</option>
+                </select>
+                <div class="meta-fields__muted">Rollup 建议选择 number 字段</div>
+              </div>
+              <span v-else class="meta-fields__muted">-</span>
+              <label class="meta-fields__checkbox meta-fields__checkbox--inline">
+                <input v-model="editReadonly" type="checkbox" :disabled="editReadonlyForced" />
+                只读
+                <span v-if="editReadonlyForced" class="meta-fields__muted">（lookup/rollup 自动只读）</span>
+              </label>
+            </template>
+            <template v-else>
+              <span class="meta-fields__mono">{{ formatOptions(field) }}</span>
+            </template>
+          </td>
+          <td>
+            <div v-if="readonlyInfoById[field.id]" class="meta-fields__readonly" :title="readonlyInfoById[field.id].detail">
+              <span class="meta-fields__readonly-tag">{{ readonlyInfoById[field.id].tag }}</span>
+              <span class="meta-fields__readonly-reason">{{ readonlyInfoById[field.id].reason }}</span>
+            </div>
+            <span v-else class="meta-fields__muted">可编辑</span>
+          </td>
+          <td class="meta-fields__actions">
+            <template v-if="editingId === field.id">
+              <button type="button" class="meta-fields__btn meta-fields__btn--primary" :disabled="editSaving" @click="saveEdit">
+                {{ editSaving ? '保存中…' : '保存' }}
+              </button>
+              <button type="button" class="meta-fields__btn" :disabled="editSaving" @click="cancelEdit">取消</button>
+            </template>
+            <template v-else>
+              <button type="button" class="meta-fields__btn" @click="beginEdit(field)">编辑</button>
+            </template>
+
+            <button
+              type="button"
+              class="meta-fields__btn"
+              :disabled="loading || editingId !== null || !canMoveUp(field)"
+              @click="move(field, -1)"
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              class="meta-fields__btn"
+              :disabled="loading || editingId !== null || !canMoveDown(field)"
+              @click="move(field, 1)"
+            >
+              ↓
+            </button>
+
+            <button
+              type="button"
+              class="meta-fields__btn meta-fields__btn--danger"
+              :disabled="deleteLoadingId === field.id || editSaving"
+              @click="deleteField(field.id)"
+            >
+              {{ deleteLoadingId === field.id ? '删除中…' : '删除' }}
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { apiFetch } from '../utils/api'
+
+type ApiError = { code: string; message: string }
+
+type Field = {
+  id: string
+  name: string
+  type: string
+  order?: number
+  options?: Array<{ value: string; color?: string }>
+  property?: Record<string, unknown>
+}
+
+type ReadonlyInfo = {
+  tag: string
+  reason: string
+  detail: string
+}
+
+type FieldsResponse = {
+  ok: boolean
+  data?: { fields: Field[] }
+  error?: ApiError
+}
+
+type CreateFieldResponse = {
+  ok: boolean
+  data?: { field: Field }
+  error?: ApiError
+}
+
+type UpdateFieldResponse = {
+  ok: boolean
+  data?: { field: Field }
+  error?: ApiError
+}
+
+type DeleteFieldResponse = {
+  ok: boolean
+  data?: { deleted: string }
+  error?: ApiError
+}
+
+const route = useRoute()
+const sheetId = computed(() => String(route.params.sheetId ?? '').trim())
+
+const fields = ref<Field[]>([])
+const loading = ref(false)
+const error = ref('')
+
+const createName = ref('新字段')
+const createType = ref<'string' | 'number' | 'boolean' | 'formula' | 'select' | 'link' | 'lookup' | 'rollup'>('string')
+const createOptionsText = ref('')
+const createLinkForeignSheetId = ref('')
+const createLinkDisplayFieldId = ref('')
+const createLinkLimitSingleRecord = ref(false)
+const createLookupLinkFieldId = ref('')
+const createLookupTargetFieldId = ref('')
+const createRollupLinkFieldId = ref('')
+const createRollupTargetFieldId = ref('')
+const createRollupAgg = ref<'count' | 'sum' | 'avg' | 'min' | 'max'>('count')
+const createReadonly = ref(false)
+const createLoading = ref(false)
+const createError = ref('')
+const createReadonlyForced = computed(() => createType.value === 'lookup' || createType.value === 'rollup')
+
+const editingId = ref<string | null>(null)
+const editName = ref('')
+const editType = ref<'string' | 'number' | 'boolean' | 'formula' | 'select' | 'link' | 'lookup' | 'rollup'>('string')
+const editOptionsText = ref('')
+const editProperty = ref<Record<string, unknown>>({})
+const editLinkForeignSheetId = ref('')
+const editLinkDisplayFieldId = ref('')
+const editLinkLimitSingleRecord = ref(false)
+const editLookupLinkFieldId = ref('')
+const editLookupTargetFieldId = ref('')
+const editRollupLinkFieldId = ref('')
+const editRollupTargetFieldId = ref('')
+const editRollupAgg = ref<'count' | 'sum' | 'avg' | 'min' | 'max'>('count')
+const editReadonly = ref(false)
+const editSaving = ref(false)
+const deleteLoadingId = ref<string | null>(null)
+const editReadonlyForced = computed(() => editType.value === 'lookup' || editType.value === 'rollup')
+
+const foreignFieldsBySheetId = ref<Record<string, Field[]>>({})
+const foreignFieldsLoadingBySheetId = ref<Record<string, boolean>>({})
+const foreignFieldsErrorBySheetId = ref<Record<string, string>>({})
+
+async function parseJsonSafe<T>(res: Response): Promise<T | null> {
+  try {
+    return (await res.json()) as T
+  } catch {
+    return null
+  }
+}
+
+function parseSelectOptions(text: string): Array<{ value: string; color?: string }> {
+  const lines = text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+
+  const options: Array<{ value: string; color?: string }> = []
+  for (const line of lines) {
+    const [valueRaw, colorRaw] = line.split('|')
+    const value = (valueRaw ?? '').trim()
+    const color = (colorRaw ?? '').trim()
+    if (!value) continue
+    if (color) options.push({ value, color })
+    else options.push({ value })
+  }
+  return options
+}
+
+function resolveForeignSheetId(property?: Record<string, unknown>): string {
+  if (!property) return ''
+  const foreign = property.foreignDatasheetId ?? property.foreignSheetId ?? property.datasheetId
+  return typeof foreign === 'string' ? foreign.trim() : ''
+}
+
+function resolveForeignSheetIdByFieldId(fieldId: string): string {
+  if (!fieldId) return ''
+  const field = fields.value.find((f) => f.id === fieldId)
+  if (!field || field.type !== 'link') return ''
+  return resolveForeignSheetId(field.property)
+}
+
+const linkFieldOptions = computed(() =>
+  fields.value
+    .filter((field) => field.type === 'link')
+    .map((field) => ({
+      id: field.id,
+      name: field.name,
+      foreignSheetId: resolveForeignSheetId(field.property),
+    })),
+)
+
+const createLookupForeignSheetId = computed(() => resolveForeignSheetIdByFieldId(createLookupLinkFieldId.value))
+const createRollupForeignSheetId = computed(() => resolveForeignSheetIdByFieldId(createRollupLinkFieldId.value))
+const editLookupForeignSheetId = computed(() => resolveForeignSheetIdByFieldId(editLookupLinkFieldId.value))
+const editRollupForeignSheetId = computed(() => resolveForeignSheetIdByFieldId(editRollupLinkFieldId.value))
+const createLinkForeignSheet = computed(() => createLinkForeignSheetId.value.trim())
+const editLinkForeignSheet = computed(() => editLinkForeignSheetId.value.trim())
+
+function getForeignFields(sheetId: string): Field[] {
+  if (!sheetId) return []
+  return foreignFieldsBySheetId.value[sheetId] ?? []
+}
+
+function getForeignFieldsError(sheetId: string): string {
+  if (!sheetId) return ''
+  return foreignFieldsErrorBySheetId.value[sheetId] ?? ''
+}
+
+const createLookupForeignFields = computed(() => getForeignFields(createLookupForeignSheetId.value))
+const createRollupForeignFields = computed(() => getForeignFields(createRollupForeignSheetId.value))
+const editLookupForeignFields = computed(() => getForeignFields(editLookupForeignSheetId.value))
+const editRollupForeignFields = computed(() => getForeignFields(editRollupForeignSheetId.value))
+const createLinkForeignFields = computed(() => getForeignFields(createLinkForeignSheet.value))
+const editLinkForeignFields = computed(() => getForeignFields(editLinkForeignSheet.value))
+
+const createLookupForeignError = computed(() => getForeignFieldsError(createLookupForeignSheetId.value))
+const createRollupForeignError = computed(() => getForeignFieldsError(createRollupForeignSheetId.value))
+const editLookupForeignError = computed(() => getForeignFieldsError(editLookupForeignSheetId.value))
+const editRollupForeignError = computed(() => getForeignFieldsError(editRollupForeignSheetId.value))
+const createLinkForeignError = computed(() => getForeignFieldsError(createLinkForeignSheet.value))
+const editLinkForeignError = computed(() => getForeignFieldsError(editLinkForeignSheet.value))
+
+watch(createLinkForeignSheet, (sheet) => {
+  if (sheet) ensureForeignFields(sheet)
+})
+
+watch(editLinkForeignSheet, (sheet) => {
+  if (sheet) ensureForeignFields(sheet)
+})
+
+async function ensureForeignFields(sheetId: string) {
+  if (!sheetId) return
+  if (foreignFieldsBySheetId.value[sheetId]) return
+  if (foreignFieldsLoadingBySheetId.value[sheetId]) return
+
+  foreignFieldsLoadingBySheetId.value = { ...foreignFieldsLoadingBySheetId.value, [sheetId]: true }
+  foreignFieldsErrorBySheetId.value = { ...foreignFieldsErrorBySheetId.value, [sheetId]: '' }
+
+  try {
+    const res = await apiFetch(`/api/univer-meta/fields?sheetId=${encodeURIComponent(sheetId)}`)
+    const json = await parseJsonSafe<FieldsResponse>(res)
+    if (!res.ok || !json?.ok || !json.data) {
+      throw new Error(json?.error?.message ?? `加载外表字段失败 (${res.status})`)
+    }
+    foreignFieldsBySheetId.value = { ...foreignFieldsBySheetId.value, [sheetId]: json.data.fields }
+  } catch (err) {
+    foreignFieldsErrorBySheetId.value = {
+      ...foreignFieldsErrorBySheetId.value,
+      [sheetId]: err instanceof Error ? err.message : String(err),
+    }
+  } finally {
+    foreignFieldsLoadingBySheetId.value = { ...foreignFieldsLoadingBySheetId.value, [sheetId]: false }
+  }
+}
+
+function validateLookupConfig(linkFieldId: string, targetFieldId: string): string | null {
+  if (!linkFieldId.trim()) return 'Lookup 需要选择本表 Link 字段'
+  const foreignId = resolveForeignSheetIdByFieldId(linkFieldId.trim())
+  if (!foreignId) return '所选 Link 字段缺少 foreignSheetId'
+  if (!targetFieldId.trim()) return 'Lookup 需要填写外表字段 ID'
+  return null
+}
+
+function validateRollupConfig(linkFieldId: string, targetFieldId: string): string | null {
+  if (!linkFieldId.trim()) return 'Rollup 需要选择本表 Link 字段'
+  const foreignId = resolveForeignSheetIdByFieldId(linkFieldId.trim())
+  if (!foreignId) return '所选 Link 字段缺少 foreignSheetId'
+  if (!targetFieldId.trim()) return 'Rollup 需要填写外表字段 ID'
+  return null
+}
+
+watch(createLookupForeignSheetId, (sheet) => {
+  if (sheet) ensureForeignFields(sheet)
+})
+
+watch(createRollupForeignSheetId, (sheet) => {
+  if (sheet) ensureForeignFields(sheet)
+})
+
+watch(editLookupForeignSheetId, (sheet) => {
+  if (sheet) ensureForeignFields(sheet)
+})
+
+watch(editRollupForeignSheetId, (sheet) => {
+  if (sheet) ensureForeignFields(sheet)
+})
+
+function formatOptions(field: Field): string {
+  if (field.type === 'select') {
+    const opts = Array.isArray(field.options) ? field.options : []
+    if (opts.length === 0) return '(empty)'
+    return opts.map((o) => (o.color ? `${o.value}|${o.color}` : o.value)).join(', ')
+  }
+
+  if (field.type === 'link') {
+    const prop = field.property ?? {}
+    const foreign = prop.foreignDatasheetId ?? prop.foreignSheetId ?? prop.datasheetId
+    const foreignText = typeof foreign === 'string' && foreign.trim().length > 0 ? foreign.trim() : ''
+    const single = prop.limitSingleRecord === true
+    const displayFld = typeof prop.displayFieldId === 'string' ? prop.displayFieldId : ''
+    const parts: string[] = []
+    if (foreignText) parts.push(foreignText)
+    if (displayFld) parts.push(`display: ${displayFld}`)
+    if (single) parts.push('single')
+    if (parts.length === 0) return '-'
+    return parts.join(', ')
+  }
+
+  if (field.type === 'lookup') {
+    const prop = field.property ?? {}
+    const linkField = prop.relatedLinkFieldId ?? prop.linkFieldId ?? prop.linkedFieldId
+    const targetField = prop.lookUpTargetFieldId ?? prop.lookupTargetFieldId ?? prop.targetFieldId
+    const parts: string[] = []
+    if (typeof linkField === 'string' && linkField.trim().length > 0) parts.push(`link: ${linkField.trim()}`)
+    if (typeof targetField === 'string' && targetField.trim().length > 0) parts.push(`target: ${targetField.trim()}`)
+    return parts.length > 0 ? parts.join(', ') : '-'
+  }
+
+  if (field.type === 'rollup') {
+    const prop = field.property ?? {}
+    const linkField = prop.linkedFieldId ?? prop.linkFieldId ?? prop.relatedLinkFieldId
+    const targetField = prop.targetFieldId ?? prop.lookUpTargetFieldId ?? prop.lookupTargetFieldId
+    const aggregation = prop.aggregation ?? prop.agg ?? prop.function
+    const parts: string[] = []
+    if (typeof linkField === 'string' && linkField.trim().length > 0) parts.push(`link: ${linkField.trim()}`)
+    if (typeof targetField === 'string' && targetField.trim().length > 0) parts.push(`target: ${targetField.trim()}`)
+    if (typeof aggregation === 'string' && aggregation.trim().length > 0) parts.push(`agg: ${aggregation.trim()}`)
+    return parts.length > 0 ? parts.join(', ') : '-'
+  }
+
+  return '-'
+}
+
+const READONLY_HINTS = {
+  property: '只读字段',
+  lookup: 'Lookup 计算结果',
+  rollup: 'Rollup 计算结果',
+}
+
+function resolveReadonlyTag(field: Field): string {
+  if (field.type === 'lookup') return 'Lookup'
+  if (field.type === 'rollup') return 'Rollup'
+  if (field.property?.readonly === true) return '只读'
+  return '只读'
+}
+
+function formatReadonlyDetail(field: Field, reason: string): string {
+  const label = field.name?.trim() || '该字段'
+  return `字段【${label}】为${reason}，无法编辑`
+}
+
+function resolveReadonlyInfo(field: Field): ReadonlyInfo | null {
+  if (field.type === 'lookup') {
+    return {
+      tag: resolveReadonlyTag(field),
+      reason: READONLY_HINTS.lookup,
+      detail: formatReadonlyDetail(field, READONLY_HINTS.lookup),
+    }
+  }
+  if (field.type === 'rollup') {
+    return {
+      tag: resolveReadonlyTag(field),
+      reason: READONLY_HINTS.rollup,
+      detail: formatReadonlyDetail(field, READONLY_HINTS.rollup),
+    }
+  }
+  if (field.property?.readonly === true) {
+    return {
+      tag: resolveReadonlyTag(field),
+      reason: READONLY_HINTS.property,
+      detail: formatReadonlyDetail(field, READONLY_HINTS.property),
+    }
+  }
+  return null
+}
+
+const readonlyInfoById = computed<Record<string, ReadonlyInfo>>(() => {
+  const mapping: Record<string, ReadonlyInfo> = {}
+  for (const field of fields.value) {
+    const info = resolveReadonlyInfo(field)
+    if (info) mapping[field.id] = info
+  }
+  return mapping
+})
+
+function canMoveUp(field: Field): boolean {
+  const idx = fields.value.findIndex((f) => f.id === field.id)
+  return idx > 0
+}
+
+function canMoveDown(field: Field): boolean {
+  const idx = fields.value.findIndex((f) => f.id === field.id)
+  return idx >= 0 && idx < fields.value.length - 1
+}
+
+async function refresh() {
+  if (!sheetId.value) {
+    fields.value = []
+    error.value = '缺少 sheetId'
+    return
+  }
+
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await apiFetch(`/api/univer-meta/fields?sheetId=${encodeURIComponent(sheetId.value)}`)
+    const json = await parseJsonSafe<FieldsResponse>(res)
+    if (!res.ok || !json?.ok || !json.data) {
+      fields.value = []
+      error.value = json?.error?.message ?? `加载失败 (${res.status})`
+      return
+    }
+    fields.value = json.data.fields
+  } catch (err) {
+    fields.value = []
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function createField() {
+  if (!sheetId.value) return
+  if (!createName.value.trim()) return
+  if (createLoading.value) return
+
+  createLoading.value = true
+  createError.value = ''
+
+  try {
+    if (createType.value === 'lookup') {
+      const err = validateLookupConfig(createLookupLinkFieldId.value, createLookupTargetFieldId.value)
+      if (err) {
+        createError.value = err
+        return
+      }
+    }
+    if (createType.value === 'rollup') {
+      const err = validateRollupConfig(createRollupLinkFieldId.value, createRollupTargetFieldId.value)
+      if (err) {
+        createError.value = err
+        return
+      }
+    }
+    const property: Record<string, unknown> = {}
+    if (createType.value === 'select') {
+      property.options = parseSelectOptions(createOptionsText.value)
+    }
+    if (createType.value === 'link') {
+      const foreignId = createLinkForeignSheetId.value.trim()
+      if (foreignId) property.foreignDatasheetId = foreignId
+      const displayFieldId = createLinkDisplayFieldId.value.trim()
+      if (displayFieldId) property.displayFieldId = displayFieldId
+      if (createLinkLimitSingleRecord.value) property.limitSingleRecord = true
+    }
+    if (createType.value === 'lookup') {
+      const linkFieldId = createLookupLinkFieldId.value.trim()
+      const targetFieldId = createLookupTargetFieldId.value.trim()
+      if (linkFieldId) property.relatedLinkFieldId = linkFieldId
+      if (targetFieldId) property.lookUpTargetFieldId = targetFieldId
+    }
+    if (createType.value === 'rollup') {
+      const linkFieldId = createRollupLinkFieldId.value.trim()
+      const targetFieldId = createRollupTargetFieldId.value.trim()
+      if (linkFieldId) property.linkedFieldId = linkFieldId
+      if (targetFieldId) property.targetFieldId = targetFieldId
+      property.aggregation = createRollupAgg.value
+    }
+    if (createReadonly.value && !createReadonlyForced.value) {
+      property.readonly = true
+    }
+    const res = await apiFetch('/api/univer-meta/fields', {
+      method: 'POST',
+      body: JSON.stringify({
+        sheetId: sheetId.value,
+        name: createName.value.trim(),
+        type: createType.value,
+        property,
+      }),
+    })
+    const json = await parseJsonSafe<CreateFieldResponse>(res)
+    if (!res.ok || !json?.ok || !json.data?.field) {
+      createError.value = json?.error?.message ?? `创建失败 (${res.status})`
+      return
+    }
+    createName.value = '新字段'
+    createOptionsText.value = ''
+    createLinkForeignSheetId.value = ''
+    createLinkDisplayFieldId.value = ''
+    createLinkLimitSingleRecord.value = false
+    createLookupLinkFieldId.value = ''
+    createLookupTargetFieldId.value = ''
+    createRollupLinkFieldId.value = ''
+    createRollupTargetFieldId.value = ''
+    createRollupAgg.value = 'count'
+    createReadonly.value = false
+    await refresh()
+  } catch (err) {
+    createError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    createLoading.value = false
+  }
+}
+
+function beginEdit(field: Field) {
+  editingId.value = field.id
+  editName.value = field.name
+  editType.value = (field.type as any) ?? 'string'
+  editProperty.value = field.property ?? {}
+  editOptionsText.value = Array.isArray(field.options)
+    ? field.options.map((o) => (o.color ? `${o.value}|${o.color}` : o.value)).join('\n')
+    : ''
+
+  const foreign =
+    editProperty.value.foreignDatasheetId ?? editProperty.value.foreignSheetId ?? editProperty.value.datasheetId
+  editLinkForeignSheetId.value = typeof foreign === 'string' ? foreign : ''
+  const displayFld = editProperty.value.displayFieldId
+  editLinkDisplayFieldId.value = typeof displayFld === 'string' ? displayFld : ''
+  editLinkLimitSingleRecord.value = editProperty.value.limitSingleRecord === true
+  editReadonly.value = editProperty.value.readonly === true
+
+  if (field.type === 'lookup') {
+    const linkField = editProperty.value.relatedLinkFieldId ?? editProperty.value.linkFieldId ?? editProperty.value.linkedFieldId
+    const targetField = editProperty.value.lookUpTargetFieldId ?? editProperty.value.lookupTargetFieldId ?? editProperty.value.targetFieldId
+    editLookupLinkFieldId.value = typeof linkField === 'string' ? linkField : ''
+    editLookupTargetFieldId.value = typeof targetField === 'string' ? targetField : ''
+  } else {
+    editLookupLinkFieldId.value = ''
+    editLookupTargetFieldId.value = ''
+  }
+
+  if (field.type === 'rollup') {
+    const linkField = editProperty.value.linkedFieldId ?? editProperty.value.linkFieldId ?? editProperty.value.relatedLinkFieldId
+    const targetField = editProperty.value.targetFieldId ?? editProperty.value.lookUpTargetFieldId ?? editProperty.value.lookupTargetFieldId
+    const aggregation = editProperty.value.aggregation ?? editProperty.value.agg ?? editProperty.value.function
+    editRollupLinkFieldId.value = typeof linkField === 'string' ? linkField : ''
+    editRollupTargetFieldId.value = typeof targetField === 'string' ? targetField : ''
+    editRollupAgg.value = typeof aggregation === 'string' ? (aggregation as any) : 'count'
+  } else {
+    editRollupLinkFieldId.value = ''
+    editRollupTargetFieldId.value = ''
+    editRollupAgg.value = 'count'
+  }
+}
+
+function cancelEdit() {
+  editingId.value = null
+  editName.value = ''
+  editOptionsText.value = ''
+  editProperty.value = {}
+  editLinkForeignSheetId.value = ''
+  editLinkDisplayFieldId.value = ''
+  editLinkLimitSingleRecord.value = false
+  editLookupLinkFieldId.value = ''
+  editLookupTargetFieldId.value = ''
+  editRollupLinkFieldId.value = ''
+  editRollupTargetFieldId.value = ''
+  editRollupAgg.value = 'count'
+  editReadonly.value = false
+}
+
+async function saveEdit() {
+  if (!editingId.value) return
+  if (!editName.value.trim()) return
+  if (editSaving.value) return
+
+  editSaving.value = true
+  try {
+    if (editType.value === 'lookup') {
+      const err = validateLookupConfig(editLookupLinkFieldId.value, editLookupTargetFieldId.value)
+      if (err) {
+        window.alert(err)
+        return
+      }
+    }
+    if (editType.value === 'rollup') {
+      const err = validateRollupConfig(editRollupLinkFieldId.value, editRollupTargetFieldId.value)
+      if (err) {
+        window.alert(err)
+        return
+      }
+    }
+    const base: Record<string, unknown> = { ...(editProperty.value ?? {}) }
+    if (editType.value === 'select') {
+      base.options = parseSelectOptions(editOptionsText.value)
+    }
+    if (editType.value === 'link') {
+      const foreignId = editLinkForeignSheetId.value.trim()
+      if (foreignId) {
+        base.foreignDatasheetId = foreignId
+        delete (base as any).foreignSheetId
+        delete (base as any).datasheetId
+        base.limitSingleRecord = editLinkLimitSingleRecord.value
+        const displayFieldId = editLinkDisplayFieldId.value.trim()
+        if (displayFieldId) {
+          base.displayFieldId = displayFieldId
+        } else {
+          delete (base as any).displayFieldId
+        }
+      } else {
+        delete (base as any).foreignDatasheetId
+        delete (base as any).foreignSheetId
+        delete (base as any).datasheetId
+        delete (base as any).limitSingleRecord
+        delete (base as any).displayFieldId
+      }
+    }
+    if (editType.value === 'lookup') {
+      const linkFieldId = editLookupLinkFieldId.value.trim()
+      const targetFieldId = editLookupTargetFieldId.value.trim()
+      if (linkFieldId) base.relatedLinkFieldId = linkFieldId
+      else delete (base as any).relatedLinkFieldId
+      if (targetFieldId) base.lookUpTargetFieldId = targetFieldId
+      else delete (base as any).lookUpTargetFieldId
+    } else {
+      delete (base as any).relatedLinkFieldId
+      delete (base as any).lookUpTargetFieldId
+      delete (base as any).lookupTargetFieldId
+      delete (base as any).targetFieldId
+    }
+    if (editType.value === 'rollup') {
+      const linkFieldId = editRollupLinkFieldId.value.trim()
+      const targetFieldId = editRollupTargetFieldId.value.trim()
+      if (linkFieldId) base.linkedFieldId = linkFieldId
+      else delete (base as any).linkedFieldId
+      if (targetFieldId) base.targetFieldId = targetFieldId
+      else delete (base as any).targetFieldId
+      base.aggregation = editRollupAgg.value
+    } else {
+      delete (base as any).linkedFieldId
+      delete (base as any).aggregation
+      delete (base as any).agg
+      delete (base as any).function
+    }
+    if (editReadonlyForced.value) {
+      delete (base as any).readonly
+    } else if (editReadonly.value) {
+      base.readonly = true
+    } else {
+      delete (base as any).readonly
+    }
+    const property = base
+    const res = await apiFetch(`/api/univer-meta/fields/${encodeURIComponent(editingId.value)}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name: editName.value.trim(), type: editType.value, property }),
+    })
+    const json = await parseJsonSafe<UpdateFieldResponse>(res)
+    if (!res.ok || !json?.ok || !json.data?.field) {
+      window.alert(json?.error?.message ?? `保存失败 (${res.status})`)
+      return
+    }
+    cancelEdit()
+    await refresh()
+  } catch (err) {
+    window.alert(err instanceof Error ? err.message : String(err))
+  } finally {
+    editSaving.value = false
+  }
+}
+
+async function move(field: Field, dir: -1 | 1) {
+  if (!field.id) return
+  const idx = fields.value.findIndex((f) => f.id === field.id)
+  if (idx < 0) return
+
+  const currentOrder = field.order ?? idx
+  const nextOrder = Math.max(currentOrder + dir, 0)
+
+  try {
+    const res = await apiFetch(`/api/univer-meta/fields/${encodeURIComponent(field.id)}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ order: nextOrder }),
+    })
+    const json = await parseJsonSafe<UpdateFieldResponse>(res)
+    if (!res.ok || !json?.ok) {
+      window.alert(json?.error?.message ?? `移动失败 (${res.status})`)
+      return
+    }
+    await refresh()
+  } catch (err) {
+    window.alert(err instanceof Error ? err.message : String(err))
+  }
+}
+
+async function deleteField(fieldId: string) {
+  if (!fieldId) return
+  if (deleteLoadingId.value) return
+
+  const ok = window.confirm(`确定删除字段？\n\n${fieldId}`)
+  if (!ok) return
+
+  deleteLoadingId.value = fieldId
+  try {
+    const res = await apiFetch(`/api/univer-meta/fields/${encodeURIComponent(fieldId)}`, { method: 'DELETE' })
+    const json = await parseJsonSafe<DeleteFieldResponse>(res)
+    if (!res.ok || !json?.ok) {
+      window.alert(json?.error?.message ?? `删除失败 (${res.status})`)
+      return
+    }
+    await refresh()
+  } catch (err) {
+    window.alert(err instanceof Error ? err.message : String(err))
+  } finally {
+    deleteLoadingId.value = null
+  }
+}
+
+onMounted(() => {
+  refresh().catch(() => null)
+})
+</script>
+
+<style scoped>
+.meta-fields {
+  padding: 18px 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.meta-fields__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.meta-fields__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.meta-fields__subtitle {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.meta-fields__mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.meta-fields__muted {
+  color: #9ca3af;
+}
+
+.meta-fields__readonly {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+
+.meta-fields__readonly-tag {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  font-weight: 600;
+}
+
+.meta-fields__readonly-reason {
+  color: #6b7280;
+}
+
+.meta-fields__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #374151;
+  margin-top: 8px;
+}
+
+.meta-fields__checkbox--inline {
+  margin-top: 8px;
+}
+
+.meta-fields__link-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-fields__header-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.meta-fields__create {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 14px;
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.meta-fields__options {
+  width: 100%;
+}
+
+.meta-fields__link-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.meta-fields__input {
+  height: 34px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0 10px;
+  min-width: 220px;
+}
+
+.meta-fields__input--inline {
+  min-width: 180px;
+}
+
+.meta-fields__select {
+  height: 34px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0 8px;
+  background: #fff;
+}
+
+.meta-fields__select--inline {
+  width: 120px;
+}
+
+.meta-fields__textarea {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  resize: vertical;
+}
+
+.meta-fields__textarea--inline {
+  max-width: 460px;
+}
+
+.meta-fields__btn {
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  padding: 0 12px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #111827;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.meta-fields__btn:hover {
+  background: #f3f4f6;
+}
+
+.meta-fields__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.meta-fields__btn--primary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+.meta-fields__btn--primary:hover {
+  background: #1d4ed8;
+}
+
+.meta-fields__btn--danger {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.meta-fields__btn--danger:hover {
+  background: #fef2f2;
+}
+
+.meta-fields__error {
+  color: #b91c1c;
+  font-size: 13px;
+}
+
+.meta-fields__error--block {
+  margin-bottom: 12px;
+}
+
+.meta-fields__empty {
+  padding: 14px;
+  border: 1px dashed #d1d5db;
+  border-radius: 10px;
+  color: #6b7280;
+  background: #fff;
+}
+
+.meta-fields__table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.meta-fields__table th,
+.meta-fields__table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+  vertical-align: top;
+}
+
+.meta-fields__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+</style>

--- a/apps/web/src/views/UniverGridPOC.vue
+++ b/apps/web/src/views/UniverGridPOC.vue
@@ -1,0 +1,2119 @@
+<template>
+  <div class="univer-poc">
+    <div class="univer-poc__header">
+      <h2 class="univer-poc__title">Univer Grid POC</h2>
+      <div class="univer-poc__subtitle">Vue 外壳嵌入验证（Phase 0.F1）</div>
+      <div class="univer-poc__meta">
+        <div>viewId: {{ viewId }}</div>
+        <div v-if="activeSheetId && activeSheetId !== viewId" class="univer-poc__sheet-id">
+          sheetId: {{ activeSheetId }}
+        </div>
+        <label v-if="sourceIsMeta" class="univer-poc__view-picker">
+          <span>视图</span>
+          <select v-model="selectedViewId" class="univer-poc__select" @change="handleViewChange">
+            <option value="">(当前 Sheet)</option>
+            <option v-for="view in availableViews" :key="view.id" :value="view.id">
+              {{ view.name || view.id }} ({{ view.type }})
+            </option>
+          </select>
+        </label>
+        <div v-if="viewSummary" class="univer-poc__view-summary">
+          <span class="univer-poc__view-chip">view: {{ viewSummary.name }} ({{ viewSummary.type }})</span>
+          <span class="univer-poc__view-chip">id: {{ viewSummary.id }}</span>
+          <span v-if="viewSummary.groupLabel" class="univer-poc__view-chip">group: {{ viewSummary.groupLabel }}</span>
+          <span v-if="viewSummary.sortLabel" class="univer-poc__view-chip">sort: {{ viewSummary.sortLabel }}</span>
+          <span v-if="viewSummary.filterLabel" class="univer-poc__view-chip">filter: {{ viewSummary.filterLabel }}</span>
+          <span v-if="viewSummary.hiddenCount > 0" class="univer-poc__view-chip">hidden: {{ viewSummary.hiddenCount }}</span>
+          <span
+            v-if="viewSummary.computedFilterSort"
+            class="univer-poc__view-chip univer-poc__view-chip--warn"
+          >
+            computed filter/sort
+          </span>
+        </div>
+        <div v-if="diagnosticsItems.length" class="univer-poc__diagnostics">
+          <span class="univer-poc__diagnostics-label">诊断</span>
+          <span
+            v-for="item in diagnosticsItems"
+            :key="item.label"
+            class="univer-poc__diagnostics-chip"
+            :title="item.ids.join(', ')"
+          >
+            {{ item.label }} ({{ item.ids.length }})
+          </span>
+        </div>
+        <div v-if="page">loaded: {{ loadedCount }}/{{ page.total }}</div>
+        <button
+          v-if="page && page.hasMore"
+          type="button"
+          class="univer-poc__meta-btn"
+          :disabled="loadingMore"
+          @click="loadMore"
+        >
+          {{ loadingMore ? '加载中...' : '加载更多' }}
+        </button>
+        <button type="button" class="univer-poc__meta-btn" @click="reloadView">重算</button>
+        <div v-if="statusText" :class="statusKind === 'error' ? 'univer-poc__status univer-poc__status--error' : 'univer-poc__status'">
+          {{ statusText }}
+        </div>
+        <div v-if="statusHint && statusText.startsWith('Sheet not found:')" class="univer-poc__status-hint">
+          {{ statusHint }}
+        </div>
+        <div v-if="viewWarnings.length" class="univer-poc__warning">
+          <div v-for="(warning, idx) in viewWarnings" :key="idx">
+            {{ warning }}
+          </div>
+        </div>
+        <div v-if="relatedUpdateCount > 0" class="univer-poc__related">
+          <span>外表更新 {{ relatedUpdateCount }} 条</span>
+          <button type="button" class="univer-poc__meta-btn" @click="reloadView">点击刷新</button>
+          <span v-if="relatedUpdateSheets.length" class="univer-poc__related-note">
+            来源: {{ relatedUpdateSheets.join(', ') }}
+          </span>
+        </div>
+        <div v-if="demoHint" class="univer-poc__hint">
+          <span>{{ demoHint.text }}</span>
+          <a :href="demoHint.href" class="univer-poc__hint-link">打开可编辑示例表</a>
+          <span class="univer-poc__hint-note">{{ demoHint.note }}</span>
+        </div>
+        <div v-if="readonlyFields.length" class="univer-poc__readonly">
+          <span class="univer-poc__readonly-label">只读字段</span>
+          <button
+            v-for="item in readonlyFields"
+            :key="item.id"
+            type="button"
+            class="univer-poc__readonly-item"
+            :title="item.reason"
+            @click="focusReadonlyField(item.id)"
+          >
+            <span class="univer-poc__readonly-name">{{ item.label }}</span>
+            <span class="univer-poc__readonly-tag">{{ item.tag }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="univer-poc__body" :class="{ 'univer-poc__body--with-comments': commentsEnabled }">
+      <div
+        ref="wrapperRef"
+        class="univer-poc__container"
+        :class="{ 'univer-poc__container--with-comments': commentsEnabled }"
+      >
+        <div ref="containerRef" class="univer-poc__mount" />
+
+        <div v-if="readonlyHeaderIcons.length" class="univer-poc__header-icons">
+          <div
+            v-for="icon in readonlyHeaderIcons"
+            :key="icon.fieldId"
+            class="univer-poc__header-icon"
+            :style="{ left: `${icon.left}px`, top: `${icon.top}px` }"
+            :title="icon.title"
+            :data-readonly-header-icon="icon.fieldId"
+            tabindex="0"
+            @mouseenter="showHeaderTooltip(icon)"
+            @mouseleave="hideHeaderTooltip"
+            @focus="showHeaderTooltip(icon)"
+            @blur="hideHeaderTooltip"
+          >
+            RO
+          </div>
+          <div
+            v-if="headerTooltip"
+            class="univer-poc__header-tooltip"
+            :style="{ left: `${headerTooltip.left}px`, top: `${headerTooltip.top}px` }"
+          >
+            {{ headerTooltip.text }}
+          </div>
+        </div>
+
+        <div v-if="commentsEnabled && commentBadges.length" class="univer-poc__comment-badges">
+          <div
+            v-for="badge in commentBadges"
+            :key="badge.recordId"
+            class="univer-poc__comment-badge"
+            :style="{ left: `${badge.left}px`, top: `${badge.top}px` }"
+            :title="badge.title"
+          >
+            {{ badge.text }}
+          </div>
+        </div>
+
+        <div
+          v-if="overlay?.kind === 'select'"
+          class="univer-poc__overlay"
+          :style="{ left: `${overlay.left}px`, top: `${overlay.top}px` }"
+          @mousedown.stop
+        >
+          <div v-if="overlay.options.length === 0" class="univer-poc__overlay-empty">No options</div>
+          <button
+            v-for="opt in overlay.options"
+            :key="opt.value"
+            type="button"
+            class="univer-poc__pill"
+            :style="{ background: opt.color || resolveFallbackSelectColor(opt.value) || '#1677ff' }"
+            @click="applySelect(opt.value, opt.color)"
+          >
+            {{ opt.value }}
+          </button>
+        </div>
+
+        <div
+          v-if="overlay?.kind === 'link'"
+          class="univer-poc__overlay univer-poc__overlay--link"
+          :style="{ left: `${overlay.left}px`, top: `${overlay.top}px` }"
+          @mousedown.stop
+        >
+          <LinkPicker
+            v-model="linkDraft"
+            :foreign-sheet-id="overlay.foreignSheetId"
+            :display-field-id="overlay.displayFieldId"
+            :multiple="overlay.multiple"
+            :api-prefix="getApiPrefix()"
+            placeholder="Select linked record..."
+            @change="applyLink"
+          />
+          <div class="univer-poc__link-actions">
+            <button type="button" class="univer-poc__btn" @click="overlay = null">Cancel</button>
+          </div>
+        </div>
+
+        <div
+          v-if="overlay?.kind === 'readonly'"
+          class="univer-poc__overlay univer-poc__overlay--readonly"
+          :style="{ left: `${overlay.left}px`, top: `${overlay.top}px` }"
+        >
+          {{ overlay.message }}
+        </div>
+      </div>
+
+      <CommentsPanel
+        v-if="commentsEnabled"
+        class="univer-poc__comments"
+        :spreadsheet-id="commentsSpreadsheetId"
+        :record-id="selectedRecordId"
+        :field-id="selectedFieldId"
+        :field-label="selectedFieldLabel"
+        @comment-updated="handleCommentUpdated"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { ICellData, IWorkbookData } from '@univerjs/core'
+import { LocaleType } from '@univerjs/core'
+import { defaultTheme } from '@univerjs/design'
+import { createUniver } from '@univerjs/presets'
+import type { FUniver } from '@univerjs/presets'
+import { UniverSheetsCorePreset } from '@univerjs/presets/preset-sheets-core'
+import { SetRangeValuesMutation, SetSelectionsOperation } from '@univerjs/sheets'
+
+import '@univerjs/design/lib/index.css'
+import '@univerjs/ui/lib/index.css'
+import '@univerjs/sheets-ui/lib/index.css'
+
+
+import { apiFetch, apiGet } from '../utils/api'
+import { buildUniverSheetsLocales } from '../utils/univerLocales'
+import { createUniverEmbed } from '../utils/univerEmbed'
+import { createUniverPatchQueue, type UniverPatchQueue } from '../utils/univerPatchQueue'
+import {
+  buildLinkCell,
+  buildSelectCell,
+  applyReadonlyStyle,
+  extractValueFromCell,
+  isFormulaValue,
+  resolveFallbackSelectColor,
+} from '../utils/univerValue'
+import LinkPicker, { type LinkChangePayload } from '../components/LinkPicker.vue'
+import CommentsPanel from '../components/CommentsPanel.vue'
+
+const wrapperRef = ref<HTMLDivElement | null>(null)
+const containerRef = ref<HTMLDivElement | null>(null)
+const viewId = ref<string>('')
+const activeSheetId = ref<string>('')
+const statusText = ref<string>('')
+const statusKind = ref<'ok' | 'error'>('ok')
+const statusHint = ref<string>('')
+const viewWarnings = ref<string[]>([])
+const viewSummary = ref<ViewSummary | null>(null)
+const diagnosticsItems = ref<DiagnosticsItem[]>([])
+const availableViews = ref<Array<{ id: string; name: string; type: string }>>([])
+const selectedViewId = ref<string>('')
+const page = ref<UniverMockView['page'] | null>(null)
+const loadedCount = ref<number>(0)
+const baseOffset = ref<number>(0)
+const loadingMore = ref<boolean>(false)
+const readonlyFields = ref<ReadonlyFieldEntry[]>([])
+const readonlyHeaderIcons = ref<ReadonlyHeaderIcon[]>([])
+const headerTooltip = ref<ReadonlyHeaderTooltip | null>(null)
+const readonlyMetrics = ref<ReadonlyMetrics>({
+  total: 0,
+  byField: {},
+  byKind: {},
+  lastFieldId: null,
+  lastReason: null,
+  lastKind: null,
+})
+const relatedUpdates = ref<RelatedRecord[]>([])
+const relatedUpdateCount = computed(() => relatedUpdates.value.length)
+const relatedUpdateSheets = computed(() =>
+  Array.from(new Set(relatedUpdates.value.map((record) => record.sheetId))).filter((id) => id.length > 0),
+)
+const commentsEnabled = computed(() => toStr(route.query.source)?.toLowerCase() === 'meta')
+const commentsSpreadsheetId = computed(() => (commentsEnabled.value ? viewId.value : ''))
+const selectedRecordId = ref<string>('')
+const selectedFieldId = ref<string | undefined>(undefined)
+const selectedFieldLabel = computed(() => {
+  const fieldId = selectedFieldId.value
+  if (!fieldId) return ''
+  return mapping.fieldIdToLabel[fieldId] ?? fieldId
+})
+const commentSummary = ref<Record<string, { total: number; open: number }>>({})
+const commentBadges = ref<Array<{ recordId: string; left: number; top: number; text: string; title: string }>>([])
+let commentSummaryTimer = 0
+
+const route = useRoute()
+const router = useRouter()
+const EDITABLE_DEMO_ID = 'editable_demo'
+
+const demoHint = computed(() => {
+  const source = toStr(route.query.source)?.toLowerCase()
+  const sheetId = toStr(route.query.sheetId)
+  if (source !== 'meta' || sheetId !== 'lookup_source_demo') return null
+  return {
+    text: '此表包含 lookup/rollup/只读字段，仅用于验证。',
+    href: `/univer?source=meta&sheetId=${EDITABLE_DEMO_ID}`,
+    note: '如需可编辑示例，运行 scripts/setup-editable-demo.sh',
+  }
+})
+
+type OverlayState =
+  | {
+      kind: 'select'
+      row: number
+      col: number
+      left: number
+      top: number
+      fieldId: string
+      options: Array<{ value: string; color?: string }>
+    }
+  | {
+      kind: 'link'
+      row: number
+      col: number
+      left: number
+      top: number
+      fieldId: string
+      foreignSheetId: string
+      displayFieldId?: string
+      multiple: boolean
+    }
+  | {
+      kind: 'readonly'
+      row: number
+      col: number
+      left: number
+      top: number
+      message: string
+    }
+
+type ReadonlyFieldEntry = {
+  id: string
+  label: string
+  reason: string
+  tag: string
+}
+
+type ReadonlyHeaderIcon = {
+  fieldId: string
+  left: number
+  top: number
+  title: string
+}
+
+type ReadonlyHeaderTooltip = {
+  text: string
+  left: number
+  top: number
+}
+
+type ReadonlyHitKind = 'select' | 'list' | 'edit'
+
+type ReadonlyMetrics = {
+  total: number
+  byField: Record<string, number>
+  byKind: Record<string, number>
+  lastFieldId: string | null
+  lastReason: string | null
+  lastKind: ReadonlyHitKind | null
+}
+
+const overlay = ref<OverlayState | null>(null)
+const linkDraft = ref<string[]>([])
+
+let univerAPI: FUniver | null = null
+let univerDispose: (() => void) | null = null
+let patchQueue: UniverPatchQueue | null = null
+let startLoad: (() => Promise<void>) | null = null
+
+type UniverMockField = {
+  id: string
+  name: string
+  type: 'string' | 'number' | 'boolean' | 'formula' | 'select' | 'link' | 'lookup' | 'rollup'
+  options?: Array<{ value: string; color?: string }>
+  property?: {
+    foreignDatasheetId?: string
+    foreignSheetId?: string
+    limitSingleRecord?: boolean
+    displayFieldId?: string
+    readonly?: boolean
+    relatedLinkFieldId?: string
+    lookUpTargetFieldId?: string
+    linkedFieldId?: string
+    targetFieldId?: string
+    aggregation?: string
+    [key: string]: unknown
+  }
+}
+
+type UniverMockRecord = {
+  id: string
+  version: number
+  data: Record<string, unknown>
+}
+
+type RelatedRecord = {
+  sheetId: string
+  recordId: string
+  data: Record<string, unknown>
+}
+
+type UniverMockViewConfig = {
+  id?: string
+  sheetId?: string
+  name?: string
+  type?: string
+  filterInfo?: Record<string, unknown>
+  sortInfo?: Record<string, unknown>
+  groupInfo?: Record<string, unknown>
+  hiddenFieldIds?: string[]
+}
+
+type UniverMockView = {
+  id: string
+  fields: UniverMockField[]
+  rows: UniverMockRecord[]
+  view?: UniverMockViewConfig
+  meta?: {
+    warnings?: string[]
+    computedFilterSort?: boolean
+    ignoredSortFieldIds?: string[]
+    ignoredFilterFieldIds?: string[]
+    ignoredHiddenFieldIds?: string[]
+    ignoredGroupFieldIds?: string[]
+  }
+  page?: {
+    offset: number
+    limit: number
+    total: number
+    hasMore: boolean
+  }
+}
+
+type UniverMetaViewsResponse = {
+  ok: boolean
+  data?: { views: Array<{ id: string; name: string; type: string }> }
+  error?: { code: string; message: string }
+}
+
+type UniverMockViewResponse = {
+  ok: boolean
+  data?: UniverMockView
+  error?: { code: string; message: string }
+}
+
+type UniverMockPatchResponse = {
+  ok: boolean
+  data?: { updated: Array<{ recordId: string; version: number }> }
+  error?: { code: string; message: string; serverVersion?: number }
+}
+
+type ViewSummary = {
+  id: string
+  name: string
+  type: string
+  groupLabel: string | null
+  sortLabel: string | null
+  filterLabel: string | null
+  hiddenCount: number
+  computedFilterSort: boolean
+}
+
+type DiagnosticsItem = {
+  label: string
+  ids: string[]
+}
+
+const mapping = {
+  rowIndexToRecordId: [] as string[],
+  colIndexToFieldId: [] as string[],
+  recordIdToVersion: {} as Record<string, number>,
+  recordIdToRowIndex: {} as Record<string, number>,
+  recordIdToData: {} as Record<string, Record<string, unknown>>,
+  fieldIdToColIndex: {} as Record<string, number>,
+  fieldIdToType: {} as Record<string, UniverMockField['type']>,
+  fieldIdToSelectOptions: {} as Record<string, Array<{ value: string; color?: string }>>,
+  fieldIdToProperty: {} as Record<string, UniverMockField['property']>,
+  fieldIdToReadonlyReason: {} as Record<string, string>,
+  fieldIdToLabel: {} as Record<string, string>,
+}
+
+let suppressChanges = false
+let sheetRowCount = 0
+let headerIconRaf = 0
+let headerIconCleanup: (() => void) | null = null
+let commentBadgeRaf = 0
+
+function createDemoWorkbook(): IWorkbookData {
+  const sheetId = 'sheet-1'
+  return {
+    id: 'workbook-1',
+    name: 'MetaSheet Univer POC',
+    appVersion: '0.12.4',
+    locale: LocaleType.ZH_CN,
+    styles: {},
+    sheetOrder: [sheetId],
+    sheets: {
+      [sheetId]: {
+        id: sheetId,
+        name: 'Sheet1',
+        rowCount: 50,
+        columnCount: 10,
+        cellData: {
+          0: {
+            0: { v: 'Hello' },
+            1: { v: 1 },
+            2: { v: 2 },
+            3: { f: '=SUM(B1,C1)' },
+          },
+        },
+      },
+    },
+  }
+}
+
+function toStr(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return undefined
+}
+
+function queueCommentSummaryRefresh(recordIds?: string[]) {
+  if (commentSummaryTimer) window.clearTimeout(commentSummaryTimer)
+  commentSummaryTimer = window.setTimeout(() => {
+    commentSummaryTimer = 0
+    fetchCommentSummary(recordIds).catch((err) => {
+      console.error('[UniverGridPOC] load comment summary failed:', err)
+    })
+  }, 200)
+}
+
+async function fetchCommentSummary(recordIds?: string[]) {
+  if (!commentsEnabled.value || !commentsSpreadsheetId.value) {
+    commentSummary.value = {}
+    commentBadges.value = []
+    return
+  }
+
+  const ids = recordIds && recordIds.length > 0 ? recordIds : mapping.rowIndexToRecordId.filter(Boolean)
+  if (ids.length === 0) {
+    commentSummary.value = {}
+    commentBadges.value = []
+    return
+  }
+
+  const qs = new URLSearchParams({
+    spreadsheetId: commentsSpreadsheetId.value,
+    rowIds: ids.join(','),
+  })
+
+  const res = await apiFetch(`/api/comments/summary?${qs.toString()}`)
+  const json = await res.json().catch(() => ({}))
+  if (!res.ok || !json.ok) {
+    throw new Error(json.error?.message || 'Failed to load comment summary')
+  }
+
+  const next = { ...commentSummary.value }
+  for (const rowId of ids) {
+    next[rowId] = { total: 0, open: 0 }
+  }
+
+  const items = Array.isArray(json.data?.items) ? json.data.items : []
+  for (const item of items) {
+    const rowId = String(item.rowId)
+    next[rowId] = {
+      total: Number(item.total ?? 0),
+      open: Number(item.open ?? 0),
+    }
+  }
+
+  commentSummary.value = next
+  requestCommentBadgeUpdate()
+}
+
+function requestCommentBadgeUpdate() {
+  if (commentBadgeRaf) window.cancelAnimationFrame(commentBadgeRaf)
+  commentBadgeRaf = window.requestAnimationFrame(() => {
+    commentBadgeRaf = 0
+    updateCommentBadges()
+  })
+}
+
+function updateCommentBadges() {
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  const wrapperEl = wrapperRef.value
+  if (!sheet || !wrapperEl || !commentsEnabled.value) {
+    commentBadges.value = []
+    return
+  }
+
+  const wrapperRect = wrapperEl.getBoundingClientRect()
+  const badges: Array<{ recordId: string; left: number; top: number; text: string; title: string }> = []
+  for (let rowIndex = 0; rowIndex < mapping.rowIndexToRecordId.length; rowIndex += 1) {
+    const recordId = mapping.rowIndexToRecordId[rowIndex]
+    if (!recordId) continue
+    const summary = commentSummary.value[recordId]
+    if (!summary || summary.total <= 0) continue
+
+    let rect: DOMRect | undefined
+    try {
+      const range = sheet.getRange(rowIndex, 0) as any
+      rect = range?.getCellRect?.()
+    } catch {
+      rect = undefined
+    }
+    if (!rect || rect.width < 6 || rect.height < 6) continue
+
+    const text = summary.open > 0 ? `${summary.open}/${summary.total}` : `${summary.total}`
+    const title =
+      summary.open > 0 ? `${summary.open} 未解决 / ${summary.total} 总计` : `${summary.total} 评论`
+    const left = rect.left - wrapperRect.left + rect.width - 28
+    const top = rect.top - wrapperRect.top + 4
+    badges.push({
+      recordId,
+      left: Math.max(4, left),
+      top: Math.max(2, top),
+      text,
+      title,
+    })
+  }
+  commentBadges.value = badges
+}
+
+watch(
+  () => [commentsEnabled.value, commentsSpreadsheetId.value],
+  () => {
+    queueCommentSummaryRefresh()
+  },
+  { immediate: true }
+)
+
+const DEFAULT_WINDOW = {
+  size: 200,
+  buffer: 100,
+  max: 1000,
+}
+
+function toPositiveInt(value: string | undefined, fallback: number, min = 1): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) return fallback
+  if (parsed < min) return fallback
+  return parsed
+}
+
+function resolveWindowing() {
+  const flag = toStr(route.query.window)?.toLowerCase()
+  const enabled = flag === '1' || flag === 'true' || flag === 'on'
+  const size = toPositiveInt(toStr(route.query.windowSize), DEFAULT_WINDOW.size, 1)
+  const buffer = toPositiveInt(toStr(route.query.windowBuffer), DEFAULT_WINDOW.buffer, 0)
+  const maxRaw = toPositiveInt(toStr(route.query.windowMax), DEFAULT_WINDOW.max, 1)
+  const max = Math.max(size, maxRaw)
+  return { enabled, size, buffer, max }
+}
+
+function resolveWindowRowCount(total: number | undefined, loaded: number, windowing: { enabled: boolean; max: number }) {
+  if (!windowing.enabled) return Math.max(loaded, 50)
+  const safeTotal = typeof total === 'number' && Number.isFinite(total) ? total : loaded
+  const cap = Math.min(windowing.max, safeTotal)
+  return Math.max(loaded, 50, cap)
+}
+
+function buildMissingSheetHint(error: unknown): { title: string; hint: string } | null {
+  const message = error instanceof Error ? error.message : String(error)
+  if (!message.includes('404')) return null
+  const source = toStr(route.query.source)?.toLowerCase()
+  const sheetId = toStr(route.query.sheetId)
+  if (source !== 'meta' || !sheetId) return null
+  return {
+    title: `Sheet not found: ${sheetId}`,
+    hint: 'Run: scripts/setup-lookup-rollup-demo.sh then reload.',
+  }
+}
+
+function getApiPrefix(): string {
+  const source = toStr(route.query.source)?.toLowerCase()
+  return source === 'meta' ? '/api/univer-meta' : '/api/univer-mock'
+}
+
+const sourceIsMeta = computed(() => toStr(route.query.source)?.toLowerCase() === 'meta')
+
+async function loadAvailableViews(sheetId: string) {
+  if (!sheetId) return
+  try {
+    const res = await apiFetch(`/api/univer-meta/views?sheetId=${encodeURIComponent(sheetId)}`)
+    const json = (await res.json().catch(() => ({}))) as UniverMetaViewsResponse
+    if (!res.ok || !json.ok || !json.data) return
+    availableViews.value = json.data.views ?? []
+  } catch {
+    availableViews.value = []
+  }
+}
+
+function handleViewChange() {
+  const nextViewId = selectedViewId.value
+  const query = { ...route.query }
+  if (nextViewId) {
+    query.viewId = nextViewId
+    delete query.sheetId
+  } else {
+    delete query.viewId
+  }
+  router.replace({ query }).catch(() => null)
+  reloadView()
+}
+
+function getQueryString(): string {
+  const qs = new URLSearchParams()
+  const rows = toStr(route.query.rows)
+  const cols = toStr(route.query.cols)
+  const queryViewId = toStr(route.query.viewId)
+  const mode = toStr(route.query.mode)
+  const refresh = toStr(route.query.refresh)
+  const source = toStr(route.query.source)?.toLowerCase()
+  const sheetId = toStr(route.query.sheetId)
+  const seed = toStr(route.query.seed)
+  const limit = toStr(route.query.limit)
+  const offset = toStr(route.query.offset)
+  const windowing = resolveWindowing()
+  const resolvedLimit = source === 'meta' ? (limit || (windowing.enabled ? String(windowing.size) : '50')) : limit
+  const resolvedOffset = source === 'meta' ? (offset || '0') : offset
+
+  if (rows) qs.set('rows', rows)
+  if (cols) qs.set('cols', cols)
+  if (queryViewId) qs.set('viewId', queryViewId)
+  if (mode) qs.set('mode', mode)
+  if (refresh) qs.set('refresh', refresh)
+  if (source === 'meta') {
+    if (sheetId) qs.set('sheetId', sheetId)
+    if (seed) qs.set('seed', seed)
+    qs.set('limit', resolvedLimit ?? '50')
+    qs.set('offset', resolvedOffset ?? '0')
+  }
+
+  const text = qs.toString()
+  return text ? `?${text}` : ''
+}
+
+function resolveFieldLabel(fields: UniverMockField[], fieldId: string): string {
+  const field = fields.find((f) => f.id === fieldId)
+  return field?.name?.trim() || fieldId
+}
+
+function isFilterValueDisabled(operator: string): boolean {
+  const op = operator.trim().toLowerCase()
+  return op === 'isempty' || op === 'isnotempty'
+}
+
+function formatFilterValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => toStr(v))
+      .filter((v): v is string => Boolean(v))
+      .join(', ')
+  }
+  return toStr(value) ?? ''
+}
+
+function buildViewSummary(view: UniverMockView): ViewSummary | null {
+  const cfg = view.view
+  if (!cfg) return null
+
+  const name = typeof cfg.name === 'string' && cfg.name.trim().length > 0 ? cfg.name.trim() : '未命名视图'
+  const id = typeof cfg.id === 'string' && cfg.id.trim().length > 0 ? cfg.id.trim() : view.id
+  const type = typeof cfg.type === 'string' && cfg.type.trim().length > 0 ? cfg.type.trim() : 'grid'
+  const hiddenCount = Array.isArray(cfg.hiddenFieldIds)
+    ? cfg.hiddenFieldIds.filter((v) => typeof v === 'string' && v.trim().length > 0).length
+    : 0
+
+  const summary: ViewSummary = {
+    id,
+    name,
+    type,
+    groupLabel: null,
+    sortLabel: null,
+    filterLabel: null,
+    hiddenCount,
+    computedFilterSort: view.meta?.computedFilterSort === true,
+  }
+
+  const groupId =
+    cfg.groupInfo && typeof cfg.groupInfo === 'object' && !Array.isArray(cfg.groupInfo)
+      ? (cfg.groupInfo as Record<string, unknown>).fieldId
+      : undefined
+  if (typeof groupId === 'string' && groupId.trim().length > 0) {
+    summary.groupLabel = resolveFieldLabel(view.fields, groupId.trim())
+  }
+
+  const rules =
+    cfg.sortInfo && typeof cfg.sortInfo === 'object' && !Array.isArray(cfg.sortInfo)
+      ? (cfg.sortInfo as Record<string, unknown>).rules
+      : undefined
+  if (Array.isArray(rules) && rules.length > 0) {
+    const rule = rules[0] as Record<string, unknown>
+    const fieldId = typeof rule.fieldId === 'string' ? rule.fieldId.trim() : ''
+    if (fieldId) {
+      const dir = rule.desc === true ? '↓' : '↑'
+      summary.sortLabel = `${resolveFieldLabel(view.fields, fieldId)} ${dir}`
+    }
+  }
+
+  const conditions =
+    cfg.filterInfo && typeof cfg.filterInfo === 'object' && !Array.isArray(cfg.filterInfo)
+      ? (cfg.filterInfo as Record<string, unknown>).conditions
+      : undefined
+  if (Array.isArray(conditions) && conditions.length > 0) {
+    const cond = conditions[0] as Record<string, unknown>
+    const fieldId = typeof cond.fieldId === 'string' ? cond.fieldId.trim() : ''
+    const operator = typeof cond.operator === 'string' ? cond.operator.trim() : ''
+    if (fieldId && operator) {
+      const label = resolveFieldLabel(view.fields, fieldId)
+      if (isFilterValueDisabled(operator)) {
+        summary.filterLabel = `${label} ${operator}`
+      } else {
+        const value = formatFilterValue(cond.value)
+        summary.filterLabel = value ? `${label} ${operator} ${value}` : `${label} ${operator}`
+      }
+    }
+  }
+
+  return summary
+}
+
+function buildDiagnostics(view: UniverMockView): DiagnosticsItem[] {
+  const meta = view.meta
+  if (!meta) return []
+  const items: DiagnosticsItem[] = []
+  const add = (label: string, ids?: string[]) => {
+    if (!ids || ids.length === 0) return
+    items.push({ label, ids })
+  }
+  add('sort', meta.ignoredSortFieldIds)
+  add('filter', meta.ignoredFilterFieldIds)
+  add('hidden', meta.ignoredHiddenFieldIds)
+  add('group', meta.ignoredGroupFieldIds)
+  return items
+}
+
+watch(
+  () => [route.query.source, route.query.sheetId, route.query.viewId],
+  () => {
+    if (!sourceIsMeta.value) {
+      availableViews.value = []
+      selectedViewId.value = ''
+      return
+    }
+    const sheetId = toStr(route.query.sheetId) || activeSheetId.value
+    if (sheetId) loadAvailableViews(sheetId)
+    selectedViewId.value = toStr(route.query.viewId) ?? ''
+  },
+  { immediate: true },
+)
+
+const READONLY_HINTS = {
+  property: '只读字段',
+  lookup: 'Lookup 计算结果',
+  rollup: 'Rollup 计算结果',
+}
+
+function resolveReadonlyTag(field: UniverMockField): string {
+  if (field.type === 'lookup') return 'Lookup'
+  if (field.type === 'rollup') return 'Rollup'
+  if (field.property?.readonly) return '只读'
+  return '只读'
+}
+
+function formatReadonlyReason(field: UniverMockField, reason: string): string {
+  const label = field.name?.trim() || '该字段'
+  return `字段【${label}】为${reason}，无法编辑`
+}
+
+function resolveReadonlyReason(field: UniverMockField): string | null {
+  if (field.type === 'lookup') return formatReadonlyReason(field, READONLY_HINTS.lookup)
+  if (field.type === 'rollup') return formatReadonlyReason(field, READONLY_HINTS.rollup)
+  if (field.property?.readonly) return formatReadonlyReason(field, READONLY_HINTS.property)
+  return null
+}
+
+function buildReadonlyFields(fields: UniverMockField[]): ReadonlyFieldEntry[] {
+  return fields
+    .map((field) => {
+      const reason = resolveReadonlyReason(field)
+      if (!reason) return null
+      return {
+        id: field.id,
+        label: field.name?.trim() || String(field.id),
+        reason,
+        tag: resolveReadonlyTag(field),
+      }
+    })
+    .filter((entry): entry is ReadonlyFieldEntry => Boolean(entry))
+}
+
+function syncReadonlyFields(fields: UniverMockField[]) {
+  readonlyFields.value = buildReadonlyFields(fields)
+  requestReadonlyHeaderUpdate()
+}
+
+function getReadonlyReason(fieldId: string): string | null {
+  const reason = mapping.fieldIdToReadonlyReason[fieldId]
+  return reason && reason.trim().length > 0 ? reason : null
+}
+
+function requestReadonlyHeaderUpdate() {
+  if (headerIconRaf) window.cancelAnimationFrame(headerIconRaf)
+  headerIconRaf = window.requestAnimationFrame(() => {
+    headerIconRaf = 0
+    updateReadonlyHeaderIcons()
+  })
+}
+
+function showHeaderTooltip(icon: ReadonlyHeaderIcon) {
+  headerTooltip.value = {
+    text: icon.title,
+    left: icon.left + 8,
+    top: Math.max(6, icon.top - 32),
+  }
+}
+
+function hideHeaderTooltip() {
+  headerTooltip.value = null
+}
+
+function handleCommentUpdated(payload: { rowId: string }) {
+  if (!payload?.rowId) return
+  queueCommentSummaryRefresh([payload.rowId])
+}
+
+function recordReadonlyHit(fieldId: string, reason: string, kind: ReadonlyHitKind) {
+  readonlyMetrics.value.total += 1
+  readonlyMetrics.value.byField[fieldId] = (readonlyMetrics.value.byField[fieldId] ?? 0) + 1
+  readonlyMetrics.value.byKind[kind] = (readonlyMetrics.value.byKind[kind] ?? 0) + 1
+  readonlyMetrics.value.lastFieldId = fieldId
+  readonlyMetrics.value.lastReason = reason
+  readonlyMetrics.value.lastKind = kind
+  try {
+    ;(window as any).__readonlyMetrics = { ...readonlyMetrics.value }
+  } catch {
+    // ignore
+  }
+}
+
+function updateReadonlyHeaderIcons() {
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  const wrapperEl = wrapperRef.value
+  hideHeaderTooltip()
+  if (!sheet || !wrapperEl) return
+  if (readonlyFields.value.length === 0) {
+    readonlyHeaderIcons.value = []
+    return
+  }
+
+  const wrapperRect = wrapperEl.getBoundingClientRect()
+  const icons: ReadonlyHeaderIcon[] = []
+  for (const entry of readonlyFields.value) {
+    const colIndex = mapping.fieldIdToColIndex[entry.id]
+    if (typeof colIndex !== 'number' || !Number.isFinite(colIndex)) continue
+
+    let rect: DOMRect | undefined
+    try {
+      const range = sheet.getRange(0, colIndex) as any
+      rect = range?.getCellRect?.()
+    } catch {
+      rect = undefined
+    }
+    if (!rect || rect.width < 4) continue
+
+    const left = rect.left - wrapperRect.left + Math.max(2, rect.width - 18)
+    const top = rect.top - wrapperRect.top - 18
+
+    icons.push({
+      fieldId: entry.id,
+      left: Math.max(4, left),
+      top: Math.max(2, top),
+      title: entry.reason,
+    })
+  }
+  readonlyHeaderIcons.value = icons
+}
+
+function showReadonlyOverlay(fieldId: string, row: number, col: number, message: string, kind: ReadonlyHitKind): boolean {
+  const wrapperEl = wrapperRef.value
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  recordReadonlyHit(fieldId, message, kind)
+  if (!wrapperEl || !sheet) return false
+
+  let rect: DOMRect | undefined
+  try {
+    const range = sheet.getRange(row, col) as any
+    rect = range?.getCellRect?.()
+  } catch {
+    rect = undefined
+  }
+  if (!rect) return false
+
+  const wrapperRect = wrapperEl.getBoundingClientRect()
+  const left = rect.left - wrapperRect.left
+  const top = rect.bottom - wrapperRect.top + 4
+
+  overlay.value = {
+    kind: 'readonly',
+    row,
+    col,
+    left,
+    top,
+    message,
+  }
+  return true
+}
+
+function focusReadonlyField(fieldId: string) {
+  const colIndex = mapping.fieldIdToColIndex[fieldId]
+  if (typeof colIndex !== 'number' || !Number.isFinite(colIndex)) return
+  const reason = getReadonlyReason(fieldId) || `字段【${mapping.fieldIdToLabel[fieldId] ?? fieldId}】只读，无法编辑`
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  try {
+    const range = sheet.getRange(0, colIndex) as any
+    sheet.setActiveRange(range)
+  } catch {
+    // ignore
+  }
+
+  if (!showReadonlyOverlay(fieldId, 0, colIndex, reason, 'list')) {
+    statusText.value = reason
+    statusKind.value = 'error'
+  }
+}
+
+function buildCellValue(fieldType: UniverMockField['type'], raw: unknown): ICellData | null {
+  if (raw === null || raw === undefined) return null
+
+  if (typeof raw === 'string' && raw.startsWith('=')) {
+    return { f: raw }
+  }
+
+  if (fieldType === 'link') {
+    if (typeof raw === 'string') {
+      if (!raw.trim()) return null
+      return buildLinkCell(raw) as any
+    }
+    if (Array.isArray(raw)) {
+      const text = raw
+        .filter((v) => typeof v === 'string' || typeof v === 'number')
+        .map((v) => String(v))
+        .join(', ')
+      if (!text.trim()) return null
+      return buildLinkCell(text) as any
+    }
+  }
+
+  if (fieldType === 'lookup') {
+    if (Array.isArray(raw)) {
+      const text = raw
+        .filter((v) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
+        .map((v) => String(v))
+        .join(', ')
+      if (!text.trim()) return null
+      return { v: text }
+    }
+    if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+      return { v: raw }
+    }
+  }
+
+  if (fieldType === 'rollup') {
+    if (typeof raw === 'number' || typeof raw === 'string' || typeof raw === 'boolean') {
+      return { v: raw }
+    }
+  }
+
+  if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+    return { v: raw }
+  }
+
+  return { v: JSON.stringify(raw) }
+}
+
+function buildCellForField(field: UniverMockField, raw: unknown): ICellData | null {
+  const cell = buildCellValue(field.type, raw)
+  if (!cell) return null
+  const reason = resolveReadonlyReason(field)
+  return reason ? applyReadonlyStyle(cell, reason) : cell
+}
+
+function restoreReadonlyCell(row: number, col: number, recordId: string, fieldId: string) {
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+  const raw = mapping.recordIdToData[recordId]?.[fieldId]
+  const fieldType = mapping.fieldIdToType[fieldId]
+  const reason = getReadonlyReason(fieldId)
+  const baseCell = buildCellValue(fieldType, raw) ?? { v: '' }
+  const cell = reason ? applyReadonlyStyle(baseCell as any, reason) : baseCell
+
+  try {
+    suppressChanges = true
+    sheet.getRange(row, col).setValueForCell(cell as any)
+  } catch {
+    // ignore
+  } finally {
+    suppressChanges = false
+  }
+}
+
+function applyComputedRecords(records: Array<{ recordId: string; data: Record<string, unknown> }>) {
+  if (!records.length) return
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  try {
+    suppressChanges = true
+    for (const record of records) {
+      const rowIndex = mapping.recordIdToRowIndex[record.recordId]
+      if (typeof rowIndex !== 'number' || !Number.isFinite(rowIndex)) continue
+
+      const existing = mapping.recordIdToData[record.recordId] ?? {}
+      mapping.recordIdToData[record.recordId] = { ...existing, ...record.data }
+
+      for (const [fieldId, value] of Object.entries(record.data)) {
+        const fieldType = mapping.fieldIdToType[fieldId]
+        if (fieldType !== 'lookup' && fieldType !== 'rollup') continue
+        const colIndex = mapping.fieldIdToColIndex[fieldId]
+        if (typeof colIndex !== 'number' || !Number.isFinite(colIndex)) continue
+
+        const baseCell = buildCellValue(fieldType, value) ?? { v: '' }
+        const reason = getReadonlyReason(fieldId)
+        const cell = reason ? applyReadonlyStyle(baseCell as any, reason) : baseCell
+        sheet.getRange(rowIndex, colIndex).setValueForCell(cell as any)
+      }
+    }
+  } finally {
+    suppressChanges = false
+  }
+}
+
+function mergeRelatedUpdates(
+  existing: RelatedRecord[],
+  incoming: RelatedRecord[],
+): RelatedRecord[] {
+  const merged = new Map<string, RelatedRecord>()
+  for (const record of existing) {
+    merged.set(`${record.sheetId}:${record.recordId}`, record)
+  }
+  for (const record of incoming) {
+    merged.set(`${record.sheetId}:${record.recordId}`, record)
+  }
+  return Array.from(merged.values())
+}
+
+function handleRelatedRecords(records: RelatedRecord[]) {
+  if (!records.length) return
+  const currentSheetId = viewId.value
+  const sameSheet = records.filter((record) => record.sheetId === currentSheetId)
+  if (sameSheet.length > 0) {
+    applyComputedRecords(sameSheet.map((record) => ({ recordId: record.recordId, data: record.data })))
+  }
+  const external = records.filter((record) => record.sheetId !== currentSheetId)
+  if (external.length === 0) return
+  relatedUpdates.value = mergeRelatedUpdates(relatedUpdates.value, external)
+}
+
+async function reloadView() {
+  relatedUpdates.value = []
+  await loadView()
+}
+
+async function loadView() {
+  if (!univerAPI || !startLoad) return
+  statusText.value = 'Reloading...'
+  statusKind.value = 'ok'
+  await startLoad()
+}
+
+function transformToWorkbook(view: UniverMockView): {
+  workbook: IWorkbookData
+  mapping: {
+    rowIndexToRecordId: string[]
+    colIndexToFieldId: string[]
+    recordIdToVersion: Record<string, number>
+    recordIdToRowIndex: Record<string, number>
+    recordIdToData: Record<string, Record<string, unknown>>
+    fieldIdToColIndex: Record<string, number>
+    fieldIdToType: Record<string, UniverMockField['type']>
+    fieldIdToReadonlyReason: Record<string, string>
+    fieldIdToLabel: Record<string, string>
+  }
+} {
+  const sheetId = view.id
+  const rowIndexToRecordId = view.rows.map((r) => r.id)
+  const colIndexToFieldId = view.fields.map((f) => f.id)
+
+  const recordIdToVersion = Object.fromEntries(view.rows.map((r) => [r.id, r.version]))
+  const recordIdToRowIndex = Object.fromEntries(rowIndexToRecordId.map((id, idx) => [id, idx]))
+  const recordIdToData = Object.fromEntries(view.rows.map((r) => [r.id, { ...r.data }]))
+  const fieldIdToColIndex = Object.fromEntries(colIndexToFieldId.map((id, idx) => [id, idx]))
+  const fieldIdToType = Object.fromEntries(view.fields.map((f) => [f.id, f.type]))
+  const fieldIdToReadonlyReason: Record<string, string> = {}
+  const fieldIdToLabel: Record<string, string> = {}
+  view.fields.forEach((field) => {
+    const label = field.name?.trim() || String(field.id)
+    fieldIdToLabel[field.id] = label
+    const reason = resolveReadonlyReason(field)
+    if (reason) fieldIdToReadonlyReason[field.id] = reason
+  })
+
+  const cellData: Record<number, Record<number, ICellData>> = {}
+  view.rows.forEach((record, rowIndex) => {
+    const rowCells: Record<number, ICellData> = {}
+    view.fields.forEach((field, colIndex) => {
+      const raw = (record.data[field.id] ?? record.data[field.name]) as unknown
+      const cell = buildCellForField(field, raw)
+      if (cell) rowCells[colIndex] = cell
+    })
+    if (Object.keys(rowCells).length > 0) {
+      cellData[rowIndex] = rowCells
+    }
+  })
+
+  const windowing = resolveWindowing()
+  const rowTotal = view.page?.total ?? view.rows.length
+  const rowCount = resolveWindowRowCount(rowTotal, view.rows.length, windowing)
+  const workbook: IWorkbookData = {
+    id: `workbook_${sheetId}`,
+    name: `MetaSheet(${sheetId})`,
+    appVersion: '0.12.4',
+    locale: LocaleType.ZH_CN,
+    styles: {},
+    sheetOrder: [sheetId],
+    sheets: {
+      [sheetId]: {
+        id: sheetId,
+        name: 'Sheet1',
+        rowCount,
+        columnCount: Math.max(view.fields.length, 10),
+        cellData,
+      },
+    },
+  }
+
+  return {
+    workbook,
+    mapping: {
+      rowIndexToRecordId,
+      colIndexToFieldId,
+      recordIdToVersion,
+      recordIdToRowIndex,
+      recordIdToData,
+      fieldIdToColIndex,
+      fieldIdToType,
+      fieldIdToReadonlyReason,
+      fieldIdToLabel,
+    },
+  }
+}
+
+function applySelect(value: string, color?: string) {
+  const current = overlay.value
+  if (!current || current.kind !== 'select' || !univerAPI) return
+  const sheet = univerAPI.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  const resolvedColor = color || resolveFallbackSelectColor(value) || '#1677ff'
+  try {
+    sheet.getRange(current.row, current.col).setValueForCell(buildSelectCell(value, resolvedColor) as any)
+  } catch (err) {
+    console.error('[UniverGridPOC] applySelect failed:', err)
+  }
+  overlay.value = null
+}
+
+function applyLink(payload: LinkChangePayload) {
+  const current = overlay.value
+  if (!current || current.kind !== 'link' || !univerAPI) return
+  const sheet = univerAPI.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  try {
+    const { ids, displays } = payload
+    // Display text shows names, but internal value stores IDs
+    const displayText = displays.filter(Boolean).join(', ')
+    // Build cell with display text but mark the underlying data as IDs for patch
+    const cell = buildLinkCell(displayText)
+    // Store IDs in cell custom field for patch queue to extract
+    ;(cell as any).__linkIds = ids
+    sheet.getRange(current.row, current.col).setValueForCell(cell as any)
+  } catch (err) {
+    console.error('[UniverGridPOC] applyLink failed:', err)
+  }
+  overlay.value = null
+}
+
+const loadMore = async () => {
+  const currentPage = page.value
+  const source = toStr(route.query.source)?.toLowerCase()
+  if (!currentPage || source !== 'meta') return
+  if (loadingMore.value) return
+
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  const windowing = resolveWindowing()
+  const nextOffset = baseOffset.value + loadedCount.value
+  if (nextOffset >= currentPage.total) {
+    page.value = { ...currentPage, hasMore: false }
+    return
+  }
+
+  loadingMore.value = true
+  statusText.value = 'Loading more...'
+  statusKind.value = 'ok'
+
+  try {
+    const qs = new URLSearchParams()
+    const queryViewId = toStr(route.query.viewId)
+    const resolvedSheetId = viewId.value
+    if (queryViewId) {
+      qs.set('viewId', queryViewId)
+      if (resolvedSheetId) qs.set('sheetId', resolvedSheetId)
+    } else if (resolvedSheetId) {
+      qs.set('sheetId', resolvedSheetId)
+    } else {
+      return
+    }
+    qs.set('limit', String(currentPage.limit))
+    qs.set('offset', String(nextOffset))
+    if (toStr(route.query.seed)) qs.set('seed', String(route.query.seed))
+
+    const response = await apiGet<UniverMockViewResponse>(`${getApiPrefix()}/view?${qs.toString()}`)
+    if (!response.ok || !response.data) {
+      throw new Error(response.error?.message ?? 'failed to load next page')
+    }
+
+    const rows = response.data.rows ?? []
+    if (rows.length === 0) {
+      page.value = {
+        ...currentPage,
+        offset: windowing.enabled ? baseOffset.value : currentPage.offset,
+        hasMore: false,
+      }
+      statusText.value = 'No more rows'
+      statusKind.value = 'ok'
+      return
+    }
+
+    const startRow = mapping.rowIndexToRecordId.length
+    const total = response.data.page?.total ?? currentPage.total
+    const nextRowCount = resolveWindowRowCount(total, startRow + rows.length, windowing)
+
+    suppressChanges = true
+    if (sheetRowCount < nextRowCount) {
+      sheet.setRowCount(nextRowCount)
+      sheetRowCount = nextRowCount
+    }
+
+    for (let i = 0; i < rows.length; i += 1) {
+      const record = rows[i]
+      const rowIndex = startRow + i
+      mapping.rowIndexToRecordId[rowIndex] = record.id
+      mapping.recordIdToVersion[record.id] = record.version
+      mapping.recordIdToRowIndex[record.id] = rowIndex
+      mapping.recordIdToData[record.id] = { ...record.data }
+
+      for (let colIndex = 0; colIndex < response.data.fields.length; colIndex += 1) {
+        const field = response.data.fields[colIndex]
+        const raw = (record.data[field.id] ?? record.data[field.name]) as unknown
+        const cell = buildCellForField(field, raw)
+        if (cell) sheet.getRange(rowIndex, colIndex).setValueForCell(cell as any)
+      }
+    }
+
+    loadedCount.value += rows.length
+    if (windowing.enabled && windowing.max > 0 && loadedCount.value > windowing.max) {
+      const evictCount = loadedCount.value - windowing.max
+      if (evictCount > 0) {
+        patchQueue?.flushNow()
+        const evictedIds = mapping.rowIndexToRecordId.splice(0, evictCount)
+        for (const recordId of evictedIds) {
+          if (!recordId) continue
+          delete mapping.recordIdToRowIndex[recordId]
+          delete mapping.recordIdToData[recordId]
+          delete mapping.recordIdToVersion[recordId]
+        }
+        for (let i = 0; i < mapping.rowIndexToRecordId.length; i += 1) {
+          const rid = mapping.rowIndexToRecordId[i]
+          if (rid) mapping.recordIdToRowIndex[rid] = i
+        }
+        try {
+          sheet.deleteRows(0, evictCount)
+        } catch (err) {
+          console.error('[UniverGridPOC] deleteRows failed:', err)
+        }
+        baseOffset.value += evictCount
+        loadedCount.value = mapping.rowIndexToRecordId.length
+        const windowRowCount = resolveWindowRowCount(total, loadedCount.value, windowing)
+        sheet.setRowCount(windowRowCount)
+        sheetRowCount = windowRowCount
+      }
+    }
+    page.value = {
+      ...currentPage,
+      offset: windowing.enabled ? baseOffset.value : currentPage.offset,
+      total,
+      hasMore: baseOffset.value + loadedCount.value < total,
+    }
+    queueCommentSummaryRefresh()
+    requestCommentBadgeUpdate()
+    try {
+      ;(window as any).__pocRecordIds = mapping.rowIndexToRecordId.slice()
+    } catch {
+      // ignore
+    }
+
+    statusText.value = `Loaded +${rows.length}`
+    statusKind.value = 'ok'
+  } catch (err) {
+    console.error('[UniverGridPOC] loadMore failed:', err)
+    statusText.value = 'Load more failed'
+    statusKind.value = 'error'
+  } finally {
+    suppressChanges = false
+    loadingMore.value = false
+    requestReadonlyHeaderUpdate()
+  }
+}
+
+onMounted(() => {
+  const hostEl = containerRef.value
+  if (!hostEl) return
+
+  const embed = createUniverEmbed(
+    hostEl,
+    (mountEl) =>
+      createUniver({
+        theme: defaultTheme,
+        locale: LocaleType.ZH_CN,
+        locales: buildUniverSheetsLocales(),
+        presets: [UniverSheetsCorePreset({ container: mountEl })],
+      }),
+    { exposeToWindow: true },
+  )
+
+  univerAPI = embed.univerAPI
+
+  const handleScroll = () => {
+    requestReadonlyHeaderUpdate()
+    requestCommentBadgeUpdate()
+  }
+  wrapperRef.value?.addEventListener('scroll', handleScroll, true)
+  window.addEventListener('resize', handleScroll)
+  headerIconCleanup = () => {
+    wrapperRef.value?.removeEventListener('scroll', handleScroll, true)
+    window.removeEventListener('resize', handleScroll)
+    if (headerIconRaf) window.cancelAnimationFrame(headerIconRaf)
+    headerIconRaf = 0
+    if (commentBadgeRaf) window.cancelAnimationFrame(commentBadgeRaf)
+    commentBadgeRaf = 0
+  }
+
+  patchQueue = createUniverPatchQueue({
+    getViewId: () => viewId.value,
+    getApiPrefix,
+    mapping,
+    setStatus: (text, kind) => {
+      statusText.value = text
+      statusKind.value = kind
+    },
+    onRecords: applyComputedRecords,
+    onRelatedRecords: handleRelatedRecords,
+    flushDelayMs: 120,
+  })
+
+  const disposable = univerAPI.addEvent(univerAPI.Event.CommandExecuted, (event) => {
+    if (event.id === SetSelectionsOperation.id) {
+      const selections = (event.params as { selections?: Array<{ primary?: { actualRow?: number; actualColumn?: number } | null }> })
+        ?.selections
+      const primary = selections?.find(s => s?.primary)?.primary
+      const row = primary?.actualRow
+      const col = primary?.actualColumn
+      if (typeof row !== 'number' || typeof col !== 'number') {
+        overlay.value = null
+        selectedRecordId.value = ''
+        selectedFieldId.value = undefined
+        return
+      }
+
+      const fieldId = mapping.colIndexToFieldId[col]
+      const fieldType = mapping.fieldIdToType[fieldId]
+      if (!fieldId) {
+        overlay.value = null
+        selectedRecordId.value = ''
+        selectedFieldId.value = undefined
+        return
+      }
+      const recordId = mapping.rowIndexToRecordId[row] ?? ''
+      selectedRecordId.value = recordId
+      selectedFieldId.value = fieldId
+
+      const readonlyReason = getReadonlyReason(fieldId)
+      if (readonlyReason) {
+        if (!showReadonlyOverlay(fieldId, row, col, readonlyReason, 'select')) {
+          overlay.value = null
+        }
+        return
+      }
+      if (fieldType !== 'select' && fieldType !== 'link') {
+        overlay.value = null
+        return
+      }
+
+      const wrapperEl = wrapperRef.value
+      const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+      if (!wrapperEl || !sheet) {
+        overlay.value = null
+        return
+      }
+
+      let rect: DOMRect | undefined
+      try {
+        const range = sheet.getRange(row, col) as any
+        rect = range?.getCellRect?.()
+      } catch {
+        rect = undefined
+      }
+      if (!rect) {
+        overlay.value = null
+        return
+      }
+
+      const wrapperRect = wrapperEl.getBoundingClientRect()
+      const left = rect.left - wrapperRect.left
+      const top = rect.bottom - wrapperRect.top + 4
+
+      if (fieldType === 'select') {
+        overlay.value = {
+          kind: 'select',
+          row,
+          col,
+          left,
+          top,
+          fieldId,
+          options: mapping.fieldIdToSelectOptions[fieldId] ?? [],
+        }
+        return
+      }
+
+      // Get field property for foreignSheetId and limitSingleRecord
+      const fieldProp = mapping.fieldIdToProperty[fieldId] ?? {}
+      const foreignSheetId = fieldProp.foreignDatasheetId ?? fieldProp.foreignSheetId ?? ''
+      const multiple = fieldProp.limitSingleRecord !== true
+      const displayFieldId = fieldProp.displayFieldId ?? undefined
+
+      overlay.value = {
+        kind: 'link',
+        row,
+        col,
+        left,
+        top,
+        fieldId,
+        foreignSheetId,
+        displayFieldId,
+        multiple,
+      }
+      try {
+        // Parse current value as array of IDs (prefer __linkIds if present)
+        const current = sheet.getRange(row, col).getCellData?.() as { v?: unknown; __linkIds?: unknown } | undefined
+        const rawIds = Array.isArray(current?.__linkIds) ? current?.__linkIds : undefined
+        const val = rawIds ?? current?.v
+        if (Array.isArray(val)) {
+          linkDraft.value = val.filter((v): v is string => typeof v === 'string')
+        } else if (typeof val === 'string' && val.trim()) {
+          // Try to parse as JSON array or comma-separated
+          try {
+            const parsed = JSON.parse(val)
+            linkDraft.value = Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [val]
+          } catch {
+            linkDraft.value = val.includes(',') ? val.split(',').map(s => s.trim()).filter(Boolean) : [val]
+          }
+        } else {
+          linkDraft.value = []
+        }
+      } catch {
+        linkDraft.value = []
+      }
+      return
+    }
+
+    if (event.id !== SetRangeValuesMutation.id) return
+    if (suppressChanges) return
+    const cellValue = (event.params as { cellValue?: Record<string, Record<string, unknown>> })?.cellValue
+    if (!cellValue) return
+
+    for (const [rowKey, rowValue] of Object.entries(cellValue)) {
+      const row = Number(rowKey)
+      if (!Number.isFinite(row)) continue
+      const recordId = mapping.rowIndexToRecordId[row]
+      if (!recordId) continue
+
+      for (const [colKey, cell] of Object.entries(rowValue)) {
+        const col = Number(colKey)
+        if (!Number.isFinite(col)) continue
+        const fieldId = mapping.colIndexToFieldId[col]
+        if (!fieldId) continue
+
+        const readonlyReason = getReadonlyReason(fieldId)
+        if (readonlyReason) {
+          restoreReadonlyCell(row, col, recordId, fieldId)
+          recordReadonlyHit(fieldId, readonlyReason, 'edit')
+          statusText.value = readonlyReason
+          statusKind.value = 'error'
+          continue
+        }
+
+        const value = extractValueFromCell(cell)
+        const fieldType = mapping.fieldIdToType[fieldId]
+        if (fieldType === 'lookup' || fieldType === 'rollup') continue
+        if (fieldType === 'formula' && !isFormulaValue(value)) continue
+
+        if (mapping.recordIdToData[recordId]) {
+          mapping.recordIdToData[recordId][fieldId] = value as any
+        }
+
+        patchQueue.stageChange(recordId, fieldId, value)
+      }
+    }
+
+    patchQueue.requestFlush(120)
+  })
+
+  const start = async () => {
+    try {
+      const qs = getQueryString()
+      const response = await apiGet<UniverMockViewResponse>(`${getApiPrefix()}/view${qs}`)
+      if (!response.ok || !response.data) {
+        throw new Error(response.error?.message ?? 'failed to load view')
+      }
+      activeSheetId.value = response.data.id
+      viewSummary.value = buildViewSummary(response.data)
+      viewId.value = response.data.id
+      selectedViewId.value = toStr(route.query.viewId) ?? ''
+      viewWarnings.value = Array.isArray(response.data.meta?.warnings) ? response.data.meta!.warnings!.slice() : []
+      diagnosticsItems.value = buildDiagnostics(response.data)
+      const source = toStr(route.query.source)?.toLowerCase()
+      const windowing = resolveWindowing()
+      const viewRows =
+        windowing.enabled && source !== 'meta'
+          ? response.data.rows.slice(0, windowing.size)
+          : response.data.rows
+      const viewData = { ...response.data, rows: viewRows }
+      const transformed = transformToWorkbook(viewData)
+      Object.assign(mapping, transformed.mapping)
+      mapping.fieldIdToSelectOptions = Object.fromEntries(
+        response.data.fields
+          .filter((f) => f.type === 'select' && Array.isArray(f.options))
+          .map((f) => [f.id, f.options ?? []]),
+      )
+      mapping.fieldIdToProperty = Object.fromEntries(
+        response.data.fields
+          .filter((f) => f.property)
+          .map((f) => [f.id, f.property]),
+      )
+      mapping.fieldIdToReadonlyReason = Object.fromEntries(
+        response.data.fields
+          .map((f) => [f.id, resolveReadonlyReason(f)] as const)
+          .filter((entry) => Boolean(entry[1])),
+      ) as Record<string, string>
+      mapping.fieldIdToLabel = Object.fromEntries(
+        response.data.fields
+          .map((f) => [f.id, f.name?.trim() || String(f.id)] as const),
+      ) as Record<string, string>
+      syncReadonlyFields(response.data.fields)
+      const hiddenFieldIds = Array.isArray(response.data.view?.hiddenFieldIds)
+        ? response.data.view!.hiddenFieldIds!.map((v) => (typeof v === 'string' ? v.trim() : '')).filter((v) => v.length > 0)
+        : []
+      univerAPI!.createWorkbook(transformed.workbook)
+      requestReadonlyHeaderUpdate()
+      queueCommentSummaryRefresh()
+      requestCommentBadgeUpdate()
+      const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+      if (sheet && hiddenFieldIds.length > 0) {
+        for (const fieldId of hiddenFieldIds) {
+          const colIndex = mapping.fieldIdToColIndex[fieldId]
+          if (typeof colIndex !== 'number' || !Number.isFinite(colIndex)) continue
+          try {
+            sheet.hideColumns(colIndex, 1)
+          } catch {
+            // ignore
+          }
+        }
+      }
+      try {
+        ;(window as any).__pocHiddenFieldIds = hiddenFieldIds
+        ;(window as any).__pocHiddenCols = sheet?.getSheet?.().getHiddenCols?.() ?? []
+        ;(window as any).__pocRecordIds = mapping.rowIndexToRecordId.slice()
+      } catch {
+        // ignore
+      }
+      sheetRowCount = transformed.workbook.sheets?.[response.data.id]?.rowCount ?? 0
+      page.value = response.data.page ?? null
+      loadedCount.value = transformed.mapping.rowIndexToRecordId.length
+      baseOffset.value = response.data.page?.offset ?? 0
+      if (page.value) {
+        page.value = {
+          ...page.value,
+          offset: windowing.enabled ? baseOffset.value : page.value.offset,
+          hasMore: baseOffset.value + loadedCount.value < page.value.total,
+        }
+      }
+      statusText.value = 'Loaded'
+      statusKind.value = 'ok'
+      statusHint.value = ''
+    } catch (err) {
+      console.error('[UniverGridPOC] load view failed, fallback to demo:', err)
+      viewId.value = 'demo'
+      activeSheetId.value = ''
+      viewSummary.value = null
+      diagnosticsItems.value = []
+      univerAPI!.createWorkbook(createDemoWorkbook())
+      requestReadonlyHeaderUpdate()
+      commentSummary.value = {}
+      commentBadges.value = []
+      page.value = null
+      loadedCount.value = 0
+      baseOffset.value = 0
+      viewWarnings.value = []
+      const hint = buildMissingSheetHint(err)
+      if (hint) {
+        statusText.value = hint.title
+        statusHint.value = hint.hint
+      } else {
+        statusText.value = 'Loaded demo workbook (backend unavailable)'
+        statusHint.value = ''
+      }
+      statusKind.value = 'error'
+    }
+  }
+
+  startLoad = async () => {
+    await start()
+  }
+
+  startLoad().catch((err) => {
+    console.error('[UniverGridPOC] start failed:', err)
+  })
+
+  univerDispose = () => {
+    headerIconCleanup?.()
+    if (commentSummaryTimer) window.clearTimeout(commentSummaryTimer)
+    commentSummaryTimer = 0
+    commentBadges.value = []
+    commentSummary.value = {}
+    patchQueue.dispose()
+    disposable.dispose()
+    embed.dispose()
+  }
+})
+
+onUnmounted(() => {
+  univerDispose?.()
+  univerDispose = null
+  univerAPI = null
+  startLoad = null
+  overlay.value = null
+})
+</script>
+
+<style scoped>
+.univer-poc {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 50px);
+}
+
+.univer-poc__header {
+  flex: 0 0 auto;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e0e0;
+  background: #fff;
+}
+
+.univer-poc__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+  background: #f8fafc;
+}
+
+.univer-poc__body--with-comments {
+  background: #f3f4f6;
+}
+
+.univer-poc__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.univer-poc__subtitle {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.univer-poc__meta {
+  margin-top: 6px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.univer-poc__sheet-id {
+  color: #4b5563;
+}
+
+.univer-poc__view-summary {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.univer-poc__diagnostics {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #92400e;
+}
+
+.univer-poc__diagnostics-label {
+  font-weight: 600;
+}
+
+.univer-poc__diagnostics-chip {
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(234, 179, 8, 0.5);
+  background: rgba(234, 179, 8, 0.15);
+  color: #92400e;
+  font-size: 11px;
+}
+
+.univer-poc__view-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: #f8fafc;
+  color: #374151;
+  font-size: 11px;
+}
+
+.univer-poc__view-chip--warn {
+  border-color: rgba(255, 77, 79, 0.35);
+  background: rgba(255, 77, 79, 0.08);
+  color: #c2410c;
+}
+
+.univer-poc__status {
+  color: #1677ff;
+}
+
+.univer-poc__status--error {
+  color: #ff4d4f;
+}
+
+.univer-poc__status-hint {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.univer-poc__warning {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid #ffd591;
+  background: #fff7e6;
+  color: #8c6d1f;
+  font-size: 12px;
+}
+
+.univer-poc__related {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid #ffd591;
+  background: #fff7e6;
+  color: #8c6d1f;
+  font-size: 12px;
+}
+
+.univer-poc__related-note {
+  color: #6b7280;
+}
+
+.univer-poc__hint {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  color: #8c6d1f;
+}
+
+.univer-poc__hint-link {
+  color: #1677ff;
+  text-decoration: none;
+}
+
+.univer-poc__hint-link:hover {
+  text-decoration: underline;
+}
+
+.univer-poc__hint-note {
+  color: #6b7280;
+}
+
+.univer-poc__readonly {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.univer-poc__readonly-label {
+  font-weight: 600;
+  color: #8c6d1f;
+}
+
+.univer-poc__readonly-item {
+  border: 1px solid #ffe58f;
+  background: #fffbe6;
+  color: #8c6d1f;
+  border-radius: 999px;
+  padding: 2px 8px;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.univer-poc__readonly-item:hover {
+  border-color: #ffd666;
+}
+
+.univer-poc__readonly-name {
+  font-weight: 600;
+}
+
+.univer-poc__readonly-tag {
+  font-size: 11px;
+  color: #8c6d1f;
+}
+
+.univer-poc__meta-btn {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: #fff;
+  color: #1677ff;
+  padding: 4px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.univer-poc__meta-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.univer-poc__container {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  background: #fff;
+  position: relative;
+  overflow: hidden;
+}
+
+.univer-poc__container--with-comments {
+  border-right: 1px solid #e5e7eb;
+}
+
+.univer-poc__comments {
+  flex: 0 0 280px;
+  max-width: 320px;
+}
+
+.univer-poc__mount {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.univer-poc__header-icons {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 15;
+}
+
+.univer-poc__header-icon {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  border: 1px solid #ffe58f;
+  background: #fffbe6;
+  color: #8c6d1f;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  cursor: help;
+}
+
+.univer-poc__header-tooltip {
+  position: absolute;
+  z-index: 16;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(17, 17, 17, 0.88);
+  color: #fff;
+  font-size: 11px;
+  line-height: 1.4;
+  max-width: 220px;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.univer-poc__comment-badges {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 16;
+}
+
+.univer-poc__comment-badge {
+  position: absolute;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #0f766e;
+  background: #ecfdf3;
+  border: 1px solid #bbf7d0;
+  white-space: nowrap;
+}
+
+.univer-poc__overlay {
+  position: absolute;
+  z-index: 20;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(6px);
+}
+
+.univer-poc__overlay-empty {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.univer-poc__pill {
+  border: 0;
+  border-radius: 999px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 16px;
+  color: #fff;
+}
+
+.univer-poc__overlay--link {
+  min-width: 300px;
+  max-width: 400px;
+}
+
+.univer-poc__overlay--readonly {
+  padding: 6px 10px;
+  font-size: 12px;
+  color: #8c6d1f;
+  background: #fffbe6;
+  border-color: #ffe58f;
+  pointer-events: none;
+}
+
+.univer-poc__link-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.univer-poc__link-input {
+  width: 260px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  outline: none;
+}
+
+.univer-poc__btn {
+  border: 0;
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #fff;
+  background: #1677ff;
+}
+</style>

--- a/apps/web/src/views/UniverKanbanPOC.vue
+++ b/apps/web/src/views/UniverKanbanPOC.vue
@@ -1,0 +1,2483 @@
+<template>
+  <div class="univer-kanban">
+    <div class="univer-kanban__header">
+      <div>
+        <h2 class="univer-kanban__title">Univer + Kanban (POC)</h2>
+        <div class="univer-kanban__subtitle">单一数据源，多视图同步（Phase 0.D）</div>
+      </div>
+      <div class="univer-kanban__meta">
+        <div>viewId: {{ viewId }}</div>
+        <div v-if="activeSheetId && activeSheetId !== viewId" class="univer-kanban__sheet-id">
+          sheetId: {{ activeSheetId }}
+        </div>
+        <label v-if="sourceIsMeta" class="univer-kanban__view-picker">
+          <span>视图</span>
+          <select v-model="selectedViewId" class="univer-kanban__select" @change="handleViewChange">
+            <option value="">(当前 Sheet)</option>
+            <option v-for="view in availableViews" :key="view.id" :value="view.id">
+              {{ view.name || view.id }} ({{ view.type }})
+            </option>
+          </select>
+        </label>
+        <div v-if="viewSummary" class="univer-kanban__view-summary">
+          <span class="univer-kanban__view-chip">view: {{ viewSummary.name }} ({{ viewSummary.type }})</span>
+          <span class="univer-kanban__view-chip">id: {{ viewSummary.id }}</span>
+          <span v-if="viewSummary.groupLabel" class="univer-kanban__view-chip">group: {{ viewSummary.groupLabel }}</span>
+          <span v-if="viewSummary.sortLabel" class="univer-kanban__view-chip">sort: {{ viewSummary.sortLabel }}</span>
+          <span v-if="viewSummary.filterLabel" class="univer-kanban__view-chip">filter: {{ viewSummary.filterLabel }}</span>
+          <span v-if="viewSummary.hiddenCount > 0" class="univer-kanban__view-chip">hidden: {{ viewSummary.hiddenCount }}</span>
+          <span
+            v-if="viewSummary.computedFilterSort"
+            class="univer-kanban__view-chip univer-kanban__view-chip--warn"
+          >
+            computed filter/sort
+          </span>
+        </div>
+        <div v-if="diagnosticsItems.length" class="univer-kanban__diagnostics">
+          <span class="univer-kanban__diagnostics-label">诊断</span>
+          <span
+            v-for="item in diagnosticsItems"
+            :key="item.label"
+            class="univer-kanban__diagnostics-chip"
+            :title="item.ids.join(', ')"
+          >
+            {{ item.label }} ({{ item.ids.length }})
+          </span>
+        </div>
+        <div v-if="page">loaded: {{ loadedCount }}/{{ page.total }}</div>
+        <button
+          v-if="page && page.hasMore"
+          type="button"
+          class="univer-kanban__btn"
+          :disabled="loadingMore"
+          @click="loadMore"
+        >
+          {{ loadingMore ? '加载中...' : '加载更多' }}
+        </button>
+        <button type="button" class="univer-kanban__btn" @click="reload">重算</button>
+        <div v-if="statusText" :class="statusKind === 'error' ? 'univer-kanban__status univer-kanban__status--error' : 'univer-kanban__status'">
+          {{ statusText }}
+        </div>
+        <div v-if="statusHint && statusText.startsWith('Sheet not found:')" class="univer-kanban__status-hint">
+          {{ statusHint }}
+        </div>
+        <div v-if="viewWarnings.length" class="univer-kanban__warning">
+          <div v-for="(warning, idx) in viewWarnings" :key="idx">
+            {{ warning }}
+          </div>
+        </div>
+        <div v-if="relatedUpdateCount > 0" class="univer-kanban__related">
+          <span>外表更新 {{ relatedUpdateCount }} 条</span>
+          <button type="button" class="univer-kanban__btn" @click="reload">点击刷新</button>
+          <span v-if="relatedUpdateSheets.length" class="univer-kanban__related-note">
+            来源: {{ relatedUpdateSheets.join(', ') }}
+          </span>
+        </div>
+        <div v-if="demoHint" class="univer-kanban__hint">
+          <span>{{ demoHint.text }}</span>
+          <a :href="demoHint.href" class="univer-kanban__hint-link">打开可编辑示例表</a>
+          <span class="univer-kanban__hint-note">{{ demoHint.note }}</span>
+        </div>
+        <div v-if="readonlyFields.length" class="univer-kanban__readonly">
+          <span class="univer-kanban__readonly-label">只读字段</span>
+          <button
+            v-for="item in readonlyFields"
+            :key="item.id"
+            type="button"
+            class="univer-kanban__readonly-item"
+            :title="item.reason"
+            @click="focusReadonlyField(item.id)"
+          >
+            <span class="univer-kanban__readonly-name">{{ item.label }}</span>
+            <span class="univer-kanban__readonly-tag">{{ item.tag }}</span>
+          </button>
+        </div>
+        <button
+          v-if="hasConflict"
+          type="button"
+          class="univer-kanban__btn univer-kanban__btn--danger"
+          @click="reload"
+        >
+          重新加载
+        </button>
+        <button type="button" class="univer-kanban__btn" @click="createRecord">+ 新记录</button>
+      </div>
+    </div>
+
+    <div class="univer-kanban__body" :class="{ 'univer-kanban__body--with-comments': commentsEnabled }">
+      <div ref="gridWrapperRef" class="univer-kanban__grid">
+        <div ref="gridMountRef" class="univer-kanban__grid-mount" />
+
+        <div v-if="readonlyHeaderIcons.length" class="univer-kanban__header-icons">
+          <div
+            v-for="icon in readonlyHeaderIcons"
+            :key="icon.fieldId"
+            class="univer-kanban__header-icon"
+            :style="{ left: `${icon.left}px`, top: `${icon.top}px` }"
+            :title="icon.title"
+            :data-readonly-header-icon="icon.fieldId"
+            tabindex="0"
+            @mouseenter="showHeaderTooltip(icon)"
+            @mouseleave="hideHeaderTooltip"
+            @focus="showHeaderTooltip(icon)"
+            @blur="hideHeaderTooltip"
+          >
+            RO
+          </div>
+          <div
+            v-if="headerTooltip"
+            class="univer-kanban__header-tooltip"
+            :style="{ left: `${headerTooltip.left}px`, top: `${headerTooltip.top}px` }"
+          >
+            {{ headerTooltip.text }}
+          </div>
+        </div>
+
+        <div
+          v-if="overlay?.kind === 'select'"
+          class="univer-kanban__overlay"
+          :style="{ left: `${overlay.left}px`, top: `${overlay.top}px` }"
+          @mousedown.stop
+        >
+          <div v-if="overlay.options.length === 0" class="univer-kanban__overlay-empty">No options</div>
+          <button
+            v-for="opt in overlay.options"
+            :key="opt.value"
+            type="button"
+            class="univer-kanban__pill"
+            :style="{ background: opt.color || resolveFallbackSelectColor(opt.value) || '#1677ff' }"
+            @click="applySelect(opt.value, opt.color)"
+          >
+            {{ opt.value }}
+          </button>
+        </div>
+
+        <div
+          v-if="overlay?.kind === 'link'"
+          class="univer-kanban__overlay"
+          :style="{ left: `${overlay.left}px`, top: `${overlay.top}px` }"
+          @mousedown.stop
+        >
+          <input
+            v-model="linkDraft"
+            class="univer-kanban__link-input"
+            placeholder="输入链接/关联值"
+            @keydown.esc="overlay = null"
+            @keydown.enter.prevent="applyLink()"
+          />
+          <button type="button" class="univer-kanban__btn" @click="applyLink()">保存</button>
+        </div>
+
+        <div
+          v-if="overlay?.kind === 'readonly'"
+          class="univer-kanban__overlay univer-kanban__overlay--readonly"
+          :style="{ left: `${overlay.left}px`, top: `${overlay.top}px` }"
+        >
+          {{ overlay.message }}
+        </div>
+      </div>
+
+      <div class="univer-kanban__kanban">
+        <div
+          v-for="col in kanbanColumns"
+          :key="col.id"
+          class="univer-kanban__column"
+          :data-kanban-column="col.id"
+          @drop="handleDrop($event, col.id)"
+          @dragover.prevent
+          @dragenter.prevent
+        >
+          <div class="univer-kanban__column-header">
+            <div class="univer-kanban__column-title">{{ col.title }}</div>
+            <div class="univer-kanban__column-count">{{ col.cards.length }}</div>
+          </div>
+
+          <div class="univer-kanban__cards">
+            <div
+              v-for="card in col.cards"
+              :key="card.id"
+              class="univer-kanban__card"
+              :data-kanban-card="card.id"
+              draggable="true"
+              @click="selectRecord(card.id)"
+              @dragstart="handleDragStart($event, card.id, col.id)"
+            >
+              <div class="univer-kanban__card-header">
+                <div class="univer-kanban__card-title">{{ card.title }}</div>
+                <button
+                  type="button"
+                  class="univer-kanban__card-delete"
+                  title="删除"
+                  @mousedown.stop
+                  @click.stop="deleteRecord(card.id)"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="univer-kanban__card-meta">
+                <span class="univer-kanban__card-meta-text">{{ card.meta }}</span>
+                <span
+                  v-if="commentSummary[card.id]?.total"
+                  class="univer-kanban__comment-badge"
+                  :title="commentSummary[card.id].open > 0 ? `${commentSummary[card.id].open} 未解决 / ${commentSummary[card.id].total} 总计` : `${commentSummary[card.id].total} 评论`"
+                >
+                  {{ commentSummary[card.id].open > 0 ? `${commentSummary[card.id].open}/${commentSummary[card.id].total}` : commentSummary[card.id].total }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <CommentsPanel
+        v-if="commentsEnabled"
+        class="univer-kanban__comments"
+        :spreadsheet-id="commentsSpreadsheetId"
+        :record-id="selectedRecordId"
+        :field-id="selectedFieldId"
+        :field-label="selectedFieldLabel"
+        @comment-updated="handleCommentUpdated"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { ICellData, IWorkbookData } from '@univerjs/core'
+import { LocaleType } from '@univerjs/core'
+import { defaultTheme } from '@univerjs/design'
+import { createUniver } from '@univerjs/presets'
+import type { FUniver } from '@univerjs/presets'
+import { UniverSheetsCorePreset } from '@univerjs/presets/preset-sheets-core'
+import { SetRangeValuesMutation, SetSelectionsOperation } from '@univerjs/sheets'
+
+import '@univerjs/design/lib/index.css'
+import '@univerjs/ui/lib/index.css'
+import '@univerjs/sheets-ui/lib/index.css'
+
+import { apiFetch, apiGet } from '../utils/api'
+import { formatApiErrorMessage } from '../utils/apiErrors'
+import { buildUniverSheetsLocalesMinimal } from '../utils/univerLocales'
+import { createUniverEmbed } from '../utils/univerEmbed'
+import { createUniverPatchQueue, type UniverPatchQueue } from '../utils/univerPatchQueue'
+import {
+  buildLinkCell,
+  buildSelectCell,
+  applyReadonlyStyle,
+  extractValueFromCell,
+  isFormulaValue,
+  resolveFallbackSelectColor,
+} from '../utils/univerValue'
+import CommentsPanel from '../components/CommentsPanel.vue'
+
+type UniverMockField = {
+  id: string
+  name: string
+  type: 'string' | 'number' | 'boolean' | 'formula' | 'select' | 'link' | 'lookup' | 'rollup'
+  options?: Array<{ value: string; color?: string }>
+  property?: {
+    foreignDatasheetId?: string
+    foreignSheetId?: string
+    limitSingleRecord?: boolean
+    displayFieldId?: string
+    readonly?: boolean
+    relatedLinkFieldId?: string
+    lookUpTargetFieldId?: string
+    linkedFieldId?: string
+    targetFieldId?: string
+    aggregation?: string
+    [key: string]: unknown
+  }
+}
+
+type UniverMockRecord = {
+  id: string
+  version: number
+  data: Record<string, unknown>
+}
+
+type RelatedRecord = {
+  sheetId: string
+  recordId: string
+  data: Record<string, unknown>
+}
+
+type UniverMockViewConfig = {
+  id: string
+  sheetId: string
+  name: string
+  type: string
+  filterInfo?: Record<string, unknown>
+  sortInfo?: Record<string, unknown>
+  groupInfo?: Record<string, unknown>
+  hiddenFieldIds?: string[]
+}
+
+type UniverMockView = {
+  id: string
+  fields: UniverMockField[]
+  rows: UniverMockRecord[]
+  view?: UniverMockViewConfig
+  meta?: {
+    warnings?: string[]
+    computedFilterSort?: boolean
+    ignoredSortFieldIds?: string[]
+    ignoredFilterFieldIds?: string[]
+    ignoredHiddenFieldIds?: string[]
+    ignoredGroupFieldIds?: string[]
+  }
+  page?: {
+    offset: number
+    limit: number
+    total: number
+    hasMore: boolean
+  }
+}
+
+type UniverMockViewResponse = {
+  ok: boolean
+  data?: UniverMockView
+  error?: { code: string; message: string }
+}
+
+type UniverMockPatchResponse = {
+  ok: boolean
+  data?: { updated: Array<{ recordId: string; version: number }> }
+  error?: { code: string; message: string; serverVersion?: number }
+}
+
+type ViewSummary = {
+  id: string
+  name: string
+  type: string
+  groupLabel: string | null
+  sortLabel: string | null
+  filterLabel: string | null
+  hiddenCount: number
+  computedFilterSort: boolean
+}
+
+type DiagnosticsItem = {
+  label: string
+  ids: string[]
+}
+
+type UniverMockCreateRecordResponse = {
+  ok: boolean
+  data?: { record: { id: string; version: number; data: Record<string, unknown> } }
+  error?: { code: string; message: string }
+}
+
+type UniverMockDeleteRecordResponse = {
+  ok: boolean
+  data?: { deleted: string }
+  error?: { code: string; message: string; serverVersion?: number }
+}
+
+type OverlayState =
+  | {
+      kind: 'select'
+      row: number
+      col: number
+      left: number
+      top: number
+      fieldId: string
+      options: Array<{ value: string; color?: string }>
+    }
+  | {
+      kind: 'link'
+      row: number
+      col: number
+      left: number
+      top: number
+      fieldId: string
+    }
+  | {
+      kind: 'readonly'
+      row: number
+      col: number
+      left: number
+      top: number
+      message: string
+    }
+
+type ReadonlyFieldEntry = {
+  id: string
+  label: string
+  reason: string
+  tag: string
+}
+
+type ReadonlyHeaderIcon = {
+  fieldId: string
+  left: number
+  top: number
+  title: string
+}
+
+type ReadonlyHeaderTooltip = {
+  text: string
+  left: number
+  top: number
+}
+
+type ReadonlyHitKind = 'select' | 'list' | 'edit'
+
+type ReadonlyMetrics = {
+  total: number
+  byField: Record<string, number>
+  byKind: Record<string, number>
+  lastFieldId: string | null
+  lastReason: string | null
+  lastKind: ReadonlyHitKind | null
+}
+
+const route = useRoute()
+const router = useRouter()
+const EDITABLE_DEMO_ID = 'editable_demo'
+
+const demoHint = computed(() => {
+  const source = toStr(route.query.source)?.toLowerCase()
+  const sheetId = toStr(route.query.sheetId)
+  if (source !== 'meta' || sheetId !== 'lookup_source_demo') return null
+  return {
+    text: '此表包含 lookup/rollup/只读字段，仅用于验证。',
+    href: `/univer-kanban?source=meta&sheetId=${EDITABLE_DEMO_ID}`,
+    note: '如需可编辑示例，运行 scripts/setup-editable-demo.sh',
+  }
+})
+
+const gridWrapperRef = ref<HTMLDivElement | null>(null)
+const gridMountRef = ref<HTMLDivElement | null>(null)
+
+const viewId = ref<string>('univer_demo_view')
+const activeSheetId = ref<string>('')
+const statusText = ref<string>('')
+const statusKind = ref<'ok' | 'error'>('ok')
+const statusHint = ref<string>('')
+const viewWarnings = ref<string[]>([])
+const viewSummary = ref<ViewSummary | null>(null)
+const hiddenFieldIds = ref<string[]>([])
+const availableViews = ref<Array<{ id: string; name: string; type: string }>>([])
+const selectedViewId = ref<string>('')
+const diagnosticsItems = ref<DiagnosticsItem[]>([])
+const hasConflict = ref<boolean>(false)
+const conflictServerVersion = ref<number | null>(null)
+const page = ref<UniverMockView['page'] | null>(null)
+const loadedCount = ref<number>(0)
+const baseOffset = ref<number>(0)
+const loadingMore = ref<boolean>(false)
+const readonlyFields = ref<ReadonlyFieldEntry[]>([])
+const readonlyHeaderIcons = ref<ReadonlyHeaderIcon[]>([])
+const headerTooltip = ref<ReadonlyHeaderTooltip | null>(null)
+const readonlyMetrics = ref<ReadonlyMetrics>({
+  total: 0,
+  byField: {},
+  byKind: {},
+  lastFieldId: null,
+  lastReason: null,
+  lastKind: null,
+})
+const relatedUpdates = ref<RelatedRecord[]>([])
+const relatedUpdateCount = computed(() => relatedUpdates.value.length)
+const relatedUpdateSheets = computed(() =>
+  Array.from(new Set(relatedUpdates.value.map((record) => record.sheetId))).filter((id) => id.length > 0),
+)
+const commentsEnabled = computed(() => toStr(route.query.source)?.toLowerCase() === 'meta')
+const commentsSpreadsheetId = computed(() => (commentsEnabled.value ? viewId.value : ''))
+const selectedRecordId = ref<string>('')
+const selectedFieldId = ref<string | undefined>(undefined)
+const selectedFieldLabel = computed(() => {
+  const fieldId = selectedFieldId.value
+  if (!fieldId) return ''
+  return mapping.fieldIdToLabel[fieldId] ?? fieldId
+})
+const commentSummary = ref<Record<string, { total: number; open: number }>>({})
+let commentSummaryTimer = 0
+
+const overlay = ref<OverlayState | null>(null)
+const linkDraft = ref<string>('')
+
+const recordsById = ref<Record<string, UniverMockRecord>>({})
+const titleFieldId = ref<string>('name')
+const priorityFieldId = ref<string>('priority')
+const relatedFieldId = ref<string>('related')
+
+const dragState = ref<{ recordId: string; from: string } | null>(null)
+
+let univerAPI: FUniver | null = null
+let univerDispose: (() => void) | null = null
+let patchQueue: UniverPatchQueue | null = null
+let startLoad: (() => Promise<void>) | null = null
+let sheetRowCount = 0
+let suppressChanges = false
+let headerIconRaf = 0
+let headerIconCleanup: (() => void) | null = null
+
+const mapping = {
+  rowIndexToRecordId: [] as string[],
+  colIndexToFieldId: [] as string[],
+  recordIdToVersion: {} as Record<string, number>,
+  recordIdToRowIndex: {} as Record<string, number>,
+  recordIdToData: {} as Record<string, Record<string, unknown>>,
+  fieldIdToColIndex: {} as Record<string, number>,
+  fieldIdToType: {} as Record<string, UniverMockField['type']>,
+  fieldIdToSelectOptions: {} as Record<string, Array<{ value: string; color?: string }>>,
+  fieldIdToProperty: {} as Record<string, UniverMockField['property']>,
+  fieldIdToReadonlyReason: {} as Record<string, string>,
+  fieldIdToLabel: {} as Record<string, string>,
+}
+
+function toStr(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return undefined
+}
+
+function queueCommentSummaryRefresh(rowIds?: string[]) {
+  if (commentSummaryTimer) window.clearTimeout(commentSummaryTimer)
+  commentSummaryTimer = window.setTimeout(() => {
+    commentSummaryTimer = 0
+    fetchCommentSummary(rowIds).catch((err) => {
+      console.error('[UniverKanbanPOC] load comment summary failed:', err)
+    })
+  }, 200)
+}
+
+async function fetchCommentSummary(rowIds?: string[]) {
+  if (!commentsEnabled.value || !commentsSpreadsheetId.value) {
+    commentSummary.value = {}
+    return
+  }
+
+  const ids = rowIds && rowIds.length > 0 ? rowIds : Object.keys(recordsById.value)
+  if (ids.length === 0) {
+    commentSummary.value = {}
+    return
+  }
+
+  const qs = new URLSearchParams({
+    spreadsheetId: commentsSpreadsheetId.value,
+    rowIds: ids.join(','),
+  })
+
+  const res = await apiFetch(`/api/comments/summary?${qs.toString()}`)
+  const json = await res.json().catch(() => ({}))
+  if (!res.ok || !json.ok) {
+    throw new Error(json.error?.message || 'Failed to load comment summary')
+  }
+
+  const next = { ...commentSummary.value }
+  for (const rowId of ids) {
+    next[rowId] = { total: 0, open: 0 }
+  }
+
+  const items = Array.isArray(json.data?.items) ? json.data.items : []
+  for (const item of items) {
+    const rowId = String(item.rowId)
+    next[rowId] = {
+      total: Number(item.total ?? 0),
+      open: Number(item.open ?? 0),
+    }
+  }
+
+  commentSummary.value = next
+}
+
+const DEFAULT_WINDOW = {
+  size: 200,
+  buffer: 100,
+  max: 1000,
+}
+
+function toPositiveInt(value: string | undefined, fallback: number, min = 1): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) return fallback
+  if (parsed < min) return fallback
+  return parsed
+}
+
+function resolveWindowing() {
+  const flag = toStr(route.query.window)?.toLowerCase()
+  const enabled = flag === '1' || flag === 'true' || flag === 'on'
+  const size = toPositiveInt(toStr(route.query.windowSize), DEFAULT_WINDOW.size, 1)
+  const buffer = toPositiveInt(toStr(route.query.windowBuffer), DEFAULT_WINDOW.buffer, 0)
+  const maxRaw = toPositiveInt(toStr(route.query.windowMax), DEFAULT_WINDOW.max, 1)
+  const max = Math.max(size, maxRaw)
+  return { enabled, size, buffer, max }
+}
+
+function resolveWindowRowCount(total: number | undefined, loaded: number, windowing: { enabled: boolean; max: number }) {
+  if (!windowing.enabled) return Math.max(loaded, 50)
+  const safeTotal = typeof total === 'number' && Number.isFinite(total) ? total : loaded
+  const cap = Math.min(windowing.max, safeTotal)
+  return Math.max(loaded, 50, cap)
+}
+
+function buildMissingSheetHint(error: unknown): { title: string; hint: string } | null {
+  const message = error instanceof Error ? error.message : String(error)
+  if (!message.includes('404')) return null
+  const source = toStr(route.query.source)?.toLowerCase()
+  const sheetId = toStr(route.query.sheetId)
+  if (source !== 'meta' || !sheetId) return null
+  return {
+    title: `Sheet not found: ${sheetId}`,
+    hint: 'Run: scripts/setup-lookup-rollup-demo.sh then reload.',
+  }
+}
+
+function getApiPrefix(): string {
+  const source = toStr(route.query.source)?.toLowerCase()
+  return source === 'meta' ? '/api/univer-meta' : '/api/univer-mock'
+}
+
+const sourceIsMeta = computed(() => toStr(route.query.source)?.toLowerCase() === 'meta')
+
+type UniverMetaViewsResponse = {
+  ok: boolean
+  data?: { views: Array<{ id: string; name: string; type: string }> }
+  error?: { code: string; message: string }
+}
+
+async function loadAvailableViews(sheetId: string) {
+  if (!sheetId) return
+  try {
+    const res = await apiFetch(`/api/univer-meta/views?sheetId=${encodeURIComponent(sheetId)}`)
+    const json = (await res.json().catch(() => ({}))) as UniverMetaViewsResponse
+    if (!res.ok || !json.ok || !json.data) return
+    availableViews.value = json.data.views ?? []
+  } catch {
+    availableViews.value = []
+  }
+}
+
+function handleViewChange() {
+  const nextViewId = selectedViewId.value
+  const query = { ...route.query }
+  if (nextViewId) {
+    query.viewId = nextViewId
+    delete query.sheetId
+  } else {
+    delete query.viewId
+  }
+  router.replace({ query }).catch(() => null)
+  reload()
+}
+
+function resolveFieldId(fields: UniverMockField[], opts: { preferId: string; type: UniverMockField['type']; nameRe: RegExp }): string {
+  const byId = fields.find(f => f.id === opts.preferId)
+  if (byId) return byId.id
+
+  const byTypeName = fields.find(f => f.type === opts.type && opts.nameRe.test(f.name))
+  if (byTypeName) return byTypeName.id
+
+  const byType = fields.find(f => f.type === opts.type)
+  if (byType) return byType.id
+
+  return fields[0]?.id ?? opts.preferId
+}
+
+function getQueryString(): string {
+  const qs = new URLSearchParams()
+  const rows = toStr(route.query.rows)
+  const cols = toStr(route.query.cols)
+  const queryViewId = toStr(route.query.viewId)
+  const mode = toStr(route.query.mode)
+  const refresh = toStr(route.query.refresh)
+  const source = toStr(route.query.source)?.toLowerCase()
+  const sheetId = toStr(route.query.sheetId)
+  const seed = toStr(route.query.seed)
+  const limit = toStr(route.query.limit)
+  const offset = toStr(route.query.offset)
+  const windowing = resolveWindowing()
+  const resolvedLimit = source === 'meta' ? (limit || (windowing.enabled ? String(windowing.size) : '50')) : limit
+  const resolvedOffset = source === 'meta' ? (offset || '0') : offset
+
+  if (rows) qs.set('rows', rows)
+  if (cols) qs.set('cols', cols)
+  if (queryViewId) qs.set('viewId', queryViewId)
+  if (mode) qs.set('mode', mode)
+  if (refresh) qs.set('refresh', refresh)
+  if (source === 'meta') {
+    if (sheetId) qs.set('sheetId', sheetId)
+    if (seed) qs.set('seed', seed)
+    qs.set('limit', resolvedLimit ?? '50')
+    qs.set('offset', resolvedOffset ?? '0')
+  }
+
+  const text = qs.toString()
+  return text ? `?${text}` : ''
+}
+
+function resolveFieldLabel(fields: UniverMockField[], fieldId: string): string {
+  const field = fields.find((f) => f.id === fieldId)
+  return field?.name?.trim() || fieldId
+}
+
+function isFilterValueDisabled(operator: string): boolean {
+  const op = operator.trim().toLowerCase()
+  return op === 'isempty' || op === 'isnotempty'
+}
+
+function formatFilterValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => toStr(v))
+      .filter((v): v is string => Boolean(v))
+      .join(', ')
+  }
+  return toStr(value) ?? ''
+}
+
+function buildViewSummary(view: UniverMockView): ViewSummary | null {
+  const cfg = view.view
+  if (!cfg) return null
+
+  const name = typeof cfg.name === 'string' && cfg.name.trim().length > 0 ? cfg.name.trim() : '未命名视图'
+  const id = typeof cfg.id === 'string' && cfg.id.trim().length > 0 ? cfg.id.trim() : view.id
+  const type = typeof cfg.type === 'string' && cfg.type.trim().length > 0 ? cfg.type.trim() : 'grid'
+  const hiddenCount = Array.isArray(cfg.hiddenFieldIds)
+    ? cfg.hiddenFieldIds.filter((v) => typeof v === 'string' && v.trim().length > 0).length
+    : 0
+
+  const summary: ViewSummary = {
+    id,
+    name,
+    type,
+    groupLabel: null,
+    sortLabel: null,
+    filterLabel: null,
+    hiddenCount,
+    computedFilterSort: view.meta?.computedFilterSort === true,
+  }
+
+  const groupId =
+    cfg.groupInfo && typeof cfg.groupInfo === 'object' && !Array.isArray(cfg.groupInfo)
+      ? (cfg.groupInfo as Record<string, unknown>).fieldId
+      : undefined
+  if (typeof groupId === 'string' && groupId.trim().length > 0) {
+    summary.groupLabel = resolveFieldLabel(view.fields, groupId.trim())
+  }
+
+  const rules =
+    cfg.sortInfo && typeof cfg.sortInfo === 'object' && !Array.isArray(cfg.sortInfo)
+      ? (cfg.sortInfo as Record<string, unknown>).rules
+      : undefined
+  if (Array.isArray(rules) && rules.length > 0) {
+    const rule = rules[0] as Record<string, unknown>
+    const fieldId = typeof rule.fieldId === 'string' ? rule.fieldId.trim() : ''
+    if (fieldId) {
+      const dir = rule.desc === true ? '↓' : '↑'
+      summary.sortLabel = `${resolveFieldLabel(view.fields, fieldId)} ${dir}`
+    }
+  }
+
+  const conditions =
+    cfg.filterInfo && typeof cfg.filterInfo === 'object' && !Array.isArray(cfg.filterInfo)
+      ? (cfg.filterInfo as Record<string, unknown>).conditions
+      : undefined
+  if (Array.isArray(conditions) && conditions.length > 0) {
+    const cond = conditions[0] as Record<string, unknown>
+    const fieldId = typeof cond.fieldId === 'string' ? cond.fieldId.trim() : ''
+    const operator = typeof cond.operator === 'string' ? cond.operator.trim() : ''
+    if (fieldId && operator) {
+      const label = resolveFieldLabel(view.fields, fieldId)
+      if (isFilterValueDisabled(operator)) {
+        summary.filterLabel = `${label} ${operator}`
+      } else {
+        const value = formatFilterValue(cond.value)
+        summary.filterLabel = value ? `${label} ${operator} ${value}` : `${label} ${operator}`
+      }
+    }
+  }
+
+  return summary
+}
+
+function buildDiagnostics(view: UniverMockView): DiagnosticsItem[] {
+  const meta = view.meta
+  if (!meta) return []
+  const items: DiagnosticsItem[] = []
+  const add = (label: string, ids?: string[]) => {
+    if (!ids || ids.length === 0) return
+    items.push({ label, ids })
+  }
+  add('sort', meta.ignoredSortFieldIds)
+  add('filter', meta.ignoredFilterFieldIds)
+  add('hidden', meta.ignoredHiddenFieldIds)
+  add('group', meta.ignoredGroupFieldIds)
+  return items
+}
+
+watch(
+  () => [route.query.source, route.query.sheetId, route.query.viewId],
+  () => {
+    if (!sourceIsMeta.value) {
+      availableViews.value = []
+      selectedViewId.value = ''
+      return
+    }
+    const sheetId = toStr(route.query.sheetId) || activeSheetId.value
+    if (sheetId) loadAvailableViews(sheetId)
+    selectedViewId.value = toStr(route.query.viewId) ?? ''
+  },
+  { immediate: true },
+)
+
+const READONLY_HINTS = {
+  property: '只读字段',
+  lookup: 'Lookup 计算结果',
+  rollup: 'Rollup 计算结果',
+}
+
+function resolveReadonlyTag(field: UniverMockField): string {
+  if (field.type === 'lookup') return 'Lookup'
+  if (field.type === 'rollup') return 'Rollup'
+  if (field.property?.readonly) return '只读'
+  return '只读'
+}
+
+function formatReadonlyReason(field: UniverMockField, reason: string): string {
+  const label = field.name?.trim() || '该字段'
+  return `字段【${label}】为${reason}，无法编辑`
+}
+
+function resolveReadonlyReason(field: UniverMockField): string | null {
+  if (field.type === 'lookup') return formatReadonlyReason(field, READONLY_HINTS.lookup)
+  if (field.type === 'rollup') return formatReadonlyReason(field, READONLY_HINTS.rollup)
+  if (field.property?.readonly) return formatReadonlyReason(field, READONLY_HINTS.property)
+  return null
+}
+
+function buildReadonlyFields(fields: UniverMockField[]): ReadonlyFieldEntry[] {
+  return fields
+    .map((field) => {
+      const reason = resolveReadonlyReason(field)
+      if (!reason) return null
+      return {
+        id: field.id,
+        label: field.name?.trim() || String(field.id),
+        reason,
+        tag: resolveReadonlyTag(field),
+      }
+    })
+    .filter((entry): entry is ReadonlyFieldEntry => Boolean(entry))
+}
+
+function syncReadonlyFields(fields: UniverMockField[]) {
+  readonlyFields.value = buildReadonlyFields(fields)
+  requestReadonlyHeaderUpdate()
+}
+
+function getReadonlyReason(fieldId: string): string | null {
+  const reason = mapping.fieldIdToReadonlyReason[fieldId]
+  return reason && reason.trim().length > 0 ? reason : null
+}
+
+function requestReadonlyHeaderUpdate() {
+  if (headerIconRaf) window.cancelAnimationFrame(headerIconRaf)
+  headerIconRaf = window.requestAnimationFrame(() => {
+    headerIconRaf = 0
+    updateReadonlyHeaderIcons()
+  })
+}
+
+function showHeaderTooltip(icon: ReadonlyHeaderIcon) {
+  headerTooltip.value = {
+    text: icon.title,
+    left: icon.left + 8,
+    top: Math.max(6, icon.top - 32),
+  }
+}
+
+function hideHeaderTooltip() {
+  headerTooltip.value = null
+}
+
+function recordReadonlyHit(fieldId: string, reason: string, kind: ReadonlyHitKind) {
+  readonlyMetrics.value.total += 1
+  readonlyMetrics.value.byField[fieldId] = (readonlyMetrics.value.byField[fieldId] ?? 0) + 1
+  readonlyMetrics.value.byKind[kind] = (readonlyMetrics.value.byKind[kind] ?? 0) + 1
+  readonlyMetrics.value.lastFieldId = fieldId
+  readonlyMetrics.value.lastReason = reason
+  readonlyMetrics.value.lastKind = kind
+  try {
+    ;(window as any).__readonlyMetrics = { ...readonlyMetrics.value }
+  } catch {
+    // ignore
+  }
+}
+
+function updateReadonlyHeaderIcons() {
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  const wrapperEl = gridWrapperRef.value
+  hideHeaderTooltip()
+  if (!sheet || !wrapperEl) return
+  if (readonlyFields.value.length === 0) {
+    readonlyHeaderIcons.value = []
+    return
+  }
+
+  const wrapperRect = wrapperEl.getBoundingClientRect()
+  const icons: ReadonlyHeaderIcon[] = []
+  for (const entry of readonlyFields.value) {
+    const colIndex = mapping.fieldIdToColIndex[entry.id]
+    if (typeof colIndex !== 'number' || !Number.isFinite(colIndex)) continue
+
+    let rect: DOMRect | undefined
+    try {
+      const range = sheet.getRange(0, colIndex) as any
+      rect = range?.getCellRect?.()
+    } catch {
+      rect = undefined
+    }
+    if (!rect || rect.width < 4) continue
+
+    const left = rect.left - wrapperRect.left + Math.max(2, rect.width - 18)
+    const top = rect.top - wrapperRect.top - 18
+
+    icons.push({
+      fieldId: entry.id,
+      left: Math.max(4, left),
+      top: Math.max(2, top),
+      title: entry.reason,
+    })
+  }
+  readonlyHeaderIcons.value = icons
+}
+
+function showReadonlyOverlay(fieldId: string, row: number, col: number, message: string, kind: ReadonlyHitKind): boolean {
+  const wrapperEl = gridWrapperRef.value
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  recordReadonlyHit(fieldId, message, kind)
+  if (!wrapperEl || !sheet) return false
+
+  let rect: DOMRect | undefined
+  try {
+    const range = sheet.getRange(row, col) as any
+    rect = range?.getCellRect?.()
+  } catch {
+    rect = undefined
+  }
+  if (!rect) return false
+
+  const wrapperRect = wrapperEl.getBoundingClientRect()
+  const left = rect.left - wrapperRect.left
+  const top = rect.bottom - wrapperRect.top + 4
+
+  overlay.value = {
+    kind: 'readonly',
+    row,
+    col,
+    left,
+    top,
+    message,
+  }
+  return true
+}
+
+function focusReadonlyField(fieldId: string) {
+  const colIndex = mapping.fieldIdToColIndex[fieldId]
+  if (typeof colIndex !== 'number' || !Number.isFinite(colIndex)) return
+  const reason = getReadonlyReason(fieldId) || `字段【${mapping.fieldIdToLabel[fieldId] ?? fieldId}】只读，无法编辑`
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  try {
+    const range = sheet.getRange(0, colIndex) as any
+    sheet.setActiveRange(range)
+  } catch {
+    // ignore
+  }
+
+  if (!showReadonlyOverlay(fieldId, 0, colIndex, reason, 'list')) {
+    statusText.value = reason
+    statusKind.value = 'error'
+  }
+}
+
+function buildCellValue(fieldType: UniverMockField['type'], raw: unknown): ICellData | null {
+  if (raw === null || raw === undefined) return null
+
+  if (typeof raw === 'string' && raw.startsWith('=')) {
+    return { f: raw }
+  }
+
+  if (fieldType === 'link') {
+    if (typeof raw === 'string') {
+      if (!raw.trim()) return null
+      return buildLinkCell(raw) as any
+    }
+    if (Array.isArray(raw)) {
+      const text = raw
+        .filter((v) => typeof v === 'string' || typeof v === 'number')
+        .map((v) => String(v))
+        .join(', ')
+      if (!text.trim()) return null
+      return buildLinkCell(text) as any
+    }
+  }
+
+  if (fieldType === 'lookup') {
+    if (Array.isArray(raw)) {
+      const text = raw
+        .filter((v) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
+        .map((v) => String(v))
+        .join(', ')
+      if (!text.trim()) return null
+      return { v: text }
+    }
+    if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+      return { v: raw }
+    }
+  }
+
+  if (fieldType === 'rollup') {
+    if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+      return { v: raw }
+    }
+  }
+
+  if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+    return { v: raw }
+  }
+
+  return { v: JSON.stringify(raw) }
+}
+
+function buildCellForField(field: UniverMockField, raw: unknown): ICellData | null {
+  const cell = buildCellValue(field.type, raw)
+  if (!cell) return null
+  const reason = resolveReadonlyReason(field)
+  return reason ? applyReadonlyStyle(cell, reason) : cell
+}
+
+function restoreReadonlyCell(row: number, col: number, recordId: string, fieldId: string) {
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+  const raw = recordsById.value[recordId]?.data?.[fieldId]
+  const fieldType = mapping.fieldIdToType[fieldId]
+  const reason = getReadonlyReason(fieldId)
+  const baseCell = buildCellValue(fieldType, raw) ?? { v: '' }
+  const cell = reason ? applyReadonlyStyle(baseCell as any, reason) : baseCell
+
+  try {
+    suppressChanges = true
+    sheet.getRange(row, col).setValueForCell(cell as any)
+  } catch {
+    // ignore
+  } finally {
+    suppressChanges = false
+  }
+}
+
+function applyReadonlyIfNeeded(fieldId: string, cell: ICellData) {
+  const reason = getReadonlyReason(fieldId)
+  return reason ? applyReadonlyStyle(cell as any, reason) : cell
+}
+
+function applyComputedRecords(records: Array<{ recordId: string; data: Record<string, unknown> }>) {
+  if (!records.length) return
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  try {
+    suppressChanges = true
+    const nextRecords: Record<string, UniverMockRecord> = { ...recordsById.value }
+
+    for (const record of records) {
+      const rowIndex = mapping.recordIdToRowIndex[record.recordId]
+      if (typeof rowIndex !== 'number' || !Number.isFinite(rowIndex)) continue
+
+      const existing = mapping.recordIdToData[record.recordId] ?? {}
+      mapping.recordIdToData[record.recordId] = { ...existing, ...record.data }
+
+      const kanbanRecord = nextRecords[record.recordId]
+      if (kanbanRecord) {
+        kanbanRecord.data = { ...kanbanRecord.data, ...record.data }
+      }
+
+      for (const [fieldId, value] of Object.entries(record.data)) {
+        const fieldType = mapping.fieldIdToType[fieldId]
+        if (fieldType !== 'lookup' && fieldType !== 'rollup') continue
+        const colIndex = mapping.fieldIdToColIndex[fieldId]
+        if (typeof colIndex !== 'number' || !Number.isFinite(colIndex)) continue
+
+        const baseCell = buildCellValue(fieldType, value) ?? { v: '' }
+        const cell = applyReadonlyIfNeeded(fieldId, baseCell)
+        sheet.getRange(rowIndex, colIndex).setValueForCell(cell as any)
+      }
+    }
+
+    recordsById.value = nextRecords
+  } finally {
+    suppressChanges = false
+  }
+}
+
+function mergeRelatedUpdates(existing: RelatedRecord[], incoming: RelatedRecord[]): RelatedRecord[] {
+  const merged = new Map<string, RelatedRecord>()
+  for (const record of existing) {
+    merged.set(`${record.sheetId}:${record.recordId}`, record)
+  }
+  for (const record of incoming) {
+    merged.set(`${record.sheetId}:${record.recordId}`, record)
+  }
+  return Array.from(merged.values())
+}
+
+function handleRelatedRecords(records: RelatedRecord[]) {
+  if (!records.length) return
+  const currentSheetId = viewId.value
+  const sameSheet = records.filter((record) => record.sheetId === currentSheetId)
+  if (sameSheet.length > 0) {
+    applyComputedRecords(sameSheet.map((record) => ({ recordId: record.recordId, data: record.data })))
+  }
+  const external = records.filter((record) => record.sheetId !== currentSheetId)
+  if (external.length === 0) return
+  relatedUpdates.value = mergeRelatedUpdates(relatedUpdates.value, external)
+}
+
+function transformToWorkbook(view: UniverMockView): IWorkbookData {
+  const sheetId = view.id
+
+  const cellData: Record<number, Record<number, ICellData>> = {}
+  view.rows.forEach((record, rowIndex) => {
+    const rowCells: Record<number, ICellData> = {}
+    view.fields.forEach((field, colIndex) => {
+      const raw = (record.data[field.id] ?? record.data[field.name]) as unknown
+      const cell = buildCellForField(field, raw)
+      if (cell) rowCells[colIndex] = cell
+    })
+  if (Object.keys(rowCells).length > 0) {
+      cellData[rowIndex] = rowCells
+    }
+  })
+
+  const windowing = resolveWindowing()
+  const rowTotal = view.page?.total ?? view.rows.length
+  const rowCount = resolveWindowRowCount(rowTotal, view.rows.length, windowing)
+
+  return {
+    id: `workbook_${sheetId}`,
+    name: `MetaSheet(${sheetId})`,
+    appVersion: '0.12.4',
+    locale: LocaleType.ZH_CN,
+    styles: {},
+    sheetOrder: [sheetId],
+    sheets: {
+      [sheetId]: {
+        id: sheetId,
+        name: 'Sheet1',
+        rowCount,
+        columnCount: Math.max(view.fields.length, 10),
+        cellData,
+      },
+    },
+  }
+}
+
+function applySelect(value: string, color?: string) {
+  const current = overlay.value
+  if (!current || current.kind !== 'select' || !univerAPI) return
+  const sheet = univerAPI.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  const resolvedColor = color || resolveFallbackSelectColor(value) || '#1677ff'
+  try {
+    sheet.getRange(current.row, current.col).setValueForCell(buildSelectCell(value, resolvedColor) as any)
+  } catch (err) {
+    console.error('[UniverKanbanPOC] applySelect failed:', err)
+  }
+  overlay.value = null
+}
+
+function applyLink() {
+  const current = overlay.value
+  if (!current || current.kind !== 'link' || !univerAPI) return
+  const sheet = univerAPI.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  try {
+    sheet.getRange(current.row, current.col).setValueForCell(buildLinkCell(linkDraft.value) as any)
+  } catch (err) {
+    console.error('[UniverKanbanPOC] applyLink failed:', err)
+  }
+  overlay.value = null
+}
+
+function getSelectColor(fieldId: string, value: string): string | undefined {
+  const opt = mapping.fieldIdToSelectOptions[fieldId]?.find(o => o.value === value)
+  return opt?.color ?? resolveFallbackSelectColor(value)
+}
+
+function isFieldHidden(fieldId: string): boolean {
+  if (!fieldId) return false
+  return hiddenFieldIds.value.includes(fieldId)
+}
+
+function resolveVisibleTitleFieldId(): string {
+  const preferred = titleFieldId.value
+  if (preferred && !isFieldHidden(preferred)) return preferred
+  for (const fieldId of mapping.colIndexToFieldId) {
+    if (!fieldId || isFieldHidden(fieldId)) continue
+    if (mapping.fieldIdToType[fieldId] === 'string') return fieldId
+  }
+  return ''
+}
+
+async function createRecord() {
+  if (!viewId.value) return
+  statusText.value = 'Creating...'
+  statusKind.value = 'ok'
+
+  try {
+    const initialData: Record<string, unknown> = {}
+    const nameId = titleFieldId.value
+    const priorityId = priorityFieldId.value
+    const relatedId = relatedFieldId.value
+    if (mapping.fieldIdToType[nameId] === 'string') {
+      initialData[nameId] = `新记录 ${new Date().toISOString().slice(11, 19)}`
+    }
+    if (mapping.fieldIdToType[priorityId] === 'select') {
+      const options = mapping.fieldIdToSelectOptions[priorityId] ?? []
+      const prefer = ['P1', 'P0', 'P2', 'Done']
+      const picked = prefer.find(v => options.some(o => o.value === v)) ?? options[0]?.value ?? ''
+      if (picked) initialData[priorityId] = picked
+    }
+    if (mapping.fieldIdToType[relatedId] === 'link') {
+      initialData[relatedId] = `PLM#${Math.floor(Date.now() / 1000)}`
+    }
+
+    const res = await apiFetch(`${getApiPrefix()}/records`, {
+      method: 'POST',
+      body: JSON.stringify({ viewId: viewId.value, data: Object.keys(initialData).length > 0 ? initialData : undefined }),
+    })
+    const json = (await res.json().catch(() => ({}))) as UniverMockCreateRecordResponse
+    if (!res.ok || !json.ok || !json.data) {
+      statusText.value = `Create failed: ${formatApiErrorMessage(json.error, String(res.status))}`
+      statusKind.value = 'error'
+      return
+    }
+
+    const record = json.data.record
+    const rowIndex = mapping.rowIndexToRecordId.length
+    mapping.rowIndexToRecordId.push(record.id)
+    mapping.recordIdToRowIndex[record.id] = rowIndex
+    mapping.recordIdToVersion[record.id] = record.version
+    mapping.recordIdToData[record.id] = { ...record.data }
+    recordsById.value = {
+      ...recordsById.value,
+      [record.id]: { id: record.id, version: record.version, data: { ...record.data } },
+    }
+    loadedCount.value += 1
+    if (page.value) {
+      page.value = { ...page.value, total: page.value.total + 1 }
+    }
+    try {
+      ;(window as any).__pocRecordIds = mapping.rowIndexToRecordId.slice()
+    } catch {
+      // ignore
+    }
+
+    const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+    if (sheet) {
+      try {
+        suppressChanges = true
+        const nextRowCount = Math.max(sheetRowCount, rowIndex + 1, 50)
+        if (sheetRowCount < nextRowCount) {
+          sheet.setRowCount(nextRowCount)
+          sheetRowCount = nextRowCount
+        }
+
+        for (let colIndex = 0; colIndex < mapping.colIndexToFieldId.length; colIndex += 1) {
+          const fieldId = mapping.colIndexToFieldId[colIndex]
+          const fieldType = mapping.fieldIdToType[fieldId]
+          const raw = record.data[fieldId] as unknown
+          if (raw == null) continue
+
+          if (typeof raw === 'string' && raw.startsWith('=')) {
+            sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, { f: raw }) as any)
+            continue
+          }
+
+          if (fieldType === 'select' && typeof raw === 'string') {
+            const color = raw ? getSelectColor(fieldId, raw) ?? '#1677ff' : undefined
+            if (color) sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, buildSelectCell(raw, color) as any))
+            else sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, { v: raw }) as any)
+            continue
+          }
+
+          if (fieldType === 'link') {
+            if (typeof raw === 'string') {
+              if (raw.trim().length > 0) {
+                sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, buildLinkCell(raw) as any))
+              } else {
+                sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, { v: raw }) as any)
+              }
+              continue
+            }
+            if (Array.isArray(raw)) {
+              const text = raw
+                .filter((v) => typeof v === 'string' || typeof v === 'number')
+                .map((v) => String(v))
+                .join(', ')
+              if (text.trim().length > 0) {
+                sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, buildLinkCell(text) as any))
+              } else {
+                sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, { v: text }) as any)
+              }
+              continue
+            }
+          }
+
+          if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+            sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, { v: raw }) as any)
+            continue
+          }
+
+          sheet.getRange(rowIndex, colIndex).setValueForCell(applyReadonlyIfNeeded(fieldId, { v: JSON.stringify(raw) }) as any)
+        }
+      } catch (err) {
+        console.error('[UniverKanbanPOC] append created row failed:', err)
+      } finally {
+        suppressChanges = false
+      }
+    }
+    statusText.value = `Created (${record.id})`
+    statusKind.value = 'ok'
+  } catch (err) {
+    console.error('[UniverKanbanPOC] create record failed:', err)
+    statusText.value = 'Create failed (network error)'
+    statusKind.value = 'error'
+  }
+}
+
+async function deleteRecord(recordId: string) {
+  if (!viewId.value) return
+  if (!recordId) return
+
+  const rowIndex = mapping.recordIdToRowIndex[recordId]
+  const expectedVersion = mapping.recordIdToVersion[recordId]
+
+  statusText.value = 'Deleting...'
+  statusKind.value = 'ok'
+
+  try {
+    const qs = new URLSearchParams()
+    if (typeof expectedVersion === 'number') qs.set('expectedVersion', String(expectedVersion))
+    if (getApiPrefix() === '/api/univer-mock') qs.set('viewId', viewId.value)
+
+    const url = `${getApiPrefix()}/records/${encodeURIComponent(recordId)}${qs.toString() ? `?${qs.toString()}` : ''}`
+    const res = await apiFetch(url, { method: 'DELETE' })
+    const json = (await res.json().catch(() => ({}))) as UniverMockDeleteRecordResponse
+    if (!res.ok || !json.ok) {
+      statusText.value = `Delete failed: ${formatApiErrorMessage(json.error, String(res.status))}`
+      statusKind.value = 'error'
+      return
+    }
+
+      if (typeof rowIndex === 'number' && Number.isFinite(rowIndex)) {
+        mapping.rowIndexToRecordId.splice(rowIndex, 1)
+        delete mapping.recordIdToRowIndex[recordId]
+        delete mapping.recordIdToVersion[recordId]
+        delete mapping.recordIdToData[recordId]
+        for (let i = rowIndex; i < mapping.rowIndexToRecordId.length; i += 1) {
+          const rid = mapping.rowIndexToRecordId[i]
+          if (rid) mapping.recordIdToRowIndex[rid] = i
+        }
+
+      const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+      if (sheet) {
+        try {
+          suppressChanges = true
+          sheet.deleteRows(rowIndex, 1)
+          sheetRowCount = Math.max(1, sheetRowCount - 1)
+        } catch (err) {
+          console.error('[UniverKanbanPOC] deleteRows failed:', err)
+        } finally {
+          suppressChanges = false
+        }
+      }
+    }
+
+    const nextRecords = { ...recordsById.value }
+    delete nextRecords[recordId]
+    recordsById.value = nextRecords
+    loadedCount.value = Math.max(0, loadedCount.value - 1)
+    if (selectedRecordId.value === recordId) {
+      selectedRecordId.value = ''
+      selectedFieldId.value = undefined
+    }
+
+    if (page.value) {
+      const total = Math.max(0, page.value.total - 1)
+      const windowing = resolveWindowing()
+      const offset = windowing.enabled ? baseOffset.value : Math.min(page.value.offset, total)
+      const hasMore = baseOffset.value + loadedCount.value < total
+      page.value = { ...page.value, total, offset, hasMore }
+    }
+
+    try {
+      ;(window as any).__pocRecordIds = mapping.rowIndexToRecordId.slice()
+    } catch {
+      // ignore
+    }
+
+    statusText.value = `Deleted (${recordId})`
+    statusKind.value = 'ok'
+  } catch (err) {
+    console.error('[UniverKanbanPOC] delete record failed:', err)
+    statusText.value = 'Delete failed (network error)'
+    statusKind.value = 'error'
+  }
+}
+
+const loadMore = async () => {
+  const currentPage = page.value
+  const source = toStr(route.query.source)?.toLowerCase()
+  if (!currentPage || source !== 'meta') return
+  if (loadingMore.value) return
+
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet) return
+
+  const windowing = resolveWindowing()
+  const nextOffset = baseOffset.value + loadedCount.value
+  if (nextOffset >= currentPage.total) {
+    page.value = { ...currentPage, hasMore: false }
+    return
+  }
+
+  loadingMore.value = true
+  statusText.value = 'Loading more...'
+  statusKind.value = 'ok'
+
+  try {
+    const qs = new URLSearchParams()
+    const queryViewId = toStr(route.query.viewId)
+    const resolvedSheetId = viewId.value
+    if (queryViewId) {
+      qs.set('viewId', queryViewId)
+      if (resolvedSheetId) qs.set('sheetId', resolvedSheetId)
+    } else if (resolvedSheetId) {
+      qs.set('sheetId', resolvedSheetId)
+    } else {
+      return
+    }
+    qs.set('limit', String(currentPage.limit))
+    qs.set('offset', String(nextOffset))
+    if (toStr(route.query.seed)) qs.set('seed', String(route.query.seed))
+
+    const response = await apiGet<UniverMockViewResponse>(`${getApiPrefix()}/view?${qs.toString()}`)
+    if (!response.ok || !response.data) {
+      throw new Error(response.error?.message ?? 'failed to load next page')
+    }
+
+    const rows = response.data.rows ?? []
+    const newRows = rows.filter((r) => typeof mapping.recordIdToRowIndex[r.id] !== 'number')
+    if (newRows.length === 0) {
+      const total = response.data.page?.total ?? currentPage.total
+      page.value = {
+        ...currentPage,
+        offset: windowing.enabled ? baseOffset.value : currentPage.offset,
+        limit: response.data.page?.limit ?? currentPage.limit,
+        total,
+        hasMore: baseOffset.value + loadedCount.value < total,
+      }
+      statusText.value = 'No more rows'
+      statusKind.value = 'ok'
+      return
+    }
+
+    const startRowIndex = mapping.rowIndexToRecordId.length
+    const total = response.data.page?.total ?? currentPage.total
+    const nextRowCount = resolveWindowRowCount(total, startRowIndex + newRows.length, windowing)
+
+    suppressChanges = true
+    if (sheetRowCount < nextRowCount) {
+      sheet.setRowCount(nextRowCount)
+      sheetRowCount = nextRowCount
+    }
+
+    const nextRecords: Record<string, UniverMockRecord> = { ...recordsById.value }
+    for (let i = 0; i < newRows.length; i += 1) {
+      const record = newRows[i]
+      const rowIndex = startRowIndex + i
+      mapping.rowIndexToRecordId.push(record.id)
+      mapping.recordIdToRowIndex[record.id] = rowIndex
+      mapping.recordIdToVersion[record.id] = record.version
+      mapping.recordIdToData[record.id] = { ...record.data }
+      nextRecords[record.id] = { id: record.id, version: record.version, data: { ...record.data } }
+
+      for (let colIndex = 0; colIndex < response.data.fields.length; colIndex += 1) {
+        const field = response.data.fields[colIndex]
+        const fieldId = field.id
+        const raw = (record.data[fieldId] ?? record.data[field.name]) as unknown
+        const cell = buildCellForField(field, raw)
+        if (cell) sheet.getRange(rowIndex, colIndex).setValueForCell(cell as any)
+      }
+    }
+
+    recordsById.value = nextRecords
+    loadedCount.value += newRows.length
+    if (windowing.enabled && windowing.max > 0 && loadedCount.value > windowing.max) {
+      const evictCount = loadedCount.value - windowing.max
+      if (evictCount > 0) {
+        patchQueue?.flushNow()
+        const evictedIds = mapping.rowIndexToRecordId.splice(0, evictCount)
+        const updatedRecords: Record<string, UniverMockRecord> = { ...recordsById.value }
+        for (const recordId of evictedIds) {
+          if (!recordId) continue
+          delete mapping.recordIdToRowIndex[recordId]
+          delete mapping.recordIdToVersion[recordId]
+          delete mapping.recordIdToData[recordId]
+          delete updatedRecords[recordId]
+        }
+        for (let i = 0; i < mapping.rowIndexToRecordId.length; i += 1) {
+          const rid = mapping.rowIndexToRecordId[i]
+          if (rid) mapping.recordIdToRowIndex[rid] = i
+        }
+        recordsById.value = updatedRecords
+        try {
+          sheet.deleteRows(0, evictCount)
+        } catch (err) {
+          console.error('[UniverKanbanPOC] deleteRows failed:', err)
+        }
+        baseOffset.value += evictCount
+        loadedCount.value = mapping.rowIndexToRecordId.length
+        const windowRowCount = resolveWindowRowCount(total, loadedCount.value, windowing)
+        sheet.setRowCount(windowRowCount)
+        sheetRowCount = windowRowCount
+      }
+    }
+    page.value = {
+      ...currentPage,
+      offset: windowing.enabled ? baseOffset.value : currentPage.offset,
+      limit: response.data.page?.limit ?? currentPage.limit,
+      total,
+      hasMore: baseOffset.value + loadedCount.value < total,
+    }
+    try {
+      ;(window as any).__pocRecordIds = mapping.rowIndexToRecordId.slice()
+    } catch {
+      // ignore
+    }
+
+    statusText.value = `Loaded +${newRows.length}`
+    statusKind.value = 'ok'
+  } catch (err) {
+    console.error('[UniverKanbanPOC] loadMore failed:', err)
+    statusText.value = 'Load more failed'
+    statusKind.value = 'error'
+  } finally {
+    suppressChanges = false
+    loadingMore.value = false
+    requestReadonlyHeaderUpdate()
+  }
+}
+
+async function reloadView() {
+  if (!startLoad) return
+  relatedUpdates.value = []
+  hasConflict.value = false
+  conflictServerVersion.value = null
+  overlay.value = null
+  statusText.value = 'Reloading...'
+  statusKind.value = 'ok'
+  await startLoad()
+}
+
+function reload() {
+  reloadView().catch((err) => {
+    console.error('[UniverKanbanPOC] reload failed:', err)
+  })
+}
+
+function selectRecord(recordId: string) {
+  if (!recordId) {
+    selectedRecordId.value = ''
+    selectedFieldId.value = undefined
+    return
+  }
+  selectedRecordId.value = recordId
+  selectedFieldId.value = undefined
+}
+
+function handleCommentUpdated(payload: { rowId: string }) {
+  if (!payload?.rowId) return
+  queueCommentSummaryRefresh([payload.rowId])
+}
+
+function handleDragStart(_event: DragEvent, recordId: string, fromColumn: string) {
+  dragState.value = { recordId, from: fromColumn }
+  selectRecord(recordId)
+}
+
+function handleDrop(_event: DragEvent, toColumn: string) {
+  const dragged = dragState.value
+  if (!dragged || dragged.from === toColumn) return
+  dragState.value = null
+
+  const record = recordsById.value[dragged.recordId]
+  if (!record) return
+
+  const fieldId = priorityFieldId.value
+  const row = mapping.recordIdToRowIndex[record.id]
+  const col = mapping.fieldIdToColIndex[fieldId]
+  const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+  if (!sheet || typeof row !== 'number' || typeof col !== 'number') return
+
+  const color = getSelectColor(fieldId, toColumn) ?? '#1677ff'
+  try {
+    sheet.getRange(row, col).setValueForCell(buildSelectCell(toColumn, color) as any)
+  } catch (err) {
+    console.error('[UniverKanbanPOC] drop setValueForCell failed:', err)
+  }
+}
+
+const kanbanColumns = computed(() => {
+  const priorityId = priorityFieldId.value
+  const titleId = resolveVisibleTitleFieldId()
+  const metaId = relatedFieldId.value
+
+  const optionValues = (mapping.fieldIdToSelectOptions[priorityId] ?? []).map(o => o.value).filter(Boolean)
+  const order = optionValues.length > 0 ? optionValues : (['P0', 'P1', 'P2', 'Done'] as const)
+  const groups: Record<string, Array<{ id: string; title: string; meta: string }>> = Object.fromEntries(order.map(v => [v, []]))
+  const fallback = order.includes('P1') ? 'P1' : (order[0] ?? 'P1')
+
+  for (const r of Object.values(recordsById.value)) {
+    const rawPriority = r.data[priorityId]
+    const priority = typeof rawPriority === 'string' && rawPriority ? rawPriority : fallback
+    const key = priority in groups ? priority : fallback
+    const rawTitle = titleId ? r.data[titleId] : undefined
+    const title = typeof rawTitle === 'string' && rawTitle ? rawTitle : r.id
+    const rawMeta = isFieldHidden(metaId) ? undefined : r.data[metaId]
+    const meta =
+      typeof rawMeta === 'string'
+        ? rawMeta
+        : Array.isArray(rawMeta)
+          ? rawMeta
+              .filter((v) => typeof v === 'string' || typeof v === 'number')
+              .map((v) => String(v))
+              .join(', ')
+          : ''
+    groups[key].push({ id: r.id, title, meta })
+  }
+
+  return order.map((id) => ({ id, title: id, cards: groups[id].slice(0, 50) }))
+})
+
+watch(
+  () => [commentsEnabled.value, commentsSpreadsheetId.value, Object.keys(recordsById.value).join('|')],
+  () => {
+    queueCommentSummaryRefresh()
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  const hostEl = gridMountRef.value
+  if (!hostEl) return
+
+  const embed = createUniverEmbed(
+    hostEl,
+    (mountEl) =>
+      createUniver({
+        theme: defaultTheme,
+        locale: LocaleType.ZH_CN,
+        locales: buildUniverSheetsLocalesMinimal(),
+        presets: [UniverSheetsCorePreset({ container: mountEl })],
+      }),
+    { exposeToWindow: true },
+  )
+
+  univerAPI = embed.univerAPI
+
+  const handleScroll = () => requestReadonlyHeaderUpdate()
+  gridWrapperRef.value?.addEventListener('scroll', handleScroll, true)
+  window.addEventListener('resize', handleScroll)
+  headerIconCleanup = () => {
+    gridWrapperRef.value?.removeEventListener('scroll', handleScroll, true)
+    window.removeEventListener('resize', handleScroll)
+    if (headerIconRaf) window.cancelAnimationFrame(headerIconRaf)
+    headerIconRaf = 0
+  }
+
+  patchQueue = createUniverPatchQueue({
+    getViewId: () => viewId.value,
+    getApiPrefix,
+    mapping,
+    setStatus: (text, kind) => {
+      statusText.value = text
+      statusKind.value = kind
+    },
+    onUpdated: (updated) => {
+      for (const u of updated) {
+        const record = recordsById.value[u.recordId]
+        if (record) record.version = u.version
+      }
+    },
+    onRecords: applyComputedRecords,
+    onRelatedRecords: handleRelatedRecords,
+    onConflict: (serverVersion) => {
+      hasConflict.value = true
+      conflictServerVersion.value = serverVersion
+    },
+    flushDelayMs: 120,
+  })
+
+  const disposable = univerAPI.addEvent(univerAPI.Event.CommandExecuted, (event) => {
+    if (event.id === SetSelectionsOperation.id) {
+      const selections = (event.params as { selections?: Array<{ primary?: { actualRow?: number; actualColumn?: number } | null }> })
+        ?.selections
+      const primary = selections?.find(s => s?.primary)?.primary
+      const row = primary?.actualRow
+      const col = primary?.actualColumn
+      if (typeof row !== 'number' || typeof col !== 'number') {
+        overlay.value = null
+        return
+      }
+
+      const fieldId = mapping.colIndexToFieldId[col]
+      const fieldType = mapping.fieldIdToType[fieldId]
+      if (!fieldId) {
+        overlay.value = null
+        selectedRecordId.value = ''
+        selectedFieldId.value = undefined
+        return
+      }
+
+      const recordId = mapping.rowIndexToRecordId[row] ?? ''
+      if (!recordId) {
+        overlay.value = null
+        selectedRecordId.value = ''
+        selectedFieldId.value = undefined
+        return
+      }
+      selectedRecordId.value = recordId
+      selectedFieldId.value = fieldId
+
+      const readonlyReason = getReadonlyReason(fieldId)
+      if (readonlyReason) {
+        if (!showReadonlyOverlay(fieldId, row, col, readonlyReason, 'select')) {
+          overlay.value = null
+        }
+        return
+      }
+      if (fieldType !== 'select' && fieldType !== 'link') {
+        overlay.value = null
+        return
+      }
+
+      const wrapperEl = gridWrapperRef.value
+      const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+      if (!wrapperEl || !sheet) {
+        overlay.value = null
+        return
+      }
+
+      let rect: DOMRect | undefined
+      try {
+        const range = sheet.getRange(row, col) as any
+        rect = range?.getCellRect?.()
+      } catch {
+        rect = undefined
+      }
+      if (!rect) {
+        overlay.value = null
+        return
+      }
+
+      const wrapperRect = wrapperEl.getBoundingClientRect()
+      const left = rect.left - wrapperRect.left
+      const top = rect.bottom - wrapperRect.top + 4
+
+      if (fieldType === 'select') {
+        overlay.value = {
+          kind: 'select',
+          row,
+          col,
+          left,
+          top,
+          fieldId,
+          options: mapping.fieldIdToSelectOptions[fieldId] ?? [],
+        }
+        return
+      }
+
+      overlay.value = {
+        kind: 'link',
+        row,
+        col,
+        left,
+        top,
+        fieldId,
+      }
+      try {
+        const current = sheet.getRange(row, col).getDisplayValue?.()
+        linkDraft.value = typeof current === 'string' ? current : ''
+      } catch {
+        linkDraft.value = ''
+      }
+      return
+    }
+
+    if (event.id !== SetRangeValuesMutation.id) return
+    if (suppressChanges) return
+    const cellValue = (event.params as { cellValue?: Record<string, Record<string, unknown>> })?.cellValue
+    if (!cellValue) return
+
+    for (const [rowKey, rowValue] of Object.entries(cellValue)) {
+      const row = Number(rowKey)
+      if (!Number.isFinite(row)) continue
+      const recordId = mapping.rowIndexToRecordId[row]
+      if (!recordId) continue
+
+      for (const [colKey, cell] of Object.entries(rowValue)) {
+        const col = Number(colKey)
+        if (!Number.isFinite(col)) continue
+        const fieldId = mapping.colIndexToFieldId[col]
+        if (!fieldId) continue
+
+        const readonlyReason = getReadonlyReason(fieldId)
+        if (readonlyReason) {
+          restoreReadonlyCell(row, col, recordId, fieldId)
+          recordReadonlyHit(fieldId, readonlyReason, 'edit')
+          statusText.value = readonlyReason
+          statusKind.value = 'error'
+          continue
+        }
+
+        const value = extractValueFromCell(cell)
+        const fieldType = mapping.fieldIdToType[fieldId]
+        if (fieldType === 'lookup' || fieldType === 'rollup') continue
+        if (fieldType === 'formula' && !isFormulaValue(value)) continue
+
+        // Store sync (grid -> kanban)
+        const record = recordsById.value[recordId]
+        if (record) record.data[fieldId] = value
+        if (mapping.recordIdToData[recordId]) {
+          mapping.recordIdToData[recordId][fieldId] = value as any
+        }
+
+        patchQueue.stageChange(recordId, fieldId, value)
+      }
+    }
+
+    patchQueue.requestFlush(120)
+  })
+
+  const start = async () => {
+    try {
+      const qs = getQueryString()
+      const response = await apiGet<UniverMockViewResponse>(`${getApiPrefix()}/view${qs}`)
+      if (!response.ok || !response.data) {
+        throw new Error(response.error?.message ?? 'failed to load view')
+      }
+
+      titleFieldId.value = resolveFieldId(response.data.fields, { preferId: 'name', type: 'string', nameRe: /名称|name|title/i })
+      priorityFieldId.value = resolveFieldId(response.data.fields, { preferId: 'priority', type: 'select', nameRe: /优先|priority/i })
+      relatedFieldId.value = resolveFieldId(response.data.fields, { preferId: 'related', type: 'link', nameRe: /关联|related|link/i })
+
+      const source = toStr(route.query.source)?.toLowerCase()
+      const groupInfo = response.data.view?.groupInfo
+      const groupFieldId = toStr(
+        groupInfo && typeof groupInfo === 'object' && !Array.isArray(groupInfo)
+          ? (groupInfo as Record<string, unknown>).fieldId
+          : undefined,
+      )
+      if (source === 'meta' && groupFieldId) {
+        const groupField = response.data.fields.find((f) => f.id === groupFieldId)
+        if (groupField?.type === 'select') {
+          priorityFieldId.value = groupField.id
+        }
+      }
+
+      activeSheetId.value = response.data.id
+      viewSummary.value = buildViewSummary(response.data)
+      viewId.value = response.data.id
+      selectedViewId.value = toStr(route.query.viewId) ?? ''
+      viewWarnings.value = Array.isArray(response.data.meta?.warnings) ? response.data.meta!.warnings!.slice() : []
+      diagnosticsItems.value = buildDiagnostics(response.data)
+      mapping.rowIndexToRecordId = response.data.rows.map(r => r.id)
+      mapping.recordIdToRowIndex = Object.fromEntries(mapping.rowIndexToRecordId.map((id, idx) => [id, idx]))
+      mapping.colIndexToFieldId = response.data.fields.map(f => f.id)
+      mapping.fieldIdToColIndex = Object.fromEntries(mapping.colIndexToFieldId.map((id, idx) => [id, idx]))
+      mapping.recordIdToVersion = Object.fromEntries(response.data.rows.map(r => [r.id, r.version]))
+      mapping.fieldIdToType = Object.fromEntries(response.data.fields.map(f => [f.id, f.type]))
+      mapping.fieldIdToSelectOptions = Object.fromEntries(
+        response.data.fields
+          .filter((f) => f.type === 'select' && Array.isArray(f.options))
+          .map((f) => [f.id, f.options ?? []]),
+      )
+      mapping.fieldIdToProperty = Object.fromEntries(
+        response.data.fields
+          .filter((f) => f.property)
+          .map((f) => [f.id, f.property]),
+      )
+      mapping.fieldIdToReadonlyReason = Object.fromEntries(
+        response.data.fields
+          .map((f) => [f.id, resolveReadonlyReason(f)] as const)
+          .filter((entry) => Boolean(entry[1])),
+      ) as Record<string, string>
+      mapping.fieldIdToLabel = Object.fromEntries(
+        response.data.fields
+          .map((f) => [f.id, f.name?.trim() || String(f.id)] as const),
+      ) as Record<string, string>
+      syncReadonlyFields(response.data.fields)
+      const windowing = resolveWindowing()
+      const viewRows =
+        windowing.enabled && source !== 'meta'
+          ? response.data.rows.slice(0, windowing.size)
+          : response.data.rows
+      const viewData = { ...response.data, rows: viewRows }
+
+      mapping.recordIdToData = Object.fromEntries(viewRows.map((r) => [r.id, { ...r.data }]))
+
+      recordsById.value = Object.fromEntries(viewRows.map((r) => [r.id, { id: r.id, version: r.version, data: { ...r.data } }]))
+
+      univerAPI!.createWorkbook(transformToWorkbook(viewData))
+      requestReadonlyHeaderUpdate()
+      const sheet = univerAPI?.getActiveWorkbook?.()?.getActiveSheet?.()
+      const hiddenIds = Array.isArray(response.data.view?.hiddenFieldIds)
+        ? response.data.view!.hiddenFieldIds!.map((v) => (typeof v === 'string' ? v.trim() : '')).filter((v) => v.length > 0)
+        : []
+      hiddenFieldIds.value = hiddenIds
+      if (sheet && hiddenIds.length > 0) {
+        for (const fieldId of hiddenIds) {
+          const colIndex = mapping.fieldIdToColIndex[fieldId]
+          if (typeof colIndex !== 'number' || !Number.isFinite(colIndex)) continue
+          try {
+            sheet.hideColumns(colIndex, 1)
+          } catch {
+            // ignore
+          }
+        }
+      }
+      try {
+        ;(window as any).__pocHiddenFieldIds = hiddenIds
+        ;(window as any).__pocHiddenCols = sheet?.getSheet?.().getHiddenCols?.() ?? []
+      } catch {
+        // ignore
+      }
+      const total = response.data.page?.total ?? response.data.rows.length
+      sheetRowCount = resolveWindowRowCount(total, viewRows.length, windowing)
+      page.value = response.data.page ?? null
+      loadedCount.value = viewRows.length
+      baseOffset.value = response.data.page?.offset ?? 0
+      if (page.value) {
+        page.value = {
+          ...page.value,
+          offset: windowing.enabled ? baseOffset.value : page.value.offset,
+          hasMore: baseOffset.value + loadedCount.value < page.value.total,
+        }
+      }
+      try {
+        ;(window as any).__pocRecordIds = mapping.rowIndexToRecordId.slice()
+      } catch {
+        // ignore
+      }
+      statusText.value = 'Loaded'
+      statusKind.value = 'ok'
+      statusHint.value = ''
+    } catch (err) {
+      console.error('[UniverKanbanPOC] load view failed:', err)
+      const hint = buildMissingSheetHint(err)
+      if (hint) {
+        statusText.value = hint.title
+        statusHint.value = hint.hint
+      } else {
+        statusText.value = 'Load failed'
+        statusHint.value = ''
+      }
+      statusKind.value = 'error'
+      viewWarnings.value = []
+      activeSheetId.value = ''
+      viewSummary.value = null
+      hiddenFieldIds.value = []
+      diagnosticsItems.value = []
+    }
+  }
+
+  startLoad = async () => {
+    await start()
+  }
+
+  startLoad().catch((err) => {
+    console.error('[UniverKanbanPOC] start failed:', err)
+  })
+
+  univerDispose = () => {
+    headerIconCleanup?.()
+    patchQueue.dispose()
+    disposable.dispose()
+    embed.dispose()
+  }
+})
+
+onUnmounted(() => {
+  univerDispose?.()
+  univerDispose = null
+  univerAPI = null
+  startLoad = null
+  overlay.value = null
+})
+</script>
+
+<style scoped>
+.univer-kanban {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 50px);
+}
+
+.univer-kanban__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e0e0;
+  background: #fff;
+}
+
+.univer-kanban__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.univer-kanban__subtitle {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.univer-kanban__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.univer-kanban__view-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #4b5563;
+}
+
+.univer-kanban__select {
+  height: 26px;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  background: #fff;
+  padding: 0 6px;
+  font-size: 12px;
+}
+
+.univer-kanban__sheet-id {
+  color: #4b5563;
+}
+
+.univer-kanban__view-summary {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.univer-kanban__diagnostics {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+  color: #92400e;
+}
+
+.univer-kanban__diagnostics-label {
+  font-weight: 600;
+}
+
+.univer-kanban__diagnostics-chip {
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(234, 179, 8, 0.5);
+  background: rgba(234, 179, 8, 0.15);
+  color: #92400e;
+  font-size: 11px;
+}
+
+.univer-kanban__view-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: #f8fafc;
+  color: #374151;
+  font-size: 11px;
+}
+
+.univer-kanban__view-chip--warn {
+  border-color: rgba(255, 77, 79, 0.35);
+  background: rgba(255, 77, 79, 0.08);
+  color: #c2410c;
+}
+
+.univer-kanban__status {
+  color: #1677ff;
+}
+
+.univer-kanban__status--error {
+  color: #ff4d4f;
+}
+
+.univer-kanban__status-hint {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.univer-kanban__warning {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid #ffd591;
+  background: #fff7e6;
+  color: #8c6d1f;
+  font-size: 12px;
+}
+
+.univer-kanban__related {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid #ffd591;
+  background: #fff7e6;
+  color: #8c6d1f;
+  font-size: 12px;
+}
+
+.univer-kanban__related-note {
+  color: #6b7280;
+}
+
+.univer-kanban__hint {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  color: #8c6d1f;
+}
+
+.univer-kanban__hint-link {
+  color: #1677ff;
+  text-decoration: none;
+}
+
+.univer-kanban__hint-link:hover {
+  text-decoration: underline;
+}
+
+.univer-kanban__hint-note {
+  color: #6b7280;
+}
+
+.univer-kanban__readonly {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.univer-kanban__readonly-label {
+  font-weight: 600;
+  color: #8c6d1f;
+}
+
+.univer-kanban__readonly-item {
+  border: 1px solid #ffe58f;
+  background: #fffbe6;
+  color: #8c6d1f;
+  border-radius: 999px;
+  padding: 2px 8px;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.univer-kanban__readonly-item:hover {
+  border-color: #ffd666;
+}
+
+.univer-kanban__readonly-name {
+  font-weight: 600;
+}
+
+.univer-kanban__readonly-tag {
+  font-size: 11px;
+  color: #8c6d1f;
+}
+
+.univer-kanban__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  background: #f3f4f6;
+  overflow: hidden;
+}
+
+.univer-kanban__body--with-comments {
+  grid-template-columns: minmax(0, 1fr) 380px 280px;
+}
+
+.univer-kanban__grid {
+  position: relative;
+  background: #fff;
+  min-height: 0;
+}
+
+.univer-kanban__grid-mount {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.univer-kanban__header-icons {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 15;
+}
+
+.univer-kanban__header-icon {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  border: 1px solid #ffe58f;
+  background: #fffbe6;
+  color: #8c6d1f;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  cursor: help;
+}
+
+.univer-kanban__header-tooltip {
+  position: absolute;
+  z-index: 16;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(17, 17, 17, 0.88);
+  color: #fff;
+  font-size: 11px;
+  line-height: 1.4;
+  max-width: 220px;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.univer-kanban__kanban {
+  border-left: 1px solid rgba(0, 0, 0, 0.08);
+  background: #f5f5f5;
+  padding: 10px;
+  overflow: auto;
+  display: grid;
+  gap: 10px;
+}
+
+.univer-kanban__comments {
+  border-left: 1px solid #e5e7eb;
+  background: #fafafa;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.univer-kanban__column {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.univer-kanban__column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  background: #fff;
+}
+
+.univer-kanban__column-title {
+  font-weight: 600;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.78);
+}
+
+.univer-kanban__column-count {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.univer-kanban__cards {
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 44px;
+}
+
+.univer-kanban__card {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  padding: 10px;
+  cursor: grab;
+}
+
+.univer-kanban__card:active {
+  cursor: grabbing;
+}
+
+.univer-kanban__card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.univer-kanban__card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.82);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.univer-kanban__card-delete {
+  border: 0;
+  border-radius: 8px;
+  padding: 2px 6px;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 16px;
+  color: rgba(0, 0, 0, 0.65);
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.univer-kanban__card-delete:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.univer-kanban__card-meta {
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.univer-kanban__card-meta-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.univer-kanban__comment-badge {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #0f766e;
+  background: #ecfdf3;
+  border: 1px solid #bbf7d0;
+}
+
+.univer-kanban__overlay {
+  position: absolute;
+  z-index: 20;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(6px);
+}
+
+.univer-kanban__overlay--readonly {
+  padding: 6px 10px;
+  font-size: 12px;
+  color: #8c6d1f;
+  background: #fffbe6;
+  border-color: #ffe58f;
+  pointer-events: none;
+}
+
+.univer-kanban__overlay-empty {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.univer-kanban__pill {
+  border: 0;
+  border-radius: 999px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 16px;
+  color: #fff;
+}
+
+.univer-kanban__link-input {
+  width: 220px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  outline: none;
+}
+
+.univer-kanban__btn {
+  border: 0;
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #fff;
+  background: #1677ff;
+}
+
+.univer-kanban__btn--danger {
+  background: #ff4d4f;
+}
+</style>


### PR DESCRIPTION
## Summary\n- prefer lookup/rollup readonly hints over generic readonly\n- ensure readonly tooltips/status reflect computed fields\n\n## Testing\n- BACKEND_MODE=core bash scripts/verify-univer-all.sh