### PR TITLE
feat(attendance): P1 production hardening (audit/limits/obs/ui)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ coverage/
 .cache/
 temp/
 tmp/
+idempotencyKey
+'idempotencyKey'
 
 # Insync sync files
 .~*

--- a/docker/observability/docker-compose.yml
+++ b/docker/observability/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ../../ops/prometheus/phase5-recording-rules.yml:/etc/prometheus/rules/phase5-recording-rules.yml:ro
       - ../../ops/prometheus/phase5-alerts.yml:/etc/prometheus/rules/phase5-alerts.yml:ro
+      - ../../ops/prometheus/attendance-alerts.yml:/etc/prometheus/rules/attendance-alerts.yml:ro
       - prometheus-data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/docker/observability/grafana/dashboards/attendance-overview.json
+++ b/docker/observability/grafana/dashboards/attendance-overview.json
@@ -1,0 +1,93 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "${DS_PROM}",
+        "enable": true,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "name": "Prom Alerts",
+        "target": {
+          "expr": "ALERTS{alertstate=\"firing\"}",
+          "format": "time_series"
+        }
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Attendance API Errors (rate)",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        { "expr": "sum(rate(attendance_api_errors_total{job=\"$job\"}[5m]))", "datasource": "${DS_PROM}" }
+      ],
+      "options": { "legend": { "displayMode": "table" }, "tooltip": { "mode": "multi" } },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "Attendance Rate Limited (rate)",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 10 },
+      "targets": [
+        { "expr": "sum(rate(attendance_rate_limited_total{job=\"$job\"}[5m]))", "datasource": "${DS_PROM}" }
+      ],
+      "options": { "legend": { "displayMode": "table" }, "tooltip": { "mode": "multi" } },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "Import Commit Errors (rate)",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 20 },
+      "targets": [
+        {
+          "expr": "sum(rate(attendance_api_errors_total{job=\"$job\",route=\"/api/attendance/import/commit\"}[5m]))",
+          "datasource": "${DS_PROM}"
+        }
+      ],
+      "options": { "legend": { "displayMode": "table" }, "tooltip": { "mode": "multi" } },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+    },
+    {
+      "type": "table",
+      "title": "Top Error Routes (5m rate)",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 30 },
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(attendance_api_errors_total{job=\"$job\"}[5m])) by (route))",
+          "datasource": "${DS_PROM}",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+    }
+  ],
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["attendance"],
+  "templating": {
+    "list": [
+      { "type": "datasource", "name": "DS_PROM", "query": "prometheus" },
+      {
+        "type": "query",
+        "name": "job",
+        "datasource": "${DS_PROM}",
+        "refresh": 2,
+        "query": "label_values(up, job)",
+        "current": { "text": "metasheet-backend", "value": "metasheet-backend" }
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "",
+  "title": "Attendance Overview",
+  "uid": "attendance-overview",
+  "version": 1
+}
+

--- a/docker/observability/prometheus/prometheus.yml
+++ b/docker/observability/prometheus/prometheus.yml
@@ -30,6 +30,7 @@ scrape_configs:
 rule_files:
   - "/etc/prometheus/rules/phase5-recording-rules.yml"
   - "/etc/prometheus/rules/phase5-alerts.yml"
+  - "/etc/prometheus/rules/attendance-alerts.yml"
 
 # Alerting configuration (optional)
 # alerting:

--- a/docs/attendance-production-acceptance-20260207.md
+++ b/docs/attendance-production-acceptance-20260207.md
@@ -235,6 +235,17 @@ Execution record (2026-02-09):
     - `output/playwright/attendance-prod-acceptance/20260209-110635/gate-api-smoke.log`
 - Strict run #2 (consecutive): `PASS`
   - Evidence: `output/playwright/attendance-prod-acceptance/20260209-110911/`
+ - Strict run #3: `PASS`
+   - Note: Gate 1 `Preflight` was `SKIP` because the gate runner was executed from a workstation that does not have `docker/app.env`.
+   - Evidence: `output/playwright/attendance-prod-acceptance/20260209-123959/`
+   - API smoke log includes `idempotency ok` + `export csv ok`:
+     - `output/playwright/attendance-prod-acceptance/20260209-123959/gate-api-smoke.log`
+   - Provisioning scripts executed (role bundles):
+     - `output/playwright/attendance-prod-acceptance/20260209-123959/gate-provision-employee.log`
+     - `output/playwright/attendance-prod-acceptance/20260209-123959/gate-provision-approver.log`
+     - `output/playwright/attendance-prod-acceptance/20260209-123959/gate-provision-admin.log`
+ - Strict run #4 (consecutive): `PASS`
+   - Evidence: `output/playwright/attendance-prod-acceptance/20260209-124300/`
 
 Historical (pre-deploy remote image):
 - Gate 2 `API Smoke`: `FAIL` (idempotency retry required a commitToken)

--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -71,11 +71,26 @@ Notes:
 ## Post-Delivery Backlog (P1/P2)
 
 P1 (1-2 weeks, production hardening):
-- Observability + alerts: import/approve error rate, latency, and failure reason aggregation (Grafana dashboards + Prometheus alerts).
-- Audit trail: who imported/approved/changed rules, and when (admin-visible logs + retention policy).
-- Admin productization: improve User Access UI (batch grant/revoke, templates, and audit traceability).
-- Import performance: async/streaming preview + commit for large files (10k-100k rows), with timeout/retry strategy.
-- Security: enforce import/export rate limits + optional IP allowlist by default; lock down admin endpoints with stronger guardrails.
+- Observability + alerts (implemented 2026-02-09):
+  - Prometheus alert rules: `ops/prometheus/attendance-alerts.yml`
+  - Grafana dashboard: `docker/observability/grafana/dashboards/attendance-overview.json`
+- Audit trail + retention (implemented 2026-02-09):
+  - Attendance audit inserts into `operation_audit_logs` (best-effort, write ops + exports).
+  - Retention worker (production-only by default): `packages/core-backend/src/audit/operation-audit-retention.ts`
+  - Admin audit API: `GET /api/attendance-admin/audit-logs`
+- Admin productization (implemented 2026-02-09):
+  - Batch role assign/unassign API:
+    - `POST /api/attendance-admin/users/batch/roles/assign`
+    - `POST /api/attendance-admin/users/batch/roles/unassign`
+  - Admin Center UI:
+    - Batch Provisioning (multi-UUID input)
+    - Audit Logs viewer (search + paging + meta preview)
+- Import performance (partial, implemented 2026-02-09):
+  - Import commit uses buffered bulk inserts for items (reduces DB roundtrips).
+  - Remaining: async/streaming preview + commit for large files (10k-100k rows), with timeout/retry strategy.
+- Security (implemented 2026-02-09):
+  - Rate limits for import/export/admin writes (production-only by default).
+  - Optional IP allowlist enforcement (when configured in `attendance.settings`).
 
 P2 (later, feature expansion):
 - Payroll: full salary settlement pipeline (beyond payroll cycles and anomaly batching).

--- a/docs/attendance-production-p1-hardening-20260209.md
+++ b/docs/attendance-production-p1-hardening-20260209.md
@@ -1,0 +1,116 @@
+# Attendance Production P1 Hardening (2026-02-09)
+
+This document records the P1 hardening work completed after the initial "production usable" gates were passing.
+
+P1 scope for this iteration:
+
+1. Observability + alerts
+2. Audit trail + retention
+3. Admin productization (batch role provisioning + audit viewer)
+4. Import performance (reduce DB roundtrips)
+5. Security (rate limits + IP allowlist enforcement)
+
+## Changes Shipped (Code)
+
+### Observability
+
+- New metrics (Prometheus):
+  - `attendance_api_errors_total{route,method,status,error_code}`
+  - `attendance_rate_limited_total{route,method}`
+  - Source: `packages/core-backend/src/metrics/attendance-metrics.ts`
+- Prometheus alerts:
+  - `ops/prometheus/attendance-alerts.yml`
+- Grafana dashboard:
+  - `docker/observability/grafana/dashboards/attendance-overview.json`
+
+### Audit Trail + Retention
+
+- Attendance audit middleware (best-effort insert into `operation_audit_logs`):
+  - `packages/core-backend/src/middleware/attendance-production.ts`
+- Schema hardening migration (occurred_at + meta backfill):
+  - `packages/core-backend/src/db/migrations/zzzz20260209100000_fix_operation_audit_logs_schema.ts`
+- Retention worker (production-only by default):
+  - `packages/core-backend/src/audit/operation-audit-retention.ts`
+
+### Admin Productization
+
+- Batch role provisioning API:
+  - `POST /api/attendance-admin/users/batch/roles/assign`
+  - `POST /api/attendance-admin/users/batch/roles/unassign`
+- Audit log query API:
+  - `GET /api/attendance-admin/audit-logs?q=&page=&pageSize=`
+- Admin Center UI (Attendance -> Admin Center):
+  - Batch Provisioning section
+  - Audit Logs section
+
+### Import Performance
+
+- Import commit buffered bulk insert for import items:
+  - `plugins/plugin-attendance/index.cjs`
+
+### Security
+
+- IP allowlist enforcement for import/export/admin endpoints (enabled when configured in `attendance.settings`).
+- Rate limiting for import/export/admin write endpoints (enabled by default when `NODE_ENV=production`).
+  - Env controls:
+    - `ATTENDANCE_RATE_LIMIT_ENABLED=true|false`
+    - `ATTENDANCE_RATE_LIMIT_IMPORT_PREPARE_PER_MIN`
+    - `ATTENDANCE_RATE_LIMIT_IMPORT_PREVIEW_PER_MIN`
+    - `ATTENDANCE_RATE_LIMIT_IMPORT_COMMIT_PER_MIN`
+    - `ATTENDANCE_RATE_LIMIT_EXPORT_PER_MIN`
+    - `ATTENDANCE_RATE_LIMIT_ADMIN_WRITE_PER_MIN`
+
+## Verification (Strict Gates + Evidence)
+
+We use the repo gate runner to validate:
+
+- Strict API smoke:
+  - `REQUIRE_ATTENDANCE_ADMIN_API=true`
+  - `REQUIRE_IDEMPOTENCY=true`
+  - `REQUIRE_IMPORT_EXPORT=true`
+- Playwright desktop + mobile
+
+Command (no secrets; token placeholder only):
+
+```bash
+REQUIRE_ATTENDANCE_ADMIN_API="true" \
+REQUIRE_IDEMPOTENCY="true" \
+REQUIRE_IMPORT_EXPORT="true" \
+RUN_PREFLIGHT="false" \
+API_BASE="http://142.171.239.56:8081/api" \
+AUTH_TOKEN="<ADMIN_JWT>" \
+EXPECT_PRODUCT_MODE="attendance" \
+scripts/ops/attendance-run-gates.sh
+```
+
+Execution record (2026-02-09):
+
+1. Strict run #1: PASS
+   - Evidence: `output/playwright/attendance-prod-acceptance/20260209-123959/`
+   - API smoke: `output/playwright/attendance-prod-acceptance/20260209-123959/gate-api-smoke.log`
+2. Strict run #2 (consecutive): PASS
+   - Evidence: `output/playwright/attendance-prod-acceptance/20260209-124300/`
+
+Provisioning role-bundle scripts were also executed and stored under:
+
+- `output/playwright/attendance-prod-acceptance/20260209-123959/gate-provision-employee.log`
+- `output/playwright/attendance-prod-acceptance/20260209-123959/gate-provision-approver.log`
+- `output/playwright/attendance-prod-acceptance/20260209-123959/gate-provision-admin.log`
+
+Notes:
+
+- Gate 1 (Preflight) was skipped in the recorded runs because the runner host did not have `docker/app.env`.
+- The Playwright scripts treat `PUNCH_TOO_SOON` as a best-effort business guard; it must not fail the run.
+
+## Local Observability Stack (Optional)
+
+To view the new metrics/dashboard locally:
+
+```bash
+docker compose -f docker/observability/docker-compose.yml up -d
+```
+
+- Prometheus: http://localhost:9090
+- Grafana: http://localhost:3000 (admin/admin)
+- Dashboard: "Attendance Overview"
+

--- a/docs/attendance-production-polish-verification-20260208.md
+++ b/docs/attendance-production-polish-verification-20260208.md
@@ -198,6 +198,9 @@ Strict gate notes:
   - Note: Gate 1 preflight is host-only and may show as `SKIP` when the gate runner is executed from a workstation without `docker/app.env`.
   - Evidence: `output/playwright/attendance-prod-acceptance/20260209-110635/`
   - Evidence: `output/playwright/attendance-prod-acceptance/20260209-110911/`
+  - Additional strict runs (2026-02-09): two more consecutive strict gate runs passed (provisioning logs captured under the first run directory).
+  - Evidence: `output/playwright/attendance-prod-acceptance/20260209-123959/`
+  - Evidence: `output/playwright/attendance-prod-acceptance/20260209-124300/`
 - Historical (pre-deploy remote image): idempotency retry required a commitToken.
   - Evidence: `output/playwright/attendance-prod-acceptance/20260208-152606/gate-api-smoke.log`
 

--- a/ops/prometheus/attendance-alerts.yml
+++ b/ops/prometheus/attendance-alerts.yml
@@ -1,0 +1,33 @@
+groups:
+  - name: attendance-production
+    rules:
+      - alert: AttendanceApi5xxHigh
+        expr: sum(rate(attendance_api_errors_total{status=~"5.."}[5m])) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          component: attendance
+        annotations:
+          summary: Attendance API 5xx rate is high
+          runbook: Check backend logs and recent deploys; validate DB/Redis health; inspect import/approval endpoints.
+
+      - alert: AttendanceImportCommitErrors
+        expr: sum(rate(attendance_api_errors_total{route="/api/attendance/import/commit"}[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: attendance
+        annotations:
+          summary: Attendance import commit is failing
+          runbook: Inspect import batch audit logs; verify idempotency behavior; check DB constraints and plugin status.
+
+      - alert: AttendanceRateLimitedHigh
+        expr: sum(rate(attendance_rate_limited_total[5m])) > 0.2
+        for: 10m
+        labels:
+          severity: warning
+          component: attendance
+        annotations:
+          summary: Attendance API rate limiting is frequently triggered
+          runbook: Confirm allowlist and rate limit settings; check for abusive traffic; adjust ATTENDANCE_RATE_LIMIT_* envs if needed.
+

--- a/packages/core-backend/src/audit/operation-audit-retention.ts
+++ b/packages/core-backend/src/audit/operation-audit-retention.ts
@@ -1,0 +1,79 @@
+import { Logger } from '../core/logger'
+import { query } from '../db/pg'
+import { isDatabaseSchemaError } from '../utils/database-errors'
+
+export type OperationAuditRetentionOptions = {
+  retentionDays?: number
+  intervalMs?: number
+  logger?: Logger
+}
+
+function parseRetentionDays(raw: string | undefined): number {
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) return 90
+  return Math.min(Math.max(Math.floor(parsed), 1), 3650)
+}
+
+function parseIntervalMs(raw: string | undefined): number {
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) return 24 * 60 * 60 * 1000
+  return Math.min(Math.max(Math.floor(parsed), 10_000), 7 * 24 * 60 * 60 * 1000)
+}
+
+function isEnabled(): boolean {
+  if (process.env.OPERATION_AUDIT_RETENTION_ENABLED) {
+    return process.env.OPERATION_AUDIT_RETENTION_ENABLED === 'true'
+  }
+  return process.env.NODE_ENV === 'production'
+}
+
+export function startOperationAuditRetention(options: OperationAuditRetentionOptions = {}): () => void {
+  if (!isEnabled()) return () => {}
+
+  const logger = options.logger ?? new Logger('OperationAuditRetention')
+  const retentionDays = options.retentionDays ?? parseRetentionDays(process.env.OPERATION_AUDIT_LOG_RETENTION_DAYS)
+  const intervalMs = options.intervalMs ?? parseIntervalMs(process.env.OPERATION_AUDIT_RETENTION_INTERVAL_MS)
+
+  let stopped = false
+
+  async function runOnce(): Promise<void> {
+    if (stopped) return
+
+    try {
+      const result = await query(
+        `DELETE FROM operation_audit_logs
+         WHERE occurred_at < now() - make_interval(days => $1)`,
+        [retentionDays],
+      )
+
+      if (typeof result.rowCount === 'number' && result.rowCount > 0) {
+        logger.info(`Operation audit retention deleted ${result.rowCount} row(s) (retentionDays=${retentionDays})`)
+      }
+    } catch (error) {
+      if (isDatabaseSchemaError(error)) {
+        logger.warn('Operation audit retention skipped: operation_audit_logs not ready', error as Error)
+        return
+      }
+      logger.warn('Operation audit retention failed', error as Error)
+    }
+  }
+
+  // Fire-and-forget initial cleanup.
+  void runOnce()
+
+  const timer = setInterval(() => {
+    void runOnce()
+  }, intervalMs)
+
+  // Avoid holding the event loop open in CLI/tests.
+  timer.unref?.()
+
+  logger.info(`Operation audit retention started (retentionDays=${retentionDays}, intervalMs=${intervalMs})`)
+
+  return () => {
+    stopped = true
+    clearInterval(timer)
+    logger.info('Operation audit retention stopped')
+  }
+}
+

--- a/packages/core-backend/src/db/migrations/zzzz20260209100000_fix_operation_audit_logs_schema.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260209100000_fix_operation_audit_logs_schema.ts
@@ -1,0 +1,65 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+/**
+ * operation_audit_logs schema hardening
+ *
+ * The codebase historically wrote to `created_at` + `metadata`, while the query
+ * router (`/api/audit-logs`) expects `occurred_at` + `meta`. This migration
+ * aligns the schema and backfills existing rows.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'operation_audit_logs')
+  if (!exists) return
+
+  await sql`ALTER TABLE operation_audit_logs
+    ADD COLUMN IF NOT EXISTS occurred_at timestamptz
+  `.execute(db)
+
+  // Backfill occurred_at for existing rows written before this column existed.
+  await sql`UPDATE operation_audit_logs
+    SET occurred_at = created_at
+    WHERE occurred_at IS NULL
+  `.execute(db)
+
+  // Keep occurred_at non-null for future writes.
+  await sql`ALTER TABLE operation_audit_logs
+    ALTER COLUMN occurred_at SET DEFAULT now()
+  `.execute(db)
+  await sql`ALTER TABLE operation_audit_logs
+    ALTER COLUMN occurred_at SET NOT NULL
+  `.execute(db)
+
+  // Ensure meta has a default, and backfill from legacy metadata where missing.
+  await sql`ALTER TABLE operation_audit_logs
+    ADD COLUMN IF NOT EXISTS meta jsonb
+  `.execute(db)
+  await sql`ALTER TABLE operation_audit_logs
+    ALTER COLUMN meta SET DEFAULT '{}'::jsonb
+  `.execute(db)
+  await sql`UPDATE operation_audit_logs
+    SET meta = metadata
+    WHERE (meta IS NULL OR meta = '{}'::jsonb)
+      AND metadata IS NOT NULL
+  `.execute(db)
+
+  // Normalize IP column for older writers.
+  await sql`UPDATE operation_audit_logs
+    SET ip = ip_address
+    WHERE ip IS NULL AND ip_address IS NOT NULL
+  `.execute(db)
+
+  await sql`CREATE INDEX IF NOT EXISTS idx_operation_audit_logs_occurred_at
+    ON operation_audit_logs(occurred_at DESC)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'operation_audit_logs')
+  if (!exists) return
+
+  await sql`DROP INDEX IF EXISTS idx_operation_audit_logs_occurred_at`.execute(db)
+  await sql`ALTER TABLE operation_audit_logs DROP COLUMN IF EXISTS occurred_at`.execute(db)
+}
+

--- a/packages/core-backend/src/guards/audit-integration.ts
+++ b/packages/core-backend/src/guards/audit-integration.ts
@@ -78,8 +78,11 @@ export async function logSafetyOperation(entry: AuditEntry): Promise<void> {
         resource_type,
         resource_id,
         metadata,
-        created_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        meta,
+        ip,
+        created_at,
+        occurred_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $6, $8, $7, $7)`,
       [
         entry.userId,
         'user',
@@ -87,7 +90,8 @@ export async function logSafetyOperation(entry: AuditEntry): Promise<void> {
         'admin_operation',
         entry.operationType,
         JSON.stringify({ ...metadata, ip: entry.userIp }),
-        entry.timestamp
+        entry.timestamp,
+        entry.userIp
       ]
     );
 

--- a/packages/core-backend/src/metrics/attendance-metrics.ts
+++ b/packages/core-backend/src/metrics/attendance-metrics.ts
@@ -1,0 +1,19 @@
+import client from 'prom-client'
+import { registry } from './metrics'
+
+// Keep labels low-cardinality. `route` must be normalized (no UUIDs).
+export const attendanceApiErrorsTotal = new client.Counter({
+  name: 'attendance_api_errors_total',
+  help: 'Attendance API errors by route/method/status/error_code',
+  labelNames: ['route', 'method', 'status', 'error_code'] as const,
+})
+
+export const attendanceRateLimitedTotal = new client.Counter({
+  name: 'attendance_rate_limited_total',
+  help: 'Attendance API rate-limited responses',
+  labelNames: ['route', 'method'] as const,
+})
+
+registry.registerMetric(attendanceApiErrorsTotal)
+registry.registerMetric(attendanceRateLimitedTotal)
+

--- a/packages/core-backend/src/middleware/attendance-production.ts
+++ b/packages/core-backend/src/middleware/attendance-production.ts
@@ -1,0 +1,357 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import { Logger, getLogContext } from '../core/logger'
+import { query } from '../db/pg'
+import { TokenBucketRateLimiter } from '../integration/rate-limiting/token-bucket'
+import { attendanceApiErrorsTotal, attendanceRateLimitedTotal } from '../metrics/attendance-metrics'
+
+type AttendanceSettings = {
+  ipAllowlist: string[]
+}
+
+const logger = new Logger('AttendanceProduction')
+const SETTINGS_KEY = 'attendance.settings'
+const SETTINGS_CACHE_TTL_MS = 10_000
+
+let settingsCache: { loadedAt: number; value: AttendanceSettings } = {
+  loadedAt: 0,
+  value: { ipAllowlist: [] },
+}
+
+function toStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return raw.map((v) => String(v || '').trim()).filter(Boolean)
+}
+
+async function loadAttendanceSettings(): Promise<AttendanceSettings> {
+  if (Date.now() - settingsCache.loadedAt < SETTINGS_CACHE_TTL_MS) return settingsCache.value
+  try {
+    const { rows } = await query<{ value: string }>(
+      'SELECT value FROM system_configs WHERE key = $1',
+      [SETTINGS_KEY],
+    )
+    if (!rows.length) {
+      settingsCache = { loadedAt: Date.now(), value: { ipAllowlist: [] } }
+      return settingsCache.value
+    }
+    const parsed = JSON.parse(rows[0].value || '{}')
+    const next: AttendanceSettings = {
+      ipAllowlist: toStringArray((parsed && typeof parsed === 'object') ? (parsed as Record<string, unknown>).ipAllowlist : []),
+    }
+    settingsCache = { loadedAt: Date.now(), value: next }
+    return next
+  } catch (error) {
+    // Fail open: allow traffic if settings cannot be loaded.
+    logger.warn('Failed to load attendance.settings; continuing without allowlist enforcement', error as Error)
+    settingsCache = { loadedAt: Date.now(), value: { ipAllowlist: [] } }
+    return settingsCache.value
+  }
+}
+
+function getClientIp(req: Request): string {
+  const forwarded = req.headers['x-forwarded-for']
+  const header = Array.isArray(forwarded) ? forwarded[0] : forwarded
+  const raw = header ? String(header).split(',')[0]?.trim() : req.ip
+  if (!raw) return ''
+  return raw.startsWith('::ffff:') ? raw.slice(7) : raw
+}
+
+function isIpAllowed(ip: string, allowlist: string[]): boolean {
+  if (!allowlist || allowlist.length === 0) return true
+  const normalized = ip.trim()
+  return allowlist.some((entry) => {
+    if (!entry) return false
+    const rule = entry.trim()
+    if (!rule) return false
+    if (rule.endsWith('*')) {
+      const prefix = rule.slice(0, -1)
+      return normalized.startsWith(prefix)
+    }
+    if (rule.includes('/')) {
+      const [base, mask] = rule.split('/')
+      if (mask === '32') return normalized === base
+      if (mask === '24') {
+        const prefix = base.split('.').slice(0, 3).join('.') + '.'
+        return normalized.startsWith(prefix)
+      }
+      return normalized === base
+    }
+    return normalized === rule
+  })
+}
+
+function normalizeRouteForLabels(pathname: string): string {
+  // Replace UUID-like segments and numeric segments with :id for low-cardinality labels.
+  const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  return pathname
+    .split('/')
+    .map((seg) => {
+      if (!seg) return seg
+      if (uuidRe.test(seg)) return ':id'
+      if (/^\d+$/.test(seg)) return ':id'
+      return seg
+    })
+    .join('/')
+}
+
+function shouldAudit(req: Request): boolean {
+  if (!req.path.startsWith('/api/')) return false
+  if (req.path.startsWith('/api/attendance/')) return true
+  if (req.path.startsWith('/api/attendance-admin/')) return true
+  return false
+}
+
+function shouldLogAuditForRequest(req: Request): boolean {
+  // Default to write operations + exports. Avoid logging high-volume reads.
+  if (req.method !== 'GET') return true
+  return req.path.endsWith('.csv') || req.path.includes('/export')
+}
+
+function pickUserId(req: Request): string | null {
+  const user = req.user as Record<string, unknown> | undefined
+  const raw = user?.id ?? user?.sub ?? user?.userId
+  if (typeof raw === 'string' && raw.trim()) return raw.trim()
+  if (typeof raw === 'number' && Number.isFinite(raw)) return String(raw)
+  return null
+}
+
+function extractResourceId(req: Request, captured: { batchId?: string; requestId?: string; targetUserId?: string }): string | null {
+  if (captured.batchId) return captured.batchId
+  if (captured.requestId) return captured.requestId
+  if (captured.targetUserId) return captured.targetUserId
+  const parts = String(req.path || '').split('/').filter(Boolean)
+  // Try common patterns:
+  // /api/attendance/import/batches/:id/...
+  const batchIdx = parts.indexOf('batches')
+  if (batchIdx >= 0 && parts[batchIdx + 1]) return parts[batchIdx + 1]
+  // /api/attendance/requests/:id/...
+  const reqIdx = parts.indexOf('requests')
+  if (reqIdx >= 0 && parts[reqIdx + 1]) return parts[reqIdx + 1]
+  // /api/attendance-admin/users/:userId/...
+  const usersIdx = parts.indexOf('users')
+  if (usersIdx >= 0 && parts[usersIdx + 1]) return parts[usersIdx + 1]
+  return null
+}
+
+function sanitizeErrorMessage(message: unknown): string | null {
+  if (typeof message !== 'string') return null
+  const trimmed = message.trim().replace(/[\r\n]+/g, ' ')
+  if (!trimmed) return null
+  return trimmed.length > 240 ? `${trimmed.slice(0, 240)}…` : trimmed
+}
+
+function redactBodyKeys(input: unknown): string[] {
+  if (!input || typeof input !== 'object') return []
+  const keys = Object.keys(input as Record<string, unknown>)
+  const redacted = new Set(['token', 'auth', 'authorization', 'commitToken', 'csvText'])
+  return keys.filter((k) => !redacted.has(k)).slice(0, 50)
+}
+
+export function attendanceAuditMiddleware(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!shouldAudit(req)) return next()
+
+    const startNs = process.hrtime.bigint()
+    const normalizedRoute = normalizeRouteForLabels(req.path)
+    const method = req.method
+    const ip = getClientIp(req)
+    const userAgent = String(req.headers['user-agent'] || '')
+    const requestId = getLogContext()?.requestId ?? String(req.headers['x-request-id'] || '')
+    const actorId = pickUserId(req)
+
+    let responseOk: boolean | null = null
+    let errorCode: string | null = null
+    let errorMessage: string | null = null
+    const captured: { batchId?: string; requestId?: string; targetUserId?: string } = {}
+
+    const originalJson = res.json.bind(res)
+    res.json = (body: unknown) => {
+      try {
+        if (body && typeof body === 'object') {
+          const obj = body as Record<string, unknown>
+          if (typeof obj.ok === 'boolean') responseOk = obj.ok
+          const err = obj.error as Record<string, unknown> | undefined
+          if (err && typeof err === 'object') {
+            if (typeof err.code === 'string' && err.code.trim()) errorCode = err.code.trim()
+            errorMessage = sanitizeErrorMessage(err.message)
+          }
+          const data = obj.data as Record<string, unknown> | undefined
+          if (data && typeof data === 'object') {
+            if (typeof data.batchId === 'string') captured.batchId = data.batchId
+          }
+        }
+      } catch {
+        // ignore capture errors
+      }
+      return originalJson(body)
+    }
+
+    res.on('finish', async () => {
+      try {
+        if (!shouldLogAuditForRequest(req)) return
+
+        const durMs = Number(process.hrtime.bigint() - startNs) / 1e6
+        const statusCode = res.statusCode
+
+        // Metrics: record only error responses, avoid unbounded series.
+        if (statusCode >= 400 || responseOk === false) {
+          const code = errorCode || `HTTP_${statusCode}`
+          attendanceApiErrorsTotal.inc({
+            route: normalizedRoute,
+            method,
+            status: String(statusCode),
+            error_code: code,
+          })
+        }
+
+        const action = `attendance_http:${method}:${normalizedRoute}`
+        const resourceType = 'attendance'
+        const resourceId = extractResourceId(req, captured)
+        const meta = {
+          ok: responseOk,
+          error: errorCode ? { code: errorCode, message: errorMessage } : null,
+          request: {
+            method,
+            route: normalizedRoute,
+            path: req.path,
+            queryKeys: Object.keys(req.query || {}).slice(0, 50),
+            bodyKeys: redactBodyKeys(req.body),
+          },
+        }
+
+        // Best effort insert; do not block the request lifecycle on audit issues.
+        await query(
+          `INSERT INTO operation_audit_logs (
+            actor_id,
+            actor_type,
+            action,
+            resource_type,
+            resource_id,
+            request_id,
+            ip,
+            user_agent,
+            route,
+            status_code,
+            latency_ms,
+            meta,
+            occurred_at,
+            created_at
+          ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb, now(), now())`,
+          [
+            actorId,
+            actorId ? 'user' : null,
+            action,
+            resourceType,
+            resourceId,
+            requestId || null,
+            ip || null,
+            userAgent || null,
+            normalizedRoute,
+            statusCode,
+            Math.round(durMs),
+            JSON.stringify(meta),
+          ],
+        )
+      } catch (error) {
+        logger.warn('Attendance audit insert failed', error as Error)
+      }
+    })
+
+    next()
+  }
+}
+
+function makeLimiter(perMinuteDefault: number): TokenBucketRateLimiter {
+  const perMinRaw = Number.isFinite(Number(perMinuteDefault)) ? Number(perMinuteDefault) : 60
+  const perMin = Math.max(1, perMinRaw)
+  const tokensPerSecond = perMin / 60
+  return new TokenBucketRateLimiter({
+    tokensPerSecond,
+    bucketCapacity: Math.max(2, Math.ceil(perMin / 6)), // ~10s burst by default
+    enableMetrics: false,
+  })
+}
+
+const importPrepareLimiter = makeLimiter(Number(process.env.ATTENDANCE_RATE_LIMIT_IMPORT_PREPARE_PER_MIN ?? 120))
+const importPreviewLimiter = makeLimiter(Number(process.env.ATTENDANCE_RATE_LIMIT_IMPORT_PREVIEW_PER_MIN ?? 60))
+const importCommitLimiter = makeLimiter(Number(process.env.ATTENDANCE_RATE_LIMIT_IMPORT_COMMIT_PER_MIN ?? 10))
+const exportLimiter = makeLimiter(Number(process.env.ATTENDANCE_RATE_LIMIT_EXPORT_PER_MIN ?? 60))
+const attendanceAdminWriteLimiter = makeLimiter(Number(process.env.ATTENDANCE_RATE_LIMIT_ADMIN_WRITE_PER_MIN ?? 120))
+
+function pickLimiter(req: Request): { limiter: TokenBucketRateLimiter; keyPrefix: string } | null {
+  const path = req.path
+  if (!path.startsWith('/api/')) return null
+
+  if (path === '/api/attendance/import/prepare' && req.method === 'POST') {
+    return { limiter: importPrepareLimiter, keyPrefix: 'attendance_import_prepare' }
+  }
+  if (path === '/api/attendance/import/preview' && req.method === 'POST') {
+    return { limiter: importPreviewLimiter, keyPrefix: 'attendance_import_preview' }
+  }
+  if (path === '/api/attendance/import/commit' && req.method === 'POST') {
+    return { limiter: importCommitLimiter, keyPrefix: 'attendance_import_commit' }
+  }
+  if (path === '/api/attendance/export' && req.method === 'GET') {
+    return { limiter: exportLimiter, keyPrefix: 'attendance_export' }
+  }
+  if (path.endsWith('/export.csv') && req.method === 'GET') {
+    return { limiter: exportLimiter, keyPrefix: 'attendance_export_csv' }
+  }
+  if (path.startsWith('/api/attendance-admin/') && req.method !== 'GET') {
+    return { limiter: attendanceAdminWriteLimiter, keyPrefix: 'attendance_admin_write' }
+  }
+  return null
+}
+
+function shouldEnforceAllowlist(req: Request): boolean {
+  const path = req.path
+  if (path.startsWith('/api/attendance/import/')) return true
+  if (path.startsWith('/api/attendance-admin/')) return true
+  if (path === '/api/attendance/export') return true
+  if (path.endsWith('/export.csv')) return true
+  return false
+}
+
+export function attendanceSecurityMiddleware(): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    if (!shouldAudit(req)) return next()
+
+    // IP allowlist
+    if (shouldEnforceAllowlist(req)) {
+      const settings = await loadAttendanceSettings()
+      if (settings.ipAllowlist.length > 0) {
+        const ip = getClientIp(req)
+        if (!isIpAllowed(ip, settings.ipAllowlist)) {
+          res.status(403).json({ ok: false, error: { code: 'IP_RESTRICTED', message: 'Request not allowed from this IP' } })
+          return
+        }
+      }
+    }
+
+    // Rate limiting (enabled by default in production; can be forced off).
+    const enabled = process.env.ATTENDANCE_RATE_LIMIT_ENABLED
+      ? process.env.ATTENDANCE_RATE_LIMIT_ENABLED === 'true'
+      : process.env.NODE_ENV === 'production'
+    if (!enabled) return next()
+
+    const picked = pickLimiter(req)
+    if (!picked) return next()
+
+    const userId = pickUserId(req) || 'anonymous'
+    const ip = getClientIp(req) || 'unknown'
+    const key = `${picked.keyPrefix}:${userId}:${ip}`
+    const result = picked.limiter.consume(key, 1)
+    if (result.allowed) return next()
+
+    const routeLabel = normalizeRouteForLabels(req.path)
+    attendanceRateLimitedTotal.inc({ route: routeLabel, method: req.method })
+    res.setHeader('Retry-After', String(Math.ceil(result.retryAfterMs / 1000)))
+    res.status(429).json({
+      ok: false,
+      error: {
+        code: 'RATE_LIMITED',
+        message: 'Too many requests. Please retry later.',
+        retryAfterMs: result.retryAfterMs,
+      },
+    })
+  }
+}


### PR DESCRIPTION
## What

P1 hardening for Attendance production readiness:

- Observability: add attendance error + rate limit metrics, Prometheus alerts, Grafana dashboard
- Audit trail: best-effort write of attendance admin/import/export actions into operation audit log + retention worker
- Admin productization: batch role provisioning APIs + audit log query API + Admin Center UI sections
- Import performance: buffered bulk insert for commit items (reduce DB roundtrips)
- Security: IP allowlist enforcement (when configured) + production-default rate limits (env override available)

## Docs

- docs/attendance-production-p1-hardening-20260209.md
- docs/attendance-production-delivery-20260207.md
- docs/attendance-production-acceptance-20260207.md
- docs/attendance-production-polish-verification-20260208.md

## How To Verify

Local build/tests:

- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/web exec vitest run --watch=false

Remote strict gates (token placeholder only):

```bash
REQUIRE_ATTENDANCE_ADMIN_API="true" \
REQUIRE_IDEMPOTENCY="true" \
REQUIRE_IMPORT_EXPORT="true" \
RUN_PREFLIGHT="false" \
API_BASE="http://142.171.239.56:8081/api" \
AUTH_TOKEN="<ADMIN_JWT>" \
EXPECT_PRODUCT_MODE="attendance" \
./scripts/ops/attendance-run-gates.sh
```

Notes:
- Artifacts are written under output/playwright/ (gitignored).
- Do not include any real tokens/secrets in docs or PR comments.