### PR TITLE
docs(attendance): record zh smoke workflow rollout evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3348,3 +3348,19 @@ Auth note:
 - Workflow first validates `ATTENDANCE_ADMIN_JWT`.
 - If JWT is invalid and `ATTENDANCE_ADMIN_EMAIL` + `ATTENDANCE_ADMIN_PASSWORD` are configured, it auto-logins and continues.
 - If neither path yields a valid token, run fails with explicit rotation guidance.
+
+### Update (2026-03-01): Auth Failure Path Evidence Verified
+
+Runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Locale zh Smoke (Prod) | [#22540304225](https://github.com/zensgit/metasheet2/actions/runs/22540304225) | FAIL | `Resolve valid auth token` failed (`Invalid token`) |
+| Attendance Locale zh Smoke (Prod, auth fallback) | [#22540373968](https://github.com/zensgit/metasheet2/actions/runs/22540373968) | FAIL | Explicit remediation message in step log |
+| Attendance Locale zh Smoke (Prod, auth artifact hardening) | [#22540422680](https://github.com/zensgit/metasheet2/actions/runs/22540422680) | FAIL (expected until secret rotation) | `output/playwright/ga/22540422680/auth-error.txt` |
+
+Observed:
+- Workflow now always uploads evidence artifact even when auth bootstrap fails.
+- Current remaining blocker for screenshot capture is credential rotation:
+  - rotate `ATTENDANCE_ADMIN_JWT`, or
+  - set `ATTENDANCE_ADMIN_EMAIL` + `ATTENDANCE_ADMIN_PASSWORD`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2670,6 +2670,33 @@ Decision:
 
 - **GO maintained** (feature validation coverage strengthened; remote run requires fresh admin JWT at execution time).
 
+## Post-Go Verification (2026-03-01): zh Locale Production Screenshot Workflow Rollout
+
+Goal:
+
+- Enable reproducible production screenshot verification for zh attendance calendar (lunar + holiday badge) without ad-hoc local token sharing.
+
+Code changes merged:
+
+- [#300](https://github.com/zensgit/metasheet2/pull/300)
+  - Added `.github/workflows/attendance-locale-zh-smoke-prod.yml`.
+- [#301](https://github.com/zensgit/metasheet2/pull/301)
+  - Added token validation + login fallback (`ATTENDANCE_ADMIN_EMAIL`/`ATTENDANCE_ADMIN_PASSWORD`).
+- [#302](https://github.com/zensgit/metasheet2/pull/302)
+  - Guaranteed artifact output on auth failure (`auth-error.txt`).
+
+Verification runs:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| zh Smoke workflow initial run | [#22540304225](https://github.com/zensgit/metasheet2/actions/runs/22540304225) | FAIL | Invalid JWT detected during holiday API check |
+| zh Smoke workflow with auth fallback | [#22540373968](https://github.com/zensgit/metasheet2/actions/runs/22540373968) | FAIL | Explicit auth remediation message |
+| zh Smoke workflow with auth-failure artifact | [#22540422680](https://github.com/zensgit/metasheet2/actions/runs/22540422680) | FAIL (expected until secret rotation) | `output/playwright/ga/22540422680/auth-error.txt` |
+
+Decision:
+
+- **GO maintained (P0 unaffected)**; zh screenshot gate is operational and auditable, currently blocked only by admin credential secret freshness.
+
 ## Post-Go Validation (2026-03-01): i18n/Calendar Delivery + Gate Semantics Alignment
 
 Merged changes:


### PR DESCRIPTION
## Summary
- append 2026-03-01 zh smoke workflow execution records to:
  - `docs/attendance-production-ga-daily-gates-20260209.md`
  - `docs/attendance-production-go-no-go-20260211.md`
- include run IDs and local artifact path for auth-failure evidence:
  - `output/playwright/ga/22540422680/auth-error.txt`

## Notes
- this is doc-only evidence closure for PRs #300/#301/#302
- no secrets/tokens added
