### PR TITLE
docs(attendance): add 100k perf baseline recheck evidence

### DIFF
--- a/docs/attendance-parallel-development-20260308.md
+++ b/docs/attendance-parallel-development-20260308.md
@@ -275,3 +275,33 @@ Result: PASS
 - `output/playwright/attendance-post-merge-verify/20260308-pr379/summary.md`
 - `output/playwright/attendance-post-merge-verify/20260308-pr379/summary.json`
 - `output/playwright/attendance-post-merge-verify/20260308-pr379/results.tsv`
+
+## Round 7 Validation (Perf Line: 100k Baseline Re-Check)
+
+### Scope
+- execute an additional 100k perf baseline on `main` with `upload_csv=true` requested, to verify fallback behavior and bulk-path health.
+
+### Execution
+- workflow: `attendance-import-perf-baseline.yml`
+- run: `22816159099`
+- dispatch inputs:
+  - `rows=100000`
+  - `mode=commit`
+  - `commit_async=false`
+  - `upload_csv=true`
+
+### Result
+- workflow status: PASS
+- summary highlights:
+  - `rows=100000`
+  - `engine=bulk`
+  - `recordUpsertStrategy=staging`
+  - `uploadCsvRequested=true`
+  - `uploadCsv=false`
+  - `payloadSource=rows`
+  - `payloadSourceReason=rows_exceeds_csv_limit_hint(20000)`
+  - `regressions=[]`
+
+### Evidence
+- `output/playwright/ga/22816159099/attendance-import-perf-22816159099-1/attendance-perf-mmhest9g-9i59fm/perf-summary.json`
+- `output/playwright/ga/22816159099/attendance-import-perf-22816159099-1/perf.log`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2636,6 +2636,28 @@ Decision:
 
 - **GO maintained**.
 
+## Post-Go Verification (2026-03-08): Perf Baseline 100k Re-Check (Upload Requested)
+
+Scope:
+
+- re-run high-row perf baseline after PR #379/#380 merges to confirm bulk path stability and upload fallback telemetry.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Attendance Import Perf Baseline (`rows=100000`, `upload_csv=true`, `mode=commit`, `commit_async=false`) | #22816159099 | PASS | `output/playwright/ga/22816159099/attendance-import-perf-22816159099-1/attendance-perf-mmhest9g-9i59fm/perf-summary.json`, `output/playwright/ga/22816159099/attendance-import-perf-22816159099-1/perf.log` |
+
+Observed highlights:
+
+- `engine=bulk`, `recordUpsertStrategy=staging`.
+- `uploadCsvRequested=true` but `uploadCsv=false` with `payloadSource=rows` because production hint remains `CSV_ROWS_LIMIT_HINT=20000`.
+- `regressions=[]`.
+
+Decision:
+
+- **GO maintained**.
+
 ## Post-Go Verification (2026-03-08): Legacy Import Result Parity
 
 Scope:


### PR DESCRIPTION
## Summary
- record additional 100k perf baseline evidence after PR #379/#380 merge
- append run 22816159099 metrics and artifact paths to delivery docs

## Verification
- workflow dispatch: attendance-import-perf-baseline.yml
  - rows=100000
  - mode=commit
  - commit_async=false
  - upload_csv=true
- run 22816159099: PASS
- key summary fields:
  - engine=bulk
  - recordUpsertStrategy=staging
  - uploadCsvRequested=true
  - uploadCsv=false
  - payloadSource=rows
  - regressions=[]
