### PR TITLE
fix(auth): stop login refresh loop on guest bootstrap

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -65,7 +65,9 @@ const showNav = computed(() => {
   return route.meta?.hideNavbar !== true
 })
 
-const isPublicRoute = computed(() => route.meta?.requiresAuth === false)
+const isPublicRoute = computed(() => {
+  return route.path === '/login' || route.meta?.requiresAuth === false || route.meta?.requiresGuest === true
+})
 const attendanceFocused = computed(() => isAttendanceFocused())
 const isAdmin = computed(() => hasFeature('attendanceAdmin'))
 const isLoggedIn = computed(() => getStoredAuthToken().length > 0)

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -122,6 +122,13 @@ const router = createRouter({
 router.beforeEach(async (to, _from, next) => {
   const token = getStoredAuthToken()
   const isLoginRoute = to.path === ROUTE_PATHS.LOGIN
+  const title = to.meta?.title
+
+  if (title) {
+    document.title = `${title} - MetaSheet`
+  } else {
+    document.title = 'MetaSheet'
+  }
 
   if (!token && !isLoginRoute) {
     return next({
@@ -131,7 +138,9 @@ router.beforeEach(async (to, _from, next) => {
   }
 
   if (token && isLoginRoute) {
-    const verify = await apiFetch('/api/auth/me')
+    const verify = await apiFetch('/api/auth/me', {
+      suppressUnauthorizedRedirect: true,
+    })
     if (!verify.ok) {
       clearStoredAuthState()
       return next()
@@ -148,13 +157,6 @@ router.beforeEach(async (to, _from, next) => {
       // noop
     }
     return next(redirect || flags.resolveHomePath())
-  }
-
-  const title = to.meta?.title
-  if (title) {
-    document.title = `${title} - MetaSheet`
-  } else {
-    document.title = 'MetaSheet'
   }
 
   // Product capability guard + attendance focused mode restriction.
@@ -203,9 +205,14 @@ router.beforeEach(async (to, _from, next) => {
 })
 
 // Create and mount app
-const app = createApp(App)
+async function bootstrap(): Promise<void> {
+  const app = createApp(App)
 
-app.use(ElementPlus)
-app.use(router)
+  app.use(ElementPlus)
+  app.use(router)
 
-app.mount('#app')
+  await router.isReady()
+  app.mount('#app')
+}
+
+void bootstrap()

--- a/apps/web/src/stores/featureFlags.ts
+++ b/apps/web/src/stores/featureFlags.ts
@@ -1,5 +1,5 @@
 import { computed, reactive, readonly } from 'vue'
-import { apiFetch } from '../utils/api'
+import { apiFetch, getStoredAuthToken } from '../utils/api'
 
 export type ProductMode = 'platform' | 'attendance' | 'plm-workbench'
 
@@ -240,7 +240,10 @@ async function loadProductFeatures(
   options: LoadProductFeatureOptions = {},
 ): Promise<ProductFeatures> {
   const requiresSessionProbe = !options.skipSessionProbe
-  if (state.loaded && !force && (!requiresSessionProbe || state.sessionAwareLoaded)) return state.features
+  if (state.loaded && !force) {
+    if (requiresSessionProbe && state.sessionAwareLoaded) return state.features
+    if (!requiresSessionProbe && !state.sessionAwareLoaded) return state.features
+  }
   if (state.loading && loadPromise) return loadPromise
 
   state.loading = true
@@ -249,18 +252,20 @@ async function loadProductFeatures(
   loadPromise = (async () => {
     let mePayload: any = null
     let pluginPayload: any = null
+    const hasStoredToken = getStoredAuthToken().length > 0
 
     try {
-      const requests: Array<Promise<Response | null>> = [
-        apiFetch('/api/plugins').catch(() => null),
-      ]
+      const requests: Array<Promise<Response | null>> = []
 
       if (requiresSessionProbe) {
-        requests.unshift(apiFetch('/api/auth/me').catch(() => null))
+        requests.push(apiFetch('/api/auth/me').catch(() => null))
+        requests.push(apiFetch('/api/plugins').catch(() => null))
+      } else if (hasStoredToken) {
+        requests.push(apiFetch('/api/plugins').catch(() => null))
       }
 
-      const responses = await Promise.all(requests)
-      const pluginRes = responses.at(-1) ?? null
+      const responses = requests.length > 0 ? await Promise.all(requests) : []
+      const pluginRes = requests.length > 0 ? (responses.at(-1) ?? null) : null
       const meRes = requiresSessionProbe ? (responses[0] ?? null) : null
 
       if (meRes?.ok) {
@@ -281,7 +286,7 @@ async function loadProductFeatures(
 
     state.features = resolveFeatures(backendFeatures, overrideFeatures, pluginInference, adminRole)
     state.loaded = true
-    state.sessionAwareLoaded = state.sessionAwareLoaded || requiresSessionProbe
+    state.sessionAwareLoaded = requiresSessionProbe
     state.loading = false
 
     return state.features

--- a/apps/web/src/utils/api.ts
+++ b/apps/web/src/utils/api.ts
@@ -20,6 +20,10 @@ const TOKEN_STORAGE_KEYS = ['auth_token', 'jwt', 'devToken'] as const
 const USER_STATE_KEYS = ['metasheet_features', 'metasheet_product_mode', 'user_permissions', 'user_roles'] as const
 let authRedirecting = false
 
+export interface ApiFetchOptions extends RequestInit {
+  suppressUnauthorizedRedirect?: boolean
+}
+
 /**
  * Get the API base URL from environment or default to relative path
  */
@@ -116,21 +120,22 @@ function handleUnauthorized(path: string): void {
  */
 export async function apiFetch(
   path: string,
-  options: RequestInit = {}
+  options: ApiFetchOptions = {},
 ): Promise<Response> {
   const base = getApiBase()
+  const { suppressUnauthorizedRedirect = false, ...requestOptions } = options
   const headers = {
     'Content-Type': 'application/json',
     ...authHeaders(),
-    ...(options.headers || {})
+    ...(requestOptions.headers || {})
   }
 
   const response = await fetch(`${base}${path}`, {
-    ...options,
+    ...requestOptions,
     headers
   })
 
-  if (response.status === 401) {
+  if (response.status === 401 && !suppressUnauthorizedRedirect) {
     handleUnauthorized(path)
   }
 

--- a/apps/web/tests/App.spec.ts
+++ b/apps/web/tests/App.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, ref, type App as VueApp, type Component } from 'vue'
+import App from '../src/App.vue'
+
+const loadProductFeatures = vi.fn().mockResolvedValue(undefined)
+const fetchPlugins = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    path: '/login',
+    meta: {
+      hideNavbar: true,
+      requiresGuest: true,
+    },
+  }),
+}))
+
+vi.mock('../src/composables/usePlugins', () => ({
+  usePlugins: () => ({
+    navItems: ref([]),
+    fetchPlugins,
+  }),
+}))
+
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({
+    loadProductFeatures,
+    isAttendanceFocused: () => false,
+    hasFeature: () => false,
+  }),
+}))
+
+vi.mock('../src/composables/useLocale', () => ({
+  useLocale: () => ({
+    locale: ref('zh-CN'),
+    isZh: ref(true),
+    setLocale: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/utils/api', () => ({
+  clearStoredAuthState: vi.fn(),
+  getStoredAuthToken: vi.fn(() => ''),
+}))
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('App guest bootstrap', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  it('skips session probing and plugin fetches on guest routes', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp(App as Component)
+    app.component('router-view', { render: () => h('div') })
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        return h('a', { href: this.$props.to }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    expect(loadProductFeatures).toHaveBeenCalledTimes(1)
+    expect(loadProductFeatures).toHaveBeenCalledWith(false, { skipSessionProbe: true })
+    expect(fetchPlugins).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/featureFlags.spec.ts
+++ b/apps/web/tests/featureFlags.spec.ts
@@ -15,23 +15,15 @@ describe('featureFlags', () => {
   })
 
   it('skips auth bootstrap when feature loading is requested for a public route', async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
+    localStorage.setItem('metasheet_features', JSON.stringify({
+      attendance: true,
+      attendanceAdmin: false,
+      attendanceImport: false,
+      workflow: false,
+      mode: 'attendance',
+    }))
 
-      if (url.endsWith('/api/plugins')) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            list: [
-              { name: 'plugin-attendance', status: 'active' },
-            ],
-          }),
-        }
-      }
-
-      throw new Error(`Unexpected fetch URL: ${url}`)
-    })
+    const fetchMock = vi.fn()
 
     vi.stubGlobal('fetch', fetchMock)
 
@@ -40,8 +32,8 @@ describe('featureFlags', () => {
     const features = await flags.loadProductFeatures(true, { skipSessionProbe: true })
 
     expect(features.attendance).toBe(true)
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(String(fetchMock.mock.calls[0]?.[0] ?? '')).toMatch(/\/api\/plugins$/)
+    expect(features.mode).toBe('attendance')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('refreshes with a session probe after an anonymous bootstrap', async () => {
@@ -89,12 +81,71 @@ describe('featureFlags', () => {
     const flags = useFeatureFlags()
 
     const anonymous = await flags.loadProductFeatures(true, { skipSessionProbe: true })
+    expect(anonymous.attendance).toBe(false)
     expect(anonymous.attendanceAdmin).toBe(false)
 
     const authenticated = await flags.loadProductFeatures()
     expect(authenticated.attendanceAdmin).toBe(true)
     const urls = fetchMock.mock.calls.map((call) => String(call[0]))
-    expect(urls.filter((url) => url.endsWith('/api/plugins'))).toHaveLength(2)
+    expect(urls.filter((url) => url.endsWith('/api/plugins'))).toHaveLength(1)
+    expect(urls.filter((url) => url.endsWith('/api/auth/me'))).toHaveLength(1)
+  })
+
+  it('drops session-aware flags on public bootstrap after logout', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/api/plugins')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            list: [
+              { name: 'plugin-attendance', status: 'active' },
+            ],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/auth/me')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: {
+              user: {
+                role: 'admin',
+                features: {
+                  attendance: true,
+                  attendance_admin: true,
+                  attendance_import: true,
+                  mode: 'attendance',
+                },
+              },
+            },
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { useFeatureFlags } = await import('../src/stores/featureFlags')
+    const flags = useFeatureFlags()
+
+    localStorage.setItem('auth_token', 'session-token')
+    const authenticated = await flags.loadProductFeatures(true)
+    expect(authenticated.attendanceAdmin).toBe(true)
+
+    localStorage.clear()
+    const anonymous = await flags.loadProductFeatures(false, { skipSessionProbe: true })
+    expect(anonymous.attendance).toBe(false)
+    expect(anonymous.attendanceAdmin).toBe(false)
+
+    const urls = fetchMock.mock.calls.map((call) => String(call[0]))
+    expect(urls.filter((url) => url.endsWith('/api/plugins'))).toHaveLength(1)
     expect(urls.filter((url) => url.endsWith('/api/auth/me'))).toHaveLength(1)
   })
 })

--- a/apps/web/tests/utils/api.test.ts
+++ b/apps/web/tests/utils/api.test.ts
@@ -187,5 +187,31 @@ describe('API Utils', () => {
 
       expect(replace).not.toHaveBeenCalled()
     })
+
+    it('does not redirect when unauthorized redirect suppression is enabled', async () => {
+      const replace = vi.fn()
+      Object.defineProperty(window, 'location', {
+        value: {
+          pathname: '/login',
+          search: '',
+          hash: '',
+          replace,
+          href: 'https://app.example.com/login',
+          origin: 'https://app.example.com',
+        },
+        writable: true,
+        configurable: true,
+      })
+
+      window.localStorage.setItem('auth_token', 'expired-token')
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 401 }))
+
+      await apiFetch('/api/auth/me', {
+        suppressUnauthorizedRedirect: true,
+      })
+
+      expect(window.localStorage.getItem('auth_token')).toBe('expired-token')
+      expect(replace).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- wait for router initial navigation before mounting the Vue app
- avoid guest-route feature probing and suppress login-route auth probe redirects
- add focused frontend regressions for guest bootstrap, feature flag refresh, and unauthorized probe handling

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/App.spec.ts tests/featureFlags.spec.ts tests/useAuth.spec.ts tests/utils/api.test.ts
- pnpm --filter @metasheet/web build
- browser smoke: direct /login load for 3s shows no /api/auth/me or /api/plugins requests and no reload loop