### PR TITLE
fix(attendance-dashboard): skip cancelled strict runs when resolving gate source

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -3997,3 +3997,32 @@ Key assertions:
   - `gateFlat.strict.conclusion=success`
   - `gateFlat.protection.runId=22798505815`
 - open `[Attendance ...]` issues: none.
+
+### Update (2026-03-07): Dashboard Strict Source Hardening (`cancelled` filtering)
+
+Scope:
+
+- fixed dashboard strict source selection to avoid false P0 failures caused by `cancelled` strict runs.
+
+Implementation:
+
+- file: `scripts/ops/attendance-daily-gate-report.mjs`
+  - new helper: `pickLatestCompletedRun(runList, { excludeConclusions })`
+  - strict gate selection now excludes `cancelled`, `neutral`, and `skipped` conclusions, then falls back to latest completed if no preferred run exists.
+- file: `scripts/ops/attendance-daily-gate-report.test.mjs`
+  - added selection regression tests for excluded/fallback/no-completed scenarios.
+
+Local verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| `node --check scripts/ops/attendance-daily-gate-report.mjs` | PASS | local command output |
+| `node --test scripts/ops/attendance-daily-gate-report.test.mjs` | PASS | local command output |
+| `GH_TOKEN=... node scripts/ops/attendance-daily-gate-report.mjs` | PASS | `output/playwright/attendance-daily-gate-dashboard/20260307-121208/attendance-daily-gate-dashboard.json`, `output/playwright/attendance-daily-gate-dashboard/20260307-121208/attendance-daily-gate-dashboard.md` |
+
+Key assertions:
+
+- generated dashboard keeps strict gate on effective success source:
+  - `gateFlat.strict.runId=22798551601`
+  - `gateFlat.strict.conclusion=success`
+  - `overallStatus=pass`, `p0Status=pass`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4055,3 +4055,38 @@ Observed highlights:
 Decision:
 
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-07): Dashboard Strict Source Selection Hardening (`cancelled` filter)
+
+Goal:
+
+- prevent false P0 dashboard failures when a newer strict run is `cancelled` and a valid strict signal already exists.
+
+Code changes:
+
+- `scripts/ops/attendance-daily-gate-report.mjs`
+  - added `pickLatestCompletedRun()` with exclusion support.
+  - strict gate now selects latest completed run excluding `cancelled|neutral|skipped` (with fallback when no valid run exists).
+  - added direct-execution guard (`import.meta.url`) to allow safe function import for tests.
+- `scripts/ops/attendance-daily-gate-report.test.mjs`
+  - added regression tests for strict source selection behavior.
+
+Verification:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Node syntax | local | PASS | `node --check scripts/ops/attendance-daily-gate-report.mjs` |
+| Source selection unit tests | local | PASS | `node --test scripts/ops/attendance-daily-gate-report.test.mjs` |
+| Dashboard report generation (main, lookback=48h) | local (20260307-121208) | PASS | `output/playwright/attendance-daily-gate-dashboard/20260307-121208/attendance-daily-gate-dashboard.json`, `output/playwright/attendance-daily-gate-dashboard/20260307-121208/attendance-daily-gate-dashboard.md` |
+
+Observed highlights:
+
+- dashboard result remains green and binds strict source to success run:
+  - `overallStatus=pass`
+  - `p0Status=pass`
+  - `gateFlat.strict.runId=22798551601`
+  - `gateFlat.strict.conclusion=success`
+
+Decision:
+
+- **GO maintained**.

--- a/scripts/ops/attendance-daily-gate-report.mjs
+++ b/scripts/ops/attendance-daily-gate-report.mjs
@@ -15,6 +15,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
+import { pathToFileURL } from 'url'
 
 const token = String(process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '').trim()
 const repo = String(process.env.GITHUB_REPOSITORY || 'zensgit/metasheet2').trim()
@@ -555,6 +556,25 @@ function formatRun(run) {
     updatedAt: run.updated_at || null,
     url: run.html_url || null,
   }
+}
+
+export function pickLatestCompletedRun(runList, options = {}) {
+  const list = Array.isArray(runList) ? runList : []
+  const excluded = new Set(
+    Array.isArray(options.excludeConclusions)
+      ? options.excludeConclusions
+        .map((value) => String(value || '').trim().toLowerCase())
+        .filter(Boolean)
+      : [],
+  )
+
+  const completedRuns = list.filter((run) => run?.status === 'completed')
+  const preferred = completedRuns.find((run) => {
+    const conclusion = String(run?.conclusion || '').trim().toLowerCase()
+    return !excluded.has(conclusion)
+  })
+  if (preferred) return preferred
+  return completedRuns[0] ?? null
 }
 
 function evaluateGate({ name, severity, latestAny, latestCompleted, now, lookbackHoursValue, fetchError }) {
@@ -1281,23 +1301,25 @@ async function run() {
   }
 
   const preflightLatestAny = preflightList[0] ?? null
-  const preflightLatestCompleted = preflightList.find((run) => run?.status === 'completed') ?? null
+  const preflightLatestCompleted = pickLatestCompletedRun(preflightList)
   const protectionLatestAny = protectionList[0] ?? null
-  const protectionLatestCompleted = protectionList.find((run) => run?.status === 'completed') ?? null
+  const protectionLatestCompleted = pickLatestCompletedRun(protectionList)
   const metricsLatestAny = metricsList[0] ?? null
-  const metricsLatestCompleted = metricsList.find((run) => run?.status === 'completed') ?? null
+  const metricsLatestCompleted = pickLatestCompletedRun(metricsList)
   const storageLatestAny = storageList[0] ?? null
-  const storageLatestCompleted = storageList.find((run) => run?.status === 'completed') ?? null
+  const storageLatestCompleted = pickLatestCompletedRun(storageList)
   const cleanupLatestAny = cleanupList[0] ?? null
-  const cleanupLatestCompleted = cleanupList.find((run) => run?.status === 'completed') ?? null
+  const cleanupLatestCompleted = pickLatestCompletedRun(cleanupList)
   const strictLatestAny = strictList[0] ?? null
-  const strictLatestCompleted = strictList.find((run) => run?.status === 'completed') ?? null
+  const strictLatestCompleted = pickLatestCompletedRun(strictList, {
+    excludeConclusions: ['cancelled', 'neutral', 'skipped'],
+  })
   const perfLatestAny = perfList[0] ?? null
-  const perfLatestCompleted = perfList.find((run) => run?.status === 'completed') ?? null
+  const perfLatestCompleted = pickLatestCompletedRun(perfList)
   const longrunLatestAny = longrunList[0] ?? null
-  const longrunLatestCompleted = longrunList.find((run) => run?.status === 'completed') ?? null
+  const longrunLatestCompleted = pickLatestCompletedRun(longrunList)
   const contractLatestAny = contractList[0] ?? null
-  const contractLatestCompleted = contractList.find((run) => run?.status === 'completed') ?? null
+  const contractLatestCompleted = pickLatestCompletedRun(contractList)
 
   const preflightGate = evaluateGate({
     name: 'Remote Preflight',
@@ -1797,7 +1819,15 @@ async function run() {
   console.log(`REPORT_JSON=${jsonPath}`)
 }
 
-run().catch((error) => {
-  const message = error instanceof Error ? error.message : String(error)
-  die(message)
-})
+const isDirectExecution = (() => {
+  const argvPath = process.argv[1]
+  if (!argvPath) return false
+  return import.meta.url === pathToFileURL(argvPath).href
+})()
+
+if (isDirectExecution) {
+  run().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error)
+    die(message)
+  })
+}

--- a/scripts/ops/attendance-daily-gate-report.test.mjs
+++ b/scripts/ops/attendance-daily-gate-report.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { pickLatestCompletedRun } from './attendance-daily-gate-report.mjs'
+
+test('pickLatestCompletedRun skips excluded conclusions and falls back to previous valid run', () => {
+  const list = [
+    { id: 4, status: 'in_progress', conclusion: '' },
+    { id: 3, status: 'completed', conclusion: 'cancelled' },
+    { id: 2, status: 'completed', conclusion: 'success' },
+    { id: 1, status: 'completed', conclusion: 'failure' },
+  ]
+
+  const picked = pickLatestCompletedRun(list, {
+    excludeConclusions: ['cancelled', 'neutral', 'skipped'],
+  })
+
+  assert.equal(picked?.id, 2)
+  assert.equal(picked?.conclusion, 'success')
+})
+
+test('pickLatestCompletedRun falls back to latest completed when all are excluded', () => {
+  const list = [
+    { id: 3, status: 'completed', conclusion: 'cancelled' },
+    { id: 2, status: 'completed', conclusion: 'cancelled' },
+    { id: 1, status: 'queued', conclusion: '' },
+  ]
+
+  const picked = pickLatestCompletedRun(list, {
+    excludeConclusions: ['cancelled'],
+  })
+
+  assert.equal(picked?.id, 3)
+  assert.equal(picked?.conclusion, 'cancelled')
+})
+
+test('pickLatestCompletedRun returns null when no completed run exists', () => {
+  const list = [
+    { id: 2, status: 'queued', conclusion: '' },
+    { id: 1, status: 'in_progress', conclusion: '' },
+  ]
+
+  const picked = pickLatestCompletedRun(list, {
+    excludeConclusions: ['cancelled'],
+  })
+
+  assert.equal(picked, null)
+})


### PR DESCRIPTION
## Summary
- fix daily dashboard strict source selection to avoid false P0 when latest strict run is cancelled
- add `pickLatestCompletedRun()` helper and strict exclusions (`cancelled|neutral|skipped`)
- add regression tests for selection fallback behavior
- append 2026-03-07 verification evidence to production gate docs

## Verification
- `node --check scripts/ops/attendance-daily-gate-report.mjs`
- `node --test scripts/ops/attendance-daily-gate-report.test.mjs`
- `GH_TOKEN="$(gh auth token)" BRANCH=main LOOKBACK_HOURS=48 node scripts/ops/attendance-daily-gate-report.mjs`
  - output: `output/playwright/attendance-daily-gate-dashboard/20260307-121208/attendance-daily-gate-dashboard.json`
  - assert: `gateFlat.strict.runId=22798551601`, `gateFlat.strict.conclusion=success`, `p0Status=pass`
