### PR TITLE
docs(attendance): add nightly post-merge gate evidence run

### DIFF
--- a/docs/attendance-parallel-development-20260308.md
+++ b/docs/attendance-parallel-development-20260308.md
@@ -205,6 +205,9 @@ Result: PASS
   - perf-baseline run `22814866134` PASS
   - daily-dashboard run `22814879184` PASS
   - perf-baseline-contract PASS.
+- Nightly workflow validation (after merge to main):
+  - `Attendance Post-Merge Verify (Nightly)` run `22815149297` PASS
+  - artifact summary: `output/playwright/ga/22815149297/attendance-post-merge-verify-22815149297-1/summary.md`
 - Note:
   - direct dispatch of new workflow file on non-default branch returns GitHub API 404; this is expected until merged to `main`.
 

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4476,6 +4476,7 @@ Verification:
 |---|---|---|
 | workflow YAML parse | PASS | `python3` yaml load for `.github/workflows/attendance-post-merge-verify-nightly.yml` |
 | equivalent verify run (same script/runtime) | PASS | `output/playwright/attendance-post-merge-verify/20260308-parallel-next/summary.md` |
+| nightly workflow dispatch (main) | PASS (run `#22815149297`) | `output/playwright/ga/22815149297/attendance-post-merge-verify-22815149297-1/summary.md` |
 
 Notes:
 

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2665,6 +2665,7 @@ Verification:
 | Strict Gates (main) | #22814788217 | PASS | `output/playwright/attendance-post-merge-verify/20260308-parallel-next/ga/22814788217/attendance-strict-gates-prod-22814788217-1/20260308-070006-1/gate-summary.json` |
 | Perf Baseline (main) | #22814866134 | PASS | `output/playwright/attendance-post-merge-verify/20260308-parallel-next/ga/22814866134/attendance-import-perf-22814866134-1/attendance-perf-mmhbl86j-lsc9xo/perf-summary.json` |
 | Daily Dashboard (main) | #22814879184 | PASS | `output/playwright/attendance-post-merge-verify/20260308-parallel-next/ga/22814879184/attendance-daily-gate-dashboard-22814879184-1/attendance-daily-gate-dashboard.md` |
+| Nightly post-merge verify workflow (main) | #22815149297 | PASS | `output/playwright/ga/22815149297/attendance-post-merge-verify-22815149297-1/summary.md` |
 | Frontend import regression spec | local | PASS | `pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-import-preview-regression.spec.ts` |
 
 Observed highlights:


### PR DESCRIPTION
## Summary
- record nightly workflow run #22815149297 evidence in attendance docs
- sync GA daily gates, go/no-go, and parallel development report with latest artifact path

## Evidence
- output/playwright/ga/22815149297/attendance-post-merge-verify-22815149297-1/summary.md
