### PR TITLE
test(attendance): assert async import telemetry in full flow

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2228,6 +2228,10 @@ Updates:
    - `Resume import job` (new one-click timeout recovery)
    - `Reload import job` (compatibility fallback)
 2. This keeps CI/remote UI verification compatible while frontend recovery UX evolves.
+3. Recovery assertion now also checks async telemetry fields in the job card:
+   - `Processed: <n> · Failed: <n>`
+   - `Elapsed: <ms> ms`
+   - can be disabled only with `ASSERT_IMPORT_JOB_TELEMETRY=false`.
 
 ## Latest Notes (2026-02-23): Post-PR #233 Branch Policy and Dashboard Re-Verify
 

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1614,6 +1614,9 @@ Changes:
   - Recovery assertion now accepts both status actions:
     - `Resume import job` (new UX)
     - `Reload import job` (backward-compatible fallback)
+  - Recovery assertion also validates async telemetry lines in the card:
+    - `Processed: <n> · Failed: <n>`
+    - `Elapsed: <ms> ms`
 
 Local verification:
 

--- a/scripts/verify-attendance-full-flow.mjs
+++ b/scripts/verify-attendance-full-flow.mjs
@@ -19,6 +19,7 @@ const outputDir = process.env.OUTPUT_DIR || 'output/playwright/attendance-full-f
 const expectProductModeRaw = process.env.EXPECT_PRODUCT_MODE || ''
 const assertAdminRetry = process.env.ASSERT_ADMIN_RETRY !== 'false'
 const assertImportJobRecovery = process.env.ASSERT_IMPORT_JOB_RECOVERY === 'true'
+const assertImportJobTelemetry = process.env.ASSERT_IMPORT_JOB_TELEMETRY !== 'false'
 const importRecoveryTimeoutMs = Math.max(10, Number(process.env.IMPORT_RECOVERY_TIMEOUT_MS || 80))
 const importRecoveryIntervalMs = Math.max(10, Number(process.env.IMPORT_RECOVERY_INTERVAL_MS || 25))
 const adminReadyTimeoutMs = Number(process.env.ADMIN_READY_TIMEOUT || Math.max(timeoutMs, 90000))
@@ -453,6 +454,12 @@ async function assertImportJobRecoveryFlow(page, importSection, apiBase) {
       page.getByText(/Preview job completed \(/).first().waitFor({ timeout: timeoutMs }),
       page.getByText(/Imported \d+(\/\d+)? rows \(async job\)\./).first().waitFor({ timeout: timeoutMs }),
     ])
+
+    if (assertImportJobTelemetry) {
+      await asyncCard.getByText(/Processed:\s*\d+\s*·\s*Failed:\s*\d+/i).first().waitFor({ timeout: timeoutMs })
+      await asyncCard.getByText(/Elapsed:\s*\d+\s*ms/i).first().waitFor({ timeout: timeoutMs })
+    }
+
     logInfo('Admin import recovery assertion passed')
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- extend `verify-attendance-full-flow.mjs` async import recovery assertion to validate telemetry lines in the async job card
- telemetry assertions cover:
  - `Processed: <n> · Failed: <n>`
  - `Elapsed: <ms> ms`
- keep an explicit opt-out toggle for exceptional environments: `ASSERT_IMPORT_JOB_TELEMETRY=false`
- update production MD docs to reflect new verification behavior

## Verification
- `node --check scripts/verify-attendance-full-flow.mjs`
