### PR TITLE
perf(ci): decouple 10k thresholds from legacy commit var

### DIFF
--- a/.github/workflows/attendance-import-perf-baseline.yml
+++ b/.github/workflows/attendance-import-perf-baseline.yml
@@ -171,7 +171,7 @@ jobs:
       CSV_ROWS_LIMIT_HINT: ${{ inputs.csv_rows_limit_hint || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_CSV_ROWS_LIMIT_HINT_HIGH || '100000')) || vars.ATTENDANCE_IMPORT_CSV_MAX_ROWS || '20000' }}
       PERF_WORK_DATE_SPAN_DAYS: ${{ inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_WORK_DATE_SPAN_DAYS_HIGH || '180') || vars.ATTENDANCE_PERF_WORK_DATE_SPAN_DAYS || '366' }}
       MAX_PREVIEW_MS: ${{ inputs.max_preview_ms || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_MAX_PREVIEW_MS_HIGH || '240000')) || vars.ATTENDANCE_PERF_MAX_PREVIEW_MS || '' }}
-      MAX_COMMIT_MS: ${{ inputs.max_commit_ms || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_MAX_COMMIT_MS_HIGH || '420000')) || vars.ATTENDANCE_PERF_MAX_COMMIT_MS || '420000' }}
+      MAX_COMMIT_MS: ${{ inputs.max_commit_ms || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_MAX_COMMIT_MS_HIGH || '420000')) || vars.ATTENDANCE_PERF_MAX_COMMIT_MS_STANDARD || '420000' }}
       MAX_EXPORT_MS: ${{ inputs.max_export_ms || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_MAX_EXPORT_MS_HIGH || '90000')) || vars.ATTENDANCE_PERF_MAX_EXPORT_MS || '' }}
       MAX_ROLLBACK_MS: ${{ inputs.max_rollback_ms || vars.ATTENDANCE_PERF_BASELINE_MAX_ROLLBACK_MS || '30000' }}
       IMPORT_JOB_POLL_TIMEOUT_MS: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_SCHEDULE_MS || '600000') || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_HIGH_MS || '3600000')) || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_STANDARD_MS || vars.ATTENDANCE_IMPORT_JOB_POLL_TIMEOUT_MS || '600000' }}

--- a/.github/workflows/attendance-import-perf-longrun.yml
+++ b/.github/workflows/attendance-import-perf-longrun.yml
@@ -162,7 +162,7 @@ jobs:
             rollback: 'false'
             expected_upsert_strategy: ''
             max_preview_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_PREVIEW_MS || vars.ATTENDANCE_PERF_MAX_PREVIEW_MS || '100000' }}
-            max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_COMMIT_MS || vars.ATTENDANCE_PERF_MAX_COMMIT_MS || '420000' }}
+            max_commit_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_COMMIT_MS || vars.ATTENDANCE_PERF_MAX_COMMIT_MS_STANDARD || '420000' }}
             max_export_ms: ${{ vars.ATTENDANCE_PERF_LONGRUN_10K_MAX_EXPORT_MS || vars.ATTENDANCE_PERF_MAX_EXPORT_MS || '25000' }}
             max_rollback_ms: ''
             import_job_poll_interval_ms: '2000'


### PR DESCRIPTION
## Summary
- stop inheriting legacy global `ATTENDANCE_PERF_MAX_COMMIT_MS` for standard 10k commit gates
- baseline standard now uses `ATTENDANCE_PERF_MAX_COMMIT_MS_STANDARD || 420000`
- longrun rows10k commit now uses `ATTENDANCE_PERF_MAX_COMMIT_MS_STANDARD || 420000`

## Why
- production still has legacy `ATTENDANCE_PERF_MAX_COMMIT_MS=150000` which overrides workflow-level 10k tuning
- latest async baseline run succeeded functionally but failed only due threshold mismatch:
  - run `22940682440`: `commit ok ... ms=165795`, then `commitMs=165795 exceeds maxCommitMs=150000`

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/attendance-import-perf-baseline.yml'); YAML.load_file('.github/workflows/attendance-import-perf-longrun.yml'); puts 'yaml-ok'"`
