### PR TITLE
chore(lint): normalize backend type-only imports

### DIFF
--- a/docs/development/backend-type-imports-cleanup-development-20260319.md
+++ b/docs/development/backend-type-imports-cleanup-development-20260319.md
@@ -1,0 +1,31 @@
+# Backend Type Imports Cleanup Development Report
+
+Date: 2026-03-19
+
+## Scope
+
+This batch addresses the first backend lint debt slice after the root validation gates became real.
+
+Targeted rule:
+
+- `@typescript-eslint/consistent-type-imports`
+
+## Changes
+
+Applied ESLint auto-fixes to the backend source files that still imported type-only symbols as value imports.
+
+Files changed:
+
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts`
+- `packages/core-backend/src/di/identifiers.ts`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/routes/comments.ts`
+- `packages/core-backend/src/services/CollabService.ts`
+- `packages/core-backend/src/services/CommentService.ts`
+- `packages/core-backend/src/services/HealthAggregatorService.ts`
+
+## Outcome
+
+- eliminated all `consistent-type-imports` warnings in backend `src`
+- reduced root backend lint warnings from `123` to `113`
+- kept the batch behavior-preserving by limiting the scope to import syntax normalization

--- a/docs/development/backend-type-imports-cleanup-verification-20260319.md
+++ b/docs/development/backend-type-imports-cleanup-verification-20260319.md
@@ -1,0 +1,29 @@
+# Backend Type Imports Cleanup Verification Report
+
+Date: 2026-03-19
+
+## Commands Run
+
+```bash
+pnpm --filter @metasheet/core-backend exec eslint src --ext .ts -f json -o /tmp/metasheet2-backend-eslint.json
+pnpm --filter @metasheet/core-backend exec eslint src/data-adapters/PLMAdapter.ts src/di/identifiers.ts src/index.ts src/routes/comments.ts src/services/CollabService.ts src/services/CommentService.ts src/services/HealthAggregatorService.ts --fix
+pnpm --filter @metasheet/core-backend exec eslint src --ext .ts -f json -o /tmp/metasheet2-backend-eslint-after.json
+pnpm lint
+pnpm type-check
+```
+
+## Results
+
+- pre-fix lint rule counts:
+  - `@typescript-eslint/no-explicit-any`: `108`
+  - `@typescript-eslint/consistent-type-imports`: `10`
+  - `@typescript-eslint/no-unused-vars`: `5`
+- post-fix lint rule counts:
+  - `@typescript-eslint/no-explicit-any`: `108`
+  - `@typescript-eslint/no-unused-vars`: `5`
+
+## Verification Summary
+
+- `consistent-type-imports` warnings: `10 -> 0`
+- root `pnpm lint`: passed with `0` errors and `113` warnings
+- root `pnpm type-check`: passed

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -1,7 +1,7 @@
 import { Inject, Optional } from '@wendellhu/redi'
 import { IConfigService, ILogger } from '../di/identifiers'
 import { HTTPAdapter } from './HTTPAdapter'
-import { QueryResult, DataSourceConfig } from './BaseAdapter'
+import type { QueryResult, DataSourceConfig } from './BaseAdapter'
 
 export interface PLMProduct {
   id: string

--- a/packages/core-backend/src/di/identifiers.ts
+++ b/packages/core-backend/src/di/identifiers.ts
@@ -1,7 +1,7 @@
 import { createIdentifier } from '@wendellhu/redi';
-import { ConfigValue } from '../services/ConfigService';
-import { CollectionDefinition } from '../types/collection';
-import { Repository } from '../core/database/Repository';
+import type { ConfigValue } from '../services/ConfigService';
+import type { CollectionDefinition } from '../types/collection';
+import type { Repository } from '../core/database/Repository';
 import type { PluginLoader } from '../core/plugin-loader';
 import type { CoreAPI } from '../types/plugin';
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -11,10 +11,11 @@ import { createServer } from 'http'
 import cors from 'cors'
 import crypto from 'crypto'
 import { EventEmitter } from 'eventemitter3'
-import { Injector } from '@wendellhu/redi' // IoC Container
+import type { Injector } from '@wendellhu/redi' // IoC Container
 import { createContainer } from './di/container'
 import { IConfigService, ILogger, ICollabService, ICoreAPI, IPluginLoader, ICollectionManager, IPLMAdapter, IAthenaAdapter, IDedupCADAdapter, ICADMLAdapter, IVisionAdapter, IFormulaService } from './di/identifiers'
-import { PluginLoader, type LoadedPlugin } from './core/plugin-loader'
+import type { PluginLoader} from './core/plugin-loader';
+import { type LoadedPlugin } from './core/plugin-loader'
 import { Logger, setLogContext } from './core/logger'
 import type {
   CoreAPI,

--- a/packages/core-backend/src/routes/comments.ts
+++ b/packages/core-backend/src/routes/comments.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express'
 import { Router } from 'express'
 import { z } from 'zod'
-import { Injector } from '@wendellhu/redi'
+import type { Injector } from '@wendellhu/redi'
 import { ICommentService, type CommentQueryOptions } from '../di/identifiers'
 import { Logger } from '../core/logger'
 import { rbacGuard } from '../rbac/rbac'

--- a/packages/core-backend/src/services/CollabService.ts
+++ b/packages/core-backend/src/services/CollabService.ts
@@ -1,4 +1,5 @@
-import { Server as SocketServer, Socket } from 'socket.io'
+import type { Socket } from 'socket.io';
+import { Server as SocketServer } from 'socket.io'
 import type { Server as HttpServer } from 'http'
 import type { ILogger } from '../di/identifiers'
 import type { EventBus } from '../integration/events/event-bus'

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -1,6 +1,6 @@
 
 import { ICollabService, ILogger, type CommentQueryOptions } from '../di/identifiers';
-import { CollabService } from './CollabService';
+import type { CollabService } from './CollabService';
 import { db } from '../db/db';
 
 export interface Comment {

--- a/packages/core-backend/src/services/HealthAggregatorService.ts
+++ b/packages/core-backend/src/services/HealthAggregatorService.ts
@@ -20,7 +20,7 @@ import { poolManager } from '../integration/db/connection-pool'
 import { messageBus } from '../integration/messaging/message-bus'
 import { pluginHealthService, type PluginHealth } from './PluginHealthService'
 import { getRateLimiter } from '../integration/rate-limiting'
-import { DeadLetterQueueService } from './DeadLetterQueueService'
+import type { DeadLetterQueueService } from './DeadLetterQueueService'
 import { coreMetrics } from '../integration/metrics/metrics'
 
 export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown'


### PR DESCRIPTION
## Summary
- normalize backend type-only imports in the remaining `consistent-type-imports` warning sites
- reduce the root backend lint warning count from 123 to 113 without changing runtime behavior
- add development and verification notes for this lint debt batch

## Scope
This PR intentionally handles only the first low-risk lint debt slice:
- `@typescript-eslint/consistent-type-imports`

It does not attempt to clean the larger `no-explicit-any` or `no-unused-vars` backlog.

## Verification
- `pnpm lint`
- `pnpm type-check`
