### PR TITLE
docs(attendance): append locale gate post-merge evidence

### DIFF
--- a/docs/attendance-parallel-development-20260308.md
+++ b/docs/attendance-parallel-development-20260308.md
@@ -406,3 +406,24 @@ Result: PASS
   - `output/playwright/ga/22816933373/attendance-locale-zh-smoke-prod-22816933373-1/drill/drill.txt`
   - `output/playwright/ga/22816946058/attendance-daily-gate-dashboard-22816946058-1/attendance-daily-gate-dashboard.json`
   - `output/playwright/ga/22816958859/attendance-daily-gate-dashboard-22816958859-1/attendance-daily-gate-dashboard.json`
+
+## Round 11 Validation (Post-Merge Gate Sweep after PR #386)
+
+### Scope
+- verify `main` remains green after merging locale-zh gate integration.
+
+### Execution
+- command:
+  - `OUTPUT_ROOT=output/playwright/attendance-post-merge-verify/20260308-pr386 bash scripts/ops/attendance-post-merge-verify.sh`
+
+### Results
+- `branch-policy` run `22817065562` PASS
+- `strict-gates` run `22817072638` PASS
+- `perf-baseline` run `22817126369` PASS
+- `perf-baseline-contract` PASS
+- `daily-dashboard` run `22817137242` PASS
+
+### Evidence
+- `output/playwright/attendance-post-merge-verify/20260308-pr386/summary.md`
+- `output/playwright/attendance-post-merge-verify/20260308-pr386/summary.json`
+- `output/playwright/attendance-post-merge-verify/20260308-pr386/results.tsv`

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4527,3 +4527,12 @@ Notes:
 - drill issue lifecycle validated with safe title:
   - issue `#384` (`[Attendance Locale Drill] zh smoke gate test`) reopened on drill FAIL and closed on drill PASS.
 - dashboard drill issue (`#385`) used safe override title and was manually closed after verification.
+
+Post-merge sweep on `main` (after PR #386):
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift | #22817065562 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817065562/attendance-branch-policy-drift-prod-22817065562-1/policy.json` |
+| Strict Gates | #22817072638 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817072638/attendance-strict-gates-prod-22817072638-1/20260308-080412-1/gate-summary.json` |
+| Perf Baseline | #22817126369 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817126369/attendance-import-perf-22817126369-1/attendance-perf-mmhh3ql8-r0dnt1/perf-summary.json` |
+| Daily Dashboard | #22817137242 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817137242/attendance-daily-gate-dashboard-22817137242-1/attendance-daily-gate-dashboard.md` |

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -2686,6 +2686,25 @@ Decision:
 
 - **GO maintained** (locale gate coverage added; branch validation completed with expected drill outcomes).
 
+## Post-Go Verification (2026-03-08): Post-Merge Sweep after PR #386
+
+Scope:
+
+- confirm `main` gate chain remains green after merging locale-zh gate integration.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift (main) | #22817065562 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817065562/attendance-branch-policy-drift-prod-22817065562-1/policy.json` |
+| Strict Gates (main) | #22817072638 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817072638/attendance-strict-gates-prod-22817072638-1/20260308-080412-1/gate-summary.json` |
+| Perf Baseline (main) | #22817126369 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817126369/attendance-import-perf-22817126369-1/attendance-perf-mmhh3ql8-r0dnt1/perf-summary.json` |
+| Daily Dashboard (main) | #22817137242 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817137242/attendance-daily-gate-dashboard-22817137242-1/attendance-daily-gate-dashboard.json` |
+
+Decision:
+
+- **GO maintained** (post-merge chain PASS with `Failures: 0`).
+
 ## Post-Go Verification (2026-03-08): PR #382 Post-Merge Gate Sweep
 
 Scope:


### PR DESCRIPTION
## Summary
- Add post-merge evidence records after locale zh gate rollout.
- Update parallel development report, daily gates handbook, and go/no-go record with mainline run IDs and artifact paths.

## Verification
- Evidence sourced from post-merge verifier output: `output/playwright/attendance-post-merge-verify/20260308-pr386/`.
- Mainline gate runs recorded:
  - branch-policy `#22817065562`
  - strict `#22817072638`
  - perf baseline `#22817126369`
  - daily dashboard `#22817137242`
