### PR TITLE
fix(deploy): avoid tar pipefail in on-prem package verify

### DIFF
--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 PACKAGE_FILE="${1:-}"
 VERIFY_SHA="${VERIFY_SHA:-1}"
 EXTRACT_ROOT="${EXTRACT_ROOT:-}"
+cleanup_extract_root=0
+list_file=""
 
 function die() {
   echo "[attendance-onprem-package-verify] ERROR: $*" >&2
@@ -48,13 +50,22 @@ fi
 
 if [[ -z "$EXTRACT_ROOT" ]]; then
   EXTRACT_ROOT="$(mktemp -d)"
-  trap 'rm -rf "$EXTRACT_ROOT"' EXIT
+  cleanup_extract_root=1
 else
   mkdir -p "$EXTRACT_ROOT"
 fi
 
 tar -xzf "$PACKAGE_FILE" -C "$EXTRACT_ROOT"
-pkg_name="$(tar -tzf "$PACKAGE_FILE" | head -n 1 | cut -d/ -f1)"
+list_file="$(mktemp)"
+cleanup() {
+  [[ -n "$list_file" ]] && rm -f "$list_file" || true
+  if [[ "$cleanup_extract_root" == "1" ]]; then
+    rm -rf "$EXTRACT_ROOT"
+  fi
+}
+trap cleanup EXIT
+tar -tzf "$PACKAGE_FILE" > "$list_file"
+pkg_name="$(head -n 1 "$list_file" | cut -d/ -f1)"
 pkg_root="${EXTRACT_ROOT}/${pkg_name}"
 
 required=(


### PR DESCRIPTION
## Summary\n- fix package verify script to avoid tar pipefail error on GitHub runner\n- preserve EXTRACT_ROOT cleanup behavior for user-specified paths\n\n## Verification\n- bash -n scripts/ops/attendance-onprem-package-verify.sh\n- scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.tgz\n\n## Why\n- workflow run #22745128332 failed at verify step with `tar: stdout: write error` due pipefail