### PR TITLE
Improve Yuantus product/doc/approval mapping

### DIFF
--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -227,6 +227,8 @@ Entry points:
   - Artifact: `artifacts/plm-ui-regression-20260115_144649.png`
   - Report: `docs/verification-plm-ui-regression-20260115_144649.md`
   - Artifact: `artifacts/plm-ui-regression-20260115_144649.png`
+  - Report: `docs/verification-plm-ui-regression-20260115_164310.md`
+  - Artifact: `artifacts/plm-ui-regression-20260115_164310.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`
@@ -239,6 +241,7 @@ Entry points:
   - Report: `docs/verification-plm-ui-full-20260110_191218.md`
   - Report: `docs/verification-plm-ui-full-20260115_142128.md`
   - Report: `docs/verification-plm-ui-full-20260115_144649.md`
+  - Report: `docs/verification-plm-ui-full-20260115_164310.md`
 - PLM UI deep-link autoload:
   - Script: `scripts/verify-plm-ui-deeplink.sh`
   - Report: `docs/verification-plm-ui-deeplink-20260108_131533.md`

--- a/docs/verification-plm-ui-full-20260115_164310.md
+++ b/docs/verification-plm-ui-full-20260115_164310.md
@@ -1,0 +1,20 @@
+# Verification: PLM UI Full Regression - 20260115_164310
+
+## Goal
+Run BOM tools seed + PLM UI regression in a single workflow.
+
+## Environment
+- PLM base: http://127.0.0.1:7910
+- Tenant/org: tenant-1 / org-1
+
+## Steps
+1. BOM tools seed
+   - Report: artifacts/plm-bom-tools-20260115_164310.md
+   - JSON: artifacts/plm-bom-tools-20260115_164310.json
+2. UI regression
+   - Report: docs/verification-plm-ui-regression-20260115_164310.md
+   - Screenshot: artifacts/plm-ui-regression-20260115_164310.png
+
+## Cleanup
+- PLM_CLEANUP: false
+- Status: skipped

--- a/docs/verification-plm-ui-regression-20260115_164310.md
+++ b/docs/verification-plm-ui-regression-20260115_164310.md
@@ -1,0 +1,29 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260115_164310
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7788
+- PLM: http://127.0.0.1:7910
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260115_164310.json
+
+## Data
+- Search query: UI-CMP-A-1768466600
+- Product ID: 13a00a29-cb89-4f5b-a134-ce6b94c2d063
+- Where-used child ID: 0fc36593-f7cf-46ea-9089-a7c40c7fa45b
+- Where-used expect: R1,R2
+- BOM compare left/right: 13a00a29-cb89-4f5b-a134-ce6b94c2d063 / f1f6ed2d-a511-4526-8635-145087fcb68d
+- BOM compare expect: UI Child Z
+- Substitute BOM line: 963b8081-3af5-45af-80ab-4e96f824bebe
+- Substitute expect: UI Substitute
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Screenshot: artifacts/plm-ui-regression-20260115_164310.png

--- a/docs/verification-summary-2026-01-15.md
+++ b/docs/verification-summary-2026-01-15.md
@@ -9,7 +9,11 @@
 - PLM BOM tools seed: `artifacts/plm-bom-tools-20260115_144649.md`
 - PLM UI regression: `docs/verification-plm-ui-regression-20260115_144649.md`
 - PLM UI full regression: `docs/verification-plm-ui-full-20260115_144649.md`
+- PLM BOM tools seed: `artifacts/plm-bom-tools-20260115_164310.md`
+- PLM UI regression: `docs/verification-plm-ui-regression-20260115_164310.md`
+- PLM UI full regression: `docs/verification-plm-ui-full-20260115_164310.md`
 
 ## Environment Notes
-- Yuantus PLM ran on `http://127.0.0.1:7911`.
+- Yuantus PLM ran on `http://127.0.0.1:7910`.
+- MetaSheet API ran on `http://127.0.0.1:7788` and UI on `http://127.0.0.1:8899`.
 - `PLM_URL` set to the same base to avoid stale defaults.


### PR DESCRIPTION
## Summary\n- enrich Yuantus product mapping with part numbers/revisions/item types and merge search detail fields\n- expand Yuantus document metadata mapping (names, roles, preview/download URLs, source info)\n- include product context in approval mapping and refresh verification docs/index\n\n## Testing\n- API_BASE=http://127.0.0.1:7788 WEB_BASE=http://127.0.0.1:8899 PLM_BASE_URL=http://127.0.0.1:7910 PLM_URL=http://127.0.0.1:7910 AUTO_START=true bash scripts/verify-plm-ui-full.sh