### PR TITLE
docs(attendance): append latest mainline gate snapshot evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4204,3 +4204,29 @@ Validation:
 Key assertions:
 
 - report remained green with all gate conclusions at `success`.
+
+### Update (2026-03-07): Mainline Gate Snapshot Refresh (`228011*`)
+
+Scope:
+
+- refresh evidence after latest strict rerun and rebind dashboard to latest strict/policy sources.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Branch Policy Drift (Prod) | #22801116838 | PASS | `output/playwright/ga/22801116838/attendance-branch-policy-drift-prod-22801116838-1/policy.json`, `output/playwright/ga/22801116838/attendance-branch-policy-drift-prod-22801116838-1/step-summary.md` |
+| Attendance Strict Gates (Prod) | #22801122984 | PASS | `output/playwright/ga/22801122984/attendance-strict-gates-prod-22801122984-1/20260307-144829-1/gate-summary.json`, `output/playwright/ga/22801122984/attendance-strict-gates-prod-22801122984-1/20260307-144829-2/gate-api-smoke.log` |
+| Attendance Daily Gate Dashboard | #22801208941 | PASS | `output/playwright/ga/22801208941/attendance-daily-gate-dashboard-22801208941-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22801208941/attendance-daily-gate-dashboard-22801208941-1/attendance-daily-gate-dashboard.md` |
+
+Key assertions:
+
+- strict smoke logs keep strict upload/idempotency/export coverage:
+  - `import upload ok`
+  - `idempotency ok`
+  - `export csv ok`
+  - `SMOKE PASS`
+- refreshed dashboard now references latest successful strict/policy runs:
+  - `gateFlat.strict.runId=22801122984`
+  - `gateFlat.protection.runId=22801116838`
+  - `overallStatus=pass`, `p0Status=pass`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4356,3 +4356,36 @@ Verification:
 Decision:
 
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-07): Mainline Gate Snapshot Refresh (`228011*`)
+
+Scope:
+
+- validate latest production gate chain on `main` after dashboard source-selection hardening and perf baseline default stabilization merges.
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Branch Policy Drift (Prod) | #22801116838 | PASS | `output/playwright/ga/22801116838/attendance-branch-policy-drift-prod-22801116838-1/policy.json`, `output/playwright/ga/22801116838/attendance-branch-policy-drift-prod-22801116838-1/step-summary.md` |
+| Attendance Strict Gates (Prod) | #22801122984 | PASS | `output/playwright/ga/22801122984/attendance-strict-gates-prod-22801122984-1/20260307-144829-1/gate-summary.json`, `output/playwright/ga/22801122984/attendance-strict-gates-prod-22801122984-1/20260307-144829-2/gate-api-smoke.log` |
+| Attendance Daily Gate Dashboard | #22801208941 | PASS | `output/playwright/ga/22801208941/attendance-daily-gate-dashboard-22801208941-1/attendance-daily-gate-dashboard.json`, `output/playwright/ga/22801208941/attendance-daily-gate-dashboard-22801208941-1/attendance-daily-gate-dashboard.md` |
+
+Observed highlights:
+
+- strict smoke keeps production-required checks green:
+  - `import upload ok`
+  - `idempotency ok`
+  - `export csv ok`
+  - `SMOKE PASS`
+- dashboard rebound to latest successful strict/policy runs:
+  - `gateFlat.strict.runId=22801122984`
+  - `gateFlat.protection.runId=22801116838`
+  - `overallStatus=pass`
+  - `p0Status=pass`
+- open attendance tracking issues:
+  - `[]` (checked via `gh issue list --search "[Attendance" --state open`)
+
+Decision:
+
+- **GO maintained**.


### PR DESCRIPTION
## Summary
- append latest 2026-03-07 mainline gate snapshot evidence to production docs
- record runIds for branch policy, strict gates, and dashboard rebind
- include local artifact paths and key assertions (`import upload ok`, `idempotency ok`, `export csv ok`)

## Verification
- `gh run watch 22801122984 --exit-status`
- `gh run watch 22801208941 --exit-status`
- `gh run download 22801116838 -D output/playwright/ga/22801116838`
- `gh run download 22801122984 -D output/playwright/ga/22801122984`
- `gh run download 22801208941 -D output/playwright/ga/22801208941`
- `node -e "const fs=require('fs');const p='output/playwright/ga/22801208941/attendance-daily-gate-dashboard-22801208941-1/attendance-daily-gate-dashboard.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));console.log(JSON.stringify({overallStatus:j.overallStatus,p0Status:j.p0Status,strictRun:j.gateFlat?.strict?.runId,protectionRun:j.gateFlat?.protection?.runId},null,2));"`
- `gh issue list --search "[Attendance" --state open --limit 20`
