### PR TITLE
fix(ops): make attendance preflight tolerant of missing keys

### DIFF
--- a/scripts/ops/attendance-preflight.sh
+++ b/scripts/ops/attendance-preflight.sh
@@ -26,7 +26,12 @@ function get_env_value() {
   fi
   # Don't "source" the env file because values can contain '#' and other characters.
   # We treat it as a simple KEY=VALUE file (no spaces around '=').
-  grep -E "^${key}=" "$ENV_FILE" | tail -n 1 | sed -E "s/^${key}=//"
+  #
+  # IMPORTANT: keys may be absent; that must not hard-fail preflight before we can
+  # emit a helpful error/warn. We therefore avoid `pipefail` propagation here.
+  local line
+  line="$(grep -E "^${key}=" "$ENV_FILE" | tail -n 1 || true)"
+  echo "${line#${key}=}"
 }
 
 info "Repo root: ${ROOT_DIR}"
@@ -79,4 +84,3 @@ elif [[ "$PRODUCT_MODE" != "attendance" && "$PRODUCT_MODE" != "platform" && "$PR
 fi
 
 info "Preflight OK"
-


### PR DESCRIPTION
Fixes attendance preflight helper so missing optional env keys (e.g. PRODUCT_MODE) don't cause a silent exit under set -euo pipefail. This makes preflight emit proper WARN/ERROR messages and proceed to a deterministic result.