### PR TITLE
chore(repo): harden root quality gates

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -76,8 +76,14 @@ jobs:
           path: install.log
 
       - name: Run linting
+        if: matrix.node-version == '20.x'
         run: |
-          pnpm lint || true # Non-blocking for now
+          pnpm lint
+
+      - name: Run type checking
+        if: matrix.node-version == '20.x'
+        run: |
+          pnpm type-check
 
       - name: Run core-backend tests
         run: |

--- a/docs/development/root-quality-gates-development-20260319.md
+++ b/docs/development/root-quality-gates-development-20260319.md
@@ -1,0 +1,31 @@
+# Root quality gates development report
+
+Date: 2026-03-19
+
+## Scope
+
+Harden repository-level quality gates so the recent backend lint cleanup cannot silently regress.
+
+Changed files:
+
+- `package.json`
+- `.github/workflows/plugin-tests.yml`
+
+## Implementation summary
+
+### Root lint script
+
+- Updated `lint:backend` to run ESLint with `--max-warnings 0`.
+- This converts root `pnpm lint` from a soft warning collector into a true failing gate for backend lint regressions.
+
+### PR CI enforcement
+
+- Updated `Plugin System Tests` workflow so the existing `test (20.x)` matrix job runs:
+  - `pnpm lint`
+  - `pnpm type-check`
+- Chose Node 20 only for these gates to avoid duplicate work across both matrix legs while still making the check blocking inside an already-required PR workflow.
+
+## Expected outcome
+
+- New lint warnings now fail local `pnpm lint`.
+- PR CI now executes both `pnpm lint` and `pnpm type-check` as blocking checks through the existing plugin test workflow.

--- a/docs/development/root-quality-gates-verification-20260319.md
+++ b/docs/development/root-quality-gates-verification-20260319.md
@@ -1,0 +1,21 @@
+# Root quality gates verification report
+
+Date: 2026-03-19
+
+## Verification commands
+
+```bash
+CI=true pnpm install --ignore-scripts
+pnpm lint
+pnpm type-check
+```
+
+## Expected CI behavior
+
+- `Plugin System Tests` workflow runs `pnpm lint` under `test (20.x)`.
+- `Plugin System Tests` workflow runs `pnpm type-check` under `test (20.x)`.
+- Root `pnpm lint` fails on any backend ESLint warning because `--max-warnings 0` is now enabled.
+
+## Notes
+
+- This change intentionally reuses the existing plugin test workflow instead of adding a separate quality-gate workflow, so the enforcement lands in an already-established PR check path.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "lint": "pnpm lint:backend",
-    "lint:backend": "pnpm --filter @metasheet/core-backend exec eslint src --ext .ts",
+    "lint:backend": "pnpm --filter @metasheet/core-backend exec eslint src --ext .ts --max-warnings 0",
     "type-check": "pnpm type-check:backend && pnpm type-check:web",
     "type-check:backend": "pnpm --filter @metasheet/core-backend build",
     "type-check:web": "pnpm --filter @metasheet/web exec vue-tsc --noEmit",


### PR DESCRIPTION
# Root quality gates development report

Date: 2026-03-19

## Scope

Harden repository-level quality gates so the recent backend lint cleanup cannot silently regress.

Changed files:

- `package.json`
- `.github/workflows/plugin-tests.yml`

## Implementation summary

### Root lint script

- Updated `lint:backend` to run ESLint with `--max-warnings 0`.
- This converts root `pnpm lint` from a soft warning collector into a true failing gate for backend lint regressions.

### PR CI enforcement

- Updated `Plugin System Tests` workflow so the existing `test (20.x)` matrix job runs:
  - `pnpm lint`
  - `pnpm type-check`
- Chose Node 20 only for these gates to avoid duplicate work across both matrix legs while still making the check blocking inside an already-required PR workflow.

## Expected outcome

- New lint warnings now fail local `pnpm lint`.
- PR CI now executes both `pnpm lint` and `pnpm type-check` as blocking checks through the existing plugin test workflow.
