### PR TITLE
Add where-used tree toggles and compare row highlighting

### DIFF
--- a/docs/PLM_UI_BOM_TOOLS_ENHANCEMENT_REPORT.md
+++ b/docs/PLM_UI_BOM_TOOLS_ENHANCEMENT_REPORT.md
@@ -1,7 +1,7 @@
 # PLM UI BOM Tools Enhancement Report (2026-01-15)
 
 ## Scope
-Enhance the PLM UI panels for Where-Used / BOM Compare / Substitutes so they are more resilient to payload shape differences and more searchable when compare payloads omit child fields.
+Enhance the PLM UI panels for Where-Used / BOM Compare / Substitutes so they are more resilient to payload shape differences, more searchable when compare payloads omit child fields, and easier to navigate in tree view.
 
 ## Changes
 - `apps/web/src/views/PlmProductView.vue`
@@ -15,12 +15,16 @@ Enhance the PLM UI panels for Where-Used / BOM Compare / Substitutes so they are
     - path nodes (`path[].id/item_number/name/...`)
     - line props (`find_num`, `refdes`, `quantity`, `uom`)
     - this keeps filtering effective even when `include_child_fields=false`.
+  - Where-Used tree view supports expand/collapse per node and expand/collapse all controls.
+  - BOM Compare changed rows now get severity-tinted row backgrounds for faster scanning.
 
 ## Why
 - Yuantus BOM compare payloads can return data in `line`, `properties`, or `relationship.properties`; UI should not lose fields depending on mode.
 - Changed entries carry `before_line`/`after_line`, which we now surface in effectivity/substitute fields for quick inspection.
 - When child fields are excluded, only `path` remains; filtering by path keeps search usable.
+- Tree view expands rapidly on deep BOMs; collapse controls make navigation manageable.
+- Severity shading reduces time spent scanning changed rows.
 
 ## Verification
-- BOM tools seed (Yuantus @ 7911): `artifacts/plm-bom-tools-20260115_2201.md`
-- UI regression (item number + bom tools): `docs/verification-plm-ui-regression-20260115_220146.md`
+- BOM tools seed (Yuantus @ 7911): `artifacts/plm-bom-tools-20260115_2229.md`
+- UI regression (tree/compare UI): `docs/verification-plm-ui-regression-20260115_222941.md`

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -154,6 +154,8 @@ Entry points:
   - Artifact: `artifacts/plm-bom-tools-20260110_170622.json`
   - Report: `artifacts/plm-bom-tools-20260115_2201.md`
   - Artifact: `artifacts/plm-bom-tools-20260115_2201.json`
+  - Report: `artifacts/plm-bom-tools-20260115_2229.md`
+  - Artifact: `artifacts/plm-bom-tools-20260115_2229.json`
 - PLM UI BOM tools:
   - Report: `docs/verification-plm-ui-bom-tools-20260105_175018.md`
   - Artifact: `artifacts/plm-ui-bom-tools-20260105_175018.png`
@@ -239,6 +241,8 @@ Entry points:
   - Artifact: `artifacts/plm-ui-regression-20260115_212143.png`
   - Report: `docs/verification-plm-ui-regression-20260115_220146.md`
   - Artifact: `artifacts/plm-ui-regression-20260115_220146.png`
+  - Report: `docs/verification-plm-ui-regression-20260115_222941.md`
+  - Artifact: `artifacts/plm-ui-regression-20260115_222941.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`

--- a/docs/verification-plm-ui-regression-20260115_222941.md
+++ b/docs/verification-plm-ui-regression-20260115_222941.md
@@ -1,0 +1,39 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260115_222941
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7790
+- PLM: http://127.0.0.1:7911
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260115_2229.json
+
+## Data
+- Search query: UI-CMP-A-1768487371
+- Product ID: 2821019e-11f9-454b-90ad-dd3dba82fdb1
+- Where-used child ID: 61d33aa8-9890-4eca-8241-58623dcc23ff
+- Where-used expect: R1,R2
+- BOM compare left/right: 2821019e-11f9-454b-90ad-dd3dba82fdb1 / b22453b2-0014-408f-99d8-410d49b10a7e
+- BOM compare expect: UI Child Z
+- Substitute BOM line: d101bdfb-7822-4bb8-afa7-2b812173b48e
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768487371.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768487371
+- Approval product number: UI-CMP-A-1768487371
+- Item number-only load: UI-CMP-A-1768487371
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260115_222941.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260115_222941.json

--- a/docs/verification-summary-2026-01-15.md
+++ b/docs/verification-summary-2026-01-15.md
@@ -20,8 +20,11 @@
 - PLM UI regression (item number load): `docs/verification-plm-ui-regression-20260115_212143.md`
 - PLM BOM tools seed: `artifacts/plm-bom-tools-20260115_2201.md`
 - PLM UI regression (bom tools refresh): `docs/verification-plm-ui-regression-20260115_220146.md`
+- PLM BOM tools seed: `artifacts/plm-bom-tools-20260115_2229.md`
+- PLM UI regression (tree/compare UI): `docs/verification-plm-ui-regression-20260115_222941.md`
 
 ## Environment Notes
 - Yuantus PLM ran on `http://127.0.0.1:7910` (earlier) and `http://127.0.0.1:7911` (latest).
+- Latest UI regression used MetaSheet API `http://127.0.0.1:7790`.
 - MetaSheet API ran on `http://127.0.0.1:7788` and UI on `http://127.0.0.1:8899`.
 - `PLM_URL` set to the same base to avoid stale defaults.


### PR DESCRIPTION
## Summary\n- add collapse/expand controls for where-used tree view\n- add severity row tinting for BOM compare changed entries\n- refresh UI regression report and verification index/summary\n\n## Testing\n- bash scripts/verify-plm-bom-tools.sh (API_BASE=7790, PLM=7911)\n- bash scripts/verify-plm-ui-regression.sh (API_BASE=7790, PLM=7911)