### PR TITLE
feat(attendance-ops): automate daily gate dashboard and escalation

### DIFF
--- a/.github/workflows/attendance-daily-gate-dashboard.yml
+++ b/.github/workflows/attendance-daily-gate-dashboard.yml
@@ -1,0 +1,119 @@
+name: Attendance Daily Gate Dashboard
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to evaluate'
+        required: false
+        default: 'main'
+      lookback_hours:
+        description: 'Max age (hours) for latest completed runs'
+        required: false
+        default: '36'
+  schedule:
+    # Daily after strict/perf scheduled windows.
+    - cron: '30 4 * * *'
+
+concurrency:
+  group: attendance-daily-gate-dashboard
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  dashboard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BRANCH: ${{ inputs.branch || 'main' }}
+      LOOKBACK_HOURS: ${{ inputs.lookback_hours || '36' }}
+      STRICT_WORKFLOW: attendance-strict-gates-prod.yml
+      PERF_WORKFLOW: attendance-import-perf-baseline.yml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate gate dashboard
+        id: report
+        run: |
+          set -euo pipefail
+          node ./scripts/ops/attendance-daily-gate-report.mjs
+
+      - name: Add markdown to step summary
+        if: always()
+        run: |
+          cat "${{ steps.report.outputs.report_markdown }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload dashboard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: attendance-daily-gate-dashboard-${{ github.run_id }}-${{ github.run_attempt }}
+          retention-days: 30
+          path: |
+            ${{ steps.report.outputs.report_dir }}/**
+
+      - name: Open/update escalation issue on failure
+        if: steps.report.outputs.report_status != 'pass'
+        uses: actions/github-script@v7
+        env:
+          REPORT_MARKDOWN: ${{ steps.report.outputs.report_markdown }}
+          REPORT_STATUS: ${{ steps.report.outputs.report_status }}
+        with:
+          script: |
+            const fs = require('fs')
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const title = '[Attendance Gate] Daily dashboard alert'
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
+            const markdownPath = process.env.REPORT_MARKDOWN
+            const markdown = fs.readFileSync(markdownPath, 'utf8')
+            const body = [
+              'Automated attendance gate escalation.',
+              '',
+              `Run: ${runUrl}`,
+              '',
+              markdown.slice(0, 60000),
+            ].join('\n')
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            })
+
+            const existing = issues.find((issue) => !issue.pull_request && issue.title === title)
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              })
+              core.info(`Updated issue #${existing.number}`)
+            } else {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+              })
+              core.info(`Created issue #${created.data.number}`)
+            }
+
+      - name: Fail workflow when dashboard status is fail
+        if: steps.report.outputs.report_status != 'pass'
+        run: |
+          echo "Attendance daily gate dashboard failed"
+          exit 1

--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -72,6 +72,7 @@ Out of scope for this delivery:
 - GitHub Actions (recommended for daily verification):
   - Strict gates: `.github/workflows/attendance-strict-gates-prod.yml`
   - Perf baseline (scheduled + manual): `.github/workflows/attendance-import-perf-baseline.yml`
+  - Daily dashboard + escalation: `.github/workflows/attendance-daily-gate-dashboard.yml`
 
 ## Rollback
 

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -150,6 +150,46 @@ Artifacts:
 - Uploaded for 14 days:
   - `output/playwright/attendance-import-perf/**`
 
+### C) Daily Gate Dashboard (Scheduled + Manual)
+
+Workflow:
+
+- `.github/workflows/attendance-daily-gate-dashboard.yml`
+
+Purpose:
+
+- Build a daily dashboard from latest strict/perf workflow runs.
+- Apply escalation rules automatically:
+  - `P0`: strict gate failure
+  - `P1`: perf gate failure or stale run
+- Open/update GitHub issue `[Attendance Gate] Daily dashboard alert` when dashboard status is `FAIL`.
+
+Schedule:
+
+- Daily at `04:30 UTC` (after strict/perf scheduled windows).
+
+Artifacts:
+
+- Uploaded for 30 days:
+  - `output/playwright/attendance-daily-gate-dashboard/**`
+
+Manual local generation (operator workstation):
+
+```bash
+GH_TOKEN="$(gh auth token)" \
+GITHUB_REPOSITORY="zensgit/metasheet2" \
+BRANCH="main" \
+LOOKBACK_HOURS="48" \
+node scripts/ops/attendance-daily-gate-report.mjs
+```
+
+Expected outputs:
+
+- `REPORT_STATUS=pass|fail`
+- `REPORT_DIR=...`
+- `REPORT_MARKDOWN=...`
+- `REPORT_JSON=...`
+
 ## Daily Record Template (Copy/Paste)
 
 Date:
@@ -302,6 +342,16 @@ Production workflow closure (main, after PR #136 + #137):
     - `exportMs=390`
     - `rollbackMs=114`
     - `regressions=[]`
+
+Daily dashboard local verification (2026-02-11):
+
+- Command:
+  - `GH_TOKEN="$(gh auth token)" GITHUB_REPOSITORY="zensgit/metasheet2" BRANCH="main" LOOKBACK_HOURS="48" node scripts/ops/attendance-daily-gate-report.mjs`
+- Result:
+  - `REPORT_STATUS=pass`
+- Evidence:
+  - `output/playwright/attendance-daily-gate-dashboard/20260211-100235/attendance-daily-gate-dashboard.md`
+  - `output/playwright/attendance-daily-gate-dashboard/20260211-100235/attendance-daily-gate-dashboard.json`
 
 10k perf baseline now passes through nginx after fixing deploy host config sync (deploy now fast-forwards the repo via `git pull --ff-only origin main` before `docker compose up`):
 

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -52,3 +52,13 @@ Remediation shipped:
 Rationale:
 
 - Strict gates and perf threshold gates are both passing on `main` after migration-enabled deploy.
+
+## Continuous Monitoring (Post-Go)
+
+- Daily dashboard workflow:
+  - `.github/workflows/attendance-daily-gate-dashboard.yml`
+- Dashboard generator:
+  - `scripts/ops/attendance-daily-gate-report.mjs`
+- Escalation behavior:
+  - `P0` strict gate failure -> open/update issue `[Attendance Gate] Daily dashboard alert` and fail workflow.
+  - `P1` perf gate failure/stale runs -> open/update same issue and fail workflow.

--- a/scripts/ops/attendance-daily-gate-report.mjs
+++ b/scripts/ops/attendance-daily-gate-report.mjs
@@ -1,0 +1,311 @@
+/**
+ * Attendance Daily Gate Dashboard Report
+ *
+ * Collects the latest runs for strict/perf workflows from GitHub Actions,
+ * evaluates gate health, and writes Markdown + JSON evidence.
+ *
+ * Outputs (stdout + optional GITHUB_OUTPUT):
+ * - REPORT_STATUS=pass|fail
+ * - REPORT_DIR=...
+ * - REPORT_MARKDOWN=...
+ * - REPORT_JSON=...
+ */
+
+import fs from 'fs/promises'
+import path from 'path'
+
+const token = String(process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '').trim()
+const repo = String(process.env.GITHUB_REPOSITORY || 'zensgit/metasheet2').trim()
+const apiBase = String(process.env.GITHUB_API_URL || 'https://api.github.com').replace(/\/+$/, '')
+const branch = String(process.env.BRANCH || 'main').trim()
+const strictWorkflow = String(process.env.STRICT_WORKFLOW || 'attendance-strict-gates-prod.yml').trim()
+const perfWorkflow = String(process.env.PERF_WORKFLOW || 'attendance-import-perf-baseline.yml').trim()
+const lookbackHours = Math.max(1, Number(process.env.LOOKBACK_HOURS || 36))
+const outputRoot = String(process.env.OUTPUT_DIR || 'output/playwright/attendance-daily-gate-dashboard').trim()
+
+const [owner, repoName] = repo.split('/')
+
+function die(message) {
+  console.error(`[attendance-daily-gate-report] ERROR: ${message}`)
+  process.exit(1)
+}
+
+function info(message) {
+  console.log(`[attendance-daily-gate-report] ${message}`)
+}
+
+function toIsoNoMs(date) {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+function makeRunId() {
+  const d = new Date()
+  const yyyy = d.getUTCFullYear()
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(d.getUTCDate()).padStart(2, '0')
+  const hh = String(d.getUTCHours()).padStart(2, '0')
+  const mi = String(d.getUTCMinutes()).padStart(2, '0')
+  const ss = String(d.getUTCSeconds()).padStart(2, '0')
+  return `${yyyy}${mm}${dd}-${hh}${mi}${ss}`
+}
+
+async function apiGet(pathname) {
+  const url = `${apiBase}${pathname}`
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'attendance-daily-gate-report',
+    },
+  })
+  const raw = await res.text()
+  let body = null
+  try {
+    body = raw ? JSON.parse(raw) : null
+  } catch {
+    body = null
+  }
+  if (!res.ok) {
+    throw new Error(`GET ${pathname} failed: HTTP ${res.status} ${raw.slice(0, 240)}`)
+  }
+  return body
+}
+
+function ageHours(now, iso) {
+  if (!iso) return Number.POSITIVE_INFINITY
+  const value = Date.parse(iso)
+  if (!Number.isFinite(value)) return Number.POSITIVE_INFINITY
+  return (now.getTime() - value) / (1000 * 60 * 60)
+}
+
+function formatRun(run) {
+  if (!run) {
+    return {
+      id: null,
+      status: 'missing',
+      conclusion: 'missing',
+      event: null,
+      createdAt: null,
+      updatedAt: null,
+      url: null,
+    }
+  }
+  return {
+    id: run.id ?? null,
+    status: String(run.status || 'unknown'),
+    conclusion: String(run.conclusion || ''),
+    event: String(run.event || ''),
+    createdAt: run.created_at || null,
+    updatedAt: run.updated_at || null,
+    url: run.html_url || null,
+  }
+}
+
+function evaluateGate({ name, severity, latestAny, latestCompleted, now, lookbackHoursValue }) {
+  const findings = []
+  let ok = true
+  const completed = formatRun(latestCompleted)
+  const latest = formatRun(latestAny)
+
+  if (!latestCompleted) {
+    ok = false
+    findings.push({
+      severity,
+      code: 'NO_COMPLETED_RUN',
+      gate: name,
+      message: `${name}: no completed run found on branch '${branch}'`,
+      runUrl: latest.url,
+    })
+  } else {
+    const runAgeHours = ageHours(now, completed.updatedAt)
+    if (runAgeHours > lookbackHoursValue) {
+      ok = false
+      findings.push({
+        severity: severity === 'P0' ? 'P1' : severity,
+        code: 'STALE_RUN',
+        gate: name,
+        message: `${name}: latest completed run is stale (${runAgeHours.toFixed(1)}h > ${lookbackHoursValue}h)`,
+        runUrl: completed.url,
+      })
+    }
+    if (completed.conclusion !== 'success') {
+      ok = false
+      findings.push({
+        severity,
+        code: 'RUN_FAILED',
+        gate: name,
+        message: `${name}: latest completed run conclusion=${completed.conclusion || 'unknown'}`,
+        runUrl: completed.url,
+      })
+    }
+  }
+
+  return {
+    name,
+    severity,
+    ok,
+    latest,
+    completed,
+    findings,
+  }
+}
+
+function renderMarkdown({ generatedAt, repoValue, branchValue, lookbackHoursValue, strictGate, perfGate, overallStatus, findings }) {
+  const lines = []
+  lines.push('# Attendance Daily Gate Dashboard')
+  lines.push('')
+  lines.push(`Generated at (UTC): \`${generatedAt}\``)
+  lines.push(`Repository: \`${repoValue}\``)
+  lines.push(`Branch: \`${branchValue}\``)
+  lines.push(`Lookback: \`${lookbackHoursValue}h\``)
+  lines.push(`Overall: **${overallStatus.toUpperCase()}**`)
+  lines.push('')
+  lines.push('## Gate Status')
+  lines.push('')
+  lines.push('| Gate | Severity | Latest Completed | Conclusion | Updated (UTC) | Status | Link |')
+  lines.push('|---|---|---|---|---|---|---|')
+
+  for (const gate of [strictGate, perfGate]) {
+    const completed = gate.completed
+    const runId = completed.id ? `#${completed.id}` : '-'
+    const conclusion = completed.conclusion || '-'
+    const updatedAt = completed.updatedAt || '-'
+    const status = gate.ok ? 'PASS' : 'FAIL'
+    const link = completed.url ? `[run](${completed.url})` : '-'
+    lines.push(`| ${gate.name} | ${gate.severity} | ${runId} | ${conclusion} | ${updatedAt} | ${status} | ${link} |`)
+  }
+
+  lines.push('')
+  lines.push('## Escalation Rules')
+  lines.push('')
+  lines.push('- `P0` (Strict gate failure): immediate production block, rerun strict gate after fix, do not proceed with release actions.')
+  lines.push('- `P1` (Perf gate failure/stale runs): fix same day, rerun perf baseline with thresholds and record evidence.')
+  lines.push('- `P2` (missing evidence metadata only): update docs within 24h.')
+  lines.push('')
+
+  if (findings.length === 0) {
+    lines.push('## Findings')
+    lines.push('')
+    lines.push('- None.')
+  } else {
+    lines.push('## Findings')
+    lines.push('')
+    for (const finding of findings) {
+      const link = finding.runUrl ? ` ([run](${finding.runUrl}))` : ''
+      lines.push(`- [${finding.severity}] ${finding.gate} / ${finding.code}: ${finding.message}${link}`)
+    }
+  }
+
+  lines.push('')
+  lines.push('## Suggested Actions')
+  lines.push('')
+  lines.push('1. Re-run strict gate manually when any `P0` finding exists.')
+  lines.push('2. Re-run perf baseline manually when any `P1` finding exists.')
+  lines.push('3. Record evidence paths in production acceptance docs after gate recovery.')
+  return `${lines.join('\n')}\n`
+}
+
+async function writeGithubOutput(outputs) {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (!outputPath) return
+  const lines = []
+  for (const [key, value] of Object.entries(outputs)) {
+    lines.push(`${key}=${String(value)}`)
+  }
+  await fs.appendFile(outputPath, `${lines.join('\n')}\n`, 'utf8')
+}
+
+async function run() {
+  if (!owner || !repoName) {
+    die(`invalid GITHUB_REPOSITORY: '${repo}'`)
+  }
+  if (!token) {
+    die('GH_TOKEN or GITHUB_TOKEN is required')
+  }
+
+  const now = new Date()
+  const generatedAt = toIsoNoMs(now)
+  const runId = makeRunId()
+  const outDir = path.join(outputRoot, runId)
+  await fs.mkdir(outDir, { recursive: true })
+
+  info(`repository=${repo} branch=${branch}`)
+
+  const strictRuns = await apiGet(`/repos/${owner}/${repoName}/actions/workflows/${encodeURIComponent(strictWorkflow)}/runs?branch=${encodeURIComponent(branch)}&per_page=20`)
+  const perfRuns = await apiGet(`/repos/${owner}/${repoName}/actions/workflows/${encodeURIComponent(perfWorkflow)}/runs?branch=${encodeURIComponent(branch)}&per_page=20`)
+
+  const strictList = Array.isArray(strictRuns?.workflow_runs) ? strictRuns.workflow_runs : []
+  const perfList = Array.isArray(perfRuns?.workflow_runs) ? perfRuns.workflow_runs : []
+
+  const strictLatestAny = strictList[0] ?? null
+  const strictLatestCompleted = strictList.find((run) => run?.status === 'completed') ?? null
+  const perfLatestAny = perfList[0] ?? null
+  const perfLatestCompleted = perfList.find((run) => run?.status === 'completed') ?? null
+
+  const strictGate = evaluateGate({
+    name: 'Strict Gates',
+    severity: 'P0',
+    latestAny: strictLatestAny,
+    latestCompleted: strictLatestCompleted,
+    now,
+    lookbackHoursValue: lookbackHours,
+  })
+  const perfGate = evaluateGate({
+    name: 'Perf Baseline',
+    severity: 'P1',
+    latestAny: perfLatestAny,
+    latestCompleted: perfLatestCompleted,
+    now,
+    lookbackHoursValue: lookbackHours,
+  })
+
+  const findings = [...strictGate.findings, ...perfGate.findings]
+  const overallStatus = findings.length === 0 ? 'pass' : 'fail'
+
+  const report = {
+    generatedAt,
+    repository: repo,
+    branch,
+    lookbackHours,
+    overallStatus,
+    gates: {
+      strict: strictGate,
+      perf: perfGate,
+    },
+    findings,
+  }
+
+  const markdown = renderMarkdown({
+    generatedAt,
+    repoValue: repo,
+    branchValue: branch,
+    lookbackHoursValue: lookbackHours,
+    strictGate,
+    perfGate,
+    overallStatus,
+    findings,
+  })
+
+  const markdownPath = path.join(outDir, 'attendance-daily-gate-dashboard.md')
+  const jsonPath = path.join(outDir, 'attendance-daily-gate-dashboard.json')
+  await fs.writeFile(markdownPath, markdown, 'utf8')
+  await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+
+  const outputs = {
+    report_status: overallStatus,
+    report_dir: outDir,
+    report_markdown: markdownPath,
+    report_json: jsonPath,
+  }
+  await writeGithubOutput(outputs)
+
+  console.log(`REPORT_STATUS=${overallStatus}`)
+  console.log(`REPORT_DIR=${outDir}`)
+  console.log(`REPORT_MARKDOWN=${markdownPath}`)
+  console.log(`REPORT_JSON=${jsonPath}`)
+}
+
+run().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error)
+  die(message)
+})


### PR DESCRIPTION
## Summary
Adds a production-facing daily attendance gate dashboard automation:

- New report script: `scripts/ops/attendance-daily-gate-report.mjs`
  - Pulls latest strict/perf workflow runs from GitHub Actions
  - Evaluates gate status with escalation severity (P0/P1)
  - Writes Markdown + JSON evidence under `output/playwright/attendance-daily-gate-dashboard/<runId>/`
  - Emits outputs for CI steps
- New workflow: `.github/workflows/attendance-daily-gate-dashboard.yml`
  - Scheduled daily (`04:30 UTC`) + manual dispatch
  - Uploads dashboard artifacts
  - Opens/updates issue `[Attendance Gate] Daily dashboard alert` when failed
  - Fails workflow on dashboard failure (explicit escalation signal)

## Docs updated
- `docs/attendance-production-ga-daily-gates-20260209.md`
- `docs/attendance-production-delivery-20260207.md`
- `docs/attendance-production-go-no-go-20260211.md`

## Verification
- `node --check scripts/ops/attendance-daily-gate-report.mjs`
- Local report generation:
  - `GH_TOKEN="$(gh auth token)" GITHUB_REPOSITORY="zensgit/metasheet2" BRANCH="main" LOOKBACK_HOURS="48" node scripts/ops/attendance-daily-gate-report.mjs`
- Evidence:
  - `output/playwright/attendance-daily-gate-dashboard/20260211-100235/attendance-daily-gate-dashboard.md`
  - `output/playwright/attendance-daily-gate-dashboard/20260211-100235/attendance-daily-gate-dashboard.json`
