### PR TITLE
fix(attendance-import): allow idempotencyKey commit retries without commitToken

### DIFF
--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -12,7 +12,8 @@ This is the delivery package definition for bringing the Attendance plugin to a 
    - `/api/attendance/import/commit`
 3. Import commit tokens are safe across restarts (DB-backed when required).
 4. Import commits support an optional `idempotencyKey` (deduplicates retries; unique per org).
-   - Requires DB migration: `packages/core-backend/src/db/migrations/zzzz20260208120000_add_attendance_import_idempotency_key.ts`
+   - Works even when the `attendance_import_batches.idempotency_key` column is not present by falling back to `attendance_import_batches.meta.idempotencyKey`.
+   - Recommended hardening (uniqueness + faster lookup): `packages/core-backend/src/db/migrations/zzzz20260208120000_add_attendance_import_idempotency_key.ts`
 5. Reverse proxy remains stable across backend redeploys (no stale backend container IP).
 6. Repeatable acceptance using Playwright with stored artifacts.
 7. Admins can provision employee/approver/admin permissions via the existing permission APIs.
@@ -30,7 +31,7 @@ Out of scope for this delivery:
 - Postgres and Redis must NOT be exposed on public interfaces.
   - Production compose must not include `ports: ["5432:5432"]` or `ports: ["6379:6379"]`.
   - For debug only, use `docker-compose.app.debug.yml` which binds DB/Redis to localhost.
- - `docker/app.env` must not use default secrets.
+- `docker/app.env` must not use default secrets.
 
 ### Deploy
 

--- a/docs/attendance-production-polish-verification-20260208.md
+++ b/docs/attendance-production-polish-verification-20260208.md
@@ -24,6 +24,7 @@ Required migrations for this iteration:
   - `packages/core-backend/src/db/migrations/zzzz20260207150000_create_attendance_import_tokens.ts`
 - Import commit idempotency (recommended):
   - `packages/core-backend/src/db/migrations/zzzz20260208120000_add_attendance_import_idempotency_key.ts`
+  - Note: idempotency retries also work without this column by falling back to `attendance_import_batches.meta.idempotencyKey`, but the migration adds uniqueness + faster lookup.
 
 If running via docker compose (production):
 ```bash
@@ -185,6 +186,12 @@ On the remote environment, the following gates were reported as PASS:
 - Gate 3: Permission Provisioning PASS (employee/approver/admin)
 - Gate 4: Playwright Desktop PASS
 - Gate 4: Playwright Mobile PASS
+
+Strict flags (idempotency + export) should be treated as P0 for production.
+
+Current note:
+- `REQUIRE_IDEMPOTENCY=true` failed on the remote image before deploying the idempotency fix in `plugins/plugin-attendance/index.cjs` (retry required a commitToken).
+  - Evidence: `output/playwright/attendance-prod-acceptance/20260208-152606/gate-api-smoke.log`
 
 Artifacts (example):
 - `output/playwright/attendance-prod-acceptance/*`

--- a/docs/attendance-production-ready-verification-20260207.md
+++ b/docs/attendance-production-ready-verification-20260207.md
@@ -47,7 +47,8 @@ The following migrations must be applied when `ATTENDANCE_IMPORT_REQUIRE_TOKEN=1
 Optional (recommended) import reliability hardening:
 
 - `packages/core-backend/src/db/migrations/zzzz20260208120000_add_attendance_import_idempotency_key.ts`
-  - Enables `idempotencyKey` de-duplication across commit retries (unique per org).
+  - Adds `attendance_import_batches.idempotency_key` + unique index (per org) for faster lookup and stronger uniqueness.
+  - Note: commit retries can still be de-duplicated without this column via `attendance_import_batches.meta.idempotencyKey` fallback (but without DB-enforced uniqueness).
 
 ## End-to-End Verification (Playwright)
 


### PR DESCRIPTION
## Problem
Strict production gate `REQUIRE_IDEMPOTENCY=true` fails because `POST /api/attendance/import/commit` requires a fresh `commitToken` on retry, even when an `idempotencyKey` is provided.

In practice, `commitToken` is single-use and may be unavailable on client/network retries, so idempotent retries must work without it.

Evidence (before deploy): `output/playwright/attendance-prod-acceptance/20260208-152606/gate-api-smoke.log`

## Fix
- Short-circuit commit on `idempotencyKey` **before** enforcing `commitToken`.
- Load the committed import batch by `idempotencyKey` using:
  - `attendance_import_batches.idempotency_key` when the column exists
  - fallback to `attendance_import_batches.meta->>'idempotencyKey'` when the column does not exist (schema-free compatibility)
- Ensure batch mapping exposes `idempotencyKey` via meta fallback.

## Tests
- Add integration coverage: commit retry with same `idempotencyKey` returns the same `batchId` and `idempotent=true` without requiring `commitToken`.

## Docs
- Update production delivery/acceptance docs to clarify the meta fallback and keep the migration as recommended hardening.

## How To Verify (Remote)
After deploying this branch to `142.171.239.56`, run:

```bash
REQUIRE_ATTENDANCE_ADMIN_API=true
REQUIRE_IDEMPOTENCY=true
REQUIRE_IMPORT_EXPORT=true
API_BASE=http://142.171.239.56:8081/api
AUTH_TOKEN=ADMIN_JWT
EXPECT_PRODUCT_MODE=attendance
./scripts/ops/attendance-run-gates.sh
```

Expected: Gate 2 API Smoke logs `idempotency ok` and passes.
