### PR TITLE
feat(attendance): enforce PR-review defaults and expose import telemetry

### DIFF
--- a/.github/workflows/attendance-branch-policy-drift-prod.yml
+++ b/.github/workflows/attendance-branch-policy-drift-prod.yml
@@ -24,7 +24,7 @@ on:
       require_pr_reviews:
         description: 'Require required_pull_request_reviews to be enabled (true/false)'
         required: false
-        default: 'false'
+        default: 'true'
       min_approving_review_count:
         description: 'Minimum approving review count required when PR review checks are enabled'
         required: false
@@ -66,7 +66,7 @@ jobs:
       REQUIRED_CHECKS_CSV: ${{ inputs.required_checks_csv || 'contracts (strict),contracts (dashboard)' }}
       REQUIRE_STRICT: ${{ inputs.require_strict || 'true' }}
       REQUIRE_ENFORCE_ADMINS: ${{ inputs.require_enforce_admins || 'true' }}
-      REQUIRE_PR_REVIEWS: ${{ inputs.require_pr_reviews || 'false' }}
+      REQUIRE_PR_REVIEWS: ${{ inputs.require_pr_reviews || 'true' }}
       MIN_APPROVING_REVIEW_COUNT: ${{ inputs.min_approving_review_count || '1' }}
       REQUIRE_CODE_OWNER_REVIEWS: ${{ inputs.require_code_owner_reviews || 'false' }}
       DRILL_FAIL: ${{ inputs.drill_fail || 'false' }}

--- a/.github/workflows/attendance-branch-protection-prod.yml
+++ b/.github/workflows/attendance-branch-protection-prod.yml
@@ -24,7 +24,7 @@ on:
       require_pr_reviews:
         description: 'Require required_pull_request_reviews to be enabled (true/false)'
         required: false
-        default: 'false'
+        default: 'true'
       min_approving_review_count:
         description: 'Minimum approving review count required when PR review checks are enabled'
         required: false
@@ -66,7 +66,7 @@ jobs:
       REQUIRED_CHECKS_CSV: ${{ inputs.required_checks_csv || 'contracts (strict),contracts (dashboard)' }}
       REQUIRE_STRICT: ${{ inputs.require_strict || 'true' }}
       REQUIRE_ENFORCE_ADMINS: ${{ inputs.require_enforce_admins || 'true' }}
-      REQUIRE_PR_REVIEWS: ${{ inputs.require_pr_reviews || 'false' }}
+      REQUIRE_PR_REVIEWS: ${{ inputs.require_pr_reviews || 'true' }}
       MIN_APPROVING_REVIEW_COUNT: ${{ inputs.min_approving_review_count || '1' }}
       REQUIRE_CODE_OWNER_REVIEWS: ${{ inputs.require_code_owner_reviews || 'false' }}
       DRILL_FAIL: ${{ inputs.drill_fail || 'false' }}


### PR DESCRIPTION
## Summary
- set branch-policy/protection workflow defaults to `require_pr_reviews=true`
- expose import commit/job telemetry fields (`engine`, `processedRows`, `failedRows`, `elapsedMs`) in attendance plugin responses
- add frontend helpers to render import job processed/failed/elapsed values
- extend backend integration assertions for commit/idempotency telemetry
- refresh closure report for this delivery slice

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts`
- `pnpm --filter @metasheet/web build`
