### PR TITLE
fix(attendance): stream async csvFileId imports

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import type { MetaSheetServer } from '../../src/index'
 import * as path from 'path'
 import net from 'net'
@@ -3477,6 +3477,130 @@ describe('Attendance Plugin Integration', () => {
       body: '{}',
     })
     expect(rollbackRes.status).toBe(200)
+  })
+
+  it('streams csvFileId data for commit-async without fs.readFile on the csv payload', async () => {
+    if (!baseUrl) return
+    if (!importUploadDir) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=attendance-test&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    if (!token) return
+
+    const orgId = 'default'
+    const runSuffix = Date.now().toString(36)
+    const workDate = new Date().toISOString().slice(0, 10)
+    const csvText = [
+      '日期,UserId,考勤组,上班1打卡时间,下班1打卡时间,考勤结果',
+      `${workDate},attendance-stream-${runSuffix}-a,CSV Stream Group ${runSuffix},09:00,18:00,正常`,
+      `${workDate},attendance-stream-${runSuffix}-b,CSV Stream Group ${runSuffix},09:10,18:10,正常`,
+      '',
+    ].join('\n')
+
+    const uploadRes = await requestJson(`${baseUrl}/api/attendance/import/upload?orgId=${encodeURIComponent(orgId)}&filename=async-stream.csv`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'text/csv',
+      },
+      body: csvText,
+    })
+    expect(uploadRes.status).toBe(201)
+    const fileId = (uploadRes.body as { data?: { fileId?: string } } | undefined)?.data?.fileId
+    expect(typeof fileId).toBe('string')
+
+    const prepareRes = await requestJson(`${baseUrl}/api/attendance/import/prepare`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    })
+    expect(prepareRes.status).toBe(200)
+    const commitToken = (prepareRes.body as { data?: { commitToken?: string } } | undefined)?.data?.commitToken
+    expect(commitToken).toBeTruthy()
+
+    const originalReadFile = fs.readFile.bind(fs)
+    const readFileSpy = vi.spyOn(fs, 'readFile').mockImplementation(async (target: any, options?: any) => {
+      const targetPath = typeof target === 'string'
+        ? target
+        : target instanceof URL
+          ? target.pathname
+          : String(target)
+      if (targetPath.endsWith('.csv')) {
+        throw new Error(`csv readFile should not be used for async csvFileId import: ${targetPath}`)
+      }
+      return originalReadFile(target, options)
+    })
+
+    let batchId = ''
+    try {
+      const commitRes = await requestJson(`${baseUrl}/api/attendance/import/commit-async`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          orgId,
+          userId: 'attendance-test',
+          timezone: 'UTC',
+          csvFileId: String(fileId || ''),
+          idempotencyKey: `upload-async-stream-${Date.now()}`,
+          mappingProfileId: 'dingtalk_csv_daily_summary',
+          mode: 'override',
+          commitToken,
+        }),
+      })
+      expect(commitRes.status).toBe(200)
+      const commitData = (commitRes.body as { data?: { job?: any } } | undefined)?.data
+      const jobId = String(commitData?.job?.id || '')
+      batchId = String(commitData?.job?.batchId || '')
+      expect(jobId).toBeTruthy()
+      expect(batchId).toBeTruthy()
+
+      let completedJob: any = null
+      for (let i = 0; i < 160; i += 1) {
+        const jobRes = await requestJson(`${baseUrl}/api/attendance/import/jobs/${jobId}`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+        })
+        expect(jobRes.status).toBe(200)
+        const jobData = (jobRes.body as { data?: any } | undefined)?.data
+        const status = String(jobData?.status || '')
+        if (status === 'completed') {
+          completedJob = jobData
+          break
+        }
+        if (status === 'failed') {
+          throw new Error(String(jobData?.error || 'async csv stream job failed'))
+        }
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+      expect(completedJob).toBeTruthy()
+      expect(Number(completedJob?.processedRows ?? 0)).toBeGreaterThanOrEqual(2)
+      expect(readFileSpy).toHaveBeenCalled()
+    } finally {
+      readFileSpy.mockRestore()
+      if (batchId) {
+        const rollbackRes = await requestJson(`${baseUrl}/api/attendance/import/rollback/${batchId}`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: '{}',
+        })
+        expect(rollbackRes.status).toBe(200)
+      }
+    }
   })
 
   it('returns NOT_FOUND for preview-async when csvFileId does not exist', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -4,6 +4,7 @@ const fsp = require('fs/promises')
 const path = require('path')
 const { Transform, Readable } = require('stream')
 const { pipeline } = require('stream/promises')
+const { StringDecoder } = require('string_decoder')
 const { z } = require('zod')
 const { createRuleEngine } = require('./engine/index.cjs')
 const { validateConfig: validateEngineConfig } = require('./engine/schema.cjs')
@@ -1095,6 +1096,100 @@ async function iterateCsvRowsAsync(csvText, delimiter = ',', onRow) {
   return { rowCount, stoppedEarly }
 }
 
+async function iterateCsvRowsStreamAsync(readable, delimiter = ',', onRow) {
+  if (!readable || typeof readable[Symbol.asyncIterator] !== 'function') {
+    return { rowCount: 0, stoppedEarly: false }
+  }
+  const sep = typeof delimiter === 'string' && delimiter.length > 0 ? delimiter[0] : ','
+  const decoder = new StringDecoder('utf8')
+  let row = []
+  let field = ''
+  let inQuotes = false
+  let rowCount = 0
+  let stoppedEarly = false
+
+  const emitRow = async () => {
+    row.push(field)
+    field = ''
+    const keepRow = row.length > 1 || row[0]?.trim()
+    if (!keepRow) {
+      row = []
+      return true
+    }
+    const shouldContinue = typeof onRow === 'function'
+      ? await onRow(row, rowCount) !== false
+      : true
+    rowCount += 1
+    row = []
+    if (!shouldContinue) {
+      stoppedEarly = true
+      return false
+    }
+    return true
+  }
+
+  const processChunk = async (text) => {
+    for (let i = 0; i < text.length; i += 1) {
+      const ch = text[i]
+      if (inQuotes) {
+        if (ch === '"') {
+          const next = text[i + 1]
+          if (next === '"') {
+            field += '"'
+            i += 1
+          } else {
+            inQuotes = false
+          }
+        } else if (ch === '\r') {
+          if (text[i + 1] === '\n') i += 1
+          field += '\n'
+        } else {
+          field += ch
+        }
+        continue
+      }
+
+      if (ch === '"') {
+        inQuotes = true
+        continue
+      }
+      if (ch === sep) {
+        row.push(field)
+        field = ''
+        continue
+      }
+      if (ch === '\n' || ch === '\r') {
+        if (ch === '\r' && text[i + 1] === '\n') i += 1
+        if (!await emitRow()) return false
+        continue
+      }
+      field += ch
+    }
+    return true
+  }
+
+  for await (const chunk of readable) {
+    const text = typeof chunk === 'string' ? chunk : decoder.write(chunk)
+    if (!text) continue
+    if (!await processChunk(text)) break
+  }
+
+  if (!stoppedEarly) {
+    const tail = decoder.end()
+    if (tail) {
+      await processChunk(tail)
+    }
+  } else {
+    decoder.end()
+  }
+
+  if (!stoppedEarly) {
+    await emitRow()
+  }
+
+  return { rowCount, stoppedEarly }
+}
+
 function normalizeCsvHeaderValue(value) {
   if (value === undefined || value === null) return ''
   const text = String(value).replace(/\ufeff/g, '').trim()
@@ -1347,6 +1442,65 @@ async function iterateImportRowsFromCsvAsync({ csvText, csvOptions, maxRows, onR
     if (rowIndex < headerRowIndex) return true
     if (rowIndex === headerRowIndex) {
       header = rawRow.map(normalizeCsvHeaderValue)
+      return true
+    }
+    if (!header.length) return true
+    if (rowCount >= resolvedMaxRows) {
+      limitExceeded = true
+      return false
+    }
+    const row = buildImportRowFromCsvRawRow(header, rawRow)
+    if (!row) return true
+    const nextIndex = rowCount
+    rowCount += 1
+    if (typeof onRow === 'function') return await onRow(row, nextIndex) !== false
+    return true
+  })
+
+  return finalizeImportCsvIteration({
+    seenRows,
+    header,
+    rowCount,
+    limitExceeded,
+    maxRows: resolvedMaxRows,
+  })
+}
+
+async function iterateImportRowsFromCsvFileAsync({ csvPath, csvOptions, maxRows, onRow }) {
+  const delimiter = csvOptions?.delimiter || ','
+  const resolvedMaxRowsRaw = Number(maxRows ?? ATTENDANCE_IMPORT_CSV_MAX_ROWS)
+  const resolvedMaxRows = Number.isFinite(resolvedMaxRowsRaw) && resolvedMaxRowsRaw > 0
+    ? Math.floor(resolvedMaxRowsRaw)
+    : ATTENDANCE_IMPORT_CSV_MAX_ROWS
+  const explicitHeaderRowIndex = Number.isFinite(csvOptions?.headerRowIndex)
+    ? Math.max(0, Number(csvOptions.headerRowIndex))
+    : null
+
+  let seenRows = 0
+  let header = []
+  let rowCount = 0
+  let limitExceeded = false
+  let resolvedHeaderRowIndex = explicitHeaderRowIndex
+
+  const csvStream = fs.createReadStream(csvPath, { encoding: 'utf8' })
+  await iterateCsvRowsStreamAsync(csvStream, delimiter, async (rawRow, rowIndex) => {
+    seenRows += 1
+    if (resolvedHeaderRowIndex === null) {
+      const normalized = rawRow.map(normalizeCsvHeaderValue).filter(Boolean)
+      if (normalized.length > 0) {
+        const hasName = normalized.some((cell) => cell === '姓名' || cell.toLowerCase() === 'name')
+        const hasDate = normalized.some((cell) => ['日期', 'date', 'workdate', 'work_date'].includes(cell.toLowerCase()))
+        if (rowIndex === 0 || (hasName && hasDate)) {
+          resolvedHeaderRowIndex = rowIndex
+          header = rawRow.map(normalizeCsvHeaderValue)
+          return true
+        }
+      }
+      return true
+    }
+    if (rowIndex < resolvedHeaderRowIndex) return true
+    if (rowIndex === resolvedHeaderRowIndex) {
+      if (!header.length) header = rawRow.map(normalizeCsvHeaderValue)
       return true
     }
     if (!header.length) return true
@@ -6046,12 +6200,13 @@ module.exports = {
 	    const resolveAsyncImportRowSource = async ({ payload, orgId, fallbackUserId }) => {
 	      if (typeof payload?.csvFileId === 'string' && payload.csvFileId.trim()) {
 	        const csvFileId = payload.csvFileId.trim()
-	        const { csvText } = await readImportUploadCsvText({ orgId, fileId: csvFileId })
+	        await loadImportUploadMetaOrThrow({ orgId, fileId: csvFileId })
+	        const { csvPath } = getImportUploadPaths({ orgId, fileId: csvFileId })
 	        return {
 	          csvFileId,
 	          iterateRows: async (onRow) => {
-	            const result = await iterateImportRowsFromCsvAsync({
-	              csvText,
+	            const result = await iterateImportRowsFromCsvFileAsync({
+	              csvPath,
 	              csvOptions: payload.csvOptions,
 	              onRow,
 	            })


### PR DESCRIPTION
## Summary
- stream async `csvFileId` imports from the uploaded CSV file instead of loading the full CSV text into memory first
- preserve existing header auto-detection/fallback behavior for async CSV iteration
- add an integration regression that fails if async `commit-async` falls back to `fs.readFile(...csv)`

## Verification
- node --check plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "supports commit-async with csvFileId and idempotent retry after upload cleanup|streams csvFileId data for commit-async without fs.readFile on the csv payload|routes high-scale csvFileId imports to async endpoints and preserves upload for async lanes"
- pnpm --filter @metasheet/core-backend build
- git diff --check
