### PR TITLE
docs(onprem): update command sheets to latest current release

### DIFF
--- a/docs/attendance-onprem-package-build-verification-20260306.md
+++ b/docs/attendance-onprem-package-build-verification-20260306.md
@@ -93,6 +93,41 @@ Verification result:
   - `scripts/ops/attendance-wsl-portproxy-refresh.ps1`
   - `scripts/ops/attendance-wsl-portproxy-task.ps1`
 
+## GitHub Actions Verification (Latest Current Release Audit)
+
+Execution date: `2026-03-06`
+
+Run metadata:
+
+- Workflow: `attendance-onprem-package-build.yml`
+- Run ID: `22752221246`
+- Result: `SUCCESS`
+- Release Tag: `v2.5.0-onprem-20260306-current`
+- Release URL: `https://github.com/zensgit/metasheet2/releases/tag/v2.5.0-onprem-20260306-current`
+
+Evidence (downloaded locally):
+
+- `output/playwright/release-audit/v2.5.0-onprem-20260306-current/metasheet-attendance-onprem-v2.5.0-20260306-current.tgz`
+- `output/playwright/release-audit/v2.5.0-onprem-20260306-current/metasheet-attendance-onprem-v2.5.0-20260306-current.zip`
+- `output/playwright/release-audit/v2.5.0-onprem-20260306-current/SHA256SUMS`
+- `output/playwright/release-audit/v2.5.0-onprem-20260306-current/tgz-manifest.txt`
+- `output/playwright/release-audit/v2.5.0-onprem-20260306-current/zip-manifest.txt`
+- `output/playwright/release-audit/v2.5.0-onprem-20260306-current/audit-summary.txt`
+
+Verification result:
+
+- `attendance-onprem-package-verify.sh` on downloaded `.tgz`: `PASS`
+- `attendance-onprem-package-verify.sh` on downloaded `.zip`: `PASS`
+- `SHA256SUMS` digest check for `.tgz/.zip`: `PASS`
+- Key files confirmed in both archives:
+  - `apps/web/dist/index.html`
+  - `packages/core-backend/dist/src/db/migrate.js`
+  - `scripts/ops/attendance-onprem-deploy-easy.sh`
+  - `scripts/ops/attendance-wsl-portproxy-refresh.ps1`
+  - `scripts/ops/attendance-wsl-portproxy-task.ps1`
+  - `docs/deployment/attendance-windows-wsl-direct-commands-20260306.md`
+  - `docs/deployment/attendance-windows-wsl-customer-profiled-commands-20260306.md`
+
 ## Notes
 
 - Database instance creation is still external (`CREATE DATABASE` by DBA/installer).

--- a/docs/deployment/attendance-windows-wsl-customer-profiled-commands-20260306.md
+++ b/docs/deployment/attendance-windows-wsl-customer-profiled-commands-20260306.md
@@ -6,7 +6,7 @@
 
 ```powershell
 $Distro = "Ubuntu-22.04"
-$PkgZip = "C:\deploy\metasheet-attendance-onprem-v2.5.0-20260306-wsltask.zip"
+$PkgZip = "C:\deploy\metasheet-attendance-onprem-v2.5.0-20260306-current.zip"
 $WorkDir = "C:\metasheet"
 $WindowsServerIp = "192.168.1.50"
 $AdminEmail = "admin@customer.local"
@@ -59,7 +59,7 @@ sudo systemctl enable --now postgresql redis-server nginx
 sudo mkdir -p /opt/metasheet
 sudo chown -R "$USER":"$USER" /opt/metasheet
 cd /opt
-unzip -q /mnt/c/deploy/metasheet-attendance-onprem-v2.5.0-20260306-wsltask.zip
+unzip -q /mnt/c/deploy/metasheet-attendance-onprem-v2.5.0-20260306-current.zip
 mv /opt/metasheet-attendance-onprem-* /opt/metasheet 2>/dev/null || true
 cd /opt/metasheet
 mkdir -p /opt/metasheet/storage/attendance-import

--- a/docs/deployment/attendance-windows-wsl-direct-commands-20260306.md
+++ b/docs/deployment/attendance-windows-wsl-direct-commands-20260306.md
@@ -4,14 +4,14 @@
 
 默认包名示例：
 
-- `metasheet-attendance-onprem-v2.5.0-20260306-wsltask.zip`
+- `metasheet-attendance-onprem-v2.5.0-20260306-current.zip`
 
 ## A. Windows 管理员 PowerShell（先执行）
 
 ```powershell
 # 0) 基本变量（按实际修改）
 $Distro = "Ubuntu-22.04"
-$PkgZip = "C:\deploy\metasheet-attendance-onprem-v2.5.0-20260306-wsltask.zip"
+$PkgZip = "C:\deploy\metasheet-attendance-onprem-v2.5.0-20260306-current.zip"
 $WorkDir = "C:\metasheet"
 
 # 1) 启用 WSL2（首次机器执行，可能要求重启）
@@ -70,7 +70,7 @@ sudo systemctl enable --now postgresql redis-server nginx
 sudo mkdir -p /opt/metasheet
 sudo chown -R "$USER":"$USER" /opt/metasheet
 cd /opt
-unzip -q /mnt/c/deploy/metasheet-attendance-onprem-v2.5.0-20260306-wsltask.zip
+unzip -q /mnt/c/deploy/metasheet-attendance-onprem-v2.5.0-20260306-current.zip
 mv /opt/metasheet-attendance-onprem-* /opt/metasheet 2>/dev/null || true
 cd /opt/metasheet
 


### PR DESCRIPTION
Summary:
- update Windows+WSL direct/profiled command docs to use latest release package name (20260306-current)
- append latest release audit record to package verification doc

Verification:
- latest release run 22752221246 succeeded
- release audit summary generated under output/playwright/release-audit/v2.5.0-onprem-20260306-current/
- tgz/zip verify pass and key files confirmed