### PR TITLE
docs(attendance): add final strict-gates and dashboard stability evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2371,3 +2371,25 @@ Observed dashboard status (`#22337693734`):
 - `gateFlat.protection.requirePrReviews=true`
 - `gateFlat.protection.minApprovingReviews=1`
 - `gateFlat.perf.recordUpsertStrategy=staging`
+
+## Latest Notes (2026-02-24): Final Strict Gates Twice + Post-Policy Dashboard Bind
+
+Execution summary:
+
+1. Triggered `Attendance Strict Gates (Prod)` on `main`.
+2. Verified both strict iterations passed with upload-channel API smoke and Playwright desktop/mobile coverage.
+3. Re-ran `Attendance Branch Policy Drift (Prod)` and then `Attendance Daily Gate Dashboard` (`lookback_hours=48`) to bind latest policy evidence.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Strict Gates (twice, non-drill) | [#22337802322](https://github.com/zensgit/metasheet2/actions/runs/22337802322) | PASS | `output/playwright/ga/22337802322/attendance-strict-gates-prod-22337802322-1/20260224-052221-1/gate-summary.json`, `output/playwright/ga/22337802322/attendance-strict-gates-prod-22337802322-1/20260224-052221-2/gate-summary.json`, `output/playwright/ga/22337802322/attendance-strict-gates-prod-22337802322-1/20260224-052221-1/gate-api-smoke.log`, `output/playwright/ga/22337802322/attendance-strict-gates-prod-22337802322-1/20260224-052221-2/gate-api-smoke.log` |
+| Branch Policy Drift (main, non-drill) | [#22337759756](https://github.com/zensgit/metasheet2/actions/runs/22337759756) | PASS | `output/playwright/ga/22337759756/attendance-branch-policy-drift-prod-22337759756-1/policy.json`, `output/playwright/ga/22337759756/attendance-branch-policy-drift-prod-22337759756-1/policy.log`, `output/playwright/ga/22337759756/attendance-branch-policy-drift-prod-22337759756-1/step-summary.md` |
+| Daily Dashboard (`lookback_hours=48`, post-policy rerun) | [#22337780063](https://github.com/zensgit/metasheet2/actions/runs/22337780063) | PASS | `output/playwright/ga/22337780063/attendance-daily-gate-dashboard-22337780063-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22337780063/attendance-daily-gate-dashboard-22337780063-1/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22337780063/attendance-daily-gate-dashboard-22337780063-1/gate-meta/protection/meta.json` |
+
+Observed status:
+
+- Strict API smoke logs contain `import upload ok`, `idempotency ok`, `export csv ok`, `SMOKE PASS` in both iterations.
+- Dashboard `#22337780063` keeps `overallStatus=pass` and binds `gateFlat.protection.runId=22337759756`.
+- Branch protection contract remains: `requirePrReviews=true`, `minApprovingReviews=1`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1595,6 +1595,46 @@ Decision:
 
 - `GO` unchanged.
 
+## Post-Go Verification (2026-02-24): Final Strict Gates + Policy/Dashboard Stability Check
+
+Goal:
+
+- Confirm production gates remain stable after the latest merge cycle by re-running strict gates twice and re-checking branch-policy/dashboard coupling.
+
+Execution:
+
+1. Triggered `Attendance Strict Gates (Prod)` on `main` (default strict settings).
+2. Verified both strict iterations passed (`apiSmoke`, provisioning, Playwright production/desktop/mobile).
+3. Re-ran `Attendance Branch Policy Drift (Prod)` and `Attendance Daily Gate Dashboard` to confirm protection baseline and dashboard binding.
+
+Evidence:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Strict Gates (twice, non-drill) | [#22337802322](https://github.com/zensgit/metasheet2/actions/runs/22337802322) | PASS | `output/playwright/ga/22337802322/attendance-strict-gates-prod-22337802322-1/20260224-052221-1/gate-summary.json`, `output/playwright/ga/22337802322/attendance-strict-gates-prod-22337802322-1/20260224-052221-2/gate-summary.json`, `output/playwright/ga/22337802322/attendance-strict-gates-prod-22337802322-1/20260224-052221-1/gate-api-smoke.log`, `output/playwright/ga/22337802322/attendance-strict-gates-prod-22337802322-1/20260224-052221-2/gate-api-smoke.log` |
+| Branch Policy Drift (main, non-drill) | [#22337759756](https://github.com/zensgit/metasheet2/actions/runs/22337759756) | PASS | `output/playwright/ga/22337759756/attendance-branch-policy-drift-prod-22337759756-1/policy.json`, `output/playwright/ga/22337759756/attendance-branch-policy-drift-prod-22337759756-1/policy.log`, `output/playwright/ga/22337759756/attendance-branch-policy-drift-prod-22337759756-1/step-summary.md` |
+| Daily Gate Dashboard (`lookback_hours=48`, post-policy rerun) | [#22337780063](https://github.com/zensgit/metasheet2/actions/runs/22337780063) | PASS | `output/playwright/ga/22337780063/attendance-daily-gate-dashboard-22337780063-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22337780063/attendance-daily-gate-dashboard-22337780063-1/attendance-daily-gate-dashboard.md`, `output/playwright/ga/22337780063/attendance-daily-gate-dashboard-22337780063-1/gate-meta/protection/meta.json` |
+
+Observed highlights:
+
+- Strict API smoke logs include:
+  - `import upload ok`
+  - `idempotency ok`
+  - `export csv ok`
+  - `SMOKE PASS`
+- `gate-summary.json` (`-1` and `-2`) both show `exitCode=0`.
+- Dashboard (`#22337780063`) shows:
+  - `overallStatus=pass`
+  - `p0Status=pass`
+  - `gateFlat.protection.runId=22337759756`
+  - `gateFlat.protection.requirePrReviews=true`
+  - `gateFlat.protection.minApprovingReviews=1`
+  - `gateFlat.perf.recordUpsertStrategy=staging`
+
+Decision:
+
+- `GO` unchanged.
+
 ## Post-Go Verification (2026-02-24): Post-PR #240 Final Policy Restore and Dashboard Bind
 
 Goal:


### PR DESCRIPTION
## Summary
- append final 2026-02-24 evidence for strict gates twice and post-policy dashboard bind
- record latest run IDs for strict, branch policy drift, and dashboard workflows
- capture strict API smoke signal checks (`import upload ok`, `idempotency ok`, `export csv ok`)

## Validation
- Strict gates PASS: `#22337802322`
- Branch policy drift PASS: `#22337759756`
- Daily dashboard PASS: `#22337780063`
- Artifacts downloaded to:
  - `output/playwright/ga/22337802322/...`
  - `output/playwright/ga/22337759756/...`
  - `output/playwright/ga/22337780063/...`
