### PR TITLE
fix(attendance): address run14 post-deploy regressions

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -9,7 +9,7 @@ import 'element-plus/dist/index.css'
 import App from './App.vue'
 import { ROUTE_PATHS } from './router/types'
 import { useFeatureFlags } from './stores/featureFlags'
-import { normalizePostLoginRedirect } from './utils/authRedirect'
+import { normalizePostLoginRedirect, normalizePreLoginRedirect } from './utils/authRedirect'
 import { apiFetch, clearStoredAuthState, getStoredAuthToken } from './utils/api'
 
 // Import views
@@ -132,9 +132,10 @@ router.beforeEach(async (to, _from, next) => {
   }
 
   if (!token && !isLoginRoute) {
+    const redirect = normalizePreLoginRedirect(to.fullPath || '/attendance')
     return next({
       path: ROUTE_PATHS.LOGIN,
-      query: { redirect: to.fullPath || '/attendance' },
+      query: { redirect },
     })
   }
 

--- a/apps/web/src/utils/api.ts
+++ b/apps/web/src/utils/api.ts
@@ -2,6 +2,8 @@
  * API utilities for frontend-backend communication
  */
 
+import { normalizePreLoginRedirect } from './authRedirect'
+
 // Vite environment type declaration
 declare global {
   interface ImportMetaEnv {
@@ -95,7 +97,8 @@ function buildLoginRedirectUrl(): string {
   if (typeof window === 'undefined') return '/login'
   const current = `${window.location.pathname || ''}${window.location.search || ''}${window.location.hash || ''}` || '/'
   if (current.startsWith('/login')) return '/login'
-  return `/login?redirect=${encodeURIComponent(current)}`
+  const redirect = normalizePreLoginRedirect(current)
+  return `/login?redirect=${encodeURIComponent(redirect)}`
 }
 
 function handleUnauthorized(path: string): void {

--- a/apps/web/src/utils/authRedirect.ts
+++ b/apps/web/src/utils/authRedirect.ts
@@ -1,7 +1,21 @@
+const DEFAULT_AUTH_HOME_PATH = '/attendance'
+
+function isSafeInAppRedirect(value: string): boolean {
+  return value.startsWith('/') && !value.startsWith('//')
+}
+
 export function normalizePostLoginRedirect(value: unknown): string | null {
   if (typeof value !== 'string') return null
   const normalized = value.trim()
-  if (!normalized.startsWith('/') || normalized.startsWith('//')) return null
+  if (!isSafeInAppRedirect(normalized)) return null
   if (normalized === '/' || normalized.startsWith('/login')) return null
+  return normalized
+}
+
+export function normalizePreLoginRedirect(value: unknown, fallback = DEFAULT_AUTH_HOME_PATH): string {
+  if (typeof value !== 'string') return fallback
+  const normalized = value.trim()
+  if (!isSafeInAppRedirect(normalized)) return fallback
+  if (normalized === '/' || normalized.startsWith('/login')) return fallback
   return normalized
 }

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1921,6 +1921,10 @@ function classifyStatusError(
     message = tr('Session expired or token is invalid.', '登录已过期或令牌无效。')
     meta.hint = tr('Sign in again, then retry the action.', '请重新登录后再重试。')
     meta.action = 'refresh-overview'
+  } else if (code === 'DUPLICATE_REQUEST' || status === 409) {
+    message = tr('An identical attendance request already exists for this date.', '同一天同类型的相同申请已存在。')
+    meta.hint = tr('Refresh the request list before submitting again.', '请先刷新申请列表，确认现有申请状态后再提交。')
+    meta.action = 'reload-requests'
   } else if (status === 403 || code === 'FORBIDDEN' || code === 'PERMISSION_DENIED') {
     message = rawMessage === fallbackMessage ? tr('Permission denied for this action.', '当前操作无权限。') : rawMessage
     meta.hint = tr('Use an account with required attendance permissions, then reload data.', '请使用具备所需考勤权限的账号，并重新加载数据。')
@@ -2254,6 +2258,7 @@ function validateRequestForm(): string | null {
 }
 
 async function submitRequest() {
+  if (requestSubmitting.value) return
   requestSubmitting.value = true
   try {
     const validationMessage = validateRequestForm()

--- a/apps/web/tests/authRedirect.spec.ts
+++ b/apps/web/tests/authRedirect.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { normalizePostLoginRedirect } from '../src/utils/authRedirect'
+import { normalizePostLoginRedirect, normalizePreLoginRedirect } from '../src/utils/authRedirect'
 
 describe('normalizePostLoginRedirect', () => {
   it('drops root and login redirects so login can go straight to the resolved home path', () => {
@@ -13,5 +13,20 @@ describe('normalizePostLoginRedirect', () => {
     expect(normalizePostLoginRedirect('/plm?tab=bom')).toBe('/plm?tab=bom')
     expect(normalizePostLoginRedirect('https://example.com')).toBeNull()
     expect(normalizePostLoginRedirect('//example.com')).toBeNull()
+  })
+})
+
+describe('normalizePreLoginRedirect', () => {
+  it('redirects root and login paths to the attendance home target', () => {
+    expect(normalizePreLoginRedirect('/')).toBe('/attendance')
+    expect(normalizePreLoginRedirect('/login')).toBe('/attendance')
+    expect(normalizePreLoginRedirect('/login?redirect=%2Fattendance')).toBe('/attendance')
+  })
+
+  it('keeps safe in-app paths and falls back for unsafe values', () => {
+    expect(normalizePreLoginRedirect('/attendance')).toBe('/attendance')
+    expect(normalizePreLoginRedirect('/plm?tab=bom')).toBe('/plm?tab=bom')
+    expect(normalizePreLoginRedirect('https://example.com')).toBe('/attendance')
+    expect(normalizePreLoginRedirect('//example.com')).toBe('/attendance')
   })
 })

--- a/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
+++ b/docs/deployment/attendance-windows-onprem-easy-start-20260306.md
@@ -106,6 +106,19 @@ scripts/ops/attendance-onprem-deploy-easy.sh
 5. 初始化管理员账号与权限
 6. 健康检查
 
+如果部署脚本没有把 migration 跑完，或者你手工覆盖安装包后想先单独补跑数据库迁移，就先在 Windows 侧执行：
+
+```powershell
+.\run-migrate.bat
+```
+
+常见需要补跑的情况：
+
+- `POST /api/attendance/leave-types` 之类接口返回 `503`
+- 健康检查能过，但考勤配置类接口提示表不存在
+
+先跑一次 `run-migrate.bat`，再继续验收或重试部署。
+
 ## 6) 打开系统
 
 - 页面：`http://<你的服务器IP>/attendance`
@@ -119,6 +132,8 @@ ENV_FILE=/opt/metasheet/docker/app.env \
 REQUIRE_ATTENDANCE_ONLY=1 \
 scripts/ops/attendance-onprem-update.sh
 ```
+
+`attendance-onprem-update.sh` 默认会自动跑 migration。只有在你显式设置 `RUN_MIGRATIONS=0`、跳过脚本，或遇到上面的 `503` / 表不存在情况时，才需要手工执行 `run-migrate.bat`。
 
 ## 8) 快速自检（照抄）
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -484,6 +484,8 @@ export class MetaSheetServer {
         } catch { /* ignore plugin summary errors */ }
         res.json({
           status: 'ok',
+          ok: true,
+          success: true,
           timestamp: new Date().toISOString(),
           plugins: this.pluginLoader.getPlugins().size,
           pluginsSummary: pluginsSummary || undefined,

--- a/packages/core-backend/src/server.js
+++ b/packages/core-backend/src/server.js
@@ -102,6 +102,8 @@ async function handleRequest(req, res) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     return res.end(JSON.stringify({
       status: 'ok',
+      ok: true,
+      success: true,
       timestamp: new Date().toISOString()
     }));
   }

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -198,8 +198,9 @@ describe('Attendance Plugin Integration', () => {
   it('registers attendance routes and lists plugin', async () => {
     if (!baseUrl) return
     const runSuffix = Date.now().toString(36)
+    const testUserId = `attendance-test-${runSuffix}`
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=attendance-test&roles=admin&perms=attendance:read,attendance:write,attendance:admin,attendance:approve`
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin,attendance:approve`
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     if (!token) return
@@ -386,7 +387,7 @@ describe('Attendance Plugin Integration', () => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        userId: 'attendance-test',
+        userId: testUserId,
         shiftId,
         startDate: workDate,
         isActive: true,
@@ -452,7 +453,7 @@ describe('Attendance Plugin Integration', () => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        userId: 'attendance-test',
+        userId: testUserId,
         rotationRuleId,
         startDate: workDate,
         isActive: true,
@@ -564,7 +565,7 @@ describe('Attendance Plugin Integration', () => {
     expect(importTemplateData?.payloadExample?.ruleSetId).toBeUndefined()
 
     const importPayload = {
-      userId: 'attendance-test',
+      userId: testUserId,
       rows: [
         {
           workDate,
@@ -645,7 +646,7 @@ describe('Attendance Plugin Integration', () => {
     })()
 
     const anomalyPayload = {
-      userId: 'attendance-test',
+      userId: testUserId,
       rows: [
         {
           workDate: anomalyDate,
@@ -737,7 +738,7 @@ describe('Attendance Plugin Integration', () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          userIds: ['attendance-test'],
+          userIds: [testUserId],
         }),
       })
       expect(addGroupMemberRes.status).toBe(200)
@@ -749,12 +750,12 @@ describe('Attendance Plugin Integration', () => {
       })
       expect(listGroupMembersRes.status).toBe(200)
       const groupMemberItems = (listGroupMembersRes.body as { data?: { items?: { userId?: string }[] } } | undefined)?.data?.items ?? []
-      expect(groupMemberItems.some(item => item.userId === 'attendance-test')).toBe(true)
+      expect(groupMemberItems.some(item => item.userId === testUserId)).toBe(true)
     }
 
     const csvGroupName = `CSV Group ${runSuffix}`
     const csvImportPayload = {
-      userId: 'attendance-test',
+      userId: testUserId,
       csvText: `日期,工号,考勤组,上班1打卡时间,下班1打卡时间,考勤结果\n${workDate},A001,${csvGroupName},09:00,18:00,正常`,
       mapping: {
         columns: [
@@ -767,7 +768,7 @@ describe('Attendance Plugin Integration', () => {
         ],
       },
       userMap: {
-        A001: 'attendance-test',
+        A001: testUserId,
       },
       groupSync: {
         autoCreate: true,
@@ -809,7 +810,7 @@ describe('Attendance Plugin Integration', () => {
       })
       expect(csvGroupMembersRes.status).toBe(200)
       const csvGroupMembers = (csvGroupMembersRes.body as { data?: { items?: { userId?: string }[] } } | undefined)?.data?.items ?? []
-      expect(csvGroupMembers.some(item => item.userId === 'attendance-test')).toBe(true)
+      expect(csvGroupMembers.some(item => item.userId === testUserId)).toBe(true)
     }
 
     const numericGroupName = '1'
@@ -822,7 +823,7 @@ describe('Attendance Plugin Integration', () => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        userId: 'attendance-test',
+        userId: testUserId,
         csvText: `日期,工号,考勤组,上班1打卡时间,下班1打卡时间,考勤结果\n${workDate},A001,${numericGroupName},09:05,18:05,正常`,
         mapping: {
           columns: [
@@ -835,7 +836,7 @@ describe('Attendance Plugin Integration', () => {
           ],
         },
         userMap: {
-          A001: 'attendance-test',
+          A001: testUserId,
         },
         groupSync: {
           autoCreate: true,
@@ -980,8 +981,10 @@ describe('Attendance Plugin Integration', () => {
 
     const healthRes = await requestJson(`${baseUrl}/api/health`)
     expect(healthRes.status).toBe(200)
-    const body = (healthRes.body as { status?: string; timestamp?: string } | undefined) ?? {}
+    const body = (healthRes.body as { status?: string; ok?: boolean; success?: boolean; timestamp?: string } | undefined) ?? {}
     expect(body.status).toBe('ok')
+    expect(body.ok).toBe(true)
+    expect(body.success).toBe(true)
     expect(typeof body.timestamp).toBe('string')
   })
 
@@ -1029,9 +1032,80 @@ describe('Attendance Plugin Integration', () => {
     )
 
     expect(calendarRes.status).toBe(200)
-    const body = (calendarRes.body as { ok?: boolean; data?: { items?: unknown[] } } | undefined) ?? {}
+    const body = (calendarRes.body as { ok?: boolean; success?: boolean; data?: { items?: unknown[] } } | undefined) ?? {}
     expect(body.ok).toBe(true)
+    expect(body.success).toBe(true)
     expect(Array.isArray(body.data?.items)).toBe(true)
+  })
+
+  it('rejects invalid attendance calendar date ranges with 400', async () => {
+    if (!baseUrl) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=attendance-calendar-invalid-test&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const calendarRes = await requestJson(
+      `${baseUrl}/api/attendance/calendar?from=invalid&to=invalid`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    )
+
+    expect(calendarRes.status).toBe(400)
+    const body = (calendarRes.body as { ok?: boolean; error?: { code?: string; message?: string } } | undefined) ?? {}
+    expect(body.ok).toBe(false)
+    expect(body.error?.code).toBe('VALIDATION_ERROR')
+    expect(body.error?.message).toContain('YYYY-MM-DD')
+  })
+
+  it('rejects duplicate attendance requests for the same day and request payload', async () => {
+    if (!baseUrl) return
+
+    const testUserId = `attendance-request-dedupe-${Date.now().toString(36)}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin,attendance:approve`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const workDate = new Date().toISOString().slice(0, 10)
+    const requestedInAt = new Date().toISOString()
+    const payload = {
+      workDate,
+      requestType: 'missed_check_in',
+      requestedInAt,
+      reason: 'dedupe test',
+    }
+
+    const firstRes = await requestJson(`${baseUrl}/api/attendance/requests`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+    expect(firstRes.status).toBe(201)
+
+    const secondRes = await requestJson(`${baseUrl}/api/attendance/requests`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+    expect(secondRes.status).toBe(409)
+    const secondBody = (secondRes.body as { ok?: boolean; error?: { code?: string } } | undefined) ?? {}
+    expect(secondBody.ok).toBe(false)
+    expect(secondBody.error?.code).toBe('DUPLICATE_REQUEST')
   })
 
   it('exports attendance CSV with ISO date values and timezone-consistent timestamps', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -623,6 +623,83 @@ function parseDateInput(value) {
   return date
 }
 
+function normalizeDateOnlyStrict(value) {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) return null
+  const date = new Date(`${normalized}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toISOString().slice(0, 10) === normalized ? normalized : null
+}
+
+function resolveAttendanceDateRange(fromValue, toValue, fallbackDays = 30) {
+  const fallbackFrom = new Date(Date.now() - 1000 * 60 * 60 * 24 * fallbackDays).toISOString().slice(0, 10)
+  const fallbackTo = new Date().toISOString().slice(0, 10)
+  const from = fromValue === undefined ? fallbackFrom : normalizeDateOnlyStrict(fromValue)
+  if (fromValue !== undefined && !from) {
+    return { ok: false, message: 'Invalid "from" date. Use YYYY-MM-DD.' }
+  }
+  const to = toValue === undefined ? fallbackTo : normalizeDateOnlyStrict(toValue)
+  if (toValue !== undefined && !to) {
+    return { ok: false, message: 'Invalid "to" date. Use YYYY-MM-DD.' }
+  }
+  if (from > to) {
+    return { ok: false, message: '"from" date must be on or before "to" date.' }
+  }
+  return { ok: true, from, to }
+}
+
+function normalizeOptionalText(value) {
+  if (value === null || value === undefined) return null
+  const normalized = String(value).trim()
+  return normalized || null
+}
+
+function normalizeDuplicateRequestTimestamp(value) {
+  const parsed = value instanceof Date ? value : parseDateInput(value)
+  return parsed ? parsed.toISOString() : null
+}
+
+function buildAttendanceRequestFingerprint(input) {
+  return {
+    requestedInAt: normalizeDuplicateRequestTimestamp(input.requestedInAt),
+    requestedOutAt: normalizeDuplicateRequestTimestamp(input.requestedOutAt),
+    reason: normalizeOptionalText(input.reason),
+    minutes: Number.isFinite(Number(input.minutes)) ? Number(input.minutes) : null,
+    attachmentUrl: normalizeOptionalText(input.attachmentUrl),
+    leaveTypeId: normalizeOptionalText(input.leaveTypeId),
+    leaveTypeCode: normalizeOptionalText(input.leaveTypeCode),
+    overtimeRuleId: normalizeOptionalText(input.overtimeRuleId),
+    overtimeRuleName: normalizeOptionalText(input.overtimeRuleName),
+  }
+}
+
+function matchesAttendanceRequestFingerprint(row, fingerprint) {
+  const metadata = normalizeMetadata(row.metadata)
+  const rowFingerprint = buildAttendanceRequestFingerprint({
+    requestedInAt: row.requested_in_at,
+    requestedOutAt: row.requested_out_at,
+    reason: row.reason,
+    minutes: metadata.minutes,
+    attachmentUrl: metadata.attachmentUrl,
+    leaveTypeId: metadata.leaveType?.id,
+    leaveTypeCode: metadata.leaveType?.code,
+    overtimeRuleId: metadata.overtimeRule?.id,
+    overtimeRuleName: metadata.overtimeRule?.name,
+  })
+  return (
+    rowFingerprint.requestedInAt === fingerprint.requestedInAt
+    && rowFingerprint.requestedOutAt === fingerprint.requestedOutAt
+    && rowFingerprint.reason === fingerprint.reason
+    && rowFingerprint.minutes === fingerprint.minutes
+    && rowFingerprint.attachmentUrl === fingerprint.attachmentUrl
+    && rowFingerprint.leaveTypeId === fingerprint.leaveTypeId
+    && rowFingerprint.leaveTypeCode === fingerprint.leaveTypeCode
+    && rowFingerprint.overtimeRuleId === fingerprint.overtimeRuleId
+    && rowFingerprint.overtimeRuleName === fingerprint.overtimeRuleName
+  )
+}
+
 function normalizeStatusLabel(value) {
   if (value === null || value === undefined) return null
   const text = String(value).trim()
@@ -2258,9 +2335,9 @@ function mapImportBatchRow(row) {
 	  }
 	}
 
-	async function acquireImportIdempotencyLock(client, orgId, idempotencyKey) {
-	  const clean = typeof idempotencyKey === 'string' ? idempotencyKey.trim() : ''
-	  if (!clean) return
+		async function acquireImportIdempotencyLock(client, orgId, idempotencyKey) {
+		  const clean = typeof idempotencyKey === 'string' ? idempotencyKey.trim() : ''
+		  if (!clean) return
 	  try {
 	    await client.query(
 	      'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
@@ -2268,10 +2345,37 @@ function mapImportBatchRow(row) {
 	    )
 	  } catch (_error) {
 	    // Best-effort: keep functional behavior even if advisory locks are unavailable.
-	  }
-	}
+		  }
+		}
 
-function mapIntegrationRow(row) {
+		async function acquireAttendanceRequestLock(client, orgId, userId, workDate, requestType) {
+		  try {
+		    await client.query(
+		      'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
+		      [String(orgId ?? '') + ':' + String(userId ?? ''), `${String(workDate ?? '')}:${String(requestType ?? '')}`]
+		    )
+		  } catch (_error) {
+		    // Best-effort: preserve functional behavior if advisory locks are unavailable.
+		  }
+		}
+
+		async function findDuplicateAttendanceRequest(client, { orgId, userId, workDate, requestType }) {
+		  const rows = await client.query(
+		    `SELECT id, requested_in_at, requested_out_at, reason, status, metadata
+		     FROM attendance_requests
+		     WHERE org_id = $1
+		       AND user_id = $2
+		       AND work_date = $3
+		       AND request_type = $4
+		       AND status IN ('pending', 'approved')
+		     ORDER BY created_at DESC
+		     LIMIT 20`,
+		    [orgId, userId, workDate, requestType]
+		  )
+		  return rows[0] ?? null
+		}
+
+	function mapIntegrationRow(row) {
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
@@ -8337,9 +8441,13 @@ module.exports = {
           }
         }
 
-        const { page, pageSize, offset } = parsePagination(req.query)
-        const from = parsed.data.from ?? new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString().slice(0, 10)
-        const to = parsed.data.to ?? new Date().toISOString().slice(0, 10)
+		        const { page, pageSize, offset } = parsePagination(req.query)
+		        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+		        if (!dateRange.ok) {
+		          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+		          return
+		        }
+		        const { from, to } = dateRange
 
         try {
           const countRows = await db.query(
@@ -8372,9 +8480,10 @@ module.exports = {
             }
           })
 
-          res.json({
-            ok: true,
-            data: {
+			          res.json({
+			            ok: true,
+			            success: true,
+		            data: {
               items: records,
               total,
               page,
@@ -8443,8 +8552,12 @@ module.exports = {
 	        }
 
 	        const { page, pageSize, offset } = parsePagination(req.query)
-	        const from = parsed.data.from ?? new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString().slice(0, 10)
-	        const to = parsed.data.to ?? new Date().toISOString().slice(0, 10)
+	        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+	        if (!dateRange.ok) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+	          return
+	        }
+	        const { from, to } = dateRange
 
 	        const excludedStatuses = ['normal', 'off', 'adjusted']
 
@@ -8618,13 +8731,17 @@ module.exports = {
           }
         }
 
-        const orgId = getOrgId(req)
-        const from = parsed.data.from ?? new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString().slice(0, 10)
-        const to = parsed.data.to ?? new Date().toISOString().slice(0, 10)
+	        const orgId = getOrgId(req)
+	        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+	        if (!dateRange.ok) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+	          return
+	        }
+	        const { from, to } = dateRange
 
-        try {
-          const summary = await loadAttendanceSummary(db, orgId, targetUserId, from, to)
-          res.json({ ok: true, data: summary })
+	        try {
+	          const summary = await loadAttendanceSummary(db, orgId, targetUserId, from, to)
+	          res.json({ ok: true, success: true, data: summary })
         } catch (error) {
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
@@ -8674,9 +8791,13 @@ module.exports = {
           }
         }
 
-        const orgId = getOrgId(req)
-        const from = parsed.data.from ?? new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString().slice(0, 10)
-        const to = parsed.data.to ?? new Date().toISOString().slice(0, 10)
+	        const orgId = getOrgId(req)
+	        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+	        if (!dateRange.ok) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+	          return
+	        }
+	        const { from, to } = dateRange
 
         try {
           const rows = await db.query(
@@ -8697,7 +8818,7 @@ module.exports = {
             minutes: Number(row.total_minutes ?? 0),
           }))
 
-          res.json({ ok: true, data: { items, from, to } })
+	          res.json({ ok: true, success: true, data: { items, from, to } })
         } catch (error) {
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
@@ -8735,15 +8856,20 @@ module.exports = {
           return
         }
 
-        const userId = getUserId(req)
-        if (!userId) {
-          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
-          return
-        }
+	        const userId = getUserId(req)
+	        if (!userId) {
+	          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+	          return
+	        }
 
-        const orgId = getOrgId(req)
-        const requestedInAt = parseDateInput(parsed.data.requestedInAt)
-        const requestedOutAt = parseDateInput(parsed.data.requestedOutAt)
+	        const orgId = getOrgId(req)
+	        const workDate = normalizeDateOnlyStrict(parsed.data.workDate)
+	        if (!workDate) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'workDate must use YYYY-MM-DD format' } })
+	          return
+	        }
+	        const requestedInAt = parseDateInput(parsed.data.requestedInAt)
+	        const requestedOutAt = parseDateInput(parsed.data.requestedOutAt)
         if (requestedInAt && requestedOutAt && requestedOutAt <= requestedInAt) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'requestedOutAt must be after requestedInAt' } })
           return
@@ -8811,11 +8937,11 @@ module.exports = {
           return
         }
 
-        const approvalFlow = await loadApprovalFlow(db, orgId, {
-          requestType,
-          flowId: parsed.data.approvalFlowId,
-        })
-        const metadata = {}
+	        const approvalFlow = await loadApprovalFlow(db, orgId, {
+	          requestType,
+	          flowId: parsed.data.approvalFlowId,
+	        })
+	        const metadata = {}
         if (durationMinutes) metadata.minutes = durationMinutes
         if (leaveType) {
           metadata.leaveType = {
@@ -8852,10 +8978,20 @@ module.exports = {
 
         const approvalId = `apv_${randomUUID()}`
 
-        try {
-          const request = await db.transaction(async (trx) => {
-            await trx.query(
-              'INSERT INTO approval_instances (id, status, version) VALUES ($1, $2, $3)',
+	        try {
+	          const request = await db.transaction(async (trx) => {
+	            await acquireAttendanceRequestLock(trx, orgId, userId, workDate, requestType)
+	            const duplicateRequest = await findDuplicateAttendanceRequest(trx, {
+	              orgId,
+	              userId,
+	              workDate,
+	              requestType,
+	            })
+	            if (duplicateRequest) {
+	              throw new HttpError(409, 'DUPLICATE_REQUEST', 'Duplicate attendance request already exists for this date')
+	            }
+	            await trx.query(
+	              'INSERT INTO approval_instances (id, status, version) VALUES ($1, $2, $3)',
               [approvalId, 'pending', 0]
             )
 
@@ -8864,13 +9000,13 @@ module.exports = {
                (id, user_id, org_id, work_date, request_type, requested_in_at, requested_out_at, reason, status, approval_instance_id, metadata)
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
                RETURNING *`,
-              [
-                randomUUID(),
-                userId,
-                orgId,
-                parsed.data.workDate,
-                requestType,
-                requestedInAt,
+	              [
+	                randomUUID(),
+	                userId,
+	                orgId,
+	                workDate,
+	                requestType,
+	                requestedInAt,
                 requestedOutAt,
                 parsed.data.reason ?? null,
                 'pending',
@@ -8882,17 +9018,21 @@ module.exports = {
             return rows[0]
           })
 
-          emitEvent('attendance.requested', {
-            orgId,
-            userId,
-            workDate: parsed.data.workDate,
-            requestType,
-          })
-          res.status(201).json({ ok: true, data: { request } })
-        } catch (error) {
-          if (isDatabaseSchemaError(error)) {
-            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
-            return
+	          emitEvent('attendance.requested', {
+	            orgId,
+	            userId,
+	            workDate,
+	            requestType,
+	          })
+	          res.status(201).json({ ok: true, data: { request } })
+	        } catch (error) {
+	          if (error instanceof HttpError) {
+	            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+	            return
+	          }
+	          if (isDatabaseSchemaError(error)) {
+	            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+	            return
           }
           logger.error('Attendance request creation failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create request' } })
@@ -8940,10 +9080,14 @@ module.exports = {
           }
         }
 
-        const { page, pageSize, offset } = parsePagination(req.query)
-        const orgId = getOrgId(req)
-        const from = parsed.data.from ?? new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString().slice(0, 10)
-        const to = parsed.data.to ?? new Date().toISOString().slice(0, 10)
+	        const { page, pageSize, offset } = parsePagination(req.query)
+	        const orgId = getOrgId(req)
+	        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+	        if (!dateRange.ok) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+	          return
+	        }
+	        const { from, to } = dateRange
 
         try {
           const params = [targetUserId, orgId, from, to]
@@ -8970,7 +9114,7 @@ module.exports = {
             params
           )
 
-          res.json({ ok: true, data: { items: rows, total, page, pageSize } })
+	          res.json({ ok: true, success: true, data: { items: rows, total, page, pageSize } })
         } catch (error) {
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
@@ -12721,6 +12865,7 @@ module.exports = {
 
 	          res.json({
 	            ok: true,
+	            success: true,
 	            data: {
 	              batchId,
 	              imported: importedCount,
@@ -16216,9 +16361,13 @@ module.exports = {
           return
         }
 
-        const orgId = getOrgId(req)
-        const from = parsed.data.from ?? new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString().slice(0, 10)
-        const to = parsed.data.to ?? new Date().toISOString().slice(0, 10)
+	        const orgId = getOrgId(req)
+	        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+	        if (!dateRange.ok) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+	          return
+	        }
+	        const { from, to } = dateRange
 
         try {
           const countRows = await db.query(
@@ -16237,7 +16386,7 @@ module.exports = {
             [orgId, from, to]
           )
 
-          res.json({ ok: true, data: { items: rows.map(mapHolidayRow), total } })
+	          res.json({ ok: true, success: true, data: { items: rows.map(mapHolidayRow), total } })
         } catch (error) {
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
@@ -16549,8 +16698,12 @@ module.exports = {
           }
         }
 
-        const from = parsed.data.from ?? new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString().slice(0, 10)
-        const to = parsed.data.to ?? new Date().toISOString().slice(0, 10)
+	        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+	        if (!dateRange.ok) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+	          return
+	        }
+	        const { from, to } = dateRange
         const requestedLimit = parseNumber(parsed.data.limit, 1000)
         const limit = Math.min(Math.max(requestedLimit, 1), 5000)
 

--- a/run-migrate.bat
+++ b/run-migrate.bat
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+
+if "%WSL_DISTRO%"=="" set "WSL_DISTRO=Ubuntu-22.04"
+if "%METASHEET_LINUX_ROOT%"=="" set "METASHEET_LINUX_ROOT=/opt/metasheet"
+
+echo [run-migrate] WSL_DISTRO=%WSL_DISTRO%
+echo [run-migrate] METASHEET_LINUX_ROOT=%METASHEET_LINUX_ROOT%
+
+wsl.exe -d "%WSL_DISTRO%" --cd "%METASHEET_LINUX_ROOT%" bash -lc "set -euo pipefail; test -f docker/app.env || { echo '[run-migrate] docker/app.env not found under %METASHEET_LINUX_ROOT%' >&2; exit 1; }; source docker/app.env; node packages/core-backend/dist/src/db/migrate.js"
+if errorlevel 1 exit /b %errorlevel%
+
+echo [run-migrate] Migration completed successfully.
+endlocal

--- a/scripts/ops/attendance-onprem-package-build.sh
+++ b/scripts/ops/attendance-onprem-package-build.sh
@@ -30,6 +30,7 @@ REQUIRED_PATHS=(
   "scripts/ops/attendance-onprem-env-check.sh"
   "scripts/ops/attendance-onprem-healthcheck.sh"
   "scripts/ops/attendance-onprem-update.sh"
+  "run-migrate.bat"
   "scripts/ops/attendance-wsl-portproxy-refresh.ps1"
   "scripts/ops/attendance-wsl-portproxy-task.ps1"
   "docker/app.env.example"

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -126,6 +126,7 @@ required=(
   "plugins/plugin-attendance/index.cjs"
   "scripts/ops/attendance-onprem-package-install.sh"
   "scripts/ops/attendance-onprem-package-upgrade.sh"
+  "run-migrate.bat"
   "scripts/ops/attendance-wsl-portproxy-refresh.ps1"
   "scripts/ops/attendance-wsl-portproxy-task.ps1"
   "docker/app.env.example"


### PR DESCRIPTION
## Summary
- validate attendance date ranges and return 400 for invalid calendar/query dates instead of leaking 500s
- remove login flash by normalizing pre-login redirects away from `/` and guard duplicate request submits on the client
- dedupe same-user same-day same-type attendance requests on the server and package a Windows migration helper with deployment guidance
- add compatibility `ok/success` fields to health/calendar responses called out in run14 feedback

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/authRedirect.spec.ts tests/utils/api.test.ts`
- `pnpm --filter @metasheet/web build`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "keeps /api/health public for probes|keeps /api/attendance/calendar available as records compatibility alias|rejects invalid attendance calendar date ranges with 400|rejects duplicate attendance requests for the same day and request payload|registers attendance routes and lists plugin"`
- `pnpm --filter @metasheet/core-backend build`
- `node --check plugins/plugin-attendance/index.cjs`
- `bash -n scripts/ops/attendance-onprem-package-build.sh`
- `bash -n scripts/ops/attendance-onprem-package-verify.sh`

## Notes
- API envelope unification is only handled compatibly for the endpoints called out in run14 feedback; a full envelope normalization pass should stay separate.
- `is_workday` still needs deployment-side confirmation against real holiday/scheduling data.
