### PR TITLE
fix(attendance-ui): localize request/import status chips in zh

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -283,7 +283,7 @@
                 <div>
                   <strong>{{ item.work_date }}</strong> · {{ formatRequestType(item.request_type) }}
                   <span class="attendance__status-chip" :class="`attendance__status-chip--${item.status}`">
-                    {{ item.status }}
+                    {{ formatStatus(item.status) }}
                   </span>
                 </div>
                 <div class="attendance__request-meta" v-if="item.metadata">
@@ -337,7 +337,7 @@
                         class="attendance__status-chip"
                         :class="`attendance__status-chip--${item.request.status}`"
                       >
-                        {{ item.request.status }}
+                        {{ formatStatus(item.request.status) }}
                       </span>
                     </template>
                     <span v-else>--</span>
@@ -378,7 +378,7 @@
               <tbody>
                 <tr v-for="row in requestReport" :key="`${row.requestType}-${row.status}`">
                   <td>{{ formatRequestType(row.requestType) }}</td>
-                  <td>{{ row.status }}</td>
+                  <td>{{ formatStatus(row.status) }}</td>
                   <td>{{ row.total }}</td>
                   <td>{{ row.minutes }}</td>
                 </tr>
@@ -1899,7 +1899,7 @@
                   </button>
                 </div>
                 <div>
-                  {{ tr('Status', '状态') }}: <strong>{{ importPreviewTask.status }}</strong>
+                  {{ tr('Status', '状态') }}: <strong>{{ formatStatus(importPreviewTask.status) }}</strong>
                   <template v-if="importPreviewTask.mode === 'chunked'">
                     · {{ tr('Chunks', '分块') }} {{ importPreviewTask.completedChunks }} / {{ importPreviewTask.totalChunks }}
                   </template>
@@ -1940,7 +1940,7 @@
                   </div>
                 </div>
                 <div>
-                  {{ tr('Status', '状态') }}: <strong>{{ importAsyncJob.status }}</strong>
+                  {{ tr('Status', '状态') }}: <strong>{{ formatStatus(importAsyncJob.status) }}</strong>
                   <span v-if="importAsyncPolling"> · {{ tr('polling...', '轮询中...') }}</span>
                 </div>
                 <div v-if="importAsyncJob.total">
@@ -2014,7 +2014,7 @@
                   <tbody>
                     <tr v-for="batch in importBatches" :key="batch.id">
                       <td>{{ batch.id.slice(0, 8) }}</td>
-                      <td>{{ batch.status }}</td>
+                      <td>{{ formatStatus(batch.status) }}</td>
                       <td>{{ batch.rowCount }}</td>
                       <td>{{ resolveImportBatchEngine(batch) }}</td>
                       <td>{{ resolveImportBatchChunkLabel(batch) }}</td>
@@ -2436,7 +2436,7 @@
                       <td>{{ payrollTemplateName(item.templateId) }}</td>
                       <td>{{ item.startDate }}</td>
                       <td>{{ item.endDate }}</td>
-                      <td>{{ item.status }}</td>
+                      <td>{{ formatStatus(item.status) }}</td>
                       <td class="attendance__table-actions">
                         <button class="attendance__btn" @click="editPayrollCycle(item)">{{ tr('Edit', '编辑') }}</button>
                         <button class="attendance__btn attendance__btn--danger" @click="deletePayrollCycle(item.id)">
@@ -4468,6 +4468,9 @@ function formatDateTime(value: string | null): string {
 }
 
 function formatStatus(value: string): string {
+  const raw = String(value || '').trim()
+  if (!raw) return '--'
+  const normalized = raw.toLowerCase()
   const map: Record<string, string> = isZh.value
     ? {
         normal: '正常',
@@ -4478,6 +4481,29 @@ function formatStatus(value: string): string {
         absent: '缺勤',
         adjusted: '已调整',
         off: '休息',
+        pending: '待处理',
+        approved: '已批准',
+        rejected: '已驳回',
+        cancelled: '已取消',
+        canceled: '已取消',
+        queued: '已排队',
+        running: '运行中',
+        processing: '处理中',
+        completed: '已完成',
+        success: '成功',
+        failed: '失败',
+        error: '错误',
+        committed: '已提交',
+        rolled_back: '已回滚',
+        rollback_pending: '回滚中',
+        active: '启用',
+        inactive: '停用',
+        enabled: '启用',
+        disabled: '停用',
+        open: '打开',
+        closed: '关闭',
+        draft: '草稿',
+        submitted: '已提交',
       }
     : {
         normal: 'Normal',
@@ -4488,8 +4514,31 @@ function formatStatus(value: string): string {
         absent: 'Absent',
         adjusted: 'Adjusted',
         off: 'Off',
+        pending: 'Pending',
+        approved: 'Approved',
+        rejected: 'Rejected',
+        cancelled: 'Cancelled',
+        canceled: 'Canceled',
+        queued: 'Queued',
+        running: 'Running',
+        processing: 'Processing',
+        completed: 'Completed',
+        success: 'Success',
+        failed: 'Failed',
+        error: 'Error',
+        committed: 'Committed',
+        rolled_back: 'Rolled back',
+        rollback_pending: 'Rollback pending',
+        active: 'Active',
+        inactive: 'Inactive',
+        enabled: 'Enabled',
+        disabled: 'Disabled',
+        open: 'Open',
+        closed: 'Closed',
+        draft: 'Draft',
+        submitted: 'Submitted',
       }
-  return map[value] ?? value
+  return map[normalized] ?? raw
 }
 
 function formatList(items?: Array<string> | null): string {

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3607,6 +3607,21 @@ Notes:
 - PR [#331](https://github.com/zensgit/metasheet2/pull/331) is awaiting required human approval (`reviewDecision=REVIEW_REQUIRED`).
 - branch policy blocks self-approval/self-merge; use another write-access reviewer to approve, then merge.
 
+### Update (2026-03-05): zh Status Chip Localization Sweep
+
+Scope:
+
+- removed remaining mixed-language status chips/tables in Attendance overview/admin by replacing direct `status` rendering with `formatStatus()`.
+- expanded `formatStatus()` map for request/import/payroll lifecycle statuses.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Web build | local (2026-03-05) | PASS | command: `pnpm --filter @metasheet/web build` |
+| zh copy contract | local (2026-03-05) | PASS | command: `pnpm verify:attendance-zh-copy-contract` |
+| zh status chip runtime check (local web + prod API) | local Playwright (2026-03-05) | PASS | `output/playwright/attendance-locale-zh-smoke-local/attendance-zh-status-chip-localized.png` (`hasEnglishRequestState=false`) |
+
 ### Update (2026-03-04): Remote Preflight Drift Recovery (`ATTENDANCE_IMPORT_CSV_MAX_ROWS`)
 
 Scope:

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2666,6 +2666,26 @@ Notes:
 - merge is currently blocked by branch policy (`REVIEW_REQUIRED`, at least one approving review from another write user).
 - no secret/token is committed to repo docs.
 
+### Update (2026-03-05): zh Status Chip Localization Sweep
+
+Scope:
+
+- localized remaining direct status rendering points in `apps/web/src/views/AttendanceView.vue`:
+  - recent request chips
+  - anomaly-linked request chips
+  - request report status column
+  - import preview/import async/import batch status display
+  - payroll cycle status display
+- expanded `formatStatus()` mapping to cover request/import/payroll lifecycle states (`pending/approved/rejected/...`) in zh/en.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Web build | local (2026-03-05) | PASS | command: `pnpm --filter @metasheet/web build` |
+| zh copy contract | local (2026-03-05) | PASS | command: `pnpm verify:attendance-zh-copy-contract` |
+| zh status chip runtime check (local web + prod API) | local Playwright (2026-03-05) | PASS | `output/playwright/attendance-locale-zh-smoke-local/attendance-zh-status-chip-localized.png` (`sample=[待处理, 已批准, ...]`, `hasEnglishRequestState=false`) |
+
 ## Post-Go Verification (2026-03-04): Remote Preflight Drift Fix + Gate Recovery
 
 Goal:


### PR DESCRIPTION
## Summary
- replace direct status rendering with `formatStatus(...)` in Attendance overview/admin status surfaces
- localize request/anomaly/request-report/import/payroll status values in zh locale
- extend `formatStatus()` mapping to cover request/import/payroll lifecycle states
- append verification evidence to production go/no-go + GA daily gate docs

## Verification
- pnpm --filter @metasheet/web build
- pnpm verify:attendance-zh-copy-contract
- local Playwright runtime check (`status chip sample=[待处理, 已批准, ...]`, `hasEnglishRequestState=false`)
