### PR TITLE
fix(deploy): run migrations before production smoke checks

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -82,6 +82,8 @@ jobs:
             "git pull --ff-only origin main"
             "docker compose -f \"${DEPLOY_COMPOSE_FILE}\" pull backend web"
             "docker compose -f \"${DEPLOY_COMPOSE_FILE}\" up -d --no-deps --force-recreate backend web"
+            "# Ensure DB schema is up to date before smoke checks."
+            "docker compose -f \"${DEPLOY_COMPOSE_FILE}\" exec -T backend node packages/core-backend/dist/src/db/migrate.js"
             "# Post-deploy smoke checks"
             "for i in {1..10}; do"
               "  if curl -fsS http://127.0.0.1:8900/api/plugins >/dev/null; then"


### PR DESCRIPTION
## Summary
Production deploy workflow was recreating backend/web containers but not applying DB migrations.
This left runtime schema behind image code and caused attendance gates to fail with:
- `AUDIT_LOGS_EXPORT_FAILED` (`occurred_at` missing)
- `DB_NOT_READY` for async import jobs

## Change
- Update `.github/workflows/docker-build.yml` deploy remote commands to run:
  - `docker compose -f "$DEPLOY_COMPOSE_FILE" exec -T backend node packages/core-backend/dist/src/db/migrate.js`

This aligns CI deploy behavior with `scripts/ops/deploy-attendance-prod.sh`.

## Why now
Latest strict/perf workflow runs on 2026-02-11 failed on production due to stale schema after deploy.
Applying migrations in deploy path is required for production-consistent gates.
