### PR TITLE
fix(attendance-dashboard): apply non-signal filtering to all gate sources

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4181,3 +4181,26 @@ Key assertions:
 - dashboard remains green and binds perf/longrun to effective runs:
   - `gateFlat.perf.runId=22800666933`
   - `gateFlat.longrun.runId=22800250399`.
+
+### Update (2026-03-07): Non-signal Conclusion Filter Applied to All Gates
+
+Scope:
+
+- extend `cancelled/neutral/skipped` filtering from strict/perf to all gate sources for consistent signal selection.
+
+Implementation:
+
+- file: `scripts/ops/attendance-daily-gate-report.mjs`
+- shared exclusion list now used by source selection of:
+  - preflight / protection / metrics / storage / cleanup / strict / perf / longrun / contract
+
+Validation:
+
+| Check | Status | Evidence |
+|---|---|---|
+| Source-selection unit tests | PASS | `node --test scripts/ops/attendance-daily-gate-report.test.mjs` |
+| Dashboard report generation (main) | PASS | `output/playwright/attendance-daily-gate-dashboard/20260307-143813/attendance-daily-gate-dashboard.json`, `output/playwright/attendance-daily-gate-dashboard/20260307-143813/attendance-daily-gate-dashboard.md` |
+
+Key assertions:
+
+- report remained green with all gate conclusions at `success`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2662,6 +2662,38 @@ Decision:
 
 - **GO maintained** (false-alert surface reduced, no contract change).
 
+## Post-Go Hardening (2026-03-07): Dashboard Non-signal Conclusion Filter for All Gates
+
+Goal:
+
+- unify gate source selection so `cancelled/neutral/skipped` runs do not become primary signals for any gate.
+
+Change:
+
+- file: `scripts/ops/attendance-daily-gate-report.mjs`
+- introduced shared `nonSignalConclusions` and applied it to:
+  - Remote Preflight
+  - Branch Protection
+  - Host Metrics
+  - Storage Health
+  - Upload Cleanup
+  - Strict Gates
+  - Perf Baseline
+  - Perf Long Run
+  - Gate Contract Matrix
+
+Verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| `node --check scripts/ops/attendance-daily-gate-report.mjs` | PASS | local command |
+| `node --test scripts/ops/attendance-daily-gate-report.test.mjs` | PASS | local command |
+| Dashboard report generation (`main`) | PASS | `output/playwright/attendance-daily-gate-dashboard/20260307-143813/attendance-daily-gate-dashboard.json`, `output/playwright/attendance-daily-gate-dashboard/20260307-143813/attendance-daily-gate-dashboard.md` (`overallStatus=pass`, all gate conclusions `success`) |
+
+Decision:
+
+- **GO maintained** (run-source behavior is now consistent across all gates).
+
 ## Post-Go Hardening (2026-03-07): Perf Baseline Manual Default Profile
 
 Goal:

--- a/scripts/ops/attendance-daily-gate-report.mjs
+++ b/scripts/ops/attendance-daily-gate-report.mjs
@@ -30,6 +30,7 @@ const strictWorkflow = String(process.env.STRICT_WORKFLOW || 'attendance-strict-
 const perfWorkflow = String(process.env.PERF_WORKFLOW || 'attendance-import-perf-baseline.yml').trim()
 const longrunWorkflow = String(process.env.LONGRUN_WORKFLOW || 'attendance-import-perf-longrun.yml').trim()
 const contractWorkflow = String(process.env.CONTRACT_WORKFLOW || 'attendance-gate-contract-matrix.yml').trim()
+const nonSignalConclusions = ['cancelled', 'neutral', 'skipped']
 const protectionWorkflow = String(process.env.PROTECTION_WORKFLOW || 'attendance-branch-policy-drift-prod.yml').trim()
 const protectionArtifactPrefix = protectionWorkflow.includes('branch-policy-drift')
   ? 'attendance-branch-policy-drift-prod'
@@ -1301,29 +1302,41 @@ async function run() {
   }
 
   const preflightLatestAny = preflightList[0] ?? null
-  const preflightLatestCompleted = pickLatestCompletedRun(preflightList)
+  const preflightLatestCompleted = pickLatestCompletedRun(preflightList, {
+    excludeConclusions: nonSignalConclusions,
+  })
   const protectionLatestAny = protectionList[0] ?? null
-  const protectionLatestCompleted = pickLatestCompletedRun(protectionList)
+  const protectionLatestCompleted = pickLatestCompletedRun(protectionList, {
+    excludeConclusions: nonSignalConclusions,
+  })
   const metricsLatestAny = metricsList[0] ?? null
-  const metricsLatestCompleted = pickLatestCompletedRun(metricsList)
+  const metricsLatestCompleted = pickLatestCompletedRun(metricsList, {
+    excludeConclusions: nonSignalConclusions,
+  })
   const storageLatestAny = storageList[0] ?? null
-  const storageLatestCompleted = pickLatestCompletedRun(storageList)
+  const storageLatestCompleted = pickLatestCompletedRun(storageList, {
+    excludeConclusions: nonSignalConclusions,
+  })
   const cleanupLatestAny = cleanupList[0] ?? null
-  const cleanupLatestCompleted = pickLatestCompletedRun(cleanupList)
+  const cleanupLatestCompleted = pickLatestCompletedRun(cleanupList, {
+    excludeConclusions: nonSignalConclusions,
+  })
   const strictLatestAny = strictList[0] ?? null
   const strictLatestCompleted = pickLatestCompletedRun(strictList, {
-    excludeConclusions: ['cancelled', 'neutral', 'skipped'],
+    excludeConclusions: nonSignalConclusions,
   })
   const perfLatestAny = perfList[0] ?? null
   const perfLatestCompleted = pickLatestCompletedRun(perfList, {
-    excludeConclusions: ['cancelled', 'neutral', 'skipped'],
+    excludeConclusions: nonSignalConclusions,
   })
   const longrunLatestAny = longrunList[0] ?? null
   const longrunLatestCompleted = pickLatestCompletedRun(longrunList, {
-    excludeConclusions: ['cancelled', 'neutral', 'skipped'],
+    excludeConclusions: nonSignalConclusions,
   })
   const contractLatestAny = contractList[0] ?? null
-  const contractLatestCompleted = pickLatestCompletedRun(contractList)
+  const contractLatestCompleted = pickLatestCompletedRun(contractList, {
+    excludeConclusions: nonSignalConclusions,
+  })
 
   const preflightGate = evaluateGate({
     name: 'Remote Preflight',


### PR DESCRIPTION
## Summary
- apply non-signal conclusion filtering (`cancelled|neutral|skipped`) to all dashboard gate source selections
- keeps failure signal intact (`failure` is not excluded)
- unifies source-selection behavior across preflight/protection/metrics/storage/cleanup/strict/perf/longrun/contract
- append verification evidence to Go/No-Go and Daily Gates docs

## Why
Cancelled/superseded runs are common in daily automation. Selecting them as the latest completed source can create false gate failures. This change ensures each gate prefers an effective signal run while preserving failure detection.

## Verification
- `node --check scripts/ops/attendance-daily-gate-report.mjs`
- `node --test scripts/ops/attendance-daily-gate-report.test.mjs`
- `GH_TOKEN="$(gh auth token)" BRANCH=main LOOKBACK_HOURS=48 node scripts/ops/attendance-daily-gate-report.mjs`
- `jq '{overallStatus,p0Status,preflight:.gateFlat.preflight.conclusion,protection:.gateFlat.protection.conclusion,metrics:.gateFlat.metrics.conclusion,storage:.gateFlat.storage.conclusion,cleanup:.gateFlat.cleanup.conclusion,strict:.gateFlat.strict.conclusion,perf:.gateFlat.perf.conclusion,longrun:.gateFlat.longrun.conclusion,contract:.gateFlat.contract.conclusion}' output/playwright/attendance-daily-gate-dashboard/20260307-143813/attendance-daily-gate-dashboard.json`

## Evidence
- `output/playwright/attendance-daily-gate-dashboard/20260307-143813/attendance-daily-gate-dashboard.json`
- `output/playwright/attendance-daily-gate-dashboard/20260307-143813/attendance-daily-gate-dashboard.md`
