### PR TITLE
feat(attendance-web): harden async import recovery actions

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2195,3 +2195,36 @@ Observed dashboard status (`#22310807657`):
 - `gateFlat.protection.runId=22310774604`
 - `gateFlat.protection.requirePrReviews=true`
 - `gateFlat.protection.minApprovingReviews=1`
+
+## Latest Notes (2026-02-23): Post-PR #232 Gate Re-Verify
+
+Execution summary:
+
+1. Merged PR [#232](https://github.com/zensgit/metasheet2/pull/232) (docs evidence sync).
+2. Re-ran `Attendance Branch Policy Drift (Prod)` on `main`.
+3. Re-ran `Attendance Daily Gate Dashboard` (`lookback_hours=48`) and validated protection gate source run.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (main, non-drill) | [#22310999119](https://github.com/zensgit/metasheet2/actions/runs/22310999119) | PASS | `output/playwright/ga/22310999119/attendance-branch-policy-drift-prod-22310999119-1/policy.json`, `output/playwright/ga/22310999119/attendance-branch-policy-drift-prod-22310999119-1/policy.log`, `output/playwright/ga/22310999119/attendance-branch-policy-drift-prod-22310999119-1/step-summary.md` |
+| Daily Dashboard (`lookback_hours=48`, post-policy rerun) | [#22311046163](https://github.com/zensgit/metasheet2/actions/runs/22311046163) | PASS | `output/playwright/ga/22311046163/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22311046163/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22311046163/gate-meta/protection/meta.json` |
+
+Observed dashboard status (`#22311046163`):
+
+- `overallStatus=pass`
+- `p0Status=pass`
+- `gateFlat.protection.status=PASS`
+- `gateFlat.protection.runId=22310999119`
+- `gateFlat.protection.requirePrReviews=true`
+- `gateFlat.protection.minApprovingReviews=1`
+
+## Latest Notes (2026-02-23): Full-Flow Recovery Assertion Update
+
+Updates:
+
+1. `scripts/verify-attendance-full-flow.mjs` recovery assertion now accepts both status actions:
+   - `Resume import job` (new one-click timeout recovery)
+   - `Reload import job` (compatibility fallback)
+2. This keeps CI/remote UI verification compatible while frontend recovery UX evolves.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1595,6 +1595,38 @@ Decision:
 
 - `GO` unchanged.
 
+## Post-Go Development Verification (2026-02-23): Async Import Recovery UX Hardening
+
+Goal:
+
+- Improve admin-side recovery guidance for async import timeout/failed/canceled states and keep Playwright recovery assertion aligned.
+
+Changes:
+
+- `apps/web/src/views/AttendanceView.vue`
+  - Added status action `resume-import-job` for one-click recovery after `IMPORT_JOB_TIMEOUT`.
+  - Improved import error classification for:
+    - `INVALID_CSV_FILE_ID` (friendly message + `Re-apply CSV`)
+    - `IMPORT_JOB_NOT_FOUND` (new retry guidance)
+    - `IMPORT_JOB_FAILED` nested causes (`EXPIRED`, `COMMIT_TOKEN_*`, `CSV_TOO_LARGE`, `PAYLOAD_TOO_LARGE`) with actionable retry hints.
+  - Updated `IMPORT_JOB_CANCELED` guidance to direct retry flow.
+- `scripts/verify-attendance-full-flow.mjs`
+  - Recovery assertion now accepts both status actions:
+    - `Resume import job` (new UX)
+    - `Reload import job` (backward-compatible fallback)
+
+Local verification:
+
+| Check | Command | Status |
+|---|---|---|
+| Playwright script syntax | `node --check scripts/verify-attendance-full-flow.mjs` | PASS |
+| Web build | `pnpm --filter @metasheet/web build` | PASS |
+| Web unit tests | `pnpm --filter @metasheet/web exec vitest run --watch=false` | PASS (`26 passed`) |
+
+Decision:
+
+- `GO` unchanged (UX hardening only, backward-compatible behavior preserved).
+
 ## Post-Go Development Verification (2026-02-23): Import Staging Fast Path Auto-Switch (50k+)
 
 Goal:


### PR DESCRIPTION
## Summary
- improve attendance admin async import recovery UX with a new status action: `Resume import job`
- refine import error classification for `IMPORT_JOB_*` and upload/token-related nested causes
- provide clearer operator guidance for invalid/expired CSV references and canceled/failed async jobs
- update full-flow Playwright verifier to accept both `Resume import job` and legacy `Reload import job` status actions
- append latest gate evidence and verification notes to production MD docs

## Verification
- `node --check scripts/verify-attendance-full-flow.mjs`
- `pnpm --filter @metasheet/web build`
- `pnpm --filter @metasheet/web exec vitest run --watch=false`
