### PR TITLE
feat(attendance-ops): add gate-issue channel sync and threshold tuning records

### DIFF
--- a/.github/workflows/attendance-gate-issue-notify.yml
+++ b/.github/workflows/attendance-gate-issue-notify.yml
@@ -1,0 +1,92 @@
+name: Attendance Gate Issue Notify
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  workflow_dispatch:
+    inputs:
+      title:
+        description: 'Issue title for manual notification test'
+        required: false
+        default: '[Attendance Gate] Manual notify test'
+      issue_url:
+        description: 'Issue URL for manual notification test'
+        required: false
+        default: 'https://github.com/zensgit/metasheet2/issues/0'
+      status:
+        description: 'pass/fail status string'
+        required: false
+        default: 'fail'
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Prepare message
+        id: prep
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName
+            const isManual = eventName === 'workflow_dispatch'
+            const issueTitle = isManual
+              ? String(core.getInput('title') || '[Attendance Gate] Manual notify test')
+              : String(context.payload.issue?.title || '')
+            const issueUrl = isManual
+              ? String(core.getInput('issue_url') || '')
+              : String(context.payload.issue?.html_url || '')
+            const issueState = isManual
+              ? String(core.getInput('status') || 'fail')
+              : String(context.payload.issue?.state || 'open')
+
+            const shouldNotify = issueTitle.startsWith('[Attendance Gate]')
+            core.setOutput('should_notify', shouldNotify ? 'true' : 'false')
+            core.setOutput('issue_title', issueTitle)
+            core.setOutput('issue_url', issueUrl)
+
+            const lines = [
+              '[Attendance Gate Alert]',
+              `repo: ${context.repo.owner}/${context.repo.repo}`,
+              `event: ${eventName}`,
+              `title: ${issueTitle}`,
+              `state: ${issueState}`,
+              issueUrl ? `url: ${issueUrl}` : '',
+            ].filter(Boolean)
+            core.setOutput('message', lines.join('\n'))
+
+      - name: Summary
+        run: |
+          echo "should_notify=${{ steps.prep.outputs.should_notify }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "issue_title=${{ steps.prep.outputs.issue_title }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "issue_url=${{ steps.prep.outputs.issue_url }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify Slack webhook
+        if: steps.prep.outputs.should_notify == 'true' && secrets.ATTENDANCE_ALERT_SLACK_WEBHOOK_URL != ''
+        env:
+          WEBHOOK_URL: ${{ secrets.ATTENDANCE_ALERT_SLACK_WEBHOOK_URL }}
+          MESSAGE: ${{ steps.prep.outputs.message }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -nc --arg text "$MESSAGE" '{text:$text}')"
+          curl -fsS -X POST -H 'Content-type: application/json' --data "$payload" "$WEBHOOK_URL"
+
+      - name: Notify DingTalk webhook
+        if: steps.prep.outputs.should_notify == 'true' && secrets.ATTENDANCE_ALERT_DINGTALK_WEBHOOK_URL != ''
+        env:
+          WEBHOOK_URL: ${{ secrets.ATTENDANCE_ALERT_DINGTALK_WEBHOOK_URL }}
+          MESSAGE: ${{ steps.prep.outputs.message }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -nc --arg text "$MESSAGE" '{msgtype:"text", text:{content:$text}}')"
+          curl -fsS -X POST -H 'Content-type: application/json' --data "$payload" "$WEBHOOK_URL"
+
+      - name: Warn when no outbound channel configured
+        if: steps.prep.outputs.should_notify == 'true' && secrets.ATTENDANCE_ALERT_SLACK_WEBHOOK_URL == '' && secrets.ATTENDANCE_ALERT_DINGTALK_WEBHOOK_URL == ''
+        run: |
+          echo "No channel webhook configured. Set ATTENDANCE_ALERT_SLACK_WEBHOOK_URL and/or ATTENDANCE_ALERT_DINGTALK_WEBHOOK_URL."
+          echo "No channel webhook configured." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -73,6 +73,8 @@ Out of scope for this delivery:
   - Strict gates: `.github/workflows/attendance-strict-gates-prod.yml`
   - Perf baseline (scheduled + manual): `.github/workflows/attendance-import-perf-baseline.yml`
   - Daily dashboard + escalation: `.github/workflows/attendance-daily-gate-dashboard.yml`
+  - Issue-to-channel sync (Slack/DingTalk): `.github/workflows/attendance-gate-issue-notify.yml`
+    - Secrets (optional, at least one): `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`, `ATTENDANCE_ALERT_DINGTALK_WEBHOOK_URL`
 
 ## Rollback
 

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -62,8 +62,17 @@ Rationale:
 - Escalation behavior:
   - `P0` strict gate failure -> open/update issue `[Attendance Gate] Daily dashboard alert` and fail workflow.
   - `P1` perf gate failure/stale runs -> open/update same issue and fail workflow.
+- Channel sync workflow:
+  - `.github/workflows/attendance-gate-issue-notify.yml`
+  - Routes `[Attendance Gate]` issue events to Slack/DingTalk webhooks when configured.
 - Workflow validation:
   - [Attendance Daily Gate Dashboard #21900762111](https://github.com/zensgit/metasheet2/actions/runs/21900762111) (`SUCCESS`)
   - Evidence:
     - `output/playwright/ga/21900762111/attendance-daily-gate-dashboard.md`
     - `output/playwright/ga/21900762111/attendance-daily-gate-dashboard.json`
+- Failure drill validation:
+  - [Attendance Daily Gate Dashboard #21912261134](https://github.com/zensgit/metasheet2/actions/runs/21912261134) (`FAILURE`, expected)
+  - Escalation issue created:
+    - [#141](https://github.com/zensgit/metasheet2/issues/141)
+  - Evidence:
+    - `output/playwright/ga/21912261134/attendance-daily-gate-dashboard.md`


### PR DESCRIPTION
## Summary
Completes production-ops step 3 + 4 follow-ups:

1. Add issue-event channel sync workflow for attendance gate alerts.
2. Record failure drill evidence and 7-day threshold-tuning execution in production docs.

## Changes
- New workflow: `.github/workflows/attendance-gate-issue-notify.yml`
  - Triggers on issue events (`opened/reopened/edited`) and manual dispatch
  - Filters title prefix `[Attendance Gate]`
  - Sends to optional secrets:
    - `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`
    - `ATTENDANCE_ALERT_DINGTALK_WEBHOOK_URL`
  - Writes summary warning when no outbound webhook is configured
- Docs updated:
  - `docs/attendance-production-ga-daily-gates-20260209.md`
  - `docs/attendance-production-delivery-20260207.md`
  - `docs/attendance-production-go-no-go-20260211.md`

## Evidence captured
- Failure drill run:
  - https://github.com/zensgit/metasheet2/actions/runs/21912261134
  - issue created: https://github.com/zensgit/metasheet2/issues/141
- 7-day threshold review summary:
  - `output/playwright/attendance-next-phase/20260211-160000-threshold-review/perf-7d-summary.json`
- Repo variables tightened:
  - `ATTENDANCE_PERF_MAX_PREVIEW_MS=100000`
  - `ATTENDANCE_PERF_MAX_COMMIT_MS=150000`
  - `ATTENDANCE_PERF_MAX_EXPORT_MS=25000`
  - `ATTENDANCE_PERF_MAX_ROLLBACK_MS=8000`
