### PR TITLE
fix(attendance): recover highscale capacity classification

### DIFF
--- a/.github/workflows/attendance-import-perf-highscale.yml
+++ b/.github/workflows/attendance-import-perf-highscale.yml
@@ -288,48 +288,20 @@ jobs:
           log_dir="output/playwright/attendance-import-perf-highscale"
           final_log="${log_dir}/perf.log"
           mismatch_file="${log_dir}/perf-capacity-mismatch.json"
-
-          last_failure_line="$(grep -E '^\[attendance-import-perf\] Failed:' "$final_log" | tail -n 1 || true)"
-          if [[ -z "$last_failure_line" ]]; then
-            last_failure_line="$(tail -n 40 "$final_log" | tr '\n' ' ')"
-          fi
-
-          rows_value="${ROWS}"
-          hint_value="${CSV_ROWS_LIMIT_HINT}"
-          remote_value="${REMOTE_CSV_ROWS_LIMIT}"
-          upload_csv_value="$(printf '%s' "${UPLOAD_CSV}" | tr '[:upper:]' '[:lower:]')"
-          payload_source_value="$(printf '%s' "${PAYLOAD_SOURCE}" | tr '[:upper:]' '[:lower:]')"
-          would_use_csv='false'
-
-          if [[ "${upload_csv_value}" == 'true' ]]; then
-            case "${payload_source_value}" in
-              csv)
-                would_use_csv='true'
-                ;;
-              auto)
-                if [[ "${rows_value}" =~ ^[0-9]+$ && "${hint_value}" =~ ^[0-9]+$ ]] && (( rows_value <= hint_value )); then
-                  would_use_csv='true'
-                fi
-                ;;
-            esac
-          fi
-
-          if [[ "${rows_value}" =~ ^[0-9]+$ && "${hint_value}" =~ ^[0-9]+$ && "${remote_value}" =~ ^[0-9]+$ ]] \
-            && [[ "${would_use_csv}" == 'true' ]] \
-            && (( rows_value > remote_value )) \
-            && printf '%s' "${last_failure_line}" | grep -Eq 'CSV exceeds max rows'; then
-            cat > "${mismatch_file}" <<EOF
-          {
-            "classification": "capacity_mismatch",
-            "requestedRows": ${rows_value},
-            "payloadSourceRequested": "${payload_source_value}",
-            "uploadCsvRequested": ${upload_csv_value},
-            "csvRowsLimitHint": ${hint_value},
-            "remoteCsvRowsLimit": ${remote_value},
-            "failureLine": $(printf '%s' "${last_failure_line}" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))'),
-            "suggestedAction": "Align the high-scale gate with the deployed CSV row cap or raise ATTENDANCE_IMPORT_CSV_MAX_ROWS after capacity validation."
-          }
-          EOF
+          if PERF_LOG="${final_log}" \
+            OUTPUT_FILE="${mismatch_file}" \
+            ROWS="${ROWS}" \
+            CSV_ROWS_LIMIT_HINT="${CSV_ROWS_LIMIT_HINT}" \
+            REMOTE_CSV_ROWS_LIMIT="${REMOTE_CSV_ROWS_LIMIT}" \
+            UPLOAD_CSV="${UPLOAD_CSV}" \
+            PAYLOAD_SOURCE="${PAYLOAD_SOURCE}" \
+            node ./scripts/ops/attendance-classify-perf-capacity-mismatch.mjs >/dev/null; then
+            last_failure_line="$(jq -r '.failureLine // empty' "${mismatch_file}")"
+            rows_value="$(jq -r '.requestedRows // empty' "${mismatch_file}")"
+            hint_value="$(jq -r '.csvRowsLimitHint // empty' "${mismatch_file}")"
+            remote_value="$(jq -r '.remoteCsvRowsLimit // empty' "${mismatch_file}")"
+            remote_value_source="$(jq -r '.remoteCsvRowsLimitSource // empty' "${mismatch_file}")"
+            payload_source_value="$(jq -r '.payloadSourceRequested // empty' "${mismatch_file}")"
             echo "classification=capacity_mismatch" >> "$GITHUB_OUTPUT"
             {
               echo "High-scale perf benchmark classified as known capacity mismatch."
@@ -337,7 +309,7 @@ jobs:
               echo "- requested rows: \`${rows_value}\`"
               echo "- payload source requested: \`${payload_source_value}\`"
               echo "- csv rows limit hint: \`${hint_value}\`"
-              echo "- remote csv rows limit: \`${remote_value}\`"
+              echo "- remote csv rows limit: \`${remote_value}\` (${remote_value_source:-unknown})"
               echo "- failure: \`${last_failure_line}\`"
             } >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/scripts/ops/attendance-classify-perf-capacity-mismatch.mjs
+++ b/scripts/ops/attendance-classify-perf-capacity-mismatch.mjs
@@ -1,0 +1,93 @@
+import fs from 'node:fs/promises'
+
+function toPositiveInt(value) {
+  const num = Number(value)
+  if (!Number.isFinite(num) || num <= 0) return null
+  return Math.floor(num)
+}
+
+function toBooleanString(value) {
+  return String(value || '').trim().toLowerCase()
+}
+
+function findLastFailureLine(logText) {
+  const lines = String(logText || '')
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]
+    if (/^\[attendance-import-perf\] Failed:/.test(line)) {
+      return line.trim()
+    }
+  }
+  const tail = lines.slice(-40).join(' ').trim()
+  return tail || ''
+}
+
+function determineCsvUsage({ rowsValue, hintValue, uploadCsvValue, payloadSourceValue }) {
+  if (uploadCsvValue !== 'true') return false
+  if (payloadSourceValue === 'csv') return true
+  if (payloadSourceValue !== 'auto') return false
+  if (rowsValue === null || hintValue === null) return false
+  return rowsValue <= hintValue
+}
+
+async function main() {
+  const perfLogPath = process.env.PERF_LOG
+  if (!perfLogPath) {
+    console.error('PERF_LOG is required')
+    process.exit(2)
+  }
+
+  const logText = await fs.readFile(perfLogPath, 'utf8')
+  const lastFailureLine = findLastFailureLine(logText)
+  if (!/CSV exceeds max rows/i.test(lastFailureLine)) {
+    process.exit(1)
+  }
+
+  const rowsValue = toPositiveInt(process.env.ROWS)
+  const hintValue = toPositiveInt(process.env.CSV_ROWS_LIMIT_HINT)
+  const remoteEnvValue = toPositiveInt(process.env.REMOTE_CSV_ROWS_LIMIT)
+  const uploadCsvValue = toBooleanString(process.env.UPLOAD_CSV)
+  const payloadSourceValue = toBooleanString(process.env.PAYLOAD_SOURCE)
+  const wouldUseCsv = determineCsvUsage({
+    rowsValue,
+    hintValue,
+    uploadCsvValue,
+    payloadSourceValue,
+  })
+  if (!wouldUseCsv || rowsValue === null || hintValue === null) {
+    process.exit(1)
+  }
+
+  const remoteFromFailureMatch = lastFailureLine.match(/CSV exceeds max rows \((\d+)\)/i)
+  const remoteFromFailureValue = toPositiveInt(remoteFromFailureMatch?.[1])
+  const remoteLimitValue = remoteFromFailureValue ?? remoteEnvValue
+  if (remoteLimitValue === null || rowsValue <= remoteLimitValue) {
+    process.exit(1)
+  }
+
+  const payload = {
+    classification: 'capacity_mismatch',
+    requestedRows: rowsValue,
+    payloadSourceRequested: payloadSourceValue || 'auto',
+    uploadCsvRequested: uploadCsvValue === 'true',
+    csvRowsLimitHint: hintValue,
+    remoteCsvRowsLimit: remoteLimitValue,
+    remoteCsvRowsLimitSource: remoteFromFailureValue !== null ? 'failure_line' : 'env',
+    failureLine: lastFailureLine,
+    suggestedAction: 'Align the high-scale gate with the deployed CSV row cap or raise ATTENDANCE_IMPORT_CSV_MAX_ROWS after capacity validation.',
+  }
+
+  const outputJson = JSON.stringify(payload, null, 2)
+  const outputFile = process.env.OUTPUT_FILE
+  if (outputFile) {
+    await fs.writeFile(outputFile, `${outputJson}\n`, 'utf8')
+  }
+  process.stdout.write(`${outputJson}\n`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(2)
+})

--- a/scripts/ops/attendance-classify-perf-capacity-mismatch.test.mjs
+++ b/scripts/ops/attendance-classify-perf-capacity-mismatch.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const ROOT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const SCRIPT_PATH = path.join(ROOT_DIR, 'scripts', 'ops', 'attendance-classify-perf-capacity-mismatch.mjs');
+
+function runClassifier({
+  logText,
+  rows = '100000',
+  csvRowsLimitHint = '100000',
+  remoteCsvRowsLimit = '100000',
+  uploadCsv = 'true',
+  payloadSource = 'auto',
+}) {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'attendance-capacity-classify-'));
+  const perfLog = path.join(tempRoot, 'perf.log');
+  const outputFile = path.join(tempRoot, 'perf-capacity-mismatch.json');
+  writeFileSync(perfLog, logText, 'utf8');
+
+  const result = spawnSync('node', [SCRIPT_PATH], {
+    cwd: ROOT_DIR,
+    env: {
+      ...process.env,
+      PERF_LOG: perfLog,
+      OUTPUT_FILE: outputFile,
+      ROWS: rows,
+      CSV_ROWS_LIMIT_HINT: csvRowsLimitHint,
+      REMOTE_CSV_ROWS_LIMIT: remoteCsvRowsLimit,
+      UPLOAD_CSV: uploadCsv,
+      PAYLOAD_SOURCE: payloadSource,
+    },
+    encoding: 'utf8',
+  });
+
+  return { ...result, outputFile };
+}
+
+test('classifier prefers failure-line row cap when remote env is stale', () => {
+  const result = runClassifier({
+    logText: [
+      '[attendance-import-perf] payload_source=csv reason=auto_csv upload_csv_requested=true upload_csv_effective=true csv_rows_limit_hint=100000',
+      '[attendance-import-perf] Failed: async commit job failed: CSV exceeds max rows (20000)',
+      '',
+    ].join('\n'),
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  assert.equal(existsSync(result.outputFile), true);
+
+  const payload = JSON.parse(readFileSync(result.outputFile, 'utf8'));
+  assert.equal(payload.classification, 'capacity_mismatch');
+  assert.equal(payload.remoteCsvRowsLimit, 20000);
+  assert.equal(payload.remoteCsvRowsLimitSource, 'failure_line');
+  assert.equal(payload.requestedRows, 100000);
+});
+
+test('classifier skips when CSV upload lane would not be used', () => {
+  const result = runClassifier({
+    logText: '[attendance-import-perf] Failed: async commit job failed: CSV exceeds max rows (20000)\n',
+    rows: '100001',
+    csvRowsLimitHint: '100000',
+    payloadSource: 'auto',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(existsSync(result.outputFile), false);
+});

--- a/scripts/ops/attendance-post-merge-verify.sh
+++ b/scripts/ops/attendance-post-merge-verify.sh
@@ -592,7 +592,22 @@ function perf_highscale_has_capacity_mismatch() {
   local mismatch_path=''
   mismatch_path="$(find "$artifacts_dir" -type f -name 'perf-capacity-mismatch.json' | sort | tail -n 1 || true)"
   if [[ -z "$mismatch_path" || ! -f "$mismatch_path" ]]; then
-    return 1
+    local perf_log_path=''
+    perf_log_path="$(find "$artifacts_dir" -type f -name 'perf.log' | sort | tail -n 1 || true)"
+    if [[ -z "$perf_log_path" || ! -f "$perf_log_path" ]]; then
+      return 1
+    fi
+    mismatch_path="$(dirname "$perf_log_path")/perf-capacity-mismatch.json"
+    if ! PERF_LOG="$perf_log_path" \
+      OUTPUT_FILE="$mismatch_path" \
+      ROWS="$PERF_HIGHSCALE_ROWS" \
+      CSV_ROWS_LIMIT_HINT="$PERF_HIGHSCALE_CSV_ROWS_LIMIT_HINT" \
+      REMOTE_CSV_ROWS_LIMIT="${REMOTE_CSV_ROWS_LIMIT:-}" \
+      UPLOAD_CSV="$PERF_HIGHSCALE_UPLOAD_CSV" \
+      PAYLOAD_SOURCE="$PERF_HIGHSCALE_PAYLOAD_SOURCE" \
+      node ./scripts/ops/attendance-classify-perf-capacity-mismatch.mjs >/dev/null; then
+      return 1
+    fi
   fi
   jq -e '.classification == "capacity_mismatch"' "$mismatch_path" >/dev/null 2>&1
 }

--- a/scripts/ops/attendance-run-perf-highscale.sh
+++ b/scripts/ops/attendance-run-perf-highscale.sh
@@ -86,6 +86,22 @@ summary_md="${DOWNLOAD_ROOT}/summary.md"
 summary_json="${DOWNLOAD_ROOT}/summary.json"
 
 capacity_mismatch_path="$(find "$artifact_root" -type f -name 'perf-capacity-mismatch.json' | sort | tail -n1 || true)"
+if [[ -z "$capacity_mismatch_path" ]]; then
+  perf_log_path="$(find "$artifact_root" -type f -name 'perf.log' | sort | tail -n1 || true)"
+  if [[ -n "$perf_log_path" ]]; then
+    inferred_capacity_mismatch_path="$(dirname "$perf_log_path")/perf-capacity-mismatch.json"
+    if PERF_LOG="$perf_log_path" \
+      OUTPUT_FILE="$inferred_capacity_mismatch_path" \
+      ROWS="$ROWS" \
+      CSV_ROWS_LIMIT_HINT="$CSV_ROWS_LIMIT_HINT" \
+      REMOTE_CSV_ROWS_LIMIT="${REMOTE_CSV_ROWS_LIMIT:-}" \
+      UPLOAD_CSV="$UPLOAD_CSV" \
+      PAYLOAD_SOURCE="$PAYLOAD_SOURCE" \
+      node ./scripts/ops/attendance-classify-perf-capacity-mismatch.mjs >/dev/null; then
+      capacity_mismatch_path="$inferred_capacity_mismatch_path"
+    fi
+  fi
+fi
 if [[ -n "$capacity_mismatch_path" ]]; then
   requested_rows="$(jq -r '.requestedRows // empty' "$capacity_mismatch_path")"
   remote_csv_rows_limit="$(jq -r '.remoteCsvRowsLimit // empty' "$capacity_mismatch_path")"

--- a/scripts/ops/attendance-run-perf-highscale.test.mjs
+++ b/scripts/ops/attendance-run-perf-highscale.test.mjs
@@ -17,11 +17,18 @@ function writeDispatcher({
   commitAsync = true,
   payloadSource = 'auto',
   capacityMismatch = null,
+  perfLog = '',
 }) {
   const dispatcherPath = path.join(root, 'fake-dispatcher.sh');
   const capacityMismatchScript = capacityMismatch
     ? `cat > "\${DOWNLOAD_DIR}/\${run_id}/artifact/perf-capacity-mismatch.json" <<'EOF'
 ${JSON.stringify(capacityMismatch, null, 2)}
+EOF
+`
+    : '';
+  const perfLogScript = perfLog
+    ? `cat > "\${DOWNLOAD_DIR}/\${run_id}/artifact/perf.log" <<'EOF'
+${perfLog}
 EOF
 `
     : '';
@@ -42,6 +49,7 @@ cat > "\${DOWNLOAD_DIR}/\${run_id}/artifact/perf-summary.json" <<'EOF'
 }
 EOF
 ${capacityMismatchScript}
+${perfLogScript}
 echo "RUN_ID=\${run_id}"
 `;
   writeFileSync(dispatcherPath, script, 'utf8');
@@ -155,6 +163,40 @@ test('attendance-run-perf-highscale classifies known capacity mismatch from arti
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   const summary = JSON.parse(readFileSync(path.join(outputRoot, 'summary.json'), 'utf8'));
   assert.equal(summary.status, 'known_capacity_mismatch');
+  assert.equal(summary.classification, 'capacity_mismatch');
+  assert.equal(summary.capacityMismatch.remoteCsvRowsLimit, 20000);
+  assert.equal(summary.capacityMismatch.requestedRows, 100000);
+});
+
+test('attendance-run-perf-highscale infers capacity mismatch from perf.log when artifact is missing', () => {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'attendance-highscale-log-capacity-'));
+  const outputRoot = path.join(tempRoot, 'out');
+  const dispatcherPath = writeDispatcher({
+    root: tempRoot,
+    perfLog: [
+      '[attendance-import-perf] payload_source=csv reason=auto_csv upload_csv_requested=true upload_csv_effective=true csv_rows_limit_hint=100000',
+      '[attendance-import-perf] Failed: async commit job failed: CSV exceeds max rows (20000)',
+      '',
+    ].join('\n'),
+  });
+
+  const result = spawnSync('bash', [SCRIPT_PATH], {
+    cwd: ROOT_DIR,
+    env: {
+      ...process.env,
+      DOWNLOAD_ROOT: outputRoot,
+      DISPATCHER: dispatcherPath,
+      ROWS: '100000',
+      PAYLOAD_SOURCE: 'auto',
+      UPLOAD_CSV: 'true',
+      CSV_ROWS_LIMIT_HINT: '100000',
+      REMOTE_CSV_ROWS_LIMIT: '100000',
+    },
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const summary = JSON.parse(readFileSync(path.join(outputRoot, 'summary.json'), 'utf8'));
   assert.equal(summary.classification, 'capacity_mismatch');
   assert.equal(summary.capacityMismatch.remoteCsvRowsLimit, 20000);
   assert.equal(summary.capacityMismatch.requestedRows, 100000);


### PR DESCRIPTION
## Summary
- classify highscale CSV-cap failures from the observed server limit in the failure log, not only the workflow env hint
- reuse the shared classifier from the workflow, local highscale wrapper, and post-merge verifier so nightly summaries and issue comments stay aligned
- add focused tests for stale remote-cap env values and missing mismatch artifacts

## Verification
- bash -n scripts/ops/attendance-run-perf-highscale.sh
- bash -n scripts/ops/attendance-post-merge-verify.sh
- node --test scripts/ops/attendance-classify-perf-capacity-mismatch.test.mjs scripts/ops/attendance-run-perf-highscale.test.mjs
- PERF_LOG=/tmp/attendance-post-merge-23177887559.xCQJHJ/ga/23178048633/attendance-import-perf-highscale-23178048633-1/perf.log ROWS=100000 CSV_ROWS_LIMIT_HINT=100000 REMOTE_CSV_ROWS_LIMIT=100000 UPLOAD_CSV=true PAYLOAD_SOURCE=auto node ./scripts/ops/attendance-classify-perf-capacity-mismatch.mjs