### PR TITLE
docs(attendance): record dashboard commitGate visibility evidence

### DIFF
--- a/docs/attendance-production-ga-daily-gates-20260209.md
+++ b/docs/attendance-production-ga-daily-gates-20260209.md
@@ -5569,3 +5569,12 @@ gh workflow run attendance-import-perf-baseline.yml -f profile=standard -f uploa
 gh workflow run attendance-import-perf-longrun.yml -f upload_csv=true -f fail_on_regression=false
 gh workflow run attendance-daily-gate-dashboard.yml -f lookback_hours=48
 ```
+
+Dashboard gateFlat verification (post PR #435):
+
+- run: `#22942361131` (PASS)
+- `gateFlat.perf.commitMs=574071`
+- `gateFlat.perf.commitGateMs=18000`
+- `gateFlat.perf.commitGateSource=jobElapsedMs`
+- evidence:
+  - `output/playwright/ga/22942361131/attendance-daily-gate-dashboard-22942361131-1/attendance-daily-gate-dashboard.json`

--- a/docs/attendance-production-go-no-go-20260211.md
+++ b/docs/attendance-production-go-no-go-20260211.md
@@ -5804,3 +5804,32 @@ Decision:
 - perf gates recovered to green under real-world proxy jitter, without lowering thresholds.
 - dashboard overall status returned to `PASS`.
 - **GO maintained**.
+
+## Post-Go Verification (2026-03-11): Dashboard Perf Gate Visibility
+
+Scope:
+
+- expose async commit gate metric (`commitGateMs`) in daily dashboard output to improve triage speed under proxy jitter.
+
+Changes:
+
+- PR #435 (`feat(gates): surface async commit gate metrics in dashboard`)
+  - file: `scripts/ops/attendance-daily-gate-report.mjs`
+  - parse and emit `commitGateMs` + `commitGateSource` for perf gates.
+
+Verification:
+
+| Gate | Run | Status | Evidence |
+|---|---|---|---|
+| Daily Gate Dashboard (post-fix) | #22942361131 | PASS | `output/playwright/ga/22942361131/attendance-daily-gate-dashboard-22942361131-1/attendance-daily-gate-dashboard.json` |
+
+Observed (`#22942361131`):
+
+- `gateFlat.perf.commitMs=574071`
+- `gateFlat.perf.commitGateMs=18000`
+- `gateFlat.perf.commitGateSource=jobElapsedMs`
+
+Decision:
+
+- dashboard now distinguishes wall-clock latency from gated async job telemetry.
+- **GO maintained**.


### PR DESCRIPTION
## Summary
- append post-go validation for dashboard commitGate fields
- record run #22942361131 evidence in go/no-go and daily gates docs

## Evidence
- `output/playwright/ga/22942361131/attendance-daily-gate-dashboard-22942361131-1/attendance-daily-gate-dashboard.json`
