### PR TITLE
docs(plm-ui): add UI regression design + verification

### DIFF
--- a/docs/PLM_UI_WHERE_USED_COMPARE_SUBSTITUTES_UI_DESIGN_20260127.md
+++ b/docs/PLM_UI_WHERE_USED_COMPARE_SUBSTITUTES_UI_DESIGN_20260127.md
@@ -1,0 +1,70 @@
+# PLM UI Where-Used / BOM Compare / Substitutes UI Design (2026-01-27)
+
+## Scope
+Validate PLM UI panels for:
+- Where-Used
+- BOM Compare
+- Substitutes
+
+## UI Entry
+- Route: `/plm`
+- Vite dev server: `http://127.0.0.1:8899/plm`
+
+## Auth Strategy (UI)
+- UI requests use `Authorization: Bearer <token>` from localStorage keys: `auth_token` / `jwt` / `devToken`.
+- Use core-backend dev token endpoint in non-prod:
+  - `GET /api/auth/dev-token?userId=dev-plm&roles=admin`
+- For dev-only flows set `RBAC_TOKEN_TRUST=true` in core-backend env.
+
+## Data Dependencies (Yuantus)
+Seeded Parts and BOM:
+- Parents: P1, P2
+- Children: C1, C2
+- Substitutes: S1, S2
+- BOM Lines:
+  - P1 -> C1 (bom_line_id)
+  - P1 -> C2
+  - P2 -> C1
+
+## UI Behavior Checklist
+
+### Where-Used Panel
+- Input: item_id (C1)
+- Options: recursive=true, maxLevels=3
+- Expected:
+  - count=2
+  - parents include P1 + P2
+- CSV export: `plm-where-used-<timestamp>.csv`
+
+### BOM Compare Panel
+- Inputs:
+  - leftId=P1
+  - rightId=P2
+  - includeSubstitutes=true
+  - includeEffectivity=true
+- Expected:
+  - schema loaded (line_fields > 0)
+  - summary shows removed=1, changed=1
+- CSV export:
+  - list: `plm-bom-compare-<timestamp>.csv`
+  - detail: `plm-bom-compare-detail-<timestamp>.csv`
+
+### Substitutes Panel
+- Input: bom_line_id for P1 -> C1
+- Actions:
+  - load list
+  - add substitute (S2 + rank/note)
+  - remove the newly added substitute
+- Expected:
+  - count increments (1 -> 2)
+  - delete returns ok
+- CSV export: `plm-substitutes-<timestamp>.csv`
+
+## Deep Link + Presets
+- Use deep link copy buttons for each panel
+- Filter presets (where-used / BOM) should save + export + import JSON
+
+## Environment
+- core-backend: 7778
+- web: 8899
+- PLM (Yuantus): 7910

--- a/docs/verification-plm-ui-where-used-compare-substitutes-ui-20260127_0046.md
+++ b/docs/verification-plm-ui-where-used-compare-substitutes-ui-20260127_0046.md
@@ -1,0 +1,48 @@
+# Verification - PLM UI Where-Used / BOM Compare / Substitutes (2026-01-27)
+
+## Environment
+- Yuantus PLM: http://127.0.0.1:7910
+- MetaSheet core-backend: http://127.0.0.1:7778
+- MetaSheet web: http://127.0.0.1:8899
+- Core-backend env:
+  - PLM_API_MODE=yuantus
+  - PLM_BASE_URL=http://127.0.0.1:7910
+  - PLM_TENANT_ID=tenant-1
+  - PLM_ORG_ID=org-1
+  - PLM_USERNAME=admin
+  - PLM_PASSWORD=admin
+  - RBAC_TOKEN_TRUST=true (dev-only)
+
+## Data
+- P1: 65b77bcc-9a45-41e5-aeda-029519be9dc9
+- P2: ed88f795-fc5d-40bd-9c49-cd579a0ddd30
+- C1: 073d4add-4b86-418a-8e74-9476acdb5930
+- C2: 3b8804bf-1e11-4c7c-afef-ddca36ed1f0e
+- S1: 2b80cca5-700c-4385-931e-6db6c8000849
+- S2: e5463d2b-a877-4baa-97b6-89817e3aaaab
+- BOM line P1 -> C1: 34816b5e-3da5-48df-9b54-effd5382bd63
+
+## UI Availability
+- `GET http://127.0.0.1:8899/plm` => 200
+- Chrome DevTools MCP unavailable (Transport closed). UI automation not executed; federation API validation used instead.
+
+## Federation Validation (Proxy for UI calls)
+
+Where-Used:
+- Request: `operation=where_used` for C1 (recursive=true, maxLevels=3)
+- Result:
+  - count=2
+  - parents include P1 + P2
+
+BOM Compare:
+- Schema line_fields=8
+- Compare summary: added=0, removed=1, changed=1, changed_major=1
+
+Substitutes:
+- before count=1
+- add substitute S2 => substitute_id=8333b84e-1887-415e-99f9-c20b0a74ee8e
+- after count=2
+- remove ok=true
+
+## Outcome
+Federation endpoints returned expected payloads for where-used, BOM compare, and substitutes. UI page is reachable; automated UI interaction was skipped due to DevTools MCP transport failure.


### PR DESCRIPTION
## Summary
- Add UI regression design notes for where-used / BOM compare / substitutes.
- Add verification record for UI regression (API proxy + page availability).

## Verification
- HTTP 200 on /plm via Vite dev server.
- Federation API validation (where-used / compare / substitutes).
- Report: docs/verification-plm-ui-where-used-compare-substitutes-ui-20260127_0046.md
