### PR TITLE
docs(ops): note internal db ports for preprod

### DIFF
--- a/docs/operations/deploy-ghcr.md
+++ b/docs/operations/deploy-ghcr.md
@@ -37,6 +37,7 @@ bash scripts/deploy-ghcr-gh.sh
 ## Notes
 
 - `docker/app.env` and `docker-compose.override.yml` are gitignored.
+- For preprod/production, keep Postgres and Redis internal (avoid exposing `5432`/`6379`); use SSH tunneling if remote access is required.
 - To change the web port or image tag, edit `WEB_PORT` or `IMAGE_TAG` near the top of the script.
 - If you want to avoid `sudo`, re-login after running `usermod -aG docker $USER`.
 


### PR DESCRIPTION
## Summary\n- document keeping Postgres/Redis ports internal for preprod/prod\n\n## Testing\n- not run (doc-only change)