### PR TITLE
docs(attendance): add post-309 zh verification run evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3488,3 +3488,17 @@ Observed:
   - locale forced to `zh-CN`
   - lunar labels present and meaningful
   - created holiday badge rendered and cleaned up via API.
+
+### Update (2026-03-02): Mainline Verification After Records zh Localization (PR #309)
+
+Merged:
+
+- PR [#309](https://github.com/zensgit/metasheet2/pull/309)
+  - localized Attendance Overview `Records` panel labels/actions for zh locale.
+
+Mainline verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Locale zh Smoke (main, post-merge) | [#22580807870](https://github.com/zensgit/metasheet2/actions/runs/22580807870) | PASS | `output/playwright/ga/22580807870-zh-main-post309/attendance-locale-zh-smoke-prod-22580807870-1/attendance-zh-locale-calendar.png` |
+| Attendance Daily Gate Dashboard (main, post-merge) | [#22580875100](https://github.com/zensgit/metasheet2/actions/runs/22580875100) | PASS | `output/playwright/ga/22580875100-dashboard-main-post309/attendance-daily-gate-dashboard-22580875100-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22580875100-dashboard-main-post309/attendance-daily-gate-dashboard-22580875100-1/attendance-daily-gate-dashboard.md` |

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2669,6 +2669,28 @@ Decision:
 
 - **GO maintained** (P0 production chain unchanged; zh locale gate reliability improved).
 
+## Post-Go Verification (2026-03-02): Records Panel zh Localization (PR #309)
+
+Goal:
+
+- Remove remaining English strings from Attendance Overview `Records` panel under zh locale.
+
+Merged:
+
+- PR [#309](https://github.com/zensgit/metasheet2/pull/309)
+  - localized records title, reload/export buttons, empty state, and table headers via `tr()` mapping.
+
+Verification runs:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Locale zh Smoke (main, post-merge) | [#22580807870](https://github.com/zensgit/metasheet2/actions/runs/22580807870) | PASS | `output/playwright/ga/22580807870-zh-main-post309/attendance-locale-zh-smoke-prod-22580807870-1/attendance-zh-locale-calendar.png` |
+| Attendance Daily Gate Dashboard (main, post-merge) | [#22580875100](https://github.com/zensgit/metasheet2/actions/runs/22580875100) | PASS | `output/playwright/ga/22580875100-dashboard-main-post309/attendance-daily-gate-dashboard-22580875100-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22580875100-dashboard-main-post309/attendance-daily-gate-dashboard-22580875100-1/attendance-daily-gate-dashboard.md` |
+
+Decision:
+
+- **GO maintained**.
+
 ## Post-Go Verification (2026-03-02): Perf Longrun Async Timeout Recovery Follow-up (PR #307)
 
 Goal:


### PR DESCRIPTION
## Summary
- add post-PR #309 zh locale verification records to GA handbook and Go/No-Go docs
- include mainline run IDs and local artifact paths for reproducibility

## Verification
- Evidence references:
  - run 22580807870 (zh smoke, PASS)
  - run 22580875100 (daily dashboard, PASS)
