### PR TITLE
chore(lint): narrow backend explicit-any usage

### DIFF
--- a/docs/development/backend-no-explicit-any-slice1-development-20260319.md
+++ b/docs/development/backend-no-explicit-any-slice1-development-20260319.md
@@ -1,0 +1,43 @@
+# Backend No Explicit Any Slice 1 Development Report
+
+Date: 2026-03-19
+
+## Scope
+
+This batch starts the backend `@typescript-eslint/no-explicit-any` cleanup with a low-risk slice.
+
+Files changed:
+
+- `packages/core-backend/src/routes/attendance-admin.ts`
+- `packages/core-backend/src/services/CommentService.ts`
+- `packages/core-backend/src/index.ts`
+
+## Changes
+
+### 1. Attendance audit CSV export typing
+
+In `attendance-admin.ts`:
+
+- introduced a local export row type for audit CSV generation
+- normalized `meta` parsing through typed helpers
+- removed `any` casts when reading exported audit fields
+
+### 2. Comment row mapping typing
+
+In `CommentService.ts`:
+
+- introduced a `CommentRow` mapping type
+- replaced the `mapRowToComment(row: any)` path with typed row mapping
+- removed the inline `any` from the count query callback
+
+### 3. Plugin raw query guard
+
+In `index.ts`:
+
+- added a `RawQueryConfig` runtime/type guard
+- replaced the `queryConfig as any` raw query handoff with explicit validation and typed forwarding
+
+## Outcome
+
+- reduced backend `no-explicit-any` warnings from `108` to `92`
+- kept the batch limited to isolated route/service/server adapter points

--- a/docs/development/backend-no-explicit-any-slice1-verification-20260319.md
+++ b/docs/development/backend-no-explicit-any-slice1-verification-20260319.md
@@ -1,0 +1,26 @@
+# Backend No Explicit Any Slice 1 Verification Report
+
+Date: 2026-03-19
+
+## Commands Run
+
+```bash
+pnpm exec eslint src/routes/attendance-admin.ts src/services/CommentService.ts src/index.ts
+pnpm --filter @metasheet/core-backend build
+pnpm lint
+pnpm type-check
+pnpm --filter @metasheet/core-backend exec eslint src --ext .ts -f json -o /tmp/metasheet2-backend-any-slice1-after.json
+```
+
+## Results
+
+- backend `no-explicit-any` warnings:
+  - before: `108`
+  - after: `92`
+- root `pnpm lint`: passed with `0` errors and `92` warnings
+- backend build: passed
+- root `pnpm type-check`: passed
+
+## Notes
+
+- This slice intentionally avoided `di/identifiers.ts` and `routes/univer-meta.ts` because they carry larger type-surface risk and should be handled in later focused batches.

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -74,6 +74,18 @@ import { cacheRegistry } from '../core/cache/CacheRegistry'
 import { loadObservabilityConfig } from './config/observability'
 import { initObservability } from './observability/otel'
 
+type RawQueryConfig = {
+  text: string
+  values?: unknown[]
+}
+
+function isRawQueryConfig(value: unknown): value is RawQueryConfig {
+  if (typeof value !== 'object' || value === null) return false
+  const maybeConfig = value as { text?: unknown; values?: unknown }
+  if (typeof maybeConfig.text !== 'string') return false
+  return maybeConfig.values === undefined || Array.isArray(maybeConfig.values)
+}
+
 type PluginRuntimeState = {
   status: 'active' | 'inactive' | 'failed'
   error?: string
@@ -238,7 +250,10 @@ export class MetaSheetServer {
                 return result.rows
               },
               rawQuery: async (queryConfig: unknown) => {
-                return client.query(queryConfig as any)
+                if (!isRawQueryConfig(queryConfig)) {
+                  throw new TypeError('rawQuery expects a query config with text and optional values')
+                }
+                return client.query(queryConfig.text, queryConfig.values)
               },
               __rawClient: client,
               commit: async () => {

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -65,6 +65,46 @@ type AttendanceAuditFilterInput = {
   to?: Date | null
 }
 
+type AttendanceAuditExportRow = {
+  id: unknown
+  actor_id: unknown
+  actor_type: unknown
+  action: unknown
+  route: unknown
+  status_code: unknown
+  latency_ms: unknown
+  resource_type: unknown
+  resource_id: unknown
+  request_id: unknown
+  ip: unknown
+  user_agent: unknown
+  occurred_at: unknown
+  meta: unknown
+}
+
+type AttendanceAuditMeta = Record<string, unknown> & {
+  error?: {
+    code?: unknown
+    message?: unknown
+  }
+}
+
+function normalizeAuditMeta(value: unknown): AttendanceAuditMeta {
+  return typeof value === 'object' && value !== null ? (value as AttendanceAuditMeta) : {}
+}
+
+function readAuditMetaText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return ''
+}
+
+function formatAuditOccurredAt(value: unknown): string {
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string' || typeof value === 'number') return new Date(value).toISOString()
+  return ''
+}
+
 function normalizeStatusClass(raw: unknown): string | null {
   const text = String(raw || '').trim().toLowerCase()
   if (!text) return null
@@ -515,7 +555,7 @@ export function attendanceAdminRouter(): Router {
         LIMIT $${limitIdx}
       `
 
-      const rows = await query(sql, [...params, limit])
+      const rows = await query<AttendanceAuditExportRow>(sql, [...params, limit])
 
       const filename = `attendance-audit-logs-${new Date().toISOString().replace(/[:.]/g, '-')}.csv`
       res.setHeader('Content-Type', 'text/csv; charset=utf-8')
@@ -542,29 +582,24 @@ export function attendanceAdminRouter(): Router {
       const lines: string[] = [header]
 
       for (const row of rows.rows) {
-        const meta = (row as any).meta ?? {}
-        const errorCode = meta?.error?.code ?? ''
-        const errorMessage = meta?.error?.message ?? ''
-        const occurredRaw = (row as any).occurred_at
-        const occurredAt = occurredRaw instanceof Date
-          ? occurredRaw.toISOString()
-          : occurredRaw
-            ? new Date(occurredRaw).toISOString()
-            : ''
+        const meta = normalizeAuditMeta(row.meta)
+        const errorCode = readAuditMetaText(meta.error?.code)
+        const errorMessage = readAuditMetaText(meta.error?.message)
+        const occurredAt = formatAuditOccurredAt(row.occurred_at)
         lines.push([
           csvCell(occurredAt),
-          csvCell((row as any).id),
-          csvCell((row as any).actor_id),
-          csvCell((row as any).actor_type),
-          csvCell((row as any).action),
-          csvCell((row as any).route),
-          csvCell((row as any).status_code),
-          csvCell((row as any).latency_ms),
-          csvCell((row as any).resource_type),
-          csvCell((row as any).resource_id),
-          csvCell((row as any).request_id),
-          csvCell((row as any).ip),
-          csvCell((row as any).user_agent),
+          csvCell(row.id),
+          csvCell(row.actor_id),
+          csvCell(row.actor_type),
+          csvCell(row.action),
+          csvCell(row.route),
+          csvCell(row.status_code),
+          csvCell(row.latency_ms),
+          csvCell(row.resource_type),
+          csvCell(row.resource_id),
+          csvCell(row.request_id),
+          csvCell(row.ip),
+          csvCell(row.user_agent),
           csvCell(errorCode),
           csvCell(errorMessage),
           csvCell(meta),

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -17,6 +17,20 @@ export interface Comment {
   mentions: string[];
 }
 
+type CommentRow = {
+  id: string;
+  spreadsheet_id: string;
+  row_id: string;
+  field_id: string | null;
+  content: string;
+  author_id: string;
+  parent_id: string | null;
+  resolved: boolean;
+  created_at: string | Date;
+  updated_at: string | Date;
+  mentions: string | string[] | null;
+}
+
 export class CommentService {
   static inject = [ICollabService, ILogger];
 
@@ -74,8 +88,7 @@ export class CommentService {
     const offset = Math.max(0, Number(options?.offset ?? 0));
 
     const totalObj = await query
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .select((eb: any) => eb.fn.countAll().as('c'))
+      .select(({ fn }) => fn.countAll<number>().as('c'))
       .executeTakeFirst();
     const total = totalObj ? Number((totalObj as { c: string | number }).c) : 0;
 
@@ -86,7 +99,7 @@ export class CommentService {
       .offset(offset)
       .execute();
 
-    return { items: rows.map(this.mapRowToComment), total };
+    return { items: rows.map((row) => this.mapRowToComment(row)), total };
   }
 
   async resolveComment(commentId: string): Promise<void> {
@@ -106,7 +119,11 @@ export class CommentService {
     return row ? this.mapRowToComment(row) : undefined;
   }
 
-  private mapRowToComment(row: any): Comment {
+  private mapRowToComment(row: CommentRow): Comment {
+    const mentions = typeof row.mentions === 'string'
+      ? JSON.parse(row.mentions) as unknown
+      : row.mentions
+
     return {
       id: row.id,
       spreadsheetId: row.spreadsheet_id,
@@ -116,9 +133,9 @@ export class CommentService {
       authorId: row.author_id,
       parentId: row.parent_id || undefined,
       resolved: row.resolved,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-      mentions: typeof row.mentions === 'string' ? JSON.parse(row.mentions) : (row.mentions || [])
+      createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+      updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : row.updated_at,
+      mentions: Array.isArray(mentions) ? mentions.filter((value): value is string => typeof value === 'string') : []
     };
   }
 


### PR DESCRIPTION
# Backend No Explicit Any Slice 1 Development Report

Date: 2026-03-19

## Scope

This batch starts the backend `@typescript-eslint/no-explicit-any` cleanup with a low-risk slice.

Files changed:

- `packages/core-backend/src/routes/attendance-admin.ts`
- `packages/core-backend/src/services/CommentService.ts`
- `packages/core-backend/src/index.ts`

## Changes

### 1. Attendance audit CSV export typing

In `attendance-admin.ts`:

- introduced a local export row type for audit CSV generation
- normalized `meta` parsing through typed helpers
- removed `any` casts when reading exported audit fields

### 2. Comment row mapping typing

In `CommentService.ts`:

- introduced a `CommentRow` mapping type
- replaced the `mapRowToComment(row: any)` path with typed row mapping
- removed the inline `any` from the count query callback

### 3. Plugin raw query guard

In `index.ts`:

- added a `RawQueryConfig` runtime/type guard
- replaced the `queryConfig as any` raw query handoff with explicit validation and typed forwarding

## Outcome

- reduced backend `no-explicit-any` warnings from `108` to `92`
- kept the batch limited to isolated route/service/server adapter points
