### PR TITLE
fix(ci): run required plugin tests on all PRs

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -14,14 +14,6 @@ on:
       - '.github/workflows/*.yml'
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'packages/core-backend/**'
-      - 'plugins/**'
-      - 'apps/web/src/**'
-      - 'scripts/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/*.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- remove the `pull_request.paths` filter from `Plugin System Tests`
- make the required `test (20.x)` check reachable for every PR, including docs-only changes

## Why

`main` currently requires `test (20.x)` in branch protection, but the workflow only ran on a subset of paths. That made docs-only PRs structurally unmergeable because the required check never existed.

## Verification

- reviewed the workflow diff to confirm the change is limited to `pull_request` triggering
- existing `push` path filtering remains unchanged
