### PR TITLE
feat(onprem): add scheduled task installer for wsl portproxy refresh

### DIFF
--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -71,6 +71,7 @@ metasheet/
     attendance-onprem-healthcheck.sh
     attendance-onprem-update.sh
     attendance-wsl-portproxy-refresh.ps1
+    attendance-wsl-portproxy-task.ps1
   docker/app.env.example
   docker/app.env.attendance-onprem.template
   docker/app.env.attendance-onprem.ready.env

--- a/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
+++ b/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
@@ -143,6 +143,7 @@ scripts/ops/attendance-onprem-healthcheck.sh
 
 - [attendance-windows-wsl-onprem-20260306.md](/Users/huazhou/Downloads/Github/metasheet2/docs/deployment/attendance-windows-wsl-onprem-20260306.md)
   - 其中包含一键脚本：`scripts/ops/attendance-wsl-portproxy-refresh.ps1`
+  - 以及开机自动刷新任务脚本：`scripts/ops/attendance-wsl-portproxy-task.ps1`
 
 如需“只发安装包、不拉代码”的规范与升级命令，见：
 

--- a/docs/deployment/attendance-windows-wsl-onprem-20260306.md
+++ b/docs/deployment/attendance-windows-wsl-onprem-20260306.md
@@ -148,6 +148,31 @@ powershell -ExecutionPolicy Bypass -File .\scripts\ops\attendance-wsl-portproxy-
 powershell -ExecutionPolicy Bypass -File .\scripts\ops\attendance-wsl-portproxy-refresh.ps1 -Distro Ubuntu-22.04 -WhatIfOnly
 ```
 
+建议配置“开机自动刷新”计划任务（PowerShell 管理员）：
+
+```powershell
+cd C:\metasheet
+powershell -ExecutionPolicy Bypass -File .\scripts\ops\attendance-wsl-portproxy-task.ps1 -Action Install -Distro Ubuntu-22.04
+```
+
+查看任务状态：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\ops\attendance-wsl-portproxy-task.ps1 -Action Status
+```
+
+手动触发一次：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\ops\attendance-wsl-portproxy-task.ps1 -Action RunNow
+```
+
+如需移除任务：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\ops\attendance-wsl-portproxy-task.ps1 -Action Uninstall
+```
+
 先获取 WSL IP（PowerShell）：
 
 ```powershell

--- a/scripts/ops/attendance-onprem-package-build.sh
+++ b/scripts/ops/attendance-onprem-package-build.sh
@@ -28,6 +28,7 @@ REQUIRED_PATHS=(
   "scripts/ops/attendance-onprem-healthcheck.sh"
   "scripts/ops/attendance-onprem-update.sh"
   "scripts/ops/attendance-wsl-portproxy-refresh.ps1"
+  "scripts/ops/attendance-wsl-portproxy-task.ps1"
   "docker/app.env.example"
   "docker/app.env.attendance-onprem.template"
   "docker/app.env.attendance-onprem.ready.env"

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -92,6 +92,7 @@ required=(
   "scripts/ops/attendance-onprem-package-install.sh"
   "scripts/ops/attendance-onprem-package-upgrade.sh"
   "scripts/ops/attendance-wsl-portproxy-refresh.ps1"
+  "scripts/ops/attendance-wsl-portproxy-task.ps1"
   "docker/app.env.example"
   "docker/app.env.attendance-onprem.template"
   "docker/app.env.attendance-onprem.ready.env"

--- a/scripts/ops/attendance-wsl-portproxy-task.ps1
+++ b/scripts/ops/attendance-wsl-portproxy-task.ps1
@@ -1,0 +1,148 @@
+param(
+  [ValidateSet("Install", "Uninstall", "Status", "RunNow")]
+  [string]$Action = "Install",
+  [string]$TaskName = "MetaSheet-WSL-PortProxy-Refresh",
+  [string]$Distro = "Ubuntu-22.04",
+  [string]$ListenAddress = "0.0.0.0",
+  [int[]]$Ports = @(80, 443),
+  [int]$DelaySeconds = 20,
+  [switch]$SkipFirewall,
+  [string]$RefreshScriptPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Info([string]$Message) {
+  Write-Host "[attendance-wsl-portproxy-task] $Message"
+}
+
+function Throw-Err([string]$Message) {
+  throw "[attendance-wsl-portproxy-task] ERROR: $Message"
+}
+
+function Require-Admin {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+  if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Throw-Err "Run this script in an elevated PowerShell window (Run as Administrator)."
+  }
+}
+
+function Resolve-RefreshScriptPath([string]$InputPath) {
+  if ($InputPath -and $InputPath.Trim().Length -gt 0) {
+    return (Resolve-Path $InputPath).Path
+  }
+  $selfDir = Split-Path -Parent $PSCommandPath
+  $candidate = Join-Path $selfDir "attendance-wsl-portproxy-refresh.ps1"
+  if (-not (Test-Path $candidate)) {
+    Throw-Err "Cannot find refresh script: $candidate. Use -RefreshScriptPath to specify it."
+  }
+  return (Resolve-Path $candidate).Path
+}
+
+function Build-RefreshArguments([string]$ScriptPath) {
+  if (-not $Ports -or $Ports.Count -eq 0) {
+    Throw-Err "Ports cannot be empty."
+  }
+
+  foreach ($port in $Ports) {
+    if ($port -lt 1 -or $port -gt 65535) {
+      Throw-Err "Invalid port: $port"
+    }
+  }
+
+  if ($DelaySeconds -lt 0 -or $DelaySeconds -gt 3600) {
+    Throw-Err "DelaySeconds must be between 0 and 3600."
+  }
+
+  $portArg = ($Ports | ForEach-Object { [string]$_ }) -join " "
+  $args = @(
+    "-NoProfile"
+    "-ExecutionPolicy Bypass"
+    "-File `"$ScriptPath`""
+    "-Distro `"$Distro`""
+    "-ListenAddress `"$ListenAddress`""
+    "-Ports $portArg"
+  )
+
+  if ($SkipFirewall) {
+    $args += "-SkipFirewall"
+  }
+
+  return ($args -join " ")
+}
+
+function Ensure-ScheduledTaskModule {
+  if (-not (Get-Command Register-ScheduledTask -ErrorAction SilentlyContinue)) {
+    Throw-Err "ScheduledTasks module/cmdlets are not available on this host."
+  }
+}
+
+function Install-Task {
+  Ensure-ScheduledTaskModule
+  $refreshScript = Resolve-RefreshScriptPath -InputPath $RefreshScriptPath
+  $arguments = Build-RefreshArguments -ScriptPath $refreshScript
+
+  Write-Info "Registering scheduled task '$TaskName'"
+  Write-Info "Target refresh script: $refreshScript"
+  Write-Info "Arguments: $arguments"
+
+  $taskAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $arguments
+  $taskTrigger = New-ScheduledTaskTrigger -AtStartup
+  if ($DelaySeconds -gt 0) {
+    $taskTrigger.Delay = "PT${DelaySeconds}S"
+  }
+
+  $taskPrincipal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
+  $taskSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -StartWhenAvailable
+  $task = New-ScheduledTask -Action $taskAction -Trigger $taskTrigger -Principal $taskPrincipal -Settings $taskSettings
+
+  Register-ScheduledTask -TaskName $TaskName -InputObject $task -Force | Out-Null
+  Write-Info "Task installed."
+  Show-Status
+}
+
+function Uninstall-Task {
+  Ensure-ScheduledTaskModule
+  if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Info "Task removed: $TaskName"
+  } else {
+    Write-Info "Task not found: $TaskName"
+  }
+}
+
+function Show-Status {
+  Ensure-ScheduledTaskModule
+  $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+  if (-not $task) {
+    Write-Info "Task not found: $TaskName"
+    return
+  }
+
+  $info = Get-ScheduledTaskInfo -TaskName $TaskName
+  Write-Info "Task: $TaskName"
+  Write-Info "State: $($task.State)"
+  Write-Info "LastRunTime: $($info.LastRunTime)"
+  Write-Info "LastTaskResult: $($info.LastTaskResult)"
+  Write-Info "NextRunTime: $($info.NextRunTime)"
+}
+
+function Run-TaskNow {
+  Ensure-ScheduledTaskModule
+  if (-not (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)) {
+    Throw-Err "Task not found: $TaskName"
+  }
+  Start-ScheduledTask -TaskName $TaskName
+  Write-Info "Task triggered: $TaskName"
+}
+
+Require-Admin
+
+switch ($Action) {
+  "Install" { Install-Task }
+  "Uninstall" { Uninstall-Task }
+  "Status" { Show-Status }
+  "RunNow" { Run-TaskNow }
+  default { Throw-Err "Unknown action: $Action" }
+}


### PR DESCRIPTION
## Summary
- add `scripts/ops/attendance-wsl-portproxy-task.ps1` to manage startup scheduled task for WSL portproxy refresh
- support actions: Install / Status / RunNow / Uninstall
- wire scheduled-task usage into WSL deployment docs
- include new script in on-prem package build + verify required file list

## Verification
- `bash -n scripts/ops/attendance-onprem-package-build.sh`
- `bash -n scripts/ops/attendance-onprem-package-verify.sh`
- `PACKAGE_TAG=20260306-tasktest INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/attendance-onprem-package-build.sh`
- verify both `.tgz` and `.zip` via `attendance-onprem-package-verify.sh` (PASS)
- verify archive contains both `attendance-wsl-portproxy-refresh.ps1` and `attendance-wsl-portproxy-task.ps1`

## Note
- `pwsh` is unavailable in this macOS workspace, so runtime execution of PowerShell script is not executed here.
