### PR TITLE
Add PLM product detail copy actions

### DIFF
--- a/apps/web/src/views/PlmProductView.vue
+++ b/apps/web/src/views/PlmProductView.vue
@@ -279,6 +279,10 @@
 
       <div v-if="product" class="detail-grid">
         <div>
+          <span>ID</span>
+          <strong class="mono">{{ productView.id || '-' }}</strong>
+        </div>
+        <div>
           <span>名称</span>
           <strong>{{ productView.name }}</strong>
         </div>
@@ -306,6 +310,21 @@
           <span>创建时间</span>
           <strong>{{ formatTime(productView.createdAt) }}</strong>
         </div>
+      </div>
+      <div v-if="product" class="inline-actions">
+        <button class="btn ghost mini" :disabled="!hasProductCopyValue('id')" @click="copyProductField('id')">
+          复制 ID
+        </button>
+        <button class="btn ghost mini" :disabled="!hasProductCopyValue('number')" @click="copyProductField('number')">
+          复制料号
+        </button>
+        <button
+          class="btn ghost mini"
+          :disabled="!hasProductCopyValue('revision')"
+          @click="copyProductField('revision')"
+        >
+          复制版本
+        </button>
       </div>
       <div v-else class="empty">
         暂无产品详情
@@ -2886,6 +2905,44 @@ async function copySearchValue(item: any, kind: 'id' | 'number') {
     return
   }
   setDeepLinkMessage(`已复制${kind === 'id' ? ' ID' : '料号'}：${value}`)
+}
+
+type ProductCopyKind = 'id' | 'number' | 'revision'
+
+function normalizeProductCopyValue(value?: string): string {
+  if (!value) return ''
+  if (value === '-') return ''
+  return value
+}
+
+function getProductCopyValue(kind: ProductCopyKind): string {
+  if (kind === 'id') {
+    return normalizeProductCopyValue(productView.value.id || productId.value)
+  }
+  if (kind === 'number') {
+    return normalizeProductCopyValue(productView.value.partNumber)
+  }
+  return normalizeProductCopyValue(productView.value.revision)
+}
+
+function hasProductCopyValue(kind: ProductCopyKind): boolean {
+  return Boolean(getProductCopyValue(kind))
+}
+
+async function copyProductField(kind: ProductCopyKind) {
+  const value = getProductCopyValue(kind)
+  if (!value) {
+    const label = kind === 'id' ? 'ID' : kind === 'number' ? '料号' : '版本'
+    setDeepLinkMessage(`产品缺少${label}`, true)
+    return
+  }
+  const ok = await copyToClipboard(value)
+  if (!ok) {
+    setDeepLinkMessage('复制失败，请手动复制', true)
+    return
+  }
+  const label = kind === 'id' ? 'ID' : kind === 'number' ? '料号' : '版本'
+  setDeepLinkMessage(`已复制产品 ${label}：${value}`)
 }
 
 async function loadProduct() {

--- a/docs/PLM_UI_BOM_CHILD_ACTIONS_REPORT.md
+++ b/docs/PLM_UI_BOM_CHILD_ACTIONS_REPORT.md
@@ -16,5 +16,5 @@ Expose quick actions on BOM rows to jump to child products or copy child identif
 - "复制子件" copies the child ID if available, otherwise copies the child item number.
 
 ## Verification
-- UI regression: `docs/verification-plm-ui-regression-20260116_135254.md`
-- Screenshot: `artifacts/plm-ui-regression-20260116_135254.png`
+- UI regression: `docs/verification-plm-ui-regression-20260116_141451.md`
+- Screenshot: `artifacts/plm-ui-regression-20260116_141451.png`

--- a/docs/PLM_UI_PRODUCT_DETAIL_ACTIONS_REPORT.md
+++ b/docs/PLM_UI_PRODUCT_DETAIL_ACTIONS_REPORT.md
@@ -1,0 +1,20 @@
+# PLM UI Product Detail Actions Report
+
+## Goal
+Add quick copy actions for product ID, item number, and revision in the PLM product detail panel.
+
+## Changes
+- `apps/web/src/views/PlmProductView.vue`
+  - Added product ID row to the detail grid.
+  - Added copy buttons for product ID/number/revision.
+  - New helper methods to normalize and copy product values.
+- `scripts/verify-plm-ui-regression.sh`
+  - Added assertions for product detail copy actions.
+
+## Behavior
+- Copy buttons are disabled if the target value is missing (`-`).
+- Copy feedback surfaces via the shared status banner.
+
+## Verification
+- UI regression: `docs/verification-plm-ui-regression-20260116_141451.md`
+- Screenshot: `artifacts/plm-ui-regression-20260116_141451.png`

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -267,6 +267,11 @@ Entry points:
   - Report: `docs/verification-plm-ui-regression-20260116_135254.md`
   - Artifact: `artifacts/plm-ui-regression-20260116_135254.png`
   - Artifact: `artifacts/plm-ui-regression-item-number-20260116_135254.json`
+  - Report: `docs/verification-plm-ui-regression-20260116_141451.md`
+  - Artifact: `artifacts/plm-ui-regression-20260116_141451.png`
+  - Artifact: `artifacts/plm-ui-regression-item-number-20260116_141451.json`
+  - Report: `docs/verification-plm-ui-regression-20260116_141451.md`
+  - Artifact: `artifacts/plm-ui-regression-20260116_141451.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`

--- a/docs/verification-plm-ui-regression-20260116_141451.md
+++ b/docs/verification-plm-ui-regression-20260116_141451.md
@@ -1,0 +1,42 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260116_141451
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7778
+- PLM: http://127.0.0.1:7911
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260116_1352.json
+
+## Data
+- Search query: UI-CMP-A-1768542747
+- Product ID: 10352210-f0ec-4165-8fa1-ebdf5fbca7fc
+- Where-used child ID: d66faff1-2ae3-4160-b622-87d8d2dafa66
+- Where-used expect: R1,R2
+- BOM child ID: d66faff1-2ae3-4160-b622-87d8d2dafa66
+- BOM compare left/right: 10352210-f0ec-4165-8fa1-ebdf5fbca7fc / 458a8329-fb41-4285-8d9c-a5044dbd06c6
+- BOM compare expect: UI Child Z
+- Substitute BOM line: 29dbf8a9-2e2b-41ed-9efe-ca78abf5ed55
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768542747.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768542747
+- Approval product number: UI-CMP-A-1768542747
+- Item number-only load: UI-CMP-A-1768542747
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Product detail copy actions executed.
+- BOM child actions executed (copy + switch).
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260116_141451.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260116_141451.json

--- a/docs/verification-summary-2026-01-16.md
+++ b/docs/verification-summary-2026-01-16.md
@@ -5,7 +5,7 @@
 - PLM UI regression: `docs/verification-plm-ui-regression-20260116_101817.md`
 - PLM UI full regression: `docs/verification-plm-ui-full-20260116_101817.md`
 - PLM UI regression (docs/approvals actions): `docs/verification-plm-ui-regression-20260116_113652.md`
-- PLM UI regression (BOM child actions): `docs/verification-plm-ui-regression-20260116_135254.md`
+- PLM UI regression (product detail + BOM child actions): `docs/verification-plm-ui-regression-20260116_141451.md`
 
 ## Environment Notes
 - MetaSheet API: `http://127.0.0.1:7790`

--- a/scripts/verify-plm-ui-regression.sh
+++ b/scripts/verify-plm-ui-regression.sh
@@ -388,6 +388,22 @@ async function waitOptional(scope, text) {
   }, null, { timeout: 60000 });
   await waitOptional(detailSection, itemNumberValue);
 
+  const copyIdButton = detailSection.locator('button:has-text("复制 ID")');
+  await copyIdButton.click();
+  await detailSection.getByText('已复制产品 ID', { exact: false }).waitFor({ timeout: 60000 });
+
+  const copyNumberButton = detailSection.locator('button:has-text("复制料号")');
+  await copyNumberButton.click();
+  await detailSection.getByText('已复制产品 料号', { exact: false }).waitFor({ timeout: 60000 });
+
+  const copyRevisionButton = detailSection.locator('button:has-text("复制版本")');
+  if (await copyRevisionButton.isEnabled()) {
+    await copyRevisionButton.click();
+    await detailSection.getByText('已复制产品 版本', { exact: false }).waitFor({ timeout: 60000 });
+  } else {
+    console.warn('Skipping product revision copy; revision not available.');
+  }
+
   const bomSection = page.locator('section:has-text("BOM 结构")');
   const bomRows = bomSection.locator('table tbody tr');
   await bomRows.first().waitFor({ timeout: 60000 });
@@ -553,6 +569,7 @@ Verify the end-to-end PLM UI flow: search -> select -> load product -> where-use
 ## Results
 - Search returns matching row and selection loads product detail.
 - Item number-only load repopulates Product ID.
+- Product detail copy actions executed.
 - ${BOM_CHILD_RESULT}
 - Where-used query completes.
 - BOM compare completes.


### PR DESCRIPTION
## Summary
- add product detail ID/number/revision copy actions and display the product id
- extend PLM UI regression to cover product copy actions
- update verification docs for the latest regression run

## Testing
- AUTO_START=true PLM_BASE_URL=http://127.0.0.1:7911 scripts/verify-plm-ui-regression.sh