### PR TITLE
docs(attendance): add final stabilization closure report and gate evidence

### DIFF
--- a/docs/attendance-production-closure-report-20260221.md
+++ b/docs/attendance-production-closure-report-20260221.md
@@ -1,0 +1,47 @@
+# Attendance Production Closure Report (2026-02-21)
+
+## Scope
+
+This report closes the latest stabilization cycle for Attendance production gates on `main` (without Payroll scope expansion).
+
+## Implemented Fixes
+
+Merged PRs:
+
+- [#217](https://github.com/zensgit/metasheet2/pull/217): full-flow `/auth/me` retry hardening + longrun rollback flake reduction.
+- [#218](https://github.com/zensgit/metasheet2/pull/218): transient network retries for smoke/provision/perf/production-flow scripts.
+- [#219](https://github.com/zensgit/metasheet2/pull/219): timeout defaults tuned for heavy import workloads.
+- [#220](https://github.com/zensgit/metasheet2/pull/220): preview/commit retries now re-prepare fresh `commitToken`; baseline rollback threshold fallback aligned.
+- [#221](https://github.com/zensgit/metasheet2/pull/221): async import job polling tolerates transient fetch errors inside timeout budget.
+
+## Final Verification (main)
+
+| Gate | Run | Status | Key evidence |
+|---|---|---|---|
+| Strict Gates (twice) | [#22257658383](https://github.com/zensgit/metasheet2/actions/runs/22257658383) | PASS | `output/playwright/ga/22257658383/attendance-strict-gates-prod-22257658383-1/20260221-133025-1/gate-summary.json` |
+| Perf Baseline (100k, upload, commit_async=false) | [#22257793629](https://github.com/zensgit/metasheet2/actions/runs/22257793629) | PASS | `output/playwright/ga/22257793629/attendance-import-perf-22257793629-1/attendance-perf-mlwd8aeo-7mygl2/perf-summary.json` |
+| Perf Long Run | [#22257658595](https://github.com/zensgit/metasheet2/actions/runs/22257658595) | PASS | `output/playwright/ga/22257658595/attendance-import-perf-longrun-rows10k-commit-22257658595-1/current-flat/rows10000-commit.json` |
+| Daily Gate Dashboard | [#22257840707](https://github.com/zensgit/metasheet2/actions/runs/22257840707) | PASS | `output/playwright/ga/22257840707/attendance-daily-gate-dashboard-22257840707-1/attendance-daily-gate-dashboard.md` |
+
+## Evidence Highlights
+
+- Strict API smoke logs include required strict markers on both runs:
+  - `import upload ok`
+  - `idempotency ok`
+  - `export csv ok`
+  - `SMOKE PASS`
+- Baseline summary (`#22257793629`) reports:
+  - `rows=100000`, `uploadCsv=true`, `commitAsync=false`
+  - `regressions=[]`
+- Longrun `rows10k-commit` summary (`#22257658595`) reports:
+  - `commitAsync=false`
+  - `regressions=[]`
+
+## Decision
+
+- **GO (maintained)** for Attendance production gates and daily operations.
+
+## Notes
+
+- No real tokens/secrets are stored in this report.
+- All downloadable evidence paths are under `output/playwright/ga/<runId>/...`.

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -1980,3 +1980,30 @@ Runbook note:
 
 - `branch=feature-branch` 的 dashboard 通常会出现 `NO_COMPLETED_RUN`（remote-only gates按 `main` 调度）。这类 run 只用于脚本回归，不用于生产门禁判定。
 - 生产门禁请固定使用：`branch=main`。
+
+## Latest Notes (2026-02-21): Final Stabilization Snapshot
+
+Execution summary:
+
+1. Hardened strict/perf scripts against transient `502` / `ECONNREFUSED` / `fetch failed`.
+2. Stabilized import mutation retries by re-preparing `commitToken` on each preview/commit retry.
+3. Tuned baseline rollback threshold fallback to `30000ms`.
+4. Re-ran strict + perf baseline + perf longrun, then validated daily dashboard on `main`.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Strict gates (main) | [#22257658383](https://github.com/zensgit/metasheet2/actions/runs/22257658383) | PASS | `output/playwright/ga/22257658383/attendance-strict-gates-prod-22257658383-1/20260221-133025-1/gate-summary.json`, `output/playwright/ga/22257658383/attendance-strict-gates-prod-22257658383-1/20260221-133025-2/gate-summary.json` |
+| Perf baseline 100k (main, `commit_async=false`) | [#22257793629](https://github.com/zensgit/metasheet2/actions/runs/22257793629) | PASS | `output/playwright/ga/22257793629/attendance-import-perf-22257793629-1/attendance-perf-mlwd8aeo-7mygl2/perf-summary.json` |
+| Perf longrun (main) | [#22257658595](https://github.com/zensgit/metasheet2/actions/runs/22257658595) | PASS | `output/playwright/ga/22257658595/attendance-import-perf-longrun-rows10k-commit-22257658595-1/current-flat/rows10000-commit.json` |
+| Daily dashboard (main, final) | [#22257840707](https://github.com/zensgit/metasheet2/actions/runs/22257840707) | PASS | `output/playwright/ga/22257840707/attendance-daily-gate-dashboard-22257840707-1/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22257840707/attendance-daily-gate-dashboard-22257840707-1/attendance-daily-gate-dashboard.json` |
+
+Observed dashboard status (`#22257840707`):
+
+- `overallStatus=pass`
+- `Strict Gates=PASS`
+- `Perf Baseline=PASS`
+- `Perf Long Run=PASS`
+- `Remote Preflight=PASS`
+- `Storage Health=PASS`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -258,6 +258,30 @@ This record validates:
 | Remote Upload Cleanup (dry-run, safety limits inputs) | [#22010499353](https://github.com/zensgit/metasheet2/actions/runs/22010499353) | PASS | `output/playwright/ga/22010499353/cleanup.log`, `output/playwright/ga/22010499353/step-summary.md` |
 | Daily Gate Dashboard (includes Upload Cleanup gate) | [#22010519536](https://github.com/zensgit/metasheet2/actions/runs/22010519536) | PASS | `output/playwright/ga/22010519536/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22010519536/attendance-daily-gate-dashboard.json` |
 | Remote Upload Cleanup drill (P2 issue open, expected FAIL) | [#22011899798](https://github.com/zensgit/metasheet2/actions/runs/22011899798) | FAIL (expected) | `output/playwright/ga/22011899798/cleanup.log`, `output/playwright/ga/22011899798/step-summary.md`, Issue: [#160](https://github.com/zensgit/metasheet2/issues/160) |
+
+## Post-Go Validation (2026-02-21): Gate Stabilization Recovery
+
+This record captures the final stabilization after transient `502/ECONNREFUSED/fetch failed` regressions seen in strict/perf gates.
+
+### Code changes merged
+
+- [#217](https://github.com/zensgit/metasheet2/pull/217): harden `/auth/me` retry in full-flow verification and reduce longrun rollback cleanup flake.
+- [#218](https://github.com/zensgit/metasheet2/pull/218): add transient network retries for smoke/provision/perf/production-flow scripts.
+- [#220](https://github.com/zensgit/metasheet2/pull/220): stabilize perf import mutation retries with fresh `commitToken` per attempt, and baseline rollback threshold default alignment.
+- [#221](https://github.com/zensgit/metasheet2/pull/221): keep async import job polling alive across transient network failures.
+
+### Final verification snapshot
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Strict gates twice | [#22257658383](https://github.com/zensgit/metasheet2/actions/runs/22257658383) | PASS | `output/playwright/ga/22257658383/attendance-strict-gates-prod-22257658383-1/20260221-133025-1/gate-summary.json`, `output/playwright/ga/22257658383/attendance-strict-gates-prod-22257658383-1/20260221-133025-2/gate-summary.json` |
+| Perf baseline (100k, upload_csv=true, commit_async=false) | [#22257793629](https://github.com/zensgit/metasheet2/actions/runs/22257793629) | PASS | `output/playwright/ga/22257793629/attendance-import-perf-22257793629-1/attendance-perf-mlwd8aeo-7mygl2/perf-summary.json` |
+| Perf long run (upload path default) | [#22257658595](https://github.com/zensgit/metasheet2/actions/runs/22257658595) | PASS | `output/playwright/ga/22257658595/attendance-import-perf-longrun-rows10k-commit-22257658595-1/current/rows10k-commit/attendance-perf-mlwcvds0-3ttvdu/perf-summary.json` |
+| Daily gate dashboard | [#22257840707](https://github.com/zensgit/metasheet2/actions/runs/22257840707) | PASS | `output/playwright/ga/22257840707/attendance-daily-gate-dashboard-22257840707-1/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22257840707/attendance-daily-gate-dashboard-22257840707-1/attendance-daily-gate-dashboard.json` |
+
+### Final decision
+
+- **GO (maintained)**: no open P0/P1 blocker in the latest gate snapshot, and dashboard overall status is PASS.
 | Remote Upload Cleanup drill recovery (P2 issue auto-close) | [#22011916523](https://github.com/zensgit/metasheet2/actions/runs/22011916523) | PASS | `output/playwright/ga/22011916523/cleanup.log`, `output/playwright/ga/22011916523/step-summary.md`, Issue: [#160](https://github.com/zensgit/metasheet2/issues/160) |
 | Daily Gate Dashboard (Upload Cleanup latest run, ignores `[DRILL]`) | [#22011935825](https://github.com/zensgit/metasheet2/actions/runs/22011935825) | PASS | `output/playwright/ga/22011935825/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22011935825/attendance-daily-gate-dashboard.json` |
 | Remote Upload Cleanup (forced fail, default P2 issue open) | [#22013431489](https://github.com/zensgit/metasheet2/actions/runs/22013431489) | FAIL (expected) | `output/playwright/ga/22013431489/cleanup.log`, `output/playwright/ga/22013431489/step-summary.md`, Issue: [#161](https://github.com/zensgit/metasheet2/issues/161) |


### PR DESCRIPTION
## Summary
- append 2026-02-21 final stabilization run evidence to go/no-go and daily gates docs
- add closure report: `docs/attendance-production-closure-report-20260221.md`
- include final PASS runs for strict/baseline/longrun/dashboard and artifact paths
