### PR TITLE
fix(attendance-ops): preserve dispatch args with WORKFLOW env

### DIFF
--- a/scripts/ops/attendance-run-workflow-dispatch.sh
+++ b/scripts/ops/attendance-run-workflow-dispatch.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-WORKFLOW="${WORKFLOW:-${1:-}}"
-if [[ $# -gt 0 ]]; then
+WORKFLOW="${WORKFLOW:-}"
+if [[ $# -gt 0 && "${1:-}" != *=* ]]; then
+  WORKFLOW="$1"
   shift || true
 fi
 


### PR DESCRIPTION
## Summary
- fix argument parsing in attendance-run-workflow-dispatch.sh
- do not shift argv when first token is key=value and workflow comes from WORKFLOW env
- keep positional-workflow behavior unchanged

## Verification
- WORKFLOW='__invalid_workflow__.yml' bash scripts/ops/attendance-run-workflow-dispatch.sh lookback_hours=48
  - output contains: dispatch_args=-f lookback_hours=48
- bash scripts/ops/attendance-run-workflow-dispatch.sh __invalid_workflow__.yml lookback_hours=48
  - output contains: dispatch_args=-f lookback_hours=48
