### PR TITLE
Route PLM documents/approvals and extend UI regression

### DIFF
--- a/docs/PLM_DOCUMENT_APPROVAL_DEV_REPORT.md
+++ b/docs/PLM_DOCUMENT_APPROVAL_DEV_REPORT.md
@@ -1,0 +1,17 @@
+# PLM Document + Approval Verification Dev Report
+
+## Goal
+Add PLM document/approval coverage to UI regression and route those operations to real PLM (Yuantus).
+
+## Changes
+- `scripts/verify-plm-bom-tools.sh`: seed a document attachment + ECO, emit document/approval fixtures in JSON and report.
+- `scripts/verify-plm-ui-regression.sh`: parse document/approval expectations and validate UI tables.
+- `packages/core-backend/src/routes/federation.ts`: handle PLM `documents` and `approvals` operations (no mock fallback).
+
+## Verification
+- `docs/verification-plm-ui-regression-20260115_173732.md`
+- `docs/verification-plm-ui-full-20260115_173732.md`
+
+## Notes
+- Yuantus PLM base: `http://127.0.0.1:7910`
+- MetaSheet API/UI: `http://127.0.0.1:7788` / `http://127.0.0.1:8899`

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -229,6 +229,8 @@ Entry points:
   - Artifact: `artifacts/plm-ui-regression-20260115_144649.png`
   - Report: `docs/verification-plm-ui-regression-20260115_164310.md`
   - Artifact: `artifacts/plm-ui-regression-20260115_164310.png`
+  - Report: `docs/verification-plm-ui-regression-20260115_173732.md`
+  - Artifact: `artifacts/plm-ui-regression-20260115_173732.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`
@@ -242,6 +244,7 @@ Entry points:
   - Report: `docs/verification-plm-ui-full-20260115_142128.md`
   - Report: `docs/verification-plm-ui-full-20260115_144649.md`
   - Report: `docs/verification-plm-ui-full-20260115_164310.md`
+  - Report: `docs/verification-plm-ui-full-20260115_173732.md`
 - PLM UI deep-link autoload:
   - Script: `scripts/verify-plm-ui-deeplink.sh`
   - Report: `docs/verification-plm-ui-deeplink-20260108_131533.md`

--- a/docs/verification-plm-ui-full-20260115_173732.md
+++ b/docs/verification-plm-ui-full-20260115_173732.md
@@ -1,0 +1,20 @@
+# Verification: PLM UI Full Regression - 20260115_173732
+
+## Goal
+Run BOM tools seed + PLM UI regression in a single workflow.
+
+## Environment
+- PLM base: http://127.0.0.1:7910
+- Tenant/org: tenant-1 / org-1
+
+## Steps
+1. BOM tools seed
+   - Report: artifacts/plm-bom-tools-20260115_173732.md
+   - JSON: artifacts/plm-bom-tools-20260115_173732.json
+2. UI regression
+   - Report: docs/verification-plm-ui-regression-20260115_173732.md
+   - Screenshot: artifacts/plm-ui-regression-20260115_173732.png
+
+## Cleanup
+- PLM_CLEANUP: false
+- Status: skipped

--- a/docs/verification-plm-ui-regression-20260115_173732.md
+++ b/docs/verification-plm-ui-regression-20260115_173732.md
@@ -1,0 +1,36 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260115_173732
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7788
+- PLM: http://127.0.0.1:7910
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260115_173732.json
+
+## Data
+- Search query: UI-CMP-A-1768469854
+- Product ID: 785d314c-6e59-4fde-96d2-370f13bb1fa6
+- Where-used child ID: 8ffac749-0544-4307-906e-01eab64b3270
+- Where-used expect: R1,R2
+- BOM compare left/right: 785d314c-6e59-4fde-96d2-370f13bb1fa6 / 129c9e48-8c98-4863-8582-16c2e4e34869
+- BOM compare expect: UI Child Z
+- Substitute BOM line: 07f0bdc9-b3e6-4cfe-b15c-63cca8ea282f
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768469854.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768469854
+- Approval product number: UI-CMP-A-1768469854
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260115_173732.png

--- a/docs/verification-summary-2026-01-15.md
+++ b/docs/verification-summary-2026-01-15.md
@@ -12,6 +12,9 @@
 - PLM BOM tools seed: `artifacts/plm-bom-tools-20260115_164310.md`
 - PLM UI regression: `docs/verification-plm-ui-regression-20260115_164310.md`
 - PLM UI full regression: `docs/verification-plm-ui-full-20260115_164310.md`
+- PLM BOM tools seed: `artifacts/plm-bom-tools-20260115_173732.md`
+- PLM UI regression: `docs/verification-plm-ui-regression-20260115_173732.md`
+- PLM UI full regression: `docs/verification-plm-ui-full-20260115_173732.md`
 
 ## Environment Notes
 - Yuantus PLM ran on `http://127.0.0.1:7910`.


### PR DESCRIPTION
## Summary\n- route PLM document + approval queries through PLM adapter (avoid mock fallback)\n- seed document attachment + ECO for PLM regression and include in BOM tools JSON\n- extend UI regression to assert document + approval tables\n- add dev + verification reports\n\n## Testing\n- API_BASE=http://127.0.0.1:7788 WEB_BASE=http://127.0.0.1:8899 PLM_BASE_URL=http://127.0.0.1:7910 PLM_URL=http://127.0.0.1:7910 AUTO_START=true bash scripts/verify-plm-ui-full.sh