### PR TITLE
fix(attendance-import): stabilize 500k commit by extending heavy-query timeout

### DIFF
--- a/docker/app.env.example
+++ b/docker/app.env.example
@@ -16,6 +16,9 @@ ATTENDANCE_IMPORT_REQUIRE_TOKEN=1
 # Attendance import upload channel (csvFileId) storage.
 # NOTE: docker-compose.app.yml mounts a persistent volume at `/app/uploads/attendance-import` by default.
 ATTENDANCE_IMPORT_UPLOAD_DIR=/app/uploads/attendance-import
+# Per-query timeout (ms) for heavy attendance import SQL (bulk/staging upsert path).
+# Increase this when running large imports (for example 500k commit longrun) to avoid 30s query timeout failures.
+ATTENDANCE_IMPORT_HEAVY_QUERY_TIMEOUT_MS=180000
 POSTGRES_USER=metasheet
 POSTGRES_PASSWORD=change-me
 POSTGRES_DB=metasheet


### PR DESCRIPTION
## Summary
- add per-query timeout override support in backend connection pool (`QueryOptions.timeoutMs` now applied)
- route attendance import heavy SQL (bulk/staging upsert + import item inserts + lock-prefetch queries) through a dedicated timeout config
- add new env knob `ATTENDANCE_IMPORT_HEAVY_QUERY_TIMEOUT_MS` (default `180000`) in `docker/app.env.example`

## Why
`rows500k-commit` longrun failed in prod with `Query read timeout` while 10k/100k scenarios passed. This change makes heavy import SQL tolerant to larger batches without relaxing all API paths.

## Validation
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts`
- `pnpm --filter @metasheet/core-backend build`
