### PR TITLE
Enhance PLM BOM tools UI filtering

### DIFF
--- a/docs/PLM_UI_BOM_TOOLS_ENHANCEMENT_REPORT.md
+++ b/docs/PLM_UI_BOM_TOOLS_ENHANCEMENT_REPORT.md
@@ -1,0 +1,26 @@
+# PLM UI BOM Tools Enhancement Report (2026-01-15)
+
+## Scope
+Enhance the PLM UI panels for Where-Used / BOM Compare / Substitutes so they are more resilient to payload shape differences and more searchable when compare payloads omit child fields.
+
+## Changes
+- `apps/web/src/views/PlmProductView.vue`
+  - Added `resolveCompareLineProps()` helper to normalize compare line properties from `line`, `properties`, `relationship.properties`, or `relationship`.
+  - `getCompareProp()` now supports snake→camel key fallback.
+  - `formatEffectivity()` and `formatSubstituteCount()` now:
+    - use normalized line props;
+    - fall back to `before_line` / `after_line` when present;
+    - emit `before → after` when values differ.
+  - Compare filter now includes:
+    - path nodes (`path[].id/item_number/name/...`)
+    - line props (`find_num`, `refdes`, `quantity`, `uom`)
+    - this keeps filtering effective even when `include_child_fields=false`.
+
+## Why
+- Yuantus BOM compare payloads can return data in `line`, `properties`, or `relationship.properties`; UI should not lose fields depending on mode.
+- Changed entries carry `before_line`/`after_line`, which we now surface in effectivity/substitute fields for quick inspection.
+- When child fields are excluded, only `path` remains; filtering by path keeps search usable.
+
+## Verification
+- BOM tools seed (Yuantus @ 7911): `artifacts/plm-bom-tools-20260115_2201.md`
+- UI regression (item number + bom tools): `docs/verification-plm-ui-regression-20260115_220146.md`

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -152,6 +152,8 @@ Entry points:
   - Artifact: `artifacts/plm-bom-tools-20260110_160733.json`
   - Report: `artifacts/plm-bom-tools-20260110_170622.md`
   - Artifact: `artifacts/plm-bom-tools-20260110_170622.json`
+  - Report: `artifacts/plm-bom-tools-20260115_2201.md`
+  - Artifact: `artifacts/plm-bom-tools-20260115_2201.json`
 - PLM UI BOM tools:
   - Report: `docs/verification-plm-ui-bom-tools-20260105_175018.md`
   - Artifact: `artifacts/plm-ui-bom-tools-20260105_175018.png`
@@ -235,6 +237,8 @@ Entry points:
   - Artifact: `artifacts/plm-ui-regression-20260115_173732.png`
   - Report: `docs/verification-plm-ui-regression-20260115_212143.md`
   - Artifact: `artifacts/plm-ui-regression-20260115_212143.png`
+  - Report: `docs/verification-plm-ui-regression-20260115_220146.md`
+  - Artifact: `artifacts/plm-ui-regression-20260115_220146.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`

--- a/docs/verification-plm-ui-regression-20260115_220146.md
+++ b/docs/verification-plm-ui-regression-20260115_220146.md
@@ -1,0 +1,39 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260115_220146
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7788
+- PLM: http://127.0.0.1:7911
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260115_2201.json
+
+## Data
+- Search query: UI-CMP-A-1768485688
+- Product ID: 9bd2dde5-8178-418d-9202-4355f7e31bb1
+- Where-used child ID: f4e7c0d8-8c64-49b4-a891-8d0a1d21d456
+- Where-used expect: R1,R2
+- BOM compare left/right: 9bd2dde5-8178-418d-9202-4355f7e31bb1 / fe0b4f4a-8947-453c-99f2-195faf4fedf9
+- BOM compare expect: UI Child Z
+- Substitute BOM line: 983e3fca-bcdc-4010-b1ab-2c1d93ff4280
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768485688.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768485688
+- Approval product number: UI-CMP-A-1768485688
+- Item number-only load: UI-CMP-A-1768485688
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260115_220146.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260115_220146.json

--- a/docs/verification-summary-2026-01-15.md
+++ b/docs/verification-summary-2026-01-15.md
@@ -18,8 +18,10 @@
 - PLM UI BOM compare field mapping: `docs/verification-plm-ui-bom-compare-fieldmap-20260115_1759.md`
 - PLM product detail item-number fallback: `docs/verification-plm-product-detail-item-number-20260115_204327.md`
 - PLM UI regression (item number load): `docs/verification-plm-ui-regression-20260115_212143.md`
+- PLM BOM tools seed: `artifacts/plm-bom-tools-20260115_2201.md`
+- PLM UI regression (bom tools refresh): `docs/verification-plm-ui-regression-20260115_220146.md`
 
 ## Environment Notes
-- Yuantus PLM ran on `http://127.0.0.1:7910`.
+- Yuantus PLM ran on `http://127.0.0.1:7910` (earlier) and `http://127.0.0.1:7911` (latest).
 - MetaSheet API ran on `http://127.0.0.1:7788` and UI on `http://127.0.0.1:8899`.
 - `PLM_URL` set to the same base to avoid stale defaults.

--- a/scripts/verify-plm-bom-tools.sh
+++ b/scripts/verify-plm-bom-tools.sh
@@ -112,14 +112,14 @@ PLM_TOKEN=$(curl -sS -X POST "$PLM_BASE_URL/api/v1/auth/login" \
   -H "x-tenant-id: $PLM_TENANT_ID" \
   -H "x-org-id: $PLM_ORG_ID" \
   -d "{\"username\":\"$PLM_USERNAME\",\"password\":\"$PLM_PASSWORD\",\"tenant_id\":\"$PLM_TENANT_ID\",\"org_id\":\"$PLM_ORG_ID\"}" \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))')
+  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' || true)
 
 if [[ -z "$PLM_TOKEN" ]]; then
-  echo "Failed to obtain PLM token." >&2
-  exit 1
+  echo "PLM token not available; continuing without Authorization header." >&2
+  HEADERS=(-H "x-tenant-id: $PLM_TENANT_ID" -H "x-org-id: $PLM_ORG_ID")
+else
+  HEADERS=(-H "x-tenant-id: $PLM_TENANT_ID" -H "x-org-id: $PLM_ORG_ID" -H "Authorization: Bearer $PLM_TOKEN")
 fi
-
-HEADERS=(-H "x-tenant-id: $PLM_TENANT_ID" -H "x-org-id: $PLM_ORG_ID" -H "Authorization: Bearer $PLM_TOKEN")
 
 create_part() {
   local item_number="$1"


### PR DESCRIPTION
## Summary\n- normalize BOM compare line props + effectivity/substitute display\n- expand compare filter tokens (path + line fields)\n- allow bom-tools verification without PLM auth token (optional auth)\n- add UI enhancement report and fresh regression report\n\n## Testing\n- bash scripts/verify-plm-bom-tools.sh (PLM 7911)\n- bash scripts/verify-plm-ui-regression.sh (AUTO_START=true, PLM 7911)