### PR TITLE
test(plm-ui): add plm precheck and failure artifacts

### DIFF
--- a/docs/plm-ui-regression-precheck-report-20260120.md
+++ b/docs/plm-ui-regression-precheck-report-20260120.md
@@ -1,0 +1,23 @@
+# PLM UI Regression Precheck + Failure Artifacts (2026-01-20)
+
+## Summary
+- Added PLM health precheck before running UI automation.
+- Waits for product detail responses after search selection and manual load.
+- Captures error screenshot + last PLM response snapshot when the regression fails.
+
+## Changes
+- `scripts/verify-plm-ui-regression.sh`
+  - `check_plm_health()` verifies `/api/v1/health` (fallback `/health`).
+  - `waitForProductResponse()` waits for `/api/federation/plm/products/{id}` GET.
+  - Failure handling writes `plm-ui-regression-*-error.png` and `plm-ui-regression-last-response-*.json`.
+  - Report includes run status + error artifact paths.
+
+## Verification
+- `AUTO_START=true PLM_BASE_URL=http://127.0.0.1:7910 bash scripts/verify-plm-ui-full.sh`
+  - Reports:
+    - `docs/verification-plm-ui-regression-20260120_163900.md`
+    - `docs/verification-plm-ui-full-20260120_163900.md`
+  - Artifacts:
+    - `artifacts/plm-ui-regression-20260120_163900.png`
+    - `artifacts/plm-bom-tools-20260120_163900.json`
+    - `artifacts/plm-bom-tools-20260120_163900.md`

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -466,6 +466,8 @@ Entry points:
   - Artifact: `artifacts/plm-ui-regression-20260120_154958.png`
   - Report: `docs/verification-plm-ui-regression-20260120_155920.md`
   - Artifact: `artifacts/plm-ui-regression-20260120_155920.png`
+  - Report: `docs/verification-plm-ui-regression-20260120_163900.md`
+  - Artifact: `artifacts/plm-ui-regression-20260120_163900.png`
 - PLM CAD UI (metadata panel):
   - Report: `docs/verification-plm-cad-ui-20260110_1941.md`
   - Artifact: `artifacts/plm-cad-ui-20260110_1941.png`
@@ -499,6 +501,7 @@ Entry points:
   - Report: `docs/verification-plm-ui-full-20260116_230221.md`
   - Report: `docs/verification-plm-ui-full-20260117_000120.md`
   - Report: `docs/verification-plm-ui-full-20260120_090142.md`
+  - Report: `docs/verification-plm-ui-full-20260120_163900.md`
 - PLM UI deep-link autoload:
   - Script: `scripts/verify-plm-ui-deeplink.sh`
   - Report: `docs/verification-plm-ui-deeplink-20260108_131533.md`

--- a/docs/verification-plm-ui-full-20260120_163900.md
+++ b/docs/verification-plm-ui-full-20260120_163900.md
@@ -1,0 +1,21 @@
+# Verification: PLM UI Full Regression - 20260120_163900
+
+## Goal
+Run BOM tools seed + PLM UI regression in a single workflow.
+
+## Environment
+- PLM base: http://127.0.0.1:7910
+- Tenant/org: tenant-1 / org-1
+- BOM find_num: 010
+
+## Steps
+1. BOM tools seed
+   - Report: artifacts/plm-bom-tools-20260120_163900.md
+   - JSON: artifacts/plm-bom-tools-20260120_163900.json
+2. UI regression
+   - Report: docs/verification-plm-ui-regression-20260120_163900.md
+   - Screenshot: artifacts/plm-ui-regression-20260120_163900.png
+
+## Cleanup
+- PLM_CLEANUP: false
+- Status: skipped

--- a/docs/verification-plm-ui-regression-20260120_163900.md
+++ b/docs/verification-plm-ui-regression-20260120_163900.md
@@ -1,0 +1,55 @@
+# Verification: PLM UI Regression (Search -> Detail -> BOM Tools) - 20260120_163900
+
+## Goal
+Verify the end-to-end PLM UI flow: search -> select -> load product -> where-used -> BOM compare -> substitutes -> documents -> approvals.
+
+## Environment
+- UI: http://127.0.0.1:8899/plm
+- API: http://127.0.0.1:7778
+- PLM: http://127.0.0.1:7910
+- PLM_TENANT_ID: tenant-1
+- PLM_ORG_ID: org-1
+- BOM tools source: artifacts/plm-bom-tools-20260120_163900.json
+- Status: pass
+- Error screenshot: artifacts/plm-ui-regression-20260120_163900-error.png
+- Error response: artifacts/plm-ui-regression-last-response-20260120_163900.json
+
+## Data
+- Search query: UI-CMP-A-1768898341
+- Product ID: 232842b7-8f3f-4e4f-bbb9-8681bb4f153a
+- Where-used child ID: c4d9163b-f990-40dc-b741-a6c46d838877
+- Where-used expect: R0
+- BOM child ID: c4d9163b-f990-40dc-b741-a6c46d838877
+- BOM find #: 010
+- BOM refdes: R0
+- BOM depth: 1
+- BOM effective at: 2026-01-20T16:39
+- BOM filter: 010
+- BOM compare left/right: 232842b7-8f3f-4e4f-bbb9-8681bb4f153a / c0dc7c3f-c3c9-4cb4-84e7-f74c1538c073
+- BOM compare expect: UI Child Z
+- Substitute BOM line: d0c627b1-009e-443b-a835-02cb47a3bdbd
+- Substitute expect: UI Substitute
+- Document name: UI-DOC-1768898341.txt
+- Document role: drawing
+- Document revision: A
+- Approval title: UI ECO 1768898341
+- Approval product number: UI-CMP-A-1768898341
+- Item number-only load: UI-CMP-A-1768898341
+
+## Results
+- Search returns matching row and selection loads product detail.
+- Item number-only load repopulates Product ID.
+- Product detail copy actions executed.
+- BOM child actions executed (copy + switch).
+- BOM detail validation executed (find_num/refdes + depth/effective + filter).
+- BOM/Where-Used filter presets import/export/share/group/clear/conflict dialogs validated.
+- BOM tree view renders with expandable nodes.
+- BOM expand-to-depth button is enabled.
+- BOM tree export button is enabled.
+- Where-used query completes.
+- BOM compare completes.
+- Substitutes query completes.
+- Documents table loads with expected document metadata and extended columns.
+- Approvals table loads with expected approval metadata and extended columns.
+- Screenshot: artifacts/plm-ui-regression-20260120_163900.png
+- Item number artifact: artifacts/plm-ui-regression-item-number-20260120_163900.json


### PR DESCRIPTION
## Summary\n- add PLM health precheck before UI regression runs.\n- wait for product detail responses after search selection and manual load.\n- capture error screenshot + last PLM response snapshot on failures.\n\n## Testing\n- AUTO_START=true PLM_BASE_URL=http://127.0.0.1:7910 bash scripts/verify-plm-ui-full.sh