### PR TITLE
fix(attendance): make import template payload safe

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3551,7 +3551,17 @@ function buildImportPayload(): Record<string, any> | null {
   const resolvedUserId = importForm.userId.trim() || normalizedUserId()
   if (resolvedOrgId && !payload.orgId) payload.orgId = resolvedOrgId
   if (resolvedUserId && !payload.userId) payload.userId = resolvedUserId
-  if (importForm.ruleSetId && !payload.ruleSetId) payload.ruleSetId = importForm.ruleSetId
+  const uuidLike = (value: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+  if (importForm.ruleSetId) {
+    // Always honor the explicit selection (override template placeholders).
+    payload.ruleSetId = importForm.ruleSetId
+  } else if (typeof payload.ruleSetId === 'string') {
+    // The backend template payload example may contain placeholders like "<ruleSetId>",
+    // but the API validates ruleSetId as a UUID. If the user didn't pick a rule set,
+    // treat invalid strings as "unset" so the default rule set can be used.
+    const trimmed = payload.ruleSetId.trim()
+    if (trimmed && !uuidLike(trimmed)) delete payload.ruleSetId
+  }
   if (importForm.timezone && !payload.timezone) payload.timezone = importForm.timezone
   const userMapKeyField = resolveImportUserMapKeyField()
   const userMapSourceFields = resolveImportUserMapSourceFields()

--- a/docs/attendance-groups-csv-config-design-20260206.md
+++ b/docs/attendance-groups-csv-config-design-20260206.md
@@ -35,6 +35,24 @@ Fixed to:
 
 This aligns behavior with table constraints and expected default semantics.
 
+### 3) Import template + UI hardening (ruleSetId placeholder)
+
+During UI acceptance, `POST /api/attendance/import/preview` could fail with a validation error when the template payload contained:
+
+- `ruleSetId: "<ruleSetId>"`
+
+Because the API validates `ruleSetId` as a UUID, the placeholder must never be sent as-is.
+
+Fixes:
+
+- Backend (`plugins/plugin-attendance/index.cjs`): template `payloadExample` is now valid out-of-the-box:
+  - `ruleSetId` removed (optional; set via UI when needed)
+  - `entries: []` and `userMap: {}` to avoid accidentally importing demo rows
+- Frontend (`apps/web/src/views/AttendanceView.vue`): `buildImportPayload()` now:
+  - always honors the rule-set selector (overrides any existing `payload.ruleSetId`)
+  - deletes invalid `payload.ruleSetId` strings when no rule set is selected
+- Integration (`packages/core-backend/tests/integration/attendance-plugin.test.ts`): asserts template payload does not ship invalid placeholder UUIDs.
+
 ## Why This Matters
 
 - Prevents hidden runtime 500s in common CSV import cases.

--- a/docs/attendance-groups-csv-config-verification-20260206.md
+++ b/docs/attendance-groups-csv-config-verification-20260206.md
@@ -31,6 +31,29 @@ pnpm --filter @metasheet/core-backend test:integration:attendance
 - Fix: fallback to `DEFAULT_RULE.timezone` when timezone not provided.
 - File: `plugins/plugin-attendance/index.cjs`
 
+## Local UI Acceptance (2026-02-06)
+
+Goal: validate the end-to-end admin UI flow for CSV import + preview + commit.
+
+Environment:
+
+- Web (Vite): `http://127.0.0.1:8901/p/plugin-attendance/attendance`
+- API (Docker backend): `http://127.0.0.1:8900/api`
+
+Flow (Playwright CLI):
+
+1. Load import template
+2. Select mapping profile: `dingtalk_csv_daily_summary`
+3. Upload CSV + user-map JSON
+4. Preview -> shows 2 rows (2025-12-01 / 2025-12-02, 480 min)
+5. Import -> creates a committed batch with 2 items
+6. View items -> confirms rows imported for `driver-user-001`
+
+Artifacts:
+
+- Playwright CLI workspace: `output/playwright/attendance-ui/.playwright-cli/`
+- Viewport screenshot: `output/playwright/attendance-ui/.playwright-cli/page-2026-02-06T12-34-15-995Z.png`
+
 ## Conclusion
 
 The agreed 1/2/3 capability chain is now covered by integration tests and the import-time group auto-create path is fixed for production-safe default behavior.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -441,6 +441,9 @@ describe('Attendance Plugin Integration', () => {
       },
     })
     expect(importTemplateRes.status).toBe(200)
+    const importTemplateData = (importTemplateRes.body as { data?: any } | undefined)?.data
+    // Template payload must be valid out-of-the-box (no placeholder UUIDs that break preview/commit).
+    expect(importTemplateData?.payloadExample?.ruleSetId).toBeUndefined()
 
     const importPayload = {
       userId: 'attendance-test',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7265,50 +7265,12 @@ module.exports = {
             mappingProfiles: IMPORT_MAPPING_PROFILES,
             payloadExample: {
               source: 'dingtalk_csv',
-              ruleSetId: '<ruleSetId>',
               mode: 'override',
-              userMapKeyField: 'empNo',
-              userMap: {
-                A0054: {
-                  userId: 'tmp_9cf257fde42ac517bc769838',
-                  name: '秦夫林',
-                  empNo: 'A0054',
-                  profile: {
-                    attendanceGroup: '单休办公',
-                    department: '亚光科技-人力行政部-后勤',
-                    role: '司机',
-                    roleTags: ['driver'],
-                  },
-                },
-              },
-              entries: [
-                {
-                  userId: 'tmp_9cf257fde42ac517bc769838',
-                  occurredAt: '2026-01-20T07:51:00',
-                  eventType: 'check_in',
-                  timezone: 'Asia/Shanghai',
-                  meta: {
-                    workDate: '2026-01-20',
-                    column: '上班1打卡时间',
-                    rawTime: '07:51',
-                    sourceUserKey: 'A0054',
-                    sourceUserName: '秦夫林',
-                  },
-                },
-                {
-                  userId: 'tmp_9cf257fde42ac517bc769838',
-                  occurredAt: '2026-01-20T17:05:00',
-                  eventType: 'check_out',
-                  timezone: 'Asia/Shanghai',
-                  meta: {
-                    workDate: '2026-01-20',
-                    column: '下班1打卡时间',
-                    rawTime: '17:05',
-                    sourceUserKey: 'A0054',
-                    sourceUserName: '秦夫林',
-                  },
-                },
-              ],
+              // Keep the template payload valid out-of-the-box: ruleSetId is optional.
+              userMapKeyField: '工号',
+              userMapSourceFields: ['empNo', '工号', '姓名'],
+              userMap: {},
+              entries: [],
             },
           },
         })


### PR DESCRIPTION
## Summary\n- make attendance import template payload valid by default (no invalid placeholder ruleSetId)\n- harden AttendanceView import payload build to strip non-UUID template ruleSetId unless user explicitly selects one\n- add integration assertion that import template payloadExample does not include invalid ruleSetId\n\n## Verification\n- ATTENDANCE_TEST_DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/metasheet pnpm --filter @metasheet/core-backend test:integration:attendance\n