### PR TITLE
fix(attendance-web): recover mobile records table readability

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -397,34 +397,36 @@
           </div>
         </div>
         <div v-if="records.length === 0" class="attendance__empty">No records.</div>
-        <table v-else class="attendance__table">
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>First in</th>
-              <th>Last out</th>
-              <th>Work (min)</th>
-              <th>Late</th>
-              <th>Early leave</th>
-              <th>Leave</th>
-              <th>Overtime</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="record in records" :key="record.id">
-              <td>{{ record.work_date }}</td>
-              <td>{{ formatDateTime(record.first_in_at) }}</td>
-              <td>{{ formatDateTime(record.last_out_at) }}</td>
-              <td>{{ record.work_minutes }}</td>
-              <td>{{ record.late_minutes }}</td>
-              <td>{{ record.early_leave_minutes }}</td>
-              <td>{{ formatMetaMinutes(record.meta, 'leave') }}</td>
-              <td>{{ formatMetaMinutes(record.meta, 'overtime') }}</td>
-              <td>{{ formatStatus(record.status) }}</td>
-            </tr>
-          </tbody>
-        </table>
+        <div v-else class="attendance__table-wrapper">
+          <table class="attendance__table attendance__table--records">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>First in</th>
+                <th>Last out</th>
+                <th>Work (min)</th>
+                <th>Late</th>
+                <th>Early leave</th>
+                <th>Leave</th>
+                <th>Overtime</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="record in records" :key="record.id">
+                <td>{{ record.work_date }}</td>
+                <td>{{ formatDateTime(record.first_in_at) }}</td>
+                <td>{{ formatDateTime(record.last_out_at) }}</td>
+                <td>{{ record.work_minutes }}</td>
+                <td>{{ record.late_minutes }}</td>
+                <td>{{ record.early_leave_minutes }}</td>
+                <td>{{ formatMetaMinutes(record.meta, 'leave') }}</td>
+                <td>{{ formatMetaMinutes(record.meta, 'overtime') }}</td>
+                <td>{{ formatStatus(record.status) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         <div class="attendance__pagination">
           <button class="attendance__btn" :disabled="recordsPage <= 1 || loading" @click="changeRecordsPage(-1)">
             Prev
@@ -9813,6 +9815,10 @@ watch([provisionBatchUserIdsText, provisionBatchRole], () => {
   width: 100%;
   border-collapse: collapse;
   margin-top: 12px;
+}
+
+.attendance__table--records {
+  min-width: 860px;
 }
 
 .attendance__table-wrapper {

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -1595,6 +1595,32 @@ Decision:
 
 - `GO` unchanged.
 
+## Post-Go Development Verification (2026-02-25): Overview Records Mobile Table Recovery
+
+Goal:
+
+- Fix mobile usability regression where the `Records` table in `Attendance > Overview` could be squeezed/clipped on narrow viewports, making columns unreadable.
+
+Changes:
+
+- `apps/web/src/views/AttendanceView.vue`
+  - Wrapped Overview `Records` table with `attendance__table-wrapper` for horizontal overflow handling.
+  - Added table class `attendance__table--records`.
+  - Added style rule:
+    - `.attendance__table--records { min-width: 860px; }`
+  - Result: desktop remains unchanged; mobile can horizontally scroll records without truncating content.
+
+Local verification:
+
+| Check | Command | Status |
+|---|---|---|
+| Web build | `pnpm --filter @metasheet/web build` | PASS |
+| Web unit tests | `pnpm --filter @metasheet/web exec vitest run --watch=false` | PASS (`26 passed`) |
+
+Decision:
+
+- `GO` unchanged (UI-only resilience fix, backward-compatible).
+
 ## Post-Go Verification (2026-02-25): PR #250 Merge Re-Validation on Main
 
 Goal:


### PR DESCRIPTION
## Summary
- wrap Attendance Overview records table with `attendance__table-wrapper`
- add `attendance__table--records` min-width to preserve column readability on narrow screens
- append post-go verification note in go/no-go document

## Verification
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/web exec vitest run --watch=false