### PR TITLE
fix(attendance): restore run11 feedback compatibility

### DIFF
--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -8,6 +8,7 @@ const logger = new Logger('JWTMiddleware')
 
 const AUTH_WHITELIST = [
   '/health',
+  '/api/health',
   '/metrics',
   '/metrics/prom',
   '/api/auth/login',

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -472,8 +472,7 @@ export class MetaSheetServer {
     this.app.use(attendanceAuditMiddleware())
     this.app.use(attendanceSecurityMiddleware())
 
-    // 健康检查
-    this.app.get('/health', (req, res) => {
+    const handleHealth = (req: Request, res: Response) => {
       const endTimer = (res as unknown as Record<string, unknown>).__metricsTimer as ((opts: { route: string; method: string }) => (statusCode: number) => void) | undefined
       try {
         const stats = getPoolStats()
@@ -495,7 +494,11 @@ export class MetaSheetServer {
         endTimer?.({ route: '/health', method: 'GET' })(500)
         throw err
       }
-    })
+    }
+
+    // 健康检查
+    this.app.get('/health', handleHealth)
+    this.app.get('/api/health', handleHealth)
 
     // 路由：认证（登录/注册/token管理）
     this.app.use('/api/auth', authRouter)

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -9,6 +9,7 @@ import jwt, { type SignOptions } from 'jsonwebtoken'
 import { authService, type User } from '../auth/AuthService'
 import { FEATURE_FLAGS } from '../config/flags'
 import { Logger } from '../core/logger'
+import { query } from '../db/pg'
 
 const logger = new Logger('AuthRouter')
 
@@ -456,6 +457,79 @@ authRouter.get('/me', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Get user info error', error instanceof Error ? error : undefined)
     res.status(500).json({
+      success: false,
+      error: 'Internal server error'
+    })
+  }
+})
+
+/**
+ * 管理员用户列表（兼容旧客户端 /api/auth/users）
+ */
+authRouter.get('/users', async (req: Request, res: Response) => {
+  try {
+    const authHeader = req.headers.authorization
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null
+
+    if (!token) {
+      return res.status(401).json({
+        success: false,
+        error: 'No token provided'
+      })
+    }
+
+    const payload = jwt.verify(token, process.env.JWT_SECRET || DEV_FALLBACK_JWT_SECRET)
+    if (!payload || typeof payload !== 'object') {
+      return res.status(401).json({
+        success: false,
+        error: 'Invalid token'
+      })
+    }
+
+    const tokenUser = payload as { role?: unknown; roles?: unknown }
+    const roles = Array.isArray(tokenUser.roles) ? tokenUser.roles.map((value) => String(value)) : []
+    const isAdmin = tokenUser.role === 'admin' || roles.includes('admin')
+    if (!isAdmin) {
+      return res.status(403).json({
+        success: false,
+        error: 'Forbidden'
+      })
+    }
+
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : ''
+    const page = Math.max(1, Number.parseInt(String(req.query.page ?? '1'), 10) || 1)
+    const requestedPageSize = Number.parseInt(String(req.query.pageSize ?? '20'), 10) || 20
+    const pageSize = Math.min(100, Math.max(1, requestedPageSize))
+    const offset = (page - 1) * pageSize
+
+    const term = q ? `%${q}%` : '%'
+    const where = q ? 'WHERE email ILIKE $1 OR name ILIKE $1 OR id ILIKE $1' : ''
+    const countSql = `SELECT COUNT(*)::int AS total FROM users ${where}`
+    const listSql = `
+      SELECT id, email, name, role, is_active, is_admin, last_login_at, created_at, updated_at
+      FROM users
+      ${where}
+      ORDER BY created_at DESC
+      LIMIT $${q ? 2 : 1} OFFSET $${q ? 3 : 2}
+    `
+
+    const countResult = await query<{ total: number }>(countSql, q ? [term] : undefined)
+    const total = countResult.rows[0]?.total ?? 0
+    const listParams = q ? [term, pageSize, offset] : [pageSize, offset]
+    const listResult = await query(listSql, listParams)
+
+    return res.json({
+      success: true,
+      data: {
+        items: listResult.rows,
+        total,
+        page,
+        pageSize,
+      }
+    })
+  } catch (error) {
+    logger.error('Get users error', error instanceof Error ? error : undefined)
+    return res.status(500).json({
       success: false,
       error: 'Internal server error'
     })

--- a/packages/core-backend/src/server.js
+++ b/packages/core-backend/src/server.js
@@ -98,7 +98,7 @@ async function handleRequest(req, res) {
   }
 
   // Health check
-  if (pathname === '/health' && method === 'GET') {
+  if ((pathname === '/health' || pathname === '/api/health') && method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     return res.end(JSON.stringify({
       status: 'ok',

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -913,6 +913,134 @@ describe('Attendance Plugin Integration', () => {
     }
   })
 
+  it('keeps /api/health public for probes', async () => {
+    if (!baseUrl) return
+
+    const healthRes = await requestJson(`${baseUrl}/api/health`)
+    expect(healthRes.status).toBe(200)
+    const body = (healthRes.body as { status?: string; timestamp?: string } | undefined) ?? {}
+    expect(body.status).toBe('ok')
+    expect(typeof body.timestamp).toBe('string')
+  })
+
+  it('keeps /api/auth/users available for admin user listing', async () => {
+    if (!baseUrl) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=auth-users-test&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const usersRes = await requestJson(`${baseUrl}/api/auth/users?page=1&pageSize=5`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+
+    expect(usersRes.status).toBe(200)
+    const body = (usersRes.body as { success?: boolean; data?: { items?: unknown[]; total?: number } } | undefined) ?? {}
+    expect(body.success).toBe(true)
+    expect(Array.isArray(body.data?.items)).toBe(true)
+    expect(typeof body.data?.total).toBe('number')
+  })
+
+  it('keeps /api/attendance/calendar available as records compatibility alias', async () => {
+    if (!baseUrl) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=attendance-calendar-test&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const workDate = new Date().toISOString().slice(0, 10)
+    const calendarRes = await requestJson(
+      `${baseUrl}/api/attendance/calendar?from=${encodeURIComponent(workDate)}&to=${encodeURIComponent(workDate)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    )
+
+    expect(calendarRes.status).toBe(200)
+    const body = (calendarRes.body as { ok?: boolean; data?: { items?: unknown[] } } | undefined) ?? {}
+    expect(body.ok).toBe(true)
+    expect(Array.isArray(body.data?.items)).toBe(true)
+  })
+
+  it('exports attendance CSV with ISO date values and timezone-consistent timestamps', async () => {
+    if (!baseUrl) return
+
+    const tokenUserId = `attendance-export-${Date.now().toString(36)}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(tokenUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    expect(dbUrl).toBeTruthy()
+    if (!dbUrl) return
+
+    const workDate = '2029-03-13'
+    const firstInAt = new Date(`${workDate}T00:00:00.000Z`)
+    const lastOutAt = new Date(`${workDate}T09:00:00.000Z`)
+    const recordId = randomUuidV4()
+    const sourceBatchId = randomUuidV4()
+    const pool = new Pool({ connectionString: dbUrl })
+    try {
+      await pool.query(
+        `INSERT INTO attendance_records
+         (id, user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta, source_batch_id, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, now(), now())`,
+        [
+          recordId,
+          tokenUserId,
+          'default',
+          workDate,
+          'Asia/Tokyo',
+          firstInAt,
+          lastOutAt,
+          540,
+          0,
+          0,
+          'normal',
+          true,
+          JSON.stringify({ source: 'integration-export-format' }),
+          sourceBatchId,
+        ]
+      )
+
+      const exportRes = await requestJson(
+        `${baseUrl}/api/attendance/export?from=${encodeURIComponent(workDate)}&to=${encodeURIComponent(workDate)}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+      expect(exportRes.status).toBe(200)
+
+      const lines = exportRes.raw.trim().split('\n')
+      expect(lines.length).toBeGreaterThanOrEqual(2)
+      expect(lines[0]).toContain('work_date')
+      expect(lines[0]).toContain('timezone')
+      expect(lines[0]).toContain('is_workday')
+      expect(lines[1]).toContain(`${workDate},Asia/Tokyo,${workDate}T09:00:00+09:00,${workDate}T18:00:00+09:00`)
+      expect(lines[1]).toContain(',true')
+      expect(lines[1]).not.toContain('GMT+')
+      expect(lines[1]).not.toContain('Mon ')
+    } finally {
+      await pool.query('DELETE FROM attendance_records WHERE id = $1', [recordId]).catch(() => undefined)
+      await pool.end()
+    }
+  })
+
   it('supports import commit idempotencyKey retries (without requiring a new commitToken)', async () => {
     if (!baseUrl) return
 

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1956,6 +1956,68 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/attendance/calendar:
+    x-plugin: plugin-attendance
+    get:
+      summary: List attendance records for calendar views (compatibility alias)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            type: string
+        - in: query
+          name: orgId
+          schema:
+            type: string
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 50
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AttendanceRecord'
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/attendance/anomalies:
     x-plugin: plugin-attendance
     get:
@@ -5570,6 +5632,53 @@ paths:
                               - attendance
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /api/auth/users:
+    get:
+      summary: List users for admin consoles
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/User'
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/comments:
     get:
       summary: List comments

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2980,6 +2980,108 @@
         }
       }
     },
+    "/api/attendance/calendar": {
+      "x-plugin": "plugin-attendance",
+      "get": {
+        "summary": "List attendance records for calendar views (compatibility alias)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "userId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "orgId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "from",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "to",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/AttendanceRecord"
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
     "/api/attendance/anomalies": {
       "x-plugin": "plugin-attendance",
       "get": {
@@ -8892,6 +8994,84 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/auth/users": {
+      "get": {
+        "summary": "List users for admin consoles",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/User"
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
           }
         }
       }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1956,6 +1956,68 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/attendance/calendar:
+    x-plugin: plugin-attendance
+    get:
+      summary: List attendance records for calendar views (compatibility alias)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            type: string
+        - in: query
+          name: orgId
+          schema:
+            type: string
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 50
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AttendanceRecord'
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/attendance/anomalies:
     x-plugin: plugin-attendance
     get:
@@ -5570,6 +5632,53 @@ paths:
                               - attendance
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /api/auth/users:
+    get:
+      summary: List users for admin consoles
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/User'
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/comments:
     get:
       summary: List comments

--- a/packages/openapi/src/openapi.yml
+++ b/packages/openapi/src/openapi.yml
@@ -186,6 +186,12 @@ paths:
       responses:
         '200':
           description: OK
+  /api/health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: OK
   /api/plugins:
     get:
       summary: List plugins

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -89,6 +89,50 @@ paths:
                       pageSize: { type: integer }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /api/attendance/calendar:
+    x-plugin: plugin-attendance
+    get:
+      summary: List attendance records for calendar views (compatibility alias)
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: query
+          name: userId
+          schema: { type: string }
+        - in: query
+          name: orgId
+          schema: { type: string }
+        - in: query
+          name: from
+          schema: { type: string, format: date }
+        - in: query
+          name: to
+          schema: { type: string, format: date }
+        - in: query
+          name: page
+          schema: { type: integer, default: 1 }
+        - in: query
+          name: pageSize
+          schema: { type: integer, default: 50 }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AttendanceRecord' }
+                      total: { type: integer }
+                      page: { type: integer }
+                      pageSize: { type: integer }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
 
   /api/attendance/anomalies:
     x-plugin: plugin-attendance

--- a/packages/openapi/src/paths/auth.yml
+++ b/packages/openapi/src/paths/auth.yml
@@ -161,3 +161,37 @@ paths:
                             type: string
                             enum: [platform, attendance]
         '401': { $ref: '#/components/responses/Unauthorized' }
+  /api/auth/users:
+    get:
+      summary: List users for admin consoles
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: query
+          name: q
+          schema: { type: string }
+        - in: query
+          name: page
+          schema: { type: integer, default: 1 }
+        - in: query
+          name: pageSize
+          schema: { type: integer, default: 20 }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/User' }
+                      total: { type: integer }
+                      page: { type: integer }
+                      pageSize: { type: integer }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -5007,6 +5007,45 @@ function getWeekdayFromDateKey(dateKey) {
   return date.getUTCDay()
 }
 
+function formatDateOnlyForCsv(value) {
+  if (value === null || value === undefined || value === '') return ''
+  if (typeof value === 'string') {
+    const match = value.match(/^(\d{4}-\d{2}-\d{2})/)
+    if (match?.[1]) return match[1]
+  }
+  if (value instanceof Date) {
+    const year = value.getFullYear()
+    const month = String(value.getMonth() + 1).padStart(2, '0')
+    const day = String(value.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return String(value)
+  return date.toISOString().slice(0, 10)
+}
+
+function formatTimeZoneOffsetForCsv(offsetMinutes) {
+  const safeOffset = Number.isFinite(offsetMinutes) ? Number(offsetMinutes) : 0
+  const sign = safeOffset >= 0 ? '+' : '-'
+  const absolute = Math.abs(safeOffset)
+  const hours = String(Math.floor(absolute / 60)).padStart(2, '0')
+  const minutes = String(absolute % 60).padStart(2, '0')
+  return `${sign}${hours}:${minutes}`
+}
+
+function formatDateTimeForCsv(value, timeZone) {
+  if (value === null || value === undefined || value === '') return ''
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return String(value)
+  const zone = resolveTimeZone(timeZone, null)
+  if (!zone) return date.toISOString()
+  const parts = getZonedParts(date, zone)
+  const offsetMinutes = getTimeZoneOffset(date, zone)
+  const datePart = `${String(parts.year).padStart(4, '0')}-${String(parts.month).padStart(2, '0')}-${String(parts.day).padStart(2, '0')}`
+  const timePart = `${String(parts.hour).padStart(2, '0')}:${String(parts.minute).padStart(2, '0')}:${String(parts.second).padStart(2, '0')}`
+  return `${datePart}T${timePart}${formatTimeZoneOffsetForCsv(offsetMinutes)}`
+}
+
 function formatCsvValue(value) {
   if (value === null || value === undefined) return ''
   const text = String(value)
@@ -7852,10 +7891,7 @@ module.exports = {
       })
     )
 
-	    context.api.http.addRoute(
-	      'GET',
-	      '/api/attendance/records',
-	      withPermission('attendance:read', async (req, res) => {
+      const handleAttendanceRecordsGet = withPermission('attendance:read', async (req, res) => {
         const schema = z.object({
           userId: z.string().optional(),
           orgId: z.string().optional(),
@@ -7942,8 +7978,19 @@ module.exports = {
           }
           logger.error('Attendance records query failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load records' } })
-	        }
-	      })
+        }
+      })
+
+	    context.api.http.addRoute(
+	      'GET',
+	      '/api/attendance/records',
+	      handleAttendanceRecordsGet
+	    )
+
+	    context.api.http.addRoute(
+	      'GET',
+	      '/api/attendance/calendar',
+	      handleAttendanceRecordsGet
 	    )
 
 	    context.api.http.addRoute(
@@ -16067,7 +16114,20 @@ module.exports = {
             'status',
             'is_workday',
           ]
-          const csv = buildCsv(rows, headers)
+          const csvRows = rows.map((row) => ({
+            user_id: row.user_id ?? '',
+            org_id: row.org_id ?? '',
+            work_date: formatDateOnlyForCsv(row.work_date),
+            timezone: row.timezone ?? '',
+            first_in_at: formatDateTimeForCsv(row.first_in_at, row.timezone),
+            last_out_at: formatDateTimeForCsv(row.last_out_at, row.timezone),
+            work_minutes: row.work_minutes ?? 0,
+            late_minutes: row.late_minutes ?? 0,
+            early_leave_minutes: row.early_leave_minutes ?? 0,
+            status: row.status ?? '',
+            is_workday: row.is_workday ?? '',
+          }))
+          const csv = buildCsv(csvRows, headers)
           const filename = `attendance-${orgId}-${from}-to-${to}.csv`
 
           emitEvent('attendance.exported', {


### PR DESCRIPTION
## Summary
- restore `/api/health` as a public probe endpoint and expose `/api/health` alongside `/health`
- add compatibility endpoints for `/api/auth/users` and `/api/attendance/calendar`
- normalize attendance CSV export dates/timestamps for ISO-safe output and timezone-consistent values
- sync OpenAPI source/dist and add integration coverage for the compatibility paths

## Verification
- `pnpm --filter @metasheet/core-backend build`
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm exec tsx packages/openapi/tools/build.ts`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "registers attendance routes and lists plugin|keeps /api/health public for probes|keeps /api/auth/users available for admin user listing|keeps /api/attendance/calendar available as records compatibility alias|exports attendance CSV with ISO date values and timezone-consistent timestamps"`

## Notes
- `/api/attendance/punch` still exists in current code; if dev deploy still returns 404, that points to plugin activation/deployment drift rather than a renamed route.
- `is_workday` regression was not reproduced in runtime logic; the observed day mismatch appears consistent with the prior CSV `work_date` timezone shift.
