### PR TITLE
docs(attendance): add post-295 longrun/dashboard evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3261,3 +3261,21 @@ Current P1 perf signal (tracked, non-paging):
 - [#157](https://github.com/zensgit/metasheet2/issues/157) `[Attendance P1] Perf longrun alert` is OPEN.
 - [#213](https://github.com/zensgit/metasheet2/issues/213) `[Attendance P1] Perf baseline alert` is CLOSED (latest update at 2026-03-01 05:32 UTC).
 - Longrun failing scenarios currently show repeated upstream `502 Bad Gateway` on import commit/job polling under large-load paths.
+
+### Update (2026-03-01, post-`#295`)
+
+Merged:
+- [#295](https://github.com/zensgit/metasheet2/pull/295)
+  - Longrun `rows100k-commit` switched to async commit path.
+  - Longrun matrix timeout budget increased.
+  - Daily dashboard perf failure summary now avoids mixing successful scenario metrics into `RUN_FAILED`.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Perf Longrun (post `#295`) | [#22537963463](https://github.com/zensgit/metasheet2/actions/runs/22537963463) | FAIL (P1) | `output/playwright/ga/22537963463-r2/attendance-import-perf-longrun-rows100k-commit-22537963463-1/current/rows100k-commit/perf.log`, `output/playwright/ga/22537963463-r2/attendance-import-perf-longrun-rows500k-commit-22537963463-1/current/rows500k-commit/perf.log` |
+| Daily Dashboard (after longrun rerun) | [#22539228593](https://github.com/zensgit/metasheet2/actions/runs/22539228593) | PASS (P0) | `output/playwright/ga/22539228593-r2/attendance-daily-gate-dashboard-22539228593-1/attendance-daily-gate-dashboard.json` |
+
+Observed:
+- `gateFlat.longrun.reasonSummary` now reports `RUN_FAILED` cleanly (no misleading successful-scenario metrics appended on FAIL).

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2662,6 +2662,17 @@ Assessment:
 - Active tracker: [#157](https://github.com/zensgit/metasheet2/issues/157) (`[Attendance P1] Perf longrun alert`).
 - Baseline tracker [#213](https://github.com/zensgit/metasheet2/issues/213) is currently CLOSED.
 
+### Follow-up (2026-03-01, post-`#295`)
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Perf Longrun (post async/tuning update) | [#22537963463](https://github.com/zensgit/metasheet2/actions/runs/22537963463) | FAIL (P1) | `output/playwright/ga/22537963463-r2/attendance-import-perf-longrun-rows100k-commit-22537963463-1/current/rows100k-commit/perf.log`, `output/playwright/ga/22537963463-r2/attendance-import-perf-longrun-rows500k-commit-22537963463-1/current/rows500k-commit/perf.log` |
+| Daily Dashboard | [#22539228593](https://github.com/zensgit/metasheet2/actions/runs/22539228593) | PASS | `output/playwright/ga/22539228593-r2/attendance-daily-gate-dashboard-22539228593-1/attendance-daily-gate-dashboard.json` |
+
+Conclusion remains:
+- **GO for P0 production chain** (strict + dashboard P0 healthy).
+- **No-Go for perf hardening closure** until `[Attendance P1] Perf longrun alert` is closed with stable large-import runs.
+
 ## Post-Go Verification (2026-02-28): Mainline Localization + Lunar/Holiday Calendar Labels
 
 Goal:


### PR DESCRIPTION
## Summary
- append post-#295 evidence for longrun + dashboard runs (2026-03-01)
- record that dashboard remains PASS on P0 while longrun is tracked as P1 failure
- add latest local artifact paths for reproducibility

## Verification
- docs-only update
