### PR TITLE
feat(attendance-ops): post-merge verifier + smoke group lookup hardening

### DIFF
--- a/docs/attendance-post-merge-verify-20260307.md
+++ b/docs/attendance-post-merge-verify-20260307.md
@@ -1,0 +1,61 @@
+# Attendance Post-Merge Verify Playbook (2026-03-07)
+
+Purpose:
+
+- Run a reproducible, one-command post-merge verification on `main`.
+- Trigger three production workflows in order:
+  1. `attendance-branch-policy-drift-prod.yml`
+  2. `attendance-strict-gates-prod.yml`
+  3. `attendance-daily-gate-dashboard.yml`
+- Optionally download artifacts for every run into a single local evidence directory.
+
+## Command
+
+```bash
+pnpm verify:attendance-post-merge
+```
+
+Default behavior:
+
+- Branch: `main`
+- Download artifacts: `true`
+- Strict checks enabled (`require_import_upload=true`, `require_idempotency=true`, etc.)
+- Dashboard `lookback_hours=48`
+
+Artifacts output:
+
+- `output/playwright/attendance-post-merge-verify/<timestamp>/summary.md`
+- `output/playwright/attendance-post-merge-verify/<timestamp>/summary.json`
+- `output/playwright/attendance-post-merge-verify/<timestamp>/results.tsv`
+- Downloaded GitHub artifacts under:
+  - `output/playwright/attendance-post-merge-verify/<timestamp>/ga/<runId>/`
+
+## Useful overrides
+
+Quick run without strict (for script debugging only):
+
+```bash
+SKIP_STRICT=true pnpm verify:attendance-post-merge
+```
+
+Do not download artifacts:
+
+```bash
+DOWNLOAD_ARTIFACTS=false pnpm verify:attendance-post-merge
+```
+
+Run with stricter dashboard lookback:
+
+```bash
+LOOKBACK_HOURS=24 pnpm verify:attendance-post-merge
+```
+
+## Exit semantics
+
+- Exit `0`: all non-skipped gates succeeded.
+- Exit `1`: one or more gates failed.
+
+## Notes
+
+- This script triggers `workflow_dispatch` runs and requires `gh` CLI auth with repository workflow permissions.
+- Never write real secrets/tokens into docs; runtime env only.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "verify:attendance-locale-zh": "node scripts/verify-attendance-locale-zh-smoke.mjs",
     "verify:attendance-zh-copy-contract": "node scripts/ops/attendance-verify-zh-copy-contract.mjs",
     "verify:attendance-regression-local": "bash scripts/ops/attendance-regression-local.sh",
+    "verify:attendance-post-merge": "bash scripts/ops/attendance-post-merge-verify.sh",
     "verify:attendance-ui:optional": "bash -c 'if [ \"${RUN_ATTENDANCE_UI_SMOKE}\" = \"true\" ]; then node scripts/verify-attendance-ui.mjs; else echo \"skip attendance ui (set RUN_ATTENDANCE_UI_SMOKE=true)\"; fi'",
     "verify:univer-ui-smoke": "node scripts/verify-univer-ui-smoke.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",

--- a/scripts/ops/attendance-post-merge-verify.sh
+++ b/scripts/ops/attendance-post-merge-verify.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+BRANCH="${BRANCH:-main}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-output/playwright/attendance-post-merge-verify/$(date +%Y%m%d-%H%M%S)}"
+DOWNLOAD_ARTIFACTS="${DOWNLOAD_ARTIFACTS:-true}"
+
+SKIP_BRANCH_POLICY="${SKIP_BRANCH_POLICY:-false}"
+SKIP_STRICT="${SKIP_STRICT:-false}"
+SKIP_DASHBOARD="${SKIP_DASHBOARD:-false}"
+
+REQUIRED_CHECKS_CSV="${REQUIRED_CHECKS_CSV:-contracts (strict),contracts (dashboard)}"
+REQUIRE_STRICT="${REQUIRE_STRICT:-true}"
+REQUIRE_ENFORCE_ADMINS="${REQUIRE_ENFORCE_ADMINS:-true}"
+REQUIRE_PR_REVIEWS="${REQUIRE_PR_REVIEWS:-true}"
+MIN_APPROVING_REVIEW_COUNT="${MIN_APPROVING_REVIEW_COUNT:-1}"
+REQUIRE_CODE_OWNER_REVIEWS="${REQUIRE_CODE_OWNER_REVIEWS:-false}"
+
+API_BASE="${API_BASE:-http://142.171.239.56:8081/api}"
+EXPECT_PRODUCT_MODE="${EXPECT_PRODUCT_MODE:-attendance}"
+REQUIRE_ATTENDANCE_ADMIN_API="${REQUIRE_ATTENDANCE_ADMIN_API:-true}"
+REQUIRE_IDEMPOTENCY="${REQUIRE_IDEMPOTENCY:-true}"
+REQUIRE_IMPORT_EXPORT="${REQUIRE_IMPORT_EXPORT:-true}"
+REQUIRE_IMPORT_UPLOAD="${REQUIRE_IMPORT_UPLOAD:-true}"
+REQUIRE_IMPORT_ASYNC="${REQUIRE_IMPORT_ASYNC:-true}"
+REQUIRE_IMPORT_TELEMETRY="${REQUIRE_IMPORT_TELEMETRY:-true}"
+REQUIRE_PREVIEW_ASYNC="${REQUIRE_PREVIEW_ASYNC:-true}"
+REQUIRE_BATCH_RESOLVE="${REQUIRE_BATCH_RESOLVE:-false}"
+REQUIRE_IMPORT_JOB_RECOVERY="${REQUIRE_IMPORT_JOB_RECOVERY:-false}"
+REQUIRE_ADMIN_SETTINGS_SAVE="${REQUIRE_ADMIN_SETTINGS_SAVE:-true}"
+
+LOOKBACK_HOURS="${LOOKBACK_HOURS:-48}"
+
+mkdir -p "$OUTPUT_ROOT"
+RESULTS_TSV="${OUTPUT_ROOT}/results.tsv"
+SUMMARY_MD="${OUTPUT_ROOT}/summary.md"
+SUMMARY_JSON="${OUTPUT_ROOT}/summary.json"
+
+echo -e "gate\tworkflow\trun_id\tstatus\tconclusion\turl\tartifacts" >"$RESULTS_TSV"
+
+function info() {
+  echo "[attendance-post-merge-verify] $*" >&2
+}
+
+function die() {
+  echo "[attendance-post-merge-verify] ERROR: $*" >&2
+  exit 1
+}
+
+function require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+require_cmd gh
+require_cmd jq
+require_cmd python3
+
+RUN_ID=''
+RUN_URL=''
+RUN_CONCLUSION=''
+RUN_ARTIFACTS=''
+
+function append_result() {
+  local gate="$1"
+  local workflow="$2"
+  local run_id="$3"
+  local status="$4"
+  local conclusion="$5"
+  local url="$6"
+  local artifacts="$7"
+  echo -e "${gate}\t${workflow}\t${run_id}\t${status}\t${conclusion}\t${url}\t${artifacts}" >>"$RESULTS_TSV"
+}
+
+function trigger_and_wait() {
+  local workflow="$1"
+  shift
+  local -a args=("$@")
+  local before_id=''
+  local run_id=''
+  local run_json=''
+  local attempt
+
+  before_id="$(gh run list --workflow "$workflow" --branch "$BRANCH" --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo '0')"
+  if [[ -z "$before_id" ]]; then
+    before_id='0'
+  fi
+
+  info "dispatch workflow: ${workflow} (branch=${BRANCH})"
+  gh workflow run "$workflow" --ref "$BRANCH" "${args[@]}" >/dev/null
+
+  for attempt in $(seq 1 60); do
+    run_json="$(gh run list --workflow "$workflow" --branch "$BRANCH" --limit 20 --json databaseId,event,conclusion,status,url,createdAt 2>/dev/null || echo '[]')"
+    run_id="$(printf '%s' "$run_json" | jq -r --arg before "${before_id}" '
+      map(select(.event == "workflow_dispatch"))
+      | map(select((.databaseId | tonumber) > ($before | tonumber)))
+      | sort_by(.databaseId)
+      | last
+      | .databaseId // empty
+    ')"
+    if [[ -n "$run_id" ]]; then
+      break
+    fi
+    sleep 2
+  done
+
+  [[ -n "$run_id" ]] || return 2
+
+  info "watch run: ${run_id}"
+  gh run watch "$run_id" --exit-status
+  local watch_rc=$?
+
+  run_json="$(gh run view "$run_id" --json databaseId,url,conclusion,status 2>/dev/null || echo '{}')"
+  RUN_ID="$(printf '%s' "$run_json" | jq -r '.databaseId // empty')"
+  RUN_URL="$(printf '%s' "$run_json" | jq -r '.url // empty')"
+  RUN_CONCLUSION="$(printf '%s' "$run_json" | jq -r '.conclusion // empty')"
+  RUN_ARTIFACTS=''
+
+  if [[ "$DOWNLOAD_ARTIFACTS" == "true" && -n "$RUN_ID" ]]; then
+    local artifacts_dir="${OUTPUT_ROOT}/ga/${RUN_ID}"
+    mkdir -p "$artifacts_dir"
+    if gh run download "$RUN_ID" -D "$artifacts_dir" >"${artifacts_dir}/download.log" 2>&1; then
+      RUN_ARTIFACTS="$artifacts_dir"
+    else
+      RUN_ARTIFACTS="${artifacts_dir} (download failed; see download.log)"
+    fi
+  fi
+
+  return "$watch_rc"
+}
+
+failures=0
+
+function run_gate() {
+  local gate="$1"
+  local workflow="$2"
+  local skip="$3"
+  shift 3
+  local -a args=("$@")
+
+  if [[ "$skip" == "true" ]]; then
+    info "skip gate: ${gate}"
+    append_result "$gate" "$workflow" "" "SKIP" "" "" ""
+    return 0
+  fi
+
+  local status='PASS'
+  local rc=0
+  if ! trigger_and_wait "$workflow" "${args[@]}"; then
+    rc=$?
+    status='FAIL'
+    failures=$((failures + 1))
+  fi
+
+  append_result "$gate" "$workflow" "$RUN_ID" "$status" "$RUN_CONCLUSION" "$RUN_URL" "$RUN_ARTIFACTS"
+  info "gate result: ${gate} status=${status} run_id=${RUN_ID} conclusion=${RUN_CONCLUSION} rc=${rc}"
+}
+
+run_gate \
+  "branch-policy" \
+  "attendance-branch-policy-drift-prod.yml" \
+  "$SKIP_BRANCH_POLICY" \
+  -f "branch=${BRANCH}" \
+  -f "required_checks_csv=${REQUIRED_CHECKS_CSV}" \
+  -f "require_strict=${REQUIRE_STRICT}" \
+  -f "require_enforce_admins=${REQUIRE_ENFORCE_ADMINS}" \
+  -f "require_pr_reviews=${REQUIRE_PR_REVIEWS}" \
+  -f "min_approving_review_count=${MIN_APPROVING_REVIEW_COUNT}" \
+  -f "require_code_owner_reviews=${REQUIRE_CODE_OWNER_REVIEWS}" \
+  -f "drill_fail=false"
+
+run_gate \
+  "strict-gates" \
+  "attendance-strict-gates-prod.yml" \
+  "$SKIP_STRICT" \
+  -f "drill=false" \
+  -f "api_base=${API_BASE}" \
+  -f "expect_product_mode=${EXPECT_PRODUCT_MODE}" \
+  -f "require_attendance_admin_api=${REQUIRE_ATTENDANCE_ADMIN_API}" \
+  -f "require_idempotency=${REQUIRE_IDEMPOTENCY}" \
+  -f "require_import_export=${REQUIRE_IMPORT_EXPORT}" \
+  -f "require_import_upload=${REQUIRE_IMPORT_UPLOAD}" \
+  -f "require_import_async=${REQUIRE_IMPORT_ASYNC}" \
+  -f "require_import_telemetry=${REQUIRE_IMPORT_TELEMETRY}" \
+  -f "require_preview_async=${REQUIRE_PREVIEW_ASYNC}" \
+  -f "require_batch_resolve=${REQUIRE_BATCH_RESOLVE}" \
+  -f "require_import_job_recovery=${REQUIRE_IMPORT_JOB_RECOVERY}" \
+  -f "require_admin_settings_save=${REQUIRE_ADMIN_SETTINGS_SAVE}"
+
+run_gate \
+  "daily-dashboard" \
+  "attendance-daily-gate-dashboard.yml" \
+  "$SKIP_DASHBOARD" \
+  -f "branch=${BRANCH}" \
+  -f "lookback_hours=${LOOKBACK_HOURS}" \
+  -f "include_drill_runs=false"
+
+{
+  echo "# Attendance Post-Merge Verification Summary"
+  echo
+  echo "- Branch: \`${BRANCH}\`"
+  echo "- Output root: \`${OUTPUT_ROOT}\`"
+  echo "- Failures: \`${failures}\`"
+  echo
+  echo "| Gate | Workflow | Run ID | Status | Conclusion | URL | Artifacts |"
+  echo "|---|---|---|---|---|---|---|"
+  awk -F'\t' 'NR>1 {printf "| %s | %s | %s | %s | %s | %s | `%s` |\n", $1, $2, $3, $4, $5, $6, $7}' "$RESULTS_TSV"
+} >"$SUMMARY_MD"
+
+python3 - "$RESULTS_TSV" "$SUMMARY_JSON" "$BRANCH" "$OUTPUT_ROOT" "$failures" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+results_tsv = Path(sys.argv[1])
+summary_json = Path(sys.argv[2])
+branch = sys.argv[3]
+output_root = sys.argv[4]
+failures = int(sys.argv[5])
+
+rows = []
+with results_tsv.open() as f:
+    next(f, None)
+    for line in f:
+        gate, workflow, run_id, status, conclusion, url, artifacts = line.rstrip('\n').split('\t')
+        rows.append({
+            "gate": gate,
+            "workflow": workflow,
+            "runId": int(run_id) if run_id.isdigit() else None,
+            "status": status,
+            "conclusion": conclusion or None,
+            "url": url or None,
+            "artifacts": artifacts or None,
+        })
+
+payload = {
+    "branch": branch,
+    "outputRoot": output_root,
+    "failures": failures,
+    "status": "pass" if failures == 0 else "fail",
+    "gates": rows,
+}
+summary_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+PY
+
+cat "$SUMMARY_MD"
+
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi
+
+exit 0

--- a/scripts/ops/attendance-smoke-api.mjs
+++ b/scripts/ops/attendance-smoke-api.mjs
@@ -14,6 +14,10 @@ const requirePreviewAsync = process.env.REQUIRE_PREVIEW_ASYNC === 'true'
 const apiRetryAttempts = Math.max(1, Number(process.env.API_RETRY_ATTEMPTS || 5))
 const apiRetryDelayMs = Math.max(100, Number(process.env.API_RETRY_DELAY_MS || 1000))
 const apiTimeoutMs = Math.max(1000, Number(process.env.API_TIMEOUT_MS || 120000))
+const groupRetryAttempts = Math.max(1, Number(process.env.GROUP_RETRY_ATTEMPTS || 8))
+const groupRetryDelayMs = Math.max(100, Number(process.env.GROUP_RETRY_DELAY_MS || 1000))
+const groupPageSize = Math.max(1, Number(process.env.GROUP_PAGE_SIZE || 200))
+const groupPageMax = Math.max(1, Number(process.env.GROUP_PAGE_MAX || 20))
 const importEngines = new Set(['standard', 'bulk'])
 
 function normalizeProductMode(value) {
@@ -217,6 +221,58 @@ function assertImportTelemetry(payload, label, options = {}) {
 
 function isRetriableStatus(status) {
   return status === 408 || status === 429 || (status >= 500 && status <= 504)
+}
+
+async function findGroupByNameWithRetry(groupName) {
+  async function findGroupByNameAcrossPages() {
+    for (let page = 1; page <= groupPageMax; page += 1) {
+      const groups = await apiFetch(`/attendance/groups?pageSize=${groupPageSize}&page=${page}`, { method: 'GET' })
+      assertOk(groups, 'GET /attendance/groups')
+      const groupItems = groups.body?.data?.items || []
+      const created = groupItems.find((g) => g && g.name === groupName)
+      if (created?.id) return created
+      if (!Array.isArray(groupItems) || groupItems.length < groupPageSize) break
+    }
+    return null
+  }
+
+  for (let attempt = 1; attempt <= groupRetryAttempts; attempt += 1) {
+    const created = await findGroupByNameAcrossPages()
+    if (created?.id) {
+      if (attempt > 1) log(`group resolved after retry: attempt=${attempt}`)
+      return created
+    }
+    if (attempt < groupRetryAttempts) {
+      await sleep(groupRetryDelayMs)
+    }
+  }
+  return null
+}
+
+async function verifyGroupMembershipWithRetry(groupId, userId) {
+  async function hasGroupMemberAcrossPages() {
+    for (let page = 1; page <= groupPageMax; page += 1) {
+      const members = await apiFetch(`/attendance/groups/${groupId}/members?pageSize=${groupPageSize}&page=${page}`, { method: 'GET' })
+      assertOk(members, 'GET /attendance/groups/:id/members')
+      const memberItems = members.body?.data?.items || []
+      const hasMember = memberItems.some((m) => m && (m.userId === userId || m.user_id === userId))
+      if (hasMember) return true
+      if (!Array.isArray(memberItems) || memberItems.length < groupPageSize) break
+    }
+    return false
+  }
+
+  for (let attempt = 1; attempt <= groupRetryAttempts; attempt += 1) {
+    const hasMember = await hasGroupMemberAcrossPages()
+    if (hasMember) {
+      if (attempt > 1) log(`group membership resolved after retry: attempt=${attempt}`)
+      return true
+    }
+    if (attempt < groupRetryAttempts) {
+      await sleep(groupRetryDelayMs)
+    }
+  }
+  return false
 }
 
 async function fetchWithRetry(url, init = {}, options = {}) {
@@ -710,16 +766,10 @@ async function run() {
   log(`batch items ok: rows=${batchItems.length}`)
 
   // 8) group exists + membership
-  const groups = await apiFetch('/attendance/groups?pageSize=200', { method: 'GET' })
-  assertOk(groups, 'GET /attendance/groups')
-  const groupItems = groups.body?.data?.items || []
-  const created = groupItems.find((g) => g && g.name === groupName)
+  const created = await findGroupByNameWithRetry(groupName)
   if (!created?.id) die('created group not found')
 
-  const members = await apiFetch(`/attendance/groups/${created.id}/members?pageSize=200`, { method: 'GET' })
-  assertOk(members, 'GET /attendance/groups/:id/members')
-  const memberItems = members.body?.data?.items || []
-  const hasMember = memberItems.some((m) => m && (m.userId === userId || m.user_id === userId))
+  const hasMember = await verifyGroupMembershipWithRetry(created.id, userId)
   if (!hasMember) die('importing user is not a member of created group')
   log('group + membership ok')
 


### PR DESCRIPTION
## Summary
- add `scripts/ops/attendance-post-merge-verify.sh` for one-command post-merge verification
- add npm script `verify:attendance-post-merge`
- add playbook doc `docs/attendance-post-merge-verify-20260307.md`
- harden `scripts/ops/attendance-smoke-api.mjs` group checks:
  - retry group lookup/membership checks
  - scan paginated group/member lists (not only first page)

## Why
- recent strict failures showed intermittent/visibility issues around group validation (`created group not found`)
- post-merge verification was manual and easy to run out-of-order

## Verification
- `bash -n scripts/ops/attendance-post-merge-verify.sh`
- `node --check scripts/ops/attendance-smoke-api.mjs`
- `SKIP_STRICT=true SKIP_DASHBOARD=true pnpm verify:attendance-post-merge`
  - branch-policy run picked new run id: `#22798018578`
  - output: `output/playwright/attendance-post-merge-verify/20260307-191518/`
