### PR TITLE
fix(attendance): split perf baseline concurrency by trigger source

### DIFF
--- a/.github/workflows/attendance-import-perf-baseline.yml
+++ b/.github/workflows/attendance-import-perf-baseline.yml
@@ -63,7 +63,8 @@ on:
     - cron: '20 3 * * *'
 
 concurrency:
-  group: attendance-import-perf-baseline
+  # Avoid schedule/manual cross-cancellation while preserving dedupe per trigger source.
+  group: attendance-import-perf-baseline-${{ github.event_name == 'schedule' && 'schedule' || github.event_name == 'workflow_dispatch' && 'manual' || 'other' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
- split `Attendance Import Perf Baseline` concurrency group by trigger source (`schedule` vs `workflow_dispatch`)
- prevent schedule/manual cross-cancellation while keeping in-source dedupe (`cancel-in-progress: true`)
- keep existing perf baseline gate behavior and inputs unchanged

## Why
Recent baseline runs were frequently `cancelled` when manual verification overlapped with the scheduled window. This patch makes baseline evidence collection stable for both daily operations and ad-hoc verification.

## Verification
- workflow syntax-only change (no runtime contract changes)
- validated by inspecting generated workflow expression and branch diff
