### PR TITLE
docs(attendance): add final post-merge gate re-verify evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2129,3 +2129,27 @@ Observed dashboard status (`#22309250542`):
 - `gateFlat.protection.runId=22309204427`
 - `gateFlat.protection.requirePrReviews=true`
 - `gateFlat.protection.minApprovingReviews=1`
+
+## Latest Notes (2026-02-23): Final Re-Verify After PR #229 Merge
+
+Execution summary:
+
+1. Re-verified branch protection baseline on `main` (`require_pr_reviews=true`, `min_approving_review_count=1`).
+2. Triggered a fresh non-drill branch policy run after merge.
+3. Triggered a fresh dashboard run and confirmed it consumed the latest non-drill protection evidence.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (main, non-drill) | [#22309503350](https://github.com/zensgit/metasheet2/actions/runs/22309503350) | PASS | `output/playwright/ga/22309503350/attendance-branch-policy-drift-prod-22309503350-1/policy.json`, `output/playwright/ga/22309503350/attendance-branch-policy-drift-prod-22309503350-1/step-summary.md` |
+| Daily Dashboard (`lookback_hours=48`, post-policy rerun) | [#22309519851](https://github.com/zensgit/metasheet2/actions/runs/22309519851) | PASS | `output/playwright/ga/22309519851/attendance-daily-gate-dashboard-22309519851-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22309519851/attendance-daily-gate-dashboard-22309519851-1/attendance-daily-gate-dashboard.md` |
+
+Observed dashboard status (`#22309519851`):
+
+- `overallStatus=pass`
+- `p0Status=pass`
+- `gateFlat.protection.status=PASS`
+- `gateFlat.protection.runId=22309503350`
+- `gateFlat.protection.requirePrReviews=true`
+- `gateFlat.protection.minApprovingReviews=1`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1562,3 +1562,35 @@ Observed dashboard highlights (`#22309250542`):
 Decision:
 
 - `GO` remains unchanged.
+
+## Post-Go Verification (2026-02-23): Final Main Re-Verify After PR #229 Merge
+
+Goal:
+
+- Confirm branch policy and dashboard are still green on `main` after PR #229 merge.
+
+Execution:
+
+- Triggered `Attendance Branch Policy Drift (Prod)` non-drill run on `main`.
+- Triggered `Attendance Daily Gate Dashboard` (`lookback_hours=48`) after that run.
+- Downloaded artifacts and verified dashboard points to the latest non-drill policy run.
+
+Evidence:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (main, non-drill) | [#22309503350](https://github.com/zensgit/metasheet2/actions/runs/22309503350) | PASS | `output/playwright/ga/22309503350/attendance-branch-policy-drift-prod-22309503350-1/policy.json`, `output/playwright/ga/22309503350/attendance-branch-policy-drift-prod-22309503350-1/policy.log`, `output/playwright/ga/22309503350/attendance-branch-policy-drift-prod-22309503350-1/step-summary.md` |
+| Daily Gate Dashboard (main, post-policy rerun) | [#22309519851](https://github.com/zensgit/metasheet2/actions/runs/22309519851) | PASS | `output/playwright/ga/22309519851/attendance-daily-gate-dashboard-22309519851-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22309519851/attendance-daily-gate-dashboard-22309519851-1/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22309519851/attendance-daily-gate-dashboard-22309519851-1/gate-meta/protection/meta.json` |
+
+Observed dashboard highlights (`#22309519851`):
+
+- `overallStatus=pass`
+- `p0Status=pass`
+- `gateFlat.protection.status=PASS`
+- `gateFlat.protection.runId=22309503350`
+- `gateFlat.protection.requirePrReviews=true`
+- `gateFlat.protection.minApprovingReviews=1`
+
+Decision:
+
+- `GO` unchanged.


### PR DESCRIPTION
## Summary
- add final post-merge branch policy drift evidence run (#22309503350)
- add final post-merge daily dashboard evidence run (#22309519851)
- record `gateFlat.protection.runId=22309503350` to confirm dashboard linkage to latest non-drill policy run

## Verification
- Attendance Branch Policy Drift (Prod): https://github.com/zensgit/metasheet2/actions/runs/22309503350 (PASS)
- Attendance Daily Gate Dashboard: https://github.com/zensgit/metasheet2/actions/runs/22309519851 (PASS)
- Branch protection live check (local script):
  - `REQUIRE_PR_REVIEWS=true`
  - `MIN_APPROVING_REVIEW_COUNT=1`
  - result: PASS
- Local artifacts downloaded under:
  - `output/playwright/ga/22309503350/...`
  - `output/playwright/ga/22309519851/...`
