### PR TITLE
chore(attendance-i18n): guard experience-view zh template copy

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4288,3 +4288,28 @@ Key assertions:
 - zh contract guard now covers both:
   - `AttendanceView.vue`
   - `AttendanceWorkflowDesigner.vue`.
+
+### Update (2026-03-07): Experience View zh Template Guard
+
+Scope:
+
+- extend zh copy contract to guard `AttendanceExperienceView.vue` template from hard-coded English copy regressions.
+
+Implementation:
+
+- file: `scripts/ops/attendance-verify-zh-copy-contract.mjs`
+  - added guarded template snippets for:
+    - `Desktop recommended`
+    - `Back to Overview`
+    - `Capability not available`
+    - `Current account does not have access to this section.`
+
+Verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| zh copy contract | PASS | `node scripts/ops/attendance-verify-zh-copy-contract.mjs` |
+
+Key assertions:
+
+- attendance experience shell template now has explicit regression guard and remains localized via `t.*` bindings.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4464,3 +4464,32 @@ Observed highlights:
 Decision:
 
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-07): Experience View zh Copy Guard
+
+Scope:
+
+- add guard coverage for attendance experience shell template copy to prevent future hard-coded English regressions.
+
+Code changes:
+
+- `scripts/ops/attendance-verify-zh-copy-contract.mjs`
+  - added `AttendanceExperienceView.vue` template guard snippets:
+    - `Desktop recommended`
+    - `Back to Overview`
+    - `Capability not available`
+    - `Current account does not have access to this section.`
+
+Verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| zh copy contract | PASS | `node scripts/ops/attendance-verify-zh-copy-contract.mjs` |
+
+Observed highlights:
+
+- experience shell remains localized through computed `t` dictionary; no hard-coded English template text introduced.
+
+Decision:
+
+- **GO maintained**.

--- a/scripts/ops/attendance-verify-zh-copy-contract.mjs
+++ b/scripts/ops/attendance-verify-zh-copy-contract.mjs
@@ -65,6 +65,16 @@ const fileContracts = [
       'Workflow capability is not enabled for this tenant.',
     ],
   },
+  {
+    path: 'apps/web/src/views/attendance/AttendanceExperienceView.vue',
+    scope: 'template',
+    snippets: [
+      'Desktop recommended',
+      'Back to Overview',
+      'Capability not available',
+      'Current account does not have access to this section.',
+    ],
+  },
 ]
 
 function fail(message) {


### PR DESCRIPTION
## Summary
- extend zh copy contract guard coverage to `AttendanceExperienceView.vue` template
- prevent future hard-coded English regressions for desktop fallback shell copy
- append verification evidence to delivery/go-no-go docs

## Verification
- `node scripts/ops/attendance-verify-zh-copy-contract.mjs`
