### PR TITLE
fix(attendance-gates): retry transient remote failures across gate scripts

### DIFF
--- a/scripts/ops/attendance-import-perf.mjs
+++ b/scripts/ops/attendance-import-perf.mjs
@@ -33,6 +33,9 @@ const maxExportMs = parseOptionalPositiveInt('MAX_EXPORT_MS')
 const maxRollbackMs = parseOptionalPositiveInt('MAX_ROLLBACK_MS')
 const rollbackRetryAttempts = Math.max(1, Number(process.env.ROLLBACK_RETRY_ATTEMPTS || 3))
 const rollbackRetryDelayMs = Math.max(100, Number(process.env.ROLLBACK_RETRY_DELAY_MS || 1500))
+const apiRetryAttempts = Math.max(1, Number(process.env.API_RETRY_ATTEMPTS || 5))
+const apiRetryDelayMs = Math.max(100, Number(process.env.API_RETRY_DELAY_MS || 1000))
+const apiTimeoutMs = Math.max(1000, Number(process.env.API_TIMEOUT_MS || 15000))
 
 // Disabled by default: group creation/membership is persistent (not rolled back with import rollback).
 const groupSyncEnabled = process.env.GROUP_SYNC === 'true'
@@ -73,6 +76,50 @@ function nowMs() {
   return Number(process.hrtime.bigint() / 1_000_000n)
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isRetriableStatus(status) {
+  return status === 408 || status === 429 || (status >= 500 && status <= 504)
+}
+
+async function fetchWithRetry(url, init = {}, options = {}) {
+  const label = options.label || url
+  const allowRefresh = options.allowRefresh !== false
+
+  for (let attempt = 1; attempt <= apiRetryAttempts; attempt += 1) {
+    try {
+      const signal = typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+        ? AbortSignal.timeout(apiTimeoutMs)
+        : undefined
+      const res = await fetch(url, { ...init, signal })
+      if (res.status === 401 && allowRefresh && attempt < apiRetryAttempts) {
+        const refreshed = await refreshAuthToken()
+        if (refreshed) {
+          const delayMs = Math.min(apiRetryDelayMs * attempt, 5000)
+          log(`WARN: ${label} got 401; refreshed token and retrying in ${delayMs}ms`)
+          await sleep(delayMs)
+          continue
+        }
+      }
+      if (isRetriableStatus(res.status) && attempt < apiRetryAttempts) {
+        const delayMs = Math.min(apiRetryDelayMs * attempt, 5000)
+        log(`WARN: ${label} returned HTTP ${res.status}; retry ${attempt}/${apiRetryAttempts} in ${delayMs}ms`)
+        await sleep(delayMs)
+        continue
+      }
+      return res
+    } catch (error) {
+      if (attempt >= apiRetryAttempts) throw error
+      const delayMs = Math.min(apiRetryDelayMs * attempt, 5000)
+      log(`WARN: ${label} network error (${(error && error.message) || String(error)}); retry ${attempt}/${apiRetryAttempts} in ${delayMs}ms`)
+      await sleep(delayMs)
+    }
+  }
+  throw new Error(`${label}: exhausted retries`)
+}
+
 function decodeJwtPayload(jwt) {
   if (!jwt || typeof jwt !== 'string') return null
   const parts = jwt.split('.')
@@ -96,11 +143,11 @@ async function writeJson(filePath, data) {
 async function refreshAuthToken() {
   const url = `${apiBase}/auth/refresh-token`
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithRetry(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ token }),
-    })
+    }, { label: 'POST /auth/refresh-token', allowRefresh: false })
     const raw = await res.text()
     let body = null
     try {
@@ -135,14 +182,14 @@ async function refreshAuthToken() {
 
 async function apiFetch(pathname, init = {}) {
   const url = `${apiBase}${pathname}`
-  const res = await fetch(url, {
+  const res = await fetchWithRetry(url, {
     ...init,
     headers: {
       ...(init.headers || {}),
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-  })
+  }, { label: `${init.method || 'GET'} ${pathname}` })
   const raw = await res.text()
   let body = null
   try {
@@ -155,13 +202,13 @@ async function apiFetch(pathname, init = {}) {
 
 async function apiFetchText(pathname, init = {}) {
   const url = `${apiBase}${pathname}`
-  const res = await fetch(url, {
+  const res = await fetchWithRetry(url, {
     ...init,
     headers: {
       ...(init.headers || {}),
       Authorization: `Bearer ${token}`,
     },
-  })
+  }, { label: `${init.method || 'GET'} ${pathname}` })
   const text = await res.text()
   return { url, res, text }
 }
@@ -262,7 +309,7 @@ async function pollImportJob(jobId, { timeoutMs = 30 * 60 * 1000, intervalMs = 2
         if (Date.now() - started > timeoutMs) {
           throw new Error(`async commit job poll timed out after transient errors (last status=${status})`)
         }
-        await new Promise((r) => setTimeout(r, intervalMs))
+        await sleep(intervalMs)
         continue
       }
       throw new Error(`GET /attendance/import/jobs/:id failed: HTTP ${status} ${job.raw.slice(0, 200)}`)
@@ -281,7 +328,7 @@ async function pollImportJob(jobId, { timeoutMs = 30 * 60 * 1000, intervalMs = 2
     if (Date.now() - started > timeoutMs) {
       throw new Error('async commit job timed out')
     }
-    await new Promise((r) => setTimeout(r, intervalMs))
+    await sleep(intervalMs)
   }
 }
 


### PR DESCRIPTION
## Summary
- add transient network retry/backoff/timeout handling to attendance smoke API script
- add transient network retry/backoff/timeout handling to attendance perf baseline script
- add transient network retry/backoff/timeout handling to attendance production flow verification script
- add curl retry defaults in attendance permission provisioning script

## Why
Recent gate failures were dominated by temporary `502`/`ECONNREFUSED`/`fetch failed` on the production endpoint. These changes reduce false negatives while keeping gate assertions unchanged.

## Verification
- `node --check scripts/ops/attendance-smoke-api.mjs`
- `node --check scripts/ops/attendance-import-perf.mjs`
- `node --check scripts/verify-attendance-production-flow.mjs`
- `bash -n scripts/ops/attendance-provision-user.sh`
