### PR TITLE
perf(multitable): recut grid state hardening on current main

### DIFF
--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -116,6 +116,7 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
 // --- Main composable ---
 
 const DEFAULT_PAGE_SIZE = 50
+const SEARCH_DEBOUNCE_MS = 150
 
 export function useMultitableGrid(opts: {
   sheetId: Ref<string>
@@ -132,6 +133,7 @@ export function useMultitableGrid(opts: {
   const linkSummaries = ref<Record<string, Record<string, LinkedRecordSummary[]>>>({})
   const loading = ref(false)
   const error = ref<string | null>(null)
+  let latestLoadRequestId = 0
 
   // Pagination
   const page = ref<MetaPage>({ offset: 0, limit: pageSize, total: 0, hasMore: false })
@@ -163,12 +165,13 @@ export function useMultitableGrid(opts: {
   let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
   function setSearchQuery(q: string) {
+    if (q === searchQuery.value) return
     searchQuery.value = q
     if (searchDebounceTimer) clearTimeout(searchDebounceTimer)
     searchDebounceTimer = setTimeout(() => {
       page.value = { ...page.value, offset: 0 }
       loadViewData(0)
-    }, 300)
+    }, SEARCH_DEBOUNCE_MS)
   }
 
   // Column widths (with localStorage persistence)
@@ -193,6 +196,7 @@ export function useMultitableGrid(opts: {
     const sid = opts.sheetId.value
     const vid = opts.viewId.value
     if (!sid) return
+    const requestId = ++latestLoadRequestId
     loading.value = true
     error.value = null
     try {
@@ -208,15 +212,26 @@ export function useMultitableGrid(opts: {
         includeLinkSummaries: true,
         search: searchQuery.value || undefined,
       })
+      if (requestId !== latestLoadRequestId) return
+      const serverPage = data.page
+      const serverRows = data.rows ?? []
+      if (serverPage && !serverRows.length && offset > 0 && offset >= serverPage.total) {
+        const fallbackOffset = Math.max(0, Math.floor(Math.max(serverPage.total - 1, 0) / pageSize) * pageSize)
+        if (fallbackOffset !== offset) {
+          await loadViewData(fallbackOffset)
+          return
+        }
+      }
       fields.value = data.fields ?? []
-      rows.value = data.rows ?? []
+      rows.value = serverRows
       linkSummaries.value = data.linkSummaries ?? {}
-      if (data.page) page.value = data.page
+      if (serverPage) page.value = serverPage
       if (data.view) syncFromView(data.view)
     } catch (e: any) {
+      if (requestId !== latestLoadRequestId) return
       error.value = e.message ?? 'Failed to load view data'
     } finally {
-      loading.value = false
+      if (requestId === latestLoadRequestId) loading.value = false
     }
   }
 
@@ -264,7 +279,9 @@ export function useMultitableGrid(opts: {
   // --- Pagination ---
 
   function goToPage(p: number) {
-    const offset = Math.max(0, (p - 1) * pageSize)
+    const safePage = Math.min(Math.max(1, p), totalPages.value)
+    const offset = Math.max(0, (safePage - 1) * pageSize)
+    if (offset === page.value.offset) return
     loadViewData(offset)
   }
 

--- a/apps/web/tests/multitable-grid.spec.ts
+++ b/apps/web/tests/multitable-grid.spec.ts
@@ -67,6 +67,54 @@ describe('useMultitableGrid', () => {
     expect(grid.fields.value).toEqual([{ id: 'f1', name: 'Title', type: 'string' }])
   })
 
+  it('ignores stale load responses and keeps the latest page data', async () => {
+    let resolveFirst: ((value: Response) => void) | null = null
+    let resolveSecond: ((value: Response) => void) | null = null
+    const fetchFn = vi.fn((input: string) => {
+      if (!input.startsWith('/api/multitable/view')) throw new Error(`Unexpected request: ${input}`)
+      return new Promise<Response>((resolve) => {
+        if (!resolveFirst) {
+          resolveFirst = resolve
+          return
+        }
+        resolveSecond = resolve
+      })
+    })
+
+    const grid = useMultitableGrid({
+      sheetId: ref('s1'),
+      viewId: ref('v1'),
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    grid.loadViewData(50)
+
+    resolveSecond?.(new Response(JSON.stringify({
+      ok: true,
+      data: {
+        fields: [{ id: 'f1', name: 'Title', type: 'string' }],
+        rows: [{ id: 'r2', version: 2, data: { f1: 'latest page' } }],
+        page: { offset: 50, limit: 50, total: 100, hasMore: false },
+      },
+    }), { status: 200 }))
+    await nextTick()
+    await nextTick()
+
+    resolveFirst?.(new Response(JSON.stringify({
+      ok: true,
+      data: {
+        fields: [{ id: 'f1', name: 'Title', type: 'string' }],
+        rows: [{ id: 'r1', version: 1, data: { f1: 'stale page' } }],
+        page: { offset: 0, limit: 50, total: 100, hasMore: true },
+      },
+    }), { status: 200 }))
+    await vi.waitFor(() => {
+      expect(grid.rows.value).toEqual([{ id: 'r2', version: 2, data: { f1: 'latest page' } }])
+    })
+
+    expect(grid.page.value.offset).toBe(50)
+  })
+
   it('toggle field visibility', () => {
     const grid = useMultitableGrid({ sheetId: ref('s1'), viewId: ref('v1'), client })
     grid.toggleFieldVisibility('f1')
@@ -99,6 +147,176 @@ describe('useMultitableGrid', () => {
     grid.page.value = { offset: 20, limit: 10, total: 55, hasMore: true }
     expect(grid.currentPage.value).toBe(3)
     expect(grid.totalPages.value).toBe(6)
+  })
+
+  it('falls back to the last non-empty page when a load lands beyond the new total', async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      if (!input.startsWith('/api/multitable/view')) throw new Error(`Unexpected request: ${input}`)
+      const url = new URL(`http://localhost${input}`)
+      const offset = Number(url.searchParams.get('offset') ?? '0')
+      if (offset === 20) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            fields: [{ id: 'f1', name: 'Title', type: 'string' }],
+            rows: [],
+            page: { offset: 20, limit: 10, total: 15, hasMore: false },
+          },
+        }), { status: 200 })
+      }
+      if (offset === 10) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            fields: [{ id: 'f1', name: 'Title', type: 'string' }],
+            rows: [{ id: 'r2', version: 2, data: { f1: 'last valid page' } }],
+            page: { offset: 10, limit: 10, total: 15, hasMore: false },
+          },
+        }), { status: 200 })
+      }
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          fields: [{ id: 'f1', name: 'Title', type: 'string' }],
+          rows: [{ id: 'r0', version: 1, data: { f1: 'initial page' } }],
+          page: { offset: 0, limit: 10, total: 15, hasMore: true },
+        },
+      }), { status: 200 })
+    })
+
+    const grid = useMultitableGrid({
+      sheetId: ref('s1'),
+      viewId: ref('v1'),
+      pageSize: 10,
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    await vi.waitFor(() => {
+      expect(grid.rows.value).toEqual([{ id: 'r0', version: 1, data: { f1: 'initial page' } }])
+    })
+    fetchFn.mockClear()
+
+    await grid.loadViewData(20)
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(fetchFn.mock.calls[0]?.[0]).toContain('offset=20')
+    expect(fetchFn.mock.calls[1]?.[0]).toContain('offset=10')
+    expect(grid.page.value.offset).toBe(10)
+    expect(grid.rows.value).toEqual([{ id: 'r2', version: 2, data: { f1: 'last valid page' } }])
+  })
+
+  it('clamps goToPage to the current total page count', async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      if (!input.startsWith('/api/multitable/view')) throw new Error(`Unexpected request: ${input}`)
+      const url = new URL(`http://localhost${input}`)
+      const offset = Number(url.searchParams.get('offset') ?? '0')
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          fields: [{ id: 'f1', name: 'Title', type: 'string' }],
+          rows: [],
+          page: { offset, limit: 10, total: 23, hasMore: offset < 20 },
+        },
+      }), { status: 200 })
+    })
+
+    const grid = useMultitableGrid({
+      sheetId: ref('s1'),
+      viewId: ref('v1'),
+      pageSize: 10,
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+    fetchFn.mockClear()
+
+    grid.page.value = { offset: 10, limit: 10, total: 23, hasMore: true }
+    grid.goToPage(99)
+
+    await vi.waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+
+    expect(fetchFn.mock.calls[0]?.[0]).toContain('offset=20')
+  })
+
+  it('does not refetch when goToPage resolves to the current offset', async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      if (!input.startsWith('/api/multitable/view')) throw new Error(`Unexpected request: ${input}`)
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          fields: [{ id: 'f1', name: 'Title', type: 'string' }],
+          rows: [{ id: 'r3', version: 1, data: { f1: 'page three' } }],
+          page: { offset: 20, limit: 10, total: 23, hasMore: false },
+        },
+      }), { status: 200 })
+    })
+
+    const grid = useMultitableGrid({
+      sheetId: ref('s1'),
+      viewId: ref('v1'),
+      pageSize: 10,
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+    fetchFn.mockClear()
+
+    grid.page.value = { offset: 20, limit: 10, total: 23, hasMore: false }
+    grid.goToPage(3)
+
+    await nextTick()
+
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('does not refetch when the search query is unchanged', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchFn = vi.fn(async (input: string) => {
+        if (!input.startsWith('/api/multitable/view')) throw new Error(`Unexpected request: ${input}`)
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            fields: [{ id: 'f1', name: 'Title', type: 'string' }],
+            rows: [{ id: 'r1', version: 1, data: { f1: 'Ship pilot' } }],
+            page: { offset: 0, limit: 50, total: 1, hasMore: false },
+          },
+        }), { status: 200 })
+      })
+
+      const grid = useMultitableGrid({
+        sheetId: ref('s1'),
+        viewId: ref('v1'),
+        client: new MultitableApiClient({ fetchFn }),
+      })
+
+      await vi.waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1)
+      })
+
+      fetchFn.mockClear()
+      grid.setSearchQuery('pilot')
+      vi.advanceTimersByTime(150)
+      await vi.waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1)
+      })
+      expect(fetchFn.mock.calls[0]?.[0]).toContain('search=pilot')
+
+      fetchFn.mockClear()
+      grid.setSearchQuery('pilot')
+      vi.advanceTimersByTime(150)
+      await nextTick()
+
+      expect(fetchFn).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('clearFilters resets all', () => {

--- a/apps/web/tests/multitable-phase15.spec.ts
+++ b/apps/web/tests/multitable-phase15.spec.ts
@@ -9,19 +9,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 describe('server-side search — debounce', () => {
   beforeEach(() => { vi.useFakeTimers() })
 
-  it('should debounce search input by 300ms', () => {
+  it('should debounce search input by 150ms', () => {
     let callCount = 0
     let timer: ReturnType<typeof setTimeout> | null = null
 
     function setSearchQuery(_q: string) {
       if (timer) clearTimeout(timer)
-      timer = setTimeout(() => { callCount++ }, 300)
+      timer = setTimeout(() => { callCount++ }, 150)
     }
 
     setSearchQuery('hel')
     setSearchQuery('hell')
     setSearchQuery('hello')
-    vi.advanceTimersByTime(300)
+    vi.advanceTimersByTime(150)
     expect(callCount).toBe(1) // Only one API call after debounce
     vi.useRealTimers()
   })
@@ -32,13 +32,13 @@ describe('server-side search — debounce', () => {
 
     function setSearchQuery(_q: string) {
       if (timer) clearTimeout(timer)
-      timer = setTimeout(() => { called = true }, 300)
+      timer = setTimeout(() => { called = true }, 150)
     }
 
     setSearchQuery('test')
-    vi.advanceTimersByTime(200) // Only 200ms
+    vi.advanceTimersByTime(100) // Only 100ms
     expect(called).toBe(false)
-    vi.advanceTimersByTime(100) // Now 300ms
+    vi.advanceTimersByTime(50) // Now 150ms
     expect(called).toBe(true)
     vi.useRealTimers()
   })

--- a/docs/development/multitable-grid-hardening-recut-development-20260320.md
+++ b/docs/development/multitable-grid-hardening-recut-development-20260320.md
@@ -1,0 +1,35 @@
+# Multitable Grid Hardening Recut Development
+
+Date: 2026-03-20
+
+## Scope
+
+Re-cut the next smallest safe multitable slice from current `main` after merged PR `#508`.
+
+Included:
+
+- `apps/web/src/multitable/composables/useMultitableGrid.ts`
+- `apps/web/tests/multitable-grid.spec.ts`
+- `apps/web/tests/multitable-phase15.spec.ts`
+
+Excluded on purpose:
+
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/tests/multitable-conflict-ux.spec.ts`
+- pilot/profile workflows and smoke scripts
+- attachment/import/backend/openapi follow-up work
+
+## Changes
+
+1. Added stale-response protection in `useMultitableGrid` so older requests cannot overwrite the latest grid page state.
+2. Added pagination fallback when the requested offset lands beyond the server's new total after data shrink.
+3. Clamped `goToPage()` to the current total page range and skipped redundant reloads when the resolved offset matches the current page.
+4. Reduced search debounce from `300ms` to `150ms`.
+5. Skipped redundant search reloads when the query value is unchanged.
+6. Added targeted tests for stale response handling, pagination fallback, page clamp/no-op behavior, and unchanged-search no-op behavior.
+
+## Recut Notes
+
+The original branch also contained conflict-banner work in `MultitableWorkbench.vue`, but current `main` has already evolved around attachment/form flows in that file. Carrying the older view layer wholesale would have increased merge risk without improving this slice's core value.
+
+This recut therefore keeps the slice at the grid state-management layer only.

--- a/docs/development/multitable-grid-hardening-recut-verification-20260320.md
+++ b/docs/development/multitable-grid-hardening-recut-verification-20260320.md
@@ -1,0 +1,25 @@
+# Multitable Grid Hardening Recut Verification
+
+Date: 2026-03-20
+
+## Local Verification
+
+Executed in `/tmp/metasheet2-multitable-grid-hardening`:
+
+```bash
+CI=true pnpm install --ignore-scripts
+pnpm --filter @metasheet/web exec vitest run tests/multitable-grid.spec.ts tests/multitable-phase15.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `57/57` passed
+- `vue-tsc --noEmit`: passed
+- `pnpm --filter @metasheet/web build`: passed
+
+## Notes
+
+- The temporary recut worktree needed `pnpm install --ignore-scripts` first because workspace tool binaries were not linked yet.
+- During that install, tracked plugin `node_modules` links became dirty in the recut worktree only; they were restored before commit so the slice stays limited to the intended frontend grid files and docs.


### PR DESCRIPTION
## Summary
- recut the next smallest multitable slice from current `main`
- harden `useMultitableGrid` against stale responses and out-of-range pagination reloads
- reduce search debounce to `150ms` and skip redundant reloads for unchanged search/page requests
- add targeted recut development and verification notes

## Scope
Included:
- `apps/web/src/multitable/composables/useMultitableGrid.ts`
- `apps/web/tests/multitable-grid.spec.ts`
- `apps/web/tests/multitable-phase15.spec.ts`
- `docs/development/multitable-grid-hardening-recut-development-20260320.md`
- `docs/development/multitable-grid-hardening-recut-verification-20260320.md`

Excluded on purpose:
- `MultitableWorkbench.vue` conflict-banner UI
- pilot/profile workflows and smoke scripts
- attachment/import/backend/openapi follow-up work

## Verification
- `CI=true pnpm install --ignore-scripts`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-grid.spec.ts tests/multitable-phase15.spec.ts`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`