### PR TITLE
fix(ci): retry perf baseline once on transient gateway failures

### DIFF
--- a/.github/workflows/attendance-import-perf-baseline.yml
+++ b/.github/workflows/attendance-import-perf-baseline.yml
@@ -175,6 +175,10 @@ jobs:
       MAX_ROLLBACK_MS: ${{ inputs.max_rollback_ms || vars.ATTENDANCE_PERF_BASELINE_MAX_ROLLBACK_MS || '30000' }}
       IMPORT_JOB_POLL_TIMEOUT_MS: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_SCHEDULE_MS || '600000') || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_HIGH_MS || '3600000')) || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_MS || '2700000' }}
       IMPORT_JOB_POLL_TIMEOUT_LARGE_MS: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_SCHEDULE_MS || '900000') || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_HIGH_MS || '5400000')) || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_MS || '3600000' }}
+      COMMIT_RETRIES: ${{ vars.ATTENDANCE_PERF_COMMIT_RETRIES || '3' }}
+      COMMIT_RETRIES_LARGE: ${{ vars.ATTENDANCE_PERF_COMMIT_RETRIES_LARGE || '5' }}
+      COMMIT_RETRIES_RETRY: ${{ vars.ATTENDANCE_PERF_COMMIT_RETRIES_RETRY || '6' }}
+      COMMIT_RETRIES_LARGE_RETRY: ${{ vars.ATTENDANCE_PERF_COMMIT_RETRIES_LARGE_RETRY || '8' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -241,9 +245,46 @@ jobs:
           AUTH_TOKEN: ${{ env.AUTH_TOKEN_EFFECTIVE }}
         run: |
           set -euo pipefail
-          # Always capture logs so failures are diagnosable from artifacts.
           mkdir -p output/playwright/attendance-import-perf
-          node ./scripts/ops/attendance-import-perf.mjs 2>&1 | tee output/playwright/attendance-import-perf/perf.log
+          log_dir="output/playwright/attendance-import-perf"
+          attempt1_log="${log_dir}/perf-attempt1.log"
+          attempt2_log="${log_dir}/perf-attempt2.log"
+          final_log="${log_dir}/perf.log"
+          transient_pattern='HTTP 429|HTTP 5[0-9]{2}|fetch failed|ECONNRESET|ETIMEDOUT|Bad Gateway|timed out'
+
+          run_once() {
+            local log_file="$1"
+            shift
+            set +e
+            "$@" 2>&1 | tee "$log_file"
+            local rc="${PIPESTATUS[0]}"
+            set -e
+            return "$rc"
+          }
+
+          if run_once "$attempt1_log" node ./scripts/ops/attendance-import-perf.mjs; then
+            cp "$attempt1_log" "$final_log"
+            exit 0
+          fi
+          rc_first="$?"
+
+          if ! grep -Eiq "$transient_pattern" "$attempt1_log"; then
+            cp "$attempt1_log" "$final_log"
+            exit "$rc_first"
+          fi
+
+          echo "Transient perf failure detected; retrying once with expanded commit retries."
+          sleep 10
+          if run_once "$attempt2_log" env \
+            COMMIT_RETRIES="${COMMIT_RETRIES_RETRY}" \
+            COMMIT_RETRIES_LARGE="${COMMIT_RETRIES_LARGE_RETRY}" \
+            node ./scripts/ops/attendance-import-perf.mjs; then
+            cat "$attempt1_log" "$attempt2_log" > "$final_log"
+            exit 0
+          fi
+          rc_second="$?"
+          cat "$attempt1_log" "$attempt2_log" > "$final_log"
+          exit "$rc_second"
 
       - name: Upload perf artifacts
         if: always()


### PR DESCRIPTION
## Summary
- add workflow-level transient retry for perf baseline execution
- detect first-attempt transient failures (`HTTP 429/5xx`, `Bad Gateway`, network timeout) and run one guarded retry
- keep both attempt logs (`perf-attempt1.log`, `perf-attempt2.log`) and aggregate into `perf.log`

## Why
- recent baseline runs failed on transient gateway errors during commit/import polling even after script-level retries
- a bounded second attempt reduces flaky failures while preserving artifact evidence

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/attendance-import-perf-baseline.yml')"`
- evidence inspected: `output/playwright/ga/22935335625/perf.log`, `output/playwright/ga/22935537502/perf.log`
