### PR TITLE
docs(attendance): record 10k perf baseline (2026-02-10)

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -289,3 +289,11 @@ Follow-up strict gates workflow run (post-merge mitigation): `SUCCESS`
 - Evidence directories (downloaded):
   - `output/playwright/ga/21870551973/20260210-151448-1/`
   - `output/playwright/ga/21870551973/20260210-151448-2/`
+
+Workstation 10k perf baseline (commit + rollback): `PASS`
+
+- Evidence:
+  - `output/playwright/attendance-import-perf/attendance-perf-mlgr0m4e-d3110g/perf-summary.json`
+- previewMs: `4418`
+- commitMs: `62018`
+- rollbackMs: `913`


### PR DESCRIPTION
Record the latest workstation 10k import perf baseline (commit + rollback) evidence JSON and timing numbers.

- Evidence: `output/playwright/attendance-import-perf/attendance-perf-mlgr0m4e-d3110g/perf-summary.json`
