### PR TITLE
fix(attendance-dashboard): ignore cancelled perf/longrun source runs

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4155,3 +4155,29 @@ Key assertions:
 - baseline no-input dispatch confirms stable defaults (`rows=10000`, `commitAsync=false`, `uploadCsv=true`).
 - strict gate chain remains healthy with upload/idempotency/export checks passing.
 - dashboard remains green (`overallStatus=pass`, `p0Status=pass`).
+
+### Update (2026-03-07): Perf/Longrun Source Selection Hardening (`cancelled` filter)
+
+Scope:
+
+- align perf source selection with strict-source behavior to avoid false dashboard P1 findings on cancelled runs.
+
+Implementation:
+
+- file: `scripts/ops/attendance-daily-gate-report.mjs`
+- `pickLatestCompletedRun(..., excludeConclusions=['cancelled','neutral','skipped'])` now applied to:
+  - `Perf Baseline`
+  - `Perf Long Run`
+
+Validation:
+
+| Check | Status | Evidence |
+|---|---|---|
+| Source-selection unit tests | PASS | `node --test scripts/ops/attendance-daily-gate-report.test.mjs` |
+| Dashboard report generation (main) | PASS | `output/playwright/attendance-daily-gate-dashboard/20260307-143043/attendance-daily-gate-dashboard.json`, `output/playwright/attendance-daily-gate-dashboard/20260307-143043/attendance-daily-gate-dashboard.md` |
+
+Key assertions:
+
+- dashboard remains green and binds perf/longrun to effective runs:
+  - `gateFlat.perf.runId=22800666933`
+  - `gateFlat.longrun.runId=22800250399`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2636,6 +2636,32 @@ Decision:
 
 - **GO maintained**.
 
+## Post-Go Hardening (2026-03-07): Dashboard Perf/Longrun Source Selection (`cancelled` filtering)
+
+Goal:
+
+- avoid false P1 dashboard failures when the latest perf/longrun run is `cancelled` but a valid completed signal exists.
+
+Change:
+
+- file: `scripts/ops/attendance-daily-gate-report.mjs`
+- gate source selection now excludes `cancelled/neutral/skipped` for:
+  - `Perf Baseline`
+  - `Perf Long Run`
+- behavior matches strict gate strategy and still falls back to latest completed when all candidates are excluded.
+
+Verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| `node --check scripts/ops/attendance-daily-gate-report.mjs` | PASS | local command |
+| `node --test scripts/ops/attendance-daily-gate-report.test.mjs` | PASS | local command |
+| Dashboard report generation (`main`) | PASS | `output/playwright/attendance-daily-gate-dashboard/20260307-143043/attendance-daily-gate-dashboard.json`, `output/playwright/attendance-daily-gate-dashboard/20260307-143043/attendance-daily-gate-dashboard.md` (`gateFlat.perf.runId=22800666933`, `gateFlat.longrun.runId=22800250399`) |
+
+Decision:
+
+- **GO maintained** (false-alert surface reduced, no contract change).
+
 ## Post-Go Hardening (2026-03-07): Perf Baseline Manual Default Profile
 
 Goal:

--- a/scripts/ops/attendance-daily-gate-report.mjs
+++ b/scripts/ops/attendance-daily-gate-report.mjs
@@ -1315,9 +1315,13 @@ async function run() {
     excludeConclusions: ['cancelled', 'neutral', 'skipped'],
   })
   const perfLatestAny = perfList[0] ?? null
-  const perfLatestCompleted = pickLatestCompletedRun(perfList)
+  const perfLatestCompleted = pickLatestCompletedRun(perfList, {
+    excludeConclusions: ['cancelled', 'neutral', 'skipped'],
+  })
   const longrunLatestAny = longrunList[0] ?? null
-  const longrunLatestCompleted = pickLatestCompletedRun(longrunList)
+  const longrunLatestCompleted = pickLatestCompletedRun(longrunList, {
+    excludeConclusions: ['cancelled', 'neutral', 'skipped'],
+  })
   const contractLatestAny = contractList[0] ?? null
   const contractLatestCompleted = pickLatestCompletedRun(contractList)
 


### PR DESCRIPTION
## Summary
- harden dashboard run-source selection for perf gates to avoid false P1 failures on cancelled runs
- apply same exclusion policy used by strict gate (`cancelled|neutral|skipped`) to:
  - Perf Baseline
  - Perf Long Run
- append verification evidence to Go/No-Go and Daily Gates docs

## Why
Perf workflows can have cancelled completed runs (concurrency/superseded reruns). Selecting the latest completed unconditionally can produce false `RUN_FAILED` findings even when a newer valid success signal exists nearby.

## Verification
- `node --check scripts/ops/attendance-daily-gate-report.mjs`
- `node --test scripts/ops/attendance-daily-gate-report.test.mjs`
- `GH_TOKEN="$(gh auth token)" BRANCH=main LOOKBACK_HOURS=48 node scripts/ops/attendance-daily-gate-report.mjs`
- `jq '{perf: .gateFlat.perf.runId, longrun: .gateFlat.longrun.runId, overallStatus, p0Status}' output/playwright/attendance-daily-gate-dashboard/20260307-143043/attendance-daily-gate-dashboard.json`

## Evidence
- `output/playwright/attendance-daily-gate-dashboard/20260307-143043/attendance-daily-gate-dashboard.json`
- `output/playwright/attendance-daily-gate-dashboard/20260307-143043/attendance-daily-gate-dashboard.md`
