### PR TITLE
PLM UI: expand product mapping fallbacks

### DIFF
--- a/apps/web/src/views/PlmProductView.vue
+++ b/apps/web/src/views/PlmProductView.vue
@@ -62,7 +62,7 @@
         <tbody>
           <tr v-for="item in searchResults" :key="item.id">
             <td>{{ item.name || '-' }}</td>
-            <td>{{ item.partNumber || item.code || '-' }}</td>
+            <td>{{ item.partNumber || item.item_number || item.itemNumber || item.code || '-' }}</td>
             <td>{{ item.status || '-' }}</td>
             <td>{{ item.itemType || '-' }}</td>
             <td>{{ item.updatedAt || item.updated_at || '-' }}</td>
@@ -1761,6 +1761,8 @@ const productView = computed(() => {
   const props = data.properties || {}
   const name =
     data.name ||
+    data.item_name ||
+    data.title ||
     props.name ||
     props.item_name ||
     props.title ||
@@ -1769,6 +1771,8 @@ const productView = computed(() => {
     '-'
   const partNumber =
     data.partNumber ||
+    data.item_number ||
+    data.itemNumber ||
     data.code ||
     props.item_number ||
     props.part_number ||
@@ -1779,6 +1783,7 @@ const productView = computed(() => {
   const revision =
     data.revision ||
     data.version ||
+    data.version_label ||
     props.revision ||
     props.version ||
     props.rev ||
@@ -1786,21 +1791,28 @@ const productView = computed(() => {
     '-'
   const status =
     data.status ||
+    data.state ||
+    data.current_state ||
     props.state ||
+    props.current_state ||
     props.status ||
     props.lifecycle_state ||
     '-'
   const itemType =
     data.itemType ||
+    data.item_type_id ||
+    data.item_type ||
     data.type ||
     props.item_type ||
     props.itemType ||
+    props.item_type_id ||
     props.type ||
     DEFAULT_ITEM_TYPE
   const description = data.description || props.description || props.desc || ''
   const createdAt =
     data.createdAt ||
     data.created_at ||
+    data.created_on ||
     props.created_at ||
     props.created_on ||
     props.create_date ||
@@ -1808,6 +1820,7 @@ const productView = computed(() => {
   const updatedAt =
     data.updatedAt ||
     data.updated_at ||
+    data.modified_on ||
     props.updated_at ||
     props.modified_on ||
     props.write_date ||
@@ -2101,43 +2114,43 @@ const productFieldCatalog = [
   {
     key: 'name',
     label: '名称',
-    source: 'name / properties.name / properties.item_name / properties.title',
+    source: 'name / item_name / title / properties.name / properties.item_name / properties.title / properties.label',
     fallback: 'id',
   },
   {
     key: 'partNumber',
     label: '料号',
-    source: 'partNumber / item_number / part_number / number / code',
+    source: 'partNumber / item_number / itemNumber / part_number / number / code / properties.item_number',
     fallback: 'properties.internal_reference',
   },
   {
     key: 'revision',
     label: '版本',
-    source: 'revision / version / properties.revision / properties.version / properties.version_label',
+    source: 'revision / version / version_label / properties.revision / properties.version / properties.version_label',
     fallback: '-',
   },
   {
     key: 'status',
     label: '状态',
-    source: 'status / state / properties.state / properties.status',
+    source: 'status / state / current_state / properties.state / properties.current_state / properties.status',
     fallback: '-',
   },
   {
     key: 'itemType',
     label: '类型',
-    source: 'itemType / item.type / properties.item_type',
+    source: 'itemType / item_type_id / item_type / type / properties.item_type / properties.itemType / properties.item_type_id',
     fallback: 'Part',
   },
   {
     key: 'createdAt',
     label: '创建时间',
-    source: 'created_at / created_on / properties.created_at / properties.created_on',
+    source: 'createdAt / created_at / created_on / properties.created_at / properties.created_on / properties.create_date',
     fallback: 'search hit created_at',
   },
   {
     key: 'updatedAt',
     label: '更新时间',
-    source: 'updated_at / modified_on / properties.updated_at / properties.modified_on',
+    source: 'updatedAt / updated_at / modified_on / properties.updated_at / properties.modified_on',
     fallback: 'search hit updated_at',
   },
 ]
@@ -2790,7 +2803,7 @@ async function searchProducts() {
 async function applySearchItem(item: any) {
   if (!item?.id) return
   productId.value = item.id
-  productItemNumber.value = item.partNumber || item.code || ''
+  productItemNumber.value = item.partNumber || item.item_number || item.itemNumber || item.code || ''
   if (item.itemType) {
     itemType.value = item.itemType
   }
@@ -2799,7 +2812,7 @@ async function applySearchItem(item: any) {
 
 function applyCompareFromSearch(item: any, side: 'left' | 'right') {
   const targetId = item?.id || item?.item_id || item?.itemId
-  const targetNumber = item?.partNumber || item?.item_number || item?.code || ''
+  const targetNumber = item?.partNumber || item?.item_number || item?.itemNumber || item?.code || ''
   if (!targetId && !targetNumber) {
     setDeepLinkMessage('搜索结果缺少 ID', true)
     return
@@ -2818,7 +2831,7 @@ function applyCompareFromSearch(item: any, side: 'left' | 'right') {
 
 async function copySearchValue(item: any, kind: 'id' | 'number') {
   const idValue = item?.id || item?.item_id || item?.itemId
-  const numberValue = item?.partNumber || item?.item_number || item?.code || ''
+  const numberValue = item?.partNumber || item?.item_number || item?.itemNumber || item?.code || ''
   const value = kind === 'id' ? idValue : numberValue
   if (!value) {
     setDeepLinkMessage(kind === 'id' ? '缺少 ID' : '缺少料号', true)

--- a/docs/PLM_UI_PRODUCT_MAPPING_ENHANCEMENT_REPORT.md
+++ b/docs/PLM_UI_PRODUCT_MAPPING_ENHANCEMENT_REPORT.md
@@ -1,0 +1,19 @@
+# PLM UI Product Mapping Enhancement Report
+
+## Goal
+Harden the PLM UI product detail and search flows against Yuantus item payload variations (item_number, item_type_id, created_on/modified_on, etc.).
+
+## Changes
+- `apps/web/src/views/PlmProductView.vue`
+  - Product detail mapping now recognizes `item_name`, `title`, `item_number`, `version_label`, `state/current_state`, `item_type_id/item_type`, and `created_on/modified_on`.
+  - Search table and actions now use `item_number`/`itemNumber` when present.
+  - Field mapping catalog updated to reflect the expanded fallback keys.
+
+## Behavior
+- Loading a product now prefers richer Yuantus fields when available and falls back safely when not.
+- Searching by item number surfaces the same identifier in the table and copy actions.
+
+## Verification
+- UI regression run: `docs/verification-plm-ui-regression-20260115_231459.md`
+- Screenshot: `artifacts/plm-ui-regression-20260115_231459.png`
+- Item-number artifact: `artifacts/plm-ui-regression-item-number-20260115_231459.json`

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -243,6 +243,11 @@ Entry points:
   - Artifact: `artifacts/plm-ui-regression-20260115_220146.png`
   - Report: `docs/verification-plm-ui-regression-20260115_222941.md`
   - Artifact: `artifacts/plm-ui-regression-20260115_222941.png`
+  - Report: `docs/verification-plm-ui-regression-20260115_230030.md`
+  - Artifact: `artifacts/plm-ui-regression-20260115_230030.png`
+  - Report: `docs/verification-plm-ui-regression-20260115_231459.md`
+  - Artifact: `artifacts/plm-ui-regression-20260115_231459.png`
+  - Artifact: `artifacts/plm-ui-regression-item-number-20260115_231459.json`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`

--- a/docs/verification-plm-ui-regression-20260115_230030.md
+++ b/docs/verification-plm-ui-regression-20260115_230030.md
@@ -1,0 +1,39 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260115_230030
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7790
+- PLM: http://127.0.0.1:7911
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260115_2229.json
+
+## Data
+- Search query: UI-CMP-A-1768487371
+- Product ID: 2821019e-11f9-454b-90ad-dd3dba82fdb1
+- Where-used child ID: 61d33aa8-9890-4eca-8241-58623dcc23ff
+- Where-used expect: R1,R2
+- BOM compare left/right: 2821019e-11f9-454b-90ad-dd3dba82fdb1 / b22453b2-0014-408f-99d8-410d49b10a7e
+- BOM compare expect: UI Child Z
+- Substitute BOM line: d101bdfb-7822-4bb8-afa7-2b812173b48e
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768487371.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768487371
+- Approval product number: UI-CMP-A-1768487371
+- Item number-only load: UI-CMP-A-1768487371
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260115_230030.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260115_230030.json

--- a/docs/verification-plm-ui-regression-20260115_231459.md
+++ b/docs/verification-plm-ui-regression-20260115_231459.md
@@ -1,0 +1,39 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260115_231459
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7790
+- PLM: http://127.0.0.1:7911
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260115_2229.json
+
+## Data
+- Search query: UI-CMP-A-1768487371
+- Product ID: 2821019e-11f9-454b-90ad-dd3dba82fdb1
+- Where-used child ID: 61d33aa8-9890-4eca-8241-58623dcc23ff
+- Where-used expect: R1,R2
+- BOM compare left/right: 2821019e-11f9-454b-90ad-dd3dba82fdb1 / b22453b2-0014-408f-99d8-410d49b10a7e
+- BOM compare expect: UI Child Z
+- Substitute BOM line: d101bdfb-7822-4bb8-afa7-2b812173b48e
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768487371.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768487371
+- Approval product number: UI-CMP-A-1768487371
+- Item number-only load: UI-CMP-A-1768487371
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260115_231459.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260115_231459.json

--- a/docs/verification-summary-2026-01-15.md
+++ b/docs/verification-summary-2026-01-15.md
@@ -22,6 +22,8 @@
 - PLM UI regression (bom tools refresh): `docs/verification-plm-ui-regression-20260115_220146.md`
 - PLM BOM tools seed: `artifacts/plm-bom-tools-20260115_2229.md`
 - PLM UI regression (tree/compare UI): `docs/verification-plm-ui-regression-20260115_222941.md`
+- PLM UI regression: `docs/verification-plm-ui-regression-20260115_230030.md`
+- PLM UI regression (product mapping fallback): `docs/verification-plm-ui-regression-20260115_231459.md`
 
 ## Environment Notes
 - Yuantus PLM ran on `http://127.0.0.1:7910` (earlier) and `http://127.0.0.1:7911` (latest).


### PR DESCRIPTION
## Summary\n- Expand product detail fallbacks for Yuantus item fields (item_name/title/item_number/version_label/state/current_state/item_type_id/created_on/modified_on).\n- Use item_number in search table and copy actions.\n- Update product field mapping catalog and add mapping report.\n\n## Testing\n- API_BASE=http://127.0.0.1:7790 WEB_BASE=http://127.0.0.1:8899 PLM_BASE_URL=http://127.0.0.1:7911 PLM_URL=http://127.0.0.1:7911 AUTO_START=true bash scripts/verify-plm-ui-regression.sh (docs/verification-plm-ui-regression-20260115_231459.md)