### PR TITLE
fix(attendance): address postdeploy run13 feedback

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -9,6 +9,7 @@ import 'element-plus/dist/index.css'
 import App from './App.vue'
 import { ROUTE_PATHS } from './router/types'
 import { useFeatureFlags } from './stores/featureFlags'
+import { normalizePostLoginRedirect } from './utils/authRedirect'
 import { apiFetch, clearStoredAuthState, getStoredAuthToken } from './utils/api'
 
 // Import views
@@ -146,10 +147,7 @@ router.beforeEach(async (to, _from, next) => {
       return next()
     }
 
-    const redirectRaw = to.query?.redirect
-    const redirect = typeof redirectRaw === 'string' && redirectRaw.startsWith('/') && !redirectRaw.startsWith('//')
-      ? redirectRaw
-      : null
+    const redirect = normalizePostLoginRedirect(to.query?.redirect)
     const flags = useFeatureFlags()
     try {
       await flags.loadProductFeatures()

--- a/apps/web/src/utils/authRedirect.ts
+++ b/apps/web/src/utils/authRedirect.ts
@@ -1,0 +1,7 @@
+export function normalizePostLoginRedirect(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  if (!normalized.startsWith('/') || normalized.startsWith('//')) return null
+  if (normalized === '/' || normalized.startsWith('/login')) return null
+  return normalized
+}

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -176,6 +176,10 @@
           :format-request-type="formatRequestType"
           :format-status="formatStatus"
           :format-warnings-short="formatWarningsShort"
+          :calendar-days="calendarDays"
+          :calendar-label="calendarLabel"
+          :shift-month="shiftMonth"
+          :week-days="weekDays"
           :request-center="requestCenterSectionBindings"
           :tr="tr"
         />
@@ -706,8 +710,10 @@ const {
   removeAttendanceGroupMember,
   resetAttendanceGroupForm,
   resetRuleSetForm,
+  closeRuleTemplateVersionView,
   resolveRuleSetName,
   restoreRuleTemplates,
+  openRuleTemplateVersion,
   ruleSetEditingId,
   ruleSetForm,
   ruleSetLoading,
@@ -718,7 +724,9 @@ const {
   ruleTemplateRestoring,
   ruleTemplateSaving,
   ruleTemplateSystemText,
+  ruleTemplateVersionLoading,
   ruleTemplateVersions,
+  selectedRuleTemplateVersion,
   saveAttendanceGroup,
   saveRuleSet,
   saveRuleTemplates,
@@ -1269,8 +1277,10 @@ const rulesAndGroupsSectionBindings = {
   removeAttendanceGroupMember,
   resetAttendanceGroupForm,
   resetRuleSetForm,
+  closeRuleTemplateVersionView,
   resolveRuleSetName,
   restoreRuleTemplates,
+  openRuleTemplateVersion,
   ruleSetEditingId,
   ruleSetForm,
   ruleSetLoading,
@@ -1281,7 +1291,9 @@ const rulesAndGroupsSectionBindings = {
   ruleTemplateRestoring,
   ruleTemplateSaving,
   ruleTemplateSystemText,
+  ruleTemplateVersionLoading,
   ruleTemplateVersions,
+  selectedRuleTemplateVersion,
   saveAttendanceGroup,
   saveRuleSet,
   saveRuleTemplates,
@@ -1406,6 +1418,8 @@ const requestCenterSectionBindings = {
   requests,
   requestSubmitting,
   resolveRequest,
+  focusCalendarMonth,
+  shiftMonth,
   submitRequest,
 }
 
@@ -1428,6 +1442,13 @@ function normalizeDateKey(value: string | null | undefined): string | null {
   const date = new Date(raw)
   if (Number.isNaN(date.getTime())) return null
   return date.toISOString().slice(0, 10)
+}
+
+function parseDateValue(value: string | null | undefined): Date | null {
+  const key = normalizeDateKey(value)
+  if (!key) return null
+  const date = new Date(`${key}T00:00:00`)
+  return Number.isNaN(date.getTime()) ? null : date
 }
 
 function formatDateTime(value: string | null | undefined): string {
@@ -2167,6 +2188,22 @@ function shiftMonth(delta: number) {
   fromDate.value = toDateInput(from)
   toDate.value = toDateInput(to)
   refreshAll()
+}
+
+async function focusCalendarMonth(value: string | null | undefined) {
+  const next = parseDateValue(value) ?? new Date()
+  const nextMonth = new Date(next.getFullYear(), next.getMonth(), 1)
+  const currentMonth = calendarMonth.value
+  if (
+    currentMonth.getFullYear() === nextMonth.getFullYear()
+    && currentMonth.getMonth() === nextMonth.getMonth()
+  ) {
+    return
+  }
+  calendarMonth.value = nextMonth
+  fromDate.value = toDateInput(new Date(nextMonth.getFullYear(), nextMonth.getMonth(), 1))
+  toDate.value = toDateInput(new Date(nextMonth.getFullYear(), nextMonth.getMonth() + 1, 0))
+  await refreshAll()
 }
 
 function validateRequestForm(): string | null {

--- a/apps/web/src/views/LoginView.vue
+++ b/apps/web/src/views/LoginView.vue
@@ -44,6 +44,7 @@ import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useLocale } from '../composables/useLocale'
 import { useFeatureFlags } from '../stores/featureFlags'
+import { normalizePostLoginRedirect } from '../utils/authRedirect'
 import { apiFetch, clearStoredAuthState } from '../utils/api'
 
 interface AuthUserPayload {
@@ -98,13 +99,6 @@ const text = computed(() => {
     networkError: 'Sign-in failed. Please try again.',
   }
 })
-
-function normalizeRedirect(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  if (!value.startsWith('/') || value.startsWith('//')) return null
-  if (value.startsWith('/login')) return null
-  return value
-}
 
 function extractUserRoles(user: AuthUserPayload | null): string[] {
   if (!user) return []
@@ -190,7 +184,7 @@ async function onSubmit(): Promise<void> {
     await hydrateAuthContext()
     await loadProductFeatures(true)
 
-    const redirect = normalizeRedirect(route.query.redirect)
+    const redirect = normalizePostLoginRedirect(route.query.redirect)
     await router.replace(redirect || resolveHomePath())
   } catch {
     errorMessage.value = text.value.networkError

--- a/apps/web/src/views/attendance/AttendanceLeavePoliciesSection.vue
+++ b/apps/web/src/views/attendance/AttendanceLeavePoliciesSection.vue
@@ -9,7 +9,13 @@
     <div class="attendance__admin-grid">
       <label class="attendance__field" for="attendance-leave-code">
         <span>{{ tr('Code', '编码') }}</span>
-        <input id="attendance-leave-code" v-model="leaveTypeForm.code" name="leaveCode" type="text" />
+        <input
+          id="attendance-leave-code"
+          v-model="leaveTypeForm.code"
+          name="leaveCode"
+          type="text"
+          :placeholder="tr('Auto-generated from name', '名称自动生成')"
+        />
       </label>
       <label class="attendance__field" for="attendance-leave-name">
         <span>{{ tr('Name', '名称') }}</span>

--- a/apps/web/src/views/attendance/AttendancePayrollAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendancePayrollAdminSection.vue
@@ -18,12 +18,15 @@
       </label>
       <label class="attendance__field" for="attendance-payroll-template-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
-        <input
+        <select
           id="attendance-payroll-template-timezone"
           v-model="payrollTemplateForm.timezone"
           name="payrollTemplateTimezone"
-          type="text"
-        />
+        >
+          <option v-for="timezone in payrollTemplateTimezones" :key="timezone" :value="timezone">
+            {{ timezone }}
+          </option>
+        </select>
       </label>
       <label class="attendance__field" for="attendance-payroll-template-start">
         <span>{{ tr('Start day', '起始日') }}</span>
@@ -369,12 +372,13 @@
 </template>
 
 <script setup lang="ts">
-import type { Ref } from 'vue'
+import { computed, type Ref } from 'vue'
 import type {
   AttendancePayrollCycle,
   AttendancePayrollSummary,
   AttendancePayrollTemplate,
 } from './useAttendanceAdminPayroll'
+import { buildTimezoneOptions } from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -462,6 +466,7 @@ const payrollCycleSummary = props.payroll.payrollCycleSummary
 const payrollTemplateForm = props.payroll.payrollTemplateForm
 const payrollCycleForm = props.payroll.payrollCycleForm
 const payrollCycleGenerateForm = props.payroll.payrollCycleGenerateForm
+const payrollTemplateTimezones = computed(() => buildTimezoneOptions(payrollTemplateForm.timezone))
 const payrollTemplateName = props.payroll.payrollTemplateName
 const resetPayrollTemplateForm = () => props.payroll.resetPayrollTemplateForm()
 const editPayrollTemplate = (item: AttendancePayrollTemplate) => props.payroll.editPayrollTemplate(item)

--- a/apps/web/src/views/attendance/AttendanceRequestCenterSection.vue
+++ b/apps/web/src/views/attendance/AttendanceRequestCenterSection.vue
@@ -4,11 +4,18 @@
     <div class="attendance__request-form">
       <label class="attendance__field" for="attendance-request-work-date">
         <span>{{ tr('Work date', '工作日期') }}</span>
-        <input
-          id="attendance-request-work-date"
+        <AttendanceScheduledDateInput
           v-model="requestForm.workDate"
-          name="requestWorkDate"
-          type="date"
+          default-time="00:00"
+          field-id="attendance-request-work-date"
+          field-name="requestWorkDate"
+          input-type="date"
+          :calendar-days="calendarDays"
+          :calendar-label="calendarLabel"
+          :focus-calendar-month="focusCalendarMonth"
+          :shift-month="shiftMonth"
+          :tr="tr"
+          :week-days="weekDays"
         />
       </label>
       <label class="attendance__field" for="attendance-request-type">
@@ -51,20 +58,34 @@
       </label>
       <label class="attendance__field" for="attendance-request-in">
         <span>{{ isLeaveOrOvertimeRequest ? tr('Start', '开始') : tr('Requested in', '申请打卡入') }}</span>
-        <input
-          id="attendance-request-in"
+        <AttendanceScheduledDateInput
           v-model="requestForm.requestedInAt"
-          name="requestedInAt"
-          type="datetime-local"
+          default-time="09:00"
+          field-id="attendance-request-in"
+          field-name="requestedInAt"
+          input-type="datetime-local"
+          :calendar-days="calendarDays"
+          :calendar-label="calendarLabel"
+          :focus-calendar-month="focusCalendarMonth"
+          :shift-month="shiftMonth"
+          :tr="tr"
+          :week-days="weekDays"
         />
       </label>
       <label class="attendance__field" for="attendance-request-out">
         <span>{{ isLeaveOrOvertimeRequest ? tr('End', '结束') : tr('Requested out', '申请打卡出') }}</span>
-        <input
-          id="attendance-request-out"
+        <AttendanceScheduledDateInput
           v-model="requestForm.requestedOutAt"
-          name="requestedOutAt"
-          type="datetime-local"
+          default-time="18:00"
+          field-id="attendance-request-out"
+          field-name="requestedOutAt"
+          input-type="datetime-local"
+          :calendar-days="calendarDays"
+          :calendar-label="calendarLabel"
+          :focus-calendar-month="focusCalendarMonth"
+          :shift-month="shiftMonth"
+          :tr="tr"
+          :week-days="weekDays"
         />
       </label>
       <label v-if="isLeaveOrOvertimeRequest" class="attendance__field" for="attendance-request-minutes">
@@ -219,6 +240,7 @@
 
 <script setup lang="ts">
 import type { Ref } from 'vue'
+import AttendanceScheduledDateInput from './AttendanceScheduledDateInput.vue'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -294,6 +316,18 @@ interface AttendanceRequestReportItem {
   minutes: number
 }
 
+interface CalendarDay {
+  key: string
+  day: number
+  isToday: boolean
+  isCurrentMonth: boolean
+  status?: string
+  statusLabel?: string
+  tooltip: string
+  holidayName?: string
+  lunarLabel?: string
+}
+
 interface RequestCenterBindings {
   requestForm: RequestFormState
   requestSubmitting: Ref<boolean>
@@ -315,10 +349,15 @@ interface RequestCenterBindings {
   loadAnomalies: () => MaybePromise<void>
   prefillRequestFromAnomaly: (item: AttendanceAnomalyItem) => MaybePromise<void>
   loadRequestReport: () => MaybePromise<void>
+  focusCalendarMonth: (value: string | null | undefined) => MaybePromise<void>
+  shiftMonth: (delta: number) => MaybePromise<void>
 }
 
 const props = defineProps<{
   requestCenter: RequestCenterBindings
+  calendarDays: CalendarDay[]
+  calendarLabel: string
+  weekDays: string[]
   formatDate: (value: string | null | undefined) => string
   formatDateTime: (value: string | null | undefined) => string
   formatRequestType: (value: string) => string
@@ -354,6 +393,8 @@ const resolveRequest = (id: string, action: RequestResolutionAction) => props.re
 const loadAnomalies = () => props.requestCenter.loadAnomalies()
 const prefillRequestFromAnomaly = (item: AttendanceAnomalyItem) => props.requestCenter.prefillRequestFromAnomaly(item)
 const loadRequestReport = () => props.requestCenter.loadRequestReport()
+const focusCalendarMonth = (value: string | null | undefined) => props.requestCenter.focusCalendarMonth(value)
+const shiftMonth = (delta: number) => props.requestCenter.shiftMonth(delta)
 
 function formatLeaveTypeLabel(item: { name?: string | null; paid?: boolean | null }): string {
   const name = String(item?.name || '').trim()

--- a/apps/web/src/views/attendance/AttendanceRulesAndGroupsSection.vue
+++ b/apps/web/src/views/attendance/AttendanceRulesAndGroupsSection.vue
@@ -120,7 +120,7 @@
           id="attendance-rule-template-system"
           v-model="ruleTemplateSystemText"
           name="ruleTemplateSystem"
-          rows="6"
+          rows="12"
           readonly
         />
       </label>
@@ -130,7 +130,7 @@
           id="attendance-rule-template-library"
           v-model="ruleTemplateLibraryText"
           name="ruleTemplateLibrary"
-          rows="8"
+          rows="18"
           placeholder="[]"
         />
       </label>
@@ -170,6 +170,9 @@
               <td>{{ formatDateTime(version.createdAt ?? null) }}</td>
               <td>{{ version.createdBy || '--' }}</td>
               <td class="attendance__table-actions">
+                <button class="attendance__btn" :disabled="ruleTemplateVersionLoading" @click="openRuleTemplateVersion(version.id)">
+                  {{ ruleTemplateVersionLoading && selectedRuleTemplateVersion && selectedRuleTemplateVersion.id === version.id ? tr('Loading...', '加载中...') : tr('View', '查看') }}
+                </button>
                 <button
                   class="attendance__btn"
                   :disabled="ruleTemplateRestoring || ruleTemplateSaving"
@@ -181,6 +184,19 @@
             </tr>
           </tbody>
         </table>
+      </div>
+      <div v-if="selectedRuleTemplateVersion" class="attendance__template-version-panel">
+        <div class="attendance__admin-section-header">
+          <h5>{{ tr('Selected version', '已选版本') }} #{{ selectedRuleTemplateVersion.version }}</h5>
+          <button class="attendance__btn" @click="closeRuleTemplateVersionView">{{ tr('Close', '关闭') }}</button>
+        </div>
+        <div class="attendance__template-version-meta">
+          <span>{{ tr('Created', '创建时间') }}: {{ formatDateTime(selectedRuleTemplateVersion.createdAt ?? null) }}</span>
+          <span>{{ tr('Created by', '创建人') }}: {{ selectedRuleTemplateVersion.createdBy || '--' }}</span>
+          <span>{{ tr('Items', '条目') }}: {{ selectedRuleTemplateVersion.itemCount ?? '--' }}</span>
+          <span>{{ tr('Source version', '来源版本') }}: {{ selectedRuleTemplateVersion.sourceVersionId || '--' }}</span>
+        </div>
+        <pre class="attendance__code attendance__code--viewer">{{ formatJson(selectedRuleTemplateVersion.templates ?? selectedRuleTemplateVersion) }}</pre>
       </div>
     </div>
   </div>
@@ -203,12 +219,16 @@
           id="attendance-group-code"
           v-model="attendanceGroupForm.code"
           type="text"
-          :placeholder="tr('optional', '可选')"
+          :placeholder="tr('Auto-generated from name', '名称自动生成')"
         />
       </label>
       <label class="attendance__field" for="attendance-group-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
-        <input id="attendance-group-timezone" v-model="attendanceGroupForm.timezone" type="text" />
+        <select id="attendance-group-timezone" v-model="attendanceGroupForm.timezone">
+          <option v-for="timezone in attendanceGroupTimezones" :key="timezone" :value="timezone">
+            {{ timezone }}
+          </option>
+        </select>
       </label>
       <label class="attendance__field" for="attendance-group-rule-set">
         <span>{{ tr('Rule set', '规则集') }}</span>
@@ -338,13 +358,14 @@
 </template>
 
 <script setup lang="ts">
-import type { Ref } from 'vue'
+import { computed, type Ref } from 'vue'
 import type {
   AttendanceGroup,
   AttendanceGroupMember,
   AttendanceRuleSet,
   AttendanceRuleTemplateVersion,
 } from './useAttendanceAdminRulesAndGroups'
+import { buildTimezoneOptions } from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -391,8 +412,12 @@ interface RulesAndGroupsBindings {
   removeAttendanceGroupMember: (userId: string) => MaybePromise<void>
   resetAttendanceGroupForm: () => MaybePromise<void>
   resetRuleSetForm: () => MaybePromise<void>
+  closeRuleTemplateVersionView: () => MaybePromise<void>
   resolveRuleSetName: (ruleSetId?: string | null) => string
   restoreRuleTemplates: (versionId: string) => MaybePromise<void>
+  openRuleTemplateVersion: (versionId: string) => MaybePromise<void>
+  ruleTemplateVersionLoading: Ref<boolean>
+  selectedRuleTemplateVersion: Ref<AttendanceRuleTemplateVersion | null>
   ruleSetEditingId: Ref<string | null>
   ruleSetForm: RuleSetFormState
   ruleSetLoading: Ref<boolean>
@@ -419,6 +444,7 @@ const tr = props.tr
 const formatDateTime = props.formatDateTime
 const attendanceGroupEditingId = props.rules.attendanceGroupEditingId
 const attendanceGroupForm = props.rules.attendanceGroupForm
+const attendanceGroupTimezones = computed(() => buildTimezoneOptions(attendanceGroupForm.timezone))
 const attendanceGroupLoading = props.rules.attendanceGroupLoading
 const attendanceGroupMemberGroupId = props.rules.attendanceGroupMemberGroupId
 const attendanceGroupMemberLoading = props.rules.attendanceGroupMemberLoading
@@ -441,8 +467,11 @@ const addAttendanceGroupMembers = () => props.rules.addAttendanceGroupMembers()
 const removeAttendanceGroupMember = (userId: string) => props.rules.removeAttendanceGroupMember(userId)
 const resetAttendanceGroupForm = () => props.rules.resetAttendanceGroupForm()
 const resetRuleSetForm = () => props.rules.resetRuleSetForm()
+const closeRuleTemplateVersionView = () => props.rules.closeRuleTemplateVersionView()
 const resolveRuleSetName = props.rules.resolveRuleSetName
 const restoreRuleTemplates = (versionId: string) => props.rules.restoreRuleTemplates(versionId)
+const openRuleTemplateVersion = (versionId: string) => props.rules.openRuleTemplateVersion(versionId)
+const selectedRuleTemplateVersion = props.rules.selectedRuleTemplateVersion
 const ruleSetEditingId = props.rules.ruleSetEditingId
 const ruleSetForm = props.rules.ruleSetForm
 const ruleSetLoading = props.rules.ruleSetLoading
@@ -453,10 +482,15 @@ const ruleTemplateLoading = props.rules.ruleTemplateLoading
 const ruleTemplateRestoring = props.rules.ruleTemplateRestoring
 const ruleTemplateSaving = props.rules.ruleTemplateSaving
 const ruleTemplateSystemText = props.rules.ruleTemplateSystemText
+const ruleTemplateVersionLoading = props.rules.ruleTemplateVersionLoading
 const ruleTemplateVersions = props.rules.ruleTemplateVersions
 const saveAttendanceGroup = () => props.rules.saveAttendanceGroup()
 const saveRuleSet = () => props.rules.saveRuleSet()
 const saveRuleTemplates = () => props.rules.saveRuleTemplates()
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+}
 </script>
 
 <style scoped>
@@ -504,6 +538,29 @@ const saveRuleTemplates = () => props.rules.saveRuleTemplates()
 
 .attendance__field--checkbox {
   justify-content: flex-end;
+}
+
+.attendance__template-version-panel {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid #d9e3f1;
+  border-radius: 10px;
+  background: #f8fbff;
+}
+
+.attendance__template-version-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  color: #44546a;
+  font-size: 13px;
+}
+
+.attendance__code--viewer {
+  min-height: 280px;
+  max-height: 520px;
+  overflow: auto;
 }
 
 .attendance__field-hint {

--- a/apps/web/src/views/attendance/AttendanceScheduledDateInput.vue
+++ b/apps/web/src/views/attendance/AttendanceScheduledDateInput.vue
@@ -1,0 +1,292 @@
+<template>
+  <div class="attendance-date-input">
+    <div class="attendance-date-input__control">
+      <input
+        :id="fieldId"
+        :name="fieldName"
+        :type="inputType"
+        :value="modelValue"
+        :placeholder="placeholder"
+        @input="onInput"
+        @dblclick.prevent.stop="openPicker"
+      />
+      <button
+        class="attendance-date-input__toggle"
+        type="button"
+        :aria-expanded="pickerOpen"
+        :aria-controls="`${fieldId}-picker`"
+        @click="togglePicker"
+      >
+        {{ tr('Calendar', '日历') }}
+      </button>
+    </div>
+
+    <div v-if="pickerOpen" class="attendance-date-input__overlay" @click.self="closePicker">
+      <div :id="`${fieldId}-picker`" class="attendance-date-input__panel" @click.stop>
+        <div class="attendance-date-input__header">
+          <button class="attendance-date-input__nav" type="button" @click="changeMonth(-1)">
+            {{ tr('Prev', '上月') }}
+          </button>
+          <div class="attendance-date-input__month">{{ calendarLabel }}</div>
+          <button class="attendance-date-input__nav" type="button" @click="changeMonth(1)">
+            {{ tr('Next', '下月') }}
+          </button>
+        </div>
+
+        <div class="attendance-date-input__weekdays">
+          <span v-for="day in weekDays" :key="day">{{ day }}</span>
+        </div>
+
+        <div class="attendance-date-input__grid">
+          <button
+            v-for="day in calendarDays"
+            :key="day.key"
+            type="button"
+            class="attendance-date-input__day"
+            :class="[
+              !day.isCurrentMonth ? 'attendance-date-input__day--muted' : '',
+              day.isToday ? 'attendance-date-input__day--today' : '',
+              day.status ? `attendance-date-input__day--${day.status}` : '',
+              selectedDateKey === day.key ? 'attendance-date-input__day--selected' : '',
+            ]"
+            :title="day.tooltip"
+            @click="selectDay(day.key)"
+          >
+            <span class="attendance-date-input__day-number">{{ day.day }}</span>
+            <span v-if="day.statusLabel" class="attendance-date-input__day-status">{{ day.statusLabel }}</span>
+            <span v-else class="attendance-date-input__day-status attendance-date-input__day-status--empty">--</span>
+            <span v-if="day.lunarLabel" class="attendance-date-input__day-lunar">{{ day.lunarLabel }}</span>
+            <span v-if="day.holidayName" class="attendance-date-input__day-holiday">{{ day.holidayName }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+type Translate = (en: string, zh: string) => string
+type MaybePromise<T> = T | Promise<T>
+
+interface CalendarDay {
+  key: string
+  day: number
+  isToday: boolean
+  isCurrentMonth: boolean
+  status?: string
+  statusLabel?: string
+  tooltip: string
+  holidayName?: string
+  lunarLabel?: string
+}
+
+const props = defineProps<{
+  modelValue: string
+  inputType: 'date' | 'datetime-local'
+  fieldId: string
+  fieldName?: string
+  placeholder?: string
+  defaultTime?: string
+  calendarDays: CalendarDay[]
+  calendarLabel: string
+  weekDays: string[]
+  shiftMonth: (delta: number) => MaybePromise<void>
+  focusCalendarMonth: (value: string | null | undefined) => MaybePromise<void>
+  tr: Translate
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const pickerOpen = ref(false)
+
+const selectedDateKey = computed(() => {
+  const value = String(props.modelValue || '').trim()
+  if (!value) return ''
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})/)
+  return match?.[1] ?? ''
+})
+
+function onInput(event: Event): void {
+  const target = event.target as HTMLInputElement | null
+  emit('update:modelValue', target?.value ?? '')
+}
+
+function openPicker(): void {
+  pickerOpen.value = true
+  void props.focusCalendarMonth(props.modelValue || null)
+}
+
+function closePicker(): void {
+  pickerOpen.value = false
+}
+
+function togglePicker(): void {
+  if (pickerOpen.value) {
+    closePicker()
+    return
+  }
+  openPicker()
+}
+
+function changeMonth(delta: number): void {
+  void props.shiftMonth(delta)
+}
+
+function extractTimePart(value: string): string {
+  const match = String(value || '').match(/T(\d{2}:\d{2})(?::\d{2})?/)
+  if (match?.[1]) return match[1]
+  return props.defaultTime?.trim() || '00:00'
+}
+
+function buildDateValue(dateKey: string): string {
+  if (props.inputType === 'date') return dateKey
+  return `${dateKey}T${extractTimePart(props.modelValue)}`
+}
+
+function selectDay(dateKey: string): void {
+  emit('update:modelValue', buildDateValue(dateKey))
+  closePicker()
+}
+</script>
+
+<style scoped>
+.attendance-date-input {
+  position: relative;
+  display: grid;
+  gap: 8px;
+}
+
+.attendance-date-input__control {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.attendance-date-input__control input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.attendance-date-input__toggle,
+.attendance-date-input__nav,
+.attendance-date-input__day {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  color: #1f2937;
+}
+
+.attendance-date-input__toggle {
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+.attendance-date-input__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: grid;
+  place-items: start center;
+  padding: 96px 20px 20px;
+  background: rgba(15, 23, 42, 0.14);
+}
+
+.attendance-date-input__panel {
+  width: min(640px, 100%);
+  max-height: min(78vh, 760px);
+  overflow: auto;
+  border: 1px solid #dbe3ef;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 24px 60px rgba(15, 35, 95, 0.18);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.attendance-date-input__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.attendance-date-input__month {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.attendance-date-input__nav {
+  padding: 6px 12px;
+}
+
+.attendance-date-input__weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.attendance-date-input__weekdays span {
+  text-align: center;
+}
+
+.attendance-date-input__grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.attendance-date-input__day {
+  min-height: 88px;
+  padding: 8px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.attendance-date-input__day--muted {
+  opacity: 0.48;
+}
+
+.attendance-date-input__day--today {
+  border-color: #2563eb;
+}
+
+.attendance-date-input__day--selected {
+  background: #e0efff;
+  border-color: #2563eb;
+}
+
+.attendance-date-input__day--off {
+  background: #f8fafc;
+}
+
+.attendance-date-input__day-number {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.attendance-date-input__day-status {
+  font-size: 12px;
+  color: #2563eb;
+}
+
+.attendance-date-input__day-status--empty {
+  color: #94a3b8;
+}
+
+.attendance-date-input__day-lunar,
+.attendance-date-input__day-holiday {
+  font-size: 12px;
+  color: #475569;
+  line-height: 1.2;
+}
+</style>

--- a/apps/web/src/views/attendance/attendanceCode.ts
+++ b/apps/web/src/views/attendance/attendanceCode.ts
@@ -1,0 +1,22 @@
+function simpleHash(value: string): string {
+  let hash = 0
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) >>> 0
+  }
+  return hash.toString(36)
+}
+
+export function generateAttendanceCode(name: string, fallbackPrefix: string): string {
+  const text = String(name ?? '').trim().toLowerCase()
+  if (!text) return fallbackPrefix
+
+  const ascii = text
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+  if (ascii) return ascii
+
+  return `${fallbackPrefix}_${simpleHash(text).slice(0, 6)}`
+}

--- a/apps/web/src/views/attendance/attendanceTimezones.ts
+++ b/apps/web/src/views/attendance/attendanceTimezones.ts
@@ -1,0 +1,42 @@
+const FALLBACK_TIMEZONES = [
+  'UTC',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Asia/Singapore',
+  'Asia/Hong_Kong',
+  'Asia/Seoul',
+  'Europe/London',
+  'Europe/Paris',
+  'America/New_York',
+  'America/Los_Angeles',
+]
+
+let cachedSupportedTimezones: string[] | null = null
+
+function loadSupportedTimezones(): string[] {
+  if (cachedSupportedTimezones) return cachedSupportedTimezones
+
+  const resolved = (() => {
+    try {
+      if (typeof Intl.supportedValuesOf === 'function') {
+        const values = Intl.supportedValuesOf('timeZone')
+        if (Array.isArray(values) && values.length > 0) return values.filter((item) => typeof item === 'string')
+      }
+    } catch {
+      // fall through to fallback list
+    }
+    return FALLBACK_TIMEZONES
+  })()
+
+  cachedSupportedTimezones = Array.from(new Set([...resolved, ...FALLBACK_TIMEZONES])).sort((a, b) => a.localeCompare(b))
+  return cachedSupportedTimezones
+}
+
+export function buildTimezoneOptions(currentValue?: string | null): string[] {
+  const normalized = typeof currentValue === 'string' ? currentValue.trim() : ''
+  const options = [...loadSupportedTimezones()]
+  if (normalized && !options.includes(normalized)) {
+    options.unshift(normalized)
+  }
+  return options
+}

--- a/apps/web/src/views/attendance/useAttendanceAdminLeavePolicies.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminLeavePolicies.ts
@@ -1,5 +1,6 @@
-import { reactive, ref, type Ref } from 'vue'
+import { reactive, ref, watch, type Ref } from 'vue'
 import { apiFetch as defaultApiFetch } from '../../utils/api'
+import { generateAttendanceCode } from './attendanceCode'
 
 type Translate = (en: string, zh: string) => string
 type ConfirmFn = (message: string) => boolean
@@ -195,6 +196,16 @@ export function useAttendanceAdminLeavePolicies({
     setStatus(message, 'error')
   }
 
+  watch(
+    () => leaveTypeForm.name,
+    (name) => {
+      const trimmedName = name.trim()
+      if (!trimmedName || leaveTypeForm.code.trim().length > 0) return
+      leaveTypeForm.code = generateAttendanceCode(trimmedName, 'leave')
+    },
+    { immediate: true },
+  )
+
   function resetLeaveTypeForm() {
     leaveTypeEditingId.value = null
     leaveTypeForm.code = ''
@@ -246,11 +257,11 @@ export function useAttendanceAdminLeavePolicies({
     leaveTypeSaving.value = true
     const isEditing = Boolean(leaveTypeEditingId.value)
     try {
-      if (!leaveTypeForm.code.trim() || !leaveTypeForm.name.trim()) {
-        throw new Error(tr('Code and name are required', '编码和名称为必填项'))
+      if (!leaveTypeForm.name.trim()) {
+        throw new Error(tr('Name is required', '名称为必填项'))
       }
       const payload = {
-        code: leaveTypeForm.code.trim(),
+        code: leaveTypeForm.code.trim() || generateAttendanceCode(leaveTypeForm.name, 'leave'),
         name: leaveTypeForm.name.trim(),
         paid: leaveTypeForm.paid,
         requiresApproval: leaveTypeForm.requiresApproval,

--- a/apps/web/src/views/attendance/useAttendanceAdminRulesAndGroups.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRulesAndGroups.ts
@@ -1,5 +1,6 @@
-import { reactive, ref, type Ref } from 'vue'
+import { computed, reactive, ref, watch, type Ref } from 'vue'
 import { apiFetch as baseApiFetch } from '../../utils/api'
+import { generateAttendanceCode } from './attendanceCode'
 
 type ApiFetchFn = typeof baseApiFetch
 type Translate = (en: string, zh: string) => string
@@ -24,6 +25,7 @@ export interface AttendanceRuleTemplateVersion {
   createdBy?: string | null
   sourceVersionId?: string | null
   itemCount?: number | null
+  templates?: unknown[] | null
 }
 
 export interface AttendanceGroup {
@@ -205,6 +207,7 @@ export function useAttendanceAdminRulesAndGroups({
   const ruleTemplateLoading = ref(false)
   const ruleTemplateSaving = ref(false)
   const ruleTemplateRestoring = ref(false)
+  const ruleTemplateVersionLoading = ref(false)
   const attendanceGroupLoading = ref(false)
   const attendanceGroupSaving = ref(false)
   const attendanceGroupMemberLoading = ref(false)
@@ -214,6 +217,7 @@ export function useAttendanceAdminRulesAndGroups({
   const ruleTemplateSystemText = ref('[]')
   const ruleTemplateLibraryText = ref('[]')
   const ruleTemplateVersions = ref<AttendanceRuleTemplateVersion[]>([])
+  const selectedRuleTemplateVersionId = ref('')
   const attendanceGroups = ref<AttendanceGroup[]>([])
   const attendanceGroupMembers = ref<AttendanceGroupMember[]>([])
 
@@ -238,6 +242,20 @@ export function useAttendanceAdminRulesAndGroups({
     ruleSetId: '',
     description: '',
   })
+
+  const selectedRuleTemplateVersion = computed(
+    () => ruleTemplateVersions.value.find((item) => item.id === selectedRuleTemplateVersionId.value) ?? null,
+  )
+
+  watch(
+    () => attendanceGroupForm.name,
+    (name) => {
+      const trimmedName = name.trim()
+      if (!trimmedName || attendanceGroupForm.code.trim().length > 0) return
+      attendanceGroupForm.code = generateAttendanceCode(trimmedName, 'group')
+    },
+    { immediate: true },
+  )
 
   function resetRuleSetForm() {
     ruleSetEditingId.value = null
@@ -380,6 +398,9 @@ export function useAttendanceAdminRulesAndGroups({
       ruleTemplateSystemText.value = JSON.stringify(Array.isArray(data.data?.system) ? data.data?.system : [], null, 2)
       ruleTemplateLibraryText.value = JSON.stringify(Array.isArray(data.data?.library) ? data.data?.library : [], null, 2)
       ruleTemplateVersions.value = Array.isArray(data.data?.versions) ? data.data.versions : []
+      if (!ruleTemplateVersions.value.some((item) => item.id === selectedRuleTemplateVersionId.value)) {
+        selectedRuleTemplateVersionId.value = ''
+      }
       setStatus?.(tr('Rule templates loaded.', '规则模板已加载。'))
     } catch (error: unknown) {
       setStatus?.((error as Error)?.message || tr('Failed to load rule templates', '加载规则模板失败'), 'error')
@@ -457,6 +478,41 @@ export function useAttendanceAdminRulesAndGroups({
     setStatus?.(tr('System templates copied to library.', '系统模板已复制到模板库。'))
   }
 
+  async function openRuleTemplateVersion(versionId: string) {
+    if (!versionId) return
+    const current = ruleTemplateVersions.value.find((item) => item.id === versionId) ?? null
+    if (current?.templates) {
+      selectedRuleTemplateVersionId.value = versionId
+      return
+    }
+    ruleTemplateVersionLoading.value = true
+    try {
+      const response = await apiFetch(`/api/attendance/rule-templates/versions/${encodeURIComponent(versionId)}`)
+      if (response.status === 403) {
+        adminForbiddenRef.value = true
+        throw new Error(tr('Admin permissions required', '需要管理员权限'))
+      }
+      const data = asObject(await response.json().catch(() => null)) as ApiEnvelope<AttendanceRuleTemplateVersion> | null
+      if (!response.ok || !data?.ok || !data.data) {
+        throw new Error(String(data?.error?.message || tr('Failed to load template version', '加载模板版本失败')))
+      }
+      ruleTemplateVersions.value = ruleTemplateVersions.value.map((item) => (
+        item.id === versionId
+          ? { ...item, ...data.data }
+          : item
+      ))
+      selectedRuleTemplateVersionId.value = versionId
+    } catch (error: unknown) {
+      setStatus?.((error as Error)?.message || tr('Failed to load template version', '加载模板版本失败'), 'error')
+    } finally {
+      ruleTemplateVersionLoading.value = false
+    }
+  }
+
+  function closeRuleTemplateVersionView() {
+    selectedRuleTemplateVersionId.value = ''
+  }
+
   function resetAttendanceGroupForm() {
     attendanceGroupEditingId.value = null
     attendanceGroupForm.name = ''
@@ -511,7 +567,7 @@ export function useAttendanceAdminRulesAndGroups({
     try {
       const payload = {
         name: attendanceGroupForm.name.trim(),
-        code: attendanceGroupForm.code.trim() || null,
+        code: attendanceGroupForm.code.trim() || generateAttendanceCode(attendanceGroupForm.name, 'group'),
         timezone: attendanceGroupForm.timezone.trim() || defaultTimezone,
         ruleSetId: attendanceGroupForm.ruleSetId || null,
         description: attendanceGroupForm.description.trim() || null,
@@ -691,9 +747,14 @@ export function useAttendanceAdminRulesAndGroups({
     ruleTemplateRestoring,
     ruleTemplateSaving,
     ruleTemplateSystemText,
+    ruleTemplateVersionLoading,
     ruleTemplateVersions,
     saveAttendanceGroup,
     saveRuleSet,
     saveRuleTemplates,
+    selectedRuleTemplateVersion,
+    selectedRuleTemplateVersionId,
+    closeRuleTemplateVersionView,
+    openRuleTemplateVersion,
   }
 }

--- a/apps/web/tests/AttendanceScheduledDateInput.spec.ts
+++ b/apps/web/tests/AttendanceScheduledDateInput.spec.ts
@@ -1,0 +1,139 @@
+import { createApp, h, nextTick, ref, type App as VueApp, type Component } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import AttendanceScheduledDateInput from '../src/views/attendance/AttendanceScheduledDateInput.vue'
+
+const tr = (en: string, _zh: string) => en
+
+const calendarDays = [
+  {
+    key: '2026-03-16',
+    day: 16,
+    isToday: false,
+    isCurrentMonth: true,
+    status: 'normal',
+    statusLabel: 'Normal',
+    tooltip: '2026-03-16 · Normal',
+    holidayName: 'Rest day',
+    lunarLabel: '二月初八',
+  },
+  {
+    key: '2026-03-17',
+    day: 17,
+    isToday: true,
+    isCurrentMonth: true,
+    status: 'off',
+    statusLabel: 'Off',
+    tooltip: '2026-03-17 · Off',
+    holidayName: 'Holiday',
+    lunarLabel: '二月初九',
+  },
+] as const
+
+describe('AttendanceScheduledDateInput', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  it('opens the schedule picker on double click and lets the user pick a date', async () => {
+    const focusCalendarMonth = vi.fn().mockResolvedValue(undefined)
+    const shiftMonth = vi.fn().mockResolvedValue(undefined)
+    const modelValue = ref('2026-03-15')
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp({
+      setup() {
+        return () => h(AttendanceScheduledDateInput as Component, {
+          modelValue: modelValue.value,
+          inputType: 'date',
+          fieldId: 'attendance-request-work-date',
+          fieldName: 'requestWorkDate',
+          calendarDays,
+          calendarLabel: 'March 2026',
+          weekDays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+          shiftMonth,
+          focusCalendarMonth,
+          tr,
+          'onUpdate:modelValue': (value: string) => {
+            modelValue.value = value
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const input = container.querySelector('input') as HTMLInputElement | null
+    expect(input?.type).toBe('date')
+    input?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, cancelable: true }))
+    await nextTick()
+
+    expect(focusCalendarMonth).toHaveBeenCalledWith('2026-03-15')
+    expect(container.textContent).toContain('March 2026')
+    expect(container.textContent).toContain('二月初八')
+    expect(container.textContent).toContain('Rest day')
+
+    const target = container.querySelector('button[title="2026-03-16 · Normal"]') as HTMLButtonElement | null
+    expect(target).not.toBeNull()
+    target?.click()
+    await nextTick()
+
+    expect(modelValue.value).toBe('2026-03-16')
+    expect(container.querySelector('.attendance-date-input__overlay')).toBeNull()
+    expect(shiftMonth).not.toHaveBeenCalled()
+  })
+
+  it('preserves the time portion when picking a datetime-local value', async () => {
+    const focusCalendarMonth = vi.fn().mockResolvedValue(undefined)
+    const shiftMonth = vi.fn().mockResolvedValue(undefined)
+    const modelValue = ref('2026-03-15T08:30')
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp({
+      setup() {
+        return () => h(AttendanceScheduledDateInput as Component, {
+          modelValue: modelValue.value,
+          inputType: 'datetime-local',
+          fieldId: 'attendance-request-in',
+          fieldName: 'requestedInAt',
+          defaultTime: '09:00',
+          calendarDays,
+          calendarLabel: 'March 2026',
+          weekDays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+          shiftMonth,
+          focusCalendarMonth,
+          tr,
+          'onUpdate:modelValue': (value: string) => {
+            modelValue.value = value
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const input = container.querySelector('input') as HTMLInputElement | null
+    expect(input?.type).toBe('datetime-local')
+    input?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, cancelable: true }))
+    await nextTick()
+
+    const target = container.querySelector('button[title="2026-03-17 · Off"]') as HTMLButtonElement | null
+    expect(target).not.toBeNull()
+    target?.click()
+    await nextTick()
+
+    expect(modelValue.value).toBe('2026-03-17T08:30')
+  })
+})

--- a/apps/web/tests/authRedirect.spec.ts
+++ b/apps/web/tests/authRedirect.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { normalizePostLoginRedirect } from '../src/utils/authRedirect'
+
+describe('normalizePostLoginRedirect', () => {
+  it('drops root and login redirects so login can go straight to the resolved home path', () => {
+    expect(normalizePostLoginRedirect('/')).toBeNull()
+    expect(normalizePostLoginRedirect('/login')).toBeNull()
+    expect(normalizePostLoginRedirect('/login?redirect=%2Fattendance')).toBeNull()
+  })
+
+  it('keeps safe in-app paths and rejects unsafe values', () => {
+    expect(normalizePostLoginRedirect('/attendance')).toBe('/attendance')
+    expect(normalizePostLoginRedirect('/plm?tab=bom')).toBe('/plm?tab=bom')
+    expect(normalizePostLoginRedirect('https://example.com')).toBeNull()
+    expect(normalizePostLoginRedirect('//example.com')).toBeNull()
+  })
+})

--- a/apps/web/tests/useAttendanceAdminLeavePolicies.spec.ts
+++ b/apps/web/tests/useAttendanceAdminLeavePolicies.spec.ts
@@ -111,6 +111,39 @@ describe('useAttendanceAdminLeavePolicies', () => {
     expect(setStatusFromError).not.toHaveBeenCalled()
   })
 
+  it('auto-generates a leave type code from the name when the code is blank', async () => {
+    const adminForbidden = ref(false)
+    const requestForm = reactive({ leaveTypeId: '', overtimeRuleId: '' })
+    const apiFetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true, data: { id: 'leave-3' } }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true, data: { items: [] } }))
+
+    const policies = useAttendanceAdminLeavePolicies({
+      adminForbidden,
+      requestForm,
+      apiFetch,
+    })
+
+    policies.leaveTypeForm.code = '   '
+    policies.leaveTypeForm.name = 'Annual Leave'
+
+    await policies.saveLeaveType()
+
+    expect(apiFetch).toHaveBeenNthCalledWith(1, '/api/attendance/leave-types', {
+      method: 'POST',
+      body: JSON.stringify({
+        code: 'annual_leave',
+        name: 'Annual Leave',
+        paid: true,
+        requiresApproval: true,
+        requiresAttachment: false,
+        defaultMinutesPerDay: 480,
+        isActive: true,
+        orgId: undefined,
+      }),
+    })
+  })
+
   it('deletes an overtime rule after confirmation and reloads data', async () => {
     const adminForbidden = ref(false)
     const requestForm = reactive({ leaveTypeId: '', overtimeRuleId: '' })

--- a/apps/web/tests/useAttendanceAdminRulesAndGroups.spec.ts
+++ b/apps/web/tests/useAttendanceAdminRulesAndGroups.spec.ts
@@ -90,6 +90,33 @@ describe('useAttendanceAdminRulesAndGroups', () => {
     expect(options.setStatus).toHaveBeenCalledWith('Rule set saved.')
   })
 
+  it('auto-generates a group code from the name when the code is blank', async () => {
+    const apiFetch = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input === '/api/attendance/groups' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true, data: { id: 'group-1' } })
+      }
+      if (input === '/api/attendance/groups?orgId=org-1') {
+        return jsonResponse(200, { ok: true, data: { items: [] } })
+      }
+      throw new Error(`Unexpected request: ${input}`)
+    })
+    const options = createOptions({ apiFetch })
+    const rules = useAttendanceAdminRulesAndGroups(options)
+    rules.attendanceGroupForm.name = 'Operations Team'
+    rules.attendanceGroupForm.code = ''
+
+    await rules.saveAttendanceGroup()
+
+    const [, init] = apiFetch.mock.calls[0]!
+    expect(JSON.parse(String(init?.body || '{}'))).toMatchObject({
+      code: 'operations_team',
+      name: 'Operations Team',
+      timezone: 'Asia/Shanghai',
+      orgId: 'org-1',
+    })
+    expect(options.setStatus).toHaveBeenCalledWith('Attendance group saved.')
+  })
+
   it('validates rule template library schema before saving', async () => {
     const apiFetch = vi.fn()
     const options = createOptions({ apiFetch })
@@ -100,6 +127,62 @@ describe('useAttendanceAdminRulesAndGroups', () => {
 
     expect(apiFetch).not.toHaveBeenCalled()
     expect(options.setStatus).toHaveBeenCalledWith(expect.stringContaining('Template schema errors:'), 'error')
+  })
+
+  it('loads template version details when opening a stored version', async () => {
+    const apiFetch = vi.fn(async (input: string) => {
+      if (input === '/api/attendance/rule-templates') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            system: [],
+            library: [],
+            versions: [
+              {
+                id: 'version-1',
+                version: 2,
+                itemCount: 1,
+                createdAt: '2026-03-18T08:00:00.000Z',
+                createdBy: 'tester',
+              },
+            ],
+          },
+        })
+      }
+      if (input === '/api/attendance/rule-templates/versions/version-1') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            id: 'version-1',
+            version: 2,
+            itemCount: 1,
+            createdAt: '2026-03-18T08:00:00.000Z',
+            createdBy: 'tester',
+            templates: [
+              {
+                id: 'tpl-1',
+                name: 'Standard Weekday',
+                rules: [],
+              },
+            ],
+          },
+        })
+      }
+      throw new Error(`Unexpected request: ${input}`)
+    })
+    const options = createOptions({ apiFetch })
+    const rules = useAttendanceAdminRulesAndGroups(options)
+
+    await rules.loadRuleTemplates()
+    await rules.openRuleTemplateVersion('version-1')
+
+    expect(apiFetch).toHaveBeenNthCalledWith(1, '/api/attendance/rule-templates')
+    expect(apiFetch).toHaveBeenNthCalledWith(2, '/api/attendance/rule-templates/versions/version-1')
+    expect(rules.selectedRuleTemplateVersion.value?.id).toBe('version-1')
+    expect(rules.selectedRuleTemplateVersion.value?.templates).toEqual([
+      expect.objectContaining({ id: 'tpl-1', name: 'Standard Weekday' }),
+    ])
+    expect(rules.ruleTemplateVersionLoading.value).toBe(false)
   })
 
   it('loads groups, manages members, and keeps the selected group synced', async () => {

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -244,6 +244,7 @@ describe('Attendance Plugin Integration', () => {
 
     expect(cancelRes.status).toBe(200)
 
+    const leaveTypeCodeInput = `annual-${runSuffix}`
     const leaveTypeRes = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
       method: 'POST',
       headers: {
@@ -251,7 +252,7 @@ describe('Attendance Plugin Integration', () => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        code: 'annual',
+        code: leaveTypeCodeInput,
         name: 'Annual Leave',
         requiresApproval: true,
       }),
@@ -259,6 +260,8 @@ describe('Attendance Plugin Integration', () => {
 
     expect([201, 409]).toContain(leaveTypeRes.status)
     let leaveTypeId = (leaveTypeRes.body as { data?: { id?: string } } | undefined)?.data?.id
+    const leaveTypeCode = (leaveTypeRes.body as { data?: { code?: string } } | undefined)?.data?.code
+    expect(leaveTypeCode).toBe(leaveTypeCodeInput)
     if (!leaveTypeId) {
       const leaveListRes = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
         headers: {
@@ -266,8 +269,24 @@ describe('Attendance Plugin Integration', () => {
         },
       })
       const items = (leaveListRes.body as { data?: { items?: { id?: string; code?: string }[] } } | undefined)?.data?.items ?? []
-      leaveTypeId = items.find(item => item.code === 'annual')?.id
+      leaveTypeId = items.find(item => item.code === leaveTypeCodeInput)?.id
     }
+
+    const autoLeaveTypeRes = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: `Auto Leave ${runSuffix}`,
+        paid: false,
+        requiresApproval: false,
+      }),
+    })
+    expect(autoLeaveTypeRes.status).toBe(201)
+    const autoLeaveTypeCode = (autoLeaveTypeRes.body as { data?: { code?: string } } | undefined)?.data?.code
+    expect(autoLeaveTypeCode).toMatch(/^[a-z0-9-]+-[a-f0-9]{8}$/)
 
     const overtimeRuleRes = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, {
       method: 'POST',
@@ -691,8 +710,26 @@ describe('Attendance Plugin Integration', () => {
     expect(createGroupRes.status).toBe(200)
     const groupId = (createGroupRes.body as { data?: { id?: string } } | undefined)?.data?.id
     expect(groupId).toBeTruthy()
+    const createdGroupCode = (createGroupRes.body as { data?: { code?: string } } | undefined)?.data?.code
+    expect(createdGroupCode).toMatch(/^[a-z0-9-]+-[a-f0-9]{8}$/)
 
     if (groupId) {
+      const updateGroupRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: `${groupName} Updated`,
+          timezone: 'UTC',
+          description: 'integration-test-updated',
+        }),
+      })
+      expect(updateGroupRes.status).toBe(200)
+      const updatedGroupCode = (updateGroupRes.body as { data?: { code?: string } } | undefined)?.data?.code
+      expect(updatedGroupCode).toBe(createdGroupCode)
+
       const addGroupMemberRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}/members`, {
         method: 'POST',
         headers: {
@@ -887,6 +924,31 @@ describe('Attendance Plugin Integration', () => {
         const libraryNames = ((afterRestoreRes.body as { data?: { library?: { name?: string }[] } } | undefined)?.data?.library ?? [])
           .map(item => item.name)
         expect(libraryNames.includes(templateAName)).toBe(true)
+
+        const versionViewRes = await requestJson(
+          `${baseUrl}/api/attendance/rule-templates/versions/${encodeURIComponent(versionAId)}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        )
+        expect(versionViewRes.status).toBe(200)
+        const versionView = (versionViewRes.body as {
+          data?: {
+            id?: string
+            version?: number
+            itemCount?: number
+            templates?: unknown[]
+          }
+        } | undefined)?.data
+        expect(versionView?.id).toBe(versionAId)
+        expect(versionView?.version).toBeGreaterThan(0)
+        expect(Array.isArray(versionView?.templates)).toBe(true)
+        expect(versionView?.itemCount).toBeGreaterThanOrEqual(0)
+        if (Array.isArray(versionView?.templates)) {
+          expect(versionView.templates.length).toBeGreaterThan(0)
+        }
       }
     }
 

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -3255,7 +3255,6 @@ paths:
                 orgId:
                   type: string
               required:
-                - code
                 - name
       responses:
         '201':
@@ -3351,6 +3350,190 @@ paths:
                     properties:
                       id:
                         type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/attendance/rule-templates:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get rule templates
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      system:
+                        type: array
+                        items:
+                          type: object
+                      library:
+                        type: array
+                        items:
+                          type: object
+                      versions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            version:
+                              type: integer
+                            createdAt:
+                              type: string
+                              nullable: true
+                            createdBy:
+                              type: string
+                              nullable: true
+                            sourceVersionId:
+                              type: string
+                              nullable: true
+                            itemCount:
+                              type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    put:
+      summary: Save rule template library
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                templates:
+                  type: array
+                  items:
+                    type: object
+              required:
+                - templates
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          type: object
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/attendance/rule-templates/restore:
+    x-plugin: plugin-attendance
+    post:
+      summary: Restore rule template library from a version
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                versionId:
+                  type: string
+                version:
+                  type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          type: object
+                      restoredFrom:
+                        type: string
+                        nullable: true
+                      version:
+                        type: integer
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/attendance/rule-templates/versions/{versionId}:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get rule template version contents
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: versionId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      version:
+                        type: integer
+                      createdAt:
+                        type: string
+                        nullable: true
+                      createdBy:
+                        type: string
+                        nullable: true
+                      sourceVersionId:
+                        type: string
+                        nullable: true
+                      itemCount:
+                        type: integer
+                      templates:
+                        type: array
+                        items:
+                          type: object
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -5097,7 +5097,6 @@
                   }
                 },
                 "required": [
-                  "code",
                   "name"
                 ]
               }
@@ -5250,6 +5249,301 @@
                       "properties": {
                         "id": {
                           "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/attendance/rule-templates": {
+      "x-plugin": "plugin-attendance",
+      "get": {
+        "summary": "Get rule templates",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "system": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "library": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "versions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "integer"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "createdBy": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "sourceVersionId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "itemCount": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "put": {
+        "summary": "Save rule template library",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "templates": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                },
+                "required": [
+                  "templates"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "templates": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/attendance/rule-templates/restore": {
+      "x-plugin": "plugin-attendance",
+      "post": {
+        "summary": "Restore rule template library from a version",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "versionId": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "templates": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "restoredFrom": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "version": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/attendance/rule-templates/versions/{versionId}": {
+      "x-plugin": "plugin-attendance",
+      "get": {
+        "summary": "Get rule template version contents",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "integer"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "createdBy": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "sourceVersionId": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "itemCount": {
+                          "type": "integer"
+                        },
+                        "templates": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
                         }
                       }
                     }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -3255,7 +3255,6 @@ paths:
                 orgId:
                   type: string
               required:
-                - code
                 - name
       responses:
         '201':
@@ -3351,6 +3350,190 @@ paths:
                     properties:
                       id:
                         type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/attendance/rule-templates:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get rule templates
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      system:
+                        type: array
+                        items:
+                          type: object
+                      library:
+                        type: array
+                        items:
+                          type: object
+                      versions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            version:
+                              type: integer
+                            createdAt:
+                              type: string
+                              nullable: true
+                            createdBy:
+                              type: string
+                              nullable: true
+                            sourceVersionId:
+                              type: string
+                              nullable: true
+                            itemCount:
+                              type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    put:
+      summary: Save rule template library
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                templates:
+                  type: array
+                  items:
+                    type: object
+              required:
+                - templates
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          type: object
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/attendance/rule-templates/restore:
+    x-plugin: plugin-attendance
+    post:
+      summary: Restore rule template library from a version
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                versionId:
+                  type: string
+                version:
+                  type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          type: object
+                      restoredFrom:
+                        type: string
+                        nullable: true
+                      version:
+                        type: integer
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/attendance/rule-templates/versions/{versionId}:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get rule template version contents
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: versionId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      version:
+                        type: integer
+                      createdAt:
+                        type: string
+                        nullable: true
+                      createdBy:
+                        type: string
+                        nullable: true
+                      sourceVersionId:
+                        type: string
+                        nullable: true
+                      itemCount:
+                        type: integer
+                      templates:
+                        type: array
+                        items:
+                          type: object
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -1037,7 +1037,7 @@ paths:
                 defaultMinutesPerDay: { type: integer }
                 isActive: { type: boolean }
                 orgId: { type: string }
-              required: [code, name]
+              required: [name]
       responses:
         '201':
           description: Created
@@ -1111,6 +1111,145 @@ paths:
                       id: { type: string }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/attendance/rule-templates:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get rule templates
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      system:
+                        type: array
+                        items: { type: object }
+                      library:
+                        type: array
+                        items: { type: object }
+                      versions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id: { type: string }
+                            version: { type: integer }
+                            createdAt: { type: string, nullable: true }
+                            createdBy: { type: string, nullable: true }
+                            sourceVersionId: { type: string, nullable: true }
+                            itemCount: { type: integer }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    put:
+      summary: Save rule template library
+      security: [ { bearerAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                templates:
+                  type: array
+                  items: { type: object }
+              required: [templates]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items: { type: object }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/attendance/rule-templates/restore:
+    x-plugin: plugin-attendance
+    post:
+      summary: Restore rule template library from a version
+      security: [ { bearerAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                versionId: { type: string }
+                version: { type: integer }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items: { type: object }
+                      restoredFrom: { type: string, nullable: true }
+                      version: { type: integer }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/attendance/rule-templates/versions/{versionId}:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get rule template version contents
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: versionId
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      version: { type: integer }
+                      createdAt: { type: string, nullable: true }
+                      createdBy: { type: string, nullable: true }
+                      sourceVersionId: { type: string, nullable: true }
+                      itemCount: { type: integer }
+                      templates:
+                        type: array
+                        items: { type: object }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
   /api/attendance/overtime-rules:
     x-plugin: plugin-attendance
     get:

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -3916,7 +3916,16 @@ async function getTemplateLibraryVersionPayload(db, orgId, versionId, versionNum
     if (!rows.length) return null
     const row = rows[0]
     const templates = normalizeTemplateLibrary(row.templates ?? [])
-    return { id: row.id, version: Number(row.version ?? 0), templates }
+    const version = mapTemplateLibraryVersionRow(row)
+    return {
+      id: row.id,
+      version: version?.version ?? Number(row.version ?? 0),
+      createdAt: version?.createdAt ?? row.created_at ?? null,
+      createdBy: version?.createdBy ?? row.created_by ?? null,
+      sourceVersionId: version?.sourceVersionId ?? row.source_version_id ?? null,
+      itemCount: templates.length,
+      templates,
+    }
   } catch (error) {
     if (isDatabaseSchemaError(error)) return null
     throw error
@@ -5347,7 +5356,7 @@ function formatDateOnlyForCsv(value) {
 }
 
 function formatTimeZoneOffsetForCsv(offsetMinutes) {
-  const safeOffset = Number.isFinite(offsetMinutes) ? Number(offsetMinutes) : 0
+  const safeOffset = Number.isFinite(offsetMinutes) ? Math.round(Number(offsetMinutes)) : 0
   const sign = safeOffset >= 0 ? '+' : '-'
   const absolute = Math.abs(safeOffset)
   const hours = String(Math.floor(absolute / 60)).padStart(2, '0')
@@ -5375,6 +5384,28 @@ function formatCsvValue(value) {
     return `"${text.replace(/"/g, '""')}"`
   }
   return text
+}
+
+function normalizeCodeSegment(value) {
+  const text = String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return text.slice(0, 32)
+}
+
+function generateAttendanceCode(prefix, name) {
+  const base = normalizeCodeSegment(name) || normalizeCodeSegment(prefix) || 'attendance'
+  return `${base}-${randomUUID().slice(0, 8)}`
+}
+
+function resolveAttendanceCode({ explicitCode, existingCode, prefix, name }) {
+  const normalizedExplicit = typeof explicitCode === 'string' ? explicitCode.trim() : ''
+  if (normalizedExplicit) return normalizedExplicit
+  const normalizedExisting = typeof existingCode === 'string' ? existingCode.trim() : ''
+  if (normalizedExisting) return normalizedExisting
+  return generateAttendanceCode(prefix, name)
 }
 
 function buildCsv(rows, headers) {
@@ -5891,7 +5922,7 @@ module.exports = {
     })
 
     const leaveTypeCreateSchema = z.object({
-      code: z.string().min(1),
+      code: z.string().trim().optional().nullable(),
       name: z.string().min(1),
       paid: z.boolean().optional(),
       requiresApproval: z.boolean().optional(),
@@ -9411,7 +9442,12 @@ module.exports = {
 
         const orgId = getOrgId(req)
         const payload = {
-          code: parsed.data.code,
+          code: resolveAttendanceCode({
+            explicitCode: parsed.data.code,
+            existingCode: null,
+            prefix: 'leave',
+            name: parsed.data.name,
+          }),
           name: parsed.data.name,
           paid: parsed.data.paid ?? true,
           requiresApproval: parsed.data.requiresApproval ?? true,
@@ -9482,7 +9518,12 @@ module.exports = {
 
           const existing = existingRows[0]
           const payload = {
-            code: parsed.data.code ?? existing.code,
+            code: resolveAttendanceCode({
+              explicitCode: parsed.data.code,
+              existingCode: existing.code,
+              prefix: 'leave',
+              name: parsed.data.name ?? existing.name,
+            }),
             name: parsed.data.name ?? existing.name,
             paid: parsed.data.paid ?? existing.paid ?? true,
             requiresApproval: parsed.data.requiresApproval ?? existing.requires_approval,
@@ -10612,6 +10653,23 @@ module.exports = {
             library,
             versions,
           },
+        })
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/rule-templates/versions/:versionId',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const target = await getTemplateLibraryVersionPayload(db, orgId, req.params.versionId, null)
+        if (!target) {
+          res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Template version not found' } })
+          return
+        }
+        res.json({
+          ok: true,
+          data: target,
         })
       })
     )
@@ -15395,7 +15453,7 @@ module.exports = {
       withPermission('attendance:admin', async (req, res) => {
         const schema = z.object({
           name: z.string().min(1),
-          code: z.string().optional().nullable(),
+          code: z.string().trim().optional().nullable(),
           timezone: z.string().optional().nullable(),
           ruleSetId: z.string().uuid().optional().nullable(),
           description: z.string().optional().nullable(),
@@ -15409,7 +15467,12 @@ module.exports = {
 
         const orgId = getOrgId(req)
         const name = parsed.data.name.trim()
-        const code = parsed.data.code?.trim() || null
+        const code = resolveAttendanceCode({
+          explicitCode: parsed.data.code,
+          existingCode: null,
+          prefix: 'group',
+          name,
+        })
         const timezone = parsed.data.timezone?.trim() || DEFAULT_RULE.timezone
         const ruleSetId = parsed.data.ruleSetId ?? null
         const description = parsed.data.description?.trim() || null
@@ -15439,7 +15502,7 @@ module.exports = {
       withPermission('attendance:admin', async (req, res) => {
         const schema = z.object({
           name: z.string().min(1),
-          code: z.string().optional().nullable(),
+          code: z.string().trim().optional().nullable(),
           timezone: z.string().optional().nullable(),
           ruleSetId: z.string().uuid().optional().nullable(),
           description: z.string().optional().nullable(),
@@ -15453,8 +15516,23 @@ module.exports = {
 
         const orgId = getOrgId(req)
         const groupId = req.params.id
+        const existingRows = await db.query(
+          'SELECT * FROM attendance_groups WHERE id = $1 AND org_id = $2',
+          [groupId, orgId]
+        )
+        if (!existingRows.length) {
+          res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Group not found' } })
+          return
+        }
+
+        const existing = existingRows[0]
         const name = parsed.data.name.trim()
-        const code = parsed.data.code?.trim() || null
+        const code = resolveAttendanceCode({
+          explicitCode: parsed.data.code,
+          existingCode: existing.code,
+          prefix: 'group',
+          name: parsed.data.name ?? existing.name,
+        })
         const timezone = parsed.data.timezone?.trim() || DEFAULT_RULE.timezone
         const ruleSetId = parsed.data.ruleSetId ?? null
         const description = parsed.data.description?.trim() || null


### PR DESCRIPTION
## Summary
- fix post-login redirect normalization so login success does not flash back through `/` and `/login`
- improve attendance request/admin UX with scheduled date pickers, auto-generated codes, timezone selectors, and rule template version viewing
- fix attendance CSV timezone offset precision and add backend support for auto-generated group/leave codes plus rule-template version detail API

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/authRedirect.spec.ts tests/AttendanceScheduledDateInput.spec.ts tests/useAttendanceAdminRulesAndGroups.spec.ts tests/useAttendanceAdminLeavePolicies.spec.ts tests/App.spec.ts tests/utils/api.test.ts`
- `pnpm --filter @metasheet/web build`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "registers attendance routes and lists plugin|exports attendance CSV with ISO date values and timezone-consistent timestamps"`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm exec tsx packages/openapi/tools/build.ts`
- `node scripts/ops/attendance-validate-openapi-import-contract.mjs packages/openapi/dist/openapi.json packages/openapi/src/paths/attendance.yml`
