### PR TITLE
Add item-number fallback and UI regression check

### DIFF
--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -58,6 +58,8 @@ Entry points:
 
 - PLM product detail mapping:
   - Report: `docs/verification-plm-product-detail-20260104_1132.md`
+- PLM product detail mapping (item number fallback):
+  - Report: `docs/verification-plm-product-detail-item-number-20260115_204327.md`
 - PLM adapter mapping (product/docs/approvals):
   - Report: `docs/verification-plm-adapter-mapping-20260104_1559.md`
 - PLM field mapping API verification:
@@ -231,6 +233,8 @@ Entry points:
   - Artifact: `artifacts/plm-ui-regression-20260115_164310.png`
   - Report: `docs/verification-plm-ui-regression-20260115_173732.md`
   - Artifact: `artifacts/plm-ui-regression-20260115_173732.png`
+  - Report: `docs/verification-plm-ui-regression-20260115_212143.md`
+  - Artifact: `artifacts/plm-ui-regression-20260115_212143.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`

--- a/docs/verification-plm-product-detail-item-number-20260115_204327.md
+++ b/docs/verification-plm-product-detail-item-number-20260115_204327.md
@@ -1,0 +1,23 @@
+# PLM Product Detail Item Number Fallback Verification (2026-01-15)
+
+## Scope
+- Yuantus product detail resolves by item number when AML lookup misses.
+- Yuantus search hit matching now includes item_number and related property keys.
+- Added unit coverage for item-number fallback path.
+
+## Changes
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts`
+  - search hit matching includes item_number + properties.
+  - product detail falls back to search results when AML get returns empty.
+- `packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts`
+  - new test for item-number fallback.
+
+## Verification
+Command:
+```
+pnpm --filter @metasheet/core-backend test -- plm-adapter-yuantus.test.ts
+```
+
+Result:
+- PASS (vitest executed full suite; 67 files / 864 tests)
+- Exited watch mode after completion.

--- a/docs/verification-plm-ui-regression-20260115_212143.md
+++ b/docs/verification-plm-ui-regression-20260115_212143.md
@@ -1,0 +1,39 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260115_212143
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7788
+- PLM: http://127.0.0.1:7910
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260115_173732.json
+
+## Data
+- Search query: UI-CMP-A-1768469854
+- Product ID: 785d314c-6e59-4fde-96d2-370f13bb1fa6
+- Where-used child ID: 8ffac749-0544-4307-906e-01eab64b3270
+- Where-used expect: R1,R2
+- BOM compare left/right: 785d314c-6e59-4fde-96d2-370f13bb1fa6 / 129c9e48-8c98-4863-8582-16c2e4e34869
+- BOM compare expect: UI Child Z
+- Substitute BOM line: 07f0bdc9-b3e6-4cfe-b15c-63cca8ea282f
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768469854.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768469854
+- Approval product number: UI-CMP-A-1768469854
+- Item number-only load: UI-CMP-A-1768469854
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260115_212143.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260115_212143.json

--- a/docs/verification-summary-2026-01-15.md
+++ b/docs/verification-summary-2026-01-15.md
@@ -16,6 +16,8 @@
 - PLM UI regression: `docs/verification-plm-ui-regression-20260115_173732.md`
 - PLM UI full regression: `docs/verification-plm-ui-full-20260115_173732.md`
 - PLM UI BOM compare field mapping: `docs/verification-plm-ui-bom-compare-fieldmap-20260115_1759.md`
+- PLM product detail item-number fallback: `docs/verification-plm-product-detail-item-number-20260115_204327.md`
+- PLM UI regression (item number load): `docs/verification-plm-ui-regression-20260115_212143.md`
 
 ## Environment Notes
 - Yuantus PLM ran on `http://127.0.0.1:7910`.


### PR DESCRIPTION
## Summary\n- add item-number fallback when Yuantus AML detail misses (search + matching)\n- extend PLM UI regression to verify item-number-only load\n- add verification docs and index/summary entries\n\n## Testing\n- pnpm --filter @metasheet/core-backend test -- plm-adapter-yuantus.test.ts\n- bash scripts/verify-plm-ui-regression.sh (AUTO_START=true, local Yuantus)