### PR TITLE
Require BOM child id in PLM UI regression

### DIFF
--- a/docs/PLM_UI_BOM_CHILD_ACTIONS_REPORT.md
+++ b/docs/PLM_UI_BOM_CHILD_ACTIONS_REPORT.md
@@ -16,5 +16,5 @@ Expose quick actions on BOM rows to jump to child products or copy child identif
 - "复制子件" copies the child ID if available, otherwise copies the child item number.
 
 ## Verification
-- UI regression: `docs/verification-plm-ui-regression-20260116_143745.md`
-- Screenshot: `artifacts/plm-ui-regression-20260116_143745.png`
+- UI regression: `docs/verification-plm-ui-regression-20260116_151519.md`
+- Screenshot: `artifacts/plm-ui-regression-20260116_151519.png`

--- a/docs/PLM_UI_PRODUCT_DETAIL_ACTIONS_REPORT.md
+++ b/docs/PLM_UI_PRODUCT_DETAIL_ACTIONS_REPORT.md
@@ -16,5 +16,5 @@ Add quick copy actions for product ID, item number, revision, type, and status i
 - Copy feedback surfaces via the shared status banner.
 
 ## Verification
-- UI regression: `docs/verification-plm-ui-regression-20260116_150725.md`
-- Screenshot: `artifacts/plm-ui-regression-20260116_150725.png`
+- UI regression: `docs/verification-plm-ui-regression-20260116_151519.md`
+- Screenshot: `artifacts/plm-ui-regression-20260116_151519.png`

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -279,6 +279,8 @@ Entry points:
   - Artifact: `artifacts/plm-ui-regression-item-number-20260116_143745.json`
   - Report: `docs/verification-plm-ui-regression-20260116_150725.md`
   - Artifact: `artifacts/plm-ui-regression-20260116_150725.png`
+  - Report: `docs/verification-plm-ui-regression-20260116_151519.md`
+  - Artifact: `artifacts/plm-ui-regression-20260116_151519.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`

--- a/docs/verification-plm-ui-regression-20260116_151519.md
+++ b/docs/verification-plm-ui-regression-20260116_151519.md
@@ -1,0 +1,42 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260116_151519
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7778
+- PLM: http://127.0.0.1:7911
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260116_143745.json
+
+## Data
+- Search query: UI-CMP-A-1768545467
+- Product ID: dfd8c53a-92eb-4925-b047-fea7711ab17e
+- Where-used child ID: e2d059ab-94fb-4fe9-a8a4-a5fec477c9da
+- Where-used expect: R1,R2
+- BOM child ID: e2d059ab-94fb-4fe9-a8a4-a5fec477c9da
+- BOM compare left/right: dfd8c53a-92eb-4925-b047-fea7711ab17e / 37b7152b-3253-4600-8b66-8ff7fc9afa4f
+- BOM compare expect: UI Child Z
+- Substitute BOM line: e3278e2c-40f9-4f14-ab58-daed732b0a54
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768545467.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768545467
+- Approval product number: UI-CMP-A-1768545467
+- Item number-only load: UI-CMP-A-1768545467
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Product detail copy actions executed.
+- BOM child actions executed (copy + switch).
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata.
+- Approvals table loads with expected approval record.
+- Screenshot: artifacts/plm-ui-regression-20260116_151519.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260116_151519.json

--- a/docs/verification-summary-2026-01-16.md
+++ b/docs/verification-summary-2026-01-16.md
@@ -2,10 +2,10 @@
 
 ## Completed
 - PLM BOM tools seed: `artifacts/plm-bom-tools-20260116_143745.md`
-- PLM UI regression: `docs/verification-plm-ui-regression-20260116_150725.md`
+- PLM UI regression: `docs/verification-plm-ui-regression-20260116_151519.md`
 - PLM UI full regression: `docs/verification-plm-ui-full-20260116_143745.md`
 - PLM UI regression (docs/approvals actions): `docs/verification-plm-ui-regression-20260116_113652.md`
-- PLM UI regression (product detail + BOM child actions): `docs/verification-plm-ui-regression-20260116_150725.md`
+- PLM UI regression (product detail + BOM child actions): `docs/verification-plm-ui-regression-20260116_151519.md`
 
 ## Environment Notes
 - MetaSheet API: `http://127.0.0.1:7790`

--- a/scripts/verify-plm-ui-regression.sh
+++ b/scripts/verify-plm-ui-regression.sh
@@ -428,12 +428,10 @@ async function waitOptional(scope, text) {
     const match = bomRows.filter({ hasText: bomChildId });
     if (await match.count()) {
       bomTargetRow = match.first();
-    } else {
-      console.warn(`BOM child ${bomChildId} not found, falling back to first row.`);
     }
   }
   if (!bomTargetRow) {
-    bomTargetRow = bomRows.first();
+    throw new Error(`BOM child ${bomChildId || '(missing)'} not found; aborting regression.`);
   }
   const childIdCell = bomTargetRow.locator('td').nth(1).locator('.muted.mono');
   let resolvedChildId = '';


### PR DESCRIPTION
## Summary
- make BOM child id a required regression assertion (no fallback row)
- refresh BOM child/product detail verification docs

## Testing
- AUTO_START=true PLM_BASE_URL=http://127.0.0.1:7911 scripts/verify-plm-ui-regression.sh