### PR TITLE
Add product type/status copy actions

### DIFF
--- a/apps/web/src/views/PlmProductView.vue
+++ b/apps/web/src/views/PlmProductView.vue
@@ -325,6 +325,12 @@
         >
           复制版本
         </button>
+        <button class="btn ghost mini" :disabled="!hasProductCopyValue('type')" @click="copyProductField('type')">
+          复制类型
+        </button>
+        <button class="btn ghost mini" :disabled="!hasProductCopyValue('status')" @click="copyProductField('status')">
+          复制状态
+        </button>
       </div>
       <div v-else class="empty">
         暂无产品详情
@@ -2907,7 +2913,7 @@ async function copySearchValue(item: any, kind: 'id' | 'number') {
   setDeepLinkMessage(`已复制${kind === 'id' ? ' ID' : '料号'}：${value}`)
 }
 
-type ProductCopyKind = 'id' | 'number' | 'revision'
+type ProductCopyKind = 'id' | 'number' | 'revision' | 'type' | 'status'
 
 function normalizeProductCopyValue(value?: string): string {
   if (!value) return ''
@@ -2922,6 +2928,12 @@ function getProductCopyValue(kind: ProductCopyKind): string {
   if (kind === 'number') {
     return normalizeProductCopyValue(productView.value.partNumber)
   }
+  if (kind === 'type') {
+    return normalizeProductCopyValue(productView.value.itemType)
+  }
+  if (kind === 'status') {
+    return normalizeProductCopyValue(productView.value.status)
+  }
   return normalizeProductCopyValue(productView.value.revision)
 }
 
@@ -2932,7 +2944,16 @@ function hasProductCopyValue(kind: ProductCopyKind): boolean {
 async function copyProductField(kind: ProductCopyKind) {
   const value = getProductCopyValue(kind)
   if (!value) {
-    const label = kind === 'id' ? 'ID' : kind === 'number' ? '料号' : '版本'
+    const label =
+      kind === 'id'
+        ? 'ID'
+        : kind === 'number'
+          ? '料号'
+          : kind === 'revision'
+            ? '版本'
+            : kind === 'type'
+              ? '类型'
+              : '状态'
     setDeepLinkMessage(`产品缺少${label}`, true)
     return
   }
@@ -2941,7 +2962,16 @@ async function copyProductField(kind: ProductCopyKind) {
     setDeepLinkMessage('复制失败，请手动复制', true)
     return
   }
-  const label = kind === 'id' ? 'ID' : kind === 'number' ? '料号' : '版本'
+  const label =
+    kind === 'id'
+      ? 'ID'
+      : kind === 'number'
+        ? '料号'
+        : kind === 'revision'
+          ? '版本'
+          : kind === 'type'
+            ? '类型'
+            : '状态'
   setDeepLinkMessage(`已复制产品 ${label}：${value}`)
 }
 

--- a/docs/PLM_UI_PRODUCT_DETAIL_ACTIONS_REPORT.md
+++ b/docs/PLM_UI_PRODUCT_DETAIL_ACTIONS_REPORT.md
@@ -1,12 +1,12 @@
 # PLM UI Product Detail Actions Report
 
 ## Goal
-Add quick copy actions for product ID, item number, and revision in the PLM product detail panel.
+Add quick copy actions for product ID, item number, revision, type, and status in the PLM product detail panel.
 
 ## Changes
 - `apps/web/src/views/PlmProductView.vue`
   - Added product ID row to the detail grid.
-  - Added copy buttons for product ID/number/revision.
+  - Added copy buttons for product ID/number/revision/type/status.
   - New helper methods to normalize and copy product values.
 - `scripts/verify-plm-ui-regression.sh`
   - Added assertions for product detail copy actions.
@@ -16,5 +16,5 @@ Add quick copy actions for product ID, item number, and revision in the PLM prod
 - Copy feedback surfaces via the shared status banner.
 
 ## Verification
-- UI regression: `docs/verification-plm-ui-regression-20260116_143745.md`
-- Screenshot: `artifacts/plm-ui-regression-20260116_143745.png`
+- UI regression: `docs/verification-plm-ui-regression-20260116_150725.md`
+- Screenshot: `artifacts/plm-ui-regression-20260116_150725.png`

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -277,6 +277,8 @@ Entry points:
   - Report: `docs/verification-plm-ui-regression-20260116_143745.md`
   - Artifact: `artifacts/plm-ui-regression-20260116_143745.png`
   - Artifact: `artifacts/plm-ui-regression-item-number-20260116_143745.json`
+  - Report: `docs/verification-plm-ui-regression-20260116_150725.md`
+  - Artifact: `artifacts/plm-ui-regression-20260116_150725.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`

--- a/docs/verification-plm-ui-regression-20260116_150725.md
+++ b/docs/verification-plm-ui-regression-20260116_150725.md
@@ -1,0 +1,42 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260116_150725
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7778
+- PLM: http://127.0.0.1:7911
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260116_143745.json
+
+## Data
+- Search query: UI-CMP-A-1768545467
+- Product ID: dfd8c53a-92eb-4925-b047-fea7711ab17e
+- Where-used child ID: e2d059ab-94fb-4fe9-a8a4-a5fec477c9da
+- Where-used expect: R1,R2
+- BOM child ID: e2d059ab-94fb-4fe9-a8a4-a5fec477c9da
+- BOM compare left/right: dfd8c53a-92eb-4925-b047-fea7711ab17e / 37b7152b-3253-4600-8b66-8ff7fc9afa4f
+- BOM compare expect: UI Child Z
+- Substitute BOM line: e3278e2c-40f9-4f14-ab58-daed732b0a54
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768545467.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768545467
+- Approval product number: UI-CMP-A-1768545467
+- Item number-only load: UI-CMP-A-1768545467
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Product detail copy actions executed.
+- BOM child actions executed (copy + switch).
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260116_150725.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260116_150725.json

--- a/docs/verification-summary-2026-01-16.md
+++ b/docs/verification-summary-2026-01-16.md
@@ -2,10 +2,10 @@
 
 ## Completed
 - PLM BOM tools seed: `artifacts/plm-bom-tools-20260116_143745.md`
-- PLM UI regression: `docs/verification-plm-ui-regression-20260116_143745.md`
+- PLM UI regression: `docs/verification-plm-ui-regression-20260116_150725.md`
 - PLM UI full regression: `docs/verification-plm-ui-full-20260116_143745.md`
 - PLM UI regression (docs/approvals actions): `docs/verification-plm-ui-regression-20260116_113652.md`
-- PLM UI regression (product detail + BOM child actions): `docs/verification-plm-ui-regression-20260116_143745.md`
+- PLM UI regression (product detail + BOM child actions): `docs/verification-plm-ui-regression-20260116_150725.md`
 
 ## Environment Notes
 - MetaSheet API: `http://127.0.0.1:7790`

--- a/scripts/verify-plm-ui-regression.sh
+++ b/scripts/verify-plm-ui-regression.sh
@@ -404,6 +404,22 @@ async function waitOptional(scope, text) {
     console.warn('Skipping product revision copy; revision not available.');
   }
 
+  const copyTypeButton = detailSection.locator('button:has-text("复制类型")');
+  if (await copyTypeButton.isEnabled()) {
+    await copyTypeButton.click();
+    await detailSection.getByText('已复制产品 类型', { exact: false }).waitFor({ timeout: 60000 });
+  } else {
+    console.warn('Skipping product type copy; type not available.');
+  }
+
+  const copyStatusButton = detailSection.locator('button:has-text("复制状态")');
+  if (await copyStatusButton.isEnabled()) {
+    await copyStatusButton.click();
+    await detailSection.getByText('已复制产品 状态', { exact: false }).waitFor({ timeout: 60000 });
+  } else {
+    console.warn('Skipping product status copy; status not available.');
+  }
+
   const bomSection = page.locator('section:has-text("BOM 结构")');
   const bomRows = bomSection.locator('table tbody tr');
   await bomRows.first().waitFor({ timeout: 60000 });


### PR DESCRIPTION
## Summary
- add copy actions for product type/status in PLM product detail
- extend PLM UI regression to validate the new copy actions
- update product detail actions report + verification index/summary

## Testing
- AUTO_START=true PLM_BASE_URL=http://127.0.0.1:7911 scripts/verify-plm-ui-regression.sh