### PR TITLE
fix(attendance): enforce preflight import row cap + baseline default 20k

### DIFF
--- a/.github/workflows/attendance-import-perf-baseline.yml
+++ b/.github/workflows/attendance-import-perf-baseline.yml
@@ -23,9 +23,9 @@ on:
         required: false
         default: 'http://142.171.239.56:8081/api'
       rows:
-        description: 'CSV rows to generate (default 100000)'
+        description: 'CSV rows to generate (default 20000)'
         required: false
-        default: '100000'
+        default: '20000'
       mode:
         description: 'preview or commit'
         required: false
@@ -98,7 +98,7 @@ jobs:
             "mode": "commit",
             "apiBase": "<DRILL>",
             "orgId": "default",
-            "rows": 100000,
+            "rows": 20000,
             "commitAsync": true,
             "uploadCsv": true,
             "previewMs": 1111,
@@ -138,7 +138,7 @@ jobs:
     env:
       API_BASE: ${{ inputs.api_base || vars.ATTENDANCE_API_BASE || 'http://142.171.239.56:8081/api' }}
       AUTH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_JWT }}
-      ROWS: ${{ inputs.rows || vars.ATTENDANCE_PERF_BASELINE_ROWS || '100000' }}
+      ROWS: ${{ inputs.rows || vars.ATTENDANCE_PERF_BASELINE_ROWS || '20000' }}
       MODE: ${{ inputs.mode || 'commit' }}
       ROLLBACK: 'true'
       COMMIT_ASYNC: ${{ inputs.commit_async || vars.ATTENDANCE_PERF_COMMIT_ASYNC || 'true' }}

--- a/docker/app.env.example
+++ b/docker/app.env.example
@@ -16,6 +16,9 @@ ATTENDANCE_IMPORT_REQUIRE_TOKEN=1
 # Attendance import upload channel (csvFileId) storage.
 # NOTE: docker-compose.app.yml mounts a persistent volume at `/app/uploads/attendance-import` by default.
 ATTENDANCE_IMPORT_UPLOAD_DIR=/app/uploads/attendance-import
+# Production safety guardrail for CSV imports.
+# For current production-v1 capacity, keep this at 20000 unless a larger cap is validated.
+ATTENDANCE_IMPORT_CSV_MAX_ROWS=20000
 # Per-query timeout (ms) for heavy attendance import SQL (bulk/staging upsert path).
 # Increase this when running large imports (for example 500k commit longrun) to avoid 30s query timeout failures.
 ATTENDANCE_IMPORT_HEAVY_QUERY_TIMEOUT_MS=180000

--- a/docs/attendance-production-delivery-20260207.md
+++ b/docs/attendance-production-delivery-20260207.md
@@ -61,7 +61,13 @@ Out of scope for this delivery:
 4. If large imports (200k+ rows) return `413 Payload Too Large`:
    - Ensure the backend is on a build that supports per-route import payload limits (shipped on `main` after `3b85463d`).
    - Optional env (override only when needed): `ATTENDANCE_IMPORT_JSON_LIMIT=50mb` (must be <= reverse proxy `client_max_body_size`).
-5. For extreme-scale imports (200k-500k+ rows), prefer the CSV upload channel (`csvFileId`) instead of embedding `csvText` in JSON:
+5. Enforce production-safe CSV row cap:
+   - Set `ATTENDANCE_IMPORT_CSV_MAX_ROWS` explicitly in `docker/app.env`.
+   - `scripts/ops/attendance-preflight.sh` now hard-fails when:
+     - `ATTENDANCE_IMPORT_CSV_MAX_ROWS` is missing/invalid.
+     - `ATTENDANCE_IMPORT_CSV_MAX_ROWS` exceeds `ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS` (default: `20000`).
+   - Override `ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS` only after capacity validation and evidence capture.
+6. For extreme-scale imports (200k-500k+ rows), prefer the CSV upload channel (`csvFileId`) instead of embedding `csvText` in JSON:
    - Ensure `ATTENDANCE_IMPORT_UPLOAD_DIR` is on a persistent volume (see `docker-compose.app.yml`).
    - Ensure nginx allows a larger body specifically for the upload endpoint:
      - `location /api/attendance/import/upload { client_max_body_size 120m; }` (see `docker/nginx.conf`)
@@ -167,7 +173,8 @@ P1 (1-2 weeks, production hardening):
       a second idempotency read inside the transaction before insert, reducing duplicate-batch risk under concurrent retries.
   - Additional hardening (implemented 2026-02-12):
     - Streaming-style CSV row iteration (avoid full parsed matrix allocation).
-    - Server-side CSV row cap guardrail via `ATTENDANCE_IMPORT_CSV_MAX_ROWS` (default `500000`, minimum `1000`).
+    - Server-side CSV row cap guardrail via `ATTENDANCE_IMPORT_CSV_MAX_ROWS` (backend default `500000`, minimum `1000`).
+    - Production deploy preflight now requires explicit `ATTENDANCE_IMPORT_CSV_MAX_ROWS` and enforces a safe bound (default `<=20000`).
     - `CSV_TOO_LARGE` mapped to explicit `HTTP 400` on preview/commit/import endpoints.
   - Import persistence tuning (implemented 2026-02-12):
     - Import chunk sizes are now env-tunable:

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -490,7 +490,7 @@ Optional repo variables (threshold guardrails):
 - `ATTENDANCE_PERF_MAX_COMMIT_MS`
 - `ATTENDANCE_PERF_MAX_EXPORT_MS`
 - `ATTENDANCE_PERF_MAX_ROLLBACK_MS`
-- `ATTENDANCE_PERF_BASELINE_ROWS` (optional; default baseline rows, current default is `100000`)
+- `ATTENDANCE_PERF_BASELINE_ROWS` (optional; default baseline rows, current default is `20000`)
 
 Artifacts:
 
@@ -502,7 +502,7 @@ P1 tracking issue (no paging): `[Attendance P1] Perf baseline alert` (opened/reo
 
 Defaults (current):
 
-- `rows=100000` (daily baseline)
+- `rows=20000` (daily baseline, stability-first default)
 - `upload_csv=true`
 - `commit_async=true`
 - `mode=commit`
@@ -3585,6 +3585,34 @@ Local verification:
 | zh copy contract | local (2026-03-03) | PASS | command: `pnpm verify:attendance-zh-copy-contract` |
 | Attendance Gate Contract Case (strict) | local (2026-03-03) | PASS | `output/playwright/attendance-gate-contract-matrix/strict/strict/gate-summary.valid.json`, `output/playwright/attendance-gate-contract-matrix/strict/strict/gate-summary.invalid.json` |
 | Attendance Gate Contract Case (dashboard) | local (2026-03-03) | PASS | `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.valid.json`, `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.invalid.strict.json`, `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.invalid.perf.json`, `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.invalid.longrun.json`, `output/playwright/attendance-gate-contract-matrix/dashboard/dashboard.invalid.upsert.json` |
+
+### Update (2026-03-04): Production Safety Guardrail for Import Rows
+
+Scope:
+
+- Added deploy preflight hard gate for `ATTENDANCE_IMPORT_CSV_MAX_ROWS`.
+- Baseline workflow default row count moved from `100000` to `20000` for production-v1 stability.
+
+Code changes:
+
+- `scripts/ops/attendance-preflight.sh`
+  - requires `ATTENDANCE_IMPORT_CSV_MAX_ROWS` to be present and numeric.
+  - enforces `ATTENDANCE_IMPORT_CSV_MAX_ROWS <= ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS` (default `20000`).
+- `.github/workflows/attendance-import-perf-baseline.yml`
+  - manual input default `rows=20000`
+  - workflow fallback default `ROWS=20000`
+  - drill summary sample updated to `rows=20000`
+- `docker/app.env.example`
+  - added `ATTENDANCE_IMPORT_CSV_MAX_ROWS=20000`
+
+Local verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| preflight syntax (`bash -n`) | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/bash-n.txt` |
+| preflight pass case (`ATTENDANCE_IMPORT_CSV_MAX_ROWS=20000`) | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/preflight-pass.log` |
+| preflight fail case (`ATTENDANCE_IMPORT_CSV_MAX_ROWS=100000`) | local (2026-03-04) | FAIL (expected) | `output/playwright/local/20260304-preflight-row-cap/preflight-fail.log`, `output/playwright/local/20260304-preflight-row-cap/preflight-fail.rc` |
+| preflight override pass (`ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS=120000`) | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/preflight-override-pass.log` |
 
 ### Update (2026-03-04): Strict PASS + Perf Baseline Recovery + Concurrency Hardening
 

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2636,6 +2636,36 @@ Decision:
 
 - **GO maintained**.
 
+## Post-Go Verification (2026-03-04): Import Row-Cap Guardrail + Baseline Default
+
+Goal:
+
+- Prevent production drift where oversized CSV limits (`rows=100000+`) reintroduce unstable `502` behavior on current infra class.
+- Make the default perf baseline match production-safe capacity while preserving manual override for stress runs.
+
+Code changes:
+
+- `scripts/ops/attendance-preflight.sh`
+  - new hard gate: `ATTENDANCE_IMPORT_CSV_MAX_ROWS` must exist, must be numeric, and must not exceed `ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS` (default `20000`).
+- `.github/workflows/attendance-import-perf-baseline.yml`
+  - baseline default rows changed from `100000` to `20000` (inputs and env fallback).
+- `docker/app.env.example`
+  - added `ATTENDANCE_IMPORT_CSV_MAX_ROWS=20000`.
+
+Verification:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| preflight syntax | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/bash-n.txt` |
+| preflight with safe cap (`20000`) | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/preflight-pass.log` |
+| preflight with oversized cap (`100000`) | local (2026-03-04) | FAIL (expected) | `output/playwright/local/20260304-preflight-row-cap/preflight-fail.log`, `output/playwright/local/20260304-preflight-row-cap/preflight-fail.rc` |
+| preflight with temporary override (`ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS=120000`) | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/preflight-override-pass.log` |
+
+Decision:
+
+- **GO maintained** with stricter production guardrails.
+- For new server rollout, keep `ATTENDANCE_IMPORT_CSV_MAX_ROWS=20000` unless a higher cap is validated by dedicated perf evidence.
+
 ## Post-Go Validation (2026-03-04): Strict Re-Run + Perf Baseline Incident/Recovery + Workflow Hardening
 
 Goal:

--- a/scripts/ops/attendance-preflight.sh
+++ b/scripts/ops/attendance-preflight.sh
@@ -59,6 +59,8 @@ NODE_ENV="$(get_env_value NODE_ENV)"
 PRODUCT_MODE="$(get_env_value PRODUCT_MODE)"
 REQUIRE_TOKEN="$(get_env_value ATTENDANCE_IMPORT_REQUIRE_TOKEN)"
 UPLOAD_DIR="$(get_env_value ATTENDANCE_IMPORT_UPLOAD_DIR)"
+CSV_MAX_ROWS="$(get_env_value ATTENDANCE_IMPORT_CSV_MAX_ROWS)"
+PREFLIGHT_MAX_CSV_ROWS="${ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS:-20000}"
 
 [[ -n "$JWT_SECRET" ]] || die "JWT_SECRET is missing in ${ENV_FILE}"
 [[ "$JWT_SECRET" != "change-me" ]] || die "JWT_SECRET is still 'change-me' in ${ENV_FILE}"
@@ -73,6 +75,26 @@ fi
 
 if [[ "${REQUIRE_TOKEN}" != "1" ]]; then
   die "ATTENDANCE_IMPORT_REQUIRE_TOKEN must be set to '1' in ${ENV_FILE} for production import safety."
+fi
+
+if [[ ! "${PREFLIGHT_MAX_CSV_ROWS}" =~ ^[0-9]+$ ]]; then
+  die "ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS must be an integer when set (got: '${PREFLIGHT_MAX_CSV_ROWS}')."
+fi
+if (( PREFLIGHT_MAX_CSV_ROWS < 1000 )); then
+  die "ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS must be >= 1000 (got: ${PREFLIGHT_MAX_CSV_ROWS})."
+fi
+
+if [[ -z "${CSV_MAX_ROWS}" ]]; then
+  die "ATTENDANCE_IMPORT_CSV_MAX_ROWS is missing in ${ENV_FILE}. Set a production-safe cap (recommended: 20000)."
+fi
+if [[ ! "${CSV_MAX_ROWS}" =~ ^[0-9]+$ ]]; then
+  die "ATTENDANCE_IMPORT_CSV_MAX_ROWS must be an integer (got: '${CSV_MAX_ROWS}')."
+fi
+if (( CSV_MAX_ROWS < 1000 )); then
+  die "ATTENDANCE_IMPORT_CSV_MAX_ROWS must be >= 1000 (got: ${CSV_MAX_ROWS})."
+fi
+if (( CSV_MAX_ROWS > PREFLIGHT_MAX_CSV_ROWS )); then
+  die "ATTENDANCE_IMPORT_CSV_MAX_ROWS=${CSV_MAX_ROWS} exceeds safe preflight bound ${PREFLIGHT_MAX_CSV_ROWS}. Lower ATTENDANCE_IMPORT_CSV_MAX_ROWS or explicitly override ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS after capacity validation."
 fi
 
 # CSV upload channel requires a persistent upload directory and a larger nginx body size for the upload route.


### PR DESCRIPTION
## Summary
- add production hard gate in `attendance-preflight.sh` for `ATTENDANCE_IMPORT_CSV_MAX_ROWS`
- require explicit `ATTENDANCE_IMPORT_CSV_MAX_ROWS` in env; fail when missing/invalid
- enforce safe bound: `ATTENDANCE_IMPORT_CSV_MAX_ROWS <= ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS` (default `20000`)
- set perf baseline workflow default rows from `100000` to `20000` (input + env fallback + drill sample)
- update docs and app env example accordingly

## Why
Recent production evidence showed intermittent `502` under 50k/100k baseline runs on current infra. This change introduces a production-v1 safety guardrail and aligns daily baseline defaults with stable capacity.

## Validation
- `bash -n scripts/ops/attendance-preflight.sh`
- local preflight pass with `ATTENDANCE_IMPORT_CSV_MAX_ROWS=20000`
  - `output/playwright/local/20260304-preflight-row-cap/preflight-pass.log`
- local preflight expected fail with `ATTENDANCE_IMPORT_CSV_MAX_ROWS=100000`
  - `output/playwright/local/20260304-preflight-row-cap/preflight-fail.log`
- local override pass with `ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS=120000`
  - `output/playwright/local/20260304-preflight-row-cap/preflight-override-pass.log`

## Files
- `.github/workflows/attendance-import-perf-baseline.yml`
- `docker/app.env.example`
- `scripts/ops/attendance-preflight.sh`
- `docs/attendance-production-delivery-20260207.md`
- `docs/attendance-production-ga-daily-gates-20260209.md`
- `docs/attendance-production-go-no-go-20260211.md`
