### PR TITLE
chore(attendance): strict gate runner (2x consecutive)

### DIFF
--- a/docs/attendance-production-acceptance-20260207.md
+++ b/docs/attendance-production-acceptance-20260207.md
@@ -28,6 +28,16 @@ EXPECT_PRODUCT_MODE="attendance" \
 scripts/ops/attendance-run-gates.sh
 ```
 
+To enforce "stability PASS" (strict gates **twice** consecutively), use:
+
+```bash
+API_BASE="http://142.171.239.56:8081/api" \
+AUTH_TOKEN="<ADMIN_JWT>" \
+EXPECT_PRODUCT_MODE="attendance" \
+PROVISION_USER_ID="<TARGET_USER_UUID_FOR_PROVISIONING_GATE>" \
+scripts/ops/attendance-run-strict-gates-twice.sh
+```
+
 Notes:
 
 - Idempotency retries work even when the DB column `attendance_import_batches.idempotency_key` is not present by falling back to `attendance_import_batches.meta.idempotencyKey`.

--- a/docs/attendance-production-polish-verification-20260208.md
+++ b/docs/attendance-production-polish-verification-20260208.md
@@ -77,6 +77,19 @@ scripts/ops/attendance-smoke-api.sh
 Note:
 - The smoke script calls `/api/auth/refresh-token` first (best-effort) to reduce expired-token flakiness.
 
+For "stability PASS" (strict gates twice consecutively) with evidence folders:
+
+```bash
+REQUIRE_ATTENDANCE_ADMIN_API="true" \
+REQUIRE_IDEMPOTENCY="true" \
+REQUIRE_IMPORT_EXPORT="true" \
+API_BASE="http://<HOST>:<PORT>/api" \
+AUTH_TOKEN="<ADMIN_JWT>" \
+EXPECT_PRODUCT_MODE="attendance" \
+PROVISION_USER_ID="<TARGET_USER_UUID_FOR_PROVISIONING_GATE>" \
+scripts/ops/attendance-run-strict-gates-twice.sh
+```
+
 ## Gate 3: Permission Provisioning (Role Bundles)
 
 ### Option A: UI

--- a/scripts/ops/attendance-run-gates.sh
+++ b/scripts/ops/attendance-run-gates.sh
@@ -80,7 +80,9 @@ info "WEB_URL=${WEB_URL}"
 info "OUTPUT_ROOT=${OUTPUT_ROOT}"
 
 function maybe_run_preflight() {
-  local env_file="${ROOT_DIR}/docker/app.env"
+  # Keep "auto" mode ergonomic on dev machines (skip when env file is absent),
+  # but respect a user-specified ENV_FILE override when present.
+  local env_file="${ENV_FILE:-${ROOT_DIR}/docker/app.env}"
   if [[ "$RUN_PREFLIGHT" == "false" ]]; then
     gate_preflight="SKIP"
     return 0

--- a/scripts/ops/attendance-run-strict-gates-twice.sh
+++ b/scripts/ops/attendance-run-strict-gates-twice.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+API_BASE="${API_BASE:-}"
+AUTH_TOKEN="${AUTH_TOKEN:-}"
+EXPECT_PRODUCT_MODE="${EXPECT_PRODUCT_MODE:-attendance}"
+RUN_PREFLIGHT="${RUN_PREFLIGHT:-auto}" # auto|true|false
+PROVISION_USER_ID="${PROVISION_USER_ID:-}" # optional
+
+# Strictness defaults (can be overridden by env).
+REQUIRE_ATTENDANCE_ADMIN_API="${REQUIRE_ATTENDANCE_ADMIN_API:-true}"
+REQUIRE_IDEMPOTENCY="${REQUIRE_IDEMPOTENCY:-true}"
+REQUIRE_IMPORT_EXPORT="${REQUIRE_IMPORT_EXPORT:-true}"
+
+SLEEP_SECONDS="${SLEEP_SECONDS:-90}"
+
+function die() {
+  echo "[attendance-run-strict-gates-twice] ERROR: $*" >&2
+  exit 1
+}
+
+function info() {
+  echo "[attendance-run-strict-gates-twice] $*" >&2
+}
+
+[[ -n "$API_BASE" ]] || die "API_BASE is required (example: http://142.171.239.56:8081/api)"
+[[ -n "$AUTH_TOKEN" ]] || die "AUTH_TOKEN is required"
+
+timestamp="$(date -u +%Y%m%d-%H%M%S)"
+root="${ROOT_DIR}/output/playwright/attendance-prod-acceptance"
+out1="${root}/${timestamp}-1"
+out2="${root}/${timestamp}-2"
+
+info "Strict gates: admin_api=${REQUIRE_ATTENDANCE_ADMIN_API} idempotency=${REQUIRE_IDEMPOTENCY} import_export=${REQUIRE_IMPORT_EXPORT}"
+info "Run #1 output: ${out1}"
+REQUIRE_ATTENDANCE_ADMIN_API="$REQUIRE_ATTENDANCE_ADMIN_API" \
+REQUIRE_IDEMPOTENCY="$REQUIRE_IDEMPOTENCY" \
+REQUIRE_IMPORT_EXPORT="$REQUIRE_IMPORT_EXPORT" \
+RUN_PREFLIGHT="$RUN_PREFLIGHT" \
+API_BASE="$API_BASE" \
+AUTH_TOKEN="$AUTH_TOKEN" \
+EXPECT_PRODUCT_MODE="$EXPECT_PRODUCT_MODE" \
+PROVISION_USER_ID="$PROVISION_USER_ID" \
+OUTPUT_ROOT="$out1" \
+"${ROOT_DIR}/scripts/ops/attendance-run-gates.sh"
+
+info "Waiting ${SLEEP_SECONDS}s before run #2 (reduce punch interval flakiness)..."
+sleep "$SLEEP_SECONDS"
+
+info "Run #2 output: ${out2}"
+REQUIRE_ATTENDANCE_ADMIN_API="$REQUIRE_ATTENDANCE_ADMIN_API" \
+REQUIRE_IDEMPOTENCY="$REQUIRE_IDEMPOTENCY" \
+REQUIRE_IMPORT_EXPORT="$REQUIRE_IMPORT_EXPORT" \
+RUN_PREFLIGHT="$RUN_PREFLIGHT" \
+API_BASE="$API_BASE" \
+AUTH_TOKEN="$AUTH_TOKEN" \
+EXPECT_PRODUCT_MODE="$EXPECT_PRODUCT_MODE" \
+PROVISION_USER_ID="$PROVISION_USER_ID" \
+OUTPUT_ROOT="$out2" \
+"${ROOT_DIR}/scripts/ops/attendance-run-gates.sh"
+
+cat <<EOF
+
+✅ Strict gates passed twice
+
+Evidence:
+  - ${out1}
+  - ${out2}
+EOF
+


### PR DESCRIPTION
- Add scripts/ops/attendance-run-strict-gates-twice.sh: runs strict production gates twice with a configurable delay and produces two evidence folders under output/playwright/.\n- Make scripts/ops/attendance-run-gates.sh respect ENV_FILE for RUN_PREFLIGHT=auto (avoid accidental SKIP when using a non-default env file).\n- Docs: add the new 2x strict runner command snippet (no secrets).\n\nHow to verify:\n- API_BASE=... AUTH_TOKEN=<ADMIN_JWT> EXPECT_PRODUCT_MODE=attendance PROVISION_USER_ID=<UUID> scripts/ops/attendance-run-strict-gates-twice.sh\n\nNotes:\n- Uses placeholders only; no tokens are logged or committed.