### PR TITLE
fix(ci): match perf failure line for transient retry

### DIFF
--- a/.github/workflows/attendance-import-perf-baseline.yml
+++ b/.github/workflows/attendance-import-perf-baseline.yml
@@ -272,9 +272,9 @@ jobs:
             exit 0
           fi
 
-          last_failure_line="$(grep -E '^\\[attendance-import-perf\\] Failed:' "$attempt1_log" | tail -n 1 || true)"
+          last_failure_line="$(grep -E '^\[attendance-import-perf\] Failed:' "$attempt1_log" | tail -n 1 || true)"
           if [[ -z "$last_failure_line" ]]; then
-            last_failure_line="$(tail -n 3 "$attempt1_log" | tr '\n' ' ')"
+            last_failure_line="$(tail -n 40 "$attempt1_log" | tr '\n' ' ')"
           fi
           if ! printf '%s' "$last_failure_line" | grep -Eiq "$transient_pattern"; then
             cp "$attempt1_log" "$final_log"


### PR DESCRIPTION
## Summary
- fix transient retry detection in perf baseline workflow by matching the actual failure line format
- correct grep regex from double-escaped bracket pattern to `^\[attendance-import-perf\] Failed:`
- broaden fallback tail from 3 lines to 40 lines to keep transient signatures visible in multiline failures

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/attendance-import-perf-baseline.yml'); puts 'yaml-ok'"`
- baseline failure artifact `22938279435` showed no `perf-attempt2.log` because transient detector failed to match
