### PR TITLE
fix(attendance-gates): tune retry timeout defaults for import workloads

### DIFF
--- a/scripts/ops/attendance-import-perf.mjs
+++ b/scripts/ops/attendance-import-perf.mjs
@@ -35,7 +35,7 @@ const rollbackRetryAttempts = Math.max(1, Number(process.env.ROLLBACK_RETRY_ATTE
 const rollbackRetryDelayMs = Math.max(100, Number(process.env.ROLLBACK_RETRY_DELAY_MS || 1500))
 const apiRetryAttempts = Math.max(1, Number(process.env.API_RETRY_ATTEMPTS || 5))
 const apiRetryDelayMs = Math.max(100, Number(process.env.API_RETRY_DELAY_MS || 1000))
-const apiTimeoutMs = Math.max(1000, Number(process.env.API_TIMEOUT_MS || 15000))
+const apiTimeoutMs = Math.max(1000, Number(process.env.API_TIMEOUT_MS || 180000))
 
 // Disabled by default: group creation/membership is persistent (not rolled back with import rollback).
 const groupSyncEnabled = process.env.GROUP_SYNC === 'true'

--- a/scripts/ops/attendance-smoke-api.mjs
+++ b/scripts/ops/attendance-smoke-api.mjs
@@ -12,7 +12,7 @@ const requireBatchResolve = process.env.REQUIRE_BATCH_RESOLVE === 'true'
 const requirePreviewAsync = process.env.REQUIRE_PREVIEW_ASYNC === 'true'
 const apiRetryAttempts = Math.max(1, Number(process.env.API_RETRY_ATTEMPTS || 5))
 const apiRetryDelayMs = Math.max(100, Number(process.env.API_RETRY_DELAY_MS || 1000))
-const apiTimeoutMs = Math.max(1000, Number(process.env.API_TIMEOUT_MS || 15000))
+const apiTimeoutMs = Math.max(1000, Number(process.env.API_TIMEOUT_MS || 120000))
 
 function normalizeProductMode(value) {
   if (value === 'attendance' || value === 'attendance-focused') return 'attendance'

--- a/scripts/verify-attendance-production-flow.mjs
+++ b/scripts/verify-attendance-production-flow.mjs
@@ -14,7 +14,7 @@ const outputDir = process.env.OUTPUT_DIR || 'output/playwright/attendance-produc
 const allowLegacyImport = process.env.ALLOW_LEGACY_IMPORT === '1'
 const apiRetryAttempts = Math.max(1, Number(process.env.API_RETRY_ATTEMPTS || 5))
 const apiRetryDelayMs = Math.max(100, Number(process.env.API_RETRY_DELAY_MS || 1000))
-const apiTimeoutMs = Math.max(1000, Number(process.env.API_TIMEOUT_MS || 15000))
+const apiTimeoutMs = Math.max(1000, Number(process.env.API_TIMEOUT_MS || 60000))
 
 function logInfo(message) {
   console.log(`[attendance-production-flow] ${message}`)


### PR DESCRIPTION
## Summary
- increase default API timeout in `attendance-import-perf.mjs` to 180s
- increase default API timeout in `attendance-smoke-api.mjs` to 120s
- increase default API timeout in `verify-attendance-production-flow.mjs` to 60s

## Why
The previous 15s timeout introduced false failures for heavy preview calls and consumed preview commit tokens before retry.
