### PR TITLE
docs(attendance): add post-297 longrun evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3279,3 +3279,21 @@ Verification:
 
 Observed:
 - `gateFlat.longrun.reasonSummary` now reports `RUN_FAILED` cleanly (no misleading successful-scenario metrics appended on FAIL).
+
+### Update (2026-03-01, post-`#297` poll-interval tuning)
+
+Merged:
+- [#297](https://github.com/zensgit/metasheet2/pull/297)
+  - Longrun poll interval tuning for async commit scenarios:
+    - `rows100k-commit`: 5s
+    - `rows500k-commit`: 10s
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Perf Longrun (`include_rows500k_*=false`) | [#22539314446](https://github.com/zensgit/metasheet2/actions/runs/22539314446) | FAIL (P1) | `output/playwright/ga/22539314446-r2/attendance-import-perf-longrun-rows100k-commit-22539314446-1/current/rows100k-commit/perf.log` |
+
+Observed:
+- 500k scenarios were skipped as configured; 100k async commit still timed out with intermittent `GET /attendance/import/jobs/:id` 5xx/connection errors.
+- This confirms current bottleneck is beyond client poll cadence tuning and requires backend/infra performance remediation.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2673,6 +2673,16 @@ Conclusion remains:
 - **GO for P0 production chain** (strict + dashboard P0 healthy).
 - **No-Go for perf hardening closure** until `[Attendance P1] Perf longrun alert` is closed with stable large-import runs.
 
+### Follow-up (2026-03-01, post-`#297`)
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Perf Longrun (`include_rows500k_*=false`) | [#22539314446](https://github.com/zensgit/metasheet2/actions/runs/22539314446) | FAIL (P1) | `output/playwright/ga/22539314446-r2/attendance-import-perf-longrun-rows100k-commit-22539314446-1/current/rows100k-commit/perf.log` |
+
+Result:
+- Poll interval tuning alone did not recover `rows100k-commit`; failure mode remains async-job timeout under transient upstream errors.
+- Gate posture unchanged: P0 remains healthy; P1 perf hardening remains open.
+
 ## Post-Go Verification (2026-02-28): Mainline Localization + Lunar/Holiday Calendar Labels
 
 Goal:


### PR DESCRIPTION
## Summary
- append post-#297 longrun verification evidence to GA daily gates handbook
- append post-#297 longrun verification evidence to go/no-go log
- capture that poll interval tuning shipped, but rows100k-commit remains P1 timeout failure

## Verification
- docs-only update
