### PR TITLE
docs(attendance): correct current P1 issue status

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3258,5 +3258,6 @@ Verification runs:
 
 Current P1 perf signal (tracked, non-paging):
 
-- [#213](https://github.com/zensgit/metasheet2/issues/213) `[Attendance P1] Perf baseline alert` is OPEN.
+- [#157](https://github.com/zensgit/metasheet2/issues/157) `[Attendance P1] Perf longrun alert` is OPEN.
+- [#213](https://github.com/zensgit/metasheet2/issues/213) `[Attendance P1] Perf baseline alert` is CLOSED (latest update at 2026-03-01 05:32 UTC).
 - Longrun failing scenarios currently show repeated upstream `502 Bad Gateway` on import commit/job polling under large-load paths.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2659,7 +2659,8 @@ Assessment:
 
 - P0 gates remain green (`strict=PASS`, dashboard workflow now correctly keyed on `report_p0_status`).
 - P1 performance reliability remains open (upstream 502/timeouts on large import commit paths).
-- Active tracker: [#213](https://github.com/zensgit/metasheet2/issues/213) (`[Attendance P1] Perf baseline alert`).
+- Active tracker: [#157](https://github.com/zensgit/metasheet2/issues/157) (`[Attendance P1] Perf longrun alert`).
+- Baseline tracker [#213](https://github.com/zensgit/metasheet2/issues/213) is currently CLOSED.
 
 ## Post-Go Verification (2026-02-28): Mainline Localization + Lunar/Holiday Calendar Labels
 


### PR DESCRIPTION
## Summary
- correct latest P1 issue status in attendance delivery docs
- mark longrun alert issue (#157) as active tracker
- mark baseline alert issue (#213) as closed

## Verification
- docs-only change
