### PR TITLE
feat(attendance): harden async import job recovery and telemetry

### DIFF
--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1262,3 +1262,28 @@ Confirmed in `attendance-daily-gate-dashboard.json` (`#22226886691`):
 - `gateFlat.protection.status=PASS`
 - `gateFlat.protection.runId=22226864599`
 - `gateFlat.protection.requirePrReviews=false`
+
+## Post-Go Validation (2026-02-20): Import Async Job Telemetry + Recovery UX (`B+C` local)
+
+This record validates the next parallel-delivery increment:
+
+- Backend import job API adds non-breaking telemetry fields:
+  - `progressPercent`
+  - `throughputRowsPerSec`
+- Web attendance admin import panel supports recovery-first operations:
+  - `Reload job`
+  - `Resume polling`
+  - error classification/action for `IMPORT_JOB_TIMEOUT|FAILED|CANCELED`.
+
+Validation evidence:
+
+| Check | Status | Evidence |
+|---|---|---|
+| `pnpm --filter @metasheet/core-backend test:integration:attendance` | PASS | `output/playwright/attendance-next-phase/20260220-230856-import-job-ux/backend-attendance-integration.log` |
+| `pnpm --filter @metasheet/web build` | PASS | `output/playwright/attendance-next-phase/20260220-230856-import-job-ux/web-build.log` |
+
+Files changed:
+
+- `plugins/plugin-attendance/index.cjs`
+- `packages/core-backend/tests/integration/attendance-plugin.test.ts`
+- `apps/web/src/views/AttendanceView.vue`

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1120,6 +1120,8 @@ describe('Attendance Plugin Integration', () => {
     expect(typeof job?.processedRows).toBe('number')
     expect(typeof job?.failedRows).toBe('number')
     expect(typeof job?.elapsedMs).toBe('number')
+    expect(typeof job?.progressPercent).toBe('number')
+    expect(typeof job?.throughputRowsPerSec).toBe('number')
 
     // Retry should return the same job without requiring a new commitToken.
     const { commitToken: _commitToken, ...retryPayload } = commitPayload
@@ -1167,6 +1169,8 @@ describe('Attendance Plugin Integration', () => {
     expect(typeof completedJob?.failedRows).toBe('number')
     expect(completedJob?.processedRows).toBeGreaterThanOrEqual(1)
     expect(typeof completedJob?.elapsedMs).toBe('number')
+    expect(typeof completedJob?.progressPercent).toBe('number')
+    expect(typeof completedJob?.throughputRowsPerSec).toBe('number')
 
     const rollbackRes = await requestJson(`${baseUrl}/api/attendance/import/rollback/${batchId}`, {
       method: 'POST',
@@ -1246,6 +1250,8 @@ describe('Attendance Plugin Integration', () => {
     expect(typeof job?.processedRows).toBe('number')
     expect(typeof job?.failedRows).toBe('number')
     expect(typeof job?.elapsedMs).toBe('number')
+    expect(typeof job?.progressPercent).toBe('number')
+    expect(typeof job?.throughputRowsPerSec).toBe('number')
 
     const { commitToken: _commitToken, ...retryPayload } = previewPayload
     const retryRes = await requestJson(`${baseUrl}/api/attendance/import/preview-async`, {
@@ -1296,6 +1302,8 @@ describe('Attendance Plugin Integration', () => {
     expect(typeof completedPreviewJob?.failedRows).toBe('number')
     expect(completedPreviewJob?.processedRows).toBeGreaterThanOrEqual(2)
     expect(typeof completedPreviewJob?.elapsedMs).toBe('number')
+    expect(typeof completedPreviewJob?.progressPercent).toBe('number')
+    expect(typeof completedPreviewJob?.throughputRowsPerSec).toBe('number')
   })
 
   it('exports attendance admin audit logs as CSV', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -5498,6 +5498,15 @@ module.exports = {
 	        && rawIdempotencyKey.startsWith('preview:')
 	        ? rawIdempotencyKey.slice('preview:'.length)
 	        : rawIdempotencyKey
+	      const progressPercent = total > 0
+	        ? Math.max(0, Math.min(100, Math.round((Math.max(0, progress) / total) * 100)))
+	        : 0
+	      const elapsedMs = computeImportJobElapsedMs(row.started_at, row.finished_at, status)
+	      const throughputRowsPerSec = (() => {
+	        if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return 0
+	        const rows = Math.max(0, processedRows)
+	        return Number((rows / (elapsedMs / 1000)).toFixed(2))
+	      })()
 	      return {
 	        id: row.id,
 	        orgId: row.org_id ?? DEFAULT_ORG_ID,
@@ -5509,9 +5518,11 @@ module.exports = {
 	        engine: resolveImportEngineFromMeta(payload, total),
 	        progress,
 	        total,
+	        progressPercent,
 	        processedRows,
 	        failedRows,
-	        elapsedMs: computeImportJobElapsedMs(row.started_at, row.finished_at, status),
+	        elapsedMs,
+	        throughputRowsPerSec,
 	        error: row.error ?? null,
 	        preview,
 	        startedAt: row.started_at ?? null,


### PR DESCRIPTION
## Summary
- add non-breaking async import job telemetry fields in attendance plugin API:
  - `progressPercent`
  - `throughputRowsPerSec`
- harden Attendance admin import UX for async jobs:
  - `Reload job`
  - `Resume polling`
  - classify timeout/failed/canceled job states and route to `reload-import-job` action
- extend attendance integration assertions for new job fields
- append delivery evidence to parallel plan and go/no-go documents

## Verification
- `pnpm --filter @metasheet/core-backend test:integration:attendance`
- `pnpm --filter @metasheet/web build`
- Evidence:
  - `output/playwright/attendance-next-phase/20260220-230856-import-job-ux/backend-attendance-integration.log`
  - `output/playwright/attendance-next-phase/20260220-230856-import-job-ux/web-build.log`
