### PR TITLE
ci(attendance): tune longrun poll intervals for large async jobs

### DIFF
--- a/.github/workflows/attendance-import-perf-longrun.yml
+++ b/.github/workflows/attendance-import-perf-longrun.yml
@@ -144,6 +144,7 @@ jobs:
             max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_COMMIT_MS || vars.ATTENDANCE_PERF_MAX_COMMIT_MS || '150000' }}
             max_export_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_EXPORT_MS || vars.ATTENDANCE_PERF_MAX_EXPORT_MS || '25000' }}
             max_rollback_ms: ''
+            import_job_poll_interval_ms: '2000'
             import_job_poll_timeout_ms: '1800000'
             import_job_poll_timeout_large_ms: '2700000'
           - id: rows100k-commit
@@ -157,6 +158,7 @@ jobs:
             max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_COMMIT_MAX_COMMIT_MS || '300000' }}
             max_export_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_100K_COMMIT_MAX_EXPORT_MS || '45000' }}
             max_rollback_ms: ''
+            import_job_poll_interval_ms: '5000'
             import_job_poll_timeout_ms: '2700000'
             import_job_poll_timeout_large_ms: '3600000'
           - id: rows50k-preview
@@ -203,6 +205,7 @@ jobs:
             max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_500K_COMMIT_MAX_COMMIT_MS || '900000' }}
             max_export_ms: ''
             max_rollback_ms: ''
+            import_job_poll_interval_ms: '10000'
             import_job_poll_timeout_ms: '3600000'
             import_job_poll_timeout_large_ms: '5400000'
     env:
@@ -237,6 +240,7 @@ jobs:
           MAX_EXPORT_MS: ${{ matrix.max_export_ms }}
           MAX_ROLLBACK_MS: ${{ matrix.max_rollback_ms }}
           EXPECT_RECORD_UPSERT_STRATEGY: ${{ matrix.expected_upsert_strategy }}
+          IMPORT_JOB_POLL_INTERVAL_MS: ${{ matrix.import_job_poll_interval_ms }}
           IMPORT_JOB_POLL_TIMEOUT_MS: ${{ matrix.import_job_poll_timeout_ms }}
           IMPORT_JOB_POLL_TIMEOUT_LARGE_MS: ${{ matrix.import_job_poll_timeout_large_ms }}
           OUTPUT_DIR: output/playwright/attendance-import-perf-longrun/current/${{ matrix.id }}


### PR DESCRIPTION
## Summary
- tune longrun async job polling cadence by scenario size:
  - rows10k-commit: 2s
  - rows100k-commit: 5s
  - rows500k-commit: 10s
- keep per-scenario poll timeout budgets introduced earlier

## Why
- reduce high-frequency poll pressure on `/attendance/import/jobs/:id` under large async imports
- lower chance of repeated transient `502` bursts during long-running commits

## Verification
- workflow config change only
