### PR TITLE
feat(attendance-import): expose async skipped job summary

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1536,6 +1536,168 @@ describe('Attendance Plugin Integration', () => {
     expect(rollbackRes.status).toBe(200)
   })
 
+  it('retains compact skipped summary for completed commit-async jobs and idempotent retry', async () => {
+    if (!baseUrl) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=attendance-test&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    if (!token) return
+
+    const workDate = new Date().toISOString().slice(0, 10)
+    const duplicateUserId = `attendance-async-duplicate-${Date.now().toString(36)}`
+    const idempotencyKey = `integration-async-duplicate-${Date.now().toString(36)}`
+
+    const prepareRes = await requestJson(`${baseUrl}/api/attendance/import/prepare`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    })
+    expect(prepareRes.status).toBe(200)
+    const commitToken = (prepareRes.body as { data?: { commitToken?: string } } | undefined)?.data?.commitToken
+    expect(commitToken).toBeTruthy()
+
+    const commitPayload = {
+      userId: 'attendance-test',
+      idempotencyKey,
+      timezone: 'UTC',
+      rows: [
+        {
+          userId: duplicateUserId,
+          workDate,
+          fields: {
+            firstInAt: `${workDate}T09:00:00Z`,
+            lastOutAt: `${workDate}T18:00:00Z`,
+            status: 'normal',
+          },
+        },
+        {
+          userId: duplicateUserId,
+          workDate,
+          fields: {
+            firstInAt: `${workDate}T09:05:00Z`,
+            lastOutAt: `${workDate}T18:05:00Z`,
+            status: 'normal',
+          },
+        },
+      ],
+      mode: 'override',
+      commitToken,
+    }
+
+    const commitRes = await requestJson(`${baseUrl}/api/attendance/import/commit-async`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(commitPayload),
+    })
+    expect(commitRes.status).toBe(200)
+    const initialJob = (commitRes.body as { data?: { job?: any } } | undefined)?.data?.job
+    const jobId = String(initialJob?.id || '')
+    expect(jobId).toBeTruthy()
+
+    let batchId = ''
+    let completedJob: any = null
+    for (let i = 0; i < 100; i += 1) {
+      const jobRes = await requestJson(`${baseUrl}/api/attendance/import/jobs/${jobId}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+      expect(jobRes.status).toBe(200)
+      const jobData = (jobRes.body as { data?: any } | undefined)?.data
+      const status = String(jobData?.status || '')
+      if (status === 'completed') {
+        batchId = String(jobData?.batchId || '')
+        completedJob = jobData
+        break
+      }
+      if (status === 'failed') {
+        throw new Error(String(jobData?.error || 'async duplicate job failed'))
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+
+    expect(batchId).toBeTruthy()
+    expect(completedJob).toBeTruthy()
+    expect(Number(completedJob?.failedRows ?? 0)).toBe(1)
+    expect(Number(completedJob?.skippedCount ?? 0)).toBe(1)
+    expect(Array.isArray(completedJob?.skippedRows)).toBe(true)
+    expect(completedJob?.skippedRows).toHaveLength(1)
+    expect(String(completedJob?.skippedRows?.[0]?.warnings?.[0] || '')).toContain('Duplicate row')
+
+    const batchDetailRes = await requestJson(
+      `${baseUrl}/api/attendance/import/batches/${encodeURIComponent(batchId)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    )
+    expect(batchDetailRes.status).toBe(200)
+    const batchMeta = (batchDetailRes.body as { data?: { meta?: any } } | undefined)?.data?.meta
+    expect(Number(batchMeta?.skippedCount ?? 0)).toBe(1)
+    expect(Array.isArray(batchMeta?.skippedRows)).toBe(true)
+    expect(batchMeta?.skippedRows).toHaveLength(1)
+    expect(String(batchMeta?.skippedRows?.[0]?.warnings?.[0] || '')).toContain('Duplicate row')
+
+    const batchItemsRes = await requestJson(
+      `${baseUrl}/api/attendance/import/batches/${encodeURIComponent(batchId)}/items?pageSize=20`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    )
+    expect(batchItemsRes.status).toBe(200)
+    const batchItems = (batchItemsRes.body as { data?: { items?: any[] } } | undefined)?.data?.items ?? []
+    const skippedItem = batchItems.find((item) => item?.recordId == null)
+    expect(skippedItem).toBeTruthy()
+    expect(String(skippedItem?.previewSnapshot?.skip?.reason || '')).toBe('duplicate')
+    expect(String(skippedItem?.previewSnapshot?.warnings?.[0] || '')).toContain('Duplicate row')
+
+    const { commitToken: _commitToken, ...retryPayload } = commitPayload
+    const retryRes = await requestJson(`${baseUrl}/api/attendance/import/commit-async`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(retryPayload),
+    })
+    expect(retryRes.status).toBe(200)
+    const retryData = (retryRes.body as { data?: { idempotent?: boolean; job?: any } } | undefined)?.data
+    expect(retryData?.idempotent).toBe(true)
+    expect(String(retryData?.job?.id || '')).toBe(jobId)
+    expect(String(retryData?.job?.batchId || '')).toBe(batchId)
+    expect(Number(retryData?.job?.failedRows ?? 0)).toBe(1)
+    expect(Number(retryData?.job?.skippedCount ?? 0)).toBe(1)
+    expect(Array.isArray(retryData?.job?.skippedRows)).toBe(true)
+    expect(retryData?.job?.skippedRows).toHaveLength(1)
+    expect(String(retryData?.job?.skippedRows?.[0]?.warnings?.[0] || '')).toContain('Duplicate row')
+
+    const rollbackRes = await requestJson(`${baseUrl}/api/attendance/import/rollback/${batchId}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    })
+    expect(rollbackRes.status).toBe(200)
+  })
+
   it('returns NOT_FOUND for unknown async import job id', async () => {
     if (!baseUrl) return
 

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -793,6 +793,13 @@ components:
           type: integer
         failedRows:
           type: integer
+        skippedCount:
+          type: integer
+        skippedRows:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
         elapsedMs:
           type: integer
         throughputRowsPerSec:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -1165,6 +1165,16 @@
           "failedRows": {
             "type": "integer"
           },
+          "skippedCount": {
+            "type": "integer"
+          },
+          "skippedRows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
           "elapsedMs": {
             "type": "integer"
           },

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -793,6 +793,13 @@ components:
           type: integer
         failedRows:
           type: integer
+        skippedCount:
+          type: integer
+        skippedRows:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
         elapsedMs:
           type: integer
         throughputRowsPerSec:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -766,6 +766,13 @@ components:
           type: integer
         failedRows:
           type: integer
+        skippedCount:
+          type: integer
+        skippedRows:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
         elapsedMs:
           type: integer
         throughputRowsPerSec:

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -6182,14 +6182,81 @@ module.exports = {
 	      return Math.max(0, Math.floor(endMs - startMs))
 	    }
 
+	    const normalizeImportJobSkippedRows = (value, limit = 50) => {
+	      if (!Array.isArray(value) || limit <= 0) return []
+	      return value
+	        .map((entry) => normalizeMetadata(entry))
+	        .filter((entry) => entry && typeof entry === 'object' && Object.keys(entry).length > 0)
+	        .slice(0, limit)
+	    }
+
+	    const extractImportJobSkippedSummary = (...sources) => {
+	      let skippedCount = 0
+	      let skippedRows = []
+	      for (const source of sources) {
+	        const normalized = normalizeMetadata(source)
+	        if (!skippedRows.length) {
+	          skippedRows = normalizeImportJobSkippedRows(normalized?.skippedRows)
+	        }
+	        const rawCount = Number(normalized?.skippedCount)
+	        if (Number.isFinite(rawCount) && rawCount >= 0) {
+	          skippedCount = Math.max(skippedCount, Math.floor(rawCount))
+	        }
+	      }
+	      if (!skippedCount && skippedRows.length) skippedCount = skippedRows.length
+	      return { skippedCount, skippedRows }
+	    }
+
+	    const buildAsyncCommitJobSummaryPayload = ({
+	      basePayload,
+	      rowCount,
+	      processedRows,
+	      failedRows,
+	      elapsedMs,
+	      engine,
+	      recordUpsertStrategy,
+	      chunkConfig,
+	      skippedCount,
+	      skippedRows,
+	      idempotencyKey,
+	    }) => {
+	      const compactSummary = {
+	        processedRows: Math.max(0, Math.floor(Number(processedRows ?? rowCount ?? 0) || 0)),
+	        failedRows: Math.max(0, Math.floor(Number(failedRows ?? skippedCount ?? 0) || 0)),
+	        elapsedMs: Math.max(0, Math.floor(Number(elapsedMs ?? 0) || 0)),
+	        chunkConfig: chunkConfig ?? resolveImportChunkConfig(engine),
+	      }
+	      const normalizedSkippedCount = Math.max(0, Math.floor(Number(skippedCount ?? 0) || 0))
+	      const normalizedSkippedRows = normalizeImportJobSkippedRows(skippedRows)
+	      if (normalizedSkippedCount > 0) compactSummary.skippedCount = normalizedSkippedCount
+	      if (normalizedSkippedRows.length) compactSummary.skippedRows = normalizedSkippedRows
+	      return {
+	        __jobType: 'commit',
+	        idempotencyKey: basePayload?.idempotencyKey ?? idempotencyKey ?? null,
+	        __importEngine: engine ?? resolveImportEngineFromMeta(basePayload, rowCount ?? processedRows ?? 0),
+	        recordUpsertStrategy:
+	          recordUpsertStrategy
+	          ?? resolveImportRecordUpsertStrategyFromMeta(
+	            basePayload,
+	            rowCount ?? processedRows ?? 0,
+	            engine ?? resolveImportEngineFromMeta(basePayload, rowCount ?? processedRows ?? 0)
+	          ),
+	        summary: compactSummary,
+	      }
+	    }
+
 	    const mapImportJobRow = (row) => {
 	      const payload = normalizeMetadata(row.payload)
 	      const kind = payload?.__jobType === 'preview' ? 'preview' : 'commit'
 	      const status = normalizeImportJobStatus(row.status)
 	      const progress = Number(row.progress ?? 0)
 	      const total = Number(row.total ?? 0)
-	      const processedRowsRaw = Number(payload?.summary?.processedRows)
-	      const failedRowsRaw = Number(payload?.summary?.failedRows)
+	      const summary = normalizeMetadata(payload?.summary)
+	      const processedRowsRaw = Number(summary?.processedRows)
+	      const failedRowsRaw = Number(summary?.failedRows)
+	      const { skippedCount, skippedRows } = kind === 'commit'
+	        ? extractImportJobSkippedSummary(summary, payload)
+	        : { skippedCount: 0, skippedRows: [] }
 	      const processedRows = Number.isFinite(processedRowsRaw)
 	        ? Math.max(0, Math.floor(processedRowsRaw))
 	        : (status === 'completed' ? Math.max(0, Math.floor(total)) : Math.max(0, Math.floor(progress)))
@@ -6233,6 +6300,8 @@ module.exports = {
 	        progressPercent,
 	        processedRows,
 	        failedRows,
+	        skippedCount,
+	        skippedRows,
 	        elapsedMs,
 	        throughputRowsPerSec,
 	        error: row.error ?? null,
@@ -6552,25 +6621,58 @@ module.exports = {
 	      const payload = normalizeMetadata(jobRow.payload)
 	      const isPreviewJob = payload?.__jobType === 'preview'
 	      const status = normalizeImportJobStatus(jobRow.status)
+	      const idempotencyKey = typeof jobRow.idempotency_key === 'string' ? jobRow.idempotency_key : null
 	      if (status === 'completed') return
 
 	      if (!isPreviewJob) {
 	        // If the batch already exists, treat the job as complete (idempotent re-run).
 	        try {
 	          const batchRows = await db.query(
-	            'SELECT id, status, meta FROM attendance_import_batches WHERE id = $1 AND org_id = $2',
+	            'SELECT id, status, meta, row_count FROM attendance_import_batches WHERE id = $1 AND org_id = $2',
 	            [batchId, orgId]
 	          )
 	          if (batchRows.length && String(batchRows[0].status ?? '').toLowerCase() === 'committed') {
+	            const batchMeta = normalizeMetadata(batchRows[0].meta)
+	            const rowCount = Math.max(0, Number(batchRows[0].row_count ?? jobRow.total ?? 0))
+	            const { skippedCount, skippedRows } = extractImportJobSkippedSummary(batchMeta)
+	            const processedRows = Math.max(0, rowCount - skippedCount)
 	            await updateImportJobProgress({
 	              jobId: rowId,
 	              orgId,
 	              status: 'completed',
-	              progress: jobRow.total ?? 0,
-	              total: jobRow.total ?? 0,
+	              progress: rowCount,
+	              total: rowCount,
 	              error: null,
 	              finishedAt: true,
 	            })
+	            await db.query(
+	              'UPDATE attendance_import_jobs SET payload = $3::jsonb, updated_at = now() WHERE id = $1 AND org_id = $2',
+	              [
+	                rowId,
+	                orgId,
+	                JSON.stringify(
+	                  buildAsyncCommitJobSummaryPayload({
+	                    basePayload: payload,
+	                    rowCount,
+	                    processedRows,
+	                    failedRows: skippedCount,
+	                    elapsedMs: 0,
+	                    engine: resolveImportEngineFromMeta(batchMeta, rowCount) || resolveImportEngineFromMeta(payload, rowCount),
+	                    recordUpsertStrategy: resolveImportRecordUpsertStrategyFromMeta(
+	                      batchMeta,
+	                      rowCount,
+	                      resolveImportEngineFromMeta(batchMeta, rowCount) || resolveImportEngineFromMeta(payload, rowCount)
+	                    ),
+	                    chunkConfig: batchMeta?.chunkConfig ?? resolveImportChunkConfig(
+	                      resolveImportEngineFromMeta(batchMeta, rowCount) || resolveImportEngineFromMeta(payload, rowCount)
+	                    ),
+	                    skippedCount,
+	                    skippedRows,
+	                    idempotencyKey,
+	                  })
+	                ),
+	              ]
+	            )
 	            return
 	          }
 	        } catch (_error) {
@@ -6579,7 +6681,6 @@ module.exports = {
 	      }
 
 	      await updateImportJobProgress({ jobId: rowId, orgId, status: 'running', startedAt: true })
-	      const idempotencyKey = typeof jobRow.idempotency_key === 'string' ? jobRow.idempotency_key : null
 
 	      if (isPreviewJob) {
 	        try {
@@ -6643,11 +6744,19 @@ module.exports = {
 	          finishedAt: true,
 	        })
 
+	        const { skippedCount, skippedRows } = extractImportJobSkippedSummary(
+	          commitResult,
+	          commitResult?.meta,
+	          commitResult?.summary
+	        )
 	        // Drop large payload after completion while preserving compact progress metadata.
-		        const summaryPayload = {
-		          __jobType: 'commit',
-		          idempotencyKey: payload.idempotencyKey ?? idempotencyKey ?? null,
-		          __importEngine: commitResult.engine ?? resolveImportEngineFromMeta(payload, commitResult.rowCount ?? 0),
+		        const summaryPayload = buildAsyncCommitJobSummaryPayload({
+		          basePayload: payload,
+		          rowCount: commitResult.rowCount ?? commitResult.imported ?? 0,
+		          processedRows: commitResult.processedRows ?? commitResult.rowCount ?? 0,
+		          failedRows: Math.max(0, Number(commitResult.failedRows ?? skippedCount ?? 0)),
+		          elapsedMs: Number(commitResult.elapsedMs ?? 0),
+		          engine: commitResult.engine ?? resolveImportEngineFromMeta(payload, commitResult.rowCount ?? 0),
 		          recordUpsertStrategy:
 		            commitResult.recordUpsertStrategy
 		            ?? commitResult?.meta?.recordUpsertStrategy
@@ -6656,15 +6765,13 @@ module.exports = {
 		              commitResult.rowCount ?? commitResult.imported ?? 0,
 		              commitResult.engine ?? resolveImportEngineFromMeta(payload, commitResult.rowCount ?? 0)
 		            ),
-		          summary: {
-		            processedRows: Number(commitResult.processedRows ?? commitResult.rowCount ?? 0),
-		            failedRows: Math.max(0, Number(commitResult.failedRows ?? commitResult.skippedCount ?? 0)),
-		            elapsedMs: Number(commitResult.elapsedMs ?? 0),
-		            chunkConfig: commitResult?.meta?.chunkConfig ?? resolveImportChunkConfig(
-		              commitResult.engine ?? resolveImportEngineFromMeta(payload, commitResult.rowCount ?? 0)
-		            ),
-		          },
-		        }
+		          chunkConfig: commitResult?.meta?.chunkConfig ?? resolveImportChunkConfig(
+		            commitResult.engine ?? resolveImportEngineFromMeta(payload, commitResult.rowCount ?? 0)
+		          ),
+		          skippedCount,
+		          skippedRows,
+		          idempotencyKey,
+		        })
 	        await db.query(
 	          'UPDATE attendance_import_jobs SET payload = $3::jsonb, updated_at = now() WHERE id = $1 AND org_id = $2',
 	          [rowId, orgId, JSON.stringify(summaryPayload)]


### PR DESCRIPTION
## Summary
- retain compact skippedCount/skippedRows on completed async commit jobs
- backfill the same compact skip summary when async commit short-circuits to an existing committed batch
- add async commit integration coverage for duplicate-row retention across job polling, batch detail, batch items, and idempotent retry

## Verification
- node --check plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "retains compact skipped summary for completed commit-async jobs and idempotent retry|supports commit-async with csvFileId and idempotent retry after upload cleanup|supports async import commit jobs \\(commit-async \\+ job polling\\)"
- pnpm --filter @metasheet/core-backend build
- pnpm exec tsx packages/openapi/tools/build.ts
- node scripts/ops/attendance-validate-openapi-import-contract.mjs packages/openapi/dist/openapi.json packages/openapi/src/paths/attendance.yml
- bash scripts/ops/attendance-run-gate-contract-case.sh openapi