### PR TITLE
docs(attendance): add post-merge zh phase5 gate evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3585,3 +3585,21 @@ Local verification:
 | zh copy contract | local (2026-03-03) | PASS | command: `pnpm verify:attendance-zh-copy-contract` |
 | Attendance Gate Contract Case (strict) | local (2026-03-03) | PASS | `output/playwright/attendance-gate-contract-matrix/strict/strict/gate-summary.valid.json`, `output/playwright/attendance-gate-contract-matrix/strict/strict/gate-summary.invalid.json` |
 | Attendance Gate Contract Case (dashboard) | local (2026-03-03) | PASS | `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.valid.json`, `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.invalid.strict.json`, `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.invalid.perf.json`, `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.invalid.longrun.json`, `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.invalid.upsert.json` |
+
+Merged:
+
+- PR [#317](https://github.com/zensgit/metasheet2/pull/317)
+
+Post-merge mainline verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Locale zh Smoke (main, post-merge) | [#22585014328](https://github.com/zensgit/metasheet2/actions/runs/22585014328) | FAIL (env credential) | `output/playwright/ga/22585014328/attendance-locale-zh-smoke-prod-22585014328-1/auth-error.txt` |
+| Attendance Daily Gate Dashboard (main, post-merge) | [#22585014372](https://github.com/zensgit/metasheet2/actions/runs/22585014372) | PASS | `output/playwright/ga/22585014372/attendance-daily-gate-dashboard-22585014372-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22585014372/attendance-daily-gate-dashboard-22585014372-1/attendance-daily-gate-dashboard.md` |
+
+Observed:
+
+- zh smoke failure is from `Resolve valid auth token` guard:
+  - no valid `ATTENDANCE_ADMIN_JWT`
+  - no fallback `ATTENDANCE_ADMIN_EMAIL`/`ATTENDANCE_ADMIN_PASSWORD`
+- this is an environment credential rotation issue, not a UI localization regression.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2671,6 +2671,31 @@ Decision:
 
 - **GO maintained** (phase-5 zh copy changes passed local build + contract gates).
 
+## Post-Go Mainline Verification (2026-03-03): PR #317 Merge + Gate Refresh
+
+Merged:
+
+- PR [#317](https://github.com/zensgit/metasheet2/pull/317)
+  - commit: `ce84edfa7b0d63cc48a0e29abd74dd3bcc0cf1f9`
+
+Verification:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Locale zh Smoke (main, post-merge) | [#22585014328](https://github.com/zensgit/metasheet2/actions/runs/22585014328) | FAIL (env credential) | `output/playwright/ga/22585014328/attendance-locale-zh-smoke-prod-22585014328-1/auth-error.txt` |
+| Attendance Daily Gate Dashboard (main, post-merge) | [#22585014372](https://github.com/zensgit/metasheet2/actions/runs/22585014372) | PASS | `output/playwright/ga/22585014372/attendance-daily-gate-dashboard-22585014372-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22585014372/attendance-daily-gate-dashboard-22585014372-1/attendance-daily-gate-dashboard.md` |
+
+Observed:
+
+- zh smoke failed in `Resolve valid auth token`:
+  - no valid `ATTENDANCE_ADMIN_JWT`
+  - fallback login secrets not configured (`ATTENDANCE_ADMIN_EMAIL`/`ATTENDANCE_ADMIN_PASSWORD`)
+- dashboard remained green; no new strict/perf/protection regressions detected.
+
+Decision:
+
+- **Conditional GO maintained**: code quality gates are green; rotate attendance admin secrets before requiring zh smoke as blocking PASS.
+
 ## Post-Go Verification (2026-03-02): Admin zh Localization Phase 3 + Copy Contract Gate (PR #313)
 
 Goal:


### PR DESCRIPTION
## Summary
- update GA daily gates doc with PR #317 post-merge verification records
- add run evidence for mainline dashboard PASS and zh smoke credential failure trace
- update go/no-go doc with post-merge decision and remediation note for admin token rotation

## Evidence Added
- zh smoke run: https://github.com/zensgit/metasheet2/actions/runs/22585014328
- dashboard run: https://github.com/zensgit/metasheet2/actions/runs/22585014372
- local artifacts:
  - `output/playwright/ga/22585014328/attendance-locale-zh-smoke-prod-22585014328-1/auth-error.txt`
  - `output/playwright/ga/22585014372/attendance-daily-gate-dashboard-22585014372-1/attendance-daily-gate-dashboard.json`
  - `output/playwright/ga/22585014372/attendance-daily-gate-dashboard-22585014372-1/attendance-daily-gate-dashboard.md`
