### PR TITLE
ci(attendance): default perf baseline to commit-async for 100k

### DIFF
--- a/.github/workflows/attendance-import-perf-baseline.yml
+++ b/.github/workflows/attendance-import-perf-baseline.yml
@@ -33,7 +33,7 @@ on:
       commit_async:
         description: 'Use /commit-async path (true/false)'
         required: false
-        default: 'false'
+        default: 'true'
       export_csv:
         description: 'Verify export csv latency (true/false)'
         required: false
@@ -140,7 +140,7 @@ jobs:
       ROWS: ${{ inputs.rows || vars.ATTENDANCE_PERF_BASELINE_ROWS || '100000' }}
       MODE: ${{ inputs.mode || 'commit' }}
       ROLLBACK: 'true'
-      COMMIT_ASYNC: ${{ inputs.commit_async || vars.ATTENDANCE_PERF_COMMIT_ASYNC || 'false' }}
+      COMMIT_ASYNC: ${{ inputs.commit_async || vars.ATTENDANCE_PERF_COMMIT_ASYNC || 'true' }}
       EXPORT_CSV: ${{ inputs.export_csv || vars.ATTENDANCE_PERF_EXPORT_CSV || 'true' }}
       UPLOAD_CSV: ${{ inputs.upload_csv || vars.ATTENDANCE_PERF_UPLOAD_CSV || 'true' }}
       MAX_PREVIEW_MS: ${{ inputs.max_preview_ms || vars.ATTENDANCE_PERF_MAX_PREVIEW_MS || '' }}


### PR DESCRIPTION
## Summary
- set `attendance-import-perf-baseline.yml` `commit_async` workflow input default to `true`
- set perf job env fallback `COMMIT_ASYNC` default to `true`
- keep manual override capability (`workflow_dispatch` input or repo var)

## Why
- reduce 100k commit-path gateway instability under synchronous commit
- preserve gate coverage while improving daily baseline stability

## Verification
- workflow config diff only (no runtime code path change)
