### PR TITLE
fix(web-auth): surface localStorage token persistence errors

### DIFF
--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -14,13 +14,17 @@ export function useAuth() {
   function setToken(token: string) {
     try {
       if (typeof localStorage !== 'undefined') localStorage.setItem('jwt', token)
-    } catch {}
+    } catch (err) {
+      console.warn('[auth] failed to persist token in localStorage', err)
+    }
   }
 
   function clearToken() {
     try {
       if (typeof localStorage !== 'undefined') localStorage.removeItem('jwt')
-    } catch {}
+    } catch (err) {
+      console.warn('[auth] failed to clear token from localStorage', err)
+    }
   }
 
   function buildAuthHeaders(): Record<string, string> {


### PR DESCRIPTION
## Summary
- add warning logs when token persistence to localStorage fails
- add warning logs when token clearing from localStorage fails
- keep auth behavior unchanged (non-blocking)

## Why
When browser storage is blocked/full, login issues become hard to diagnose because errors were silently swallowed.

## Verification
- local spot check in dev workspace:
  - pnpm --filter @metasheet/web exec vitest run --watch=false tests/useAuth.spec.ts
  - pnpm --filter @metasheet/web build