### PR TITLE
docs(attendance): record post-pr231 gate re-verify evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2171,3 +2171,27 @@ Expected artifact checks after next perf/longrun runs:
 
 - `output/playwright/ga/<RUN_ID>/**/perf-summary.json` includes `recordUpsertStrategy`.
 - `output/playwright/ga/<RUN_ID>/**/attendance-import-perf-longrun-trend.md` includes `Upsert` column values per scenario.
+
+## Latest Notes (2026-02-23): Post-PR #231 Branch Policy and Dashboard Re-Verify
+
+Execution summary:
+
+1. Merged PR [#231](https://github.com/zensgit/metasheet2/pull/231).
+2. Re-ran `Attendance Branch Policy Drift (Prod)` on `main`.
+3. Re-ran `Attendance Daily Gate Dashboard` (`lookback_hours=48`) and validated it references the latest policy run.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (main, non-drill) | [#22310774604](https://github.com/zensgit/metasheet2/actions/runs/22310774604) | PASS | `output/playwright/ga/22310774604/attendance-branch-policy-drift-prod-22310774604-1/policy.json`, `output/playwright/ga/22310774604/attendance-branch-policy-drift-prod-22310774604-1/policy.log`, `output/playwright/ga/22310774604/attendance-branch-policy-drift-prod-22310774604-1/step-summary.md` |
+| Daily Dashboard (`lookback_hours=48`, post-policy rerun) | [#22310807657](https://github.com/zensgit/metasheet2/actions/runs/22310807657) | PASS | `output/playwright/ga/22310807657/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22310807657/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22310807657/gate-meta/protection/meta.json` |
+
+Observed dashboard status (`#22310807657`):
+
+- `overallStatus=pass`
+- `p0Status=pass`
+- `gateFlat.protection.status=PASS`
+- `gateFlat.protection.runId=22310774604`
+- `gateFlat.protection.requirePrReviews=true`
+- `gateFlat.protection.minApprovingReviews=1`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1630,3 +1630,35 @@ Local verification:
 Decision:
 
 - `GO` unchanged (feature added under backward-compatible env controls; no open P0/P1 created by this increment).
+
+## Post-Go Verification (2026-02-23): Post-PR #231 Merge and Gate Re-Verify
+
+Goal:
+
+- Confirm `main` branch protection and daily dashboard are still green after merging PR `#231`.
+
+Execution:
+
+1. Merged PR [#231](https://github.com/zensgit/metasheet2/pull/231) (merge commit `684607961b137436051f429fe5abfba056f80cb2`).
+2. Re-ran `Attendance Branch Policy Drift (Prod)` on `main`.
+3. Re-ran `Attendance Daily Gate Dashboard` (`lookback_hours=48`) and verified `gateFlat.protection` binds to the latest non-drill policy run.
+
+Evidence:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (main, non-drill) | [#22310774604](https://github.com/zensgit/metasheet2/actions/runs/22310774604) | PASS | `output/playwright/ga/22310774604/attendance-branch-policy-drift-prod-22310774604-1/policy.json`, `output/playwright/ga/22310774604/attendance-branch-policy-drift-prod-22310774604-1/policy.log`, `output/playwright/ga/22310774604/attendance-branch-policy-drift-prod-22310774604-1/step-summary.md` |
+| Daily Gate Dashboard (main, post-policy rerun) | [#22310807657](https://github.com/zensgit/metasheet2/actions/runs/22310807657) | PASS | `output/playwright/ga/22310807657/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22310807657/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22310807657/gate-meta/protection/meta.json` |
+
+Observed dashboard highlights (`#22310807657`):
+
+- `overallStatus=pass`
+- `p0Status=pass`
+- `gateFlat.protection.status=PASS`
+- `gateFlat.protection.runId=22310774604`
+- `gateFlat.protection.requirePrReviews=true`
+- `gateFlat.protection.minApprovingReviews=1`
+
+Decision:
+
+- `GO` unchanged.


### PR DESCRIPTION
## Summary
- append post-PR #231 branch-policy and dashboard rerun evidence
- record latest run IDs and local artifact paths for reproducible verification
- confirm dashboard protection gate still reads `requirePrReviews=true` and `minApprovingReviews=1`

## Verification
- Triggered and confirmed:
  - `Attendance Branch Policy Drift (Prod)` run `22310774604` (PASS)
  - `Attendance Daily Gate Dashboard` run `22310807657` (PASS)
- Verified JSON fields in downloaded artifact:
  - `overallStatus=pass`
  - `p0Status=pass`
  - `gateFlat.protection.runId=22310774604`
