### PR TITLE
test(attendance): verify zh calendar holiday badge via smoke

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3297,3 +3297,34 @@ Verification:
 Observed:
 - 500k scenarios were skipped as configured; 100k async commit still timed out with intermittent `GET /attendance/import/jobs/:id` 5xx/connection errors.
 - This confirms current bottleneck is beyond client poll cadence tuning and requires backend/infra performance remediation.
+
+## Latest Notes (2026-03-01): zh Calendar Smoke Covers Lunar + Holiday Badge
+
+Execution summary:
+
+1. Enhanced `scripts/verify-attendance-locale-zh-smoke.mjs` to verify **both**:
+   - lunar day labels rendered in calendar cells (`zh-CN-u-ca-chinese`);
+   - holiday badge rendered by creating a temporary holiday via `/api/attendance/holidays`, checking UI, then auto-cleaning it.
+2. Added npm entrypoint:
+   - `pnpm verify:attendance-locale-zh`
+
+Local validation:
+
+| Check | Status | Evidence |
+|---|---|---|
+| Script syntax (`node --check scripts/verify-attendance-locale-zh-smoke.mjs`) | PASS | local shell output |
+
+Run command (production/staging):
+
+```bash
+WEB_URL="http://142.171.239.56:8081" \
+API_BASE="http://142.171.239.56:8081/api" \
+AUTH_TOKEN="<ADMIN_JWT>" \
+ORG_ID="default" \
+pnpm verify:attendance-locale-zh
+```
+
+Expected log markers:
+- `created holiday: ...`
+- `PASS: locale=zh-CN, lunarLabels=... holidayCheck=on`
+- `deleted holiday: ...`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2636,6 +2636,40 @@ Decision:
 
 - **GO maintained**.
 
+## Post-Go Verification (2026-03-01): zh Calendar Lunar + Holiday Visibility Smoke Upgrade
+
+Goal:
+
+- Make the zh locale smoke check assert not only lunar labels, but also real holiday badge rendering in calendar cells.
+
+Code changes:
+
+- `scripts/verify-attendance-locale-zh-smoke.mjs`
+  - Added API-assisted setup/cleanup for temporary holiday (`POST/DELETE /api/attendance/holidays`).
+  - Added UI assertion for `.attendance__calendar-holiday` with created holiday name.
+- `package.json`
+  - Added script alias: `verify:attendance-locale-zh`.
+
+Verification:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Script syntax | local | PASS | `node --check scripts/verify-attendance-locale-zh-smoke.mjs` |
+
+Re-run command (prod/staging):
+
+```bash
+WEB_URL="http://142.171.239.56:8081" \
+API_BASE="http://142.171.239.56:8081/api" \
+AUTH_TOKEN="<ADMIN_JWT>" \
+ORG_ID="default" \
+pnpm verify:attendance-locale-zh
+```
+
+Decision:
+
+- **GO maintained** (feature validation coverage strengthened; remote run requires fresh admin JWT at execution time).
+
 ## Post-Go Validation (2026-03-01): i18n/Calendar Delivery + Gate Semantics Alignment
 
 Merged changes:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "verify:attendance-ui": "node scripts/verify-attendance-ui.mjs",
     "verify:attendance-import-ui": "node scripts/verify-attendance-import-ui.mjs",
     "verify:attendance-ui-regression": "node scripts/verify-attendance-ui-regression.mjs",
+    "verify:attendance-locale-zh": "node scripts/verify-attendance-locale-zh-smoke.mjs",
     "verify:attendance-ui:optional": "bash -c 'if [ \"${RUN_ATTENDANCE_UI_SMOKE}\" = \"true\" ]; then node scripts/verify-attendance-ui.mjs; else echo \"skip attendance ui (set RUN_ATTENDANCE_UI_SMOKE=true)\"; fi'",
     "verify:univer-ui-smoke": "node scripts/verify-univer-ui-smoke.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",

--- a/scripts/verify-attendance-locale-zh-smoke.mjs
+++ b/scripts/verify-attendance-locale-zh-smoke.mjs
@@ -3,13 +3,27 @@ import fs from 'fs/promises'
 import path from 'path'
 
 const webUrl = process.env.WEB_URL || 'http://localhost:8899/'
+const apiBase = resolveApiBase(process.env.API_BASE || '')
 const token = process.env.AUTH_TOKEN || ''
 const headless = process.env.HEADLESS !== 'false'
 const timeoutMs = Number(process.env.UI_TIMEOUT || 45000)
 const outputDir = process.env.OUTPUT_DIR || 'output/playwright/attendance-locale-zh-smoke'
+const orgId = String(process.env.ORG_ID || 'default').trim()
+const verifyHoliday = process.env.VERIFY_HOLIDAY !== 'false'
 
 function normalizeUrl(value) {
   return String(value || '').trim().replace(/\/+$/, '')
+}
+
+function resolveApiBase(value) {
+  const trimmed = normalizeUrl(value)
+  if (trimmed.length > 0) return trimmed
+  try {
+    const parsed = new URL(webUrl)
+    return `${normalizeUrl(parsed.origin)}/api`
+  } catch {
+    return ''
+  }
 }
 
 function log(message) {
@@ -20,12 +34,121 @@ async function ensureDir(dir) {
   await fs.mkdir(dir, { recursive: true })
 }
 
+function toDateKey(date) {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function buildApiPath(pathname, query = {}) {
+  const params = new URLSearchParams()
+  Object.entries(query).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && String(value).trim().length > 0) {
+      params.set(key, String(value))
+    }
+  })
+  const suffix = params.toString()
+  return suffix.length > 0 ? `${pathname}?${suffix}` : pathname
+}
+
+async function apiRequest(pathname, init = {}) {
+  if (!apiBase) throw new Error('API_BASE is required')
+  const url = `${apiBase}${pathname.startsWith('/') ? pathname : `/${pathname}`}`
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    ...(init.headers || {}),
+  }
+  const response = await fetch(url, {
+    ...init,
+    headers,
+  })
+  const text = await response.text()
+  let payload = null
+  if (text) {
+    try {
+      payload = JSON.parse(text)
+    } catch {
+      payload = { raw: text }
+    }
+  }
+  return { response, payload }
+}
+
+async function apiRequestJson(pathname, init = {}) {
+  const { response, payload } = await apiRequest(pathname, {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    },
+  })
+  if (!response.ok) {
+    const message = payload?.error?.message || payload?.message || `HTTP ${response.status}`
+    throw new Error(`API ${pathname} failed: ${message}`)
+  }
+  return payload
+}
+
+function pickHolidayDate(existingDates) {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth()
+  for (let day = 1; day <= 28; day += 1) {
+    const date = new Date(year, month, day)
+    const key = toDateKey(date)
+    if (!existingDates.has(key)) return key
+  }
+  return null
+}
+
 async function run() {
   if (!token) {
     throw new Error('AUTH_TOKEN is required')
   }
 
   await ensureDir(outputDir)
+
+  const monthStartDate = new Date()
+  monthStartDate.setDate(1)
+  const monthEndDate = new Date(monthStartDate.getFullYear(), monthStartDate.getMonth() + 1, 0)
+  const monthStart = toDateKey(monthStartDate)
+  const monthEnd = toDateKey(monthEndDate)
+
+  let createdHolidayId = null
+  let createdHolidayName = null
+  let createdHolidayDate = null
+
+  if (verifyHoliday) {
+    const listQuery = buildApiPath('/attendance/holidays', {
+      orgId,
+      from: monthStart,
+      to: monthEnd,
+    })
+    const listPayload = await apiRequestJson(listQuery, { method: 'GET' })
+    const items = Array.isArray(listPayload?.data?.items) ? listPayload.data.items : []
+    const existingDates = new Set(items.map(item => String(item?.date || '')))
+    const candidateDate = pickHolidayDate(existingDates)
+    if (!candidateDate) {
+      throw new Error('Unable to allocate a holiday date in the current month (days 1-28 all occupied)')
+    }
+    createdHolidayName = `回归节-${Date.now().toString().slice(-6)}`
+    const createPayload = await apiRequestJson('/attendance/holidays', {
+      method: 'POST',
+      body: JSON.stringify({
+        orgId,
+        date: candidateDate,
+        name: createdHolidayName,
+        isWorkingDay: false,
+      }),
+    })
+    createdHolidayId = String(createPayload?.data?.id || '')
+    createdHolidayDate = candidateDate
+    if (!createdHolidayId) {
+      throw new Error('Create holiday returned empty id')
+    }
+    log(`created holiday: ${createdHolidayDate} ${createdHolidayName} (${createdHolidayId})`)
+  }
 
   const browser = await chromium.launch({ headless })
   const context = await browser.newContext({
@@ -59,12 +182,30 @@ async function run() {
       throw new Error('Expected lunar labels in calendar cells, found none')
     }
 
+    if (verifyHoliday && createdHolidayName && createdHolidayDate) {
+      await page.locator('#attendance-from-date').fill(monthStart)
+      await page.locator('#attendance-to-date').fill(monthEnd)
+      await page.getByRole('button', { name: '刷新', exact: true }).click()
+      await page.waitForLoadState('networkidle', { timeout: timeoutMs })
+      await page.locator('.attendance__calendar-holiday', { hasText: createdHolidayName }).first().waitFor({ timeout: timeoutMs })
+    }
+
     const screenshotPath = path.join(outputDir, 'attendance-zh-locale-calendar.png')
     await page.screenshot({ path: screenshotPath, fullPage: true })
 
-    log(`PASS: locale=zh-CN, lunarLabels=${lunarCount}, screenshot=${screenshotPath}`)
+    log(`PASS: locale=zh-CN, lunarLabels=${lunarCount}, holidayCheck=${verifyHoliday ? 'on' : 'off'}, screenshot=${screenshotPath}`)
   } finally {
     await browser.close()
+    if (createdHolidayId) {
+      try {
+        await apiRequestJson(`/attendance/holidays/${createdHolidayId}`, {
+          method: 'DELETE',
+        })
+        log(`deleted holiday: ${createdHolidayId}`)
+      } catch (error) {
+        log(`WARN cleanup failed for holiday ${createdHolidayId}: ${error?.message || error}`)
+      }
+    }
   }
 }
 
@@ -73,4 +214,3 @@ run().catch((error) => {
   console.error(`[attendance-locale-zh-smoke] FAIL: ${message}`)
   process.exitCode = 1
 })
-


### PR DESCRIPTION
## Summary
- enhance `scripts/verify-attendance-locale-zh-smoke.mjs` to validate both:
  - zh lunar labels in calendar cells
  - holiday badge rendering with real holiday data
- script now creates a temporary holiday via `/api/attendance/holidays`, asserts UI badge visibility, then cleans up via DELETE
- add npm script alias `pnpm verify:attendance-locale-zh`
- update GA handoff docs with command and expected markers

## Validation
- `node --check scripts/verify-attendance-locale-zh-smoke.mjs`
- remote runtime blocked with currently provided JWT (`/api/auth/me` returns `401 Invalid token`), so e2e rerun command is documented with `<ADMIN_JWT>` placeholder

## Notes
- no business API changes
- no secrets/tokens added to repo docs
