### PR TITLE
docs(attendance): record mainline 20k baseline evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3614,6 +3614,12 @@ Local verification:
 | preflight fail case (`ATTENDANCE_IMPORT_CSV_MAX_ROWS=100000`) | local (2026-03-04) | FAIL (expected) | `output/playwright/local/20260304-preflight-row-cap/preflight-fail.log`, `output/playwright/local/20260304-preflight-row-cap/preflight-fail.rc` |
 | preflight override pass (`ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS=120000`) | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/preflight-override-pass.log` |
 
+Mainline verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Import Perf Baseline (main, default rows after PR #327) | [#22655694180](https://github.com/zensgit/metasheet2/actions/runs/22655694180) | PASS | `output/playwright/ga/22655694180/perf.log`, `output/playwright/ga/22655694180/attendance-perf-mmbkcie0-7r2922/perf-summary.json` (`rows=20000`, `uploadCsv=true`, `regressions=[]`) |
+
 ### Update (2026-03-04): Strict PASS + Perf Baseline Recovery + Concurrency Hardening
 
 Scope:

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2660,6 +2660,7 @@ Verification:
 | preflight with safe cap (`20000`) | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/preflight-pass.log` |
 | preflight with oversized cap (`100000`) | local (2026-03-04) | FAIL (expected) | `output/playwright/local/20260304-preflight-row-cap/preflight-fail.log`, `output/playwright/local/20260304-preflight-row-cap/preflight-fail.rc` |
 | preflight with temporary override (`ATTENDANCE_PREFLIGHT_MAX_CSV_ROWS=120000`) | local (2026-03-04) | PASS | `output/playwright/local/20260304-preflight-row-cap/preflight-override-pass.log` |
+| perf baseline (main, default rows after PR #327) | [#22655694180](https://github.com/zensgit/metasheet2/actions/runs/22655694180) | PASS | `output/playwright/ga/22655694180/attendance-perf-mmbkcie0-7r2922/perf-summary.json`, `output/playwright/ga/22655694180/perf.log` (`rows=20000`, `uploadCsv=true`, `regressions=[]`) |
 
 Decision:
 


### PR DESCRIPTION
## Summary
- append mainline verification evidence for PR #327 follow-up
- record successful perf baseline run with default `rows=20000`
- link artifacts proving `uploadCsv=true` and `regressions=[]`

## Evidence
- Run: https://github.com/zensgit/metasheet2/actions/runs/22655694180
- Local artifacts:
  - `output/playwright/ga/22655694180/perf.log`
  - `output/playwright/ga/22655694180/attendance-perf-mmbkcie0-7r2922/perf-summary.json`

## Files
- `docs/attendance-production-ga-daily-gates-20260209.md`
- `docs/attendance-production-go-no-go-20260211.md`
