### PR TITLE
fix(web): harden attendance/plm mode routing and feature override safety

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -8,6 +8,7 @@ import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 import App from './App.vue'
 import { AppRouteNames, ROUTE_PATHS, RouteGuards } from './router/types'
+import { useFeatureFlags } from './stores/featureFlags'
 
 // Import views
 import GridView from './views/GridView.vue'
@@ -110,7 +111,7 @@ const router = createRouter({
 })
 
 // Navigation guard for page title
-router.beforeEach(async (to, from, next) => {
+router.beforeEach(async (to, _from, next) => {
   const title = to.meta?.title
   if (title) {
     document.title = `${title} - MetaSheet`
@@ -120,8 +121,6 @@ router.beforeEach(async (to, from, next) => {
 
   // Product capability guard + attendance focused mode restriction.
   try {
-    const mod = await import('./stores/featureFlags')
-    const { useFeatureFlags } = mod
     const flags = useFeatureFlags()
     await flags.loadProductFeatures()
 
@@ -146,6 +145,15 @@ router.beforeEach(async (to, from, next) => {
       const path = String(to.path || '')
       if (!allowed.has(path)) {
         return next('/attendance')
+      }
+    }
+
+    if (typeof flags.isPlmWorkbenchFocused === 'function' && flags.isPlmWorkbenchFocused()) {
+      const path = String(to.path || '')
+      const allowedPrefixes = ['/plm']
+      const allowed = allowedPrefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))
+      if (!allowed) {
+        return next('/plm')
       }
     }
   } catch {

--- a/apps/web/src/stores/featureFlags.ts
+++ b/apps/web/src/stores/featureFlags.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, readonly } from 'vue'
 import { apiFetch } from '../utils/api'
 
-export type ProductMode = 'platform' | 'attendance'
+export type ProductMode = 'platform' | 'attendance' | 'plm-workbench'
 
 export interface ProductFeatures {
   attendance: boolean
@@ -66,11 +66,17 @@ function parseJwtPayload(token: string | null): Record<string, unknown> {
   }
 }
 
+function isFeatureOverrideAllowed(): boolean {
+  if (import.meta.env.DEV) return true
+  return String(import.meta.env.VITE_ALLOW_FEATURE_OVERRIDE || '').trim().toLowerCase() === 'true'
+}
+
 function parseOverrideFeatures(): Partial<ProductFeatures> {
+  if (!isFeatureOverrideAllowed()) return {}
   if (typeof localStorage === 'undefined') return {}
 
   const modeRaw = localStorage.getItem('metasheet_product_mode')
-  const mode: ProductMode | undefined = modeRaw === 'attendance' || modeRaw === 'platform'
+  const mode: ProductMode | undefined = modeRaw === 'attendance' || modeRaw === 'platform' || modeRaw === 'plm-workbench'
     ? modeRaw
     : undefined
 
@@ -90,7 +96,9 @@ function parseOverrideFeatures(): Partial<ProductFeatures> {
 
 function normalizeMode(value: unknown): ProductMode | undefined {
   if (value === 'attendance' || value === 'platform') return value
+  if (value === 'plm-workbench' || value === 'plmWorkbench') return 'plm-workbench'
   if (value === 'attendance-focused') return 'attendance'
+  if (value === 'plm-focused') return 'plm-workbench'
   return undefined
 }
 
@@ -154,7 +162,9 @@ function isAdminRole(payload: any): boolean {
   }
 
   const tokenPayload = parseJwtPayload(
-    typeof localStorage !== 'undefined' ? localStorage.getItem('auth_token') : null,
+    typeof localStorage !== 'undefined'
+      ? localStorage.getItem('auth_token') || localStorage.getItem('jwt') || localStorage.getItem('devToken')
+      : null,
   )
   if (tokenPayload.role === 'admin') return true
   if (Array.isArray(tokenPayload.roles) && tokenPayload.roles.includes('admin')) return true
@@ -274,8 +284,13 @@ function isAttendanceFocused(): boolean {
   return state.features.mode === 'attendance' && state.features.attendance
 }
 
+function isPlmWorkbenchFocused(): boolean {
+  return state.features.mode === 'plm-workbench'
+}
+
 function resolveHomePath(): string {
   if (isAttendanceFocused()) return '/attendance'
+  if (isPlmWorkbenchFocused()) return '/plm'
   return '/grid'
 }
 
@@ -287,6 +302,7 @@ export function useFeatureFlags() {
     loadProductFeatures,
     hasFeature,
     isAttendanceFocused,
+    isPlmWorkbenchFocused,
     resolveHomePath,
   }
 }


### PR DESCRIPTION
## Summary\n- harden feature override policy so localStorage overrides are disabled in production unless \n- support  as a first-class product mode in feature flags and home-path resolution\n- simplify router guard feature-store loading and enforce plm-focused route containment to \n\n## Verification\n- 
> @metasheet/web@2.0.0-alpha.1 build /Users/huazhou/Downloads/Github/metasheet2_tmp_web_guard_mainline/apps/web
> vue-tsc -b && vite build

vite v5.4.21 building for production...
transforming...
✓ 1874 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.46 kB │ gzip:   0.30 kB
dist/assets/bpmn-GG2Gc6GC.eot      47.83 kB
dist/assets/bpmn-CfAG4AR5.svg     133.05 kB │ gzip:  24.73 kB
dist/assets/index-DFmJyldo.css    524.20 kB │ gzip: 106.83 kB
dist/assets/index-C42s2Xjx.js   2,114.84 kB │ gzip: 631.54 kB
✓ built in 3.98s\n- 
 RUN  v1.6.1 /Users/huazhou/Downloads/Github/metasheet2_tmp_web_guard_mainline/apps/web

 ✓ tests/useAuth.spec.ts  (2 tests) 2ms
 ✓ tests/utils/api.test.ts  (21 tests) 3ms

 Test Files  2 passed (2)
      Tests  23 passed (23)
   Start at  09:48:07
   Duration  1.15s (transform 43ms, setup 0ms, collect 51ms, tests 5ms, environment 1.79s, prepare 216ms)