### PR TITLE
chore(onprem): add no-GitHub-link guard for delivery package

### DIFF
--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4130,3 +4130,34 @@ Observed highlights:
 Decision:
 
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-07): On-Prem Package No-GitHub-Link Guard
+
+Goal:
+
+- enforce customer delivery policy: Windows/on-prem package files must not include GitHub links.
+
+Changes:
+
+- `scripts/ops/attendance-onprem-package-verify.sh`
+  - added `VERIFY_NO_GITHUB_LINKS=1` (default enabled).
+  - now scans package `INSTALL.txt` + `docs/deployment/**` for:
+    - `github.com`
+    - `githubusercontent.com`
+    - `github.io`
+  - verification fails if any hit is found.
+- `docs/deployment/attendance-onprem-package-layout-20260306.md`
+  - removed direct GitHub release URL from packaged deployment doc.
+
+Verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| Deployment docs scan (`docs/deployment`) | PASS | `rg -n --ignore-case "github\\.com|githubusercontent\\.com|github\\.io" docs/deployment` (no hits) |
+| Local package build (link-audit tag) | PASS | `output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260307-linkaudit-local.zip`, `output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260307-linkaudit-local.tgz` |
+| Package verify (.zip) with link guard | PASS | `scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260307-linkaudit-local.zip` |
+| Package verify (.tgz) with link guard | PASS | `scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260307-linkaudit-local.tgz` |
+
+Decision:
+
+- **GO maintained**.

--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -175,7 +175,7 @@ BUILD_WEB=1 BUILD_BACKEND=1 INSTALL_DEPS=1 scripts/ops/attendance-onprem-package
 Latest release:
 
 - Tag: `v2.5.1-onprem-20260307-current`
-- Release URL: `https://github.com/zensgit/metasheet2/releases/tag/v2.5.1-onprem-20260307-current`
+- Release delivery channel: customer delivery repository / internal artifact source (no public GitHub link in package docs)
 - Package files:
   - `metasheet-attendance-onprem-v2.5.0-20260307-current.zip`
   - `metasheet-attendance-onprem-v2.5.0-20260307-current.tgz`

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 PACKAGE_FILE="${1:-}"
 VERIFY_SHA="${VERIFY_SHA:-1}"
+VERIFY_NO_GITHUB_LINKS="${VERIFY_NO_GITHUB_LINKS:-1}"
 EXTRACT_ROOT="${EXTRACT_ROOT:-}"
 cleanup_extract_root=0
 list_file=""
@@ -14,6 +15,35 @@ function die() {
 
 function info() {
   echo "[attendance-onprem-package-verify] $*" >&2
+}
+
+function verify_no_github_links() {
+  local root="$1"
+  local patterns='github\.com|githubusercontent\.com|github\.io'
+  local targets=()
+
+  [[ -f "${root}/INSTALL.txt" ]] && targets+=("${root}/INSTALL.txt")
+  [[ -d "${root}/docs/deployment" ]] && targets+=("${root}/docs/deployment")
+
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  if command -v rg >/dev/null 2>&1; then
+    if rg -n --ignore-case "$patterns" "${targets[@]}" >/tmp/attendance_onprem_link_hits.txt 2>/dev/null; then
+      cat /tmp/attendance_onprem_link_hits.txt >&2 || true
+      rm -f /tmp/attendance_onprem_link_hits.txt || true
+      die "Found disallowed GitHub links in on-prem package delivery files"
+    fi
+    rm -f /tmp/attendance_onprem_link_hits.txt || true
+  else
+    if grep -RInE "$patterns" "${targets[@]}" >/tmp/attendance_onprem_link_hits.txt 2>/dev/null; then
+      cat /tmp/attendance_onprem_link_hits.txt >&2 || true
+      rm -f /tmp/attendance_onprem_link_hits.txt || true
+      die "Found disallowed GitHub links in on-prem package delivery files"
+    fi
+    rm -f /tmp/attendance_onprem_link_hits.txt || true
+  fi
 }
 
 function verify_sha() {
@@ -106,6 +136,10 @@ required=(
 for rel in "${required[@]}"; do
   [[ -e "${pkg_root}/${rel}" ]] || die "Required package content missing: ${rel}"
 done
+
+if [[ "$VERIFY_NO_GITHUB_LINKS" == "1" ]]; then
+  verify_no_github_links "$pkg_root"
+fi
 
 info "Package verify OK"
 info "  package: ${PACKAGE_FILE}"


### PR DESCRIPTION
## Summary
- enforce no-GitHub-link policy in on-prem package verification
- scan `INSTALL.txt` and `docs/deployment/**` for `github.com|githubusercontent.com|github.io`
- remove direct GitHub release URL from packaged deployment layout doc
- append verification evidence to production Go/No-Go doc

## Verification
- `rg -n --ignore-case "github\\.com|githubusercontent\\.com|github\\.io" docs/deployment` (no hits)
- `pnpm --filter @metasheet/web build`
- `pnpm --filter @metasheet/core-backend build`
- `PACKAGE_TAG=20260307-linkaudit-local scripts/ops/attendance-onprem-package-build.sh`
- `scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260307-linkaudit-local.zip`
- `scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.5.0-20260307-linkaudit-local.tgz`
