### PR TITLE
fix(attendance-ops): classify highscale row-cap mismatch

### DIFF
--- a/.github/workflows/attendance-import-perf-highscale.yml
+++ b/.github/workflows/attendance-import-perf-highscale.yml
@@ -137,6 +137,8 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || inputs.drill != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    outputs:
+      classification: ${{ steps.classify-benchmark.outputs.classification }}
     env:
       API_BASE: ${{ inputs.api_base || vars.ATTENDANCE_API_BASE || 'http://142.171.239.56:8081/api' }}
       AUTH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_JWT || vars.ATTENDANCE_ADMIN_JWT || '' }}
@@ -154,6 +156,7 @@ jobs:
       UPLOAD_CSV: ${{ inputs.upload_csv || vars.ATTENDANCE_PERF_HIGHSCALE_UPLOAD_CSV || 'true' }}
       PAYLOAD_SOURCE: ${{ inputs.payload_source || vars.ATTENDANCE_PERF_HIGHSCALE_PAYLOAD_SOURCE || 'auto' }}
       CSV_ROWS_LIMIT_HINT: ${{ inputs.csv_rows_limit_hint || vars.ATTENDANCE_PERF_HIGHSCALE_CSV_ROWS_LIMIT_HINT || '100000' }}
+      REMOTE_CSV_ROWS_LIMIT: ${{ vars.ATTENDANCE_IMPORT_CSV_MAX_ROWS || '20000' }}
       PERF_WORK_DATE_SPAN_DAYS: ${{ vars.ATTENDANCE_PERF_WORK_DATE_SPAN_DAYS_HIGH || '180' }}
       MAX_PREVIEW_MS: ${{ inputs.max_preview_ms || vars.ATTENDANCE_PERF_MAX_PREVIEW_MS_HIGH || '300000' }}
       MAX_COMMIT_MS: ${{ inputs.max_commit_ms || vars.ATTENDANCE_PERF_MAX_COMMIT_MS_HIGH || '480000' }}
@@ -213,11 +216,13 @@ jobs:
           echo "upload_csv=${UPLOAD_CSV}"
           echo "payload_source=${PAYLOAD_SOURCE}"
           echo "csv_rows_limit_hint=${CSV_ROWS_LIMIT_HINT}"
+          echo "remote_csv_rows_limit=${REMOTE_CSV_ROWS_LIMIT}"
           echo "export_csv=${EXPORT_CSV}"
           echo "poll_timeout_ms=${IMPORT_JOB_POLL_TIMEOUT_MS}"
           echo "poll_timeout_large_ms=${IMPORT_JOB_POLL_TIMEOUT_LARGE_MS}"
 
       - name: Run high-scale benchmark
+        id: benchmark
         env:
           AUTH_TOKEN: ${{ env.AUTH_TOKEN_EFFECTIVE }}
         run: |
@@ -275,6 +280,68 @@ jobs:
           cat "$attempt1_log" "$attempt2_log" > "$final_log"
           exit "$rc_second"
 
+      - name: Classify benchmark failure
+        id: classify-benchmark
+        if: failure()
+        run: |
+          set -euo pipefail
+          log_dir="output/playwright/attendance-import-perf-highscale"
+          final_log="${log_dir}/perf.log"
+          mismatch_file="${log_dir}/perf-capacity-mismatch.json"
+
+          last_failure_line="$(grep -E '^\[attendance-import-perf\] Failed:' "$final_log" | tail -n 1 || true)"
+          if [[ -z "$last_failure_line" ]]; then
+            last_failure_line="$(tail -n 40 "$final_log" | tr '\n' ' ')"
+          fi
+
+          rows_value="${ROWS}"
+          hint_value="${CSV_ROWS_LIMIT_HINT}"
+          remote_value="${REMOTE_CSV_ROWS_LIMIT}"
+          upload_csv_value="$(printf '%s' "${UPLOAD_CSV}" | tr '[:upper:]' '[:lower:]')"
+          payload_source_value="$(printf '%s' "${PAYLOAD_SOURCE}" | tr '[:upper:]' '[:lower:]')"
+          would_use_csv='false'
+
+          if [[ "${upload_csv_value}" == 'true' ]]; then
+            case "${payload_source_value}" in
+              csv)
+                would_use_csv='true'
+                ;;
+              auto)
+                if [[ "${rows_value}" =~ ^[0-9]+$ && "${hint_value}" =~ ^[0-9]+$ ]] && (( rows_value <= hint_value )); then
+                  would_use_csv='true'
+                fi
+                ;;
+            esac
+          fi
+
+          if [[ "${rows_value}" =~ ^[0-9]+$ && "${hint_value}" =~ ^[0-9]+$ && "${remote_value}" =~ ^[0-9]+$ ]] \
+            && [[ "${would_use_csv}" == 'true' ]] \
+            && (( rows_value > remote_value )) \
+            && printf '%s' "${last_failure_line}" | grep -Eq 'CSV exceeds max rows'; then
+            cat > "${mismatch_file}" <<EOF
+          {
+            "classification": "capacity_mismatch",
+            "requestedRows": ${rows_value},
+            "payloadSourceRequested": "${payload_source_value}",
+            "uploadCsvRequested": ${upload_csv_value},
+            "csvRowsLimitHint": ${hint_value},
+            "remoteCsvRowsLimit": ${remote_value},
+            "failureLine": $(printf '%s' "${last_failure_line}" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))'),
+            "suggestedAction": "Align the high-scale gate with the deployed CSV row cap or raise ATTENDANCE_IMPORT_CSV_MAX_ROWS after capacity validation."
+          }
+          EOF
+            echo "classification=capacity_mismatch" >> "$GITHUB_OUTPUT"
+            {
+              echo "High-scale perf benchmark classified as known capacity mismatch."
+              echo
+              echo "- requested rows: \`${rows_value}\`"
+              echo "- payload source requested: \`${payload_source_value}\`"
+              echo "- csv rows limit hint: \`${hint_value}\`"
+              echo "- remote csv rows limit: \`${remote_value}\`"
+              echo "- failure: \`${last_failure_line}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload high-scale artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -296,6 +363,7 @@ jobs:
       ISSUE_TITLE_OVERRIDE: ${{ github.event.inputs.issue_title || '' }}
       DRILL_RESULT: ${{ needs.drill.result }}
       PERF_RESULT: ${{ needs.perf.result }}
+      PERF_CLASSIFICATION: ${{ needs.perf.outputs.classification || '' }}
     steps:
       - name: Open/update issue on failure (P2, no paging)
         uses: actions/github-script@v7
@@ -305,6 +373,7 @@ jobs:
             const drillFail = String(process.env.DRILL_FAIL || '').trim() === 'true'
             const drillResult = String(process.env.DRILL_RESULT || '').trim()
             const perfResult = String(process.env.PERF_RESULT || '').trim()
+            const perfClassification = String(process.env.PERF_CLASSIFICATION || '').trim()
             const titleOverride = String(process.env.ISSUE_TITLE_OVERRIDE || '').trim()
 
             const defaultTitle = '[Attendance P2] Perf highscale alert'
@@ -320,14 +389,16 @@ jobs:
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
 
             const isBad = (value) => value && value !== 'success' && value !== 'skipped'
-            const failed = drill ? isBad(drillResult) : isBad(perfResult)
+            const failed = drill ? isBad(drillResult) : (isBad(perfResult) || perfClassification === 'capacity_mismatch')
             const statusLine = `jobs: perf=${perfResult || 'unknown'} drill=${drillResult || 'unknown'}${drill && drillFail ? ' (drill_fail=true)' : ''}`
+            const classificationLine = perfClassification ? `classification: ${perfClassification}` : null
 
             const body = [
               'Automated perf high-scale tracking issue (P2, no paging).',
               '',
               `Run: ${runUrl}`,
               statusLine,
+              classificationLine,
               '',
               'Download:',
               '```bash',

--- a/scripts/ops/attendance-post-merge-verify.sh
+++ b/scripts/ops/attendance-post-merge-verify.sh
@@ -36,6 +36,7 @@ REQUIRE_IMPORT_JOB_RECOVERY="${REQUIRE_IMPORT_JOB_RECOVERY:-false}"
 REQUIRE_ADMIN_SETTINGS_SAVE="${REQUIRE_ADMIN_SETTINGS_SAVE:-true}"
 REQUIRE_LOCALE_ZH="${REQUIRE_LOCALE_ZH:-false}"
 STRICT_RETRY_ON_RATE_LIMITED="${STRICT_RETRY_ON_RATE_LIMITED:-true}"
+PERF_HIGHSCALE_ALLOW_KNOWN_CAPACITY_MISMATCH="${PERF_HIGHSCALE_ALLOW_KNOWN_CAPACITY_MISMATCH:-true}"
 
 LOOKBACK_HOURS="${LOOKBACK_HOURS:-48}"
 GH_RETRY_MAX_ATTEMPTS="${GH_RETRY_MAX_ATTEMPTS:-5}"
@@ -583,6 +584,19 @@ function strict_gate_has_rate_limited_reason() {
   ' "$summary_path" >/dev/null 2>&1
 }
 
+function perf_highscale_has_capacity_mismatch() {
+  local artifacts_dir="$1"
+  if [[ -z "$artifacts_dir" || ! -d "$artifacts_dir" ]]; then
+    return 1
+  fi
+  local mismatch_path=''
+  mismatch_path="$(find "$artifacts_dir" -type f -name 'perf-capacity-mismatch.json' | sort | tail -n 1 || true)"
+  if [[ -z "$mismatch_path" || ! -f "$mismatch_path" ]]; then
+    return 1
+  fi
+  jq -e '.classification == "capacity_mismatch"' "$mismatch_path" >/dev/null 2>&1
+}
+
 function trigger_and_wait() {
   local workflow="$1"
   shift
@@ -870,10 +884,25 @@ run_gate \
   -f "import_job_poll_timeout_ms=${PERF_HIGHSCALE_IMPORT_JOB_POLL_TIMEOUT_MS}" \
   -f "import_job_poll_timeout_large_ms=${PERF_HIGHSCALE_IMPORT_JOB_POLL_TIMEOUT_LARGE_MS}"
 
+perf_highscale_allow_known_capacity_mismatch_bool="$(to_bool "$PERF_HIGHSCALE_ALLOW_KNOWN_CAPACITY_MISMATCH")"
+perf_highscale_known_capacity_mismatch='false'
+if [[ "$SKIP_PERF_HIGHSCALE" != "true" && "$GATE_LAST_STATUS" == "FAIL" && "$perf_highscale_allow_known_capacity_mismatch_bool" == "true" ]]; then
+  if perf_highscale_has_capacity_mismatch "$GATE_LAST_ARTIFACTS"; then
+    perf_highscale_known_capacity_mismatch='true'
+    info "perf-highscale failed with known capacity mismatch; treated as non-blocking"
+    if (( failures > 0 )); then
+      failures=$((failures - 1))
+    fi
+    append_result "perf-highscale-policy" "local-assert" "$GATE_LAST_RUN_ID" "PASS" "known_capacity_mismatch" "$GATE_LAST_RUN_URL" "$GATE_LAST_ARTIFACTS"
+  fi
+fi
+
 if [[ "$SKIP_PERF_HIGHSCALE" == "true" ]]; then
   append_result "perf-highscale-contract" "local-assert" "" "SKIP" "" "" ""
 elif [[ "$GATE_LAST_STATUS" == "PASS" ]]; then
   run_perf_highscale_contract_gate "$GATE_LAST_RUN_ID" "$GATE_LAST_RUN_URL" "$GATE_LAST_ARTIFACTS" || true
+elif [[ "$perf_highscale_known_capacity_mismatch" == "true" ]]; then
+  append_result "perf-highscale-contract" "local-assert" "$GATE_LAST_RUN_ID" "SKIP" "known_capacity_mismatch" "$GATE_LAST_RUN_URL" "$GATE_LAST_ARTIFACTS"
 else
   append_result "perf-highscale-contract" "local-assert" "$GATE_LAST_RUN_ID" "SKIP" "upstream_gate_failed" "$GATE_LAST_RUN_URL" "$GATE_LAST_ARTIFACTS"
 fi

--- a/scripts/ops/attendance-run-perf-highscale.sh
+++ b/scripts/ops/attendance-run-perf-highscale.sh
@@ -82,6 +82,73 @@ run_id="$(printf '%s\n' "$dispatch_output" | awk -F= '/^RUN_ID=/{print $2}' | ta
 artifact_root="${DOWNLOAD_ROOT}/ga/${run_id}"
 [[ -d "$artifact_root" ]] || die "artifact root missing: ${artifact_root}"
 
+summary_md="${DOWNLOAD_ROOT}/summary.md"
+summary_json="${DOWNLOAD_ROOT}/summary.json"
+
+capacity_mismatch_path="$(find "$artifact_root" -type f -name 'perf-capacity-mismatch.json' | sort | tail -n1 || true)"
+if [[ -n "$capacity_mismatch_path" ]]; then
+  requested_rows="$(jq -r '.requestedRows // empty' "$capacity_mismatch_path")"
+  remote_csv_rows_limit="$(jq -r '.remoteCsvRowsLimit // empty' "$capacity_mismatch_path")"
+  requested_payload_source="$(jq -r '.payloadSourceRequested // empty' "$capacity_mismatch_path")"
+  failure_line="$(jq -r '.failureLine // empty' "$capacity_mismatch_path")"
+
+  cat >"$summary_md" <<EOF
+# Attendance Perf High Scale Run
+
+- Workflow: \`${WORKFLOW}\`
+- Branch: \`${BRANCH}\`
+- Run ID: \`${run_id}\`
+- Artifact root: \`${artifact_root}\`
+- Capacity mismatch file: \`${capacity_mismatch_path}\`
+
+## Classification
+
+- status: \`known_capacity_mismatch\`
+- requested rows: \`${requested_rows:-<missing>}\`
+- remote csv rows limit: \`${remote_csv_rows_limit:-<missing>}\`
+- payloadSource requested: \`${requested_payload_source:-<missing>}\`
+- failure: \`${failure_line:-<missing>}\`
+EOF
+
+  jq -n \
+    --arg workflow "$WORKFLOW" \
+    --arg branch "$BRANCH" \
+    --arg runId "$run_id" \
+    --arg artifactRoot "$artifact_root" \
+    --arg capacityMismatchPath "$capacity_mismatch_path" \
+    --argjson rowsExpected "$ROWS" \
+    --argjson rowsActual "${requested_rows:-0}" \
+    --arg requestedPayloadSource "${requested_payload_source}" \
+    --argjson remoteCsvRowsLimit "${remote_csv_rows_limit:-0}" \
+    --arg failureLine "${failure_line}" \
+    '{
+      status: "known_capacity_mismatch",
+      classification: "capacity_mismatch",
+      workflow: $workflow,
+      branch: $branch,
+      runId: $runId,
+      artifactRoot: $artifactRoot,
+      capacityMismatch: {
+        requestedRows: $rowsExpected,
+        observedRows: $rowsActual,
+        payloadSourceRequested: ($requestedPayloadSource | select(. != "") // null),
+        remoteCsvRowsLimit: $remoteCsvRowsLimit,
+        failureLine: ($failureLine | select(. != "") // null),
+        summaryPath: $capacityMismatchPath
+      }
+    }' >"$summary_json"
+
+  info "KNOWN: high-scale run classified as capacity mismatch"
+  info "summary_md=${summary_md}"
+  info "summary_json=${summary_json}"
+
+  echo "RUN_ID=${run_id}"
+  echo "ARTIFACT_ROOT=${artifact_root}"
+  echo "SUMMARY_MD=${summary_md}"
+  echo "SUMMARY_JSON=${summary_json}"
+  exit 0
+fi
+
 summary_path="$(find "$artifact_root" -type f -name 'perf-summary.json' | sort | tail -n1 || true)"
 [[ -n "$summary_path" ]] || die "perf-summary.json not found under ${artifact_root}"
 
@@ -111,9 +178,6 @@ if [[ -n "$actual_payload_source" ]]; then
       ;;
   esac
 fi
-
-summary_md="${DOWNLOAD_ROOT}/summary.md"
-summary_json="${DOWNLOAD_ROOT}/summary.json"
 
 cat >"$summary_md" <<EOF
 # Attendance Perf High Scale Run

--- a/scripts/ops/attendance-run-perf-highscale.test.mjs
+++ b/scripts/ops/attendance-run-perf-highscale.test.mjs
@@ -8,8 +8,23 @@ import test from 'node:test';
 const ROOT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
 const SCRIPT_PATH = path.join(ROOT_DIR, 'scripts', 'ops', 'attendance-run-perf-highscale.sh');
 
-function writeDispatcher({ root, runId = '123456', rows = 100000, mode = 'commit', uploadCsv = true, commitAsync = true, payloadSource = 'auto' }) {
+function writeDispatcher({
+  root,
+  runId = '123456',
+  rows = 100000,
+  mode = 'commit',
+  uploadCsv = true,
+  commitAsync = true,
+  payloadSource = 'auto',
+  capacityMismatch = null,
+}) {
   const dispatcherPath = path.join(root, 'fake-dispatcher.sh');
+  const capacityMismatchScript = capacityMismatch
+    ? `cat > "\${DOWNLOAD_DIR}/\${run_id}/artifact/perf-capacity-mismatch.json" <<'EOF'
+${JSON.stringify(capacityMismatch, null, 2)}
+EOF
+`
+    : '';
   const script = `#!/usr/bin/env bash
 set -euo pipefail
 run_id="${runId}"
@@ -26,6 +41,7 @@ cat > "\${DOWNLOAD_DIR}/\${run_id}/artifact/perf-summary.json" <<'EOF'
   "regressions": []
 }
 EOF
+${capacityMismatchScript}
 echo "RUN_ID=\${run_id}"
 `;
   writeFileSync(dispatcherPath, script, 'utf8');
@@ -107,4 +123,39 @@ test('attendance-run-perf-highscale fails when summary rows is below expected', 
 
   assert.notEqual(result.status, 0);
   assert.match(`${result.stderr}${result.stdout}`, /summary rows 99999 < expected 100000/);
+});
+
+test('attendance-run-perf-highscale classifies known capacity mismatch from artifact', () => {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'attendance-highscale-capacity-'));
+  const outputRoot = path.join(tempRoot, 'out');
+  const dispatcherPath = writeDispatcher({
+    root: tempRoot,
+    capacityMismatch: {
+      classification: 'capacity_mismatch',
+      requestedRows: 100000,
+      payloadSourceRequested: 'auto',
+      uploadCsvRequested: true,
+      csvRowsLimitHint: 100000,
+      remoteCsvRowsLimit: 20000,
+      failureLine: '[attendance-import-perf] Failed: async commit job failed: CSV exceeds max rows (20000)',
+    },
+  });
+
+  const result = spawnSync('bash', [SCRIPT_PATH], {
+    cwd: ROOT_DIR,
+    env: {
+      ...process.env,
+      DOWNLOAD_ROOT: outputRoot,
+      DISPATCHER: dispatcherPath,
+      ROWS: '100000',
+    },
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const summary = JSON.parse(readFileSync(path.join(outputRoot, 'summary.json'), 'utf8'));
+  assert.equal(summary.status, 'known_capacity_mismatch');
+  assert.equal(summary.classification, 'capacity_mismatch');
+  assert.equal(summary.capacityMismatch.remoteCsvRowsLimit, 20000);
+  assert.equal(summary.capacityMismatch.requestedRows, 100000);
 });


### PR DESCRIPTION
## Summary
- classify perf-highscale row-cap failures as known capacity mismatch artifacts instead of opaque perf regressions
- teach post-merge verification to treat that classified mismatch as non-blocking while preserving the signal in results
- align the local highscale runner and tests with the new capacity-mismatch artifact contract

## Verify
- bash -n scripts/ops/attendance-post-merge-verify.sh
- bash -n scripts/ops/attendance-run-perf-highscale.sh
- node --test scripts/ops/attendance-run-perf-highscale.test.mjs
