### PR TITLE
fix(attendance): address run15 validation gaps

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -34,7 +34,12 @@
       <div class="nav-actions">
         <label class="nav-locale">
           <span class="nav-locale__label">{{ navLabels.language }}</span>
-          <select class="nav-locale__select" :value="locale" @change="onLocaleChange">
+          <select
+            class="nav-locale__select"
+            data-testid="locale-switcher"
+            :value="locale"
+            @change="onLocaleChange"
+          >
             <option value="en">English</option>
             <option value="zh-CN">中文</option>
           </select>

--- a/apps/web/src/views/LoginView.vue
+++ b/apps/web/src/views/LoginView.vue
@@ -2,8 +2,22 @@
   <section class="login-page">
     <div class="login-card">
       <header class="login-header">
-        <h1>{{ text.title }}</h1>
-        <p>{{ text.subtitle }}</p>
+        <div class="login-header__content">
+          <h1>{{ text.title }}</h1>
+          <p>{{ text.subtitle }}</p>
+        </div>
+        <label class="login-locale">
+          <span class="login-locale__label">{{ text.language }}</span>
+          <select
+            class="login-locale__select"
+            data-testid="locale-switcher"
+            :value="locale"
+            @change="onLocaleChange"
+          >
+            <option value="en">English</option>
+            <option value="zh-CN">中文</option>
+          </select>
+        </label>
       </header>
 
       <form class="login-form" @submit.prevent="onSubmit">
@@ -63,7 +77,7 @@ interface AuthFeaturePayload {
 
 const router = useRouter()
 const route = useRoute()
-const { isZh } = useLocale()
+const { locale, isZh, setLocale } = useLocale()
 const { loadProductFeatures, resolveHomePath } = useFeatureFlags()
 
 const email = ref('')
@@ -78,6 +92,7 @@ const text = computed(() => {
       subtitle: '输入账号密码后进入系统。',
       email: '邮箱',
       password: '密码',
+      language: '语言',
       emailPlaceholder: 'admin@metasheet.app',
       passwordPlaceholder: '请输入密码',
       submit: '登录',
@@ -91,6 +106,7 @@ const text = computed(() => {
     subtitle: 'Use your account credentials to continue.',
     email: 'Email',
     password: 'Password',
+    language: 'Language',
     emailPlaceholder: 'admin@metasheet.app',
     passwordPlaceholder: 'Enter password',
     submit: 'Sign in',
@@ -143,13 +159,10 @@ function persistAuthContext(user: AuthUserPayload | null, features: AuthFeatureP
   }
 }
 
-async function hydrateAuthContext(): Promise<void> {
-  const response = await apiFetch('/api/auth/me')
-  if (!response.ok) return
-  const payload = await response.json().catch(() => null)
-  const user = (payload?.data?.user ?? null) as AuthUserPayload | null
-  const features = (payload?.data?.features ?? null) as AuthFeaturePayload | null
-  persistAuthContext(user, features)
+function onLocaleChange(event: Event): void {
+  const target = event.target as HTMLSelectElement | null
+  if (!target) return
+  setLocale(target.value)
 }
 
 async function onSubmit(): Promise<void> {
@@ -181,8 +194,11 @@ async function onSubmit(): Promise<void> {
       localStorage.setItem('auth_token', token)
     }
 
-    await hydrateAuthContext()
-    await loadProductFeatures(true)
+    persistAuthContext(
+      (payload?.data?.user ?? null) as AuthUserPayload | null,
+      (payload?.data?.features ?? null) as AuthFeaturePayload | null,
+    )
+    await loadProductFeatures(true, { skipSessionProbe: true })
 
     const redirect = normalizePostLoginRedirect(route.query.redirect)
     await router.replace(redirect || resolveHomePath())
@@ -216,8 +232,17 @@ async function onSubmit(): Promise<void> {
 }
 
 .login-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.login-header__content {
   display: grid;
   gap: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .login-header h1 {
@@ -229,6 +254,34 @@ async function onSubmit(): Promise<void> {
 .login-header p {
   font-size: 14px;
   color: #5f7088;
+}
+
+.login-locale {
+  display: inline-grid;
+  gap: 4px;
+  justify-items: end;
+  flex: 0 0 auto;
+}
+
+.login-locale__label {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.login-locale__select {
+  min-width: 120px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 8px;
+  font-size: 13px;
+  color: #334155;
+  background: #fff;
+}
+
+.login-locale__select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.16);
 }
 
 .login-form {

--- a/apps/web/tests/LoginView.spec.ts
+++ b/apps/web/tests/LoginView.spec.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  loadProductFeatures: vi.fn().mockResolvedValue(undefined),
+  resolveHomePath: vi.fn(() => '/attendance'),
+  routerReplace: vi.fn().mockResolvedValue(undefined),
+  apiFetch: vi.fn(async (path: string) => {
+    if (path === '/api/auth/login') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: {
+            token: 'login-token',
+            user: {
+              role: 'admin',
+              permissions: ['attendance:read'],
+            },
+            features: {
+              attendance: true,
+              workflow: false,
+              attendanceAdmin: true,
+              attendanceImport: true,
+              mode: 'attendance',
+            },
+          },
+        }),
+      }
+    }
+
+    throw new Error(`Unexpected fetch path: ${path}`)
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: {},
+  }),
+  useRouter: () => ({
+    replace: mocks.routerReplace,
+  }),
+}))
+
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({
+    loadProductFeatures: mocks.loadProductFeatures,
+    resolveHomePath: mocks.resolveHomePath,
+  }),
+}))
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: mocks.apiFetch,
+  clearStoredAuthState: vi.fn(),
+}))
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('LoginView', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+  let LoginViewComponent: Component
+
+  beforeEach(async () => {
+    window.localStorage.clear()
+    window.localStorage.setItem('metasheet_locale', 'en')
+    vi.clearAllMocks()
+    LoginViewComponent = (await import('../src/views/LoginView.vue')).default as Component
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('renders a visible locale switcher and updates locale changes', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp(LoginViewComponent)
+    app.mount(container)
+    await flushUi()
+
+    const switcher = container.querySelector('[data-testid="locale-switcher"]') as HTMLSelectElement | null
+    expect(switcher).not.toBeNull()
+    expect(switcher?.value).toBe('en')
+
+    if (switcher) {
+      switcher.value = 'zh-CN'
+      switcher.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+    await flushUi()
+
+    expect(window.localStorage.getItem('metasheet_locale')).toBe('zh-CN')
+  })
+
+  it('hydrates from the login response and skips a separate auth/me probe', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp(LoginViewComponent)
+    app.mount(container)
+    await flushUi()
+
+    const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement | null
+    const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement | null
+    const submitButton = container.querySelector('button[type="submit"]') as HTMLButtonElement | null
+
+    expect(emailInput).not.toBeNull()
+    expect(passwordInput).not.toBeNull()
+    expect(submitButton).not.toBeNull()
+
+    if (emailInput) {
+      emailInput.value = 'admin@example.com'
+      emailInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    if (passwordInput) {
+      passwordInput.value = 'secret'
+      passwordInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+
+    submitButton?.click()
+    await flushUi(8)
+
+    expect(mocks.apiFetch).toHaveBeenCalledTimes(1)
+    expect(mocks.apiFetch).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({ method: 'POST' }))
+    expect(window.localStorage.getItem('auth_token')).toBe('login-token')
+    expect(window.localStorage.getItem('user_roles')).toBe(JSON.stringify(['admin']))
+    expect(window.localStorage.getItem('user_permissions')).toBe(JSON.stringify(['attendance:read']))
+    expect(window.localStorage.getItem('metasheet_features')).toContain('"attendance":true')
+    expect(mocks.loadProductFeatures).toHaveBeenCalledWith(true, { skipSessionProbe: true })
+    expect(mocks.resolveHomePath).toHaveBeenCalled()
+    expect(mocks.routerReplace).toHaveBeenCalledWith('/attendance')
+  })
+})

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -10,6 +10,10 @@ server {
   resolver 127.0.0.11 ipv6=off valid=10s;
   set $backend_upstream backend:8900;
 
+  if ($request_uri ~* "(?:^|/)\\.\\.(?:/|$)|%2e%2e") {
+    return 400;
+  }
+
   # Allow larger bodies only for the raw CSV upload endpoint (upload channel),
   # while keeping the global `client_max_body_size` bounded.
   location /api/attendance/import/upload {
@@ -26,7 +30,16 @@ server {
     proxy_read_timeout 300s;
   }
 
-  location /api/ {
+  location = /api {
+    proxy_pass http://$backend_upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location ^~ /api/ {
     proxy_pass http://$backend_upstream;
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/ops/nginx/attendance-onprem.conf.example
+++ b/ops/nginx/attendance-onprem.conf.example
@@ -2,6 +2,10 @@ server {
   listen 80;
   server_name _;
 
+  if ($request_uri ~* "(?:^|/)\\.\\.(?:/|$)|%2e%2e") {
+    return 400;
+  }
+
   # Built frontend assets (adjust to your deployment path).
   root /opt/metasheet/apps/web/dist;
   index index.html;
@@ -23,7 +27,18 @@ server {
     proxy_send_timeout 300s;
   }
 
-  location /api {
+  location = /api {
+    proxy_pass http://127.0.0.1:8900;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+  }
+
+  location ^~ /api/ {
     proxy_pass http://127.0.0.1:8900;
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1177,6 +1177,319 @@ describe('Attendance Plugin Integration', () => {
     }
   })
 
+  it('exports attendance JSON when format=json is requested', async () => {
+    if (!baseUrl) return
+
+    const tokenUserId = `attendance-export-json-${Date.now().toString(36)}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(tokenUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    expect(dbUrl).toBeTruthy()
+    if (!dbUrl) return
+
+    const workDate = '2029-03-14'
+    const firstInAt = new Date(`${workDate}T00:00:00.000Z`)
+    const recordId = randomUuidV4()
+    const sourceBatchId = randomUuidV4()
+    const pool = new Pool({ connectionString: dbUrl })
+    try {
+      await pool.query(
+        `INSERT INTO attendance_records
+         (id, user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta, source_batch_id, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, NULL, $7, $8, $9, $10, $11, $12::jsonb, $13, now(), now())`,
+        [
+          recordId,
+          tokenUserId,
+          'default',
+          workDate,
+          'Asia/Tokyo',
+          firstInAt,
+          480,
+          0,
+          0,
+          'normal',
+          true,
+          JSON.stringify({ source: 'integration-export-json' }),
+          sourceBatchId,
+        ]
+      )
+
+      const exportRes = await requestJson(
+        `${baseUrl}/api/attendance/export?from=${encodeURIComponent(workDate)}&to=${encodeURIComponent(workDate)}&format=json`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+      expect(exportRes.status).toBe(200)
+      const body = (exportRes.body as {
+        ok?: boolean
+        success?: boolean
+        data?: { format?: string; total?: number; items?: Array<Record<string, unknown>> }
+      } | undefined) ?? {}
+      expect(body.ok).toBe(true)
+      expect(body.success).toBe(true)
+      expect(body.data?.format).toBe('json')
+      expect(body.data?.total).toBeGreaterThanOrEqual(1)
+      expect(Array.isArray(body.data?.items)).toBe(true)
+      const row = body.data?.items?.find(item => item.user_id === tokenUserId)
+      expect(row?.work_date).toBe(workDate)
+      expect(row?.first_in_at).toBe(`${workDate}T09:00:00+09:00`)
+    } finally {
+      await pool.query('DELETE FROM attendance_records WHERE id = $1', [recordId]).catch(() => undefined)
+      await pool.end()
+    }
+  })
+
+  it('rejects HTML group names and returns 409 for duplicate attendance group names', async () => {
+    if (!baseUrl) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=attendance-group-guard-${Date.now().toString(36)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const unsafeRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: '<script>alert(1)</script>',
+        timezone: 'UTC',
+      }),
+    })
+    expect(unsafeRes.status).toBe(400)
+    const unsafeBody = (unsafeRes.body as { error?: { code?: string; message?: string } } | undefined) ?? {}
+    expect(unsafeBody.error?.code).toBe('VALIDATION_ERROR')
+    expect(unsafeBody.error?.message).toContain('HTML')
+
+    const groupName = `Run15 Duplicate Group ${Date.now().toString(36)}`
+    const firstRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: groupName,
+        timezone: 'UTC',
+      }),
+    })
+    expect(firstRes.status).toBe(200)
+
+    const secondRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: groupName,
+        timezone: 'UTC',
+      }),
+    })
+    expect(secondRes.status).toBe(409)
+    const secondBody = (secondRes.body as { error?: { code?: string } } | undefined) ?? {}
+    expect(secondBody.error?.code).toBe('ALREADY_EXISTS')
+  })
+
+  it('rejects invalid timezones for attendance groups and payroll templates', async () => {
+    if (!baseUrl) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=attendance-tz-guard-${Date.now().toString(36)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const invalidGroupRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: `Invalid TZ Group ${Date.now().toString(36)}`,
+        timezone: 'Mars/Olympus',
+      }),
+    })
+    expect(invalidGroupRes.status).toBe(400)
+
+    const invalidTemplateRes = await requestJson(`${baseUrl}/api/attendance/payroll-templates`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: `Invalid TZ Payroll ${Date.now().toString(36)}`,
+        timezone: 'Mars/Olympus',
+        startDay: 1,
+        endDay: 30,
+      }),
+    })
+    expect(invalidTemplateRes.status).toBe(400)
+    const invalidTemplateBody = (invalidTemplateRes.body as { error?: { code?: string; message?: string } } | undefined) ?? {}
+    expect(invalidTemplateBody.error?.code).toBe('VALIDATION_ERROR')
+    expect(invalidTemplateBody.error?.message).toContain('IANA')
+  })
+
+  it('rejects future punches and still allows immediate check-out after check-in when min interval is enabled', async () => {
+    if (!baseUrl) return
+
+    const tokenUserId = `attendance-punch-guard-${Date.now().toString(36)}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(tokenUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(settingsRes.status).toBe(200)
+    const originalSettings = ((settingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+
+    try {
+      const saveSettingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...originalSettings,
+          minPunchIntervalMinutes: 60,
+        }),
+      })
+      expect(saveSettingsRes.status).toBe(200)
+
+      const futurePunchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          eventType: 'check_in',
+          occurredAt: '2027-03-19T09:00:00.000Z',
+        }),
+      })
+      expect(futurePunchRes.status).toBe(400)
+      const futureBody = (futurePunchRes.body as { error?: { code?: string } } | undefined) ?? {}
+      expect(futureBody.error?.code).toBe('FUTURE_PUNCH_NOT_ALLOWED')
+
+      const now = new Date().toISOString()
+      const checkInRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          eventType: 'check_in',
+          occurredAt: now,
+        }),
+      })
+      expect(checkInRes.status).toBe(200)
+
+      const checkOutRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          eventType: 'check_out',
+          occurredAt: now,
+        }),
+      })
+      expect(checkOutRes.status).toBe(200)
+    } finally {
+      await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(originalSettings),
+      }).catch(() => undefined)
+    }
+  })
+
+  it('rejects negative leave type daily_minutes aliases and exposes holiday type fields', async () => {
+    if (!baseUrl) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=attendance-leave-guard-${Date.now().toString(36)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const invalidLeaveTypeRes = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: `Negative Leave ${Date.now().toString(36)}`,
+        daily_minutes: -100,
+      }),
+    })
+    expect(invalidLeaveTypeRes.status).toBe(400)
+
+    const holidayDate = '2029-03-15'
+    const holidayCreateRes = await requestJson(`${baseUrl}/api/attendance/holidays`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        date: holidayDate,
+        name: 'Holiday Type Check',
+        isWorkingDay: false,
+      }),
+    })
+    expect([201, 409]).toContain(holidayCreateRes.status)
+    const createdHoliday =
+      ((holidayCreateRes.body as { data?: Record<string, unknown> } | undefined)?.data) ?? null
+
+    const holidayListRes = await requestJson(
+      `${baseUrl}/api/attendance/holidays?from=${holidayDate}&to=${holidayDate}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    )
+    expect(holidayListRes.status).toBe(200)
+    const items = ((holidayListRes.body as { data?: { items?: Array<Record<string, unknown>> } } | undefined)?.data?.items) ?? []
+    const holiday =
+      items.find(item => item.id === createdHoliday?.id)
+      ?? items.find(item => String(item.date ?? '').startsWith(holidayDate))
+      ?? createdHoliday
+    expect(holiday).toBeTruthy()
+    expect(holiday?.type).toBe('holiday')
+    expect(holiday?.holidayType).toBe('holiday')
+  })
+
   it('supports import commit idempotencyKey retries (without requiring a new commitToken)', async () => {
     if (!baseUrl) return
 

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1057,6 +1057,16 @@ components:
           nullable: true
         isWorkingDay:
           type: boolean
+        type:
+          type: string
+          enum:
+            - holiday
+            - working_day_override
+        holidayType:
+          type: string
+          enum:
+            - holiday
+            - working_day_override
     AttendanceSettings:
       type: object
       properties:
@@ -2501,6 +2511,7 @@ paths:
                 workDate:
                   type: string
                   format: date
+                  description: Work date in YYYY-MM-DD format.
                 requestType:
                   type: string
                   enum:
@@ -2509,24 +2520,44 @@ paths:
                     - time_correction
                     - leave
                     - overtime
+                  description: Request type.
                 requestedInAt:
                   type: string
                   format: date-time
+                  description: >-
+                    Required for missed_check_in. Optional for time_correction,
+                    leave, and overtime.
                 requestedOutAt:
                   type: string
                   format: date-time
+                  description: >-
+                    Required for missed_check_out. Optional for time_correction,
+                    leave, and overtime.
                 reason:
                   type: string
                 leaveTypeId:
                   type: string
+                  description: >-
+                    Required for leave requests unless leaveTypeCode is
+                    provided.
                 leaveTypeCode:
                   type: string
+                  description: Required for leave requests unless leaveTypeId is provided.
                 overtimeRuleId:
                   type: string
+                  description: >-
+                    Required for overtime requests unless overtimeRuleName is
+                    provided.
                 overtimeRuleName:
                   type: string
+                  description: >-
+                    Required for overtime requests unless overtimeRuleId is
+                    provided.
                 minutes:
                   type: integer
+                  description: >-
+                    Required for overtime unless derived from
+                    requestedInAt/requestedOutAt.
                 attachmentUrl:
                   type: string
                 approvalFlowId:
@@ -3442,7 +3473,7 @@ paths:
   /api/attendance/export:
     x-plugin: plugin-attendance
     get:
-      summary: Export attendance records as CSV
+      summary: Export attendance records as CSV or JSON
       security:
         - bearerAuth: []
       parameters:
@@ -3470,13 +3501,72 @@ paths:
             type: integer
             default: 1000
             maximum: 5000
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum:
+              - csv
+              - json
+            default: csv
       responses:
         '200':
-          description: CSV export
+          description: Export result
           content:
             text/csv:
               schema:
                 type: string
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            user_id:
+                              type: string
+                            org_id:
+                              type: string
+                            work_date:
+                              type: string
+                              format: date
+                            timezone:
+                              type: string
+                            first_in_at:
+                              type: string
+                            last_out_at:
+                              type: string
+                            work_minutes:
+                              type: integer
+                            late_minutes:
+                              type: integer
+                            early_leave_minutes:
+                              type: integer
+                            status:
+                              type: string
+                            is_workday:
+                              type: boolean
+                      total:
+                        type: integer
+                      from:
+                        type: string
+                        format: date
+                      to:
+                        type: string
+                        format: date
+                      format:
+                        type: string
+                        enum:
+                          - json
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3608,6 +3698,9 @@ paths:
                   type: boolean
                 defaultMinutesPerDay:
                   type: integer
+                daily_minutes:
+                  type: integer
+                  description: Compatibility alias for defaultMinutesPerDay.
                 isActive:
                   type: boolean
                 orgId:
@@ -3663,6 +3756,9 @@ paths:
                   type: boolean
                 defaultMinutesPerDay:
                   type: integer
+                daily_minutes:
+                  type: integer
+                  description: Compatibility alias for defaultMinutesPerDay.
                 isActive:
                   type: boolean
                 orgId:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -1543,6 +1543,20 @@
           },
           "isWorkingDay": {
             "type": "boolean"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "holiday",
+              "working_day_override"
+            ]
+          },
+          "holidayType": {
+            "type": "string",
+            "enum": [
+              "holiday",
+              "working_day_override"
+            ]
           }
         }
       },
@@ -3808,7 +3822,8 @@
                 "properties": {
                   "workDate": {
                     "type": "string",
-                    "format": "date"
+                    "format": "date",
+                    "description": "Work date in YYYY-MM-DD format."
                   },
                   "requestType": {
                     "type": "string",
@@ -3818,33 +3833,41 @@
                       "time_correction",
                       "leave",
                       "overtime"
-                    ]
+                    ],
+                    "description": "Request type."
                   },
                   "requestedInAt": {
                     "type": "string",
-                    "format": "date-time"
+                    "format": "date-time",
+                    "description": "Required for missed_check_in. Optional for time_correction, leave, and overtime."
                   },
                   "requestedOutAt": {
                     "type": "string",
-                    "format": "date-time"
+                    "format": "date-time",
+                    "description": "Required for missed_check_out. Optional for time_correction, leave, and overtime."
                   },
                   "reason": {
                     "type": "string"
                   },
                   "leaveTypeId": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Required for leave requests unless leaveTypeCode is provided."
                   },
                   "leaveTypeCode": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Required for leave requests unless leaveTypeId is provided."
                   },
                   "overtimeRuleId": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Required for overtime requests unless overtimeRuleName is provided."
                   },
                   "overtimeRuleName": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Required for overtime requests unless overtimeRuleId is provided."
                   },
                   "minutes": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Required for overtime unless derived from requestedInAt/requestedOutAt."
                   },
                   "attachmentUrl": {
                     "type": "string"
@@ -5349,7 +5372,7 @@
     "/api/attendance/export": {
       "x-plugin": "plugin-attendance",
       "get": {
-        "summary": "Export attendance records as CSV",
+        "summary": "Export attendance records as CSV or JSON",
         "security": [
           {
             "bearerAuth": []
@@ -5394,15 +5417,104 @@
               "default": 1000,
               "maximum": 5000
             }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "csv",
+                "json"
+              ],
+              "default": "csv"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "CSV export",
+            "description": "Export result",
             "content": {
               "text/csv": {
                 "schema": {
                   "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "user_id": {
+                                "type": "string"
+                              },
+                              "org_id": {
+                                "type": "string"
+                              },
+                              "work_date": {
+                                "type": "string",
+                                "format": "date"
+                              },
+                              "timezone": {
+                                "type": "string"
+                              },
+                              "first_in_at": {
+                                "type": "string"
+                              },
+                              "last_out_at": {
+                                "type": "string"
+                              },
+                              "work_minutes": {
+                                "type": "integer"
+                              },
+                              "late_minutes": {
+                                "type": "integer"
+                              },
+                              "early_leave_minutes": {
+                                "type": "integer"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "is_workday": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "from": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "to": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "format": {
+                          "type": "string",
+                          "enum": [
+                            "json"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5618,6 +5730,10 @@
                   "defaultMinutesPerDay": {
                     "type": "integer"
                   },
+                  "daily_minutes": {
+                    "type": "integer",
+                    "description": "Compatibility alias for defaultMinutesPerDay."
+                  },
                   "isActive": {
                     "type": "boolean"
                   },
@@ -5706,6 +5822,10 @@
                   },
                   "defaultMinutesPerDay": {
                     "type": "integer"
+                  },
+                  "daily_minutes": {
+                    "type": "integer",
+                    "description": "Compatibility alias for defaultMinutesPerDay."
                   },
                   "isActive": {
                     "type": "boolean"

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1057,6 +1057,16 @@ components:
           nullable: true
         isWorkingDay:
           type: boolean
+        type:
+          type: string
+          enum:
+            - holiday
+            - working_day_override
+        holidayType:
+          type: string
+          enum:
+            - holiday
+            - working_day_override
     AttendanceSettings:
       type: object
       properties:
@@ -2501,6 +2511,7 @@ paths:
                 workDate:
                   type: string
                   format: date
+                  description: Work date in YYYY-MM-DD format.
                 requestType:
                   type: string
                   enum:
@@ -2509,24 +2520,44 @@ paths:
                     - time_correction
                     - leave
                     - overtime
+                  description: Request type.
                 requestedInAt:
                   type: string
                   format: date-time
+                  description: >-
+                    Required for missed_check_in. Optional for time_correction,
+                    leave, and overtime.
                 requestedOutAt:
                   type: string
                   format: date-time
+                  description: >-
+                    Required for missed_check_out. Optional for time_correction,
+                    leave, and overtime.
                 reason:
                   type: string
                 leaveTypeId:
                   type: string
+                  description: >-
+                    Required for leave requests unless leaveTypeCode is
+                    provided.
                 leaveTypeCode:
                   type: string
+                  description: Required for leave requests unless leaveTypeId is provided.
                 overtimeRuleId:
                   type: string
+                  description: >-
+                    Required for overtime requests unless overtimeRuleName is
+                    provided.
                 overtimeRuleName:
                   type: string
+                  description: >-
+                    Required for overtime requests unless overtimeRuleId is
+                    provided.
                 minutes:
                   type: integer
+                  description: >-
+                    Required for overtime unless derived from
+                    requestedInAt/requestedOutAt.
                 attachmentUrl:
                   type: string
                 approvalFlowId:
@@ -3442,7 +3473,7 @@ paths:
   /api/attendance/export:
     x-plugin: plugin-attendance
     get:
-      summary: Export attendance records as CSV
+      summary: Export attendance records as CSV or JSON
       security:
         - bearerAuth: []
       parameters:
@@ -3470,13 +3501,72 @@ paths:
             type: integer
             default: 1000
             maximum: 5000
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum:
+              - csv
+              - json
+            default: csv
       responses:
         '200':
-          description: CSV export
+          description: Export result
           content:
             text/csv:
               schema:
                 type: string
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            user_id:
+                              type: string
+                            org_id:
+                              type: string
+                            work_date:
+                              type: string
+                              format: date
+                            timezone:
+                              type: string
+                            first_in_at:
+                              type: string
+                            last_out_at:
+                              type: string
+                            work_minutes:
+                              type: integer
+                            late_minutes:
+                              type: integer
+                            early_leave_minutes:
+                              type: integer
+                            status:
+                              type: string
+                            is_workday:
+                              type: boolean
+                      total:
+                        type: integer
+                      from:
+                        type: string
+                        format: date
+                      to:
+                        type: string
+                        format: date
+                      format:
+                        type: string
+                        enum:
+                          - json
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3608,6 +3698,9 @@ paths:
                   type: boolean
                 defaultMinutesPerDay:
                   type: integer
+                daily_minutes:
+                  type: integer
+                  description: Compatibility alias for defaultMinutesPerDay.
                 isActive:
                   type: boolean
                 orgId:
@@ -3663,6 +3756,9 @@ paths:
                   type: boolean
                 defaultMinutesPerDay:
                   type: integer
+                daily_minutes:
+                  type: integer
+                  description: Compatibility alias for defaultMinutesPerDay.
                 isActive:
                   type: boolean
                 orgId:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1030,6 +1030,12 @@ components:
           nullable: true
         isWorkingDay:
           type: boolean
+        type:
+          type: string
+          enum: [holiday, working_day_override]
+        holidayType:
+          type: string
+          enum: [holiday, working_day_override]
     AttendanceSettings:
       type: object
       properties:

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -225,27 +225,36 @@ paths:
                 workDate:
                   type: string
                   format: date
+                  description: Work date in YYYY-MM-DD format.
                 requestType:
                   type: string
                   enum: [missed_check_in, missed_check_out, time_correction, leave, overtime]
+                  description: Request type.
                 requestedInAt:
                   type: string
                   format: date-time
+                  description: Required for missed_check_in. Optional for time_correction, leave, and overtime.
                 requestedOutAt:
                   type: string
                   format: date-time
+                  description: Required for missed_check_out. Optional for time_correction, leave, and overtime.
                 reason:
                   type: string
                 leaveTypeId:
                   type: string
+                  description: Required for leave requests unless leaveTypeCode is provided.
                 leaveTypeCode:
                   type: string
+                  description: Required for leave requests unless leaveTypeId is provided.
                 overtimeRuleId:
                   type: string
+                  description: Required for overtime requests unless overtimeRuleName is provided.
                 overtimeRuleName:
                   type: string
+                  description: Required for overtime requests unless overtimeRuleId is provided.
                 minutes:
                   type: integer
+                  description: Required for overtime unless derived from requestedInAt/requestedOutAt.
                 attachmentUrl:
                   type: string
                 approvalFlowId:
@@ -917,7 +926,7 @@ paths:
   /api/attendance/export:
     x-plugin: plugin-attendance
     get:
-      summary: Export attendance records as CSV
+      summary: Export attendance records as CSV or JSON
       security: [ { bearerAuth: [] } ]
       parameters:
         - in: query
@@ -935,13 +944,48 @@ paths:
         - in: query
           name: limit
           schema: { type: integer, default: 1000, maximum: 5000 }
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [csv, json]
+            default: csv
       responses:
         '200':
-          description: CSV export
+          description: Export result
           content:
             text/csv:
               schema:
                 type: string
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  success: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            user_id: { type: string }
+                            org_id: { type: string }
+                            work_date: { type: string, format: date }
+                            timezone: { type: string }
+                            first_in_at: { type: string }
+                            last_out_at: { type: string }
+                            work_minutes: { type: integer }
+                            late_minutes: { type: integer }
+                            early_leave_minutes: { type: integer }
+                            status: { type: string }
+                            is_workday: { type: boolean }
+                      total: { type: integer }
+                      from: { type: string, format: date }
+                      to: { type: string, format: date }
+                      format: { type: string, enum: [json] }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
   /api/attendance/reports/requests:
@@ -1035,6 +1079,9 @@ paths:
                 requiresApproval: { type: boolean }
                 requiresAttachment: { type: boolean }
                 defaultMinutesPerDay: { type: integer }
+                daily_minutes:
+                  type: integer
+                  description: Compatibility alias for defaultMinutesPerDay.
                 isActive: { type: boolean }
                 orgId: { type: string }
               required: [name]
@@ -1074,6 +1121,9 @@ paths:
                 requiresApproval: { type: boolean }
                 requiresAttachment: { type: boolean }
                 defaultMinutesPerDay: { type: integer }
+                daily_minutes:
+                  type: integer
+                  description: Compatibility alias for defaultMinutesPerDay.
                 isActive: { type: boolean }
                 orgId: { type: string }
       responses:

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -632,6 +632,37 @@ function normalizeDateOnlyStrict(value) {
   return date.toISOString().slice(0, 10) === normalized ? normalized : null
 }
 
+function isValidTimeZoneIdentifier(value) {
+  const zone = typeof value === 'string' ? value.trim() : ''
+  if (!zone) return false
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: zone }).format(new Date())
+    return true
+  } catch {
+    return false
+  }
+}
+
+function resolveExplicitTimeZoneOrThrow(value, fallback, fieldName = 'timezone') {
+  const zone = typeof value === 'string' ? value.trim() : ''
+  if (!zone) return fallback
+  if (!isValidTimeZoneIdentifier(zone)) {
+    throw new HttpError(400, 'VALIDATION_ERROR', `${fieldName} must be a valid IANA time zone`)
+  }
+  return zone
+}
+
+function normalizeSafeDisplayName(fieldName, value) {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  if (!normalized) {
+    throw new HttpError(400, 'VALIDATION_ERROR', `${fieldName} is required`)
+  }
+  if (/[<>]/.test(normalized) || /<\/?[a-z][^>]*>/i.test(normalized)) {
+    throw new HttpError(400, 'VALIDATION_ERROR', `${fieldName} cannot contain HTML tags`)
+  }
+  return normalized
+}
+
 function resolveAttendanceDateRange(fromValue, toValue, fallbackDays = 30) {
   const fallbackFrom = new Date(Date.now() - 1000 * 60 * 60 * 24 * fallbackDays).toISOString().slice(0, 10)
   const fallbackTo = new Date().toISOString().slice(0, 10)
@@ -2171,12 +2202,15 @@ function mapShiftFromAssignmentRow(row) {
 }
 
 function mapHolidayRow(row) {
+  const holidayType = row.is_working_day === true ? 'working_day_override' : 'holiday'
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
-    date: row.holiday_date,
+    date: normalizeDateOnly(row.holiday_date) ?? row.holiday_date,
     name: row.name ?? null,
     isWorkingDay: row.is_working_day ?? false,
+    type: holidayType,
+    holidayType,
   }
 }
 
@@ -2748,7 +2782,10 @@ function normalizeNumber(value) {
 function normalizeDateOnly(value) {
   if (!value) return null
   if (value instanceof Date && !Number.isNaN(value.getTime())) {
-    return value.toISOString().slice(0, 10)
+    const year = value.getFullYear()
+    const month = String(value.getMonth() + 1).padStart(2, '0')
+    const day = String(value.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
   }
   const raw = String(value).trim()
   if (!raw) return null
@@ -2820,12 +2857,7 @@ function parseHolidayDayIndex(name) {
 function resolveTimeZone(timeZone, fallback) {
   const zone = typeof timeZone === 'string' ? timeZone.trim() : ''
   if (!zone) return fallback
-  try {
-    new Intl.DateTimeFormat('en-US', { timeZone: zone }).format(new Date())
-    return zone
-  } catch (error) {
-    return fallback
-  }
+  return isValidTimeZoneIdentifier(zone) ? zone : fallback
 }
 
 function resolveHolidayMeta(holiday) {
@@ -5550,7 +5582,7 @@ function buildPayrollSummaryCsv(summary, cycle) {
   return buildCsv(csvRows, headers)
 }
 
-async function enforcePunchConstraints({ db, userId, orgId, occurredAt, settings, req }) {
+async function enforcePunchConstraints({ db, userId, orgId, occurredAt, eventType, settings, req }) {
   if (settings.ipAllowlist && settings.ipAllowlist.length > 0) {
     const ip = getClientIp(req)
     if (!isIpAllowed(ip, settings.ipAllowlist)) {
@@ -5565,9 +5597,13 @@ async function enforcePunchConstraints({ db, userId, orgId, occurredAt, settings
     }
   }
 
+  if (occurredAt.getTime() > Date.now() + 5 * 60 * 1000) {
+    throw new HttpError(400, 'FUTURE_PUNCH_NOT_ALLOWED', 'Punch time cannot be in the future')
+  }
+
   if (settings.minPunchIntervalMinutes > 0) {
     const rows = await db.query(
-      `SELECT occurred_at
+      `SELECT occurred_at, event_type
        FROM attendance_events
        WHERE user_id = $1 AND org_id = $2
        ORDER BY occurred_at DESC
@@ -5575,6 +5611,9 @@ async function enforcePunchConstraints({ db, userId, orgId, occurredAt, settings
       [userId, orgId]
     )
     if (rows.length > 0 && rows[0].occurred_at) {
+      if (rows[0].event_type && rows[0].event_type !== eventType) {
+        return
+      }
       const last = new Date(rows[0].occurred_at)
       const diffMinutes = (occurredAt.getTime() - last.getTime()) / 60000
       if (diffMinutes < settings.minPunchIntervalMinutes) {
@@ -6032,6 +6071,7 @@ module.exports = {
       requiresApproval: z.boolean().optional(),
       requiresAttachment: z.boolean().optional(),
       defaultMinutesPerDay: z.number().int().min(0).optional(),
+      daily_minutes: z.number().int().min(0).optional(),
       isActive: z.boolean().optional(),
       orgId: z.string().optional(),
     })
@@ -8316,10 +8356,18 @@ module.exports = {
 
         try {
           const settings = await getSettings(db)
-          await enforcePunchConstraints({ db, userId, orgId, occurredAt, settings, req })
+          await enforcePunchConstraints({
+            db,
+            userId,
+            orgId,
+            occurredAt,
+            eventType: parsed.data.eventType,
+            settings,
+            req,
+          })
 
           const baseRule = await loadDefaultRule(db, orgId)
-          const baseTimezone = parsed.data.timezone ?? baseRule.timezone
+          const baseTimezone = resolveExplicitTimeZoneOrThrow(parsed.data.timezone, baseRule.timezone)
           let workDate = toWorkDate(occurredAt, baseTimezone)
           let context = await resolveWorkContext({
             db,
@@ -8328,7 +8376,7 @@ module.exports = {
             workDate,
             defaultRule: baseRule,
           })
-          let timezone = parsed.data.timezone ?? context.rule.timezone
+          let timezone = resolveExplicitTimeZoneOrThrow(parsed.data.timezone, context.rule.timezone)
           if (timezone !== baseTimezone) {
             const recalculated = toWorkDate(occurredAt, timezone)
             if (recalculated !== workDate) {
@@ -9596,7 +9644,7 @@ module.exports = {
           paid: parsed.data.paid ?? true,
           requiresApproval: parsed.data.requiresApproval ?? true,
           requiresAttachment: parsed.data.requiresAttachment ?? false,
-          defaultMinutesPerDay: parsed.data.defaultMinutesPerDay ?? 480,
+          defaultMinutesPerDay: parsed.data.defaultMinutesPerDay ?? parsed.data.daily_minutes ?? 480,
           isActive: parsed.data.isActive ?? true,
         }
 
@@ -9672,7 +9720,7 @@ module.exports = {
             paid: parsed.data.paid ?? existing.paid ?? true,
             requiresApproval: parsed.data.requiresApproval ?? existing.requires_approval,
             requiresAttachment: parsed.data.requiresAttachment ?? existing.requires_attachment,
-            defaultMinutesPerDay: parsed.data.defaultMinutesPerDay ?? existing.default_minutes_per_day,
+            defaultMinutesPerDay: parsed.data.defaultMinutesPerDay ?? parsed.data.daily_minutes ?? existing.default_minutes_per_day,
             isActive: parsed.data.isActive ?? existing.is_active,
           }
 
@@ -14819,15 +14867,24 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const payload = {
-          name: parsed.data.name,
-          timezone: parsed.data.timezone ?? 'UTC',
-          startDay: parsed.data.startDay ?? 1,
-          endDay: parsed.data.endDay ?? 30,
-          endMonthOffset: parsed.data.endMonthOffset ?? 0,
-          autoGenerate: parsed.data.autoGenerate ?? true,
-          config: parsed.data.config ?? {},
-          isDefault: parsed.data.isDefault ?? false,
+        let payload
+        try {
+          payload = {
+            name: parsed.data.name,
+            timezone: resolveExplicitTimeZoneOrThrow(parsed.data.timezone, 'UTC'),
+            startDay: parsed.data.startDay ?? 1,
+            endDay: parsed.data.endDay ?? 30,
+            endMonthOffset: parsed.data.endMonthOffset ?? 0,
+            autoGenerate: parsed.data.autoGenerate ?? true,
+            config: parsed.data.config ?? {},
+            isDefault: parsed.data.isDefault ?? false,
+          }
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          throw error
         }
 
         try {
@@ -14897,15 +14954,24 @@ module.exports = {
             return
           }
           const existing = existingRows[0]
-          const payload = {
-            name: parsed.data.name ?? existing.name,
-            timezone: parsed.data.timezone ?? existing.timezone ?? 'UTC',
-            startDay: parsed.data.startDay ?? existing.start_day ?? 1,
-            endDay: parsed.data.endDay ?? existing.end_day ?? 30,
-            endMonthOffset: parsed.data.endMonthOffset ?? existing.end_month_offset ?? 0,
-            autoGenerate: parsed.data.autoGenerate ?? existing.auto_generate ?? true,
-            config: parsed.data.config ?? normalizeMetadata(existing.config),
-            isDefault: parsed.data.isDefault ?? existing.is_default ?? false,
+          let payload
+          try {
+            payload = {
+              name: parsed.data.name ?? existing.name,
+              timezone: resolveExplicitTimeZoneOrThrow(parsed.data.timezone, existing.timezone ?? 'UTC'),
+              startDay: parsed.data.startDay ?? existing.start_day ?? 1,
+              endDay: parsed.data.endDay ?? existing.end_day ?? 30,
+              endMonthOffset: parsed.data.endMonthOffset ?? existing.end_month_offset ?? 0,
+              autoGenerate: parsed.data.autoGenerate ?? existing.auto_generate ?? true,
+              config: parsed.data.config ?? normalizeMetadata(existing.config),
+              isDefault: parsed.data.isDefault ?? existing.is_default ?? false,
+            }
+          } catch (error) {
+            if (error instanceof HttpError) {
+              res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+              return
+            }
+            throw error
           }
 
           const updated = await db.transaction(async (trx) => {
@@ -15611,14 +15677,24 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const name = parsed.data.name.trim()
+        let name
+        let timezone
+        try {
+          name = normalizeSafeDisplayName('name', parsed.data.name)
+          timezone = resolveExplicitTimeZoneOrThrow(parsed.data.timezone, DEFAULT_RULE.timezone)
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          throw error
+        }
         const code = resolveAttendanceCode({
           explicitCode: parsed.data.code,
           existingCode: null,
           prefix: 'group',
           name,
         })
-        const timezone = parsed.data.timezone?.trim() || DEFAULT_RULE.timezone
         const ruleSetId = parsed.data.ruleSetId ?? null
         const description = parsed.data.description?.trim() || null
 
@@ -15631,6 +15707,10 @@ module.exports = {
           )
           res.json({ ok: true, data: mapAttendanceGroupRow(rows[0]) })
         } catch (error) {
+          if (error?.code === '23505') {
+            res.status(409).json({ ok: false, error: { code: 'ALREADY_EXISTS', message: 'Group name or code already exists' } })
+            return
+          }
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return
@@ -15671,14 +15751,24 @@ module.exports = {
         }
 
         const existing = existingRows[0]
-        const name = parsed.data.name.trim()
+        let name
+        let timezone
+        try {
+          name = normalizeSafeDisplayName('name', parsed.data.name)
+          timezone = resolveExplicitTimeZoneOrThrow(parsed.data.timezone, DEFAULT_RULE.timezone)
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          throw error
+        }
         const code = resolveAttendanceCode({
           explicitCode: parsed.data.code,
           existingCode: existing.code,
           prefix: 'group',
           name: parsed.data.name ?? existing.name,
         })
-        const timezone = parsed.data.timezone?.trim() || DEFAULT_RULE.timezone
         const ruleSetId = parsed.data.ruleSetId ?? null
         const description = parsed.data.description?.trim() || null
 
@@ -15701,6 +15791,10 @@ module.exports = {
           }
           res.json({ ok: true, data: mapAttendanceGroupRow(rows[0]) })
         } catch (error) {
+          if (error?.code === '23505') {
+            res.status(409).json({ ok: false, error: { code: 'ALREADY_EXISTS', message: 'Group name or code already exists' } })
+            return
+          }
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return
@@ -16667,6 +16761,7 @@ module.exports = {
           from: z.string().optional(),
           to: z.string().optional(),
           limit: z.string().optional(),
+          format: z.enum(['csv', 'json']).optional(),
         })
 
         const parsed = schema.safeParse({
@@ -16675,6 +16770,7 @@ module.exports = {
           from: typeof req.query.from === 'string' ? req.query.from : undefined,
           to: typeof req.query.to === 'string' ? req.query.to : undefined,
           limit: typeof req.query.limit === 'string' ? req.query.limit : undefined,
+          format: typeof req.query.format === 'string' ? req.query.format.toLowerCase() : undefined,
         })
 
         if (!parsed.success) {
@@ -16731,7 +16827,7 @@ module.exports = {
             'status',
             'is_workday',
           ]
-          const csvRows = rows.map((row) => ({
+          const exportItems = rows.map((row) => ({
             user_id: row.user_id ?? '',
             org_id: row.org_id ?? '',
             work_date: formatDateOnlyForCsv(row.work_date),
@@ -16744,7 +16840,29 @@ module.exports = {
             status: row.status ?? '',
             is_workday: row.is_workday ?? '',
           }))
-          const csv = buildCsv(csvRows, headers)
+          if (parsed.data.format === 'json') {
+            emitEvent('attendance.exported', {
+              orgId,
+              userId: targetUserId,
+              from,
+              to,
+              total: rows.length,
+              format: 'json',
+            })
+            res.json({
+              ok: true,
+              success: true,
+              data: {
+                items: exportItems,
+                total: rows.length,
+                from,
+                to,
+                format: 'json',
+              },
+            })
+            return
+          }
+          const csv = buildCsv(exportItems, headers)
           const filename = `attendance-${orgId}-${from}-to-${to}.csv`
 
           emitEvent('attendance.exported', {


### PR DESCRIPTION
## Summary
- fix login redirect flicker and expose a stable login locale switcher for Playwright coverage
- harden attendance validation and exports for run15 feedback, including XSS-safe group names, duplicate group 409s, timezone validation, future punch rejection, duplicate request dedupe, JSON export, and holiday type fields
- harden on-prem nginx examples against traversal-like API paths and sync OpenAPI source/dist artifacts

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/LoginView.spec.ts tests/App.spec.ts tests/authRedirect.spec.ts tests/utils/api.test.ts`
- `pnpm --filter @metasheet/web build`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "exports attendance JSON when format=json is requested|rejects HTML group names and returns 409 for duplicate attendance group names|rejects invalid timezones for attendance groups and payroll templates|rejects future punches and still allows immediate check-out after check-in when min interval is enabled|rejects negative leave type daily_minutes aliases and exposes holiday type fields|rejects invalid attendance calendar date ranges with 400|rejects duplicate attendance requests for the same day and request payload|exports attendance CSV with ISO date values and timezone-consistent timestamps"`
- `pnpm --filter @metasheet/core-backend build`
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm exec tsx packages/openapi/tools/build.ts`
- `node scripts/ops/attendance-validate-openapi-import-contract.mjs packages/openapi/dist/openapi.json packages/openapi/src/paths/attendance.yml`

## Notes
- `is_workday` behavior under real holiday/scheduling data still needs environment-side verification
- API envelope unification is not part of this patch; this only adds compatibility fields where needed