### PR TITLE
docs(attendance): record 10k perf PASS + ignore docs-only deploy

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,9 @@ name: Build and Push Docker Images
 on:
   push:
     branches: [main, master]
+    paths-ignore:
+      - 'docs/**'
+      - 'output/**'
   workflow_dispatch:
 
 jobs:

--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -41,6 +41,8 @@ Out of scope for this delivery:
    - `scripts/ops/deploy-attendance-prod.sh`
 3. If large imports (10k+ rows) return `504 Gateway Time-out` via nginx:
    - Ensure `docker/nginx.conf` sets `proxy_read_timeout`/`proxy_send_timeout` high enough (example: `300s`), then restart the `web` container.
+   - If you deploy via GitHub Actions (`.github/workflows/docker-build.yml`) and the production compose mounts `./docker/nginx.conf`,
+     make sure the deploy host has pulled the latest `main` so the mounted config is up to date.
 
 ### Smoke / Acceptance
 

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -163,6 +163,17 @@ Perf baseline notes:
 - 2k preview/commit + rollback passed (examples):
   - `output/playwright/attendance-import-perf/attendance-perf-mlfhy37t-g4n509/perf-summary.json`
   - `output/playwright/attendance-import-perf/attendance-perf-mlfhywc4-6w52wb/perf-summary.json`
-- 10k preview returned `504 Gateway Time-out` through nginx on `http://142.171.239.56:8081/api`.
-  - Fix shipped in repo (requires web deploy): `docker/nginx.conf` increases `/api/` proxy timeouts to `300s`.
-  - After deployment, re-run the 10k baseline.
+- 10k preview returned `504 Gateway Time-out` through nginx on `http://142.171.239.56:8081/api` before the deploy host picked up the updated `docker/nginx.conf`.
+
+## Latest Notes (2026-02-10)
+
+10k perf baseline now passes through nginx after fixing deploy host config sync (deploy now fast-forwards the repo via `git pull --ff-only origin main` before `docker compose up`):
+
+- 10k preview PASS:
+  - Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgars47-l6wd3m/perf-summary.json`
+  - previewMs: `70321`
+- 10k commit + rollback PASS:
+  - Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgatxk0-4yzd5p/perf-summary.json`
+  - previewMs: `76092`
+  - commitMs: `119036`
+  - rollbackMs: `886`


### PR DESCRIPTION
## What
- Record the 2026-02-10 10k import perf baseline PASS (preview + commit+rollback) evidence paths + timings
- Update delivery doc note about nginx 504s and deploy host config sync
- Update `docker-build.yml` to ignore docs/output-only pushes (avoid unnecessary build+deploy)

## Verification
- 10k preview PASS evidence:
  - `output/playwright/attendance-import-perf/attendance-perf-mlgars47-l6wd3m/perf-summary.json`
- 10k commit+rollback PASS evidence:
  - `output/playwright/attendance-import-perf/attendance-perf-mlgatxk0-4yzd5p/perf-summary.json`

(No secrets/tokens in docs.)