### PR TITLE
fix(attendance-zh): add calendar utility and locale regression coverage

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -339,6 +339,13 @@ import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import { useLocale } from '../composables/useLocale'
 import { usePlugins } from '../composables/usePlugins'
 import { apiFetch } from '../utils/api'
+import {
+  formatCalendarMonthLabel,
+  formatLunarDayLabel,
+  normalizeDateKey,
+  toDateInput,
+  toDateKey,
+} from './attendanceCalendarUtils'
 import { useAttendanceAdminAuditLogs } from './attendance/useAttendanceAdminAuditLogs'
 import AttendanceAuditLogsSection from './attendance/AttendanceAuditLogsSection.vue'
 import AttendanceHolidayDataSection from './attendance/AttendanceHolidayDataSection.vue'
@@ -832,7 +839,10 @@ const weekDays = computed(() => (
     : ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 ))
 const calendarLabel = computed(() => {
-  return new Intl.DateTimeFormat(isZh.value ? 'zh-CN' : 'en-US', { year: 'numeric', month: 'long' }).format(calendarMonth.value)
+  return formatCalendarMonthLabel(calendarMonth.value, {
+    locale: isZh.value ? 'zh-CN' : 'en-US',
+    timeZone: isZh.value ? 'Asia/Shanghai' : defaultTimezone,
+  })
 })
 
 const recordMap = computed(() => {
@@ -909,7 +919,10 @@ const calendarDays = computed<CalendarDay[]>(() => {
     const holidayName = typeof holiday?.name === 'string' && holiday.name.trim().length > 0
       ? holiday.name.trim()
       : undefined
-    const lunarLabel = formatLunarDayLabel(date)
+    const lunarLabel = formatLunarDayLabel(date, {
+      enabled: isZh.value,
+      timeZone: 'Asia/Shanghai',
+    })
     let tooltip = record
       ? `${key} · ${statusLabel} · ${record.work_minutes} min`
       : key
@@ -1424,27 +1437,6 @@ const requestCenterSectionBindings = {
   submitRequest,
 }
 
-function toDateInput(date: Date): string {
-  return date.toISOString().slice(0, 10)
-}
-
-function toDateKey(date: Date): string {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-function normalizeDateKey(value: string | null | undefined): string | null {
-  const raw = String(value || '').trim()
-  if (!raw) return null
-  const direct = raw.match(/^(\d{4}-\d{2}-\d{2})/)
-  if (direct) return direct[1]
-  const date = new Date(raw)
-  if (Number.isNaN(date.getTime())) return null
-  return date.toISOString().slice(0, 10)
-}
-
 function parseDateValue(value: string | null | undefined): Date | null {
   const key = normalizeDateKey(value)
   if (!key) return null
@@ -1593,20 +1585,6 @@ function formatRequestType(value: string): string {
         overtime: 'Overtime request',
       }
   return map[value] ?? value
-}
-
-function formatLunarDayLabel(date: Date): string | undefined {
-  if (!isZh.value || Number.isNaN(date.getTime())) return undefined
-  try {
-    const text = new Intl.DateTimeFormat('zh-CN-u-ca-chinese', {
-      month: 'short',
-      day: 'numeric',
-    }).format(date)
-    const normalized = text.replace(/\s+/g, '')
-    return normalized || undefined
-  } catch {
-    return undefined
-  }
 }
 
 function formatWarningsShort(warnings: string[]): string {

--- a/apps/web/src/views/attendanceCalendarUtils.ts
+++ b/apps/web/src/views/attendanceCalendarUtils.ts
@@ -1,0 +1,101 @@
+export interface CalendarVisibleRange {
+  from: string
+  to: string
+}
+
+interface DateTimeLabelOptions {
+  locale: string
+  timeZone?: string
+}
+
+interface LunarLabelOptions {
+  enabled: boolean
+  timeZone?: string
+}
+
+const DEFAULT_LUNAR_TIME_ZONE = 'Asia/Shanghai'
+
+export function toDateInput(date: Date): string {
+  return toDateKey(date)
+}
+
+export function toDateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function normalizeDateKey(value: string | null | undefined): string | null {
+  const raw = String(value || '').trim()
+  if (!raw) return null
+  const direct = raw.match(/^(\d{4}-\d{2}-\d{2})/)
+  if (direct) return direct[1]
+  const date = new Date(raw)
+  if (Number.isNaN(date.getTime())) return null
+  return toDateKey(date)
+}
+
+export function compareDateKeys(a: string, b: string): number {
+  if (a === b) return 0
+  return a < b ? -1 : 1
+}
+
+export function getCalendarVisibleRange(calendarMonth: Date): CalendarVisibleRange {
+  const monthStart = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), 1)
+  const monthEnd = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth() + 1, 0)
+  const startOffset = (monthStart.getDay() + 6) % 7
+  const endOffset = 6 - ((monthEnd.getDay() + 6) % 7)
+  const visibleStart = new Date(monthStart)
+  visibleStart.setDate(visibleStart.getDate() - startOffset)
+  const visibleEnd = new Date(monthEnd)
+  visibleEnd.setDate(visibleEnd.getDate() + endOffset)
+  return {
+    from: toDateInput(visibleStart),
+    to: toDateInput(visibleEnd),
+  }
+}
+
+export function formatCalendarMonthLabel(date: Date, options: DateTimeLabelOptions): string {
+  const locale = String(options.locale || 'en-US')
+  const timeZone = String(options.timeZone || '').trim()
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'long',
+      ...(timeZone ? { timeZone } : {}),
+    }).format(date)
+  } catch {
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'long',
+    }).format(date)
+  }
+}
+
+export function formatLunarDayLabel(date: Date, options: LunarLabelOptions): string | undefined {
+  if (!options.enabled || Number.isNaN(date.getTime())) return undefined
+  const timeZone = String(options.timeZone || DEFAULT_LUNAR_TIME_ZONE).trim()
+  try {
+    const text = new Intl.DateTimeFormat('zh-CN-u-ca-chinese', {
+      month: 'short',
+      day: 'numeric',
+      ...(timeZone ? { timeZone } : {}),
+    }).format(date)
+    const normalized = text.replace(/\s+/g, '')
+    if (normalized) return normalized
+  } catch {
+    // Fall back to the runtime timezone when the provided timezone is invalid.
+  }
+
+  try {
+    const text = new Intl.DateTimeFormat('zh-CN-u-ca-chinese', {
+      month: 'short',
+      day: 'numeric',
+    }).format(date)
+    const normalized = text.replace(/\s+/g, '')
+    return normalized || undefined
+  } catch {
+    return undefined
+  }
+}

--- a/apps/web/tests/attendance-calendar-utils.spec.ts
+++ b/apps/web/tests/attendance-calendar-utils.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compareDateKeys,
+  formatCalendarMonthLabel,
+  formatLunarDayLabel,
+  getCalendarVisibleRange,
+  normalizeDateKey,
+  toDateInput,
+  toDateKey,
+} from '../src/views/attendanceCalendarUtils'
+
+describe('attendanceCalendarUtils', () => {
+  it('formats date keys and inputs as yyyy-mm-dd', () => {
+    const date = new Date(2026, 0, 23)
+    expect(toDateKey(date)).toBe('2026-01-23')
+    expect(toDateInput(date)).toBe('2026-01-23')
+  })
+
+  it('normalizes date keys from multiple formats', () => {
+    expect(normalizeDateKey('2026-01-23')).toBe('2026-01-23')
+    expect(normalizeDateKey('2026-01-23T10:00:00.000Z')).toMatch(/^2026-01-2[23]$/)
+    expect(normalizeDateKey('')).toBeNull()
+    expect(normalizeDateKey('invalid-date')).toBeNull()
+  })
+
+  it('compares date keys in lexicographic date order', () => {
+    expect(compareDateKeys('2026-01-23', '2026-01-23')).toBe(0)
+    expect(compareDateKeys('2026-01-22', '2026-01-23')).toBeLessThan(0)
+    expect(compareDateKeys('2026-01-24', '2026-01-23')).toBeGreaterThan(0)
+  })
+
+  it('calculates visible calendar grid range for monday-based week', () => {
+    const range = getCalendarVisibleRange(new Date(2026, 1, 1))
+    expect(range).toEqual({
+      from: '2026-01-26',
+      to: '2026-03-01',
+    })
+  })
+
+  it('formats calendar month labels with timezone fallback', () => {
+    const date = new Date('2026-02-01T00:00:00Z')
+    const zh = formatCalendarMonthLabel(date, { locale: 'zh-CN', timeZone: 'Asia/Shanghai' })
+    const en = formatCalendarMonthLabel(date, { locale: 'en-US', timeZone: 'UTC' })
+    expect(zh.length).toBeGreaterThan(0)
+    expect(en.length).toBeGreaterThan(0)
+
+    const fallback = formatCalendarMonthLabel(date, { locale: 'zh-CN', timeZone: 'Invalid/TZ' })
+    expect(fallback.length).toBeGreaterThan(0)
+  })
+
+  it('formats lunar day labels when enabled and recovers from invalid timezone', () => {
+    const date = new Date('2026-02-01T12:00:00Z')
+    expect(formatLunarDayLabel(date, { enabled: false, timeZone: 'Asia/Shanghai' })).toBeUndefined()
+
+    const label = formatLunarDayLabel(date, { enabled: true, timeZone: 'Asia/Shanghai' })
+    expect(label).toBeTruthy()
+    expect(label).toMatch(/[初十廿卅正冬腊闰月]/)
+
+    const fallbackLabel = formatLunarDayLabel(date, { enabled: true, timeZone: 'Invalid\\/TZ' })
+    expect(fallbackLabel).toBeTruthy()
+  })
+})

--- a/apps/web/tests/attendance-experience-zh-tabs.spec.ts
+++ b/apps/web/tests/attendance-experience-zh-tabs.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import { createMemoryHistory, createRouter, type Router } from 'vue-router'
+import { useLocale } from '../src/composables/useLocale'
+import AttendanceExperienceView from '../src/views/attendance/AttendanceExperienceView.vue'
+
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({
+    hasFeature: (feature: string) => feature === 'attendanceAdmin' || feature === 'workflow',
+    loadProductFeatures: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock('../src/views/attendance/AttendanceOverview.vue', () => ({
+  default: {
+    name: 'AttendanceOverviewStub',
+    template: '<div data-testid="attendance-overview">overview</div>',
+  },
+}))
+
+vi.mock('../src/views/attendance/AttendanceAdminCenter.vue', () => ({
+  default: {
+    name: 'AttendanceAdminCenterStub',
+    template: '<div data-testid="attendance-admin-center">admin-center</div>',
+  },
+}))
+
+vi.mock('../src/views/attendance/AttendanceWorkflowDesigner.vue', () => ({
+  default: {
+    name: 'AttendanceWorkflowDesignerStub',
+    template: '<div data-testid="attendance-workflow-designer">workflow-designer</div>',
+  },
+}))
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('AttendanceExperienceView zh desktop tabs', () => {
+  let app: App<Element> | null = null
+  let router: Router | null = null
+  let container: HTMLDivElement | null = null
+  const originalMatchMedia = window.matchMedia
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    window.localStorage.setItem('metasheet_locale', 'zh-CN')
+    useLocale().setLocale('zh-CN')
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/attendance', component: AttendanceExperienceView },
+      ],
+    })
+    await router.push('/attendance')
+    await router.isReady()
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({ template: '<router-view />' })
+    app.use(router)
+    app.mount(container)
+    await flushUi(6)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    })
+    app = null
+    router = null
+    container = null
+  })
+
+  it('renders zh tab labels without english fallback text', async () => {
+    const tabText = Array.from(container?.querySelectorAll('.attendance-shell__tab') ?? [])
+      .map(node => node.textContent?.trim() || '')
+      .filter(Boolean)
+
+    expect(tabText).toContain('总览')
+    expect(tabText).toContain('管理中心')
+    expect(tabText).toContain('流程设计')
+
+    expect(tabText).not.toContain('Overview')
+    expect(tabText).not.toContain('Admin Center')
+    expect(tabText).not.toContain('Workflow Designer')
+  })
+})

--- a/apps/web/tests/attendance-workflow-designer-zh.spec.ts
+++ b/apps/web/tests/attendance-workflow-designer-zh.spec.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+import AttendanceWorkflowDesigner from '../src/views/attendance/AttendanceWorkflowDesigner.vue'
+
+vi.mock('../src/views/WorkflowDesigner.vue', () => ({
+  default: {
+    name: 'WorkflowDesignerStub',
+    template: '<div data-testid="workflow-designer-runtime">workflow-runtime</div>',
+  },
+}))
+
+async function flushUi(cycles = 3): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('AttendanceWorkflowDesigner zh', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  async function mount(canDesign: boolean): Promise<void> {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(AttendanceWorkflowDesigner, { canDesign })
+    app.mount(container)
+    await flushUi()
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    window.localStorage.setItem('metasheet_locale', 'zh-CN')
+    useLocale().setLocale('zh-CN')
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('shows zh empty-state copy without english fallback when capability is disabled', async () => {
+    await mount(false)
+    const text = container?.textContent || ''
+    expect(text).toContain('审批流程设计')
+    expect(text).toContain('当前租户未启用流程能力。')
+    expect(text).not.toContain('Approval Workflow Designer')
+    expect(text).not.toContain('Workflow capability is not enabled for this tenant.')
+    expect(container?.querySelector('[data-testid="workflow-designer-runtime"]')).toBeNull()
+  })
+
+  it('renders workflow designer runtime when capability is enabled', async () => {
+    await mount(true)
+    expect(container?.querySelector('[data-testid="workflow-designer-runtime"]')).not.toBeNull()
+    expect(container?.textContent || '').not.toContain('当前租户未启用流程能力。')
+  })
+})


### PR DESCRIPTION
## Summary
- re-cut the safe frontend zh-calendar slice from historical attendance PR #403 onto current main
- extract reusable attendance calendar date/lunar helpers into `attendanceCalendarUtils.ts`
- add regression coverage for calendar helpers, zh attendance shell tabs, and zh workflow-designer copy

## Why this is split out
The old #403 branch no longer has a merge-base with current `main` and mixed multiple concerns: frontend calendar behavior, zh smoke scripts, workflow changes, and documentation evidence. This PR intentionally carries the low-risk frontend slice that still provides clean value on current main.

## Included
- timezone-safe calendar month and lunar-day formatting helpers
- `AttendanceView.vue` switched to the shared calendar helpers
- zh regression tests for:
  - attendance calendar helpers
  - attendance experience tab labels
  - workflow designer zh empty-state copy

## Excluded on purpose
- old zh smoke / contract scripts and workflow YAML, because the relevant behaviors from #405/#403 have already been superseded on current main
- historical evidence docs from the stale branch
- larger `AttendanceView.vue` behavioral deltas that are not needed for this focused regression slice

## Validation
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-calendar-utils.spec.ts tests/attendance-experience-zh-tabs.spec.ts tests/attendance-workflow-designer-zh.spec.ts`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`