### PR TITLE
ci(attendance): always emit zh smoke auth failure artifact

### DIFF
--- a/.github/workflows/attendance-locale-zh-smoke-prod.yml
+++ b/.github/workflows/attendance-locale-zh-smoke-prod.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium --with-deps
 
+      - name: Prepare output directory
+        run: mkdir -p output/playwright/attendance-locale-zh-smoke
+
       - name: Resolve valid auth token
         id: resolve-auth-token
         run: |
@@ -98,6 +101,15 @@ jobs:
             fi
           fi
 
+          cat > output/playwright/attendance-locale-zh-smoke/auth-error.txt <<EOF
+          No valid attendance admin token.
+          Tried: ATTENDANCE_ADMIN_JWT validation via /api/auth/me.
+          Fallback: ATTENDANCE_ADMIN_EMAIL + ATTENDANCE_ADMIN_PASSWORD login.
+          Remediation:
+          - Rotate ATTENDANCE_ADMIN_JWT, or
+          - Configure ATTENDANCE_ADMIN_EMAIL + ATTENDANCE_ADMIN_PASSWORD secrets.
+          API_BASE=${API_BASE}
+          EOF
           echo "::error::No valid attendance admin token. Rotate ATTENDANCE_ADMIN_JWT or configure ATTENDANCE_ADMIN_EMAIL/ATTENDANCE_ADMIN_PASSWORD."
           exit 1
 

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3341,6 +3341,8 @@ gh workflow run attendance-locale-zh-smoke-prod.yml \
 
 Artifact:
 - `attendance-locale-zh-smoke-prod-<runId>-<attempt>/attendance-zh-locale-calendar.png`
+- If auth bootstrap fails, artifact still contains:
+  - `attendance-locale-zh-smoke-prod-<runId>-<attempt>/auth-error.txt`
 
 Auth note:
 - Workflow first validates `ATTENDANCE_ADMIN_JWT`.


### PR DESCRIPTION
## Summary
- ensure zh locale smoke workflow always creates artifact evidence even on auth bootstrap failure
- adds `Prepare output directory` step
- writes `output/playwright/attendance-locale-zh-smoke/auth-error.txt` before failing auth step
- docs updated with fallback artifact path

## Why
- previous failed runs had no uploaded artifacts, making postmortem and handoff harder

## Validation
- workflow YAML updated only; run behavior verified via logic review
