### PR TITLE
feat(attendance-gates): extend post-merge verifier with locale gate policy

### DIFF
--- a/docs/attendance-parallel-development-20260308.md
+++ b/docs/attendance-parallel-development-20260308.md
@@ -427,3 +427,58 @@ Result: PASS
 - `output/playwright/attendance-post-merge-verify/20260308-pr386/summary.md`
 - `output/playwright/attendance-post-merge-verify/20260308-pr386/summary.json`
 - `output/playwright/attendance-post-merge-verify/20260308-pr386/results.tsv`
+
+## Round 12 Validation (A-line + C-line: Post-Merge Verifier Locale Gate Integration)
+
+### Scope
+- merge docs evidence PR `#387` cleanly and restore branch protection (`require_pr_reviews=true`, `min_approving_review_count=1`).
+- extend post-merge verifier to include `locale-zh-smoke` and local screenshot contract validation.
+- reduce verifier false negatives:
+  - add strict auto-retry when strict summary reason is `RATE_LIMITED`.
+  - make locale zh gate non-blocking by default (`REQUIRE_LOCALE_ZH=false`, overridable).
+
+### Implementation
+- `scripts/ops/attendance-post-merge-verify.sh`
+  - new env:
+    - `SKIP_LOCALE_ZH`
+    - `LOCALE_ZH_WEB_URL`
+    - `LOCALE_ZH_API_BASE`
+    - `LOCALE_ZH_ORG_ID`
+    - `LOCALE_ZH_VERIFY_HOLIDAY`
+    - `REQUIRE_LOCALE_ZH`
+    - `STRICT_RETRY_ON_RATE_LIMITED`
+  - new local assertion gate: `locale-zh-contract`
+    - requires artifact `attendance-zh-locale-calendar*.png` when locale gate passes.
+  - strict retry behavior:
+    - when strict fails and gate summary reason contains `RATE_LIMITED` / `PLAYWRIGHT_RATE_LIMITED`, rerun strict once (`strict-gates-retry`) before finalizing verifier failure count.
+  - locale policy behavior:
+    - when locale gate fails and `REQUIRE_LOCALE_ZH=false`, record failure but do not block verifier exit code.
+
+### Verification
+- PR merge + policy restore:
+  - PR `#387` merged at `2026-03-08T08:22:07Z` (merge commit `d8e4019b3198505e48e1ea4e1bd34b441fd392d7`).
+  - branch protection re-verified to:
+    - `strict=true`
+    - `enforce_admins=true`
+    - `pr_reviews=true`
+    - `approving_review_count=1`
+    - `code_owner_reviews=false`
+- full post-merge verifier run:
+  - command:
+    - `OUTPUT_ROOT=output/playwright/attendance-post-merge-verify/20260308-round13-locale BRANCH=main bash scripts/ops/attendance-post-merge-verify.sh`
+  - results:
+    - branch-policy `#22817319844` PASS
+    - strict-gates `#22817325614` FAIL (`playwrightProd=RATE_LIMITED`)
+    - locale-zh-smoke `#22817390323` FAIL (`auth-error.txt`: no valid admin token/login fallback)
+    - perf-baseline `#22817404505` PASS
+    - daily-dashboard `#22817416233` FAIL (reflecting strict + locale failures)
+- local smoke of script matrix:
+  - `OUTPUT_ROOT=output/playwright/attendance-post-merge-verify/20260308-round13-smoke-local SKIP_BRANCH_POLICY=true SKIP_STRICT=true SKIP_LOCALE_ZH=true SKIP_PERF_BASELINE=true SKIP_DASHBOARD=true bash scripts/ops/attendance-post-merge-verify.sh` PASS
+
+### Evidence
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale/summary.md`
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale/results.tsv`
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817325614/.../gate-summary.json`
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817390323/attendance-locale-zh-smoke-prod-22817390323-1/auth-error.txt`
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817416233/attendance-daily-gate-dashboard-22817416233-1/attendance-daily-gate-dashboard.json`
+- `output/playwright/attendance-post-merge-verify/20260308-round13-smoke-local/summary.md`

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4536,3 +4536,40 @@ Post-merge sweep on `main` (after PR #386):
 | Strict Gates | #22817072638 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817072638/attendance-strict-gates-prod-22817072638-1/20260308-080412-1/gate-summary.json` |
 | Perf Baseline | #22817126369 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817126369/attendance-import-perf-22817126369-1/attendance-perf-mmhh3ql8-r0dnt1/perf-summary.json` |
 | Daily Dashboard | #22817137242 | PASS | `output/playwright/attendance-post-merge-verify/20260308-pr386/ga/22817137242/attendance-daily-gate-dashboard-22817137242-1/attendance-daily-gate-dashboard.md` |
+
+### Update (2026-03-08): Post-Merge Verifier Includes Locale zh Gate + Strict Rate-Limit Retry
+
+Scope:
+
+- align post-merge verifier with current daily dashboard gate surface by including `locale-zh-smoke`.
+- reduce false negatives from transient strict Playwright rate limiting.
+
+Implementation:
+
+- file: `scripts/ops/attendance-post-merge-verify.sh`
+  - added new gate execution in verifier chain:
+    - `locale-zh-smoke` (`attendance-locale-zh-smoke-prod.yml`)
+    - `locale-zh-contract` local assert (`attendance-zh-locale-calendar*.png` artifact required on locale pass)
+  - added strict retry logic:
+    - if strict gate fails with `RATE_LIMITED` reason in `gate-summary.json`, auto rerun once (`strict-gates-retry`).
+  - added locale policy control:
+    - `REQUIRE_LOCALE_ZH=false` (default non-blocking)
+    - when set `true`, locale gate failure blocks verifier.
+
+Verification run:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift | #22817319844 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817319844/attendance-branch-policy-drift-prod-22817319844-1/policy.json` |
+| Strict Gates | #22817325614 | FAIL | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817325614/attendance-strict-gates-prod-22817325614-1/20260308-082507-2/gate-summary.json` (`playwrightProd=RATE_LIMITED`) |
+| Locale zh Smoke | #22817390323 | FAIL | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817390323/attendance-locale-zh-smoke-prod-22817390323-1/auth-error.txt` |
+| Perf Baseline | #22817404505 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817404505/attendance-import-perf-22817404505-1/attendance-perf-mmhhrt10-xyzxik/perf-summary.json` |
+| Daily Dashboard | #22817416233 | FAIL | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817416233/attendance-daily-gate-dashboard-22817416233-1/attendance-daily-gate-dashboard.json` |
+
+Notes:
+
+- this run captured two production remediations:
+  - strict gate retry trigger condition observed (`RATE_LIMITED`).
+  - locale smoke credential remediation required (`ATTENDANCE_ADMIN_JWT` or login secrets).
+- branch protection was kept at enforced policy after PR merge closure:
+  - `pr_reviews=true`, `min_approving_review_count=1`.

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4843,3 +4843,37 @@ Observed highlights:
 Decision:
 
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-08): PR #387 Merge Closure + Post-Merge Verifier Locale Gate Expansion
+
+Scope:
+
+- close open docs evidence PR `#387` and restore mandatory review policy.
+- include locale zh smoke in `attendance-post-merge-verify.sh`.
+- add strict `RATE_LIMITED` one-shot retry and locale non-blocking policy control.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| PR #387 merged | #387 | MERGED | `https://github.com/zensgit/metasheet2/pull/387`, merge commit `d8e4019b3198505e48e1ea4e1bd34b441fd392d7` |
+| Branch protection restore | local (2026-03-08) | PASS | `scripts/ops/attendance-check-branch-protection.sh` output: `pr_reviews_required_current=true`, `approving_review_count_current=1` |
+| Branch Policy Drift | #22817319844 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817319844/attendance-branch-policy-drift-prod-22817319844-1/policy.json` |
+| Strict Gates | #22817325614 | FAIL | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817325614/attendance-strict-gates-prod-22817325614-1/20260308-082507-2/gate-summary.json` (`playwrightProd=RATE_LIMITED`) |
+| Locale zh Smoke | #22817390323 | FAIL | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817390323/attendance-locale-zh-smoke-prod-22817390323-1/auth-error.txt` |
+| Perf Baseline | #22817404505 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817404505/attendance-import-perf-22817404505-1/attendance-perf-mmhhrt10-xyzxik/perf-summary.json` |
+| Daily Dashboard | #22817416233 | FAIL | `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817416233/attendance-daily-gate-dashboard-22817416233-1/attendance-daily-gate-dashboard.json` (`Strict Gates` + `Locale zh Smoke` findings) |
+| post-merge verifier skip matrix smoke | local (2026-03-08) | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-smoke-local/summary.md` |
+
+Observed findings:
+
+- `Strict Gates` failed because `playwrightProd=RATE_LIMITED`; this now matches retry trigger condition in updated verifier logic.
+- `Locale zh Smoke` failed due invalid credentials (`ATTENDANCE_ADMIN_JWT` and login fallback both invalid in run environment).
+- downstream dashboard failure is expected and correctly propagated from upstream P0/P1 findings.
+
+Decision:
+
+- **NO-GO until remediations are completed and rerun is green**.
+- Required remediations:
+  - rotate locale smoke auth secrets (`ATTENDANCE_ADMIN_JWT` and/or `ATTENDANCE_ADMIN_EMAIL` + `ATTENDANCE_ADMIN_PASSWORD`).
+  - rerun post-merge verifier and confirm strict passes (or strict retry succeeds).

--- a/scripts/ops/attendance-post-merge-verify.sh
+++ b/scripts/ops/attendance-post-merge-verify.sh
@@ -11,6 +11,7 @@ DOWNLOAD_ARTIFACTS="${DOWNLOAD_ARTIFACTS:-true}"
 SKIP_BRANCH_POLICY="${SKIP_BRANCH_POLICY:-false}"
 SKIP_STRICT="${SKIP_STRICT:-false}"
 SKIP_PERF_BASELINE="${SKIP_PERF_BASELINE:-false}"
+SKIP_LOCALE_ZH="${SKIP_LOCALE_ZH:-false}"
 SKIP_DASHBOARD="${SKIP_DASHBOARD:-false}"
 
 REQUIRED_CHECKS_CSV="${REQUIRED_CHECKS_CSV:-contracts (strict),contracts (dashboard)}"
@@ -32,6 +33,8 @@ REQUIRE_PREVIEW_ASYNC="${REQUIRE_PREVIEW_ASYNC:-true}"
 REQUIRE_BATCH_RESOLVE="${REQUIRE_BATCH_RESOLVE:-false}"
 REQUIRE_IMPORT_JOB_RECOVERY="${REQUIRE_IMPORT_JOB_RECOVERY:-false}"
 REQUIRE_ADMIN_SETTINGS_SAVE="${REQUIRE_ADMIN_SETTINGS_SAVE:-true}"
+REQUIRE_LOCALE_ZH="${REQUIRE_LOCALE_ZH:-false}"
+STRICT_RETRY_ON_RATE_LIMITED="${STRICT_RETRY_ON_RATE_LIMITED:-true}"
 
 LOOKBACK_HOURS="${LOOKBACK_HOURS:-48}"
 GH_RETRY_MAX_ATTEMPTS="${GH_RETRY_MAX_ATTEMPTS:-5}"
@@ -40,6 +43,11 @@ RUN_DISCOVERY_ATTEMPTS="${RUN_DISCOVERY_ATTEMPTS:-60}"
 RUN_DISCOVERY_INTERVAL_SECONDS="${RUN_DISCOVERY_INTERVAL_SECONDS:-2}"
 RUN_POLL_ATTEMPTS="${RUN_POLL_ATTEMPTS:-300}"
 RUN_POLL_INTERVAL_SECONDS="${RUN_POLL_INTERVAL_SECONDS:-3}"
+
+LOCALE_ZH_WEB_URL="${LOCALE_ZH_WEB_URL:-http://142.171.239.56:8081}"
+LOCALE_ZH_API_BASE="${LOCALE_ZH_API_BASE:-${API_BASE}}"
+LOCALE_ZH_ORG_ID="${LOCALE_ZH_ORG_ID:-default}"
+LOCALE_ZH_VERIFY_HOLIDAY="${LOCALE_ZH_VERIFY_HOLIDAY:-true}"
 
 PERF_BASELINE_API_BASE="${PERF_BASELINE_API_BASE:-${API_BASE}}"
 PERF_BASELINE_ROWS="${PERF_BASELINE_ROWS:-10000}"
@@ -306,6 +314,68 @@ function run_perf_baseline_contract_gate() {
   return 0
 }
 
+function run_locale_zh_contract_gate() {
+  local run_id="$1"
+  local run_url="$2"
+  local artifacts_dir="$3"
+  local log_file="${OUTPUT_ROOT}/gate-locale-zh-contract.log"
+
+  {
+    echo "[attendance-post-merge-verify] validating locale zh artifacts"
+    echo "run_id=${run_id}"
+    echo "artifacts_dir=${artifacts_dir}"
+  } >"$log_file"
+
+  if [[ -z "$artifacts_dir" || ! -d "$artifacts_dir" ]]; then
+    failures=$((failures + 1))
+    echo "ERROR: artifacts dir missing" >>"$log_file"
+    append_result "locale-zh-contract" "local-assert" "$run_id" "FAIL" "artifacts_missing" "$run_url" "$artifacts_dir"
+    return 1
+  fi
+
+  local screenshot_path=''
+  screenshot_path="$(find "$artifacts_dir" -type f -name 'attendance-zh-locale-calendar*.png' | head -n 1 || true)"
+  if [[ -z "$screenshot_path" || ! -f "$screenshot_path" ]]; then
+    failures=$((failures + 1))
+    {
+      echo "ERROR: expected locale screenshot missing"
+      echo "required pattern: attendance-zh-locale-calendar*.png"
+    } >>"$log_file"
+    append_result "locale-zh-contract" "local-assert" "$run_id" "FAIL" "screenshot_missing" "$run_url" "$artifacts_dir"
+    return 1
+  fi
+
+  {
+    echo "OK: locale screenshot found"
+    echo "screenshot_path=${screenshot_path}"
+  } >>"$log_file"
+  append_result "locale-zh-contract" "local-assert" "$run_id" "PASS" "success" "$run_url" "$screenshot_path"
+  info "locale-zh-contract ok: screenshot=${screenshot_path}"
+  return 0
+}
+
+function strict_gate_has_rate_limited_reason() {
+  local artifacts_dir="$1"
+  if [[ -z "$artifacts_dir" || ! -d "$artifacts_dir" ]]; then
+    return 1
+  fi
+  local summary_path=''
+  summary_path="$(find "$artifacts_dir" -type f -name 'gate-summary.json' | sort | tail -n 1 || true)"
+  if [[ -z "$summary_path" || ! -f "$summary_path" ]]; then
+    return 1
+  fi
+  jq -e '
+    [
+      .gateReasons.playwrightProd,
+      .gateReasons.playwrightDesktop,
+      .gateReasons.playwrightMobile
+    ]
+    | map(select(type == "string"))
+    | map(ascii_upcase)
+    | any(. == "RATE_LIMITED" or . == "PLAYWRIGHT_RATE_LIMITED")
+  ' "$summary_path" >/dev/null 2>&1
+}
+
 function trigger_and_wait() {
   local workflow="$1"
   shift
@@ -448,6 +518,60 @@ run_gate \
   -f "require_batch_resolve=${REQUIRE_BATCH_RESOLVE}" \
   -f "require_import_job_recovery=${REQUIRE_IMPORT_JOB_RECOVERY}" \
   -f "require_admin_settings_save=${REQUIRE_ADMIN_SETTINGS_SAVE}"
+
+strict_retry_on_rate_limited="$(to_bool "$STRICT_RETRY_ON_RATE_LIMITED")"
+if [[ "$SKIP_STRICT" != "true" && "$GATE_LAST_STATUS" == "FAIL" && "$strict_retry_on_rate_limited" == "true" ]]; then
+  if strict_gate_has_rate_limited_reason "$GATE_LAST_ARTIFACTS"; then
+    info "strict-gates failed with RATE_LIMITED reason; retrying once"
+    if (( failures > 0 )); then
+      failures=$((failures - 1))
+    fi
+    run_gate \
+      "strict-gates-retry" \
+      "attendance-strict-gates-prod.yml" \
+      "false" \
+      -f "drill=false" \
+      -f "api_base=${API_BASE}" \
+      -f "expect_product_mode=${EXPECT_PRODUCT_MODE}" \
+      -f "require_attendance_admin_api=${REQUIRE_ATTENDANCE_ADMIN_API}" \
+      -f "require_idempotency=${REQUIRE_IDEMPOTENCY}" \
+      -f "require_import_export=${REQUIRE_IMPORT_EXPORT}" \
+      -f "require_import_upload=${REQUIRE_IMPORT_UPLOAD}" \
+      -f "require_import_async=${REQUIRE_IMPORT_ASYNC}" \
+      -f "require_import_telemetry=${REQUIRE_IMPORT_TELEMETRY}" \
+      -f "require_preview_async=${REQUIRE_PREVIEW_ASYNC}" \
+      -f "require_batch_resolve=${REQUIRE_BATCH_RESOLVE}" \
+      -f "require_import_job_recovery=${REQUIRE_IMPORT_JOB_RECOVERY}" \
+      -f "require_admin_settings_save=${REQUIRE_ADMIN_SETTINGS_SAVE}"
+  fi
+fi
+
+run_gate \
+  "locale-zh-smoke" \
+  "attendance-locale-zh-smoke-prod.yml" \
+  "$SKIP_LOCALE_ZH" \
+  -f "drill=false" \
+  -f "web_url=${LOCALE_ZH_WEB_URL}" \
+  -f "api_base=${LOCALE_ZH_API_BASE}" \
+  -f "org_id=${LOCALE_ZH_ORG_ID}" \
+  -f "verify_holiday=${LOCALE_ZH_VERIFY_HOLIDAY}"
+
+require_locale_zh_bool="$(to_bool "$REQUIRE_LOCALE_ZH")"
+if [[ "$SKIP_LOCALE_ZH" != "true" && "$GATE_LAST_STATUS" == "FAIL" && "$require_locale_zh_bool" != "true" ]]; then
+  info "locale-zh-smoke failed but REQUIRE_LOCALE_ZH=false; treated as non-blocking"
+  if (( failures > 0 )); then
+    failures=$((failures - 1))
+  fi
+  append_result "locale-zh-policy" "local-assert" "$GATE_LAST_RUN_ID" "PASS" "non_blocking" "$GATE_LAST_RUN_URL" "$GATE_LAST_ARTIFACTS"
+fi
+
+if [[ "$SKIP_LOCALE_ZH" == "true" ]]; then
+  append_result "locale-zh-contract" "local-assert" "" "SKIP" "" "" ""
+elif [[ "$GATE_LAST_STATUS" == "PASS" ]]; then
+  run_locale_zh_contract_gate "$GATE_LAST_RUN_ID" "$GATE_LAST_RUN_URL" "$GATE_LAST_ARTIFACTS" || true
+else
+  append_result "locale-zh-contract" "local-assert" "$GATE_LAST_RUN_ID" "SKIP" "upstream_gate_failed" "$GATE_LAST_RUN_URL" "$GATE_LAST_ARTIFACTS"
+fi
 
 run_gate \
   "perf-baseline" \


### PR DESCRIPTION
## Summary
- extend `scripts/ops/attendance-post-merge-verify.sh` to include `locale-zh-smoke` in the post-merge gate chain
- add local `locale-zh-contract` assertion gate (requires `attendance-zh-locale-calendar*.png` artifact on locale pass)
- add strict flake mitigation: one-shot strict rerun when strict summary reason is `RATE_LIMITED`
- add locale policy control: `REQUIRE_LOCALE_ZH=false` default keeps locale as non-blocking P1 in post-merge verifier
- append run evidence to delivery/go-no-go docs

## Verification
- `bash -n scripts/ops/attendance-post-merge-verify.sh`
- `bash scripts/ops/attendance-run-gate-contract-case.sh dashboard`
- `OUTPUT_ROOT=output/playwright/attendance-post-merge-verify/20260308-round13-locale BRANCH=main bash scripts/ops/attendance-post-merge-verify.sh`
- `OUTPUT_ROOT=output/playwright/attendance-post-merge-verify/20260308-round13-smoke-local SKIP_BRANCH_POLICY=true SKIP_STRICT=true SKIP_LOCALE_ZH=true SKIP_PERF_BASELINE=true SKIP_DASHBOARD=true bash scripts/ops/attendance-post-merge-verify.sh`

## Evidence
- `output/playwright/attendance-post-merge-verify/20260308-round13-locale/summary.md`
- `output/playwright/attendance-post-merge-verify/20260308-round13-locale/results.tsv`
- `output/playwright/attendance-post-merge-verify/20260308-round13-smoke-local/summary.md`
