### PR TITLE
docs(onprem): publish 2026-03-07 package evidence + new-server UAT runbook

### DIFF
--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4090,3 +4090,43 @@ Observed highlights:
 Decision:
 
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-07): Mainline Re-Verify After PR #357 + On-Prem Release Publish
+
+Scope:
+
+- verified mainline gates after merging PR #357 (`cancelled` strict source filtering).
+- built and published a new on-prem package release for Windows/WSL deployment.
+
+Mainline gate verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Branch Policy Drift (Prod) | #22798887029 | PASS | `output/playwright/attendance-post-merge-verify/20260307-201628/ga/22798887029/attendance-branch-policy-drift-prod-22798887029-1/policy.json` |
+| Attendance Strict Gates (Prod) | #22798894891 | PASS | `output/playwright/attendance-post-merge-verify/20260307-201628/ga/22798894891/attendance-strict-gates-prod-22798894891-1/20260307-122007-1/gate-summary.json`, `output/playwright/attendance-post-merge-verify/20260307-201628/ga/22798894891/attendance-strict-gates-prod-22798894891-1/20260307-122007-2/gate-api-smoke.log` |
+| Attendance Daily Gate Dashboard | #22798961789 | PASS | `output/playwright/attendance-post-merge-verify/20260307-201628/ga/22798961789/attendance-daily-gate-dashboard-22798961789-1/attendance-daily-gate-dashboard.json`, `output/playwright/attendance-post-merge-verify/20260307-201628/ga/22798961789/attendance-daily-gate-dashboard-22798961789-1/attendance-daily-gate-dashboard.md` |
+
+Package release verification:
+
+| Check | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance On-Prem Package Build + Release publish | #22798975422 | PASS | `output/playwright/ga/22798975422/metasheet-attendance-onprem-v2.5.0-20260307-current.zip`, `output/playwright/ga/22798975422/metasheet-attendance-onprem-v2.5.0-20260307-current.tgz`, `output/playwright/ga/22798975422/SHA256SUMS` |
+| Package checksum verify | local | PASS | `cd output/playwright/ga/22798975422 && shasum -a 256 -c SHA256SUMS` |
+| Package content verify (.zip/.tgz) | local | PASS | `scripts/ops/attendance-onprem-package-verify.sh output/playwright/ga/22798975422/metasheet-attendance-onprem-v2.5.0-20260307-current.zip`, `scripts/ops/attendance-onprem-package-verify.sh output/playwright/ga/22798975422/metasheet-attendance-onprem-v2.5.0-20260307-current.tgz` |
+
+Release:
+
+- tag: `v2.5.1-onprem-20260307-current`
+- url: `https://github.com/zensgit/metasheet2/releases/tag/v2.5.1-onprem-20260307-current`
+
+Observed highlights:
+
+- dashboard is green with effective strict source:
+  - `overallStatus=pass`
+  - `p0Status=pass`
+  - `gateFlat.strict.runId=22798894891`
+- open attendance issues: `[]`.
+
+Decision:
+
+- **GO maintained**.

--- a/docs/deployment/attendance-onprem-new-server-uat-runbook-20260307.md
+++ b/docs/deployment/attendance-onprem-new-server-uat-runbook-20260307.md
@@ -1,0 +1,77 @@
+# Attendance On-Prem New-Server UAT Runbook (2026-03-07)
+
+## Scope
+
+- Target: Windows Server + WSL2 on-prem deployment.
+- Package source: Release `v2.5.1-onprem-20260307-current`.
+- Goal: complete production-readiness UAT for attendance-only mode.
+
+## Inputs (fill before execution)
+
+- `WINDOWS_SERVER_IP=<...>`
+- `WSL_DISTRO=<...>` (example: `Ubuntu-22.04`)
+- `ADMIN_EMAIL=<...>`
+- `ADMIN_PASSWORD=<...>`
+
+## Step 1: Download and verify package
+
+On operator machine:
+
+```bash
+gh release download v2.5.1-onprem-20260307-current \
+  --repo zensgit/metasheet2 \
+  --pattern 'metasheet-attendance-onprem-v2.5.0-20260307-current*' \
+  --pattern 'SHA256SUMS' \
+  -D output/playwright/onprem/v2.5.1-onprem-20260307-current
+```
+
+```bash
+cd output/playwright/onprem/v2.5.1-onprem-20260307-current
+shasum -a 256 -c SHA256SUMS
+```
+
+## Step 2: WSL deploy (copy-execute)
+
+Follow the exact commands in:
+
+- `docs/deployment/attendance-windows-wsl-customer-profiled-commands-20260306.md`
+- `docs/deployment/attendance-windows-wsl-onprem-20260306.md`
+
+Mandatory post-install checks:
+
+```bash
+cd /opt/metasheet
+ENV_FILE=/opt/metasheet/docker/app.env REQUIRE_ATTENDANCE_ONLY=1 scripts/ops/attendance-onprem-env-check.sh
+SERVICE_MANAGER=auto CHECK_NGINX=1 scripts/ops/attendance-onprem-healthcheck.sh
+```
+
+## Step 3: Functional UAT (attendance core)
+
+Open:
+
+- `http://<WINDOWS_SERVER_IP>/attendance`
+
+Checklist:
+
+1. Admin login succeeds and opens attendance-only shell.
+2. Check in/out works for employee account.
+3. Adjustment request submit/approve/reject works.
+4. Import upload + preview + commit works.
+5. Summary/records/report load without API errors.
+6. Mobile view shows core flow and desktop-only gating text where expected.
+
+## Step 4: Sign-off artifacts
+
+Capture and store:
+
+- Browser screenshots for each checklist item.
+- Healthcheck outputs.
+- Final signed template:
+  - `docs/deployment/attendance-uat-signoff-template-20260306.md`
+- Go-live checklist:
+  - `docs/deployment/attendance-go-live-checklist-20260306.md`
+
+## Status record (this turn)
+
+- Package build/release verification: complete (`run #22798975422`).
+- New-server execution: pending actual server access and operator input values.

--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -168,3 +168,35 @@ BUILD_WEB=1 BUILD_BACKEND=1 INSTALL_DEPS=1 scripts/ops/attendance-onprem-package
 5. UAT 签收模板：`docs/deployment/attendance-uat-signoff-template-20260306.md`
 6. Windows Server + WSL2 部署：`docs/deployment/attendance-windows-wsl-onprem-20260306.md`
 7. Windows Server + WSL2 参数集中命令版：`docs/deployment/attendance-windows-wsl-customer-profiled-commands-20260306.md`
+8. 新服务器 UAT 执行 Runbook：`docs/deployment/attendance-onprem-new-server-uat-runbook-20260307.md`
+
+## Update (2026-03-07): Latest Published On-Prem Package (Windows/WSL Ready)
+
+Latest release:
+
+- Tag: `v2.5.1-onprem-20260307-current`
+- Release URL: `https://github.com/zensgit/metasheet2/releases/tag/v2.5.1-onprem-20260307-current`
+- Package files:
+  - `metasheet-attendance-onprem-v2.5.0-20260307-current.zip`
+  - `metasheet-attendance-onprem-v2.5.0-20260307-current.tgz`
+  - `SHA256SUMS`
+
+Build evidence:
+
+- GitHub Actions run: `#22798975422` (workflow: `attendance-onprem-package-build.yml`)
+- Local artifact archive path:
+  - `output/playwright/ga/22798975422/`
+
+Integrity verification:
+
+```bash
+cd output/playwright/ga/22798975422
+shasum -a 256 -c SHA256SUMS
+```
+
+Package structural verification:
+
+```bash
+scripts/ops/attendance-onprem-package-verify.sh output/playwright/ga/22798975422/metasheet-attendance-onprem-v2.5.0-20260307-current.zip
+scripts/ops/attendance-onprem-package-verify.sh output/playwright/ga/22798975422/metasheet-attendance-onprem-v2.5.0-20260307-current.tgz
+```


### PR DESCRIPTION
## Summary
- append mainline re-verify + on-prem release publish evidence (2026-03-07)
- record package build run, release tag/url, and local checksum/package verification results
- add new-server UAT runbook for Windows+WSL execution

## Verification
- post-merge verify:
  - branch policy #22798887029 PASS
  - strict #22798894891 PASS
  - dashboard #22798961789 PASS
- package release build #22798975422 PASS
- local package checks:
  - `shasum -a 256 -c output/playwright/ga/22798975422/SHA256SUMS`
  - `scripts/ops/attendance-onprem-package-verify.sh` for zip and tgz
