### PR TITLE
fix(attendance-gates): stabilize locale zh smoke auth bootstrap

### DIFF
--- a/.github/workflows/attendance-locale-zh-smoke-prod.yml
+++ b/.github/workflows/attendance-locale-zh-smoke-prod.yml
@@ -116,47 +116,156 @@ jobs:
         run: |
           set -euo pipefail
 
-          validate_token() {
+          normalize_token() {
+            local raw="$1"
+            raw="$(printf '%s' "$raw" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+            raw="${raw#Bearer }"
+            raw="${raw#bearer }"
+            raw="$(printf '%s' "$raw" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+            printf '%s' "$raw"
+          }
+
+          LAST_AUTH_CODE=""
+          LAST_REFRESH_CODE=""
+          LAST_LOGIN_CODE=""
+
+          request_auth_me_code() {
             local token="$1"
+            local out_file
+            out_file="$(mktemp)"
+            curl -sS -o "${out_file}" -w '%{http_code}' \
+              --connect-timeout 8 \
+              --max-time 20 \
+              -H "Authorization: Bearer ${token}" \
+              "${API_BASE}/auth/me" || true
+          }
+
+          validate_token_with_retry() {
+            local token="$1"
+            local attempt code
+            LAST_AUTH_CODE=""
             if [[ -z "$token" ]]; then
               return 1
             fi
-            local code
-            code="$(curl -s -o /tmp/attendance_auth_me.json -w '%{http_code}' \
-              -H "Authorization: Bearer ${token}" \
-              "${API_BASE}/auth/me" || true)"
-            [[ "$code" == "200" ]]
+            for attempt in 1 2 3; do
+              code="$(request_auth_me_code "$token")"
+              LAST_AUTH_CODE="$code"
+              if [[ "$code" == "200" ]]; then
+                return 0
+              fi
+              case "$code" in
+                000|429|500|502|503|504)
+                  sleep "$attempt"
+                  ;;
+                *)
+                  break
+                  ;;
+              esac
+            done
+            return 1
           }
 
-          if validate_token "${AUTH_TOKEN:-}"; then
-            echo "AUTH_TOKEN_EFFECTIVE=${AUTH_TOKEN}" >> "$GITHUB_ENV"
-            echo "auth_source=secret_jwt" >> "$GITHUB_OUTPUT"
-            exit 0
+          refresh_token() {
+            local token="$1"
+            local refresh_json code refreshed
+            LAST_REFRESH_CODE=""
+            if [[ -z "$token" ]]; then
+              return 1
+            fi
+            refresh_json="$(mktemp)"
+            code="$(curl -sS -o "${refresh_json}" -w '%{http_code}' \
+              --connect-timeout 8 \
+              --max-time 20 \
+              -X POST "${API_BASE}/auth/refresh-token" \
+              -H 'Content-Type: application/json' \
+              -d "{\"token\":\"${token}\"}" || true)"
+            LAST_REFRESH_CODE="$code"
+            if [[ "$code" != "200" ]]; then
+              return 1
+            fi
+            refreshed="$(jq -r '.data.token // empty' "${refresh_json}")"
+            refreshed="$(normalize_token "${refreshed}")"
+            if [[ -z "$refreshed" ]]; then
+              return 1
+            fi
+            printf '%s' "$refreshed"
+          }
+
+          login_token() {
+            local login_json code token
+            LAST_LOGIN_CODE=""
+            if [[ -z "${LOGIN_EMAIL:-}" || -z "${LOGIN_PASSWORD:-}" ]]; then
+              return 1
+            fi
+            login_json="$(mktemp)"
+            code="$(curl -sS -o "${login_json}" -w '%{http_code}' \
+              --connect-timeout 8 \
+              --max-time 20 \
+              -X POST "${API_BASE}/auth/login" \
+              -H 'Content-Type: application/json' \
+              -d "{\"email\":\"${LOGIN_EMAIL}\",\"password\":\"${LOGIN_PASSWORD}\"}" || true)"
+            LAST_LOGIN_CODE="$code"
+            if [[ "$code" != "200" ]]; then
+              return 1
+            fi
+            token="$(jq -r '.data.token // empty' "${login_json}")"
+            token="$(normalize_token "${token}")"
+            if [[ -z "$token" ]]; then
+              return 1
+            fi
+            printf '%s' "$token"
+          }
+
+          resolved_token=""
+          auth_source=""
+
+          base_token="$(normalize_token "${AUTH_TOKEN:-}")"
+          if validate_token_with_retry "${base_token}"; then
+            resolved_token="${base_token}"
+            auth_source="secret_jwt"
           fi
 
-          if [[ -n "${LOGIN_EMAIL:-}" && -n "${LOGIN_PASSWORD:-}" ]]; then
-            login_json="$(mktemp)"
-            curl -sS -X POST "${API_BASE}/auth/login" \
-              -H 'Content-Type: application/json' \
-              -d "{\"email\":\"${LOGIN_EMAIL}\",\"password\":\"${LOGIN_PASSWORD}\"}" > "${login_json}"
-            login_token="$(jq -r '.data.token // empty' "${login_json}")"
-            if validate_token "${login_token}"; then
-              echo "AUTH_TOKEN_EFFECTIVE=${login_token}" >> "$GITHUB_ENV"
-              echo "auth_source=login_secret" >> "$GITHUB_OUTPUT"
-              exit 0
+          if [[ -z "${resolved_token}" ]]; then
+            refreshed_token="$(refresh_token "${base_token}" || true)"
+            refreshed_token="$(normalize_token "${refreshed_token}")"
+            if validate_token_with_retry "${refreshed_token}"; then
+              resolved_token="${refreshed_token}"
+              auth_source="refresh_secret_jwt"
             fi
+          fi
+
+          if [[ -z "${resolved_token}" ]]; then
+            login_auth_token="$(login_token || true)"
+            if validate_token_with_retry "${login_auth_token}"; then
+              resolved_token="${login_auth_token}"
+              auth_source="login_secret"
+            fi
+          fi
+
+          if [[ -n "${resolved_token}" ]]; then
+            echo "AUTH_TOKEN_EFFECTIVE=${resolved_token}" >> "$GITHUB_ENV"
+            echo "auth_source=${auth_source}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           cat > output/playwright/attendance-locale-zh-smoke/auth-error.txt <<EOF
           No valid attendance admin token.
-          Tried: ATTENDANCE_ADMIN_JWT validation via /api/auth/me.
-          Fallback: ATTENDANCE_ADMIN_EMAIL + ATTENDANCE_ADMIN_PASSWORD login (secrets or vars).
+          Tried (in order):
+          1) ATTENDANCE_ADMIN_JWT validation via /api/auth/me (retry-aware)
+          2) /api/auth/refresh-token with ATTENDANCE_ADMIN_JWT
+          3) ATTENDANCE_ADMIN_EMAIL + ATTENDANCE_ADMIN_PASSWORD login (secrets or vars)
+          Diagnostic:
+          - auth_me_last_http=${LAST_AUTH_CODE:-unknown}
+          - refresh_last_http=${LAST_REFRESH_CODE:-unknown}
+          - login_last_http=${LAST_LOGIN_CODE:-unknown}
+          - login_email_present=$([[ -n "${LOGIN_EMAIL:-}" ]] && echo true || echo false)
+          - login_password_present=$([[ -n "${LOGIN_PASSWORD:-}" ]] && echo true || echo false)
           Remediation:
           - Rotate ATTENDANCE_ADMIN_JWT, or
           - Configure ATTENDANCE_ADMIN_EMAIL + ATTENDANCE_ADMIN_PASSWORD in repo secrets/vars.
           API_BASE=${API_BASE}
           EOF
-          echo "::error::No valid attendance admin token. Rotate ATTENDANCE_ADMIN_JWT or configure ATTENDANCE_ADMIN_EMAIL/ATTENDANCE_ADMIN_PASSWORD in secrets/vars."
+          echo "::error::No valid attendance admin token. Tried token validate/refresh/login fallback; check auth-error.txt artifact."
           exit 1
 
       - name: Run zh locale smoke


### PR DESCRIPTION
## Summary
- harden locale zh smoke auth bootstrap with token normalization (strip Bearer/whitespace)
- add retry-aware `/auth/me` validation for transient 5xx/429/network failures
- add `/auth/refresh-token` fallback before login-secret fallback
- improve `auth-error.txt` diagnostics with auth/refresh/login HTTP codes

## Verification
- `python3` YAML parse PASS for `.github/workflows/attendance-locale-zh-smoke-prod.yml`
- `bash scripts/ops/attendance-run-gate-contract-case.sh dashboard` PASS
- GA smoke run PASS on branch: https://github.com/zensgit/metasheet2/actions/runs/22820870436
- locale tracking issue auto-closed on recovery: https://github.com/zensgit/metasheet2/issues/388
