### PR TITLE
feat(attendance): seed permissions

### DIFF
--- a/docs/attendance-plugin-development-report.md
+++ b/docs/attendance-plugin-development-report.md
@@ -2,6 +2,10 @@
 
 Date: 2026-01-11
 
+## Update (2026-01-17)
+- Added migration `20260117090000_add_attendance_permissions.ts` to seed attendance RBAC permissions and grant them to the `admin` role.
+- Documented a minimal enablement checklist for plugin activation and RBAC setup.
+
 ## Update (2026-01-15)
 - Added migration `z20251231_create_system_configs.ts` so attendance settings persist in new databases.
 - Activated plugins during backend startup to register attendance routes at runtime.
@@ -17,6 +21,12 @@ Date: 2026-01-11
 
 ## Overview
 The attendance module has been finalized as an optional plugin with org-aware data handling, admin settings, CSV export, automated absence scheduling, and shift/holiday scheduling. Auto-absence now respects org membership through a `user_orgs` mapping plus shift assignments and holiday overrides. Frontend support surfaces org/user filters, admin controls, shift scheduling, and export actions only when the plugin is active. OpenAPI contracts and RBAC seed data were updated accordingly.
+
+## Enablement Checklist
+- Run migrations (ensure attendance and RBAC tables exist).
+- Start backend without `SKIP_PLUGINS=true` so `plugin-attendance` activates.
+- For local smoke tests, set `RBAC_BYPASS=true` or grant `attendance:*` permissions to users/roles.
+- Populate `user_orgs` for non-default orgs so auto-absence can compute attendance.
 
 ## Backend + Plugin Changes
 - Implemented org-aware attendance routes in `plugins/plugin-attendance/index.cjs` (punch, records, summary, requests, approvals, rules, settings, export).

--- a/docs/attendance-plugin-verification-report.md
+++ b/docs/attendance-plugin-verification-report.md
@@ -2,6 +2,28 @@
 
 Date: 2026-01-11
 
+## Update (2026-01-17)
+### Commands Executed
+- `if ! docker exec -i metasheet-dev-postgres psql -U metasheet -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='metasheet_attendance_module_verify'" | grep -q 1; then docker exec -i metasheet-dev-postgres psql -U metasheet -d postgres -c "CREATE DATABASE metasheet_attendance_module_verify"; fi`
+- `DB_QUERY_TIMEOUT=120000 DB_STATEMENT_TIMEOUT=120000 DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_attendance_module_verify pnpm --filter @metasheet/core-backend migrate`
+- `DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_attendance_module_verify pnpm --filter @metasheet/core-backend test:integration:attendance`
+
+### Results
+- Migrations succeeded on `metasheet_attendance_module_verify`, including `20260117090000_add_attendance_permissions`.
+- Attendance integration smoke test passed (1 test).
+- BPMN missing-table warnings appeared for `bpmn_process_definitions` but did not block the run.
+
+### Additional Commands Executed (Full Integration)
+- `DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_attendance_module_verify pnpm --filter @metasheet/core-backend test:integration`
+
+### Results (Full Integration)
+- Full `test:integration` failed due to existing suite issues not caused by attendance.
+- Missing deps: `socket.io-client` (kanban/rooms suites) and `supertest` (spreadsheet suite).
+- Plugin loader failures: `getFailedPlugins` missing and expectations around plugin load behavior.
+- Plugins API contract expects array response from `/api/plugins`.
+- Snapshot protection E2E fails because `snapshots.view_id` is null during inserts.
+- Comments/Kanban API tests failed with `Cannot read properties of undefined (reading 'status')` in fetch assertions.
+
 ## Update (2026-01-15)
 ### Commands Executed
 - `docker exec -i metasheet-dev-postgres psql -U metasheet -d postgres -c "DROP DATABASE IF EXISTS metasheet_attendance_verify;"`

--- a/packages/core-backend/src/db/migrations/20260117090000_add_attendance_permissions.ts
+++ b/packages/core-backend/src/db/migrations/20260117090000_add_attendance_permissions.ts
@@ -1,0 +1,83 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'permissions'
+      ) THEN
+        INSERT INTO permissions (code, name, description)
+        VALUES
+          ('attendance:read', 'Attendance Read', 'Read attendance records and summaries'),
+          ('attendance:write', 'Attendance Write', 'Create attendance punches and adjustment requests'),
+          ('attendance:approve', 'Attendance Approve', 'Approve or reject attendance adjustments'),
+          ('attendance:admin', 'Attendance Admin', 'Manage attendance rules, settings, and schedules')
+        ON CONFLICT (code) DO NOTHING;
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'role_permissions'
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'permissions'
+      ) THEN
+        INSERT INTO role_permissions (role_id, permission_code)
+        VALUES
+          ('admin', 'attendance:read'),
+          ('admin', 'attendance:write'),
+          ('admin', 'attendance:approve'),
+          ('admin', 'attendance:admin')
+        ON CONFLICT DO NOTHING;
+      END IF;
+    END $$;
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'role_permissions'
+      ) THEN
+        DELETE FROM role_permissions
+        WHERE permission_code IN (
+          'attendance:read',
+          'attendance:write',
+          'attendance:approve',
+          'attendance:admin'
+        );
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'permissions'
+      ) THEN
+        DELETE FROM permissions
+        WHERE code IN (
+          'attendance:read',
+          'attendance:write',
+          'attendance:approve',
+          'attendance:admin'
+        );
+      END IF;
+    END $$;
+  `.execute(db)
+}


### PR DESCRIPTION
# Pull Request（中文模板）

文档：请参考 `AGENTS.zh-CN.md`（含“本地开发与排障”）。

## 目的
- 为考勤模块补齐 RBAC 权限种子，确保启用后可直接分配 `attendance:*` 权限。
- 同步补充启用清单与最新验证记录，便于交付和复测。

## 变更内容
- 新增迁移：`packages/core-backend/src/db/migrations/20260117090000_add_attendance_permissions.ts`
  - 插入 `attendance:read/write/approve/admin` 权限
  - 默认授予 `admin` 角色
- 更新文档：
  - `docs/attendance-plugin-development-report.md`（启用清单 + 2026-01-17 更新）
  - `docs/attendance-plugin-verification-report.md`（最新验证与 full integration 失败原因）

## 验证
- 本地命令（构建/测试）：
  - `DB_QUERY_TIMEOUT=120000 DB_STATEMENT_TIMEOUT=120000 DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_attendance_module_verify pnpm --filter @metasheet/core-backend migrate`
  - `DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_attendance_module_verify pnpm --filter @metasheet/core-backend test:integration:attendance`
  - `DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_attendance_module_verify pnpm --filter @metasheet/core-backend test:integration`
- 结果：
  - `test:integration:attendance` 通过
  - `test:integration` 失败（非考勤引入），失败原因已记录在 `docs/attendance-plugin-verification-report.md`

## 风险与回滚
- 风险：仅新增权限种子与文档更新，运行时逻辑无变更。
- 回滚：回退本次提交；如需数据库层回滚，可执行该迁移的 down。

## 清单
- [x] 单一关注点，避免无关改动
- [x] 遵循编码规范（ESM、TS、2 空格）
- [x] 文档按需更新
- [ ] CI 通过（full integration 目前仍有历史失败）
