### PR TITLE
feat(onprem): add wsl portproxy refresh powershell script

### DIFF
--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -70,6 +70,7 @@ metasheet/
     attendance-onprem-env-check.sh
     attendance-onprem-healthcheck.sh
     attendance-onprem-update.sh
+    attendance-wsl-portproxy-refresh.ps1
   docker/app.env.example
   docker/app.env.attendance-onprem.template
   docker/app.env.attendance-onprem.ready.env

--- a/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
+++ b/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
@@ -142,6 +142,7 @@ scripts/ops/attendance-onprem-healthcheck.sh
 如需 Windows Server + WSL2 专项部署步骤（含端口转发）见：
 
 - [attendance-windows-wsl-onprem-20260306.md](/Users/huazhou/Downloads/Github/metasheet2/docs/deployment/attendance-windows-wsl-onprem-20260306.md)
+  - 其中包含一键脚本：`scripts/ops/attendance-wsl-portproxy-refresh.ps1`
 
 如需“只发安装包、不拉代码”的规范与升级命令，见：
 

--- a/docs/deployment/attendance-windows-wsl-onprem-20260306.md
+++ b/docs/deployment/attendance-windows-wsl-onprem-20260306.md
@@ -135,6 +135,19 @@ scripts/ops/attendance-onprem-deploy-easy.sh
 
 WSL2 默认是 NAT 网络，局域网客户端访问 Windows IP 时，需要把 Windows 80/443 转到 WSL。
 
+推荐使用仓库脚本（PowerShell 管理员）：
+
+```powershell
+cd C:\metasheet
+powershell -ExecutionPolicy Bypass -File .\scripts\ops\attendance-wsl-portproxy-refresh.ps1 -Distro Ubuntu-22.04
+```
+
+如果需要先预览命令，不实际执行：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\ops\attendance-wsl-portproxy-refresh.ps1 -Distro Ubuntu-22.04 -WhatIfOnly
+```
+
 先获取 WSL IP（PowerShell）：
 
 ```powershell

--- a/scripts/ops/attendance-onprem-package-build.sh
+++ b/scripts/ops/attendance-onprem-package-build.sh
@@ -27,6 +27,7 @@ REQUIRED_PATHS=(
   "scripts/ops/attendance-onprem-env-check.sh"
   "scripts/ops/attendance-onprem-healthcheck.sh"
   "scripts/ops/attendance-onprem-update.sh"
+  "scripts/ops/attendance-wsl-portproxy-refresh.ps1"
   "docker/app.env.example"
   "docker/app.env.attendance-onprem.template"
   "docker/app.env.attendance-onprem.ready.env"

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -91,6 +91,7 @@ required=(
   "packages/core-backend/dist/src/db/migrate.js"
   "scripts/ops/attendance-onprem-package-install.sh"
   "scripts/ops/attendance-onprem-package-upgrade.sh"
+  "scripts/ops/attendance-wsl-portproxy-refresh.ps1"
   "docker/app.env.example"
   "docker/app.env.attendance-onprem.template"
   "docker/app.env.attendance-onprem.ready.env"

--- a/scripts/ops/attendance-wsl-portproxy-refresh.ps1
+++ b/scripts/ops/attendance-wsl-portproxy-refresh.ps1
@@ -1,0 +1,112 @@
+param(
+  [string]$Distro = "Ubuntu-22.04",
+  [string]$ListenAddress = "0.0.0.0",
+  [int[]]$Ports = @(80, 443),
+  [switch]$SkipFirewall,
+  [switch]$WhatIfOnly
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Info([string]$Message) {
+  Write-Host "[attendance-wsl-portproxy-refresh] $Message"
+}
+
+function Throw-Err([string]$Message) {
+  throw "[attendance-wsl-portproxy-refresh] ERROR: $Message"
+}
+
+function Require-Admin {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+  if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Throw-Err "Run this script in an elevated PowerShell window (Run as Administrator)."
+  }
+}
+
+function Require-Command([string]$Name) {
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    Throw-Err "Missing required command: $Name"
+  }
+}
+
+function Resolve-WslIp([string]$TargetDistro) {
+  $raw = & wsl -d $TargetDistro -- hostname -I 2>$null
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($raw)) {
+    Throw-Err "Unable to resolve WSL IP for distro '$TargetDistro'. Ensure the distro exists and is running."
+  }
+  $token = (($raw -split "\s+") | Where-Object { $_ -and $_.Trim().Length -gt 0 } | Select-Object -First 1)
+  if (-not $token) {
+    Throw-Err "WSL IP output is empty for distro '$TargetDistro'."
+  }
+  if ($token -notmatch '^(?:\d{1,3}\.){3}\d{1,3}$') {
+    Throw-Err "Invalid IPv4 from WSL: '$token'"
+  }
+  return $token
+}
+
+function Reset-PortProxy([string]$Addr, [int]$Port, [string]$TargetIp, [switch]$PreviewOnly) {
+  $deleteCmd = "netsh interface portproxy delete v4tov4 listenaddress=$Addr listenport=$Port"
+  $addCmd = "netsh interface portproxy add v4tov4 listenaddress=$Addr listenport=$Port connectaddress=$TargetIp connectport=$Port"
+
+  Write-Info "Port $Port -> deleting old mapping (if exists)"
+  if ($PreviewOnly) {
+    Write-Host "  [what-if] $deleteCmd"
+  } else {
+    cmd /c $deleteCmd *> $null
+  }
+
+  Write-Info "Port $Port -> adding mapping to $TargetIp:$Port"
+  if ($PreviewOnly) {
+    Write-Host "  [what-if] $addCmd"
+  } else {
+    cmd /c $addCmd *> $null
+  }
+}
+
+function Ensure-FirewallRule([int]$Port, [switch]$PreviewOnly) {
+  $ruleName = "MetaSheet WSL TCP $Port"
+  $delCmd = "netsh advfirewall firewall delete rule name=""$ruleName"""
+  $addCmd = "netsh advfirewall firewall add rule name=""$ruleName"" dir=in action=allow protocol=TCP localport=$Port"
+
+  Write-Info "Firewall port $Port -> resetting rule '$ruleName'"
+  if ($PreviewOnly) {
+    Write-Host "  [what-if] $delCmd"
+    Write-Host "  [what-if] $addCmd"
+  } else {
+    cmd /c $delCmd *> $null
+    cmd /c $addCmd *> $null
+  }
+}
+
+function Show-CurrentMapping {
+  Write-Info "Current portproxy rules:"
+  netsh interface portproxy show v4tov4
+}
+
+Require-Admin
+Require-Command "wsl"
+Require-Command "netsh"
+
+if (-not $Ports -or $Ports.Count -eq 0) {
+  Throw-Err "Ports cannot be empty."
+}
+
+$wslIp = Resolve-WslIp -TargetDistro $Distro
+Write-Info "Resolved WSL IP for '$Distro': $wslIp"
+
+foreach ($port in $Ports) {
+  if ($port -lt 1 -or $port -gt 65535) {
+    Throw-Err "Invalid port: $port"
+  }
+  Reset-PortProxy -Addr $ListenAddress -Port $port -TargetIp $wslIp -PreviewOnly:$WhatIfOnly
+  if (-not $SkipFirewall) {
+    Ensure-FirewallRule -Port $port -PreviewOnly:$WhatIfOnly
+  }
+}
+
+if (-not $WhatIfOnly) {
+  Show-CurrentMapping
+}
+
+Write-Info "Done. Ports [$($Ports -join ',')] now point to WSL '$Distro' ($wslIp)."


### PR DESCRIPTION
## Summary
- add `scripts/ops/attendance-wsl-portproxy-refresh.ps1` for one-click Windows admin refresh of WSL portproxy/firewall rules
- wire script into WSL deployment runbook and existing Windows deployment docs
- ensure on-prem package build/verify include the new PowerShell script

## Verification
- `bash -n scripts/ops/attendance-onprem-package-build.sh`
- `bash -n scripts/ops/attendance-onprem-package-verify.sh`
- `PACKAGE_TAG=20260306-wslproxy INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/attendance-onprem-package-build.sh`
- verify `.tgz` + `.zip` outputs both pass `attendance-onprem-package-verify.sh`
- docs scan for github links in deployment docs (no match)

## Note
- `pwsh` is not available in this macOS workspace, so runtime execution of `.ps1` was validated by script review and integration checks via package build/verify.
