### PR TITLE
docs(attendance): record post-merge mainline verification

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -2980,3 +2980,38 @@ Observed highlights:
   - `job telemetry: progressPercent=100 throughputRowsPerSec=1170.96`
 - Default P1 tracker is closed after recovery:
   - [#157](https://github.com/zensgit/metasheet2/issues/157) `[Attendance P1] Perf longrun alert` -> `CLOSED`.
+
+## Latest Notes (2026-02-27): Post-Merge Mainline Gate Confirmation (PR #268)
+
+Execution summary:
+
+1. Merged PR [#268](https://github.com/zensgit/metasheet2/pull/268) onto `main`.
+2. Triggered `Attendance Strict Gates (Prod)` on `main` with:
+   - `require_import_job_recovery=true`
+   - `require_admin_settings_save=true`
+3. Triggered `Attendance Daily Gate Dashboard` (`lookback_hours=48`) and verified it binds to the refreshed strict run.
+4. Triggered `Attendance Import Perf Baseline` on `main` (`rows=100000`, `upload_csv=true`) and verified no regression.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Strict Gates (main, post-merge) | [#22486048486](https://github.com/zensgit/metasheet2/actions/runs/22486048486) | PASS | `output/playwright/ga/22486048486/attendance-strict-gates-prod-22486048486-1/20260227-122328-1/gate-summary.json`, `output/playwright/ga/22486048486/attendance-strict-gates-prod-22486048486-1/20260227-122328-2/gate-summary.json` |
+| Daily Gate Dashboard (main, post strict refresh) | [#22486225516](https://github.com/zensgit/metasheet2/actions/runs/22486225516) | PASS | `output/playwright/ga/22486225516/attendance-daily-gate-dashboard-22486225516-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22486225516/attendance-daily-gate-dashboard-22486225516-1/attendance-daily-gate-dashboard.md` |
+| Perf Baseline (main, post-merge, upload path) | [#22486265427](https://github.com/zensgit/metasheet2/actions/runs/22486265427) | PASS | `output/playwright/ga/22486265427/attendance-import-perf-22486265427-1/attendance-perf-mm4vdr0q-8gd1or/perf-summary.json` |
+
+Observed highlights:
+
+- Strict Gates:
+  - both iterations `exitCode=0`
+  - `apiSmoke=PASS`, `provisioning=PASS`, `playwrightProd=PASS`, `playwrightDesktop=PASS`, `playwrightMobile=PASS`
+- Dashboard:
+  - `overallStatus=pass`
+  - `p0Status=pass`
+  - `openTrackingIssues=[]`
+  - `gateFlat.strict.runId=22486048486`
+- Perf Baseline:
+  - `rows=100000`
+  - `uploadCsv=true`
+  - `commitMs=95697`
+  - `regressions=[]`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2636,6 +2636,44 @@ Decision:
 
 - **GO maintained**.
 
+## Post-Go Verification (2026-02-27): Post-Merge Mainline Re-Validation (PR #268)
+
+Goal:
+
+- Confirm `main` remains production-ready after merging PR [#268](https://github.com/zensgit/metasheet2/pull/268) (`admin settings save-cycle assertion hardening` + evidence docs update).
+
+Verification runs:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Strict Gates (main, post-merge, recovery+admin-save enabled) | [#22486048486](https://github.com/zensgit/metasheet2/actions/runs/22486048486) | PASS | `output/playwright/ga/22486048486/attendance-strict-gates-prod-22486048486-1/20260227-122328-1/gate-summary.json`, `output/playwright/ga/22486048486/attendance-strict-gates-prod-22486048486-1/20260227-122328-2/gate-summary.json` |
+| Daily Gate Dashboard (main, post strict refresh) | [#22486225516](https://github.com/zensgit/metasheet2/actions/runs/22486225516) | PASS | `output/playwright/ga/22486225516/attendance-daily-gate-dashboard-22486225516-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22486225516/attendance-daily-gate-dashboard-22486225516-1/attendance-daily-gate-dashboard.md` |
+| Perf Baseline (main, post-merge, upload path) | [#22486265427](https://github.com/zensgit/metasheet2/actions/runs/22486265427) | PASS | `output/playwright/ga/22486265427/attendance-import-perf-22486265427-1/attendance-perf-mm4vdr0q-8gd1or/perf-summary.json` |
+
+Observed highlights:
+
+- Strict gate summaries (both iterations) report:
+  - `apiSmoke=PASS`
+  - `provisioning=PASS`
+  - `playwrightProd=PASS`
+  - `playwrightDesktop=PASS`
+  - `playwrightMobile=PASS`
+  - `exitCode=0`
+- Dashboard remains green and references refreshed strict signal:
+  - `overallStatus=pass`
+  - `p0Status=pass`
+  - `openTrackingIssues=[]`
+  - `gateFlat.strict.runId=22486048486`
+- Baseline summary confirms upload path performance within threshold:
+  - `rows=100000`
+  - `uploadCsv=true`
+  - `commitMs=95697`
+  - `regressions=[]`
+
+Decision:
+
+- **GO maintained**.
+
 ## Post-Go Verification (2026-02-25): `rows500k-commit` Timeout Hardening (PR #266/#267)
 
 Goal:


### PR DESCRIPTION
## Summary
- add 2026-02-27 post-merge verification records after PR #268
- include strict/main, dashboard/main, and perf baseline/main evidence run ids
- record gate highlights and GO maintained decision

## Evidence
- strict: https://github.com/zensgit/metasheet2/actions/runs/22486048486
- dashboard: https://github.com/zensgit/metasheet2/actions/runs/22486225516
- perf baseline: https://github.com/zensgit/metasheet2/actions/runs/22486265427
