### PR TITLE
ci(attendance): fail daily dashboard only on P0 findings

### DIFF
--- a/.github/workflows/attendance-daily-gate-dashboard.yml
+++ b/.github/workflows/attendance-daily-gate-dashboard.yml
@@ -375,8 +375,8 @@ jobs:
           path: |
             ${{ steps.report.outputs.report_dir }}/**
 
-      - name: Fail workflow when dashboard status is fail
-        if: steps.report.outputs.report_status != 'pass'
+      - name: Fail workflow when dashboard P0 status is fail
+        if: steps.report.outputs.report_p0_status != 'pass'
         run: |
           echo "Attendance daily gate dashboard failed"
           exit 1


### PR DESCRIPTION
## Summary
- align `attendance-daily-gate-dashboard.yml` fail condition with existing escalation semantics
- workflow now fails only when `report_p0_status != pass`
- keeps P1/P2 findings visible in report/artifacts without hard-failing the run

## Why
- escalation issue logic already gates on `report_p0_status`
- previous behavior (fail on overall status) made dashboard red for P1-only perf drift, creating noisy blocking signal

## Verification
- workflow config diff reviewed; no runtime script changes
