### PR TITLE
fix(attendance): normalize holiday date key for calendar badge

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4210,7 +4210,8 @@ const recordMap = computed(() => {
 const holidayMap = computed(() => {
   const map = new Map<string, AttendanceHoliday>()
   holidays.value.forEach((holiday) => {
-    map.set(holiday.date, holiday)
+    const key = normalizeDateKey(holiday.date)
+    if (key) map.set(key, holiday)
   })
   return map
 })
@@ -4445,6 +4446,16 @@ function toDateKey(date: Date): string {
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')
   return `${year}-${month}-${day}`
+}
+
+function normalizeDateKey(value: string | null | undefined): string | null {
+  const raw = String(value || '').trim()
+  if (!raw) return null
+  const direct = raw.match(/^(\d{4}-\d{2}-\d{2})/)
+  if (direct) return direct[1]
+  const date = new Date(raw)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toISOString().slice(0, 10)
 }
 
 function formatDateTime(value: string | null): string {

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3364,3 +3364,19 @@ Observed:
 - Current remaining blocker for screenshot capture is credential rotation:
   - rotate `ATTENDANCE_ADMIN_JWT`, or
   - set `ATTENDANCE_ADMIN_EMAIL` + `ATTENDANCE_ADMIN_PASSWORD`.
+
+### Update (2026-03-01): Holiday Badge Rendering Root Cause & Fix Prepared
+
+Root cause found during live smoke retries:
+- API holiday date is returned as ISO datetime (`YYYY-MM-DDT00:00:00.000Z`), while calendar day key uses `YYYY-MM-DD`.
+- Frontend holiday map keyed by raw `holiday.date` caused mismatch, so `.attendance__calendar-holiday` stayed empty even when holidays existed.
+
+Fix prepared on codebase:
+- Normalize holiday date key before map insert in attendance view.
+- Hardened zh smoke script:
+  - month selection based on current UI month context;
+  - richer failure screenshot/debug output.
+
+Status:
+- Code/build validated locally.
+- Production verification requires deploying the new web bundle, then rerunning `attendance-locale-zh-smoke-prod.yml`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2697,6 +2697,22 @@ Decision:
 
 - **GO maintained (P0 unaffected)**; zh screenshot gate is operational and auditable, currently blocked only by admin credential secret freshness.
 
+## Post-Go Development Note (2026-03-01): Holiday Badge Date-Key Mismatch Fix
+
+Finding:
+- Production live smoke proved holiday create/list API works, but calendar holiday badge remained empty.
+- Root cause: frontend keyed holiday map by raw ISO datetime (`YYYY-MM-DDT...Z`) instead of day key (`YYYY-MM-DD`).
+
+Fix prepared:
+- `apps/web/src/views/AttendanceView.vue`
+  - holiday map now normalizes `holiday.date` to `YYYY-MM-DD` before lookup.
+- `scripts/verify-attendance-locale-zh-smoke.mjs`
+  - strengthened month/date selection and failure diagnostics for holiday badge assertion.
+
+Validation (local):
+- `pnpm --filter @metasheet/web build` PASS.
+- Production re-verification pending deployment of this fix.
+
 ## Post-Go Validation (2026-03-01): i18n/Calendar Delivery + Gate Semantics Alignment
 
 Merged changes:

--- a/scripts/verify-attendance-locale-zh-smoke.mjs
+++ b/scripts/verify-attendance-locale-zh-smoke.mjs
@@ -90,16 +90,101 @@ async function apiRequestJson(pathname, init = {}) {
   return payload
 }
 
-function pickHolidayDate(existingDates) {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = now.getMonth()
-  for (let day = 1; day <= 28; day += 1) {
-    const date = new Date(year, month, day)
+function pickHolidayDate(existingDates, year, monthIndex) {
+  const preferredDays = [15, 16, 17, 18, 19, 20, 10, 11, 12, 13, 14, 21, 22, 23, 24, 25, 26, 27, 28, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+  for (const day of preferredDays) {
+    const date = new Date(year, monthIndex - 1, day)
     const key = toDateKey(date)
     if (!existingDates.has(key)) return key
   }
   return null
+}
+
+function parseCalendarYearMonth(label) {
+  const text = String(label || '').replace(/\s+/g, ' ').trim()
+  const zhMatch = text.match(/(\d{4})\D+(\d{1,2})/)
+  if (zhMatch) {
+    return {
+      year: Number(zhMatch[1]),
+      month: Number(zhMatch[2]),
+    }
+  }
+  const enMatch = text.match(/^([A-Za-z]+)\s+(\d{4})$/)
+  if (enMatch) {
+    const monthMap = {
+      january: 1,
+      february: 2,
+      march: 3,
+      april: 4,
+      may: 5,
+      june: 6,
+      july: 7,
+      august: 8,
+      september: 9,
+      october: 10,
+      november: 11,
+      december: 12,
+    }
+    const month = monthMap[String(enMatch[1]).toLowerCase()]
+    if (month) {
+      return {
+        year: Number(enMatch[2]),
+        month,
+      }
+    }
+  }
+  return null
+}
+
+function monthRange(year, monthIndex) {
+  const start = new Date(year, monthIndex - 1, 1)
+  const end = new Date(year, monthIndex, 0)
+  return {
+    monthStart: toDateKey(start),
+    monthEnd: toDateKey(end),
+  }
+}
+
+async function ensureHolidayExistsForMonth(from, to, expectedId) {
+  const listQuery = buildApiPath('/attendance/holidays', { orgId, from, to })
+  const listPayload = await apiRequestJson(listQuery, { method: 'GET' })
+  const items = Array.isArray(listPayload?.data?.items) ? listPayload.data.items : []
+  if (!items.some(item => String(item?.id || '') === String(expectedId || ''))) {
+    throw new Error(`Created holiday id not found via API list (${from}..${to})`)
+  }
+}
+
+async function findHolidayBadgeAcrossMonths(page, holidayName) {
+  const target = page.locator('.attendance__calendar-holiday', { hasText: holidayName }).first()
+  const navPlan = [
+    null,
+    'next',
+    'next',
+    'prev',
+    'prev',
+    'prev',
+  ]
+  const navButtonByStep = {
+    next: page.getByRole('button', { name: /^(Next|下月)$/ }),
+    prev: page.getByRole('button', { name: /^(Prev|上月)$/ }),
+  }
+
+  for (const step of navPlan) {
+    if (step) {
+      await navButtonByStep[step].first().click()
+      await page.waitForLoadState('networkidle', { timeout: timeoutMs })
+    }
+    const count = await target.count()
+    if (count > 0) {
+      await target.waitFor({ timeout: 5000 })
+      return true
+    }
+  }
+  const calendarLabel = await page.locator('.attendance__calendar-label').first().textContent().catch(() => '')
+  const badgeTexts = await page.locator('.attendance__calendar-holiday').allTextContents().catch(() => [])
+  throw new Error(
+    `Holiday badge not visible for "${holidayName}". calendarLabel="${(calendarLabel || '').trim()}", badges=${JSON.stringify(badgeTexts.slice(0, 12))}`,
+  )
 }
 
 async function run() {
@@ -109,46 +194,9 @@ async function run() {
 
   await ensureDir(outputDir)
 
-  const monthStartDate = new Date()
-  monthStartDate.setDate(1)
-  const monthEndDate = new Date(monthStartDate.getFullYear(), monthStartDate.getMonth() + 1, 0)
-  const monthStart = toDateKey(monthStartDate)
-  const monthEnd = toDateKey(monthEndDate)
-
   let createdHolidayId = null
   let createdHolidayName = null
   let createdHolidayDate = null
-
-  if (verifyHoliday) {
-    const listQuery = buildApiPath('/attendance/holidays', {
-      orgId,
-      from: monthStart,
-      to: monthEnd,
-    })
-    const listPayload = await apiRequestJson(listQuery, { method: 'GET' })
-    const items = Array.isArray(listPayload?.data?.items) ? listPayload.data.items : []
-    const existingDates = new Set(items.map(item => String(item?.date || '')))
-    const candidateDate = pickHolidayDate(existingDates)
-    if (!candidateDate) {
-      throw new Error('Unable to allocate a holiday date in the current month (days 1-28 all occupied)')
-    }
-    createdHolidayName = `回归节-${Date.now().toString().slice(-6)}`
-    const createPayload = await apiRequestJson('/attendance/holidays', {
-      method: 'POST',
-      body: JSON.stringify({
-        orgId,
-        date: candidateDate,
-        name: createdHolidayName,
-        isWorkingDay: false,
-      }),
-    })
-    createdHolidayId = String(createPayload?.data?.id || '')
-    createdHolidayDate = candidateDate
-    if (!createdHolidayId) {
-      throw new Error('Create holiday returned empty id')
-    }
-    log(`created holiday: ${createdHolidayDate} ${createdHolidayName} (${createdHolidayId})`)
-  }
 
   const browser = await chromium.launch({ headless })
   const context = await browser.newContext({
@@ -182,18 +230,77 @@ async function run() {
       throw new Error('Expected lunar labels in calendar cells, found none')
     }
 
-    if (verifyHoliday && createdHolidayName && createdHolidayDate) {
+    if (verifyHoliday) {
+      const calendarLabelNode = page.locator('.attendance__calendar-label').first()
+      await calendarLabelNode.waitFor({ timeout: timeoutMs })
+      const calendarLabelText = await calendarLabelNode.textContent().catch(() => '')
+      let ym = parseCalendarYearMonth(calendarLabelText)
+      if (!ym) {
+        const toDateValue = await page.locator('#attendance-to-date').inputValue().catch(() => '')
+        const toDateMatch = String(toDateValue).match(/^(\d{4})-(\d{2})-/)
+        if (toDateMatch) {
+          ym = {
+            year: Number(toDateMatch[1]),
+            month: Number(toDateMatch[2]),
+          }
+        } else {
+          ym = await page.evaluate(() => {
+            const d = new Date()
+            return { year: d.getFullYear(), month: d.getMonth() + 1 }
+          })
+        }
+      }
+      const { monthStart, monthEnd } = monthRange(ym.year, ym.month)
+      const listQuery = buildApiPath('/attendance/holidays', {
+        orgId,
+        from: monthStart,
+        to: monthEnd,
+      })
+      const listPayload = await apiRequestJson(listQuery, { method: 'GET' })
+      const items = Array.isArray(listPayload?.data?.items) ? listPayload.data.items : []
+      const existingDates = new Set(items.map(item => String(item?.date || '')))
+      const candidateDate = pickHolidayDate(existingDates, ym.year, ym.month)
+      if (!candidateDate) {
+        throw new Error(`Unable to allocate a holiday date for ${ym.year}-${String(ym.month).padStart(2, '0')} (days 1-28 all occupied)`)
+      }
+      createdHolidayName = `回归节-${Date.now().toString().slice(-6)}`
+      const createPayload = await apiRequestJson('/attendance/holidays', {
+        method: 'POST',
+        body: JSON.stringify({
+          orgId,
+          date: candidateDate,
+          name: createdHolidayName,
+          isWorkingDay: false,
+        }),
+      })
+      createdHolidayId = String(createPayload?.data?.id || '')
+      createdHolidayDate = candidateDate
+      if (!createdHolidayId) {
+        throw new Error('Create holiday returned empty id')
+      }
+      log(`created holiday: ${createdHolidayDate} ${createdHolidayName} (${createdHolidayId})`)
+
+      await ensureHolidayExistsForMonth(monthStart, monthEnd, createdHolidayId)
       await page.locator('#attendance-from-date').fill(monthStart)
       await page.locator('#attendance-to-date').fill(monthEnd)
       await page.getByRole('button', { name: '刷新', exact: true }).click()
       await page.waitForLoadState('networkidle', { timeout: timeoutMs })
-      await page.locator('.attendance__calendar-holiday', { hasText: createdHolidayName }).first().waitFor({ timeout: timeoutMs })
+      await findHolidayBadgeAcrossMonths(page, createdHolidayName)
     }
 
     const screenshotPath = path.join(outputDir, 'attendance-zh-locale-calendar.png')
     await page.screenshot({ path: screenshotPath, fullPage: true })
 
     log(`PASS: locale=zh-CN, lunarLabels=${lunarCount}, holidayCheck=${verifyHoliday ? 'on' : 'off'}, screenshot=${screenshotPath}`)
+  } catch (error) {
+    const failShot = path.join(outputDir, 'attendance-zh-locale-calendar-fail.png')
+    try {
+      await page.screenshot({ path: failShot, fullPage: true })
+      log(`captured failure screenshot: ${failShot}`)
+    } catch {
+      // ignore screenshot failure
+    }
+    throw error
   } finally {
     await browser.close()
     if (createdHolidayId) {


### PR DESCRIPTION
## Summary
- fix attendance calendar holiday badge rendering mismatch:
  - normalize `holiday.date` to day key (`YYYY-MM-DD`) before writing to `holidayMap`
- harden zh locale smoke script for production checks:
  - better month/date handling for temporary holiday injection
  - richer failure diagnostics + fail screenshot capture
- update production gate/go-no-go docs with root cause and verification notes

## Root cause
- `/api/attendance/holidays` returns `date` as ISO datetime (`YYYY-MM-DDT00:00:00.000Z`)
- calendar day lookup key is `YYYY-MM-DD`
- raw-key map insert prevented badge lookup hits

## Validation
- `node --check scripts/verify-attendance-locale-zh-smoke.mjs`
- `pnpm --filter @metasheet/web build`

## Notes
- production smoke still requires deployed frontend bundle + valid admin credential secret rotation
