### PR TITLE
ci(attendance): harden longrun async settings and fail summaries

### DIFF
--- a/.github/workflows/attendance-import-perf-longrun.yml
+++ b/.github/workflows/attendance-import-perf-longrun.yml
@@ -127,7 +127,7 @@ jobs:
   perf-scenarios:
     if: github.event_name != 'workflow_dispatch' || inputs.drill != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -144,10 +144,12 @@ jobs:
             max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_COMMIT_MS || vars.ATTENDANCE_PERF_MAX_COMMIT_MS || '150000' }}
             max_export_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_EXPORT_MS || vars.ATTENDANCE_PERF_MAX_EXPORT_MS || '25000' }}
             max_rollback_ms: ''
+            import_job_poll_timeout_ms: '1800000'
+            import_job_poll_timeout_large_ms: '2700000'
           - id: rows100k-commit
             rows: '100000'
             mode: 'commit'
-            commit_async: 'false'
+            commit_async: 'true'
             export_csv: 'true'
             rollback: 'false'
             expected_upsert_strategy: 'staging'
@@ -155,6 +157,8 @@ jobs:
             max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_COMMIT_MAX_COMMIT_MS || '300000' }}
             max_export_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_COMMIT_MAX_EXPORT_MS || '45000' }}
             max_rollback_ms: ''
+            import_job_poll_timeout_ms: '2700000'
+            import_job_poll_timeout_large_ms: '3600000'
           - id: rows50k-preview
             rows: '50000'
             mode: 'preview'
@@ -199,6 +203,8 @@ jobs:
             max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_500K_COMMIT_MAX_COMMIT_MS || '900000' }}
             max_export_ms: ''
             max_rollback_ms: ''
+            import_job_poll_timeout_ms: '3600000'
+            import_job_poll_timeout_large_ms: '5400000'
     env:
       API_BASE: ${{ inputs.api_base || vars.ATTENDANCE_API_BASE || 'http://142.171.239.56:8081/api' }}
       AUTH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_JWT }}
@@ -231,6 +237,8 @@ jobs:
           MAX_EXPORT_MS: ${{ matrix.max_export_ms }}
           MAX_ROLLBACK_MS: ${{ matrix.max_rollback_ms }}
           EXPECT_RECORD_UPSERT_STRATEGY: ${{ matrix.expected_upsert_strategy }}
+          IMPORT_JOB_POLL_TIMEOUT_MS: ${{ matrix.import_job_poll_timeout_ms }}
+          IMPORT_JOB_POLL_TIMEOUT_LARGE_MS: ${{ matrix.import_job_poll_timeout_large_ms }}
           OUTPUT_DIR: output/playwright/attendance-import-perf-longrun/current/${{ matrix.id }}
         run: |
           set -euo pipefail

--- a/scripts/ops/attendance-daily-gate-report.mjs
+++ b/scripts/ops/attendance-daily-gate-report.mjs
@@ -1597,6 +1597,10 @@ async function run() {
     }
 
     const summaryBits = []
+    const isPerfGate = gate.name === 'Perf Baseline' || gate.name === 'Perf Long Run'
+    const regressionsCountValue = String(meta?.regressionsCount ?? '').trim()
+    const hasPerfRegressions = regressionsCountValue !== '' && regressionsCountValue !== '0'
+    const includePerfMeta = !isPerfGate || Boolean(gate?.ok) || Boolean(meta?.reason) || hasPerfRegressions
     if (meta) {
       if (gate.name === 'Remote Preflight') {
         if (meta.rc) summaryBits.push(`rc=${meta.rc}`)
@@ -1624,17 +1628,19 @@ async function run() {
           summaryBits.push(`reasons=${pairs.slice(0, 3).map(([k, v]) => `${k}=${v}`).join(' ')}`)
         }
       } else if (gate.name === 'Perf Baseline' || gate.name === 'Perf Long Run') {
-        if (meta.schemaVersion) summaryBits.push(`schema=${meta.schemaVersion}`)
-        if (meta.engine) summaryBits.push(`engine=${meta.engine}`)
-        if (meta.recordUpsertStrategy) summaryBits.push(`upsert=${meta.recordUpsertStrategy}`)
-        if (meta.expectedRecordUpsertStrategy) summaryBits.push(`upsert_expected=${meta.expectedRecordUpsertStrategy}`)
-        if (meta.processedRows) summaryBits.push(`processed=${meta.processedRows}`)
-        if (meta.failedRows) summaryBits.push(`failed=${meta.failedRows}`)
-        if (meta.elapsedMs) summaryBits.push(`elapsed=${meta.elapsedMs}`)
-        if (meta.rows) summaryBits.push(`rows=${meta.rows}`)
-        if (meta.mode) summaryBits.push(`mode=${meta.mode}`)
-        if (meta.uploadCsv) summaryBits.push(`upload_csv=${meta.uploadCsv}`)
-        if (meta.regressionsCount) summaryBits.push(`regressions=${meta.regressionsCount}`)
+        if (includePerfMeta) {
+          if (meta.schemaVersion) summaryBits.push(`schema=${meta.schemaVersion}`)
+          if (meta.engine) summaryBits.push(`engine=${meta.engine}`)
+          if (meta.recordUpsertStrategy) summaryBits.push(`upsert=${meta.recordUpsertStrategy}`)
+          if (meta.expectedRecordUpsertStrategy) summaryBits.push(`upsert_expected=${meta.expectedRecordUpsertStrategy}`)
+          if (meta.processedRows) summaryBits.push(`processed=${meta.processedRows}`)
+          if (meta.failedRows) summaryBits.push(`failed=${meta.failedRows}`)
+          if (meta.elapsedMs) summaryBits.push(`elapsed=${meta.elapsedMs}`)
+          if (meta.rows) summaryBits.push(`rows=${meta.rows}`)
+          if (meta.mode) summaryBits.push(`mode=${meta.mode}`)
+          if (meta.uploadCsv) summaryBits.push(`upload_csv=${meta.uploadCsv}`)
+          if (meta.regressionsCount) summaryBits.push(`regressions=${meta.regressionsCount}`)
+        }
       }
     }
 
@@ -1686,24 +1692,26 @@ async function run() {
         flat.failedGates = meta.failedGates ?? null
         flat.failedGateReasons = meta.failedGateReasons ?? null
       } else if (gate.name === 'Perf Baseline' || gate.name === 'Perf Long Run') {
-        flat.summarySchemaVersion = meta.schemaVersion ?? null
-        flat.engine = meta.engine ?? null
-        flat.requestedEngine = meta.requestedEngine ?? null
-        flat.recordUpsertStrategy = meta.recordUpsertStrategy ?? null
-        flat.expectedRecordUpsertStrategy = meta.expectedRecordUpsertStrategy ?? null
-        flat.processedRows = meta.processedRows ?? null
-        flat.failedRows = meta.failedRows ?? null
-        flat.elapsedMs = meta.elapsedMs ?? null
-        flat.scenario = meta.scenario ?? null
-        flat.rows = meta.rows ?? null
-        flat.mode = meta.mode ?? null
-        flat.uploadCsv = meta.uploadCsv ?? null
-        flat.previewMs = meta.previewMs ?? null
-        flat.commitMs = meta.commitMs ?? null
-        flat.exportMs = meta.exportMs ?? null
-        flat.rollbackMs = meta.rollbackMs ?? null
-        flat.regressionsCount = meta.regressionsCount ?? null
-        flat.regressionsSample = meta.regressionsSample ?? null
+        if (includePerfMeta) {
+          flat.summarySchemaVersion = meta.schemaVersion ?? null
+          flat.engine = meta.engine ?? null
+          flat.requestedEngine = meta.requestedEngine ?? null
+          flat.recordUpsertStrategy = meta.recordUpsertStrategy ?? null
+          flat.expectedRecordUpsertStrategy = meta.expectedRecordUpsertStrategy ?? null
+          flat.processedRows = meta.processedRows ?? null
+          flat.failedRows = meta.failedRows ?? null
+          flat.elapsedMs = meta.elapsedMs ?? null
+          flat.scenario = meta.scenario ?? null
+          flat.rows = meta.rows ?? null
+          flat.mode = meta.mode ?? null
+          flat.uploadCsv = meta.uploadCsv ?? null
+          flat.previewMs = meta.previewMs ?? null
+          flat.commitMs = meta.commitMs ?? null
+          flat.exportMs = meta.exportMs ?? null
+          flat.rollbackMs = meta.rollbackMs ?? null
+          flat.regressionsCount = meta.regressionsCount ?? null
+          flat.regressionsSample = meta.regressionsSample ?? null
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- switch longrun `rows100k-commit` scenario to async commit path
- increase longrun matrix job timeout budget (`timeout-minutes: 80`)
- pass explicit import job poll timeout env per commit scenario to reduce false timeouts under transient 5xx
- clean daily dashboard fail summaries for perf/longrun gates:
  - only include perf metadata on fail when metadata is failure-relevant
  - avoid mixing PASS scenario metrics into `RUN_FAILED` reason summaries

## Verification
- `node --check scripts/ops/attendance-daily-gate-report.mjs`
- `GH_TOKEN="$(gh auth token)" ... node scripts/ops/attendance-daily-gate-report.mjs`
- inspected generated `gateFlat.perf/longrun` now show `reasonSummary=RUN_FAILED` without misleading success metrics
