### PR TITLE
feat(attendance-web): surface import commit telemetry in success status

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -5851,13 +5851,39 @@ async function runImport() {
       ...(Array.isArray(data.data?.groupWarnings) ? data.data.groupWarnings : []),
     ]
     importCsvWarnings.value = Array.from(new Set(importWarnings))
-    const count = data.data?.imported ?? 0
+    const count = Number(data.data?.imported ?? 0)
+    const processedRows = toNonNegativeNumber(data.data?.processedRows) ?? count
+    const failedRows = toNonNegativeNumber(data.data?.failedRows) ?? 0
+    const elapsedMs = toNonNegativeNumber(data.data?.elapsedMs) ?? 0
+    const importEngine = String(data.data?.engine ?? '').trim().toLowerCase()
+    const importStrategy = String(data.data?.recordUpsertStrategy ?? '').trim().toLowerCase()
     const groupCreated = data.data?.meta?.groupCreated ?? 0
     const groupMembersAdded = data.data?.meta?.groupMembersAdded ?? 0
+    const perfBitsEn: string[] = []
+    const perfBitsZh: string[] = []
+    if (importEngine) {
+      perfBitsEn.push(`engine=${importEngine}`)
+      perfBitsZh.push(`引擎=${importEngine}`)
+    }
+    if (importStrategy) {
+      perfBitsEn.push(`strategy=${importStrategy}`)
+      perfBitsZh.push(`策略=${importStrategy}`)
+    }
+    perfBitsEn.push(`processed=${processedRows}`)
+    perfBitsZh.push(`处理=${processedRows}`)
+    perfBitsEn.push(`failed=${failedRows}`)
+    perfBitsZh.push(`失败=${failedRows}`)
+    perfBitsEn.push(`elapsedMs=${elapsedMs}`)
+    perfBitsZh.push(`耗时毫秒=${elapsedMs}`)
+    const perfSuffixEn = perfBitsEn.length ? ` (${perfBitsEn.join(', ')})` : ''
+    const perfSuffixZh = perfBitsZh.length ? `（${perfBitsZh.join('，')}）` : ''
     if (groupCreated || groupMembersAdded) {
-      setStatus(tr(`Imported ${count} rows. Groups created: ${groupCreated}. Members added: ${groupMembersAdded}.`, `已导入 ${count} 行。新建分组：${groupCreated}。新增成员：${groupMembersAdded}。`))
+      setStatus(tr(
+        `Imported ${count} rows. Groups created: ${groupCreated}. Members added: ${groupMembersAdded}.${perfSuffixEn}`,
+        `已导入 ${count} 行。新建分组：${groupCreated}。新增成员：${groupMembersAdded}。${perfSuffixZh}`,
+      ))
     } else {
-      setStatus(tr(`Imported ${count} rows.`, `已导入 ${count} 行。`))
+      setStatus(tr(`Imported ${count} rows.${perfSuffixEn}`, `已导入 ${count} 行。${perfSuffixZh}`))
     }
     await loadRecords()
     await loadImportBatches()

--- a/docs/attendance-parallel-development-20260308.md
+++ b/docs/attendance-parallel-development-20260308.md
@@ -305,3 +305,22 @@ Result: PASS
 ### Evidence
 - `output/playwright/ga/22816159099/attendance-import-perf-22816159099-1/attendance-perf-mmhest9g-9i59fm/perf-summary.json`
 - `output/playwright/ga/22816159099/attendance-import-perf-22816159099-1/perf.log`
+
+## Round 8 Validation (C-line: Import Success Telemetry in Admin UI)
+
+### Scope
+- make sync import success feedback include backend execution telemetry so operators can confirm runtime path without opening batch detail.
+
+### Change
+- `apps/web/src/views/AttendanceView.vue`
+  - on successful sync import (`/api/attendance/import/commit` and legacy `/api/attendance/import` fallback), status message now appends:
+    - `engine`
+    - `recordUpsertStrategy`
+    - `processedRows`
+    - `failedRows`
+    - `elapsedMs`
+  - keeps existing group-sync success details (`groupCreated`, `groupMembersAdded`) unchanged.
+
+### Verification
+- `pnpm --filter @metasheet/web build` PASS
+- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-import-preview-regression.spec.ts` PASS

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2636,6 +2636,37 @@ Decision:
 
 - **GO maintained**.
 
+## Post-Go Verification (2026-03-08): Admin Import Success Telemetry UX
+
+Scope:
+
+- improve import operator feedback by exposing backend commit telemetry directly in the Admin UI success status text.
+
+Code changes:
+
+- `apps/web/src/views/AttendanceView.vue`
+  - sync import success text now includes:
+    - `engine`
+    - `recordUpsertStrategy`
+    - `processedRows`
+    - `failedRows`
+    - `elapsedMs`
+
+Verification:
+
+| Check | Status | Evidence |
+|---|---|---|
+| `pnpm --filter @metasheet/web build` | PASS | local command output |
+| `pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-import-preview-regression.spec.ts` | PASS | local command output |
+
+Observed highlights:
+
+- operators can confirm whether the run used `standard/bulk` and `values/unnest/staging` directly from the success toast, without opening batch item detail.
+
+Decision:
+
+- **GO maintained**.
+
 ## Post-Go Verification (2026-03-08): Perf Baseline 100k Re-Check (Upload Requested)
 
 Scope:


### PR DESCRIPTION
## Summary
- expose import commit telemetry in admin success status message
- include engine/strategy/processed/failed/elapsed for both commit endpoint and legacy import fallback
- append round-8 delivery notes to attendance docs

## Verification
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-import-preview-regression.spec.ts
