### PR TITLE
docs(attendance): record strict gates + perf baselines (2026-02-10)

### DIFF
--- a/docs/attendance-production-acceptance-20260207.md
+++ b/docs/attendance-production-acceptance-20260207.md
@@ -333,3 +333,48 @@ Historical (pre-deploy remote image):
 - Gate 2 `API Smoke`: `FAIL` (idempotency retry required a commitToken)
   - Evidence: `output/playwright/attendance-prod-acceptance/20260208-152606/gate-api-smoke.log`
   - Evidence: `output/playwright/attendance-prod-acceptance/20260208-162239/gate-api-smoke.log`
+
+## Latest Execution Record (2026-02-10) - Strict Gates (post-merge PR #129)
+
+Strict gate command (token placeholder only):
+
+```bash
+REQUIRE_ATTENDANCE_ADMIN_API="true" \
+REQUIRE_IDEMPOTENCY="true" \
+REQUIRE_IMPORT_EXPORT="true" \
+RUN_PREFLIGHT="false" \
+API_BASE="http://142.171.239.56:8081/api" \
+AUTH_TOKEN="<ADMIN_JWT>" \
+EXPECT_PRODUCT_MODE="attendance" \
+PROVISION_USER_ID="<TARGET_USER_UUID_FOR_PROVISIONING_GATE>" \
+scripts/ops/attendance-run-gates.sh
+```
+
+Results:
+
+1. Strict run #1: `PASS`
+   Evidence: `output/playwright/attendance-prod-acceptance/20260210-130211/`
+   API smoke log contains: `idempotency ok`, `export csv ok`
+2. Strict run #2 (consecutive): `PASS`
+   Evidence: `output/playwright/attendance-prod-acceptance/20260210-130454/`
+   API smoke log contains: `idempotency ok`, `export csv ok`
+
+Perf baseline (import response-size controls; large import safe defaults):
+
+- 10k commit + export + rollback: `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgm7tss-775i34/perf-summary.json`
+  previewMs: `3462`
+  commitMs: `108327`
+  exportMs: `1106`
+  rollbackMs: `327`
+- 50k preview: `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgmasnj-1bo840/perf-summary.json`
+  previewMs: `5217`
+- 100k preview: `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgmb8xc-7hkkzr/perf-summary.json`
+  previewMs: `5486`
+
+Notes:
+
+- Gate 1 (Preflight) can be `SKIP` when the gate runner host does not have `docker/app.env`.
+- Perf script defaults to response-size safe flags for `ROWS > 2000`: `previewLimit=200`, `returnItems=false`.

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -202,3 +202,26 @@ Validation run with provisioning included:
   - previewMs: `76092`
   - commitMs: `119036`
   - rollbackMs: `886`
+
+Post-merge PR `#129` (import response-size controls) verification (workstation run; token placeholder only):
+
+- Strict gates twice: `PASS`
+  Evidence 1: `output/playwright/attendance-prod-acceptance/20260210-130211/`
+  Evidence 2: `output/playwright/attendance-prod-acceptance/20260210-130454/`
+  API smoke log contains: `idempotency ok`, `export csv ok`
+- 10k perf baseline (commit + export + rollback): `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgm7tss-775i34/perf-summary.json`
+  previewMs: `3462`
+  commitMs: `108327`
+  exportMs: `1106`
+  rollbackMs: `327`
+- 50k preview baseline: `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgmasnj-1bo840/perf-summary.json`
+  previewMs: `5217`
+- 100k preview baseline: `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgmb8xc-7hkkzr/perf-summary.json`
+  previewMs: `5486`
+
+Notes:
+
+- These perf runs exercise the new "large import" safe defaults to avoid huge responses: `previewLimit=200`, `returnItems=false`.

--- a/docs/attendance-production-import-scalability-20260210.md
+++ b/docs/attendance-production-import-scalability-20260210.md
@@ -119,6 +119,38 @@ Evidence directory:
 
 - `output/playwright/attendance-import-perf/<runId>/perf-summary.json`
 
+## Remote Execution Record (2026-02-10)
+
+Strict gates (2x consecutive): `PASS`
+
+Evidence 1:
+- `output/playwright/attendance-prod-acceptance/20260210-130211/`
+
+Evidence 2:
+- `output/playwright/attendance-prod-acceptance/20260210-130454/`
+
+API smoke log contains: `idempotency ok`, `export csv ok`
+
+Perf baselines:
+
+- 10k commit + export + rollback: `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgm7tss-775i34/perf-summary.json`
+  previewMs: `3462`
+  commitMs: `108327`
+  exportMs: `1106`
+  rollbackMs: `327`
+- 50k preview: `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgmasnj-1bo840/perf-summary.json`
+  previewMs: `5217`
+- 100k preview: `PASS`
+  Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgmb8xc-7hkkzr/perf-summary.json`
+  previewMs: `5486`
+
+Notes:
+
+- For `ROWS > 2000`, the perf harness defaults to `previewLimit=200` and `returnItems=false` to avoid huge responses.
+- If 10k+ commits time out through nginx, increase web proxy timeouts (example: `proxy_read_timeout 300s`) and restart the `web` container.
+
 ## Notes / Follow-Up (P1)
 
 The above changes prevent response-size failures. The remaining work for truly large payloads (50k-100k) is:
@@ -126,4 +158,3 @@ The above changes prevent response-size failures. The remaining work for truly l
 - async/streaming preview + commit (job model + polling + paging)
 - bulk upserts (reduce per-row DB work) with consistent locking strategy
 - explicit timeout + retry strategy (nginx + backend) for long commits
-


### PR DESCRIPTION
Records the latest production verification evidence for Attendance after merging PR #129 (import response-size controls):\n\n- Strict gates twice evidence:\n  - output/playwright/attendance-prod-acceptance/20260210-130211/\n  - output/playwright/attendance-prod-acceptance/20260210-130454/\n- Import perf baselines evidence:\n  - output/playwright/attendance-import-perf/attendance-perf-mlgm7tss-775i34/perf-summary.json (10k commit+export+rollback)\n  - output/playwright/attendance-import-perf/attendance-perf-mlgmasnj-1bo840/perf-summary.json (50k preview)\n  - output/playwright/attendance-import-perf/attendance-perf-mlgmb8xc-7hkkzr/perf-summary.json (100k preview)\n\nNo secrets included; docs use <ADMIN_JWT> placeholders.