### PR TITLE
feat(federation): integration status on current main

### DIFF
--- a/apps/web/src/views/PluginManagerView.vue
+++ b/apps/web/src/views/PluginManagerView.vue
@@ -13,7 +13,33 @@
     <div v-if="error" class="plugin-admin__error">{{ error }}</div>
     <div v-else-if="loading" class="plugin-admin__loading">Loading plugins...</div>
 
-    <div v-else class="plugin-admin__grid">
+    <section v-if="integrationItems.length" class="plugin-admin__integrations">
+      <article v-for="item in integrationItems" :key="item.id" class="integration-card">
+        <div class="integration-card__header">
+          <div>
+            <h2>{{ item.id.toUpperCase() }}</h2>
+            <p class="integration-card__sub">{{ item.baseUrl || 'No upstream configured' }}</p>
+          </div>
+          <span class="status-chip" :class="integrationStatusClass(item.implementation)">
+            {{ item.implementation }}
+          </span>
+        </div>
+        <div class="integration-card__meta">
+          <span>Configured: {{ item.configured ? 'yes' : 'no' }}</span>
+          <span>Connected: {{ item.connected ? 'yes' : 'no' }}</span>
+          <span>Health check: {{ item.healthSupported ? 'supported' : 'n/a' }}</span>
+        </div>
+        <p class="integration-card__ops">
+          {{ item.supportedOperations.join(', ') || 'No declared operations' }}
+        </p>
+      </article>
+    </section>
+
+    <div v-if="integrationError" class="plugin-admin__error">
+      Integration status: {{ integrationError }}
+    </div>
+
+    <div v-if="!loading" class="plugin-admin__grid">
       <article v-for="plugin in plugins" :key="plugin.name" class="plugin-card">
         <div class="plugin-card__header">
           <div>
@@ -128,9 +154,21 @@ interface PluginConfigEntry {
   modified_by?: string | null
 }
 
+interface IntegrationItem {
+  id: string
+  implementation: 'real' | 'stub' | 'missing'
+  configured: boolean
+  connected: boolean
+  healthSupported: boolean
+  baseUrl?: string
+  supportedOperations: string[]
+}
+
 const plugins = ref<PluginEntry[]>([])
+const integrationItems = ref<IntegrationItem[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
+const integrationError = ref<string | null>(null)
 const actionLoading = reactive<Record<string, boolean>>({})
 const actionErrors = reactive<Record<string, string | null>>({})
 
@@ -149,16 +187,37 @@ const statusClass = (status: PluginStatus) => {
   return 'status-chip--inactive'
 }
 
+const integrationStatusClass = (status: IntegrationItem['implementation']) => {
+  if (status === 'real') return 'status-chip--active'
+  if (status === 'stub') return 'status-chip--inactive'
+  return 'status-chip--failed'
+}
+
 const refresh = async () => {
   loading.value = true
   error.value = null
+  integrationError.value = null
   try {
-    const response = await apiFetch('/api/admin/plugins')
-    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`)
-    const payload = await response.json()
-    plugins.value = Array.isArray(payload?.list) ? payload.list : []
+    const [pluginResponse, integrationResponse] = await Promise.all([
+      apiFetch('/api/admin/plugins'),
+      apiFetch('/api/federation/integration-status'),
+    ])
+
+    if (!pluginResponse.ok) throw new Error(`${pluginResponse.status} ${pluginResponse.statusText}`)
+    const pluginPayload = await pluginResponse.json()
+    plugins.value = Array.isArray(pluginPayload?.list) ? pluginPayload.list : []
+
+    if (integrationResponse.ok) {
+      const integrationPayload = await integrationResponse.json()
+      integrationItems.value = Array.isArray(integrationPayload?.data?.items) ? integrationPayload.data.items : []
+    } else {
+      integrationItems.value = []
+      integrationError.value = `${integrationResponse.status} ${integrationResponse.statusText}`
+    }
   } catch (err: any) {
     error.value = err?.message || 'Failed to load plugins'
+    plugins.value = []
+    integrationItems.value = []
   } finally {
     loading.value = false
   }
@@ -286,6 +345,50 @@ onMounted(() => {
 
 .plugin-admin__loading {
   color: #666;
+}
+
+.plugin-admin__integrations {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.integration-card {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.integration-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.integration-card__header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.integration-card__sub,
+.integration-card__ops {
+  margin: 0;
+  color: #666;
+  font-size: 12px;
+  word-break: break-word;
+}
+
+.integration-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: #666;
+  font-size: 12px;
 }
 
 .plugin-admin__grid {

--- a/docs/development/federation-status-recut-development-20260319.md
+++ b/docs/development/federation-status-recut-development-20260319.md
@@ -1,0 +1,27 @@
+## Federation Status Recut Development
+
+Date: 2026-03-19
+
+### Context
+
+PR `#459` (`feat(federation): add integration status visibility`) was no longer mergeable on current `main`. GitHub reported `DIRTY`, and local git showed there was no usable merge base with current `main`, so a normal branch update was not reliable.
+
+### Recut Strategy
+
+- Started from current `origin/main`
+- Reapplied only the intended feature delta from original PR head `239eddaa6066cebffba0696c44be16c4e18487eb`
+- Avoided full-file rollback of current `main` files
+- Added the original federation contract fixtures and unit test coverage
+
+### Delivered Scope
+
+- Frontend integration status visibility in `apps/web/src/views/PluginManagerView.vue`
+- Adapter runtime status support in `packages/core-backend/src/di/container.ts`
+- Federation integration status route and Athena timestamp compatibility in `packages/core-backend/src/routes/federation.ts`
+- Contract fixtures and unit coverage:
+  - `packages/core-backend/tests/fixtures/federation/contracts.ts`
+  - `packages/core-backend/tests/unit/federation.contract.test.ts`
+
+### Note
+
+The original PR `#459` should be treated as superseded once the recut PR is created, because the recut branch is the one aligned with current `main`.

--- a/docs/development/federation-status-recut-verification-20260319.md
+++ b/docs/development/federation-status-recut-verification-20260319.md
@@ -1,0 +1,22 @@
+## Federation Status Recut Verification
+
+Date: 2026-03-19
+
+### Local Verification
+
+1. `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/federation.contract.test.ts`
+   - PASS
+   - `1` file, `6` tests passed
+2. `pnpm --filter @metasheet/core-backend build`
+   - PASS
+3. `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
+   - PASS
+4. `pnpm --filter @metasheet/web build`
+   - PASS
+
+### Coverage Focus
+
+- Runtime adapter visibility for PLM/Athena integration status
+- Explicit stub adapter runtime metadata from the default container
+- PLM contract coverage for query, mutate, and detail routes
+- Athena contract coverage for query and detail routes

--- a/packages/core-backend/src/di/container.ts
+++ b/packages/core-backend/src/di/container.ts
@@ -15,12 +15,34 @@ export interface ContainerOptions {
   pluginDirs?: string[]
 }
 
+type StubImplementation = 'stub'
+
 class AdapterStub {
+  readonly implementation: StubImplementation = 'stub'
   private connected = false
 
-  async connect() { this.connected = true }
-  async disconnect() { this.connected = false }
+  constructor(
+    readonly adapterId: string,
+    readonly supportedOperations: string[],
+  ) {}
+
   isConnected() { return this.connected }
+  isConfigured() { return false }
+  async connect() { this.connected = false }
+  async disconnect() { this.connected = false }
+  async healthCheck() { return false }
+
+  getRuntimeStatus() {
+    return {
+      id: this.adapterId,
+      implementation: this.implementation,
+      configured: this.isConfigured(),
+      connected: this.isConnected(),
+      healthSupported: true,
+      supportedOperations: [...this.supportedOperations],
+    }
+  }
+
   async getProducts() { return { data: [], metadata: { totalCount: 0 } } }
   async getProductBOM() { return { data: [], metadata: { totalCount: 0 } } }
   async getProductById() { return null }
@@ -72,7 +94,10 @@ export function createContainer(options: ContainerOptions = {}): Injector {
     },
   ])
 
-  const adapterStub = new AdapterStub()
+  const athenaStub = new AdapterStub('athena', ['documents', 'search', 'preview', 'versions', 'workflow', 'collaboration'])
+  const dedupStub = new AdapterStub('dedup-cad', ['compare', 'generateDiff'])
+  const cadMlStub = new AdapterStub('cad-ml', ['analyze', 'predictCost'])
+  const visionStub = new AdapterStub('vision', ['extractText'])
   injector.add([
     IPLMAdapter,
     {
@@ -80,10 +105,10 @@ export function createContainer(options: ContainerOptions = {}): Injector {
       deps: [IConfigService, ILogger],
     },
   ])
-  injector.add([IAthenaAdapter, { useValue: adapterStub }])
-  injector.add([IDedupCADAdapter, { useValue: adapterStub }])
-  injector.add([ICADMLAdapter, { useValue: adapterStub }])
-  injector.add([IVisionAdapter, { useValue: adapterStub }])
+  injector.add([IAthenaAdapter, { useValue: athenaStub }])
+  injector.add([IDedupCADAdapter, { useValue: dedupStub }])
+  injector.add([ICADMLAdapter, { useValue: cadMlStub }])
+  injector.add([IVisionAdapter, { useValue: visionStub }])
 
   return injector
 }

--- a/packages/core-backend/src/routes/federation.ts
+++ b/packages/core-backend/src/routes/federation.ts
@@ -47,6 +47,18 @@ interface CrossSystemOperation {
   error?: string
 }
 
+interface AdapterRuntimeStatus {
+  id: string
+  implementation: 'real' | 'stub' | 'missing'
+  configured: boolean
+  connected: boolean
+  healthSupported: boolean
+  supportedOperations: string[]
+  systemStatus: FederatedSystem['status'] | 'missing'
+  baseUrl?: string
+  authType?: FederatedSystem['authType']
+}
+
 // ─────────────────────────────────────────────────────────────
 // In-memory state (would be persisted in production)
 // ─────────────────────────────────────────────────────────────
@@ -357,6 +369,64 @@ export function federationRouter(injector?: Injector): Router {
     return undefined
   }
 
+  const buildAdapterRuntimeStatus = async (
+    id: 'plm' | 'athena',
+    adapter: unknown,
+  ): Promise<AdapterRuntimeStatus> => {
+    const system = federatedSystems.get(id)
+    const systemCapabilities = system?.capabilities ?? getDefaultCapabilities(id)
+
+    if (!adapter) {
+      return {
+        id,
+        implementation: 'missing',
+        configured: false,
+        connected: false,
+        healthSupported: false,
+        supportedOperations: systemCapabilities,
+        systemStatus: system?.status ?? 'missing',
+        baseUrl: system?.baseUrl,
+        authType: system?.authType,
+      }
+    }
+
+    const runtime = typeof (adapter as { getRuntimeStatus?: () => unknown }).getRuntimeStatus === 'function'
+      ? (adapter as { getRuntimeStatus: () => unknown }).getRuntimeStatus()
+      : null
+
+    const implementation = runtime && typeof runtime === 'object' && (runtime as { implementation?: unknown }).implementation === 'stub'
+      ? 'stub'
+      : 'real'
+
+    const configured = runtime && typeof runtime === 'object' && typeof (runtime as { configured?: unknown }).configured === 'boolean'
+      ? Boolean((runtime as { configured: boolean }).configured)
+      : Boolean(system?.baseUrl)
+
+    const connected = typeof (adapter as { isConnected?: () => boolean }).isConnected === 'function'
+      ? Boolean((adapter as { isConnected: () => boolean }).isConnected())
+      : false
+
+    const healthSupported = runtime && typeof runtime === 'object' && typeof (runtime as { healthSupported?: unknown }).healthSupported === 'boolean'
+      ? Boolean((runtime as { healthSupported: boolean }).healthSupported)
+      : typeof (adapter as { healthCheck?: unknown }).healthCheck === 'function'
+
+    const supportedOperations = runtime && typeof runtime === 'object' && Array.isArray((runtime as { supportedOperations?: unknown[] }).supportedOperations)
+      ? (runtime as { supportedOperations: unknown[] }).supportedOperations.map((entry) => String(entry))
+      : systemCapabilities
+
+    return {
+      id,
+      implementation,
+      configured,
+      connected,
+      healthSupported,
+      supportedOperations,
+      systemStatus: system?.status ?? 'missing',
+      baseUrl: system?.baseUrl,
+      authType: system?.authType,
+    }
+  }
+
   const resolveAdapterError = (error: unknown, fallbackMessage: string) => {
     const status = (error as { response?: { status?: number } })?.response?.status
     const statusCode = typeof status === 'number' ? status : 502
@@ -648,6 +718,35 @@ export function federationRouter(injector?: Injector): Router {
           error: {
             code: 'INTERNAL_ERROR',
             message: error instanceof Error ? error.message : 'Failed to list systems',
+          },
+        })
+      }
+    }
+  )
+
+  router.get(
+    '/api/federation/integration-status',
+    rbacGuard('federation', 'read'),
+    async (_req: Request, res: Response) => {
+      try {
+        const items = await Promise.all([
+          buildAdapterRuntimeStatus('plm', plmAdapter),
+          buildAdapterRuntimeStatus('athena', athenaAdapter),
+        ])
+
+        return res.json({
+          ok: true,
+          data: {
+            items,
+            total: items.length,
+          },
+        })
+      } catch (error) {
+        return res.status(500).json({
+          ok: false,
+          error: {
+            code: 'INTERNAL_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to load integration status',
           },
         })
       }
@@ -2599,6 +2698,7 @@ type AthenaDocumentWire = AdapterAthenaDocument & {
   contentType?: string
   currentVersionLabel?: string
   createdAt?: string
+  modified_at?: string
   modifiedAt?: string
   updatedAt?: string
   locked?: boolean
@@ -2608,7 +2708,7 @@ function mapAthenaDocument(document: AthenaDocumentWire) {
   const mimeType = document.mimeType || document.mime_type || document.contentType || document.type || 'application/octet-stream'
   const size = typeof document.size === 'number' ? document.size : (document.file_size ?? 0)
   const createdAt = document.createdAt || document.created_at
-  const modifiedAt = document.modifiedAt || document.updatedAt || document.updated_at
+  const modifiedAt = document.modifiedAt || document.modified_at || document.updatedAt || document.updated_at
   const locked = typeof document.locked === 'boolean'
     ? document.locked
     : Boolean(document.checked_out_by || document.checked_out_at)

--- a/packages/core-backend/tests/fixtures/federation/contracts.ts
+++ b/packages/core-backend/tests/fixtures/federation/contracts.ts
@@ -1,0 +1,126 @@
+export const plmContractFixtures = {
+  products: [
+    {
+      id: 'prod-1001',
+      name: 'Servo Motor',
+      code: 'PN-1001',
+      partNumber: 'PN-1001',
+      revision: 'B',
+      status: 'released',
+      created_at: '2026-03-01T00:00:00.000Z',
+      updated_at: '2026-03-02T00:00:00.000Z',
+      itemType: 'Part',
+    },
+  ],
+  bom: [
+    {
+      id: 'line-1',
+      parent_item_id: 'prod-1001',
+      component_id: 'comp-1',
+      component_code: 'CMP-1',
+      component_name: 'Rotor',
+      quantity: 2,
+      unit: 'EA',
+      level: 1,
+    },
+  ],
+  productDetail: {
+    id: 'prod-1001',
+    name: 'Servo Motor',
+    code: 'PN-1001',
+    partNumber: 'PN-1001',
+    revision: 'B',
+    status: 'released',
+    created_at: '2026-03-01T00:00:00.000Z',
+    updated_at: '2026-03-02T00:00:00.000Z',
+    itemType: 'Part',
+  },
+  approvals: [
+    {
+      id: 'eco-1',
+      title: 'ECO-1',
+      status: 'pending',
+      product_id: 'prod-1001',
+      product_number: 'PN-1001',
+      requester_id: 'u-1',
+      created_at: '2026-03-03T00:00:00.000Z',
+    },
+  ],
+  approvalHistory: [
+    {
+      id: 'record-1',
+      status: 'approved',
+      stage: 'review',
+      type: 'manual',
+      role: 'qa',
+      user: 'user-1',
+      comment: 'looks good',
+      approved_at: '2026-03-04T00:00:00.000Z',
+      created_at: '2026-03-03T00:00:00.000Z',
+    },
+  ],
+  whereUsed: {
+    item_id: 'comp-1',
+    count: 1,
+    parents: [
+      {
+        id: 'rel-1',
+        level: 1,
+        parent: {
+          id: 'prod-parent',
+          item_number: 'PARENT-1',
+          name: 'Parent Assembly',
+        },
+        relationship: {
+          id: 'rel-1',
+          quantity: 2,
+          uom: 'EA',
+        },
+      },
+    ],
+  },
+  bomCompare: {
+    summary: {
+      added: 1,
+      removed: 0,
+      changed: 1,
+      changed_major: 0,
+      changed_minor: 1,
+      changed_info: 0,
+    },
+    added: [{ child_id: 'comp-2' }],
+    removed: [],
+    changed: [{ child_id: 'comp-1', after: { quantity: 3 } }],
+  },
+  substituteAdded: {
+    ok: true,
+    substitute_id: 'sub-1',
+    bom_line_id: 'line-1',
+    substitute_item_id: 'part-2',
+  },
+}
+
+export const athenaContractFixtures = {
+  documents: [
+    {
+      id: 'doc-1',
+      name: 'Servo Spec.pdf',
+      mime_type: 'application/pdf',
+      size: 4096,
+      version: 'A',
+      created_at: '2026-03-01T00:00:00.000Z',
+      modified_at: '2026-03-02T00:00:00.000Z',
+      locked: false,
+    },
+  ],
+  documentDetail: {
+    id: 'doc-1',
+    name: 'Servo Spec.pdf',
+    mime_type: 'application/pdf',
+    size: 4096,
+    version: 'A',
+    created_at: '2026-03-01T00:00:00.000Z',
+    modified_at: '2026-03-02T00:00:00.000Z',
+    locked: false,
+  },
+}

--- a/packages/core-backend/tests/unit/federation.contract.test.ts
+++ b/packages/core-backend/tests/unit/federation.contract.test.ts
@@ -1,0 +1,428 @@
+import express from 'express'
+import request from 'supertest'
+import { Injector } from '@wendellhu/redi'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const rbacMocks = vi.hoisted(() => ({
+  isAdmin: vi.fn(),
+  userHasPermission: vi.fn(),
+  listUserPermissions: vi.fn(),
+  invalidateUserPerms: vi.fn(),
+  getPermCacheStatus: vi.fn(),
+}))
+
+const auditMocks = vi.hoisted(() => ({
+  auditLog: vi.fn(),
+}))
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: rbacMocks.isAdmin,
+  userHasPermission: rbacMocks.userHasPermission,
+  listUserPermissions: rbacMocks.listUserPermissions,
+  invalidateUserPerms: rbacMocks.invalidateUserPerms,
+  getPermCacheStatus: rbacMocks.getPermCacheStatus,
+}))
+
+vi.mock('../../src/audit/audit', () => ({
+  auditLog: auditMocks.auditLog,
+}))
+
+import { federationRouter } from '../../src/routes/federation'
+import { createContainer } from '../../src/di/container'
+import { IAthenaAdapter, IConfigService, IPLMAdapter } from '../../src/di/identifiers'
+import { plmContractFixtures, athenaContractFixtures } from '../fixtures/federation/contracts'
+
+type RuntimeStatus = {
+  implementation?: 'stub'
+  configured?: boolean
+  healthSupported?: boolean
+  supportedOperations?: string[]
+}
+
+function createConfigServiceMock() {
+  return {
+    get: vi.fn(),
+    set: vi.fn(),
+    getAll: vi.fn(),
+    reload: vi.fn(),
+    validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }),
+  }
+}
+
+function createPlmAdapterMock(runtimeStatus: RuntimeStatus = {}) {
+  let connected = true
+
+  return {
+    isConnected: vi.fn(() => connected),
+    connect: vi.fn(async () => { connected = true }),
+    disconnect: vi.fn(async () => { connected = false }),
+    healthCheck: vi.fn(async () => true),
+    getRuntimeStatus: vi.fn(() => ({
+      configured: runtimeStatus.configured ?? true,
+      healthSupported: runtimeStatus.healthSupported ?? true,
+      supportedOperations: runtimeStatus.supportedOperations ?? ['products', 'bom', 'approvals', 'approval_history', 'bom_compare', 'substitutes_add', 'details'],
+      ...(runtimeStatus.implementation ? { implementation: runtimeStatus.implementation } : {}),
+    })),
+    getProducts: vi.fn(async () => ({
+      data: plmContractFixtures.products,
+      metadata: { totalCount: plmContractFixtures.products.length },
+    })),
+    getProductBOM: vi.fn(async () => ({
+      data: plmContractFixtures.bom,
+      metadata: { totalCount: plmContractFixtures.bom.length },
+    })),
+    getProductById: vi.fn(async () => plmContractFixtures.productDetail),
+    getApprovalHistory: vi.fn(async () => ({
+      data: plmContractFixtures.approvalHistory,
+      metadata: { totalCount: plmContractFixtures.approvalHistory.length },
+    })),
+    getBomCompare: vi.fn(async () => ({
+      data: [plmContractFixtures.bomCompare],
+      metadata: { totalCount: 1 },
+    })),
+    addBomSubstitute: vi.fn(async () => ({
+      data: [plmContractFixtures.substituteAdded],
+      metadata: { totalCount: 1 },
+    })),
+    rejectApproval: vi.fn(async (approvalId: string, comment: string) => ({
+      data: [{ id: approvalId, comment }],
+      metadata: { totalCount: 1 },
+    })),
+  }
+}
+
+function createAthenaAdapterMock(runtimeStatus: RuntimeStatus = {}) {
+  let connected = true
+
+  return {
+    isConnected: vi.fn(() => connected),
+    connect: vi.fn(async () => { connected = true }),
+    disconnect: vi.fn(async () => { connected = false }),
+    healthCheck: vi.fn(async () => true),
+    getRuntimeStatus: vi.fn(() => ({
+      configured: runtimeStatus.configured ?? true,
+      healthSupported: runtimeStatus.healthSupported ?? true,
+      supportedOperations: runtimeStatus.supportedOperations ?? ['documents', 'search', 'versions'],
+      ...(runtimeStatus.implementation ? { implementation: runtimeStatus.implementation } : {}),
+    })),
+    searchDocuments: vi.fn(async () => ({
+      data: athenaContractFixtures.documents,
+      metadata: { totalCount: athenaContractFixtures.documents.length },
+    })),
+    getDocument: vi.fn(async () => athenaContractFixtures.documentDetail),
+    getVersionHistory: vi.fn(async () => ({
+      data: [
+        {
+          version: 'A',
+          created_at: '2026-03-01T00:00:00.000Z',
+          created_by: 'user-1',
+        },
+      ],
+      metadata: { totalCount: 1 },
+    })),
+  }
+}
+
+function createFederationApp(options: {
+  plmAdapter?: any
+  athenaAdapter?: any
+} = {}) {
+  const injector = new Injector()
+  injector.add([IPLMAdapter, { useValue: options.plmAdapter ?? null }])
+  injector.add([IAthenaAdapter, { useValue: options.athenaAdapter ?? null }])
+  injector.add([IConfigService, { useValue: createConfigServiceMock() }])
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = {
+      id: 'user-1',
+      roles: ['admin'],
+      perms: ['federation:read', 'federation:write'],
+    }
+    next()
+  })
+  app.use(federationRouter(injector))
+
+  return app
+}
+
+describe('Federation contract routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    rbacMocks.userHasPermission.mockResolvedValue(true)
+    rbacMocks.listUserPermissions.mockResolvedValue(['federation:read', 'federation:write'])
+    auditMocks.auditLog.mockResolvedValue(undefined)
+  })
+
+  it('reports runtime adapter capability visibility via integration status', async () => {
+    const app = createFederationApp({
+      plmAdapter: createPlmAdapterMock(),
+      athenaAdapter: createAthenaAdapterMock({
+        implementation: 'stub',
+        configured: false,
+        supportedOperations: ['documents', 'search'],
+      }),
+    })
+
+    const response = await request(app)
+      .get('/api/federation/integration-status')
+      .expect(200)
+
+    expect(response.body.ok).toBe(true)
+    expect(response.body.data.total).toBe(2)
+    expect(response.body.data.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'plm',
+          implementation: 'real',
+          configured: true,
+          connected: true,
+        }),
+        expect.objectContaining({
+          id: 'athena',
+          implementation: 'stub',
+          configured: false,
+          connected: true,
+          supportedOperations: ['documents', 'search'],
+        }),
+      ]),
+    )
+  })
+
+  it('exposes explicit stub runtime status for default container adapters', () => {
+    const injector = createContainer()
+    const athenaAdapter = injector.get(IAthenaAdapter) as {
+      isConnected: () => boolean
+      getRuntimeStatus: () => {
+        implementation: string
+        configured: boolean
+        supportedOperations: string[]
+      }
+    }
+
+    expect(athenaAdapter.isConnected()).toBe(false)
+    expect(athenaAdapter.getRuntimeStatus()).toMatchObject({
+      implementation: 'stub',
+      configured: false,
+      supportedOperations: ['documents', 'search', 'preview', 'versions', 'workflow', 'collaboration'],
+    })
+  })
+
+  it('supports PLM query contracts for products, approval history, and BOM compare', async () => {
+    const plmAdapter = createPlmAdapterMock()
+    const app = createFederationApp({ plmAdapter })
+
+    const productsResponse = await request(app)
+      .post('/api/federation/plm/query')
+      .send({
+        operation: 'products',
+        pagination: { limit: 25, offset: 10 },
+        filters: { search: 'servo', status: 'released', itemType: 'Part' },
+      })
+      .expect(200)
+
+    expect(plmAdapter.getProducts).toHaveBeenCalledWith({
+      limit: 25,
+      offset: 10,
+      status: 'released',
+      search: 'servo',
+      itemType: 'Part',
+    })
+    expect(productsResponse.body.data).toEqual({
+      items: [
+        expect.objectContaining({
+          id: 'prod-1001',
+          partNumber: 'PN-1001',
+          revision: 'B',
+        }),
+      ],
+      total: 1,
+      limit: 25,
+      offset: 10,
+    })
+
+    const approvalHistoryResponse = await request(app)
+      .post('/api/federation/plm/query')
+      .send({
+        operation: 'approval_history',
+        filters: { ecoId: 'eco-1' },
+      })
+      .expect(200)
+
+    expect(plmAdapter.getApprovalHistory).toHaveBeenCalledWith('eco-1')
+    expect(approvalHistoryResponse.body.data).toEqual({
+      approvalId: 'eco-1',
+      items: plmContractFixtures.approvalHistory,
+      total: 1,
+    })
+
+    const bomCompareResponse = await request(app)
+      .post('/api/federation/plm/query')
+      .send({
+        operation: 'bom_compare',
+        leftId: 'left-1',
+        rightId: 'right-1',
+        includeRelationshipProps: 'findNumber,referenceDesignator',
+        filters: {
+          compareMode: 'strict',
+        },
+      })
+      .expect(200)
+
+    expect(plmAdapter.getBomCompare).toHaveBeenCalledWith({
+      leftId: 'left-1',
+      rightId: 'right-1',
+      leftType: 'item',
+      rightType: 'item',
+      lineKey: undefined,
+      compareMode: 'strict',
+      maxLevels: undefined,
+      includeSubstitutes: undefined,
+      includeEffectivity: undefined,
+      includeRelationshipProps: ['findNumber', 'referenceDesignator'],
+      effectiveAt: undefined,
+    })
+    expect(bomCompareResponse.body.data).toEqual(plmContractFixtures.bomCompare)
+  })
+
+  it('supports PLM mutation contracts for substitute add and approval reject', async () => {
+    const plmAdapter = createPlmAdapterMock()
+    const app = createFederationApp({ plmAdapter })
+
+    const addResponse = await request(app)
+      .post('/api/federation/plm/mutate')
+      .send({
+        operation: 'substitutes_add',
+        bomLineId: 'line-1',
+        substituteItemId: 'part-2',
+        properties: { preference: 'alternate' },
+      })
+      .expect(200)
+
+    expect(plmAdapter.addBomSubstitute).toHaveBeenCalledWith('line-1', 'part-2', { preference: 'alternate' })
+    expect(addResponse.body.data).toEqual(plmContractFixtures.substituteAdded)
+
+    const missingCommentResponse = await request(app)
+      .post('/api/federation/plm/mutate')
+      .send({
+        operation: 'approval_reject',
+        approvalId: 'eco-1',
+      })
+      .expect(400)
+
+    expect(missingCommentResponse.body).toEqual({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'comment is required for approval_reject',
+      },
+    })
+
+    const rejectResponse = await request(app)
+      .post('/api/federation/plm/mutate')
+      .send({
+        operation: 'approval_reject',
+        approvalId: 'eco-1',
+        comment: 'missing test evidence',
+      })
+      .expect(200)
+
+    expect(plmAdapter.rejectApproval).toHaveBeenCalledWith('eco-1', 'missing test evidence')
+    expect(rejectResponse.body.data).toEqual({
+      id: 'eco-1',
+      comment: 'missing test evidence',
+    })
+  })
+
+  it('supports PLM detail contracts for product detail and BOM detail', async () => {
+    const plmAdapter = createPlmAdapterMock()
+    const app = createFederationApp({ plmAdapter })
+
+    const detailResponse = await request(app)
+      .get('/api/federation/plm/products/prod-1001')
+      .query({ itemType: 'Part' })
+      .expect(200)
+
+    expect(plmAdapter.getProductById).toHaveBeenCalledWith('prod-1001', { itemType: 'Part' })
+    expect(detailResponse.body.data).toEqual(
+      expect.objectContaining({
+        id: 'prod-1001',
+        partNumber: 'PN-1001',
+        revision: 'B',
+      }),
+    )
+
+    const bomResponse = await request(app)
+      .get('/api/federation/plm/products/prod-1001/bom')
+      .query({ depth: 3, effective_at: '2026-03-06T00:00:00.000Z' })
+      .expect(200)
+
+    expect(plmAdapter.getProductBOM).toHaveBeenCalledWith('prod-1001', {
+      depth: 3,
+      effectiveAt: '2026-03-06T00:00:00.000Z',
+    })
+    expect(bomResponse.body.data).toEqual({
+      productId: 'prod-1001',
+      items: plmContractFixtures.bom,
+      totalItems: 1,
+    })
+  })
+
+  it('supports Athena query and detail contracts with mocked adapters', async () => {
+    const athenaAdapter = createAthenaAdapterMock()
+    const app = createFederationApp({ athenaAdapter })
+
+    const queryResponse = await request(app)
+      .post('/api/federation/athena/query')
+      .send({
+        operation: 'documents',
+        query: 'servo',
+        folderId: 'folder-1',
+        pagination: { limit: 20, offset: 5 },
+        filters: { status: 'approved' },
+      })
+      .expect(200)
+
+    expect(athenaAdapter.searchDocuments).toHaveBeenCalledWith({
+      query: 'servo',
+      folder_id: 'folder-1',
+      type: undefined,
+      status: 'approved',
+      created_by: undefined,
+      created_after: undefined,
+      created_before: undefined,
+      limit: 20,
+      offset: 5,
+    })
+    expect(queryResponse.body.data).toEqual({
+      items: [
+        expect.objectContaining({
+          id: 'doc-1',
+          mimeType: 'application/pdf',
+          version: 'A',
+        }),
+      ],
+      total: 1,
+      limit: 20,
+      offset: 5,
+    })
+
+    const detailResponse = await request(app)
+      .get('/api/federation/athena/documents/doc-1')
+      .expect(200)
+
+    expect(athenaAdapter.getDocument).toHaveBeenCalledWith('doc-1')
+    expect(detailResponse.body.data).toEqual({
+      id: 'doc-1',
+      name: 'Servo Spec.pdf',
+      mimeType: 'application/pdf',
+      size: 4096,
+      version: 'A',
+      createdAt: '2026-03-01T00:00:00.000Z',
+      modifiedAt: '2026-03-02T00:00:00.000Z',
+      locked: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- recut federation integration status visibility from current `main`
- add explicit runtime status metadata for stub adapters in the default container
- expose `/api/federation/integration-status` and cover it with federation contract tests
- supersede #459, whose branch no longer has a usable merge base with current `main`

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/federation.contract.test.ts`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`

## Docs
- `docs/development/federation-status-recut-development-20260319.md`
- `docs/development/federation-status-recut-verification-20260319.md`
