### PR TITLE
docs(attendance): record post-merge locale+lunar gate verification

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3203,3 +3203,30 @@ Observed highlights:
   - `Upload` column in Scenario Summary.
   - `Failure Attribution` section (empty for this all-pass run).
 - Workflow trend-report + issue jobs both succeeded on the same run, proving attribution output path does not break existing P1 issue tracking.
+
+## Latest Notes (2026-02-28): zh-CN UI + Lunar/Holiday Calendar Labels (Main)
+
+Execution summary:
+
+1. Merged localization baseline on `main`:
+   - PR [#285](https://github.com/zensgit/metasheet2/pull/285): language toggle (`en` / `zh-CN`) + attendance core UI localization.
+2. Merged calendar enhancement on `main`:
+   - PR [#286](https://github.com/zensgit/metasheet2/pull/286): attendance calendar cell shows lunar day label (zh locale) + holiday name badge.
+3. Re-ran production gates on `main` to verify no regression:
+   - strict gates
+   - daily dashboard
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Strict Gates (main, post `#285/#286`) | [#22522123651](https://github.com/zensgit/metasheet2/actions/runs/22522123651) | PASS | `output/playwright/ga/22522123651/attendance-strict-gates-prod-22522123651-1/20260228-135817-1/gate-summary.json`, `output/playwright/ga/22522123651/attendance-strict-gates-prod-22522123651-1/20260228-135817-2/gate-summary.json` |
+| Daily Gate Dashboard (main, post `#285/#286`) | [#22522181481](https://github.com/zensgit/metasheet2/actions/runs/22522181481) | PASS | `output/playwright/ga/22522181481/attendance-daily-gate-dashboard-22522181481-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22522181481/attendance-daily-gate-dashboard-22522181481-1/attendance-daily-gate-dashboard.md` |
+
+Observed highlights:
+
+- Attendance UI now supports manual language switch in top nav (`English` / `中文`) and persists selection in `metasheet_locale`.
+- Calendar behavior on attendance page:
+  - holiday metadata still sourced from existing holiday sync pipeline (`holiday-cn` + manual holidays);
+  - zh locale shows lunar label in date cell (`zh-CN-u-ca-chinese`) and holiday name badge when available.
+- Post-merge gate status remains green (`strict=PASS`, `dashboard=PASS`).

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2636,6 +2636,34 @@ Decision:
 
 - **GO maintained**.
 
+## Post-Go Verification (2026-02-28): Mainline Localization + Lunar/Holiday Calendar Labels
+
+Goal:
+
+- Confirm production readiness remains stable after merging:
+  - PR [#285](https://github.com/zensgit/metasheet2/pull/285) (`zh-CN` language toggle + core attendance UI localization),
+  - PR [#286](https://github.com/zensgit/metasheet2/pull/286) (attendance calendar lunar label + holiday name badge).
+
+Verification runs:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Strict Gates (main, post localization/calendar merge) | [#22522123651](https://github.com/zensgit/metasheet2/actions/runs/22522123651) | PASS | `output/playwright/ga/22522123651/attendance-strict-gates-prod-22522123651-1/20260228-135817-1/gate-summary.json`, `output/playwright/ga/22522123651/attendance-strict-gates-prod-22522123651-1/20260228-135817-2/gate-summary.json` |
+| Daily Gate Dashboard (main, post localization/calendar merge) | [#22522181481](https://github.com/zensgit/metasheet2/actions/runs/22522181481) | PASS | `output/playwright/ga/22522181481/attendance-daily-gate-dashboard-22522181481-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22522181481/attendance-daily-gate-dashboard-22522181481-1/attendance-daily-gate-dashboard.md` |
+
+Observed highlights:
+
+- Production gate baseline remains green after UI localization/calendar UX enhancement:
+  - strict gate two-pass iteration succeeded;
+  - daily dashboard remained `overallStatus=pass`.
+- Functional scope clarified:
+  - Holiday support is already production-enabled through holiday sync/admin APIs.
+  - Lunar display is now surfaced in attendance calendar cells under zh locale.
+
+Decision:
+
+- **GO maintained**.
+
 ## Post-Go Development Verification (2026-02-28): COPY Fast Path + Longrun Attribution (Branch)
 
 Goal:


### PR DESCRIPTION
## Summary
- append latest notes for zh-CN UI + lunar/holiday calendar labels on main
- record strict gates PASS and daily dashboard PASS evidence after PR #285/#286
- update go/no-go with post-go verification block and local artifact paths

## Evidence
- strict: https://github.com/zensgit/metasheet2/actions/runs/22522123651
- dashboard: https://github.com/zensgit/metasheet2/actions/runs/22522181481
