### PR TITLE
chore(lint): remove backend unused imports

### DIFF
--- a/docs/development/backend-unused-vars-cleanup-development-20260319.md
+++ b/docs/development/backend-unused-vars-cleanup-development-20260319.md
@@ -1,0 +1,29 @@
+# Backend Unused Vars Cleanup Development Report
+
+Date: 2026-03-19
+
+## Scope
+
+This batch addresses the second backend lint debt slice after root validation gates became real.
+
+Targeted rule:
+
+- `@typescript-eslint/no-unused-vars`
+
+## Changes
+
+Removed five unused backend imports without changing runtime behavior.
+
+Files changed:
+
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts`
+- `packages/core-backend/src/data-adapters/PrometheusMetrics.ts`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/routes/admin-routes.ts`
+- `packages/core-backend/src/routes/federation.ts`
+
+## Outcome
+
+- eliminated all backend `no-unused-vars` warnings in `packages/core-backend/src`
+- reduced root backend lint warnings from `113` to `108`
+- kept the batch limited to dead import removal only

--- a/docs/development/backend-unused-vars-cleanup-verification-20260319.md
+++ b/docs/development/backend-unused-vars-cleanup-verification-20260319.md
@@ -1,0 +1,26 @@
+# Backend Unused Vars Cleanup Verification Report
+
+Date: 2026-03-19
+
+## Commands Run
+
+```bash
+pnpm --filter @metasheet/core-backend exec eslint src --ext .ts -f json -o /tmp/metasheet2-backend-eslint-unused.json
+pnpm lint
+pnpm type-check
+pnpm --filter @metasheet/core-backend exec eslint src --ext .ts -f json -o /tmp/metasheet2-backend-eslint-unused-after.json
+```
+
+## Results
+
+- pre-fix lint rule counts:
+  - `@typescript-eslint/no-explicit-any`: `108`
+  - `@typescript-eslint/no-unused-vars`: `5`
+- post-fix lint rule counts:
+  - `@typescript-eslint/no-explicit-any`: `108`
+
+## Verification Summary
+
+- `no-unused-vars` warnings: `5 -> 0`
+- root `pnpm lint`: passed with `0` errors and `108` warnings
+- root `pnpm type-check`: passed

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -1,4 +1,4 @@
-import { Inject, Optional } from '@wendellhu/redi'
+import { Optional } from '@wendellhu/redi'
 import { IConfigService, ILogger } from '../di/identifiers'
 import { HTTPAdapter } from './HTTPAdapter'
 import type { QueryResult, DataSourceConfig } from './BaseAdapter'

--- a/packages/core-backend/src/data-adapters/PrometheusMetrics.ts
+++ b/packages/core-backend/src/data-adapters/PrometheusMetrics.ts
@@ -7,7 +7,7 @@
  * @see PROGRESSIVE_FEDERATION_PLAN.md Phase 4.1
  */
 
-import { Registry, Counter, Histogram, Gauge, Summary } from 'prom-client'
+import { Registry, Counter, Histogram, Gauge } from 'prom-client'
 
 // ─────────────────────────────────────────────────────────────
 // Types

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -13,7 +13,7 @@ import crypto from 'crypto'
 import { EventEmitter } from 'eventemitter3'
 import type { Injector } from '@wendellhu/redi' // IoC Container
 import { createContainer } from './di/container'
-import { IConfigService, ILogger, ICollabService, ICoreAPI, IPluginLoader, ICollectionManager, IPLMAdapter, IAthenaAdapter, IDedupCADAdapter, ICADMLAdapter, IVisionAdapter, IFormulaService } from './di/identifiers'
+import { IConfigService, ICollabService, ICoreAPI, IPluginLoader, ICollectionManager, IPLMAdapter, IAthenaAdapter, IDedupCADAdapter, ICADMLAdapter, IVisionAdapter, IFormulaService } from './di/identifiers'
 import type { PluginLoader} from './core/plugin-loader';
 import { type LoadedPlugin } from './core/plugin-loader'
 import { Logger, setLogContext } from './core/logger'

--- a/packages/core-backend/src/routes/admin-routes.ts
+++ b/packages/core-backend/src/routes/admin-routes.ts
@@ -1835,7 +1835,7 @@ router.post(
 // Sprint 7 Day 4: Health Aggregation APIs
 // ═══════════════════════════════════════════════════════════════════
 
-import { getHealthAggregator, type AggregatedHealth } from '../services/HealthAggregatorService';
+import { getHealthAggregator } from '../services/HealthAggregatorService';
 
 /**
  * GET /api/admin/health/detailed

--- a/packages/core-backend/src/routes/federation.ts
+++ b/packages/core-backend/src/routes/federation.ts
@@ -18,7 +18,6 @@ import type { BOMItem as AdapterBOMItem, PLMProduct as AdapterPLMProduct } from 
 import type { AthenaDocument as AdapterAthenaDocument, DocumentVersion as AdapterDocumentVersion } from '../data-adapters/AthenaAdapter'
 import {
   getAdapterMetrics,
-  recordCrossSystemOperation,
   startCrossSystemTimer,
 } from '../metrics/adapter-metrics'
 


### PR DESCRIPTION
## Summary
- remove the remaining backend `@typescript-eslint/no-unused-vars` warnings by deleting dead imports
- reduce the root backend lint warning count from 113 to 108
- add development and verification notes for this lint debt batch

## Scope
This PR intentionally handles only the low-risk unused-import slice.
It does not attempt to address the larger `@typescript-eslint/no-explicit-any` backlog.

## Verification
- `pnpm lint`
- `pnpm type-check`
