### PR TITLE
fix(ci): use ff merge for remote host sync in deploy

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -91,7 +91,7 @@ jobs:
             "git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo \"[deploy][error] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH}\" >&2; exit 1; }"
             "git fetch origin main"
             "git checkout main"
-            "git pull --ff-only origin main"
+            "git merge --ff-only origin/main"
             "# Preflight: validate production env/compose/nginx before (re)deploying containers."
             "echo \"=== ATTENDANCE PREFLIGHT START ===\""
             "preflight_rc=0"


### PR DESCRIPTION
## Summary
- replace remote host sync `git pull --ff-only origin main` with `git merge --ff-only origin/main`
- avoid deploy failure on hosts where `pull` resolves to multiple configured merge refs

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-build.yml')"`
- inspected failed deploy evidence from run `22934736592` (`fatal: Cannot fast-forward to multiple branches`)
