### PR TITLE
feat(attendance): P1 chunk preview + observability + admin audit UX

### DIFF
--- a/docker/observability/grafana/dashboards/attendance-overview.json
+++ b/docker/observability/grafana/dashboards/attendance-overview.json
@@ -22,7 +22,7 @@
     {
       "type": "timeseries",
       "title": "Attendance API Errors (rate)",
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
       "targets": [
         { "expr": "sum(rate(attendance_api_errors_total{job=\"$job\"}[5m]))", "datasource": "${DS_PROM}" }
       ],
@@ -32,7 +32,7 @@
     {
       "type": "timeseries",
       "title": "Attendance Rate Limited (rate)",
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 10 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
       "targets": [
         { "expr": "sum(rate(attendance_rate_limited_total{job=\"$job\"}[5m]))", "datasource": "${DS_PROM}" }
       ],
@@ -41,11 +41,37 @@
     },
     {
       "type": "timeseries",
-      "title": "Import Commit Errors (rate)",
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 20 },
+      "title": "Import Commit Latency p95 (s)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "targets": [
         {
-          "expr": "sum(rate(attendance_api_errors_total{job=\"$job\",route=\"/api/attendance/import/commit\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum(rate(attendance_operation_latency_seconds_bucket{job=\"$job\",operation=~\"import_commit|import_commit_async\",result=\"ok\"}[5m])) by (le))",
+          "datasource": "${DS_PROM}"
+        }
+      ],
+      "options": { "legend": { "displayMode": "table" }, "tooltip": { "mode": "multi" } },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "Approval Latency p95 (s)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(attendance_operation_latency_seconds_bucket{job=\"$job\",operation=~\"request_create|request_approve|request_reject\",result=\"ok\"}[5m])) by (le))",
+          "datasource": "${DS_PROM}"
+        }
+      ],
+      "options": { "legend": { "displayMode": "table" }, "tooltip": { "mode": "multi" } },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "Import & Approval Failures (rate by operation)",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum(rate(attendance_operation_failures_total{job=\"$job\",operation=~\"import_preview|import_commit|import_commit_async|request_create|request_approve|request_reject\"}[5m])) by (operation)",
           "datasource": "${DS_PROM}"
         }
       ],
@@ -54,8 +80,23 @@
     },
     {
       "type": "table",
+      "title": "Top Failure Reasons (5m rate)",
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 26 },
+      "targets": [
+        {
+          "expr": "topk(12, sum(rate(attendance_operation_failures_total{job=\"$job\",operation=~\"import_preview|import_commit|import_commit_async|request_create|request_approve|request_reject\"}[5m])) by (operation, reason))",
+          "datasource": "${DS_PROM}",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+    },
+    {
+      "type": "table",
       "title": "Top Error Routes (5m rate)",
-      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 30 },
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 26 },
       "targets": [
         {
           "expr": "topk(10, sum(rate(attendance_api_errors_total{job=\"$job\"}[5m])) by (route))",
@@ -90,4 +131,3 @@
   "uid": "attendance-overview",
   "version": 1
 }
-

--- a/ops/prometheus/attendance-alerts.yml
+++ b/ops/prometheus/attendance-alerts.yml
@@ -21,6 +21,26 @@ groups:
           summary: Attendance import commit is failing
           runbook: Inspect import batch audit logs; verify idempotency behavior; check DB constraints and plugin status.
 
+      - alert: AttendanceImportCommitLatencyP95High
+        expr: histogram_quantile(0.95, sum(rate(attendance_operation_latency_seconds_bucket{operation=~"import_commit|import_commit_async",result="ok"}[5m])) by (le)) > 20
+        for: 10m
+        labels:
+          severity: warning
+          component: attendance
+        annotations:
+          summary: Attendance import commit latency p95 is high
+          runbook: Check import job queue backlog, DB write throughput, and large payload patterns.
+
+      - alert: AttendanceApprovalFailures
+        expr: sum(rate(attendance_operation_failures_total{operation=~"request_create|request_approve|request_reject"}[5m])) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+          component: attendance
+        annotations:
+          summary: Attendance approval operations are failing
+          runbook: Inspect approval flow configuration, permission assignments, and operation_audit_logs error codes.
+
       - alert: AttendanceRateLimitedHigh
         expr: sum(rate(attendance_rate_limited_total[5m])) > 0.2
         for: 10m
@@ -30,4 +50,3 @@ groups:
         annotations:
           summary: Attendance API rate limiting is frequently triggered
           runbook: Confirm allowlist and rate limit settings; check for abusive traffic; adjust ATTENDANCE_RATE_LIMIT_* envs if needed.
-

--- a/packages/core-backend/src/metrics/attendance-metrics.ts
+++ b/packages/core-backend/src/metrics/attendance-metrics.ts
@@ -14,6 +14,27 @@ export const attendanceRateLimitedTotal = new client.Counter({
   labelNames: ['route', 'method'] as const,
 })
 
+export const attendanceOperationRequestsTotal = new client.Counter({
+  name: 'attendance_operation_requests_total',
+  help: 'Attendance operation request totals by operation/result',
+  labelNames: ['operation', 'result'] as const,
+})
+
+export const attendanceOperationFailuresTotal = new client.Counter({
+  name: 'attendance_operation_failures_total',
+  help: 'Attendance operation failures grouped by reason and status class',
+  labelNames: ['operation', 'reason', 'status_class'] as const,
+})
+
+export const attendanceOperationLatencySeconds = new client.Histogram({
+  name: 'attendance_operation_latency_seconds',
+  help: 'Attendance operation latency in seconds',
+  labelNames: ['operation', 'result'] as const,
+  buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120],
+})
+
 registry.registerMetric(attendanceApiErrorsTotal)
 registry.registerMetric(attendanceRateLimitedTotal)
-
+registry.registerMetric(attendanceOperationRequestsTotal)
+registry.registerMetric(attendanceOperationFailuresTotal)
+registry.registerMetric(attendanceOperationLatencySeconds)

--- a/scripts/ops/attendance-smoke-api.mjs
+++ b/scripts/ops/attendance-smoke-api.mjs
@@ -281,6 +281,18 @@ async function run() {
       }
       log('audit export csv ok')
     }
+
+    const auditSummaryRes = await apiFetch('/attendance-admin/audit-logs/summary?windowMinutes=60&limit=5', { method: 'GET' })
+    if (auditSummaryRes.res.status === 404) {
+      if (requireAttendanceAdminApi) die('attendance-admin audit log summary missing (404)')
+      log('WARN: attendance-admin audit log summary missing (404); skipping summary check')
+    } else {
+      assertOk(auditSummaryRes, 'GET /attendance-admin/audit-logs/summary')
+      const summaryData = auditSummaryRes.body?.data ?? {}
+      if (!Array.isArray(summaryData?.actions)) die('audit summary response missing actions')
+      if (!Array.isArray(summaryData?.errors)) die('audit summary response missing errors')
+      log('audit summary ok')
+    }
   }
 
   // 2) plugins active


### PR DESCRIPTION
## Summary\n- add chunked large-import preview path in Attendance admin UI with progress/status\n- add operation-level attendance metrics (requests/failures/latency) and wire them in middleware\n- expand attendance admin audit APIs with filters and summary endpoint\n- enrich batch role assign/unassign response with affected/unchanged user IDs\n- update admin UI for batch result details + audit filters/summary\n- extend alert rules/dashboard queries and smoke checks\n\n## Validation\n- pnpm --filter @metasheet/core-backend test:integration:attendance\n- pnpm --filter @metasheet/core-backend build\n- pnpm --filter @metasheet/web build\n- node --check scripts/ops/attendance-smoke-api.mjs\n- jq -e . docker/observability/grafana/dashboards/attendance-overview.json\n\n## Notes\n- chunked preview auto-triggers for 10k+ rows (rows/entries/csv payload)\n- chunk preview keeps aggregated warnings and sample items while avoiding single-request oversized preview\n