### PR TITLE
fix(core-backend): make audit writes best effort

### DIFF
--- a/packages/core-backend/src/audit/audit.ts
+++ b/packages/core-backend/src/audit/audit.ts
@@ -1,6 +1,8 @@
+import { Logger } from '../core/logger'
 import { AuditService } from './AuditService'
 
 export const auditService = new AuditService()
+const logger = new Logger('auditLog')
 
 export interface AuditLogOptions {
   actorId?: string
@@ -17,14 +19,23 @@ export async function auditLog(options: AuditLogOptions): Promise<void> {
     : undefined
   const userId = Number.isFinite(parsedUserId) ? parsedUserId : undefined
 
-  await auditService.logEvent(
-    options.action.toUpperCase(),
-    options.action,
-    {
-      userId,
+  try {
+    await auditService.logEvent(
+      options.action.toUpperCase(),
+      options.action,
+      {
+        userId,
+        resourceType: options.resourceType,
+        resourceId: options.resourceId,
+        actionDetails: options.meta
+      }
+    )
+  } catch (error) {
+    logger.warn('Audit log write failed; continuing without blocking request', {
+      action: options.action,
       resourceType: options.resourceType,
       resourceId: options.resourceId,
-      actionDetails: options.meta
-    }
-  )
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 }

--- a/packages/core-backend/tests/unit/audit-wrapper.test.ts
+++ b/packages/core-backend/tests/unit/audit-wrapper.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { logEventMock, warnMock } = vi.hoisted(() => ({
+  logEventMock: vi.fn(),
+  warnMock: vi.fn(),
+}))
+
+vi.mock('../../src/audit/AuditService', () => ({
+  AuditService: class {
+    logEvent = logEventMock
+  },
+}))
+
+vi.mock('../../src/core/logger', () => ({
+  Logger: class {
+    warn = warnMock
+    info = vi.fn()
+    error = vi.fn()
+    debug = vi.fn()
+  },
+}))
+
+import { auditLog } from '../../src/audit/audit'
+
+describe('auditLog', () => {
+  beforeEach(() => {
+    logEventMock.mockReset()
+    warnMock.mockReset()
+  })
+
+  it('passes numeric actor ids through to the audit service', async () => {
+    logEventMock.mockResolvedValueOnce(undefined)
+
+    await auditLog({
+      actorId: '42',
+      actorType: 'user',
+      action: 'grant',
+      resourceType: 'permission',
+      resourceId: 'user-1:attendance:read',
+      meta: { permission: 'attendance:read' },
+    })
+
+    expect(logEventMock).toHaveBeenCalledWith(
+      'GRANT',
+      'grant',
+      {
+        userId: 42,
+        resourceType: 'permission',
+        resourceId: 'user-1:attendance:read',
+        actionDetails: { permission: 'attendance:read' },
+      },
+    )
+    expect(warnMock).not.toHaveBeenCalled()
+  })
+
+  it('swallows audit write failures so callers do not fail closed', async () => {
+    logEventMock.mockRejectedValueOnce(new Error('no partition of relation "audit_logs" found for row'))
+
+    await expect(auditLog({
+      actorId: '26979f88-e7cc-4b40-a975-a0353d19aec0',
+      actorType: 'user',
+      action: 'grant',
+      resourceType: 'user-role',
+      resourceId: 'user-1:attendance_employee',
+      meta: { roleId: 'attendance_employee' },
+    })).resolves.toBeUndefined()
+
+    expect(warnMock).toHaveBeenCalledWith(
+      'Audit log write failed; continuing without blocking request',
+      expect.objectContaining({
+        action: 'grant',
+        resourceType: 'user-role',
+        resourceId: 'user-1:attendance_employee',
+        error: 'no partition of relation "audit_logs" found for row',
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- make `auditLog()` swallow write failures instead of failing request handlers
- log best-effort warnings with action/resource context
- add unit coverage for numeric actor ids and rejected audit writes

## Why
Strict gate recovery run `23295995677` still failed after the provisioning script fix because role assignment returned:

- `ROLE_ASSIGN_FAILED`
- `no partition of relation "audit_logs" found for row`

That means the real blocker is backend audit persistence, not provisioning logic. Audit writes should not turn a successful business operation into a 500.

## Verify
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/audit-wrapper.test.ts tests/unit/admin-users-routes.test.ts tests/unit/permissions-routes.test.ts`
- `pnpm --filter @metasheet/core-backend build`

## Issue
- closes #189
