### PR TITLE
fix(ci): default baseline standard profile to sync commit

### DIFF
--- a/.github/workflows/attendance-import-perf-baseline.yml
+++ b/.github/workflows/attendance-import-perf-baseline.yml
@@ -39,9 +39,9 @@ on:
         required: false
         default: 'sync'
       commit_async:
-        description: 'Use /commit-async path (true/false, default true for gateway-safe baseline runs)'
+        description: 'Use /commit-async path (true/false, default false for standard profile, true for high-scale)'
         required: false
-        default: 'true'
+        default: 'false'
       export_csv:
         description: 'Verify export csv latency (true/false)'
         required: false
@@ -164,7 +164,7 @@ jobs:
       PREVIEW_MODE: ${{ inputs.preview_mode || (inputs.profile == 'high-scale' && 'auto') || vars.ATTENDANCE_PERF_PREVIEW_MODE || 'sync' }}
       PREVIEW_ASYNC_ROW_THRESHOLD: ${{ vars.ATTENDANCE_PERF_PREVIEW_ASYNC_ROW_THRESHOLD || '50000' }}
       ROLLBACK: 'true'
-      COMMIT_ASYNC: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_PERF_COMMIT_ASYNC_SCHEDULE || 'true') || (inputs.profile == 'high-scale' && 'true') || inputs.commit_async || vars.ATTENDANCE_PERF_COMMIT_ASYNC || 'true' }}
+      COMMIT_ASYNC: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_PERF_COMMIT_ASYNC_SCHEDULE || 'false') || (inputs.profile == 'high-scale' && 'true') || inputs.commit_async || vars.ATTENDANCE_PERF_COMMIT_ASYNC || 'false' }}
       EXPORT_CSV: ${{ inputs.export_csv || vars.ATTENDANCE_PERF_EXPORT_CSV || 'true' }}
       UPLOAD_CSV: ${{ inputs.upload_csv || vars.ATTENDANCE_PERF_UPLOAD_CSV || 'true' }}
       PAYLOAD_SOURCE: ${{ inputs.payload_source || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_PAYLOAD_SOURCE_HIGH || 'auto')) || vars.ATTENDANCE_PERF_PAYLOAD_SOURCE || 'auto' }}
@@ -173,8 +173,8 @@ jobs:
       MAX_COMMIT_MS: ${{ inputs.max_commit_ms || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_MAX_COMMIT_MS_HIGH || '420000')) || vars.ATTENDANCE_PERF_MAX_COMMIT_MS || '' }}
       MAX_EXPORT_MS: ${{ inputs.max_export_ms || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_MAX_EXPORT_MS_HIGH || '90000')) || vars.ATTENDANCE_PERF_MAX_EXPORT_MS || '' }}
       MAX_ROLLBACK_MS: ${{ inputs.max_rollback_ms || vars.ATTENDANCE_PERF_BASELINE_MAX_ROLLBACK_MS || '30000' }}
-      IMPORT_JOB_POLL_TIMEOUT_MS: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_SCHEDULE_MS || '600000') || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_HIGH_MS || '3600000')) || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_MS || '2700000' }}
-      IMPORT_JOB_POLL_TIMEOUT_LARGE_MS: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_SCHEDULE_MS || '900000') || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_HIGH_MS || '5400000')) || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_MS || '3600000' }}
+      IMPORT_JOB_POLL_TIMEOUT_MS: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_SCHEDULE_MS || '600000') || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_HIGH_MS || '3600000')) || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_STANDARD_MS || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_MS || '600000' }}
+      IMPORT_JOB_POLL_TIMEOUT_LARGE_MS: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_SCHEDULE_MS || '900000') || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_HIGH_MS || '5400000')) || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_STANDARD_MS || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_LARGE_MS || '900000' }}
       COMMIT_RETRIES: ${{ vars.ATTENDANCE_PERF_COMMIT_RETRIES || '3' }}
       COMMIT_RETRIES_LARGE: ${{ vars.ATTENDANCE_PERF_COMMIT_RETRIES_LARGE || '5' }}
       COMMIT_RETRIES_RETRY: ${{ vars.ATTENDANCE_PERF_COMMIT_RETRIES_RETRY || '6' }}


### PR DESCRIPTION
## Summary
- change baseline default for standard profile to sync commit (`commit_async=false`)
- keep high-scale profile async by default
- reduce standard-profile poll timeout fallbacks (`IMPORT_JOB_POLL_TIMEOUT_MS/LARGE_MS`) to avoid prolonged hangs on repeated gateway 502 storms

## Why
- recent standard baseline runs repeatedly fail on `/attendance/import/commit-async` recovery with 502 and can run 10+ minutes
- standard baseline should stay stable/fast; async stress remains covered by high-scale/longrun workflows

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/attendance-import-perf-baseline.yml'); puts 'yaml-ok'"`
- previous run `22938494957` now shows retry path (`perf-attempt2.log`) but still failed due persistent async 502; this PR avoids async default for standard runs
