### PR TITLE
feat(attendance-import): add staging fast-path auto-switch and telemetry

### DIFF
--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -178,8 +178,14 @@ P1 (1-2 weeks, production hardening):
       - `ATTENDANCE_IMPORT_PREFETCH_MAX_WORK_DATES` (default `366`)
       - `ATTENDANCE_IMPORT_PREFETCH_MAX_SPAN_DAYS` (default `366`)
     - Import loops release processed row field payloads early to reduce heap pressure during large commits.
+  - Staging fast path auto-switch (implemented 2026-02-23):
+    - Record upsert path auto-switches to staging mode for large bulk imports:
+      - `ATTENDANCE_IMPORT_COPY_ENABLED` (default `true`)
+      - `ATTENDANCE_IMPORT_COPY_THRESHOLD_ROWS` (default `50000`)
+    - Commit/job telemetry now includes `recordUpsertStrategy` (`values|unnest|staging`).
+    - Perf summaries and trend reports include `recordUpsertStrategy` so longrun artifacts can confirm which write strategy was used.
   - Remaining:
-    - COPY-based fast path / staging-table pipeline for extreme payloads (500k+ rows).
+    - Native streaming `COPY FROM STDIN` pipeline for extreme payloads (500k+ rows, optional optimization).
     - Perf baseline refresh for 100k+ commit imports under the new tuning knobs.
 - Security (implemented 2026-02-09):
   - Rate limits for import/export/admin writes (production-only by default).
@@ -435,7 +441,7 @@ Latest head re-validation on `main` (post-`91c21cab`):
     - `output/playwright/ga/21941278046/attendance-strict-gates-prod-21941278046-1/20260212-094127-1/`
     - `output/playwright/ga/21941278046/attendance-strict-gates-prod-21941278046-1/20260212-094127-2/`
 - Bulk write defaults (runtime switches optional):
-  - `ATTENDANCE_IMPORT_RECORD_UPSERT_MODE=unnest|values` (default `unnest`)
+  - `ATTENDANCE_IMPORT_RECORD_UPSERT_MODE=unnest|values|staging` (default `unnest`)
   - `ATTENDANCE_IMPORT_ITEMS_INSERT_MODE=unnest|values` (default `unnest`)
 - Perf baseline (10k, async+export+rollback, thresholds enabled): `PASS`
   - Run: [Attendance Import Perf Baseline #21941424853](https://github.com/zensgit/metasheet2/actions/runs/21941424853) (`SUCCESS`)

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2153,3 +2153,21 @@ Observed dashboard status (`#22309519851`):
 - `gateFlat.protection.runId=22309503350`
 - `gateFlat.protection.requirePrReviews=true`
 - `gateFlat.protection.minApprovingReviews=1`
+
+## Latest Notes (2026-02-23): Perf Artifacts Add Upsert Strategy Signal
+
+Updates:
+
+1. `scripts/ops/attendance-import-perf.mjs` now writes `recordUpsertStrategy` into `perf-summary.json`.
+2. `scripts/ops/attendance-import-perf-trend-report.mjs` now shows an `Upsert` column (`VALUES|UNNEST|STAGING`) in Scenario Summary.
+3. Attendance import commit/job telemetry now exposes `recordUpsertStrategy`, enabling GA artifacts to prove which write strategy was used.
+
+Local verification:
+
+- `node --check scripts/ops/attendance-import-perf.mjs`
+- `node --check scripts/ops/attendance-import-perf-trend-report.mjs`
+
+Expected artifact checks after next perf/longrun runs:
+
+- `output/playwright/ga/<RUN_ID>/**/perf-summary.json` includes `recordUpsertStrategy`.
+- `output/playwright/ga/<RUN_ID>/**/attendance-import-perf-longrun-trend.md` includes `Upsert` column values per scenario.

--- a/docs/attendance-production-import-extreme-scale-plan-20260212.md
+++ b/docs/attendance-production-import-extreme-scale-plan-20260212.md
@@ -123,7 +123,7 @@ Proposal:
 Rollout:
 
 - Feature gate via env:
-  - `ATTENDANCE_IMPORT_RECORD_UPSERT_MODE=values|unnest`
+  - `ATTENDANCE_IMPORT_RECORD_UPSERT_MODE=values|unnest|staging`
   - default `unnest` (shipped; set `values` to revert)
 
 Validation:
@@ -177,14 +177,21 @@ Notes:
 Rollout:
 
 - Keep this path behind a threshold + explicit enable switch:
-  - `ATTENDANCE_IMPORT_COPY_ENABLED=true|false`
-  - `ATTENDANCE_IMPORT_COPY_THRESHOLD_ROWS=200000` (example)
+  - `ATTENDANCE_IMPORT_COPY_ENABLED=true|false` (default `true`)
+  - `ATTENDANCE_IMPORT_COPY_THRESHOLD_ROWS=50000` (default)
 - Fallback to the non-COPY path when COPY cannot be used.
 
 Validation:
 
 - Add a dedicated perf workflow for `200k+` (manual trigger only).
 - Keep strict gates unchanged (still run daily).
+
+Status (2026-02-23):
+
+- Shipped **staging-table auto-switch** (no new dependency) for large imports:
+  - selects `recordUpsertStrategy=staging` for bulk imports at/above threshold.
+  - exposes strategy in commit/job telemetry and perf summaries.
+- Native streaming `COPY FROM STDIN` remains optional future optimization for `500k+` heavy traffic.
 
 ## Risks / Open Questions
 

--- a/docs/attendance-production-import-scalability-20260210.md
+++ b/docs/attendance-production-import-scalability-20260210.md
@@ -333,8 +333,10 @@ To reduce SQL statement size and placeholder count during large commits, bulk wr
 
 Runtime switches (optional):
 
-- `ATTENDANCE_IMPORT_RECORD_UPSERT_MODE=unnest|values` (default `unnest`)
+- `ATTENDANCE_IMPORT_RECORD_UPSERT_MODE=unnest|values|staging` (default `unnest`)
 - `ATTENDANCE_IMPORT_ITEMS_INSERT_MODE=unnest|values` (default `unnest`)
+- `ATTENDANCE_IMPORT_COPY_ENABLED=true|false` (default `true`)
+- `ATTENDANCE_IMPORT_COPY_THRESHOLD_ROWS` (default `50000`)
 
 Verification:
 

--- a/scripts/ops/attendance-import-perf-trend-report.mjs
+++ b/scripts/ops/attendance-import-perf-trend-report.mjs
@@ -133,6 +133,7 @@ function recordFromSummary(summary, sourcePath, sourceType) {
     rows,
     mode,
     uploadCsv: Boolean(summary?.uploadCsv),
+    recordUpsertStrategy: String(summary?.recordUpsertStrategy || summary?.perfMetrics?.recordUpsertStrategy || ''),
     startedAt,
     previewMs: toNumber(summary?.previewMs),
     commitMs: toNumber(summary?.commitMs),
@@ -198,12 +199,13 @@ function renderMarkdown(payload) {
 
   lines.push('## Scenario Summary')
   lines.push('')
-  lines.push('| Scenario | Rows | Mode | Upload | Chunk | Samples | Latest Preview | Latest Commit | Latest Export | Latest Rollback | Latest Progress % | Latest Throughput | P95 Preview | P95 Commit | Status |')
-  lines.push('|---|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|')
+  lines.push('| Scenario | Rows | Mode | Upload | Upsert | Chunk | Samples | Latest Preview | Latest Commit | Latest Export | Latest Rollback | Latest Progress % | Latest Throughput | P95 Preview | P95 Commit | Status |')
+  lines.push('|---|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|')
   for (const row of payload.scenarios) {
     const upload = row?.latest?.uploadCsv ? 'YES' : 'NO'
+    const upsert = row?.latest?.recordUpsertStrategy ? String(row.latest.recordUpsertStrategy).toUpperCase() : '--'
     const chunk = formatChunk(row?.latest?.chunkItemsSize, row?.latest?.chunkRecordsSize)
-    lines.push(`| ${row.scenario} | ${row.rows ?? '--'} | ${row.mode || '--'} | ${upload} | ${chunk} | ${row.sampleCount} | ${formatMs(row.latest.previewMs)} | ${formatMs(row.latest.commitMs)} | ${formatMs(row.latest.exportMs)} | ${formatMs(row.latest.rollbackMs)} | ${formatFloat(row.latest.progressPercent)} | ${formatFloat(row.latest.throughputRowsPerSec)} rows/s | ${formatMs(row.p95.previewMs)} | ${formatMs(row.p95.commitMs)} | ${row.status.toUpperCase()} |`)
+    lines.push(`| ${row.scenario} | ${row.rows ?? '--'} | ${row.mode || '--'} | ${upload} | ${upsert} | ${chunk} | ${row.sampleCount} | ${formatMs(row.latest.previewMs)} | ${formatMs(row.latest.commitMs)} | ${formatMs(row.latest.exportMs)} | ${formatMs(row.latest.rollbackMs)} | ${formatFloat(row.latest.progressPercent)} | ${formatFloat(row.latest.throughputRowsPerSec)} rows/s | ${formatMs(row.p95.previewMs)} | ${formatMs(row.p95.commitMs)} | ${row.status.toUpperCase()} |`)
   }
 
   lines.push('')


### PR DESCRIPTION
## Summary
- add staging-table upsert strategy and auto-switch it for bulk import commits when copy threshold is reached
- persist and expose `recordUpsertStrategy` in import commit/job payloads and idempotent retry responses
- extend perf scripts/trend report to capture and display import upsert strategy (`values|unnest|staging`)
- add integration coverage for bulk auto-switch to staging strategy
- update attendance delivery/go-no-go/daily-gates docs with the new behavior and evidence notes

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `node --check scripts/ops/attendance-import-perf.mjs`
- `node --check scripts/ops/attendance-import-perf-trend-report.mjs`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts`
