### PR TITLE
feat(onprem): build zip package and optional github release publish

### DIFF
--- a/.github/workflows/attendance-onprem-package-build.yml
+++ b/.github/workflows/attendance-onprem-package-build.yml
@@ -7,9 +7,21 @@ on:
         description: 'Optional package tag suffix (default: run number)'
         required: false
         default: ''
+      publish_release:
+        description: 'Publish build outputs to GitHub Releases'
+        required: false
+        default: 'false'
+      release_tag:
+        description: 'Release tag (required when publish_release=true)'
+        required: false
+        default: ''
+      release_name:
+        description: 'Release display name (optional)'
+        required: false
+        default: ''
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build-package:
@@ -44,9 +56,45 @@ jobs:
         run: |
           chmod +x scripts/ops/attendance-onprem-package-build.sh scripts/ops/attendance-onprem-package-verify.sh
           INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/attendance-onprem-package-build.sh
-          pkg="$(ls -1 output/releases/attendance-onprem/*.tgz | sort | tail -n 1)"
-          scripts/ops/attendance-onprem-package-verify.sh "$pkg"
-          echo "PACKAGE_FILE=$pkg" >> "$GITHUB_ENV"
+          pkg_tgz="$(ls -1 output/releases/attendance-onprem/*.tgz | sort | tail -n 1)"
+          pkg_zip="$(ls -1 output/releases/attendance-onprem/*.zip | sort | tail -n 1)"
+          pkg_meta="${pkg_tgz%.tgz}.json"
+          scripts/ops/attendance-onprem-package-verify.sh "$pkg_tgz"
+          scripts/ops/attendance-onprem-package-verify.sh "$pkg_zip"
+          echo "PACKAGE_FILE=$pkg_tgz" >> "$GITHUB_ENV"
+          echo "PACKAGE_FILE_ZIP=$pkg_zip" >> "$GITHUB_ENV"
+          echo "PACKAGE_META_FILE=$pkg_meta" >> "$GITHUB_ENV"
+
+      - name: Publish GitHub Release
+        if: ${{ inputs.publish_release == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_NAME: ${{ inputs.release_name }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RELEASE_TAG}" ]]; then
+            echo "release_tag is required when publish_release=true" >&2
+            exit 1
+          fi
+
+          resolved_name="${RELEASE_NAME:-Attendance On-Prem Package ${RELEASE_TAG}}"
+          assets=(
+            "$PACKAGE_FILE"
+            "$PACKAGE_FILE_ZIP"
+            "${PACKAGE_FILE}.sha256"
+            "${PACKAGE_FILE_ZIP}.sha256"
+            "output/releases/attendance-onprem/SHA256SUMS"
+            "$PACKAGE_META_FILE"
+          )
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+          else
+            gh release create "$RELEASE_TAG" "${assets[@]}" \
+              --title "$resolved_name" \
+              --notes "Automated attendance on-prem package build."
+          fi
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4
@@ -54,6 +102,7 @@ jobs:
           name: attendance-onprem-package-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             output/releases/attendance-onprem/*.tgz
+            output/releases/attendance-onprem/*.zip
             output/releases/attendance-onprem/*.sha256
             output/releases/attendance-onprem/SHA256SUMS
             output/releases/attendance-onprem/*.json
@@ -64,8 +113,12 @@ jobs:
           {
             echo "## Attendance On-Prem Package Build"
             echo ""
-            echo "- Package: \`${PACKAGE_FILE}\`"
+            echo "- Package (.tgz): \`${PACKAGE_FILE}\`"
+            echo "- Package (.zip): \`${PACKAGE_FILE_ZIP}\`"
             echo "- Artifact: \`attendance-onprem-package-${{ github.run_id }}-${{ github.run_attempt }}\`"
+            if [[ "${{ inputs.publish_release }}" == "true" ]]; then
+              echo "- Release tag: \`${{ inputs.release_tag }}\`"
+            fi
             echo ""
             echo "Download:"
             echo '```bash'

--- a/docs/attendance-onprem-package-build-verification-20260306.md
+++ b/docs/attendance-onprem-package-build-verification-20260306.md
@@ -23,6 +23,8 @@ bash -n scripts/ops/attendance-onprem-package-upgrade.sh
 PACKAGE_TAG=20260306-r1 scripts/ops/attendance-onprem-package-build.sh
 scripts/ops/attendance-onprem-package-verify.sh \
   output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.tgz
+scripts/ops/attendance-onprem-package-verify.sh \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.zip
 ```
 
 ## Result
@@ -34,7 +36,9 @@ scripts/ops/attendance-onprem-package-verify.sh \
 ## Evidence
 
 - `output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.tgz`
+- `output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.zip`
 - `output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.tgz.sha256`
+- `output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.zip.sha256`
 - `output/releases/attendance-onprem/SHA256SUMS`
 - `output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260306-r1.json`
 

--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -16,9 +16,20 @@ scripts/ops/attendance-onprem-package-build.sh
 gh workflow run attendance-onprem-package-build.yml -f package_tag=20260306-r1
 ```
 
+如果同时发布到 GitHub Releases（推荐给 Windows 客户直接下载 `.zip`）：
+
+```bash
+gh workflow run attendance-onprem-package-build.yml \
+  -f package_tag=20260306-r1 \
+  -f publish_release=true \
+  -f release_tag=v2.5.0-onprem-20260306-r1 \
+  -f release_name='Attendance On-Prem v2.5.0 (20260306-r1)'
+```
+
 产物目录：
 
 - `output/releases/attendance-onprem/*.tgz`
+- `output/releases/attendance-onprem/*.zip`
 - `output/releases/attendance-onprem/SHA256SUMS`
 - `output/releases/attendance-onprem/*.json`
 
@@ -28,6 +39,8 @@ gh workflow run attendance-onprem-package-build.yml -f package_tag=20260306-r1
 chmod +x scripts/ops/attendance-onprem-package-verify.sh
 scripts/ops/attendance-onprem-package-verify.sh \
   output/releases/attendance-onprem/<PACKAGE_NAME>.tgz
+scripts/ops/attendance-onprem-package-verify.sh \
+  output/releases/attendance-onprem/<PACKAGE_NAME>.zip
 ```
 
 最近一次本地构建/验包记录：
@@ -142,6 +155,7 @@ BUILD_WEB=1 BUILD_BACKEND=1 INSTALL_DEPS=1 scripts/ops/attendance-onprem-package
 每个版本一个包，命名示例：
 
 - `metasheet-attendance-onprem-v1.0.0.tgz`
+- `metasheet-attendance-onprem-v1.0.0.zip`
 
 发包附带：
 

--- a/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
+++ b/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
@@ -19,6 +19,8 @@ sudo mkdir -p /opt/metasheet
 sudo chown -R "$USER":"$USER" /opt/metasheet
 # 把你们交付的安装包解压到 /opt/metasheet（示例）
 tar -xzf metasheet-attendance-onprem-<version>.tgz -C /opt
+# 如果拿到的是 Windows 友好的 zip 包：
+# unzip metasheet-attendance-onprem-<version>.zip -d /opt
 # 若解压后目录带版本号，重命名为 metasheet
 mv /opt/metasheet-attendance-onprem-* /opt/metasheet 2>/dev/null || true
 cd /opt/metasheet

--- a/scripts/ops/attendance-onprem-package-build.sh
+++ b/scripts/ops/attendance-onprem-package-build.sh
@@ -12,7 +12,8 @@ PACKAGE_TAG="${PACKAGE_TAG:-$(date +%Y%m%d-%H%M%S)}"
 PACKAGE_NAME="${PACKAGE_PREFIX}-v${PACKAGE_VERSION}-${PACKAGE_TAG}"
 BUILD_ROOT="${OUTPUT_DIR}/.build/${PACKAGE_NAME}"
 PACKAGE_ROOT="${BUILD_ROOT}/${PACKAGE_NAME}"
-ARCHIVE_PATH="${OUTPUT_DIR}/${PACKAGE_NAME}.tgz"
+ARCHIVE_TGZ_PATH="${OUTPUT_DIR}/${PACKAGE_NAME}.tgz"
+ARCHIVE_ZIP_PATH="${OUTPUT_DIR}/${PACKAGE_NAME}.zip"
 CHECKSUM_FILE="${OUTPUT_DIR}/SHA256SUMS"
 
 REQUIRED_PATHS=(
@@ -27,6 +28,8 @@ REQUIRED_PATHS=(
   "scripts/ops/attendance-onprem-healthcheck.sh"
   "scripts/ops/attendance-onprem-update.sh"
   "docker/app.env.example"
+  "docker/app.env.attendance-onprem.template"
+  "docker/app.env.attendance-onprem.ready.env"
   "ops/nginx/attendance-onprem.conf.example"
   "ops/systemd/metasheet-backend.service.example"
   "ops/systemd/metasheet-healthcheck.service.example"
@@ -38,6 +41,8 @@ REQUIRED_PATHS=(
   "docs/deployment/attendance-windows-onprem-easy-start-20260306.md"
   "docs/deployment/attendance-onprem-package-layout-20260306.md"
   "docs/deployment/attendance-windows-onprem-no-docker-20260306.md"
+  "docs/deployment/attendance-onprem-app-env-template-20260306.md"
+  "docs/deployment/attendance-onprem-postdeploy-30min-verification-20260306.md"
 )
 
 function info() {
@@ -54,15 +59,31 @@ function run() {
   "$@"
 }
 
-function hash_line() {
+function hash_value() {
   local file="$1"
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$file"
+    sha256sum "$file" | awk '{print $1}'
   elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$file"
+    shasum -a 256 "$file" | awk '{print $1}'
   else
     die "Missing hash tool: sha256sum or shasum"
   fi
+}
+
+function write_sha_file() {
+  local archive="$1"
+  local hash
+  hash="$(hash_value "$archive")"
+  printf '%s  %s\n' "$hash" "$(basename "$archive")" > "${archive}.sha256"
+}
+
+function add_checksum_entry() {
+  local archive="$1"
+  local base
+  local hash
+  base="$(basename "$archive")"
+  hash="$(hash_value "$archive")"
+  printf '%s  %s\n' "$hash" "$base"
 }
 
 function copy_path() {
@@ -97,6 +118,7 @@ done
 run rm -rf "$BUILD_ROOT"
 run mkdir -p "$PACKAGE_ROOT"
 run mkdir -p "$OUTPUT_DIR"
+command -v zip >/dev/null 2>&1 || die "zip command is required to build Windows package"
 
 for rel in "${REQUIRED_PATHS[@]}"; do
   copy_path "$rel"
@@ -114,13 +136,20 @@ Package layout guide:
   docs/deployment/attendance-onprem-package-layout-20260306.md
 EOF
 
-run tar -czf "$ARCHIVE_PATH" -C "$BUILD_ROOT" "$PACKAGE_NAME"
-hash_line "$ARCHIVE_PATH" > "${ARCHIVE_PATH}.sha256"
+run tar -czf "$ARCHIVE_TGZ_PATH" -C "$BUILD_ROOT" "$PACKAGE_NAME"
+run bash -lc "cd \"$BUILD_ROOT\" && zip -qr \"$ARCHIVE_ZIP_PATH\" \"$PACKAGE_NAME\""
+write_sha_file "$ARCHIVE_TGZ_PATH"
+write_sha_file "$ARCHIVE_ZIP_PATH"
 
 checksum_tmp="$(mktemp)"
 trap 'rm -f "$checksum_tmp"' EXIT
-grep -v " ${PACKAGE_NAME}.tgz$" "$CHECKSUM_FILE" >"$checksum_tmp" 2>/dev/null || true
-hash_line "$ARCHIVE_PATH" | sed "s|  ${ARCHIVE_PATH}$|  ${PACKAGE_NAME}.tgz|" >> "$checksum_tmp"
+if [[ -f "$CHECKSUM_FILE" ]]; then
+  awk -v tgz="${PACKAGE_NAME}.tgz" -v zip="${PACKAGE_NAME}.zip" '$2 != tgz && $2 != zip { print }' "$CHECKSUM_FILE" > "$checksum_tmp"
+else
+  : > "$checksum_tmp"
+fi
+add_checksum_entry "$ARCHIVE_TGZ_PATH" >> "$checksum_tmp"
+add_checksum_entry "$ARCHIVE_ZIP_PATH" >> "$checksum_tmp"
 mv "$checksum_tmp" "$CHECKSUM_FILE"
 trap - EXIT
 
@@ -129,13 +158,16 @@ cat > "${OUTPUT_DIR}/${PACKAGE_NAME}.json" <<EOF
   "name": "${PACKAGE_NAME}",
   "version": "${PACKAGE_VERSION}",
   "tag": "${PACKAGE_TAG}",
-  "archive": "$(basename "$ARCHIVE_PATH")",
+  "archive": "$(basename "$ARCHIVE_TGZ_PATH")",
+  "archiveZip": "$(basename "$ARCHIVE_ZIP_PATH")",
   "checksumFile": "$(basename "$CHECKSUM_FILE")",
   "generatedAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 }
 EOF
 
 info "Package built:"
-info "  archive: ${ARCHIVE_PATH}"
-info "  checksum: ${ARCHIVE_PATH}.sha256"
+info "  archive_tgz: ${ARCHIVE_TGZ_PATH}"
+info "  archive_zip: ${ARCHIVE_ZIP_PATH}"
+info "  checksum_tgz: ${ARCHIVE_TGZ_PATH}.sha256"
+info "  checksum_zip: ${ARCHIVE_ZIP_PATH}.sha256"
 info "  index: ${CHECKSUM_FILE}"

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -41,7 +41,7 @@ function verify_sha() {
   fi
 }
 
-[[ -n "$PACKAGE_FILE" ]] || die "Usage: scripts/ops/attendance-onprem-package-verify.sh <package.tgz>"
+[[ -n "$PACKAGE_FILE" ]] || die "Usage: scripts/ops/attendance-onprem-package-verify.sh <package.tgz|package.zip>"
 [[ -f "$PACKAGE_FILE" ]] || die "Package not found: ${PACKAGE_FILE}"
 
 if [[ "$VERIFY_SHA" == "1" ]]; then
@@ -55,7 +55,6 @@ else
   mkdir -p "$EXTRACT_ROOT"
 fi
 
-tar -xzf "$PACKAGE_FILE" -C "$EXTRACT_ROOT"
 list_file="$(mktemp)"
 cleanup() {
   [[ -n "$list_file" ]] && rm -f "$list_file" || true
@@ -64,7 +63,26 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
-tar -tzf "$PACKAGE_FILE" > "$list_file"
+
+case "$PACKAGE_FILE" in
+  *.tgz|*.tar.gz)
+    tar -xzf "$PACKAGE_FILE" -C "$EXTRACT_ROOT"
+    tar -tzf "$PACKAGE_FILE" > "$list_file"
+    ;;
+  *.zip)
+    command -v unzip >/dev/null 2>&1 || die "unzip is required to verify zip packages"
+    unzip -q "$PACKAGE_FILE" -d "$EXTRACT_ROOT"
+    if command -v zipinfo >/dev/null 2>&1; then
+      zipinfo -1 "$PACKAGE_FILE" > "$list_file"
+    else
+      find "$EXTRACT_ROOT" -mindepth 1 -maxdepth 3 -print | sed "s#^${EXTRACT_ROOT}/##" > "$list_file"
+    fi
+    ;;
+  *)
+    die "Unsupported package extension (expected .tgz/.tar.gz/.zip): ${PACKAGE_FILE}"
+    ;;
+esac
+
 pkg_name="$(head -n 1 "$list_file" | cut -d/ -f1)"
 pkg_root="${EXTRACT_ROOT}/${pkg_name}"
 
@@ -74,6 +92,8 @@ required=(
   "scripts/ops/attendance-onprem-package-install.sh"
   "scripts/ops/attendance-onprem-package-upgrade.sh"
   "docker/app.env.example"
+  "docker/app.env.attendance-onprem.template"
+  "docker/app.env.attendance-onprem.ready.env"
   "ops/nginx/attendance-onprem.conf.example"
   "docs/deployment/attendance-windows-onprem-easy-start-20260306.md"
 )


### PR DESCRIPTION
Summary:
- on-prem package build now outputs both .tgz and .zip archives
- package verify now supports .tgz/.tar.gz/.zip and validates new env templates in package
- workflow supports optional release publishing via inputs: publish_release, release_tag, release_name
- docs updated for zip usage and release publish commands

Local verification:
- bash -n on package build/verify scripts
- PACKAGE_TAG=20260306-ziptest scripts/ops/attendance-onprem-package-build.sh
- verify both outputs: .tgz and .zip (PASS)
- SHA256SUMS contains both .tgz and .zip entries