### PR TITLE
docs(attendance): mention strict gate runner

### DIFF
--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -44,6 +44,8 @@ Out of scope for this delivery:
 
 - Run all gates (recommended):
   - `API_BASE=... AUTH_TOKEN=... scripts/ops/attendance-run-gates.sh`
+- Strict gates twice (stability PASS, recommended for Go/No-Go):
+  - `API_BASE=... AUTH_TOKEN=... PROVISION_USER_ID=... scripts/ops/attendance-run-strict-gates-twice.sh`
 - API smoke:
   - `scripts/ops/attendance-smoke-api.sh`
 - Provision user permissions:


### PR DESCRIPTION
- Delivery doc: explicitly list scripts/ops/attendance-run-strict-gates-twice.sh as the recommended stability (2x consecutive) Go/No-Go gate command.\n\nNo secrets.