### PR TITLE
fix(attendance-web): stabilize auth bootstrap and plugin shell loading

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -139,8 +139,8 @@ function onLocaleChange(event: Event): void {
 onMounted(async () => {
   await loadProductFeatures(false, {
     skipSessionProbe: isPublicRoute.value,
-  })
-  if (isPublicRoute.value) {
+  }).catch(() => null)
+  if (isPublicRoute.value || attendanceFocused.value) {
     return
   }
   await fetchPlugins()

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,30 +1,310 @@
+import { getApiBase } from '../utils/api'
+
+const TOKEN_KEYS = ['auth_token', 'jwt', 'devToken'] as const
+const USER_SNAPSHOT_KEYS = ['user_permissions', 'user_roles'] as const
+
+type AuthAccessSnapshot = {
+  email: string
+  roles: string[]
+  permissions: string[]
+  isAdmin: boolean
+}
+
+type SessionBootstrapPayload = Record<string, unknown>
+
+type SessionBootstrapResult = {
+  ok: boolean
+  status: number
+  payload: SessionBootstrapPayload | null
+}
+
+let sessionPromise: Promise<SessionBootstrapResult> | null = null
+let sessionToken: string | null = null
+let sessionCache: SessionBootstrapResult | null = null
+
+function clearStoredUserSnapshot() {
+  try {
+    if (typeof localStorage === 'undefined') return
+    for (const key of USER_SNAPSHOT_KEYS) {
+      localStorage.removeItem(key)
+    }
+  } catch (err) {
+    console.warn('[auth] failed to clear persisted user snapshot', err)
+  }
+}
+
+function persistUserSnapshot(user: unknown): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    const record = user && typeof user === 'object' ? user as Record<string, unknown> : {}
+
+    if (Array.isArray(record.permissions)) {
+      localStorage.setItem('user_permissions', JSON.stringify(record.permissions))
+    }
+
+    if (Array.isArray(record.roles) && record.roles.length > 0) {
+      localStorage.setItem('user_roles', JSON.stringify(record.roles))
+      return
+    }
+
+    if (typeof record.role === 'string' && record.role.trim().length > 0) {
+      localStorage.setItem('user_roles', JSON.stringify([record.role]))
+    }
+  } catch (err) {
+    console.warn('[auth] failed to persist user snapshot', err)
+  }
+}
+
+function resetSessionBootstrap(clearUserSnapshot = false) {
+  sessionPromise = null
+  sessionToken = null
+  sessionCache = null
+  if (clearUserSnapshot) {
+    clearStoredUserSnapshot()
+  }
+}
+
+function extractSessionUser(payload: SessionBootstrapPayload | null): unknown {
+  if (!payload) return null
+  const data = payload.data
+  if (data && typeof data === 'object') {
+    return (data as Record<string, unknown>).user ?? null
+  }
+  return payload.user ?? null
+}
+
 export function useAuth() {
-  function getToken(): string | null {
+  function readStoredToken(): string | null {
     try {
-      return (
-        (typeof localStorage !== 'undefined' &&
-          (localStorage.getItem('jwt') || localStorage.getItem('devToken'))) ||
-        null
-      )
+      if (typeof localStorage === 'undefined') return null
+      for (const key of TOKEN_KEYS) {
+        const value = localStorage.getItem(key)
+        if (typeof value === 'string' && value.trim().length > 0) {
+          return value
+        }
+      }
+      return null
     } catch {
       return null
     }
   }
 
+  function getToken(): string | null {
+    return readStoredToken()
+  }
+
   function setToken(token: string) {
+    resetSessionBootstrap()
     try {
-      if (typeof localStorage !== 'undefined') localStorage.setItem('jwt', token)
+      if (typeof localStorage === 'undefined') return
+      localStorage.setItem('auth_token', token)
+      localStorage.setItem('jwt', token)
     } catch (err) {
       console.warn('[auth] failed to persist token in localStorage', err)
     }
   }
 
   function clearToken() {
+    resetSessionBootstrap(true)
     try {
-      if (typeof localStorage !== 'undefined') localStorage.removeItem('jwt')
+      if (typeof localStorage === 'undefined') return
+      for (const key of TOKEN_KEYS) {
+        localStorage.removeItem(key)
+      }
     } catch (err) {
       console.warn('[auth] failed to clear token from localStorage', err)
     }
+  }
+
+  function parseJwtPayload(token: string): Record<string, unknown> | null {
+    try {
+      const parts = token.split('.')
+      if (parts.length < 2) return null
+      const normalized = parts[1]
+        .replace(/-/g, '+')
+        .replace(/_/g, '/')
+        .padEnd(Math.ceil(parts[1].length / 4) * 4, '=')
+      const json = atob(normalized)
+      return JSON.parse(json) as Record<string, unknown>
+    } catch {
+      return null
+    }
+  }
+
+  function parseStringArray(raw: unknown): string[] {
+    if (Array.isArray(raw)) {
+      return raw.map((item) => String(item || '').trim()).filter(Boolean)
+    }
+    if (typeof raw === 'string' && raw.trim().startsWith('[')) {
+      try {
+        const parsed = JSON.parse(raw) as unknown
+        return parseStringArray(parsed)
+      } catch {
+        return []
+      }
+    }
+    return []
+  }
+
+  function getAccessSnapshot(): AuthAccessSnapshot {
+    const token = getToken()
+    const payload = token ? parseJwtPayload(token) : null
+    const storedRoles = typeof localStorage !== 'undefined' ? parseStringArray(localStorage.getItem('user_roles')) : []
+    const storedPermissions = typeof localStorage !== 'undefined' ? parseStringArray(localStorage.getItem('user_permissions')) : []
+    const payloadRoles = parseStringArray(payload?.roles)
+    const payloadPermissions = [...parseStringArray(payload?.perms), ...parseStringArray(payload?.permissions)]
+    const singularRole = typeof payload?.role === 'string' && payload.role.trim().length > 0 ? [payload.role.trim()] : []
+    const roles = Array.from(new Set([...storedRoles, ...payloadRoles, ...singularRole]))
+    const permissions = Array.from(new Set([...storedPermissions, ...payloadPermissions]))
+    const email = typeof payload?.email === 'string' ? payload.email : ''
+    const isAdmin =
+      roles.includes('admin') ||
+      permissions.includes('*:*') ||
+      permissions.includes('admin:all') ||
+      permissions.includes('users:write') ||
+      permissions.includes('roles:write') ||
+      permissions.includes('permissions:write')
+
+    return {
+      email,
+      roles,
+      permissions,
+      isAdmin,
+    }
+  }
+
+  async function refreshDevToken(): Promise<string | null> {
+    if (import.meta.env.PROD) return null
+
+    try {
+      const response = await fetch(`${getApiBase()}/api/auth/dev-token`)
+      if (!response.ok) return null
+
+      const payload = await response.json().catch(() => ({})) as Record<string, unknown>
+      const token =
+        typeof payload.token === 'string'
+          ? payload.token
+          : payload.data && typeof payload.data === 'object' && typeof (payload.data as Record<string, unknown>).token === 'string'
+            ? (payload.data as Record<string, unknown>).token as string
+            : null
+
+      if (!token) return null
+      setToken(token)
+
+      try {
+        if (typeof localStorage !== 'undefined') localStorage.setItem('devToken', token)
+      } catch (err) {
+        console.warn('[auth] failed to persist devToken alias in localStorage', err)
+      }
+
+      return token
+    } catch (err) {
+      console.warn('[auth] failed to refresh dev token', err)
+      return null
+    }
+  }
+
+  async function ensureToken(): Promise<string | null> {
+    const existing = getToken()
+    if (existing) return existing
+    return refreshDevToken()
+  }
+
+  async function bootstrapSession(force = false): Promise<SessionBootstrapResult> {
+    const existingToken = getToken()
+    if (!existingToken) {
+      resetSessionBootstrap(true)
+      return {
+        ok: false,
+        status: 401,
+        payload: null,
+      }
+    }
+
+    if (!force && sessionCache && sessionToken === existingToken) {
+      return sessionCache
+    }
+
+    if (!force && sessionPromise && sessionToken === existingToken) {
+      return sessionPromise
+    }
+
+    sessionToken = existingToken
+    sessionPromise = (async (): Promise<SessionBootstrapResult> => {
+      let resolvedToken = existingToken
+      let response = await fetch(`${getApiBase()}/api/auth/me`, {
+        headers: {
+          Authorization: `Bearer ${resolvedToken}`,
+        },
+      }).catch(() => null)
+
+      if (response?.status === 401) {
+        const refreshedToken = await refreshDevToken()
+        if (refreshedToken && refreshedToken !== resolvedToken) {
+          resolvedToken = refreshedToken
+          sessionToken = refreshedToken
+          response = await fetch(`${getApiBase()}/api/auth/me`, {
+            headers: {
+              Authorization: `Bearer ${resolvedToken}`,
+            },
+          }).catch(() => null)
+        }
+      }
+
+      if (!response) {
+        sessionCache = {
+          ok: false,
+          status: 0,
+          payload: null,
+        }
+        return sessionCache
+      }
+
+      let payload: SessionBootstrapPayload | null = null
+      try {
+        payload = await response.json() as SessionBootstrapPayload
+      } catch {
+        payload = null
+      }
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          clearToken()
+        }
+        sessionCache = {
+          ok: false,
+          status: response.status,
+          payload,
+        }
+        return sessionCache
+      }
+
+      persistUserSnapshot(extractSessionUser(payload))
+      sessionCache = {
+        ok: true,
+        status: response.status,
+        payload,
+      }
+      return sessionCache
+    })()
+
+    try {
+      return await sessionPromise
+    } finally {
+      sessionPromise = null
+    }
+  }
+
+  function primeSession(payload: SessionBootstrapPayload | null) {
+    const token = getToken()
+    sessionToken = token
+    sessionCache = {
+      ok: true,
+      status: 200,
+      payload,
+    }
+    sessionPromise = null
+    persistUserSnapshot(extractSessionUser(payload))
   }
 
   function buildAuthHeaders(): Record<string, string> {
@@ -36,5 +316,22 @@ export function useAuth() {
     return headers
   }
 
-  return { getToken, setToken, clearToken, buildAuthHeaders }
+  function hasAdminAccess(): boolean {
+    return getAccessSnapshot().isAdmin
+  }
+
+  return {
+    getToken,
+    setToken,
+    clearToken,
+    bootstrapSession,
+    primeSession,
+    persistUserSnapshot,
+    clearStoredUserSnapshot,
+    refreshDevToken,
+    ensureToken,
+    buildAuthHeaders,
+    getAccessSnapshot,
+    hasAdminAccess,
+  }
 }

--- a/apps/web/src/composables/usePlugins.ts
+++ b/apps/web/src/composables/usePlugins.ts
@@ -35,51 +35,69 @@ export interface PluginNavItem {
   order?: number
 }
 
-export function usePlugins() {
-  const plugins = ref<PluginInfo[]>([])
-  const views = ref<PluginViewEntry[]>([])
-  const navItems = ref<PluginNavItem[]>([])
-  const loading = ref(false)
-  const error = ref<string | null>(null)
+const plugins = ref<PluginInfo[]>([])
+const views = ref<PluginViewEntry[]>([])
+const navItems = ref<PluginNavItem[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+const loaded = ref(false)
+let inflightFetch: Promise<void> | null = null
 
-  async function fetchPlugins () {
-    loading.value = true
-    error.value = null
-    const base = getApiBase()
-    try {
-      const res = await fetch(`${base}/api/plugins`)
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-      const payload = await res.json()
-      const data: PluginInfo[] = Array.isArray(payload) ? payload : (payload?.list || [])
-      plugins.value = data
-      // Aggregate views from active plugins only
-      const active = data.filter(p => p.status === 'active')
-      const agg: PluginViewEntry[] = []
-      for (const p of active) {
-        const pv = p.contributes?.views || []
-        for (const v of pv) {
-          if (v && v.id && v.name) agg.push({ ...v, plugin: p.name })
-        }
+async function runFetchPlugins (): Promise<void> {
+  loading.value = true
+  error.value = null
+  const base = getApiBase()
+  try {
+    const res = await fetch(`${base}/api/plugins`)
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    const payload = await res.json()
+    const data: PluginInfo[] = Array.isArray(payload) ? payload : (payload?.list || [])
+    plugins.value = data
+    // Aggregate views from active plugins only
+    const active = data.filter(p => p.status === 'active')
+    const agg: PluginViewEntry[] = []
+    for (const p of active) {
+      const pv = p.contributes?.views || []
+      for (const v of pv) {
+        if (v && v.id && v.name) agg.push({ ...v, plugin: p.name })
       }
-      views.value = agg
-        .slice()
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || a.name.localeCompare(b.name))
-
-      navItems.value = views.value
-        .filter(v => v.location === 'main-nav')
-        .map(v => ({
-          id: `${v.plugin}:${v.id}`,
-          label: v.name,
-          path: `/p/${v.plugin}/${v.id}`,
-          order: v.order,
-        }))
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || a.label.localeCompare(b.label))
-    } catch (e: any) {
-      error.value = e?.message || 'Failed to load plugins'
-    } finally {
-      loading.value = false
     }
-  }
+    views.value = agg
+      .slice()
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || a.name.localeCompare(b.name))
 
+    navItems.value = views.value
+      .filter(v => v.location === 'main-nav')
+      .map(v => ({
+        id: `${v.plugin}:${v.id}`,
+        label: v.name,
+        path: `/p/${v.plugin}/${v.id}`,
+        order: v.order,
+      }))
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || a.label.localeCompare(b.label))
+    loaded.value = true
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to load plugins'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function fetchPlugins (options?: { force?: boolean }) {
+  if (!options?.force && loaded.value) {
+    return
+  }
+  if (inflightFetch) {
+    return inflightFetch
+  }
+  inflightFetch = runFetchPlugins()
+  try {
+    await inflightFetch
+  } finally {
+    inflightFetch = null
+  }
+}
+
+export function usePlugins() {
   return { plugins, views, navItems, loading, error, fetchPlugins }
 }

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -7,10 +7,10 @@ import type { RouteRecordRaw } from 'vue-router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 import App from './App.vue'
+import { useAuth } from './composables/useAuth'
 import { ROUTE_PATHS } from './router/types'
 import { useFeatureFlags } from './stores/featureFlags'
 import { normalizePostLoginRedirect, normalizePreLoginRedirect } from './utils/authRedirect'
-import { apiFetch, clearStoredAuthState, getStoredAuthToken } from './utils/api'
 
 // Import views
 import GridView from './views/GridView.vue'
@@ -121,8 +121,11 @@ const router = createRouter({
 
 // Navigation guard for page title
 router.beforeEach(async (to, _from, next) => {
-  const token = getStoredAuthToken()
+  const auth = useAuth()
+  const token = auth.getToken()
   const isLoginRoute = to.path === ROUTE_PATHS.LOGIN
+  const requiresAuth = to.meta?.requiresAuth !== false
+  const flags = useFeatureFlags()
   const title = to.meta?.title
 
   if (title) {
@@ -131,39 +134,44 @@ router.beforeEach(async (to, _from, next) => {
     document.title = 'MetaSheet'
   }
 
-  if (!token && !isLoginRoute) {
-    const redirect = normalizePreLoginRedirect(to.fullPath || '/attendance')
-    return next({
-      path: ROUTE_PATHS.LOGIN,
-      query: { redirect },
-    })
+  if (isLoginRoute) {
+    if (token) {
+      const session = await auth.bootstrapSession()
+      if (session.ok) {
+        try {
+          await flags.loadProductFeatures()
+        } catch {
+          // Fall back to shell redirect when feature probing is temporarily unavailable.
+        }
+        const redirect = normalizePostLoginRedirect(to.query?.redirect)
+        return next(redirect || flags.resolveHomePath())
+      }
+    }
+    return next()
   }
 
-  if (token && isLoginRoute) {
-    const verify = await apiFetch('/api/auth/me', {
-      suppressUnauthorizedRedirect: true,
-    })
-    if (!verify.ok) {
-      clearStoredAuthState()
-      return next()
+  if (requiresAuth) {
+    const redirect = normalizePreLoginRedirect(to.fullPath || '/attendance')
+    const ensuredToken = token || await auth.ensureToken()
+    if (!ensuredToken) {
+      return next({
+        path: ROUTE_PATHS.LOGIN,
+        query: { redirect },
+      })
     }
 
-    const redirect = normalizePostLoginRedirect(to.query?.redirect)
-    const flags = useFeatureFlags()
-    try {
-      await flags.loadProductFeatures()
-    } catch {
-      // noop
+    const session = await auth.bootstrapSession()
+    if (!session.ok) {
+      return next({
+        path: ROUTE_PATHS.LOGIN,
+        query: { redirect },
+      })
     }
-    return next(redirect || flags.resolveHomePath())
   }
 
   // Product capability guard + attendance focused mode restriction.
   try {
-    const flags = useFeatureFlags()
-    if (token) {
-      await flags.loadProductFeatures()
-    }
+    await flags.loadProductFeatures()
 
     const required = to.meta?.requiredFeature
     const requiredFeature =

--- a/apps/web/src/stores/featureFlags.ts
+++ b/apps/web/src/stores/featureFlags.ts
@@ -1,5 +1,6 @@
 import { computed, reactive, readonly } from 'vue'
-import { apiFetch, getStoredAuthToken } from '../utils/api'
+import { useAuth } from '../composables/useAuth'
+import { apiFetch } from '../utils/api'
 
 export type ProductMode = 'platform' | 'attendance' | 'plm-workbench'
 
@@ -113,6 +114,10 @@ function boolOrDefault(...values: Array<unknown>): boolean {
     if (typeof value === 'boolean') return value
   }
   return false
+}
+
+function needsPluginInference(features: Partial<ProductFeatures>): boolean {
+  return typeof features.attendance !== 'boolean' || typeof features.workflow !== 'boolean'
 }
 
 function extractFeaturesFromPayload(payload: any): Partial<ProductFeatures> {
@@ -240,10 +245,7 @@ async function loadProductFeatures(
   options: LoadProductFeatureOptions = {},
 ): Promise<ProductFeatures> {
   const requiresSessionProbe = !options.skipSessionProbe
-  if (state.loaded && !force) {
-    if (requiresSessionProbe && state.sessionAwareLoaded) return state.features
-    if (!requiresSessionProbe && !state.sessionAwareLoaded) return state.features
-  }
+  if (state.loaded && !force && (!requiresSessionProbe || state.sessionAwareLoaded)) return state.features
   if (state.loading && loadPromise) return loadPromise
 
   state.loading = true
@@ -252,41 +254,41 @@ async function loadProductFeatures(
   loadPromise = (async () => {
     let mePayload: any = null
     let pluginPayload: any = null
-    const hasStoredToken = getStoredAuthToken().length > 0
+    let backendFeatures: Partial<ProductFeatures> = {}
+    const { ensureToken, getToken, bootstrapSession } = useAuth()
 
     try {
-      const requests: Array<Promise<Response | null>> = []
+      const currentToken = getToken()
 
-      if (requiresSessionProbe) {
-        requests.push(apiFetch('/api/auth/me').catch(() => null))
-        requests.push(apiFetch('/api/plugins').catch(() => null))
-      } else if (hasStoredToken) {
-        requests.push(apiFetch('/api/plugins').catch(() => null))
+      if (!currentToken && requiresSessionProbe) {
+        await ensureToken()
       }
 
-      const responses = requests.length > 0 ? await Promise.all(requests) : []
-      const pluginRes = requests.length > 0 ? (responses.at(-1) ?? null) : null
-      const meRes = requiresSessionProbe ? (responses[0] ?? null) : null
-
-      if (meRes?.ok) {
-        mePayload = await meRes.json()
+      if (requiresSessionProbe && getToken()) {
+        const session = await bootstrapSession()
+        if (session.ok && session.payload) {
+          mePayload = session.payload
+          backendFeatures = extractFeaturesFromPayload(mePayload)
+        }
       }
 
-      if (pluginRes?.ok) {
-        pluginPayload = await pluginRes.json()
+      if (needsPluginInference(backendFeatures)) {
+        const pluginRes = await apiFetch('/api/plugins').catch(() => null)
+        if (pluginRes?.ok) {
+          pluginPayload = await pluginRes.json()
+        }
       }
     } catch (error) {
       state.error = error instanceof Error ? error.message : 'Failed to load product features'
     }
 
-    const backendFeatures = extractFeaturesFromPayload(mePayload)
     const pluginInference = inferPluginFeatures(pluginPayload)
     const overrideFeatures = parseOverrideFeatures()
     const adminRole = isAdminRole(mePayload)
 
     state.features = resolveFeatures(backendFeatures, overrideFeatures, pluginInference, adminRole)
     state.loaded = true
-    state.sessionAwareLoaded = requiresSessionProbe
+    state.sessionAwareLoaded = state.sessionAwareLoaded || requiresSessionProbe
     state.loading = false
 
     return state.features

--- a/apps/web/src/views/attendance/AttendanceExperienceView.vue
+++ b/apps/web/src/views/attendance/AttendanceExperienceView.vue
@@ -13,7 +13,11 @@
       </button>
     </nav>
 
-    <section v-if="desktopOnlyBlocked" class="attendance-shell__desktop-hint">
+    <section v-if="!featuresReady" class="attendance-shell__loading">
+      <p>{{ t.loadingAttendance }}</p>
+    </section>
+
+    <section v-else-if="desktopOnlyBlocked" class="attendance-shell__desktop-hint">
       <h3>{{ t.desktopRecommended }}</h3>
       <p>{{ desktopOnlyMessage }}</p>
       <button class="attendance-shell__btn" type="button" @click="selectTab('overview')">
@@ -55,6 +59,7 @@ const { hasFeature, loadProductFeatures } = useFeatureFlags()
 const { isZh } = useLocale()
 
 const activeTab = ref<AttendanceTab>('overview')
+const featuresReady = ref(false)
 const isMobile = ref(false)
 
 const canAccessAdmin = computed(() => hasFeature('attendanceAdmin'))
@@ -66,6 +71,7 @@ const t = computed(() => isZh.value
       overview: '总览',
       adminCenter: '管理中心',
       workflowDesigner: '流程设计',
+      loadingAttendance: '加载考勤模块...',
       desktopRecommended: '建议使用桌面端',
       backToOverview: '返回总览',
       capabilityUnavailable: '当前能力不可用',
@@ -78,6 +84,7 @@ const t = computed(() => isZh.value
       overview: 'Overview',
       adminCenter: 'Admin Center',
       workflowDesigner: 'Workflow Designer',
+      loadingAttendance: 'Loading attendance module...',
       desktopRecommended: 'Desktop recommended',
       backToOverview: 'Back to Overview',
       capabilityUnavailable: 'Capability not available',
@@ -161,10 +168,12 @@ async function selectTab(tab: AttendanceTab): Promise<void> {
 }
 
 watch(() => route.query.tab, () => {
+  if (!featuresReady.value) return
   syncFromRoute()
 })
 
 watch(availableTabs, () => {
+  if (!featuresReady.value) return
   activeTab.value = ensureTabAllowed(activeTab.value)
 })
 
@@ -172,6 +181,7 @@ onMounted(async () => {
   await loadProductFeatures()
   updateMobileState()
   syncFromRoute()
+  featuresReady.value = true
   window.addEventListener('resize', updateMobileState)
 })
 
@@ -234,5 +244,13 @@ onBeforeUnmount(() => {
   border-radius: 8px;
   padding: 8px 12px;
   cursor: pointer;
+}
+
+.attendance-shell__loading {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 20px;
+  color: #4b5563;
 }
 </style>

--- a/apps/web/tests/useAuth.spec.ts
+++ b/apps/web/tests/useAuth.spec.ts
@@ -15,6 +15,7 @@ describe('useAuth', () => {
     ;(globalThis as any).localStorage = ls
     Object.keys(store).forEach((k) => delete store[k])
     vi.clearAllMocks()
+    useAuth().clearToken()
   })
 
   afterEach(() => {
@@ -35,5 +36,121 @@ describe('useAuth', () => {
     expect(h.Authorization).toBeUndefined()
     expect(h['x-user-id']).toBe('dev-user')
   })
-})
 
+  it('persists auth_token and jwt when setToken is called', () => {
+    const { setToken, getToken } = useAuth()
+    setToken('persisted-token')
+
+    expect(store.auth_token).toBe('persisted-token')
+    expect(store.jwt).toBe('persisted-token')
+    expect(getToken()).toBe('persisted-token')
+  })
+
+  it('clears all supported token aliases', () => {
+    store.auth_token = 'auth-token'
+    store.jwt = 'jwt-token'
+    store.devToken = 'dev-token'
+
+    const { clearToken, getToken } = useAuth()
+    clearToken()
+
+    expect(store.auth_token).toBeUndefined()
+    expect(store.jwt).toBeUndefined()
+    expect(store.devToken).toBeUndefined()
+    expect(getToken()).toBeNull()
+  })
+
+  it('refreshes dev token and stores aliases', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 'dev-jwt-token' }),
+    }))
+
+    const { refreshDevToken, getToken } = useAuth()
+    await expect(refreshDevToken()).resolves.toBe('dev-jwt-token')
+
+    expect(store.auth_token).toBe('dev-jwt-token')
+    expect(store.jwt).toBe('dev-jwt-token')
+    expect(store.devToken).toBe('dev-jwt-token')
+    expect(getToken()).toBe('dev-jwt-token')
+  })
+
+  it('derives admin access from token payload and stored permissions', () => {
+    const payload = {
+      email: 'admin@example.com',
+      role: 'admin',
+      perms: ['roles:write'],
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    store.jwt = token
+    store.user_permissions = JSON.stringify(['permissions:write'])
+    store.user_roles = JSON.stringify(['admin'])
+
+    const { getAccessSnapshot, hasAdminAccess } = useAuth()
+    const snapshot = getAccessSnapshot()
+
+    expect(snapshot.email).toBe('admin@example.com')
+    expect(snapshot.roles).toContain('admin')
+    expect(snapshot.permissions).toContain('permissions:write')
+    expect(hasAdminAccess()).toBe(true)
+  })
+
+  it('bootstraps session only once for the same token and reuses the cached payload', async () => {
+    store.jwt = 'stable-token'
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          user: {
+            email: 'alpha@example.com',
+            role: 'admin',
+            permissions: ['users:write'],
+          },
+          features: {
+            attendance: true,
+            workflow: false,
+            attendanceAdmin: true,
+            attendanceImport: false,
+            mode: 'attendance',
+          },
+        },
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { bootstrapSession, getAccessSnapshot } = useAuth()
+    const first = await bootstrapSession()
+    const second = await bootstrapSession()
+
+    expect(first.ok).toBe(true)
+    expect(second.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(getAccessSnapshot().roles).toContain('admin')
+    expect(getAccessSnapshot().permissions).toContain('users:write')
+    expect(store.user_roles).toBe(JSON.stringify(['admin']))
+  })
+
+  it('clears stale tokens when bootstrap session receives 401', async () => {
+    store.auth_token = 'stale-token'
+    store.user_roles = JSON.stringify(['admin'])
+    store.user_permissions = JSON.stringify(['users:write'])
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ success: false, error: 'Invalid token' }),
+    }))
+
+    const { bootstrapSession, getToken, getAccessSnapshot } = useAuth()
+    const result = await bootstrapSession()
+
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(401)
+    expect(getToken()).toBeNull()
+    expect(store.user_roles).toBeUndefined()
+    expect(store.user_permissions).toBeUndefined()
+    expect(getAccessSnapshot().roles).toEqual([])
+  })
+})

--- a/apps/web/tests/usePlugins.spec.ts
+++ b/apps/web/tests/usePlugins.spec.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+function createJsonResponse(payload: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => payload,
+  } as Response
+}
+
+describe('usePlugins', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('dedupes concurrent fetches across consumers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse([
+      {
+        name: 'plugin-attendance',
+        status: 'active',
+        contributes: {
+          views: [
+            {
+              id: 'attendance',
+              name: 'Attendance',
+              location: 'main-nav',
+            },
+          ],
+        },
+      },
+    ]))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { usePlugins } = await import('../src/composables/usePlugins')
+    const first = usePlugins()
+    const second = usePlugins()
+
+    await Promise.all([first.fetchPlugins(), second.fetchPlugins()])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(first.plugins.value).toHaveLength(1)
+    expect(second.plugins.value).toHaveLength(1)
+    expect(first.navItems.value).toEqual([
+      {
+        id: 'plugin-attendance:attendance',
+        label: 'Attendance',
+        order: undefined,
+        path: '/p/plugin-attendance/attendance',
+      },
+    ])
+  })
+
+  it('skips repeated fetches after load unless force is requested', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse([
+      {
+        name: 'plugin-attendance',
+        status: 'active',
+        contributes: { views: [] },
+      },
+    ]))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { usePlugins } = await import('../src/composables/usePlugins')
+    const pluginsApi = usePlugins()
+
+    await pluginsApi.fetchPlugins()
+    await pluginsApi.fetchPlugins()
+    await pluginsApi.fetchPlugins({ force: true })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- re-cut the safe frontend-only stabilization slice from historical attendance PR #455 onto current main
- add cached auth bootstrap and token alias handling in `useAuth`, plus router and feature-flag integration
- dedupe plugin metadata fetches across consumers and avoid unnecessary shell/plugin loading in attendance-focused flows

## Why this is split out
The old #455 branch no longer has a merge-base with current `main`, and the original single commit mixed safe frontend stabilization with riskier changes in `AttendanceView`, RBAC, and `plugins/plugin-attendance`. This PR intentionally carries only the frontend shell/auth pieces that still apply cleanly and validate on current main.

## Excluded on purpose
- `AttendanceView.vue` admin reload queue/cooldown changes, because the core double-click reload fix already landed via #486
- `packages/core-backend/src/rbac/rbac.ts`, because it changes token-claim trust semantics and should be reviewed as a separate backend policy decision
- `plugins/plugin-attendance/index.cjs`, because current main is materially newer there and the old patch would regress newer logic

## Validation
- `pnpm --filter @metasheet/web exec vitest run tests/useAuth.spec.ts tests/usePlugins.spec.ts`
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-experience-mobile-zh.spec.ts`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`