### PR TITLE
test(attendance-gates): enforce upsert strategy dashboard contract

### DIFF
--- a/scripts/ops/attendance-daily-gate-report.mjs
+++ b/scripts/ops/attendance-daily-gate-report.mjs
@@ -347,6 +347,14 @@ function parsePerfSummaryJson(text) {
     : (typeof value?.jobElapsedMs === 'number'
       ? value.jobElapsedMs
       : (typeof value?.perfMetrics?.elapsedMs === 'number' ? value.perfMetrics.elapsedMs : null))
+  const recordUpsertStrategy = typeof value?.recordUpsertStrategy === 'string'
+    ? value.recordUpsertStrategy.trim().toLowerCase()
+    : (typeof value?.perfMetrics?.recordUpsertStrategy === 'string'
+      ? value.perfMetrics.recordUpsertStrategy.trim().toLowerCase()
+      : null)
+  const expectedRecordUpsertStrategy = typeof value?.expectations?.recordUpsertStrategy === 'string'
+    ? value.expectations.recordUpsertStrategy.trim().toLowerCase()
+    : null
 
   return {
     reason: regressionsRaw.length > 0 ? 'REGRESSION' : null,
@@ -359,6 +367,8 @@ function parsePerfSummaryJson(text) {
     processedRows: processedRows === null ? null : String(processedRows),
     failedRows: failedRows === null ? null : String(failedRows),
     elapsedMs: elapsedMs === null ? null : String(elapsedMs),
+    recordUpsertStrategy: recordUpsertStrategy || null,
+    expectedRecordUpsertStrategy: expectedRecordUpsertStrategy || null,
     uploadCsv: uploadCsv === null ? null : uploadCsv ? 'true' : 'false',
     previewMs: previewMs === null ? null : String(previewMs),
     commitMs: commitMs === null ? null : String(commitMs),
@@ -1615,6 +1625,8 @@ async function run() {
       } else if (gate.name === 'Perf Baseline' || gate.name === 'Perf Long Run') {
         if (meta.schemaVersion) summaryBits.push(`schema=${meta.schemaVersion}`)
         if (meta.engine) summaryBits.push(`engine=${meta.engine}`)
+        if (meta.recordUpsertStrategy) summaryBits.push(`upsert=${meta.recordUpsertStrategy}`)
+        if (meta.expectedRecordUpsertStrategy) summaryBits.push(`upsert_expected=${meta.expectedRecordUpsertStrategy}`)
         if (meta.processedRows) summaryBits.push(`processed=${meta.processedRows}`)
         if (meta.failedRows) summaryBits.push(`failed=${meta.failedRows}`)
         if (meta.elapsedMs) summaryBits.push(`elapsed=${meta.elapsedMs}`)
@@ -1676,6 +1688,8 @@ async function run() {
         flat.summarySchemaVersion = meta.schemaVersion ?? null
         flat.engine = meta.engine ?? null
         flat.requestedEngine = meta.requestedEngine ?? null
+        flat.recordUpsertStrategy = meta.recordUpsertStrategy ?? null
+        flat.expectedRecordUpsertStrategy = meta.expectedRecordUpsertStrategy ?? null
         flat.processedRows = meta.processedRows ?? null
         flat.failedRows = meta.failedRows ?? null
         flat.elapsedMs = meta.elapsedMs ?? null

--- a/scripts/ops/attendance-run-gate-contract-case.sh
+++ b/scripts/ops/attendance-run-gate-contract-case.sh
@@ -111,6 +111,7 @@ if [[ "$CASE_ID" == "dashboard" ]]; then
   dashboard_invalid_strict="${case_dir}/dashboard.invalid.strict.json"
   dashboard_invalid_perf="${case_dir}/dashboard.invalid.perf.json"
   dashboard_invalid_longrun="${case_dir}/dashboard.invalid.longrun.json"
+  dashboard_invalid_upsert="${case_dir}/dashboard.invalid.upsert.json"
 
   cat >"$dashboard_valid" <<'EOF'
 {
@@ -151,6 +152,8 @@ if [[ "$CASE_ID" == "dashboard" ]]; then
       "rows": 100000,
       "mode": "commit",
       "uploadCsv": "true",
+      "recordUpsertStrategy": "staging",
+      "expectedRecordUpsertStrategy": "staging",
       "previewMs": "1200",
       "regressionsCount": "0"
     },
@@ -163,6 +166,74 @@ if [[ "$CASE_ID" == "dashboard" ]]; then
       "rows": 500000,
       "mode": "preview",
       "uploadCsv": "true",
+      "recordUpsertStrategy": "values",
+      "expectedRecordUpsertStrategy": "values",
+      "previewMs": "33000",
+      "regressionsCount": "0"
+    }
+  },
+  "escalationIssue": {
+    "mode": "none_or_closed",
+    "p0Status": "pass"
+  }
+}
+EOF
+
+  cat >"$dashboard_invalid_upsert" <<'EOF'
+{
+  "p0Status": "pass",
+  "overallStatus": "pass",
+  "gates": {
+    "strict": {
+      "completed": {
+        "id": 600001,
+        "conclusion": "success"
+      }
+    },
+    "perf": {
+      "completed": {
+        "id": 600002,
+        "conclusion": "success"
+      }
+    },
+    "longrun": {
+      "completed": {
+        "id": 600003,
+        "conclusion": "success"
+      }
+    }
+  },
+  "gateFlat": {
+    "schemaVersion": 2,
+    "strict": {
+      "summaryPresent": true,
+      "summaryValid": true
+    },
+    "perf": {
+      "status": "PASS",
+      "reasonCode": null,
+      "runId": 600002,
+      "summarySchemaVersion": 2,
+      "scenario": "100000-commit",
+      "rows": 100000,
+      "mode": "commit",
+      "uploadCsv": "true",
+      "recordUpsertStrategy": "staging",
+      "expectedRecordUpsertStrategy": "values",
+      "previewMs": "1200",
+      "regressionsCount": "0"
+    },
+    "longrun": {
+      "status": "PASS",
+      "reasonCode": null,
+      "runId": 600003,
+      "summarySchemaVersion": 2,
+      "scenario": "rows500k-preview",
+      "rows": 500000,
+      "mode": "preview",
+      "uploadCsv": "true",
+      "recordUpsertStrategy": "staging",
+      "expectedRecordUpsertStrategy": "staging",
       "previewMs": "33000",
       "regressionsCount": "0"
     }
@@ -365,6 +436,8 @@ EOF
     ./scripts/ops/attendance-validate-daily-dashboard-json.sh "$dashboard_invalid_perf"
   expect_fail "dashboard longrun gateFlat contract" \
     ./scripts/ops/attendance-validate-daily-dashboard-json.sh "$dashboard_invalid_longrun"
+  expect_fail "dashboard upsert contract" \
+    ./scripts/ops/attendance-validate-daily-dashboard-json.sh "$dashboard_invalid_upsert"
 
   info "OK: dashboard contract case passed"
   exit 0


### PR DESCRIPTION
## Summary
- parse perf summaries for `recordUpsertStrategy` and `expectations.recordUpsertStrategy` in daily dashboard report
- expose these fields in `gateFlat.perf` and `gateFlat.longrun` plus markdown summary bits
- extend daily dashboard JSON contract validator and contract-case matrix with upsert mismatch negative case

## Validation
- `node --check scripts/ops/attendance-daily-gate-report.mjs`
- `bash -n scripts/ops/attendance-validate-daily-dashboard-json.sh`
- `bash -n scripts/ops/attendance-run-gate-contract-case.sh`
- `bash scripts/ops/attendance-run-gate-contract-case.sh dashboard`
- `bash scripts/ops/attendance-run-gate-contract-case.sh strict`
