### PR TITLE
fix(attendance): inherit longrun csv cap by default

### DIFF
--- a/.github/workflows/attendance-import-perf-longrun.yml
+++ b/.github/workflows/attendance-import-perf-longrun.yml
@@ -35,9 +35,9 @@ on:
         required: false
         default: '50000'
       max_csv_rows:
-        description: 'Declared remote CSV row cap for long-run payload auto-selection (legacy name for compatibility)'
+        description: 'Optional: override remote CSV row cap for long-run payload auto-selection (leave empty to inherit deployed cap)'
         required: false
-        default: '100000'
+        default: ''
       include_rows500k_preview:
         description: 'Run rows500k-preview scenario (true/false)'
         required: false


### PR DESCRIPTION
## Summary
- stop workflow_dispatch longrun runs from overriding the deployed CSV row cap with a stale 100000-row default
- leave `max_csv_rows` empty by default so manual runs inherit the deployed remote cap

## Verification
- git diff --check
- inspected failed main run 23183937399 and confirmed preview scenarios were still receiving `CSV_ROWS_LIMIT_HINT=100000` before this patch
