### PR TITLE
fix(attendance): prefer IAM role assignment in strict provisioning

### DIFF
--- a/scripts/ops/attendance-daily-gate-report.mjs
+++ b/scripts/ops/attendance-daily-gate-report.mjs
@@ -1335,11 +1335,15 @@ function renderMarkdown({
           lines.push(`- Strict Gates: \`provisioning\` failure reason detected: \`${provReason}\`.`)
         }
         if (provReason === 'AUTH_FAILED') {
-          lines.push('- Strict Gates: `provisioning` auth failed. Refresh the admin token and rerun (permission grants require admin).')
+          lines.push('- Strict Gates: `provisioning` auth failed. Refresh the admin token and rerun (access provisioning requires admin).')
         } else if (provReason === 'RATE_LIMITED') {
           lines.push('- Strict Gates: `provisioning` was rate-limited. Wait briefly and rerun.')
         } else if (provReason === 'ENDPOINT_MISSING') {
-          lines.push('- Strict Gates: `provisioning` endpoint missing. Ensure backend routes include `/api/permissions/grant`, then redeploy.')
+          lines.push('- Strict Gates: `provisioning` endpoint missing. Ensure backend routes include `/api/admin/users/:userId/roles/assign` or the legacy `/api/permissions/grant`, then redeploy.')
+        } else if (provReason === 'ROLE_NOT_FOUND') {
+          lines.push('- Strict Gates: `provisioning` attendance roles are missing. Run attendance role/RBAC migrations, confirm `attendance_employee|attendance_approver|attendance_admin` exist, then rerun.')
+        } else if (provReason === 'SERVER_ERROR') {
+          lines.push('- Strict Gates: `provisioning` returned a backend 5xx. Inspect backend logs for `/api/admin/users/:userId/roles/assign` or `/api/permissions/grant`, then rerun.')
         } else if (provReason === 'DNS_FAILED') {
           lines.push('- Strict Gates: `provisioning` failed due to DNS resolution. Check deploy DNS/network and rerun.')
         } else if (provReason === 'CONNECTION_REFUSED') {

--- a/scripts/ops/attendance-provision-user.sh
+++ b/scripts/ops/attendance-provision-user.sh
@@ -7,6 +7,8 @@ USER_ID="${USER_ID:-}"
 ROLE="${ROLE:-}"
 CURL_RETRY_ATTEMPTS="${CURL_RETRY_ATTEMPTS:-5}"
 CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
+HTTP_CODE=""
+HTTP_BODY=""
 
 function die() {
   echo "[attendance-provision-user] ERROR: $*" >&2
@@ -55,8 +57,9 @@ Usage:
     scripts/ops/attendance-provision-user.sh
 
 Notes:
-  - This script grants attendance permissions via POST /api/permissions/grant.
-  - It requires an ADMIN token (the backend enforces admin-only permission grants).
+  - This script prefers POST /api/admin/users/:userId/roles/assign with attendance roles.
+  - It falls back to POST /api/permissions/grant for older environments.
+  - It requires an ADMIN token.
 EOF
 }
 
@@ -75,14 +78,18 @@ fi
 refresh_token_if_needed
 
 permissions=()
+role_id=""
 case "$ROLE" in
   employee)
+    role_id="attendance_employee"
     permissions=("attendance:read" "attendance:write")
     ;;
   approver)
+    role_id="attendance_approver"
     permissions=("attendance:read" "attendance:approve")
     ;;
   admin)
+    role_id="attendance_admin"
     permissions=("attendance:read" "attendance:write" "attendance:approve" "attendance:admin")
     ;;
   *)
@@ -91,21 +98,79 @@ case "$ROLE" in
     ;;
 esac
 
-info "Granting permissions: role=${ROLE} userId=${USER_ID} count=${#permissions[@]}"
+function compact_body() {
+  printf '%s' "${1:-}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//'
+}
 
-for perm in "${permissions[@]}"; do
-  info "Granting ${perm}"
-  curl -fsS \
+function post_json() {
+  local path="$1"
+  local payload="$2"
+  local result
+
+  result="$(curl -sS -w '\n%{http_code}' \
     --retry "${CURL_RETRY_ATTEMPTS}" \
     --retry-delay "${CURL_RETRY_DELAY_SEC}" \
     --retry-all-errors \
     --connect-timeout 10 \
     --max-time 30 \
-    -X POST "${API_BASE}/permissions/grant" \
+    -X POST "${API_BASE}${path}" \
     -H "Authorization: Bearer ${AUTH_TOKEN}" \
     -H "Content-Type: application/json" \
-    --data "{\"userId\":\"${USER_ID}\",\"permission\":\"${perm}\"}" \
-    >/dev/null
-done
+    --data "${payload}" || true)"
+
+  HTTP_CODE="${result##*$'\n'}"
+  HTTP_BODY="${result%$'\n'*}"
+}
+
+function try_assign_role() {
+  info "Assigning role via admin route: role=${ROLE} roleId=${role_id} userId=${USER_ID}"
+  post_json "/admin/users/${USER_ID}/roles/assign" "{\"roleId\":\"${role_id}\"}"
+
+  case "${HTTP_CODE}" in
+    200|201)
+      info "Assigned role ${role_id}"
+      return 0
+      ;;
+    400)
+      if printf '%s' "${HTTP_BODY}" | grep -qE 'ROLE_NOT_FOUND|role not found'; then
+        info "WARN: role ${role_id} missing; falling back to legacy permission grants"
+        return 10
+      fi
+      ;;
+    404)
+      info "WARN: admin role assignment endpoint missing; falling back to legacy permission grants"
+      return 10
+      ;;
+  esac
+
+  info "error: ${HTTP_CODE} $(compact_body "${HTTP_BODY}")"
+  return 1
+}
+
+function grant_permissions_legacy() {
+  local perm
+  info "Granting permissions via legacy route: role=${ROLE} userId=${USER_ID} count=${#permissions[@]}"
+  for perm in "${permissions[@]}"; do
+    info "Granting ${perm}"
+    post_json "/permissions/grant" "{\"userId\":\"${USER_ID}\",\"permission\":\"${perm}\"}"
+    case "${HTTP_CODE}" in
+      200|201)
+        ;;
+      *)
+        info "error: ${HTTP_CODE} $(compact_body "${HTTP_BODY}")"
+        return 1
+        ;;
+    esac
+  done
+  return 0
+}
+
+status=0
+try_assign_role || status=$?
+if [[ "${status}" -eq 10 ]]; then
+  grant_permissions_legacy
+elif [[ "${status}" -ne 0 ]]; then
+  exit "${status}"
+fi
 
 info "OK"

--- a/scripts/ops/attendance-run-gates.sh
+++ b/scripts/ops/attendance-run-gates.sh
@@ -150,7 +150,7 @@ function maybe_run_provision() {
     return 0
   fi
 
-  info "Running permission provisioning gate (PROVISION_USER_ID set)..."
+  info "Running access provisioning gate (PROVISION_USER_ID set)..."
   if API_BASE="$API_BASE" AUTH_TOKEN="$AUTH_TOKEN" USER_ID="$PROVISION_USER_ID" ROLE="employee" "${ROOT_DIR}/scripts/ops/attendance-provision-user.sh" \
     >"${OUTPUT_ROOT}/gate-provision-employee.log" 2>&1 \
     && API_BASE="$API_BASE" AUTH_TOKEN="$AUTH_TOKEN" USER_ID="$PROVISION_USER_ID" ROLE="approver" "${ROOT_DIR}/scripts/ops/attendance-provision-user.sh" \
@@ -261,6 +261,14 @@ function detect_provision_reason() {
   fi
   if grep -qE 'error: 404' "$log"; then
     echo "ENDPOINT_MISSING"
+    return 0
+  fi
+  if grep -qE 'error: 400 .*ROLE_NOT_FOUND|error: 400 .*role not found' "$log"; then
+    echo "ROLE_NOT_FOUND"
+    return 0
+  fi
+  if grep -qE 'error: 5[0-9][0-9]' "$log"; then
+    echo "SERVER_ERROR"
     return 0
   fi
   if grep -qiE 'Could not resolve host' "$log"; then


### PR DESCRIPTION
## Summary
- prefer IAM role assignment for strict gate provisioning via `/api/admin/users/:userId/roles/assign`
- fall back to legacy `/api/permissions/grant` for older environments
- surface provisioning `SERVER_ERROR` and `ROLE_NOT_FOUND` reasons in gate diagnostics

## Why
Strict gate recovery run `23295251651` cleared the previous `apiSmoke` duplicate request regression, but then failed at provisioning because `POST /api/permissions/grant` returned HTTP 500 repeatedly and was classified as `UNKNOWN`.

This change moves the provisioning gate onto the current IAM role-assignment path first, while keeping a legacy fallback for older deployments.

## Verify
- `bash -n scripts/ops/attendance-provision-user.sh`
- `bash -n scripts/ops/attendance-run-gates.sh`
- `node --check scripts/ops/attendance-daily-gate-report.mjs`
- simulated direct success path for `/api/admin/users/:userId/roles/assign`
- simulated fallback path where role assignment returns 404 and legacy `/api/permissions/grant` succeeds

## Issue
- closes #189
