### PR TITLE
docs(attendance): record 2026-03-01 gate and perf evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3230,3 +3230,33 @@ Observed highlights:
   - holiday metadata still sourced from existing holiday sync pipeline (`holiday-cn` + manual holidays);
   - zh locale shows lunar label in date cell (`zh-CN-u-ca-chinese`) and holiday name badge when available.
 - Post-merge gate status remains green (`strict=PASS`, `dashboard=PASS`).
+
+## Latest Notes (2026-03-01): zh Admin i18n + Dashboard Contract/Gating Fixes
+
+Merged to `main`:
+
+1. PR [#288](https://github.com/zensgit/metasheet2/pull/288)
+   - Localized Attendance Admin Center labels/actions for `zh-CN`.
+   - Added zh locale smoke script: `scripts/verify-attendance-locale-zh-smoke.mjs`.
+2. PR [#289](https://github.com/zensgit/metasheet2/pull/289)
+   - Fixed daily-dashboard JSON contract validator (`reasonCode` parsing for FAIL perf gates).
+3. PR [#290](https://github.com/zensgit/metasheet2/pull/290)
+   - Perf Baseline default switched to `commit_async=true`.
+4. PR [#291](https://github.com/zensgit/metasheet2/pull/291)
+   - Perf Baseline async timeout budget increased (`timeout-minutes=45`, poll timeout env defaults added).
+5. PR [#292](https://github.com/zensgit/metasheet2/pull/292)
+   - Daily Dashboard workflow now fails only on `report_p0_status != pass` (P1 remains visible in report/issue tracking).
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Strict Gates (main, post `#292`) | [#22537677656](https://github.com/zensgit/metasheet2/actions/runs/22537677656) | PASS | `output/playwright/ga/22537677656-r2/attendance-strict-gates-prod-22537677656-1/20260301-062929-1/gate-summary.json`, `output/playwright/ga/22537677656-r2/attendance-strict-gates-prod-22537677656-1/20260301-062929-2/gate-summary.json` |
+| Daily Dashboard (main, post `#292`) | [#22537661629](https://github.com/zensgit/metasheet2/actions/runs/22537661629) | PASS | `output/playwright/ga/22537661629-r2/attendance-daily-gate-dashboard-22537661629-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22537661629-r2/attendance-daily-gate-dashboard-22537661629-1/attendance-daily-gate-dashboard.md` |
+| Perf Baseline (100k, async) | [#22536896331](https://github.com/zensgit/metasheet2/actions/runs/22536896331) | FAIL (P1) | `output/playwright/ga/22536896331-r2/attendance-import-perf-22536896331-1/perf.log` |
+| Perf Longrun (daily) | [#22536868864](https://github.com/zensgit/metasheet2/actions/runs/22536868864) | FAIL (P1) | `output/playwright/ga/22536868864-r2/attendance-import-perf-longrun-rows100k-commit-22536868864-1/current/rows100k-commit/perf.log`, `output/playwright/ga/22536868864-r2/attendance-import-perf-longrun-rows500k-commit-22536868864-1/current/rows500k-commit/perf.log` |
+
+Current P1 perf signal (tracked, non-paging):
+
+- [#213](https://github.com/zensgit/metasheet2/issues/213) `[Attendance P1] Perf baseline alert` is OPEN.
+- Longrun failing scenarios currently show repeated upstream `502 Bad Gateway` on import commit/job polling under large-load paths.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2636,6 +2636,31 @@ Decision:
 
 - **GO maintained**.
 
+## Post-Go Validation (2026-03-01): i18n/Calendar Delivery + Gate Semantics Alignment
+
+Merged changes:
+
+- [#288](https://github.com/zensgit/metasheet2/pull/288): Admin Center zh localization + locale smoke script.
+- [#289](https://github.com/zensgit/metasheet2/pull/289): daily dashboard JSON contract parser fix.
+- [#290](https://github.com/zensgit/metasheet2/pull/290): Perf Baseline default `commit_async=true`.
+- [#291](https://github.com/zensgit/metasheet2/pull/291): Perf Baseline timeout/poll budget tuning for async path.
+- [#292](https://github.com/zensgit/metasheet2/pull/292): Daily Dashboard workflow fails on P0 only (keeps P1 visible/non-paging).
+
+Validation matrix:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Strict Gates (post `#292`) | [#22537677656](https://github.com/zensgit/metasheet2/actions/runs/22537677656) | PASS | `output/playwright/ga/22537677656-r2/attendance-strict-gates-prod-22537677656-1/20260301-062929-1/gate-summary.json`, `output/playwright/ga/22537677656-r2/attendance-strict-gates-prod-22537677656-1/20260301-062929-2/gate-summary.json` |
+| Daily Dashboard (post `#292`) | [#22537661629](https://github.com/zensgit/metasheet2/actions/runs/22537661629) | PASS | `output/playwright/ga/22537661629-r2/attendance-daily-gate-dashboard-22537661629-1/attendance-daily-gate-dashboard.json` |
+| Perf Baseline (100k async) | [#22536896331](https://github.com/zensgit/metasheet2/actions/runs/22536896331) | FAIL (P1) | `output/playwright/ga/22536896331-r2/attendance-import-perf-22536896331-1/perf.log` |
+| Perf Longrun | [#22536868864](https://github.com/zensgit/metasheet2/actions/runs/22536868864) | FAIL (P1) | `output/playwright/ga/22536868864-r2/attendance-import-perf-longrun-rows100k-commit-22536868864-1/current/rows100k-commit/perf.log`, `output/playwright/ga/22536868864-r2/attendance-import-perf-longrun-rows500k-commit-22536868864-1/current/rows500k-commit/perf.log` |
+
+Assessment:
+
+- P0 gates remain green (`strict=PASS`, dashboard workflow now correctly keyed on `report_p0_status`).
+- P1 performance reliability remains open (upstream 502/timeouts on large import commit paths).
+- Active tracker: [#213](https://github.com/zensgit/metasheet2/issues/213) (`[Attendance P1] Perf baseline alert`).
+
 ## Post-Go Verification (2026-02-28): Mainline Localization + Lunar/Holiday Calendar Labels
 
 Goal:


### PR DESCRIPTION
## Summary
- append 2026-03-01 execution notes and evidence paths to daily gates handbook
- append 2026-03-01 post-go validation section to go/no-go document
- record merged PRs #288/#289/#290/#291/#292 and associated GA run IDs

## Verification
- docs-only update, no runtime code changes
