### PR TITLE
docs(deploy): record public GA package build evidence

### DIFF
--- a/docs/attendance-onprem-package-build-verification-20260306.md
+++ b/docs/attendance-onprem-package-build-verification-20260306.md
@@ -38,6 +38,28 @@ scripts/ops/attendance-onprem-package-verify.sh \
 - `output/releases/attendance-onprem/SHA256SUMS`
 - `output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.json`
 
+## GitHub Actions Verification (Public Repo)
+
+Execution date: `2026-03-06`
+
+Run metadata:
+
+- Workflow: `attendance-onprem-package-build.yml`
+- Run ID: `22746728368`
+- Result: `SUCCESS`
+
+Evidence (downloaded locally):
+
+- `output/playwright/ga/22746728368/attendance-onprem-package-22746728368-1/metasheet-attendance-onprem-v2.5.0-run3.tgz`
+- `output/playwright/ga/22746728368/attendance-onprem-package-22746728368-1/metasheet-attendance-onprem-v2.5.0-run3.tgz.sha256`
+- `output/playwright/ga/22746728368/attendance-onprem-package-22746728368-1/SHA256SUMS`
+- `output/playwright/ga/22746728368/attendance-onprem-package-22746728368-1/metasheet-attendance-onprem-v2.5.0-run3.json`
+
+Verification result:
+
+- `attendance-onprem-package-verify.sh` on the downloaded `.tgz`: `PASS`
+- Archive SHA256 matches `SHA256SUMS`: `PASS`
+
 ## Notes
 
 - Database instance creation is still external (`CREATE DATABASE` by DBA/installer).

--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -34,6 +34,12 @@ scripts/ops/attendance-onprem-package-verify.sh \
 
 - [attendance-onprem-package-build-verification-20260306.md](/Users/huazhou/Downloads/Github/metasheet2/docs/attendance-onprem-package-build-verification-20260306.md)
 
+最近一次 GitHub Actions 构建记录（仓库已为 public）：
+
+- Run ID：`22746728368`
+- 证据目录：`output/playwright/ga/22746728368/attendance-onprem-package-22746728368-1/`
+- 验签结果：`PASS`（`attendance-onprem-package-verify.sh`）
+
 ## 1. 安装包最小目录
 
 解压后目录建议固定为 `/opt/metasheet`，至少包含：


### PR DESCRIPTION
## Summary
- append public repo GA package build verification record (run 22746728368)
- add local evidence paths and verify result into deployment docs
- keep delivery docs free of GitHub links

## Verification
- 
- Run Attendance On-Prem Package Build (22746728368) has already completed with 'success'
- 
- metasheet-attendance-onprem-v2.5.0-run3.tgz: OK
-  (expect no match)