### PR TITLE
feat(attendance-i18n): localize workflow designer fallback

### DIFF
--- a/apps/web/src/views/attendance/AttendanceWorkflowDesigner.vue
+++ b/apps/web/src/views/attendance/AttendanceWorkflowDesigner.vue
@@ -1,9 +1,9 @@
 <template>
   <section v-if="!canDesign" class="attendance-workflow">
     <article class="attendance-workflow__card">
-      <h3>Approval Workflow Designer</h3>
+      <h3>{{ t.title }}</h3>
       <p class="attendance-workflow__empty">
-        Workflow capability is not enabled for this tenant.
+        {{ t.disabledHint }}
       </p>
     </article>
   </section>
@@ -12,6 +12,8 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import WorkflowDesigner from '../WorkflowDesigner.vue'
 
 withDefaults(
@@ -22,6 +24,21 @@ withDefaults(
     canDesign: false,
   },
 )
+
+const { isZh } = useLocale()
+
+const t = computed(() => {
+  if (isZh.value) {
+    return {
+      title: '审批流程设计',
+      disabledHint: '当前租户未启用流程能力。',
+    }
+  }
+  return {
+    title: 'Approval Workflow Designer',
+    disabledHint: 'Workflow capability is not enabled for this tenant.',
+  }
+})
 </script>
 
 <style scoped>

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4259,3 +4259,32 @@ Key assertions:
 
 - post-merge summary now covers branch policy + strict + perf baseline + dashboard in one run.
 - dashboard remains green after perf insertion (`overallStatus=pass`, `p0Status=pass`).
+
+### Update (2026-03-07): Workflow Designer zh Copy Guard
+
+Scope:
+
+- remove remaining hard-coded English text in attendance workflow designer fallback card.
+- extend zh copy contract guard to also protect `AttendanceWorkflowDesigner.vue`.
+
+Implementation:
+
+- file: `apps/web/src/views/attendance/AttendanceWorkflowDesigner.vue`
+  - replaced hard-coded template text with locale-aware `t` computed values (`useLocale`).
+- file: `scripts/ops/attendance-verify-zh-copy-contract.mjs`
+  - added second guarded file contract for `AttendanceWorkflowDesigner.vue`.
+  - added template-only scan scope for this file so English fallback strings in script are allowed.
+
+Verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| zh copy contract | PASS | `node scripts/ops/attendance-verify-zh-copy-contract.mjs` |
+| web build (compile) | PASS | `pnpm --filter @metasheet/web build` |
+
+Key assertions:
+
+- fallback card copy is now zh/en localized.
+- zh contract guard now covers both:
+  - `AttendanceView.vue`
+  - `AttendanceWorkflowDesigner.vue`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4433,3 +4433,34 @@ Observed highlights:
 Decision:
 
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-07): Workflow Designer zh Localization + Copy Guard
+
+Scope:
+
+- close remaining zh localization gap in attendance workflow designer fallback UI.
+- extend zh copy contract guard coverage to include workflow designer file.
+
+Code changes:
+
+- `apps/web/src/views/attendance/AttendanceWorkflowDesigner.vue`
+  - localized fallback title/hint via `useLocale` + computed `t`.
+- `scripts/ops/attendance-verify-zh-copy-contract.mjs`
+  - added guarded file contract for `apps/web/src/views/attendance/AttendanceWorkflowDesigner.vue`.
+  - added `scope: 'template'` handling to avoid false positives from valid English fallback strings in script blocks.
+
+Verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| zh copy contract | PASS | `node scripts/ops/attendance-verify-zh-copy-contract.mjs` |
+| Frontend compile | PASS | `pnpm --filter @metasheet/web build` |
+
+Observed highlights:
+
+- workflow fallback card now renders localized zh/en copy through unified locale state.
+- zh copy guard now protects both `AttendanceView.vue` and `AttendanceWorkflowDesigner.vue` from hard-coded English template regressions.
+
+Decision:
+
+- **GO maintained**.

--- a/scripts/ops/attendance-verify-zh-copy-contract.mjs
+++ b/scripts/ops/attendance-verify-zh-copy-contract.mjs
@@ -1,59 +1,70 @@
 import fs from 'node:fs/promises'
 
-const attendanceViewPath = 'apps/web/src/views/AttendanceView.vue'
-
-const legacySnippets = [
-  '<h3>Records</h3>',
-  '{{ exporting ? \'Exporting...\' : \'Export CSV\' }}',
-  '<div v-if="records.length === 0" class="attendance__empty">No records.</div>',
-  '<h4>User Access</h4>',
-  '{{ provisionLoading ? \'Loading...\' : \'Load\' }}',
-  '{{ provisionLoading ? \'Working...\' : \'Assign role\' }}',
-  '{{ provisionLoading ? \'Working...\' : \'Remove role\' }}',
-  '<span>User search (email/name/id)</span>',
-  '<h4>Batch Provisioning</h4>',
-  '<h4>Audit Logs</h4>',
-  '{{ auditLogLoading ? \'Loading...\' : \'Reload logs\' }}',
-  '{{ auditLogExporting ? \'Exporting...\' : \'Export CSV\' }}',
-  '<h4>Rule Sets</h4>',
-  '{{ ruleSetLoading ? \'Loading...\' : \'Reload rule sets\' }}',
-  '<h4>Rule Template Library</h4>',
-  '<h4>Attendance groups</h4>',
-  '<h4>Group members</h4>',
-  '<h4>Import (DingTalk / Manual)</h4>',
-  '{{ importLoading ? \'Loading...\' : \'Load template\' }}',
-  '<span>Import mode</span>',
-  '<span>CSV file (optional)</span>',
-  '<span>User map key field</span>',
-  '<h4>Import batches</h4>',
-  '<h5 class="attendance__subheading">Batch items</h5>',
-  '<h4>Approval Flows</h4>',
-  '{{ approvalFlowLoading ? \'Loading...\' : \'Reload flows\' }}',
-  '<div v-if="approvalFlows.length === 0" class="attendance__empty">No approval flows yet.</div>',
-  '<h4>Rotation Rules</h4>',
-  '{{ rotationRuleLoading ? \'Loading...\' : \'Reload rotation rules\' }}',
-  '<h4>Rotation Assignments</h4>',
-  '{{ rotationAssignmentLoading ? \'Loading...\' : \'Reload rotations\' }}',
-  '<h4>Shifts</h4>',
-  '{{ shiftLoading ? \'Loading...\' : \'Reload shifts\' }}',
-  '<h4>Assignments</h4>',
-  '{{ assignmentLoading ? \'Loading...\' : \'Reload assignments\' }}',
-  '<h4>Holidays</h4>',
-  '{{ holidayLoading ? \'Loading...\' : \'Reload holidays\' }}',
-  'if (!window.confirm(\'Delete this approval flow?\')) return',
-  'if (!window.confirm(\'Delete this rotation rule?\')) return',
-  'if (!window.confirm(\'Delete this rotation assignment?\')) return',
-  'if (!window.confirm(\'Delete this shift? Assignments will be removed.\')) return',
-  'if (!window.confirm(\'Delete this assignment?\')) return',
-  'if (!window.confirm(\'Delete this holiday?\')) return',
-  'if (!window.confirm(\'Rollback this import batch?\')) return',
-  'if (!window.confirm(\'Delete this leave type?\')) return',
-  'if (!window.confirm(\'Delete this overtime rule?\')) return',
-  'if (!window.confirm(\'Delete this rule set?\')) return',
-  'if (!window.confirm(\'Delete this attendance group?\')) return',
-  'if (!window.confirm(\'Restore this template version? This will overwrite the current library.\')) return',
-  'if (!window.confirm(\'Delete this payroll template?\')) return',
-  'if (!window.confirm(\'Delete this payroll cycle?\')) return',
+const fileContracts = [
+  {
+    path: 'apps/web/src/views/AttendanceView.vue',
+    snippets: [
+      '<h3>Records</h3>',
+      '{{ exporting ? \'Exporting...\' : \'Export CSV\' }}',
+      '<div v-if="records.length === 0" class="attendance__empty">No records.</div>',
+      '<h4>User Access</h4>',
+      '{{ provisionLoading ? \'Loading...\' : \'Load\' }}',
+      '{{ provisionLoading ? \'Working...\' : \'Assign role\' }}',
+      '{{ provisionLoading ? \'Working...\' : \'Remove role\' }}',
+      '<span>User search (email/name/id)</span>',
+      '<h4>Batch Provisioning</h4>',
+      '<h4>Audit Logs</h4>',
+      '{{ auditLogLoading ? \'Loading...\' : \'Reload logs\' }}',
+      '{{ auditLogExporting ? \'Exporting...\' : \'Export CSV\' }}',
+      '<h4>Rule Sets</h4>',
+      '{{ ruleSetLoading ? \'Loading...\' : \'Reload rule sets\' }}',
+      '<h4>Rule Template Library</h4>',
+      '<h4>Attendance groups</h4>',
+      '<h4>Group members</h4>',
+      '<h4>Import (DingTalk / Manual)</h4>',
+      '{{ importLoading ? \'Loading...\' : \'Load template\' }}',
+      '<span>Import mode</span>',
+      '<span>CSV file (optional)</span>',
+      '<span>User map key field</span>',
+      '<h4>Import batches</h4>',
+      '<h5 class="attendance__subheading">Batch items</h5>',
+      '<h4>Approval Flows</h4>',
+      '{{ approvalFlowLoading ? \'Loading...\' : \'Reload flows\' }}',
+      '<div v-if="approvalFlows.length === 0" class="attendance__empty">No approval flows yet.</div>',
+      '<h4>Rotation Rules</h4>',
+      '{{ rotationRuleLoading ? \'Loading...\' : \'Reload rotation rules\' }}',
+      '<h4>Rotation Assignments</h4>',
+      '{{ rotationAssignmentLoading ? \'Loading...\' : \'Reload rotations\' }}',
+      '<h4>Shifts</h4>',
+      '{{ shiftLoading ? \'Loading...\' : \'Reload shifts\' }}',
+      '<h4>Assignments</h4>',
+      '{{ assignmentLoading ? \'Loading...\' : \'Reload assignments\' }}',
+      '<h4>Holidays</h4>',
+      '{{ holidayLoading ? \'Loading...\' : \'Reload holidays\' }}',
+      'if (!window.confirm(\'Delete this approval flow?\')) return',
+      'if (!window.confirm(\'Delete this rotation rule?\')) return',
+      'if (!window.confirm(\'Delete this rotation assignment?\')) return',
+      'if (!window.confirm(\'Delete this shift? Assignments will be removed.\')) return',
+      'if (!window.confirm(\'Delete this assignment?\')) return',
+      'if (!window.confirm(\'Delete this holiday?\')) return',
+      'if (!window.confirm(\'Rollback this import batch?\')) return',
+      'if (!window.confirm(\'Delete this leave type?\')) return',
+      'if (!window.confirm(\'Delete this overtime rule?\')) return',
+      'if (!window.confirm(\'Delete this rule set?\')) return',
+      'if (!window.confirm(\'Delete this attendance group?\')) return',
+      'if (!window.confirm(\'Restore this template version? This will overwrite the current library.\')) return',
+      'if (!window.confirm(\'Delete this payroll template?\')) return',
+      'if (!window.confirm(\'Delete this payroll cycle?\')) return',
+    ],
+  },
+  {
+    path: 'apps/web/src/views/attendance/AttendanceWorkflowDesigner.vue',
+    scope: 'template',
+    snippets: [
+      '<h3>Approval Workflow Designer</h3>',
+      'Workflow capability is not enabled for this tenant.',
+    ],
+  },
 ]
 
 function fail(message) {
@@ -62,12 +73,21 @@ function fail(message) {
 }
 
 async function run() {
-  const source = await fs.readFile(attendanceViewPath, 'utf8')
-  const found = legacySnippets.filter((snippet) => source.includes(snippet))
-  if (found.length > 0) {
-    fail(`legacy hard-coded English snippets detected (${found.length}):\n${found.map(item => `- ${item}`).join('\n')}`)
+  const failures = []
+  for (const contract of fileContracts) {
+    const source = await fs.readFile(contract.path, 'utf8')
+    const scopedSource = contract.scope === 'template'
+      ? source.split('<script')[0] || source
+      : source
+    const found = contract.snippets.filter((snippet) => scopedSource.includes(snippet))
+    if (found.length > 0) {
+      failures.push(`file=${contract.path}\n${found.map((item) => `- ${item}`).join('\n')}`)
+    }
   }
-  console.log('[attendance-verify-zh-copy-contract] PASS: no legacy hard-coded English snippets found in guarded attendance sections')
+  if (failures.length > 0) {
+    fail(`legacy hard-coded English snippets detected:\n${failures.join('\n')}`)
+  }
+  console.log('[attendance-verify-zh-copy-contract] PASS: no legacy hard-coded English snippets found in guarded attendance files')
 }
 
 run().catch((error) => {


### PR DESCRIPTION
## Summary
- localize the attendance workflow-designer fallback card (`zh/en`) via `useLocale`
- extend `attendance-verify-zh-copy-contract` guard coverage to include `AttendanceWorkflowDesigner.vue`
- update delivery/go-no-go docs with implementation + verification evidence

## Verification
- `node scripts/ops/attendance-verify-zh-copy-contract.mjs`
- `pnpm --filter @metasheet/web build` (validated in clean run with dependencies installed for this exact patch set)
