### PR TITLE
docs(attendance): publish 2026-02-11 production closure evidence

### DIFF
--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -39,6 +39,7 @@ Out of scope for this delivery:
    - `scripts/ops/attendance-preflight.sh`
 2. Deploy + migrate + restart web:
    - `scripts/ops/deploy-attendance-prod.sh`
+   - GitHub Actions deploy path (`.github/workflows/docker-build.yml`) now also runs backend migration before smoke checks.
 3. If large imports (10k+ rows) return `504 Gateway Time-out` via nginx:
    - Ensure `docker/nginx.conf` sets `proxy_read_timeout`/`proxy_send_timeout` high enough (example: `300s`), then restart the `web` container.
    - If you deploy via GitHub Actions (`.github/workflows/docker-build.yml`) and the production compose mounts `./docker/nginx.conf`,

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -277,6 +277,32 @@ Automation hardening verification (defaults + perf thresholds):
     - `rollbackMs=76`
     - `regressions=[]`
 
+Production workflow closure (main, after PR #136 + #137):
+
+- Deploy pipeline:
+  - [Build and Push Docker Images #21894316469](https://github.com/zensgit/metasheet2/actions/runs/21894316469) (`SUCCESS`)
+  - Includes migration execution in deploy step.
+- Strict gates twice (async strict default): `PASS`
+  - Run: [Attendance Strict Gates (Prod) #21894374032](https://github.com/zensgit/metasheet2/actions/runs/21894374032)
+  - Evidence:
+    - `output/playwright/ga/21894374032/20260211-055556-1/`
+    - `output/playwright/ga/21894374032/20260211-055556-2/`
+  - `gate-api-smoke.log` includes:
+    - `audit export csv ok`
+    - `idempotency ok`
+    - `export csv ok`
+    - `import async idempotency ok`
+- Perf baseline with thresholds (10k, async+export+rollback): `PASS`
+  - Run: [Attendance Import Perf Baseline #21894377908](https://github.com/zensgit/metasheet2/actions/runs/21894377908)
+  - Evidence:
+    - `output/playwright/ga/21894377908/attendance-perf-mlhm8esx-abitlr/perf-summary.json`
+  - Metrics:
+    - `previewMs=2919`
+    - `commitMs=66985`
+    - `exportMs=390`
+    - `rollbackMs=114`
+    - `regressions=[]`
+
 10k perf baseline now passes through nginx after fixing deploy host config sync (deploy now fast-forwards the repo via `git pull --ff-only origin main` before `docker compose up`):
 
 - 10k preview PASS:

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1,0 +1,54 @@
+# Attendance Production Go/No-Go (2026-02-11)
+
+## Scope
+
+This record closes the production readiness loop for Attendance after enabling:
+
+- Async import strict gate by default
+- Perf threshold gate
+- Deploy-time DB migration execution
+
+## Final Gate Result
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Strict gates twice (async strict) | [#21894374032](https://github.com/zensgit/metasheet2/actions/runs/21894374032) | PASS | `output/playwright/ga/21894374032/20260211-055556-1/`, `output/playwright/ga/21894374032/20260211-055556-2/` |
+| Perf baseline (10k, async+export+rollback, thresholds enabled) | [#21894377908](https://github.com/zensgit/metasheet2/actions/runs/21894377908) | PASS | `output/playwright/ga/21894377908/attendance-perf-mlhm8esx-abitlr/perf-summary.json` |
+| Build + deploy (with migration step) | [#21894316469](https://github.com/zensgit/metasheet2/actions/runs/21894316469) | PASS | GitHub Actions run logs |
+
+Perf summary (`#21894377908`):
+
+- `rows=10000`
+- `previewMs=2919`
+- `commitMs=66985`
+- `exportMs=390`
+- `rollbackMs=114`
+- `regressions=[]`
+
+## Incident and Fix Trace
+
+Initial failures before closure:
+
+- [#21894139054](https://github.com/zensgit/metasheet2/actions/runs/21894139054): strict gate failed (`/attendance-admin/audit-logs/export.csv` missing).
+- [#21894142162](https://github.com/zensgit/metasheet2/actions/runs/21894142162): perf gate failed (`/attendance/import/commit-async` missing).
+- [#21894255303](https://github.com/zensgit/metasheet2/actions/runs/21894255303): strict gate failed (`occurred_at` column missing).
+- [#21894258310](https://github.com/zensgit/metasheet2/actions/runs/21894258310): perf gate failed (`DB_NOT_READY`).
+
+Root cause:
+
+- Deploy workflow recreated containers but did not run DB migrations.
+
+Remediation shipped:
+
+- PR [#137](https://github.com/zensgit/metasheet2/pull/137)
+- Commit: `24b97562`
+- Change: `.github/workflows/docker-build.yml` deploy step now executes:
+  - `docker compose ... exec -T backend node packages/core-backend/dist/src/db/migrate.js`
+
+## Decision
+
+- **GO** (production continuation approved)
+
+Rationale:
+
+- Strict gates and perf threshold gates are both passing on `main` after migration-enabled deploy.


### PR DESCRIPTION
## Summary
Adds the 2026-02-11 production closure record for Attendance, including:

- failure -> remediation -> re-verification timeline
- final strict/perf gate PASS evidence paths
- explicit Go/No-Go decision

## Included docs
- `docs/attendance-production-acceptance-20260207.md`
- `docs/attendance-production-ga-daily-gates-20260209.md`
- `docs/attendance-production-delivery-20260207.md`
- `docs/attendance-production-go-no-go-20260211.md` (new)

## References
- Strict gate PASS run: https://github.com/zensgit/metasheet2/actions/runs/21894374032
- Perf gate PASS run: https://github.com/zensgit/metasheet2/actions/runs/21894377908
- Deploy (migration-enabled) PASS run: https://github.com/zensgit/metasheet2/actions/runs/21894316469
