### PR TITLE
feat(attendance): add admin user access provisioning UI

### DIFF
--- a/docs/attendance-production-acceptance-20260207.md
+++ b/docs/attendance-production-acceptance-20260207.md
@@ -50,6 +50,11 @@ This environment must support creating at least these 3 roles via permissions:
 - approver: `attendance:read`, `attendance:approve`
 - admin: `attendance:read`, `attendance:write`, `attendance:approve`, `attendance:admin`
 
+You can provision permissions either via:
+
+- UI: `Attendance -> Admin Center -> User Access`
+- Script: `scripts/ops/attendance-provision-user.sh` (admin token required)
+
 Run (example for employee):
 
 ```bash

--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -41,8 +41,9 @@ Out of scope for this delivery:
 
 - API smoke:
   - `scripts/ops/attendance-smoke-api.sh`
-- Provision user permissions (admin token required):
-  - `scripts/ops/attendance-provision-user.sh`
+- Provision user permissions:
+  - UI (Admin Center): `Attendance -> Admin Center -> User Access`
+  - Script (admin token required): `scripts/ops/attendance-provision-user.sh`
 - Playwright acceptance (desktop admin flow):
   - `scripts/verify-attendance-production-flow.mjs`
 - Playwright acceptance (attendance-focused shell + mobile gating):


### PR DESCRIPTION
Adds a minimal User Access section in Attendance Admin Center to grant/revoke role templates (employee/approver/admin) via /api/permissions. Updates production acceptance Playwright to validate the UI, and documents the new path.