### PR TITLE
fix(perf): speed up async import poll recovery under transient 5xx

### DIFF
--- a/docs/attendance-parallel-development-20260311-round21.md
+++ b/docs/attendance-parallel-development-20260311-round21.md
@@ -1,0 +1,36 @@
+# Attendance Parallel Development Report (Round21, 2026-03-11)
+
+## Scope
+
+Reduce async import perf gate hang time and enable earlier idempotency recovery when `/attendance/import/jobs/:id` keeps returning transient 5xx/429 errors.
+
+## Problem Evidence
+
+- Perf baseline runs repeatedly entered long poll loops on `GET /attendance/import/jobs/:id` with `HTTP 502`.
+- Example artifacts:
+  - `output/playwright/ga/22933748342/perf.log`
+  - `output/playwright/ga/22934153530/perf.log`
+- Before this patch, recovery logic only triggered after full `IMPORT_JOB_POLL_TIMEOUT_MS` (default 45 minutes for large window), making failures slow and hard to close.
+
+## Implementation
+
+Updated file:
+- `scripts/ops/attendance-import-perf.mjs`
+
+Changes:
+1. Reduced default `IMPORT_JOB_POLL_RECOVERY_GRACE_MS` from `10m` to `3m`.
+2. Added transient fail-fast threshold in job polling (`transientRecoveryErrorThreshold=3`):
+   - when transient network/HTTP 5xx errors persist past recovery grace window, throw an async-poll-timeout style error immediately.
+3. This reuses existing idempotency recovery flow (`recoverAsyncCommitJobWithRetry`) earlier, instead of waiting for the full poll timeout.
+
+## Verification
+
+| Check | Command | Status |
+|---|---|---|
+| Script syntax | `node --check scripts/ops/attendance-import-perf.mjs` | PASS |
+| Recovery threshold grep | `rg -n "importJobPollRecoveryGraceMs|transientRecoveryErrorThreshold|timed out after transient errors" scripts/ops/attendance-import-perf.mjs` | PASS |
+
+## Expected Effect
+
+- For repeated transient `/jobs/:id` failures, workflow no longer stalls for full poll timeout before invoking idempotency recovery.
+- Gate runs should fail or recover earlier, making remediation loops materially faster.

--- a/scripts/ops/attendance-import-perf.mjs
+++ b/scripts/ops/attendance-import-perf.mjs
@@ -63,7 +63,7 @@ const importJobPollTimeoutLargeMs = Math.max(
 )
 const importJobPollRecoveryGraceMs = Math.max(
   60_000,
-  Number(process.env.IMPORT_JOB_POLL_RECOVERY_GRACE_MS || 10 * 60 * 1000),
+  Number(process.env.IMPORT_JOB_POLL_RECOVERY_GRACE_MS || 3 * 60 * 1000),
 )
 const previewAsyncRowThreshold = Math.max(1, Number(process.env.PREVIEW_ASYNC_ROW_THRESHOLD || 50_000))
 const importJobRecoveryAttemptsRaw = Number(process.env.IMPORT_JOB_RECOVERY_ATTEMPTS || 3)
@@ -502,6 +502,7 @@ function resolvePreviewMode() {
 async function pollImportJob(jobId, { timeoutMs = 30 * 60 * 1000, intervalMs = 2000 } = {}) {
   const started = Date.now()
   let transientErrors = 0
+  const transientRecoveryErrorThreshold = 3
   while (true) {
     let job = null
     try {
@@ -510,8 +511,12 @@ async function pollImportJob(jobId, { timeoutMs = 30 * 60 * 1000, intervalMs = 2
       transientErrors += 1
       const message = (error && error.message) || String(error)
       log(`WARN: transient job poll network error (attempt=${transientErrors}); retrying (${message})`)
-      if (Date.now() - started > timeoutMs) {
+      const elapsed = Date.now() - started
+      if (elapsed > timeoutMs) {
         throw new Error(`async commit job poll timed out after network errors: ${message}`)
+      }
+      if (transientErrors >= transientRecoveryErrorThreshold && elapsed > importJobPollRecoveryGraceMs) {
+        throw new Error(`async commit job poll timed out after transient errors (network): ${message}`)
       }
       await sleep(intervalMs)
       continue
@@ -522,7 +527,11 @@ async function pollImportJob(jobId, { timeoutMs = 30 * 60 * 1000, intervalMs = 2
       if (transient) {
         transientErrors += 1
         log(`WARN: transient job poll error (attempt=${transientErrors} status=${status}); retrying`)
-        if (Date.now() - started > timeoutMs) {
+        const elapsed = Date.now() - started
+        if (elapsed > timeoutMs) {
+          throw new Error(`async commit job poll timed out after transient errors (last status=${status})`)
+        }
+        if (transientErrors >= transientRecoveryErrorThreshold && elapsed > importJobPollRecoveryGraceMs) {
           throw new Error(`async commit job poll timed out after transient errors (last status=${status})`)
         }
         await sleep(intervalMs)


### PR DESCRIPTION
## Summary
- reduce default async import job recovery grace from 10m to 3m in `attendance-import-perf.mjs`
- add transient fail-fast threshold for `/attendance/import/jobs/:id` polling (>=3 transient errors after grace window)
- trigger existing idempotency recovery path earlier instead of waiting for full poll timeout
- add Round21 MD with failure evidence and expected effect

## Why
Recent perf baseline runs repeatedly hit `HTTP 502` on async job polling and stayed in long polling loops before recovery could run. This patch makes the recovery path engage earlier.

## Verification
- `node --check scripts/ops/attendance-import-perf.mjs`
- `rg -n "importJobPollRecoveryGraceMs|transientRecoveryErrorThreshold|timed out after transient errors" scripts/ops/attendance-import-perf.mjs`
