### PR TITLE
feat(attendance): add local regression runner for post-change validation

### DIFF
--- a/docs/attendance-local-regression-checklist-20260307.md
+++ b/docs/attendance-local-regression-checklist-20260307.md
@@ -1,0 +1,51 @@
+# Attendance Local Regression Checklist (2026-03-07)
+
+Purpose:
+
+- Provide one command to validate attendance core integrity after large source updates.
+- Produce reproducible local evidence under `output/playwright/attendance-local-regression/<timestamp>/`.
+
+## Command
+
+```bash
+pnpm verify:attendance-regression-local
+```
+
+Default checks:
+
+1. backend attendance integration test file
+2. web unit tests
+3. gate contract strict fixture
+4. gate contract dashboard fixture
+
+Generated artifacts:
+
+- `summary.md`
+- `summary.json`
+- `results.tsv`
+- one `*.log` file per check
+
+## Optional: include full-flow Playwright
+
+```bash
+RUN_PLAYWRIGHT=true \
+WEB_URL="http://142.171.239.56:8081/attendance" \
+AUTH_TOKEN="<ADMIN_JWT>" \
+pnpm verify:attendance-regression-local
+```
+
+Mobile full-flow is enabled by default when Playwright mode is on. Disable with:
+
+```bash
+RUN_PLAYWRIGHT=true PLAYWRIGHT_MOBILE=false pnpm verify:attendance-regression-local
+```
+
+## Exit semantics
+
+- Exit `0`: no failed checks (PASS/SKIP only).
+- Exit `1`: one or more checks failed.
+
+## Notes
+
+- This script is local regression tooling; it does not replace GA strict gates.
+- Do not store real tokens in docs or committed files; use runtime env vars only.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "verify:attendance-ui-regression": "node scripts/verify-attendance-ui-regression.mjs",
     "verify:attendance-locale-zh": "node scripts/verify-attendance-locale-zh-smoke.mjs",
     "verify:attendance-zh-copy-contract": "node scripts/ops/attendance-verify-zh-copy-contract.mjs",
+    "verify:attendance-regression-local": "bash scripts/ops/attendance-regression-local.sh",
     "verify:attendance-ui:optional": "bash -c 'if [ \"${RUN_ATTENDANCE_UI_SMOKE}\" = \"true\" ]; then node scripts/verify-attendance-ui.mjs; else echo \"skip attendance ui (set RUN_ATTENDANCE_UI_SMOKE=true)\"; fi'",
     "verify:univer-ui-smoke": "node scripts/verify-univer-ui-smoke.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",

--- a/scripts/ops/attendance-regression-local.sh
+++ b/scripts/ops/attendance-regression-local.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+OUTPUT_ROOT="${OUTPUT_ROOT:-output/playwright/attendance-local-regression/${timestamp}}"
+RUN_PLAYWRIGHT="${RUN_PLAYWRIGHT:-false}"
+PLAYWRIGHT_MOBILE="${PLAYWRIGHT_MOBILE:-true}"
+
+mkdir -p "$OUTPUT_ROOT"
+RESULTS_TSV="${OUTPUT_ROOT}/results.tsv"
+SUMMARY_MD="${OUTPUT_ROOT}/summary.md"
+SUMMARY_JSON="${OUTPUT_ROOT}/summary.json"
+
+echo -e "check\tstatus\trc\tlog" >"$RESULTS_TSV"
+
+function info() {
+  echo "[attendance-regression-local] $*" >&2
+}
+
+function slugify() {
+  local raw="$1"
+  raw="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  raw="$(printf '%s' "$raw" | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')"
+  printf '%s' "${raw:-check}"
+}
+
+function run_check() {
+  local name="$1"
+  local cmd="$2"
+  local slug
+  local log
+  local rc=0
+  slug="$(slugify "$name")"
+  log="${OUTPUT_ROOT}/${slug}.log"
+
+  info "run: ${name}"
+  if bash -lc "$cmd" >"$log" 2>&1; then
+    echo -e "${name}\tPASS\t0\t${log}" >>"$RESULTS_TSV"
+  else
+    rc=$?
+    echo -e "${name}\tFAIL\t${rc}\t${log}" >>"$RESULTS_TSV"
+  fi
+}
+
+backend_vitest_config="vitest.integration.config.ts"
+if [[ -f "packages/core-backend/vitest.integration.config.mts" ]]; then
+  backend_vitest_config="vitest.integration.config.mts"
+fi
+
+run_check \
+  "backend-attendance-integration" \
+  "cd packages/core-backend && pnpm exec vitest --config ${backend_vitest_config} run tests/integration/attendance-plugin.test.ts"
+
+run_check \
+  "web-unit-tests" \
+  "pnpm --filter @metasheet/web exec vitest run --watch=false"
+
+run_check \
+  "gate-contract-strict" \
+  "bash scripts/ops/attendance-run-gate-contract-case.sh strict \"$OUTPUT_ROOT/contract\""
+
+run_check \
+  "gate-contract-dashboard" \
+  "bash scripts/ops/attendance-run-gate-contract-case.sh dashboard \"$OUTPUT_ROOT/contract\""
+
+if [[ "$RUN_PLAYWRIGHT" == "true" ]]; then
+  if [[ -n "${WEB_URL:-}" && -n "${AUTH_TOKEN:-}" ]]; then
+    run_check \
+      "playwright-full-flow-desktop" \
+      "WEB_URL=\"$WEB_URL\" AUTH_TOKEN=\"$AUTH_TOKEN\" OUTPUT_DIR=\"$OUTPUT_ROOT/playwright-desktop\" node scripts/verify-attendance-full-flow.mjs"
+    if [[ "$PLAYWRIGHT_MOBILE" == "true" ]]; then
+      run_check \
+        "playwright-full-flow-mobile" \
+        "WEB_URL=\"$WEB_URL\" AUTH_TOKEN=\"$AUTH_TOKEN\" UI_MOBILE=true OUTPUT_DIR=\"$OUTPUT_ROOT/playwright-mobile\" node scripts/verify-attendance-full-flow.mjs"
+    fi
+  else
+    info "skip playwright: RUN_PLAYWRIGHT=true but WEB_URL/AUTH_TOKEN missing"
+    echo -e "playwright-full-flow\tSKIP\t0\tWEB_URL/AUTH_TOKEN missing" >>"$RESULTS_TSV"
+  fi
+fi
+
+pass_count="$(awk -F'\t' 'NR>1 && $2=="PASS" {c++} END {print c+0}' "$RESULTS_TSV")"
+fail_count="$(awk -F'\t' 'NR>1 && $2=="FAIL" {c++} END {print c+0}' "$RESULTS_TSV")"
+skip_count="$(awk -F'\t' 'NR>1 && $2=="SKIP" {c++} END {print c+0}' "$RESULTS_TSV")"
+total_count="$(awk -F'\t' 'NR>1 {c++} END {print c+0}' "$RESULTS_TSV")"
+
+{
+  echo "# Attendance Local Regression Summary"
+  echo
+  echo "- Timestamp: ${timestamp}"
+  echo "- Output root: \`${OUTPUT_ROOT}\`"
+  echo "- Totals: ${total_count} checks, ${pass_count} pass, ${fail_count} fail, ${skip_count} skip"
+  echo
+  echo "| Check | Status | RC | Log |"
+  echo "|---|---|---|---|"
+  awk -F'\t' 'NR>1 {printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}' "$RESULTS_TSV"
+} >"$SUMMARY_MD"
+
+python3 - "$RESULTS_TSV" "$SUMMARY_JSON" "$timestamp" "$OUTPUT_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+results_tsv = Path(sys.argv[1])
+summary_json = Path(sys.argv[2])
+timestamp = sys.argv[3]
+output_root = sys.argv[4]
+
+rows = []
+with results_tsv.open() as f:
+    next(f, None)
+    for line in f:
+        parts = line.rstrip("\n").split("\t")
+        if len(parts) < 4:
+            continue
+        rows.append({
+            "check": parts[0],
+            "status": parts[1],
+            "rc": int(parts[2]),
+            "log": parts[3],
+        })
+
+payload = {
+    "timestamp": timestamp,
+    "outputRoot": output_root,
+    "totals": {
+        "total": len(rows),
+        "pass": sum(1 for r in rows if r["status"] == "PASS"),
+        "fail": sum(1 for r in rows if r["status"] == "FAIL"),
+        "skip": sum(1 for r in rows if r["status"] == "SKIP"),
+    },
+    "checks": rows,
+}
+summary_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+PY
+
+cat "$SUMMARY_MD"
+
+if [[ "$fail_count" -gt 0 ]]; then
+  info "FAILED: ${fail_count} checks failed"
+  exit 1
+fi
+
+info "PASS: all required checks passed"
+exit 0

--- a/scripts/ops/attendance-validate-gate-summary.sh
+++ b/scripts/ops/attendance-validate-gate-summary.sh
@@ -25,7 +25,14 @@ if [[ ! -d "$ROOT_DIR" ]]; then
   die "root directory not found: $ROOT_DIR"
 fi
 
-mapfile -t summaries < <(find "$ROOT_DIR" -type f -name 'gate-summary.json' | sort)
+summaries=()
+if declare -F mapfile >/dev/null 2>&1; then
+  mapfile -t summaries < <(find "$ROOT_DIR" -type f -name 'gate-summary.json' | sort)
+else
+  while IFS= read -r summary; do
+    summaries+=("$summary")
+  done < <(find "$ROOT_DIR" -type f -name 'gate-summary.json' | sort)
+fi
 count="${#summaries[@]}"
 
 if (( count < EXPECT_MIN_SUMMARIES )); then


### PR DESCRIPTION
## Summary
- add `scripts/ops/attendance-regression-local.sh` for one-command local attendance regression
- add npm script `verify:attendance-regression-local`
- add doc `docs/attendance-local-regression-checklist-20260307.md`
- make `attendance-validate-gate-summary.sh` compatible with macOS bash 3.2 (`mapfile` fallback)
- support both `vitest.integration.config.ts` and `.mts` in backend regression command

## Verification
- `pnpm verify:attendance-regression-local`
  - Output root: `output/playwright/attendance-local-regression/20260307-185803`
  - checks: backend-attendance-integration PASS, web-unit-tests PASS, gate-contract-strict PASS, gate-contract-dashboard PASS
