### PR TITLE
docs(attendance): add post-merge branch-policy/dashboard evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2105,3 +2105,27 @@ Threshold tuning follow-up (`#22308829077`):
   - Evidence:
     - `output/playwright/ga/22308829077/attendance-import-perf-longrun-rows100k-commit-22308829077-1/current-flat/rows100000-commit.json`
     - `output/playwright/ga/22308829077/attendance-import-perf-longrun-trend-22308829077-1/20260223-135014/attendance-import-perf-longrun-trend.json`
+
+## Latest Notes (2026-02-23): Post-merge Branch Policy Recheck (Main)
+
+Execution summary:
+
+1. Re-ran `Attendance Branch Policy Drift (Prod)` on `main` after the latest merge cycle.
+2. Re-ran `Attendance Daily Gate Dashboard` (`lookback_hours=48`) after the new policy run.
+3. Confirmed dashboard `gateFlat.protection` now points at the latest non-drill branch-policy run.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (main, non-drill) | [#22309204427](https://github.com/zensgit/metasheet2/actions/runs/22309204427) | PASS | `output/playwright/ga/22309204427/attendance-branch-policy-drift-prod-22309204427-1/policy.json`, `output/playwright/ga/22309204427/attendance-branch-policy-drift-prod-22309204427-1/step-summary.md` |
+| Daily Dashboard (`lookback_hours=48`, post-policy rerun) | [#22309250542](https://github.com/zensgit/metasheet2/actions/runs/22309250542) | PASS | `output/playwright/ga/22309250542/attendance-daily-gate-dashboard-22309250542-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22309250542/attendance-daily-gate-dashboard-22309250542-1/attendance-daily-gate-dashboard.md` |
+
+Observed dashboard status (`#22309250542`):
+
+- `overallStatus=pass`
+- `p0Status=pass`
+- `gateFlat.protection.status=PASS`
+- `gateFlat.protection.runId=22309204427`
+- `gateFlat.protection.requirePrReviews=true`
+- `gateFlat.protection.minApprovingReviews=1`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1530,3 +1530,35 @@ Threshold policy note:
   - preview: `180000`
   - commit: `300000`
   - export: `45000`
+
+## Post-Go Verification (2026-02-23): Branch Policy + Dashboard Re-Verify (Post-Merge)
+
+Goal:
+
+- Reconfirm A-line guardrails remain green on `main` after the latest merge operations.
+
+Execution:
+
+- Triggered `Attendance Branch Policy Drift (Prod)` on `main` (non-drill).
+- Triggered `Attendance Daily Gate Dashboard` (`lookback_hours=48`) after branch-policy completion.
+- Downloaded artifacts into `output/playwright/ga/<runId>/...` and validated `gateFlat.protection` source binding.
+
+Evidence:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (main, non-drill) | [#22309204427](https://github.com/zensgit/metasheet2/actions/runs/22309204427) | PASS | `output/playwright/ga/22309204427/attendance-branch-policy-drift-prod-22309204427-1/policy.json`, `output/playwright/ga/22309204427/attendance-branch-policy-drift-prod-22309204427-1/policy.log`, `output/playwright/ga/22309204427/attendance-branch-policy-drift-prod-22309204427-1/step-summary.md` |
+| Daily Gate Dashboard (main, post-policy rerun) | [#22309250542](https://github.com/zensgit/metasheet2/actions/runs/22309250542) | PASS | `output/playwright/ga/22309250542/attendance-daily-gate-dashboard-22309250542-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22309250542/attendance-daily-gate-dashboard-22309250542-1/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22309250542/attendance-daily-gate-dashboard-22309250542-1/gate-meta/protection/meta.json` |
+
+Observed dashboard highlights (`#22309250542`):
+
+- `overallStatus=pass`
+- `p0Status=pass`
+- `gateFlat.protection.status=PASS`
+- `gateFlat.protection.runId=22309204427`
+- `gateFlat.protection.requirePrReviews=true`
+- `gateFlat.protection.minApprovingReviews=1`
+
+Decision:
+
+- `GO` remains unchanged.


### PR DESCRIPTION
## Summary
- add latest branch policy drift evidence run (#22309204427)
- add latest daily dashboard evidence run (#22309250542)
- record that dashboard now maps `gateFlat.protection.runId` to the latest non-drill policy run

## Verification
- Attendance Branch Policy Drift (Prod): https://github.com/zensgit/metasheet2/actions/runs/22309204427 (PASS)
- Attendance Daily Gate Dashboard: https://github.com/zensgit/metasheet2/actions/runs/22309250542 (PASS)
- Local artifacts downloaded under:
  - `output/playwright/ga/22309204427/...`
  - `output/playwright/ga/22309250542/...`
