### PR TITLE
docs(plm-ui): document health urls override

### DIFF
--- a/docs/PLM_LOCAL_ENV.md
+++ b/docs/PLM_LOCAL_ENV.md
@@ -43,6 +43,7 @@ export PLM_TENANT_ID=tenant-1
 export PLM_ORG_ID=org-1
 export PLM_USERNAME=admin
 export PLM_PASSWORD=admin
+export PLM_HEALTH_URLS=/api/v1/health,/health
 ```
 
 ## Verification

--- a/docs/plm-ui-health-urls-docs-report-20260120.md
+++ b/docs/plm-ui-health-urls-docs-report-20260120.md
@@ -1,0 +1,11 @@
+# PLM Health URLs Docs Update (2026-01-20)
+
+## Summary
+- Documented `PLM_HEALTH_URLS` in local PLM integration setup.
+
+## Changes
+- `docs/PLM_LOCAL_ENV.md`
+  - Added `PLM_HEALTH_URLS=/api/v1/health,/health` example.
+
+## Verification
+- Not run (documentation-only update).

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -520,6 +520,8 @@ Entry points:
   - Report: `docs/verification-plm-ui-full-20260120_172726.md`
   - Report: `docs/verification-plm-ui-full-20260120_175542.md`
   - Report: `docs/verification-plm-ui-full-20260120_193428.md`
+- PLM UI docs updates:
+  - Report: `docs/verification-plm-ui-docs-20260120_200100.md`
 - PLM UI deep-link autoload:
   - Script: `scripts/verify-plm-ui-deeplink.sh`
   - Report: `docs/verification-plm-ui-deeplink-20260108_131533.md`

--- a/docs/verification-plm-ui-docs-20260120_200100.md
+++ b/docs/verification-plm-ui-docs-20260120_200100.md
@@ -1,0 +1,10 @@
+# Verification: PLM UI Docs Update - 20260120_200100
+
+## Goal
+Record documentation updates for PLM local environment variables.
+
+## Result
+- Not run (documentation-only update).
+
+## Notes
+- Added `PLM_HEALTH_URLS` example to `docs/PLM_LOCAL_ENV.md`.


### PR DESCRIPTION
## Summary\n- document PLM_HEALTH_URLS in local PLM env guide.\n- add docs verification note.\n\n## Testing\n- Not run (docs-only).