### PR TITLE
fix(attendance-import): apply statement-timeout override for heavy commit

### DIFF
--- a/packages/core-backend/src/integration/db/connection-pool.ts
+++ b/packages/core-backend/src/integration/db/connection-pool.ts
@@ -13,6 +13,7 @@ interface QueryConfig {
   text: string
   values?: unknown[]
   query_timeout?: number
+  statement_timeout?: number
 }
 
 type TransactionQuery = <T extends QueryResultRow = QueryResultRow>(
@@ -114,6 +115,7 @@ class ConnectionPool {
     }
     if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
       queryConfig.query_timeout = Math.floor(timeoutMs)
+      queryConfig.statement_timeout = Math.floor(timeoutMs)
     }
     return queryConfig
   }


### PR DESCRIPTION
## Summary
- include `statement_timeout` in per-query timeout overrides at connection-pool level
- add transaction-local timeout setup (`SET LOCAL statement_timeout`) for attendance import heavy commit transactions
- keep the heavy-query path scoped to attendance import only

## Why
After the first fix, longrun `rows500k-commit` changed from `Query read timeout` to `canceling statement due to statement timeout`. This patch addresses the remaining server-side statement timeout on the same heavy path.

## Validation
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts`
- `pnpm --filter @metasheet/core-backend build`
