### PR TITLE
docs(attendance): record 100k perf fallback recovery evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4349,3 +4349,39 @@ Key assertions:
 
 - post-merge verifier now fails fast if perf summary profile drifts from expected merge-close contract.
 - latest mainline run finished with `Failures: 0` and no open attendance issues.
+
+### Update (2026-03-08): 100k Perf Baseline Fallback To Rows Payload
+
+Scope:
+
+- unblock `rows=100000` perf baseline when production CSV row cap is lower than longrun target (observed `CSV_TOO_LARGE` at `max rows 20000`).
+
+Implementation:
+
+- file: `scripts/ops/attendance-import-perf.mjs`
+  - added payload selection controls:
+    - `PAYLOAD_SOURCE=auto|csv|rows` (default `auto`)
+    - `CSV_ROWS_LIMIT_HINT` (default `20000`)
+  - `auto` mode now switches to `rows` payload when `ROWS > CSV_ROWS_LIMIT_HINT`.
+  - perf summary now records:
+    - `uploadCsvRequested`
+    - `uploadCsv` (effective)
+    - `payloadSource`
+    - `payloadSourceReason`
+
+Verification runs:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Import Perf Baseline (main, pre-fix) | #22802735429 | FAIL (expected, pre-fix) | `output/playwright/ga/22802735429/attendance-import-perf-22802735429-1/perf.log` |
+| Attendance Import Perf Baseline (branch validation) | #22802826190 | PASS | `output/playwright/ga/22802826190/attendance-import-perf-22802826190-1/attendance-perf-mmgjnoxs-phigcg/perf-summary.json` |
+| Attendance Import Perf Baseline (main, post-merge) | #22802882495 | PASS | `output/playwright/ga/22802882495/attendance-import-perf-22802882495-1/attendance-perf-mmgjsitb-lnb0jd/perf-summary.json`, `output/playwright/ga/22802882495/attendance-import-perf-22802882495-1/perf.log` |
+
+Key assertions:
+
+- pre-fix failure root cause was `CSV_TOO_LARGE` during preview.
+- post-fix `100k` runs pass with explicit metadata:
+  - `uploadCsvRequested=true`
+  - `uploadCsv=false`
+  - `payloadSource=rows`
+  - `payloadSourceReason=rows_exceeds_csv_limit_hint(20000)`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4533,3 +4533,39 @@ Observed highlights:
 Decision:
 
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-08): 100k Perf Baseline Recovery (`CSV_TOO_LARGE` -> Rows Payload Fallback)
+
+Scope:
+
+- resolve 100k perf baseline regressions caused by low CSV row cap (`20000`) in production profile.
+
+Code changes:
+
+- `scripts/ops/attendance-import-perf.mjs`
+  - add `PAYLOAD_SOURCE=auto|csv|rows` and `CSV_ROWS_LIMIT_HINT` controls.
+  - default `auto` now falls back to `rows` payload when `ROWS` exceeds CSV limit hint.
+  - write payload selection metadata into `perf-summary.json`.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Perf baseline (main, pre-fix) | #22802735429 | FAIL (expected) | `output/playwright/ga/22802735429/attendance-import-perf-22802735429-1/perf.log` |
+| Perf baseline (branch, fix validation) | #22802826190 | PASS | `output/playwright/ga/22802826190/attendance-import-perf-22802826190-1/attendance-perf-mmgjnoxs-phigcg/perf-summary.json` |
+| Perf baseline (main, post-merge) | #22802882495 | PASS | `output/playwright/ga/22802882495/attendance-import-perf-22802882495-1/attendance-perf-mmgjsitb-lnb0jd/perf-summary.json`, `output/playwright/ga/22802882495/attendance-import-perf-22802882495-1/perf.log` |
+
+Observed highlights:
+
+- pre-fix failure message:
+  - `POST /attendance/import/preview: HTTP 400 ... CSV exceeds max rows (20000)`.
+- post-merge run confirms fallback metadata:
+  - `uploadCsvRequested=true`
+  - `uploadCsv=false`
+  - `payloadSource=rows`
+  - `payloadSourceReason=rows_exceeds_csv_limit_hint(20000)`
+- no open attendance gate issues after recovery (`gh issue list --search "[Attendance" --state open` returned empty).
+
+Decision:
+
+- **GO maintained**.


### PR DESCRIPTION
## Summary
- add GA daily gates note for 100k perf baseline recovery after rows-payload fallback
- add Go/No-Go post-go validation record with pre-fix failure and post-merge success evidence
- include run IDs and local evidence paths under `output/playwright/ga/...`

## Evidence
- pre-fix fail (main): #22802735429
- branch validation pass: #22802826190
- post-merge pass (main): #22802882495
- no open attendance issues after recovery
