### PR TITLE
docs(attendance): record branch policy drift gate validation

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -1559,3 +1559,48 @@ Validation:
   - Verified:
     - `Overall=PASS`
     - Branch Protection row `PASS` (run `#22168482721`)
+
+## Latest Notes (2026-02-19): Branch Policy Drift Workflow + Dashboard `gateFlat.protection` Mapping
+
+Implementation:
+
+- PR: [#193](https://github.com/zensgit/metasheet2/pull/193) (`MERGED`)
+- Commit: `932223f3`
+- Added workflow:
+  - `.github/workflows/attendance-branch-policy-drift-prod.yml`
+- Daily dashboard now defaults to the new protection workflow source:
+  - `.github/workflows/attendance-daily-gate-dashboard.yml`
+  - `PROTECTION_WORKFLOW=attendance-branch-policy-drift-prod.yml`
+- Branch protection check + ensure scripts now support review policy checks:
+  - `REQUIRE_PR_REVIEWS`
+  - `MIN_APPROVING_REVIEW_COUNT`
+  - `REQUIRE_CODE_OWNER_REVIEWS`
+- Dashboard parser + `gateFlat.protection` mapping now include:
+  - `requirePrReviews`
+  - `minApprovingReviews`
+  - `requireCodeOwnerReviews`
+
+Validation:
+
+- Branch Policy Drift workflow (non-drill):
+  - [Attendance Branch Policy Drift (Prod) #22183957768](https://github.com/zensgit/metasheet2/actions/runs/22183957768) (`SUCCESS`)
+  - Evidence:
+    - `output/playwright/ga/22183957768/step-summary.md`
+    - `output/playwright/ga/22183957768/policy.log`
+    - `output/playwright/ga/22183957768/policy.json`
+  - Verified summary fields:
+    - `Require PR reviews: false`
+    - `Min approving reviews: 1`
+    - `Require code owner reviews: false`
+- Daily Dashboard after switch to policy-drift workflow:
+  - [Attendance Daily Gate Dashboard #22183988363](https://github.com/zensgit/metasheet2/actions/runs/22183988363) (`SUCCESS`)
+  - Evidence:
+    - `output/playwright/ga/22183988363/attendance-daily-gate-dashboard-22183988363-1/attendance-daily-gate-dashboard.md`
+    - `output/playwright/ga/22183988363/attendance-daily-gate-dashboard-22183988363-1/attendance-daily-gate-dashboard.json`
+    - `output/playwright/ga/22183988363/attendance-daily-gate-dashboard-22183988363-1/gate-meta/protection/meta.json`
+  - Verified `gateFlat.protection` fields:
+    - `requirePrReviews="false"`
+    - `minApprovingReviews="1"`
+    - `requireCodeOwnerReviews="false"`
+- Local negative check (expected FAIL classification):
+  - `REQUIRE_PR_REVIEWS=true` returns `reason=PR_REVIEWS_NOT_ENABLED` on current `main` policy.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1023,3 +1023,24 @@ Evidence:
 | Branch Protection post-merge re-verify | [#22168482721](https://github.com/zensgit/metasheet2/actions/runs/22168482721) | PASS | `output/playwright/ga/22168482721/step-summary.md`, `output/playwright/ga/22168482721/protection.log` (`strict_current=true`, `enforce_admins_current=true`) |
 | Daily Dashboard post-merge re-verify | [#22168496046](https://github.com/zensgit/metasheet2/actions/runs/22168496046) | PASS | `output/playwright/ga/22168496046/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22168496046/attendance-daily-gate-dashboard.json` (`Overall=PASS`, Branch Protection row PASS) |
 | Protected-main PR | [#191](https://github.com/zensgit/metasheet2/pull/191) | MERGED | Required checks satisfied under protected main policy |
+
+## Post-Go Validation (2026-02-19): Branch Policy Drift Gate + Protection Review Mapping
+
+This record validates:
+
+- Branch protection drift monitoring is decoupled into a lightweight policy workflow.
+- Daily dashboard `gateFlat.protection` now carries review-policy status fields.
+- Review-policy failures are classified with explicit reason codes.
+
+Implementation:
+
+- PR: [#193](https://github.com/zensgit/metasheet2/pull/193)
+- Commit: `932223f3`
+
+Evidence:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (Prod) non-drill | [#22183957768](https://github.com/zensgit/metasheet2/actions/runs/22183957768) | PASS | `output/playwright/ga/22183957768/step-summary.md`, `output/playwright/ga/22183957768/policy.log`, `output/playwright/ga/22183957768/policy.json` |
+| Daily Dashboard (uses policy-drift workflow source) | [#22183988363](https://github.com/zensgit/metasheet2/actions/runs/22183988363) | PASS | `output/playwright/ga/22183988363/attendance-daily-gate-dashboard-22183988363-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22183988363/attendance-daily-gate-dashboard-22183988363-1/gate-meta/protection/meta.json` (`gateFlat.protection.requirePrReviews=false`, `minApprovingReviews=1`, `requireCodeOwnerReviews=false`) |
+| Local script negative check (`REQUIRE_PR_REVIEWS=true`) | N/A | FAIL (expected) | `attendance-check-branch-protection` returns `reason=PR_REVIEWS_NOT_ENABLED` (classification verified) |


### PR DESCRIPTION
## Summary
- append latest branch policy drift gate implementation + validation notes to daily gates handbook
- append post-go validation record for policy drift workflow + `gateFlat.protection` review mapping
- include runIds and local artifact evidence paths for reproducibility

## Evidence
- Branch Policy Drift run: https://github.com/zensgit/metasheet2/actions/runs/22183957768
- Daily Dashboard run: https://github.com/zensgit/metasheet2/actions/runs/22183988363
- Artifacts downloaded to:
  - `output/playwright/ga/22183957768/`
  - `output/playwright/ga/22183988363/`
