### PR TITLE
fix(attendance): restore import retry status context

### DIFF
--- a/apps/web/src/views/attendance/useAttendanceAdminImportWorkflow.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminImportWorkflow.ts
@@ -901,6 +901,7 @@ export function useAttendanceAdminImportWorkflow({
         tr('Select a CSV file first.', '请先选择 CSV 文件。'),
         'error',
         {
+          context: 'import-preview',
           hint: tr('Choose a CSV file, then retry preview/import.', '选择 CSV 文件后，再重试预览或导入。'),
           action: 'retry-preview-import',
         },
@@ -1348,6 +1349,7 @@ export function useAttendanceAdminImportWorkflow({
         tr('Invalid JSON payload for import.', '导入载荷 JSON 无效。'),
         'error',
         {
+          context: 'import-preview',
           hint: tr('Fix JSON syntax in payload and retry preview.', '请修复载荷 JSON 语法后重试预览。'),
           action: 'retry-preview-import',
         },
@@ -1456,6 +1458,7 @@ export function useAttendanceAdminImportWorkflow({
         tr('Invalid JSON payload for import.', '导入载荷 JSON 无效。'),
         'error',
         {
+          context: 'import-run',
           hint: tr('Fix JSON syntax in payload and retry import.', '请修复载荷 JSON 语法后重试导入。'),
           action: 'retry-run-import',
         },

--- a/apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts
+++ b/apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts
@@ -180,6 +180,40 @@ describe('useAttendanceAdminImportWorkflow', () => {
     expect(setStatusFromError.mock.calls[0]?.[2]).toBe('import-preview')
   })
 
+  it.each([
+    {
+      name: 'preview invalid JSON',
+      invoke: async (workflow: ReturnType<typeof useAttendanceAdminImportWorkflow>) => workflow.previewImport(),
+      expectedMeta: {
+        context: 'import-preview',
+        hint: 'Fix JSON syntax in payload and retry preview.',
+        action: 'retry-preview-import',
+      },
+    },
+    {
+      name: 'run invalid JSON',
+      invoke: async (workflow: ReturnType<typeof useAttendanceAdminImportWorkflow>) => workflow.runImport(),
+      expectedMeta: {
+        context: 'import-run',
+        hint: 'Fix JSON syntax in payload and retry import.',
+        action: 'retry-run-import',
+      },
+    },
+  ])('reports retry metadata for $name', async ({ invoke, expectedMeta }) => {
+    const { workflow, apiFetch, setStatus } = createWorkflow()
+
+    workflow.importForm.payload = '{'
+
+    await invoke(workflow)
+
+    expect(apiFetch).not.toHaveBeenCalled()
+    expect(setStatus).toHaveBeenCalledWith(
+      'Invalid JSON payload for import.',
+      'error',
+      expectedMeta,
+    )
+  })
+
   it('refreshes records and batches after a successful import commit', async () => {
     const loadRecords = vi.fn(async () => undefined)
     const loadImportBatches = vi.fn(async () => undefined)


### PR DESCRIPTION
## Summary
- restore missing import status `context` metadata for retryable admin import errors
- ensure invalid preview/import JSON keeps the retry action visible in the admin import section
- add a focused regression test for preview/run invalid JSON retry metadata

## Why
The latest strict gates failure on `main` showed the desktop admin import flow timing out while waiting for `Retry preview`. The import error message rendered, but the retry button was hidden because these status branches did not include `context`, so `AttendanceView` treated them as non-import errors.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/useAttendanceAdminImportWorkflow.spec.ts`
- `pnpm --filter @metasheet/web build`

## Related runs
- strict-gates fail: https://github.com/zensgit/metasheet2/actions/runs/23105765178
- post-merge verify fail: https://github.com/zensgit/metasheet2/actions/runs/23105714323
