### PR TITLE
docs(deploy): add ready app env draft with 3-field replacement

### DIFF
--- a/docker/app.env.attendance-onprem.ready.env
+++ b/docker/app.env.attendance-onprem.ready.env
@@ -1,0 +1,25 @@
+# Attendance on-prem single-node ready draft
+# Replace ONLY the 3 `change-me` values below before deployment.
+
+NODE_ENV=production
+HOST=127.0.0.1
+PORT=8900
+
+PRODUCT_MODE=attendance
+DEPLOYMENT_MODEL=onprem
+
+JWT_SECRET=change-me
+
+POSTGRES_USER=metasheet
+POSTGRES_PASSWORD=change-me
+POSTGRES_DB=metasheet
+DATABASE_URL=postgres://metasheet:change-me@127.0.0.1:5432/metasheet
+
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+ATTENDANCE_IMPORT_REQUIRE_TOKEN=1
+ATTENDANCE_IMPORT_UPLOAD_DIR=/opt/metasheet/storage/attendance-import
+ATTENDANCE_IMPORT_CSV_MAX_ROWS=20000
+ATTENDANCE_IMPORT_HEAVY_QUERY_TIMEOUT_MS=180000

--- a/docs/deployment/attendance-onprem-app-env-template-20260306.md
+++ b/docs/deployment/attendance-onprem-app-env-template-20260306.md
@@ -20,6 +20,19 @@ cp docker/app.env.attendance-onprem.template docker/app.env
 
 注意：模板中的敏感值默认是 `change-me`，用于强制拦截未替换配置。请全部替换后再部署。
 
+如果你希望使用“部署草案版（非敏感项已填好）”：
+
+```bash
+cd /opt/metasheet
+cp docker/app.env.attendance-onprem.ready.env docker/app.env
+```
+
+然后只替换这 3 项：
+
+1. `JWT_SECRET`
+2. `POSTGRES_PASSWORD`
+3. `DATABASE_URL` 里的数据库密码
+
 ## 2) 推荐模板（考勤专注模式）
 
 ```env

--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -59,6 +59,7 @@ metasheet/
     attendance-onprem-update.sh
   docker/app.env.example
   docker/app.env.attendance-onprem.template
+  docker/app.env.attendance-onprem.ready.env
   ops/nginx/attendance-onprem.conf.example
   ecosystem.config.cjs
   package.json

--- a/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
+++ b/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
@@ -25,6 +25,8 @@ cd /opt/metasheet
 cp docker/app.env.example docker/app.env
 # 或直接用已准备好的考勤生产模板：
 # cp docker/app.env.attendance-onprem.template docker/app.env
+# 或直接用“只需改3项”的部署草案：
+# cp docker/app.env.attendance-onprem.ready.env docker/app.env
 # 然后把其中所有 change-me 替换为真实值
 ```
 


### PR DESCRIPTION
## Summary
- add  for deployment-day use
- only 3 values need replacement before deploy (, ,  password)
- wire this draft into deployment docs/package layout

## Verification
- no GitHub links in updated deployment docs
- env-check intentionally fails before secrets are replaced