### PR TITLE
perf(attendance-gates): enforce staging upsert in 100k longrun

### DIFF
--- a/.github/workflows/attendance-import-perf-longrun.yml
+++ b/.github/workflows/attendance-import-perf-longrun.yml
@@ -130,6 +130,7 @@ jobs:
             commit_async: 'false'
             export_csv: 'true'
             rollback: 'false'
+            expected_upsert_strategy: ''
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_PREVIEW_MS || vars.ATTENDANCE_PERF_MAX_PREVIEW_MS || '100000' }}
             max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_COMMIT_MS || vars.ATTENDANCE_PERF_MAX_COMMIT_MS || '150000' }}
             max_export_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_EXPORT_MS || vars.ATTENDANCE_PERF_MAX_EXPORT_MS || '25000' }}
@@ -140,6 +141,7 @@ jobs:
             commit_async: 'false'
             export_csv: 'true'
             rollback: 'false'
+            expected_upsert_strategy: 'staging'
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_COMMIT_MAX_PREVIEW_MS || '180000' }}
             max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_COMMIT_MAX_COMMIT_MS || '300000' }}
             max_export_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_COMMIT_MAX_EXPORT_MS || '45000' }}
@@ -150,6 +152,7 @@ jobs:
             commit_async: 'true'
             export_csv: 'false'
             rollback: 'false'
+            expected_upsert_strategy: ''
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_50K_MAX_PREVIEW_MS || '180000' }}
             max_commit_ms: ''
             max_export_ms: ''
@@ -160,6 +163,7 @@ jobs:
             commit_async: 'true'
             export_csv: 'false'
             rollback: 'false'
+            expected_upsert_strategy: ''
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_MAX_PREVIEW_MS || '240000' }}
             max_commit_ms: ''
             max_export_ms: ''
@@ -170,6 +174,7 @@ jobs:
             commit_async: 'true'
             export_csv: 'false'
             rollback: 'false'
+            expected_upsert_strategy: ''
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_500K_MAX_PREVIEW_MS || '480000' }}
             max_commit_ms: ''
             max_export_ms: ''
@@ -200,6 +205,7 @@ jobs:
           MAX_COMMIT_MS: ${{ matrix.max_commit_ms }}
           MAX_EXPORT_MS: ${{ matrix.max_export_ms }}
           MAX_ROLLBACK_MS: ${{ matrix.max_rollback_ms }}
+          EXPECT_RECORD_UPSERT_STRATEGY: ${{ matrix.expected_upsert_strategy }}
           OUTPUT_DIR: output/playwright/attendance-import-perf-longrun/current/${{ matrix.id }}
         run: |
           set -euo pipefail

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2161,6 +2161,7 @@ Updates:
 1. `scripts/ops/attendance-import-perf.mjs` now writes `recordUpsertStrategy` into `perf-summary.json`.
 2. `scripts/ops/attendance-import-perf-trend-report.mjs` now shows an `Upsert` column (`VALUES|UNNEST|STAGING`) in Scenario Summary.
 3. Attendance import commit/job telemetry now exposes `recordUpsertStrategy`, enabling GA artifacts to prove which write strategy was used.
+4. `attendance-import-perf-longrun.yml` now enforces `EXPECT_RECORD_UPSERT_STRATEGY=staging` for `rows100k-commit` to catch bulk-path regressions early.
 
 Local verification:
 

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1595,6 +1595,33 @@ Decision:
 
 - `GO` unchanged.
 
+## Post-Go Development Verification (2026-02-23): Longrun Upsert Strategy Guard
+
+Goal:
+
+- Prevent false-green longrun runs where 100k commit silently falls back from staging path.
+
+Changes:
+
+- `scripts/ops/attendance-import-perf.mjs`
+  - Added optional env assertion `EXPECT_RECORD_UPSERT_STRATEGY=values|unnest|staging`.
+  - Summary now includes `expectations.recordUpsertStrategy`.
+  - Fails with regression entry when expected strategy does not match actual telemetry.
+- `.github/workflows/attendance-import-perf-longrun.yml`
+  - Added matrix field `expected_upsert_strategy`.
+  - `rows100k-commit` now sets `expected_upsert_strategy: staging`.
+
+Local verification:
+
+| Check | Command | Status |
+|---|---|---|
+| Perf script syntax | `node --check scripts/ops/attendance-import-perf.mjs` | PASS |
+| Longrun workflow syntax | `node --check scripts/ops/attendance-import-perf-trend-report.mjs` | PASS |
+
+Decision:
+
+- `GO` unchanged (guardrail tightening only; no API behavior change).
+
 ## Post-Go Development Verification (2026-02-23): Async Import Recovery UX Hardening
 
 Goal:


### PR DESCRIPTION
## Summary
- add `EXPECT_RECORD_UPSERT_STRATEGY` assertion to `attendance-import-perf.mjs`
- include expected strategy in perf summary (`expectations.recordUpsertStrategy`)
- fail perf scenario when actual `recordUpsertStrategy` mismatches expected value
- wire longrun matrix to enforce `expected_upsert_strategy: staging` for `rows100k-commit`
- update delivery/go-no-go docs with this guardrail

## Verification
- `node --check scripts/ops/attendance-import-perf.mjs`
- `node --check scripts/ops/attendance-import-perf-trend-report.mjs`
