### PR TITLE
feat(attendance-import): response-size controls for large imports

### DIFF
--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -101,8 +101,11 @@ P1 (1-2 weeks, production hardening):
   - Admin Center UI:
     - Batch Provisioning (multi-UUID input)
     - Audit Logs viewer (search + paging + meta preview)
-- Import performance (partial, implemented 2026-02-09):
+- Import performance (partial, implemented 2026-02-09 and 2026-02-10):
   - Import commit uses buffered bulk inserts for items (reduces DB roundtrips).
+  - Import scalability flags (preview/commit response-size controls):
+    - `previewLimit`, `returnItems`, `itemsLimit`
+    - Doc: `docs/attendance-production-import-scalability-20260210.md`
   - Remaining: async/streaming preview + commit for large files (10k-100k rows), with timeout/retry strategy.
 - Security (implemented 2026-02-09):
   - Rate limits for import/export/admin writes (production-only by default).

--- a/docs/attendance-production-import-scalability-20260210.md
+++ b/docs/attendance-production-import-scalability-20260210.md
@@ -1,0 +1,129 @@
+# Attendance Import Scalability (2026-02-10)
+
+This document records the next-stage hardening focused on **large CSV imports (10k-100k rows)**.
+
+The immediate goal is to prevent UI/server failures caused by:
+
+- preview responses returning tens of thousands of computed rows
+- commit responses returning huge `items` arrays (memory + payload size)
+
+This work is **backward-compatible**: existing clients behave the same unless they opt into the new flags.
+
+## Changes Shipped
+
+### 1) Import Payload Flags (Back-End)
+
+`POST /api/attendance/import/preview` and `POST /api/attendance/import/commit` now accept:
+
+- `previewLimit?: number`
+  - When set and `rowCount > previewLimit`, the preview response returns at most `previewLimit` computed rows.
+  - Validation + dedup stats still reflect the full payload.
+- `returnItems?: boolean`
+  - Default: `true` (backward compatible).
+  - When `false`, commit response returns `items: []` while still returning `imported` and `batchId`.
+- `itemsLimit?: number`
+  - Optional cap for commit response `items` length when `returnItems=true`.
+
+Implementation:
+
+- `/Users/huazhou/Downloads/Github/metasheet2/plugins/plugin-attendance/index.cjs`
+
+### 2) Preview Response Additions
+
+When `previewLimit` is set, preview response adds:
+
+- `rowCount`: total resolved rows (after building rows from csv/entries)
+- `truncated`: boolean
+- `previewLimit`: echo
+- `stats`: `{ rowCount, invalid, duplicates }` (counts across the full payload)
+
+### 3) Commit Response Additions
+
+When `returnItems=false` or `itemsLimit` is hit, commit response includes:
+
+- `itemsTruncated`: boolean
+- `imported` remains accurate even when `items` is empty/limited
+
+### 4) Web UI Defaults (Large Imports)
+
+When the payload contains a large `rows[]` or `csvText` (heuristic: `> 2000` rows), the UI automatically:
+
+- uses `previewLimit=200` for preview
+- uses `returnItems=false` for commit (and keeps `itemsLimit=200` as a safe default)
+
+You can override by explicitly setting these fields in the JSON payload editor.
+
+Implementation:
+
+- `/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/views/AttendanceView.vue`
+
+### 5) Perf Harness Defaults
+
+`scripts/ops/attendance-import-perf.mjs` now defaults to safe flags for large `ROWS`:
+
+- `previewLimit=200` when `ROWS > 2000`
+- `returnItems=false` when `ROWS > 2000`
+
+Env overrides:
+
+- `PREVIEW_LIMIT=...`
+- `RETURN_ITEMS=true|false`
+- `ITEMS_LIMIT=...`
+
+Implementation:
+
+- `/Users/huazhou/Downloads/Github/metasheet2/scripts/ops/attendance-import-perf.mjs`
+
+## Verification
+
+### A) Back-End Integration Tests
+
+New test coverage verifies:
+
+- preview truncation (`previewLimit=1` with `rowCount=2`)
+- commit response suppression (`returnItems=false` with `imported=1` and `items=[]`)
+
+File:
+
+- `/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/tests/integration/attendance-plugin.test.ts`
+
+Run only the attendance integration suite:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/attendance-plugin.test.ts
+```
+
+### B) Web Build + Unit Specs
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false
+pnpm --filter @metasheet/web build
+```
+
+### C) Perf Baseline (Staging/Pre-Prod Recommended)
+
+Token placeholder only (do not paste real tokens into docs):
+
+```bash
+API_BASE="http://142.171.239.56:8081/api" \
+AUTH_TOKEN="<ADMIN_JWT>" \
+ROWS="10000" \
+MODE="commit" \
+ROLLBACK="true" \
+node scripts/ops/attendance-import-perf.mjs
+```
+
+Evidence directory:
+
+- `output/playwright/attendance-import-perf/<runId>/perf-summary.json`
+
+## Notes / Follow-Up (P1)
+
+The above changes prevent response-size failures. The remaining work for truly large payloads (50k-100k) is:
+
+- async/streaming preview + commit (job model + polling + paging)
+- bulk upserts (reduce per-row DB work) with consistent locking strategy
+- explicit timeout + retry strategy (nginx + backend) for long commits
+

--- a/docs/attendance-production-p1-hardening-20260209.md
+++ b/docs/attendance-production-p1-hardening-20260209.md
@@ -138,6 +138,16 @@ ROLLBACK="true" \
 node scripts/ops/attendance-import-perf.mjs
 ```
 
+Notes:
+
+- The perf script defaults to safe response-size flags for large `ROWS`:
+  - `previewLimit=200`
+  - `returnItems=false`
+- Override if needed:
+  - `PREVIEW_LIMIT=...`
+  - `RETURN_ITEMS=true|false`
+  - `ITEMS_LIMIT=...`
+
 Evidence:
 
 - `output/playwright/attendance-import-perf/<runId>/perf-summary.json`

--- a/scripts/ops/attendance-import-perf.mjs
+++ b/scripts/ops/attendance-import-perf.mjs
@@ -30,6 +30,13 @@ const groupSyncEnabled = process.env.GROUP_SYNC === 'true'
 const groupAutoCreate = process.env.GROUP_AUTO_CREATE === 'true'
 const groupAutoAssignMembers = process.env.GROUP_AUTO_ASSIGN !== 'false' // default true
 
+// Large imports should not return huge payloads. Defaults are safe for large ROWS.
+const previewLimitRaw = process.env.PREVIEW_LIMIT
+const previewLimit = previewLimitRaw ? Number(previewLimitRaw) : (rows > 2000 ? 200 : null)
+const returnItems = process.env.RETURN_ITEMS ? process.env.RETURN_ITEMS === 'true' : rows <= 2000
+const itemsLimitRaw = process.env.ITEMS_LIMIT
+const itemsLimit = itemsLimitRaw ? Number(itemsLimitRaw) : 200
+
 function die(message) {
   console.error(`[attendance-import-perf] ERROR: ${message}`)
   process.exit(1)
@@ -196,6 +203,9 @@ async function run() {
     mappingProfileId: resolvedMappingProfileId,
     csvText,
     idempotencyKey: runId,
+    previewLimit: Number.isFinite(previewLimit) && previewLimit > 0 ? Math.floor(previewLimit) : undefined,
+    returnItems,
+    itemsLimit: Number.isFinite(itemsLimit) && itemsLimit > 0 ? Math.floor(itemsLimit) : undefined,
     groupSync: groupSyncEnabled
       ? { autoCreate: groupAutoCreate, autoAssignMembers: groupAutoAssignMembers }
       : undefined,


### PR DESCRIPTION
## Summary\n- Add import payload flags: previewLimit / returnItems / itemsLimit.\n- Preview can truncate computed rows while still reporting full-payload stats.\n- Commit can suppress/limit returned items (imported count remains accurate).\n- Web UI auto-applies safe defaults for large CSV/rows payloads.\n- Perf harness defaults to safe flags for large ROWS.\n\n## Docs\n- docs/attendance-production-import-scalability-20260210.md\n\n## Verification\n- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts\n- pnpm --filter @metasheet/web exec vitest run --watch=false\n- pnpm --filter @metasheet/web build\n\n## Notes\n- Backward compatible: existing clients unaffected unless they set the new flags.