### PR TITLE
fix(attendance-gates): stabilize strict admin readiness and longrun 10k commit path

### DIFF
--- a/.github/workflows/attendance-import-perf-longrun.yml
+++ b/.github/workflows/attendance-import-perf-longrun.yml
@@ -127,6 +127,7 @@ jobs:
           - id: rows10k-commit
             rows: '10000'
             mode: 'commit'
+            commit_async: 'false'
             export_csv: 'true'
             rollback: 'true'
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_PREVIEW_MS || vars.ATTENDANCE_PERF_MAX_PREVIEW_MS || '100000' }}
@@ -136,6 +137,7 @@ jobs:
           - id: rows50k-preview
             rows: '50000'
             mode: 'preview'
+            commit_async: 'true'
             export_csv: 'false'
             rollback: 'false'
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_50K_MAX_PREVIEW_MS || '180000' }}
@@ -145,6 +147,7 @@ jobs:
           - id: rows100k-preview
             rows: '100000'
             mode: 'preview'
+            commit_async: 'true'
             export_csv: 'false'
             rollback: 'false'
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_MAX_PREVIEW_MS || '240000' }}
@@ -154,6 +157,7 @@ jobs:
           - id: rows500k-preview
             rows: '500000'
             mode: 'preview'
+            commit_async: 'true'
             export_csv: 'false'
             rollback: 'false'
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_500K_MAX_PREVIEW_MS || '480000' }}
@@ -179,6 +183,7 @@ jobs:
           SCENARIO: ${{ matrix.id }}
           ROWS: ${{ matrix.rows }}
           MODE: ${{ matrix.mode }}
+          COMMIT_ASYNC: ${{ matrix.commit_async }}
           EXPORT_CSV: ${{ matrix.export_csv }}
           ROLLBACK: ${{ matrix.rollback }}
           MAX_PREVIEW_MS: ${{ matrix.max_preview_ms }}

--- a/scripts/verify-attendance-full-flow.mjs
+++ b/scripts/verify-attendance-full-flow.mjs
@@ -21,7 +21,7 @@ const assertAdminRetry = process.env.ASSERT_ADMIN_RETRY !== 'false'
 const assertImportJobRecovery = process.env.ASSERT_IMPORT_JOB_RECOVERY === 'true'
 const importRecoveryTimeoutMs = Math.max(10, Number(process.env.IMPORT_RECOVERY_TIMEOUT_MS || 80))
 const importRecoveryIntervalMs = Math.max(10, Number(process.env.IMPORT_RECOVERY_INTERVAL_MS || 25))
-const adminReadyTimeoutMs = Number(process.env.ADMIN_READY_TIMEOUT || timeoutMs)
+const adminReadyTimeoutMs = Number(process.env.ADMIN_READY_TIMEOUT || Math.max(timeoutMs, 90000))
 
 function logInfo(message) {
   console.log(`[attendance-full-flow] ${message}`)


### PR DESCRIPTION
## Summary
- increase default admin readiness timeout in `verify-attendance-full-flow.mjs` from `UI_TIMEOUT` to `max(UI_TIMEOUT, 90s)`
- set longrun matrix `rows10k-commit` to `COMMIT_ASYNC=false` and keep preview scenarios explicit with `commit_async=true`

## Why
- strict gates on main showed intermittent admin section render latency >45s
- longrun 10k async commit occasionally failed with backend read timeout under contention
- commit/export/rollback coverage is still preserved for `rows10k-commit`

## Scope
- CI/workflow and e2e gate stabilization only
- no API contract changes
