### PR TITLE
docs(attendance): add post-policy gate rerun evidence

### DIFF
--- a/docs/attendance-parallel-development-20260308.md
+++ b/docs/attendance-parallel-development-20260308.md
@@ -472,6 +472,17 @@ Result: PASS
     - locale-zh-smoke `#22817390323` FAIL (`auth-error.txt`: no valid admin token/login fallback)
     - perf-baseline `#22817404505` PASS
     - daily-dashboard `#22817416233` FAIL (reflecting strict + locale failures)
+- post-policy rerun (after locale non-blocking policy + strict retry logic):
+  - command:
+    - `OUTPUT_ROOT=output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy BRANCH=main bash scripts/ops/attendance-post-merge-verify.sh`
+  - results:
+    - branch-policy `#22817453866` PASS
+    - strict-gates `#22817459768` PASS
+    - locale-zh-smoke `#22817525740` FAIL (expected non-blocking, credential remediation pending)
+    - locale-zh-policy local assert PASS (`non_blocking`)
+    - perf-baseline `#22817571116` PASS
+    - daily-dashboard `#22817605455` PASS
+  - verifier summary: `Failures: 0`
 - local smoke of script matrix:
   - `OUTPUT_ROOT=output/playwright/attendance-post-merge-verify/20260308-round13-smoke-local SKIP_BRANCH_POLICY=true SKIP_STRICT=true SKIP_LOCALE_ZH=true SKIP_PERF_BASELINE=true SKIP_DASHBOARD=true bash scripts/ops/attendance-post-merge-verify.sh` PASS
 
@@ -481,4 +492,7 @@ Result: PASS
 - `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817325614/.../gate-summary.json`
 - `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817390323/attendance-locale-zh-smoke-prod-22817390323-1/auth-error.txt`
 - `output/playwright/attendance-post-merge-verify/20260308-round13-locale/ga/22817416233/attendance-daily-gate-dashboard-22817416233-1/attendance-daily-gate-dashboard.json`
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/summary.md`
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/results.tsv`
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817605455/attendance-daily-gate-dashboard-22817605455-1/attendance-daily-gate-dashboard.json`
 - `output/playwright/attendance-post-merge-verify/20260308-round13-smoke-local/summary.md`

--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -4573,3 +4573,32 @@ Notes:
   - locale smoke credential remediation required (`ATTENDANCE_ADMIN_JWT` or login secrets).
 - branch protection was kept at enforced policy after PR merge closure:
   - `pr_reviews=true`, `min_approving_review_count=1`.
+
+### Update (2026-03-08): Post-Policy Rerun Green on Main (Locale Non-Blocking Active)
+
+Scope:
+
+- verify post-merge verifier behavior after adding locale non-blocking policy and strict retry logic.
+- confirm overall post-merge sweep can remain green while locale credential remediation is pending.
+
+Verification run:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift | #22817453866 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817453866/attendance-branch-policy-drift-prod-22817453866-1/policy.json` |
+| Strict Gates | #22817459768 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817459768/attendance-strict-gates-prod-22817459768-1/20260308-083325-1/gate-summary.json` |
+| Locale zh Smoke | #22817525740 | FAIL (non-blocking) | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817525740/attendance-locale-zh-smoke-prod-22817525740-1/auth-error.txt` |
+| Perf Baseline | #22817571116 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817571116/attendance-import-perf-22817571116-1/attendance-perf-mmhi7bbc-nla77p/perf-summary.json` |
+| Daily Dashboard | #22817605455 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817605455/attendance-daily-gate-dashboard-22817605455-1/attendance-daily-gate-dashboard.json` |
+
+Post-merge verifier summary:
+
+- `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/summary.md`
+- `Failures: 0`
+
+PR closure:
+
+- `#389` merged (`61735a12c7eee42ad2f7ce2c97549cc4ef540bf7`) with branch protection restored to:
+  - `strict=true`
+  - `pr_reviews=true`
+  - `min_approving_review_count=1`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -4877,3 +4877,26 @@ Decision:
 - Required remediations:
   - rotate locale smoke auth secrets (`ATTENDANCE_ADMIN_JWT` and/or `ATTENDANCE_ADMIN_EMAIL` + `ATTENDANCE_ADMIN_PASSWORD`).
   - rerun post-merge verifier and confirm strict passes (or strict retry succeeds).
+
+## Post-Go Verification (2026-03-08): Rerun Green After Locale Policy Activation
+
+Scope:
+
+- validate the updated verifier policy (`REQUIRE_LOCALE_ZH=false` default) on `main`.
+- confirm strict gate remains hard-blocking while locale gate is tracked as P1 non-blocking.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Branch Policy Drift | #22817453866 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817453866/attendance-branch-policy-drift-prod-22817453866-1/policy.json` |
+| Strict Gates | #22817459768 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817459768/attendance-strict-gates-prod-22817459768-1/20260308-083325-1/gate-summary.json` |
+| Locale zh Smoke | #22817525740 | FAIL (non-blocking policy) | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817525740/attendance-locale-zh-smoke-prod-22817525740-1/auth-error.txt` |
+| Locale policy local assert | #22817525740 | PASS (`non_blocking`) | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/results.tsv` |
+| Perf Baseline | #22817571116 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817571116/attendance-import-perf-22817571116-1/attendance-perf-mmhi7bbc-nla77p/perf-summary.json` |
+| Daily Dashboard | #22817605455 | PASS | `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/ga/22817605455/attendance-daily-gate-dashboard-22817605455-1/attendance-daily-gate-dashboard.json` |
+
+Decision:
+
+- **GO maintained**.
+- Remaining action is P1 ops remediation (rotate locale smoke credentials); it no longer blocks post-merge closure.


### PR DESCRIPTION
## Summary
- append Round 12 follow-up evidence after locale gate policy activation
- record successful post-merge sweep on `main` with `Failures: 0`
- update GA daily gates handbook and Go/No-Go log with run IDs and artifact paths

## Verification
- evidence referenced from completed runs:
  - branch-policy `#22817453866`
  - strict `#22817459768`
  - locale zh smoke `#22817525740` (non-blocking)
  - perf baseline `#22817571116`
  - daily dashboard `#22817605455`

## Evidence paths
- `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/summary.md`
- `output/playwright/attendance-post-merge-verify/20260308-round13-locale-policy/results.tsv`
