### PR TITLE
feat(plm-audit): recut collaboration context on current main

### DIFF
--- a/apps/web/src/services/plm/plmWorkbenchClient.ts
+++ b/apps/web/src/services/plm/plmWorkbenchClient.ts
@@ -583,8 +583,11 @@ export async function batchPlmWorkbenchTeamViews<Kind extends PlmWorkbenchTeamVi
   }
 }
 
-export type PlmCollaborativeAuditResourceType = 'plm-team-preset-batch' | 'plm-team-view-batch'
-export type PlmCollaborativeAuditAction = 'archive' | 'restore' | 'delete'
+export type PlmCollaborativeAuditResourceType =
+  | 'plm-team-preset-batch'
+  | 'plm-team-view-batch'
+  | 'plm-team-view-default'
+export type PlmCollaborativeAuditAction = 'archive' | 'restore' | 'delete' | 'set-default' | 'clear-default'
 
 export interface PlmCollaborativeAuditFilters {
   page?: number
@@ -602,6 +605,8 @@ export interface PlmCollaborativeAuditLogMeta {
   tenantId?: string
   ownerUserId?: string
   audit?: string
+  kind?: string
+  viewName?: string
   requestedIds?: string[]
   processedIds?: string[]
   skippedIds?: string[]
@@ -656,6 +661,8 @@ function mapPlmCollaborativeAuditMeta(value: unknown): PlmCollaborativeAuditLogM
     tenantId: typeof record.tenantId === 'string' ? record.tenantId : undefined,
     ownerUserId: typeof record.ownerUserId === 'string' ? record.ownerUserId : undefined,
     audit: typeof record.audit === 'string' ? record.audit : undefined,
+    kind: typeof record.kind === 'string' ? record.kind : undefined,
+    viewName: typeof record.viewName === 'string' ? record.viewName : undefined,
     requestedIds: toStringArray(record.requestedIds),
     processedIds: toStringArray(record.processedIds),
     skippedIds: toStringArray(record.skippedIds),
@@ -669,7 +676,9 @@ function mapPlmCollaborativeAuditMeta(value: unknown): PlmCollaborativeAuditLogM
 function mapPlmCollaborativeAuditLogItem(value: unknown): PlmCollaborativeAuditLogItem {
   const record = value && typeof value === 'object' ? value as Record<string, unknown> : {}
   const resourceType =
-    record.resourceType === 'plm-team-preset-batch' || record.resourceType === 'plm-team-view-batch'
+    record.resourceType === 'plm-team-preset-batch'
+    || record.resourceType === 'plm-team-view-batch'
+    || record.resourceType === 'plm-team-view-default'
       ? record.resourceType
       : ''
 
@@ -763,7 +772,9 @@ export async function getPlmCollaborativeAuditSummary(params?: {
       ? payload.data.resourceTypes
         .map((row) => ({
           resourceType:
-            row.resourceType === 'plm-team-preset-batch' || row.resourceType === 'plm-team-view-batch'
+            row.resourceType === 'plm-team-preset-batch'
+            || row.resourceType === 'plm-team-view-batch'
+            || row.resourceType === 'plm-team-view-default'
               ? row.resourceType
               : undefined,
           total: typeof row.total === 'number' ? row.total : 0,

--- a/apps/web/src/views/PlmAuditView.vue
+++ b/apps/web/src/views/PlmAuditView.vue
@@ -21,6 +21,31 @@
       </div>
     </header>
 
+    <section v-if="auditSceneContext" class="plm-audit__context">
+      <div>
+        <small class="plm-audit__summary-source">{{ auditSceneContext.sourceLabel }}</small>
+        <strong>{{ auditSceneContext.title }}</strong>
+        <p class="plm-audit__muted">{{ auditSceneContext.description }}</p>
+      </div>
+      <div class="plm-audit__context-meta">
+        <span v-if="auditSceneContext.sceneName">{{ tr('Scene', '场景') }}: {{ auditSceneContext.sceneName }}</span>
+        <span v-if="auditSceneContext.sceneId">ID: {{ auditSceneContext.sceneId }}</span>
+        <span v-if="auditSceneContext.sceneOwnerUserId">Owner: {{ auditSceneContext.sceneOwnerUserId }}</span>
+      </div>
+      <div class="plm-audit__context-actions">
+        <button
+          v-for="actionItem in auditSceneToken?.actions || []"
+          :key="`scene-context-${actionItem.kind}-${actionItem.emphasis}`"
+          class="plm-audit__button"
+          type="button"
+          :disabled="logsLoading"
+          @click="runAuditSceneTokenAction(actionItem.kind)"
+        >
+          {{ actionItem.label }}
+        </button>
+      </div>
+    </section>
+
     <section class="plm-audit__summary">
       <article class="plm-audit__summary-card">
         <span class="plm-audit__summary-label">{{ tr('Window', '窗口') }}</span>
@@ -33,6 +58,29 @@
       <article class="plm-audit__summary-card">
         <span class="plm-audit__summary-label">{{ tr('Top actions', '主要动作') }}</span>
         <strong>{{ actionLabel(summary.actions[0]?.action || '') || '--' }}</strong>
+      </article>
+      <article
+        v-if="auditSceneSummaryCard"
+        class="plm-audit__summary-card plm-audit__summary-card--context"
+        :class="{
+          'plm-audit__summary-card--active': auditSceneSummaryCard.active,
+          'plm-audit__summary-card--owner': auditSceneSummaryCard.kind === 'owner',
+          'plm-audit__summary-card--scene': auditSceneSummaryCard.kind === 'scene',
+        }"
+      >
+        <small class="plm-audit__summary-source">{{ auditSceneSummaryCard.sourceLabel }}</small>
+        <span class="plm-audit__summary-label">{{ auditSceneSummaryCard.label }}</span>
+        <strong>{{ auditSceneSummaryCard.value }}</strong>
+        <span class="plm-audit__muted">{{ auditSceneSummaryCard.description }}</span>
+        <button
+          v-if="auditSceneSummaryCard.action"
+          class="plm-audit__button plm-audit__button--inline"
+          type="button"
+          :disabled="logsLoading"
+          @click="runAuditSceneSummaryAction(auditSceneSummaryCard.action)"
+        >
+          {{ auditSceneSummaryCard.actionLabel }}
+        </button>
       </article>
     </section>
 
@@ -58,8 +106,61 @@
     </section>
 
     <form class="plm-audit__filters" @submit.prevent="applyFilters">
-      <label class="plm-audit__field">
+      <div
+        v-if="auditSceneFilterHighlight"
+        class="plm-audit__filter-highlight"
+        :class="{
+          'plm-audit__filter-highlight--owner': auditSceneFilterHighlight.kind === 'owner',
+          'plm-audit__filter-highlight--scene': auditSceneFilterHighlight.kind === 'scene',
+        }"
+      >
+        <div>
+          <small class="plm-audit__summary-source">{{ auditSceneFilterHighlight.sourceLabel }}</small>
+          <strong>{{ auditSceneFilterHighlight.label }}</strong>
+          <span class="plm-audit__filter-highlight-value">{{ auditSceneFilterHighlight.value }}</span>
+          <p class="plm-audit__muted">{{ auditSceneFilterHighlight.description }}</p>
+        </div>
+        <button
+          v-for="actionItem in auditSceneFilterHighlight.actions"
+          :key="`scene-filter-${actionItem.kind}-${actionItem.emphasis}`"
+          class="plm-audit__button plm-audit__button--inline"
+          type="button"
+          :disabled="logsLoading"
+          @click="runAuditSceneTokenAction(actionItem.kind)"
+        >
+          {{ actionItem.label }}
+        </button>
+      </div>
+
+      <label class="plm-audit__field" :class="{ 'plm-audit__field--active': auditSceneOwnerContextActive || auditSceneQueryContextActive }">
         <span>{{ tr('Search', '搜索') }}</span>
+        <div
+          v-if="auditSceneInputToken"
+          class="plm-audit__field-token"
+          :class="{
+            'plm-audit__field-token--locked': auditSceneInputToken.locked,
+            'plm-audit__field-token--owner': auditSceneInputToken.kind === 'owner',
+            'plm-audit__field-token--scene': auditSceneInputToken.kind === 'scene',
+          }"
+        >
+          <div class="plm-audit__field-token-meta">
+            <strong>{{ auditSceneInputToken.label }}</strong>
+            <span class="plm-audit__field-token-value">{{ auditSceneInputToken.value }}</span>
+            <small class="plm-audit__muted">{{ auditSceneInputToken.description }}</small>
+          </div>
+          <div class="plm-audit__field-token-actions">
+            <button
+              v-for="actionItem in auditSceneInputToken.actions"
+              :key="`scene-input-${actionItem.kind}-${actionItem.emphasis}`"
+              class="plm-audit__button plm-audit__button--inline"
+              type="button"
+              :disabled="logsLoading"
+              @click="runAuditSceneTokenAction(actionItem.kind)"
+            >
+              {{ actionItem.label }}
+            </button>
+          </div>
+        </div>
         <input v-model="query" type="text" :placeholder="tr('Search actor, resource, or metadata', '搜索操作者、资源或元数据')" />
       </label>
       <label class="plm-audit__field">
@@ -85,6 +186,8 @@
           <option value="archive">{{ tr('Archive', '归档') }}</option>
           <option value="restore">{{ tr('Restore', '恢复') }}</option>
           <option value="delete">{{ tr('Delete', '删除') }}</option>
+          <option value="set-default">{{ tr('Set default', '设为默认') }}</option>
+          <option value="clear-default">{{ tr('Clear default', '取消默认') }}</option>
         </select>
       </label>
       <label class="plm-audit__field">
@@ -93,6 +196,7 @@
           <option value="">{{ tr('All', '全部') }}</option>
           <option value="plm-team-preset-batch">{{ tr('Team preset batch', '团队预设批量') }}</option>
           <option value="plm-team-view-batch">{{ tr('Team view batch', '团队视图批量') }}</option>
+          <option value="plm-team-view-default">{{ tr('Team default scene', '团队默认场景') }}</option>
         </select>
       </label>
       <label class="plm-audit__field">
@@ -159,6 +263,34 @@
         </button>
       </div>
 
+      <div
+        v-if="auditTeamViewContextNote"
+        class="plm-audit__team-view-context"
+        :class="{
+          'plm-audit__team-view-context--active': auditTeamViewContextNote.active,
+          'plm-audit__team-view-context--owner': auditTeamViewContextNote.kind === 'owner',
+          'plm-audit__team-view-context--scene': auditTeamViewContextNote.kind === 'scene',
+        }"
+      >
+        <div class="plm-audit__team-view-context-meta">
+          <small class="plm-audit__summary-source">{{ auditTeamViewContextNote.sourceLabel }}</small>
+          <strong>{{ auditTeamViewContextNote.label }}: {{ auditTeamViewContextNote.value }}</strong>
+          <span class="plm-audit__muted">{{ auditTeamViewContextNote.description }}</span>
+        </div>
+        <div class="plm-audit__team-view-context-actions">
+          <button
+            v-for="actionItem in auditTeamViewContextNote.actions"
+            :key="`team-view-context-${actionItem.kind}-${actionItem.emphasis}`"
+            class="plm-audit__button plm-audit__button--inline"
+            type="button"
+            :disabled="logsLoading || auditTeamViewsLoading"
+            @click="runAuditSceneTokenAction(actionItem.kind)"
+          >
+            {{ actionItem.label }}
+          </button>
+        </div>
+      </div>
+
       <p v-if="defaultAuditTeamViewLabel" class="plm-audit__muted">
         {{ tr('Current default', '当前默认') }}: {{ defaultAuditTeamViewLabel }}
       </p>
@@ -212,6 +344,34 @@
         >
           <div class="plm-audit__saved-view-meta">
             <strong>{{ view.name }}</strong>
+            <div v-if="savedViewContextBadge(view)" class="plm-audit__saved-view-badges">
+              <span class="plm-audit__saved-view-source">{{ savedViewContextBadge(view)?.sourceLabel }}</span>
+              <span
+                class="plm-audit__saved-view-badge"
+                :class="{
+                  'plm-audit__saved-view-badge--active': savedViewContextBadge(view)?.active,
+                  'plm-audit__saved-view-badge--owner': savedViewContextBadge(view)?.kind === 'owner',
+                  'plm-audit__saved-view-badge--scene': savedViewContextBadge(view)?.kind === 'scene',
+                }"
+              >
+                {{ savedViewContextBadge(view)?.label }}: {{ savedViewContextBadge(view)?.value }}
+              </span>
+              <button
+                v-if="savedViewContextBadge(view)?.quickAction"
+                class="plm-audit__button plm-audit__button--inline"
+                type="button"
+                :disabled="savedViewContextBadge(view)?.quickAction?.disabled"
+                @click="runSavedViewContextAction(view, savedViewContextBadge(view)!.quickAction!.kind)"
+              >
+                {{ savedViewContextBadge(view)?.quickAction?.label }}
+              </button>
+            </div>
+            <span
+              v-if="savedViewContextBadge(view)?.quickAction?.disabled"
+              class="plm-audit__muted"
+            >
+              {{ savedViewContextBadge(view)?.quickAction?.hint }}
+            </span>
             <span class="plm-audit__muted">{{ savedViewSummary(view.state) }}</span>
             <span class="plm-audit__muted">{{ tr('Updated', '更新于') }}: {{ formatDate(view.updatedAt) }}</span>
           </div>
@@ -322,6 +482,29 @@ import {
   savePlmAuditSavedView,
   type PlmAuditSavedView,
 } from './plmAuditSavedViews'
+import {
+  buildPlmAuditSavedViewContextBadge,
+  buildPlmAuditSavedViewSummary,
+} from './plmAuditSavedViewSummary'
+import {
+  buildPlmAuditSceneContextBanner,
+  buildPlmAuditSceneFilterHighlight,
+  resolvePlmAuditSceneSemantic,
+} from './plmAuditSceneCopy'
+import {
+  buildPlmAuditSceneQueryValue,
+  isPlmAuditSceneOwnerContextActive,
+  isPlmAuditSceneQueryContextActive,
+  withPlmAuditSceneOwnerContext,
+  withPlmAuditSceneQueryContext,
+} from './plmAuditSceneContext'
+import { buildPlmAuditSceneInputToken } from './plmAuditSceneInputToken'
+import { buildPlmAuditSceneSummaryCard } from './plmAuditSceneSummary'
+import {
+  buildPlmAuditSceneToken,
+  type PlmAuditSceneTokenActionKind,
+} from './plmAuditSceneToken'
+import { buildPlmAuditTeamViewContextNote } from './plmAuditTeamViewContext'
 import { copyTextToClipboard } from './plm/plmClipboard'
 import type { PlmWorkbenchTeamView } from './plm/plmPanelModels'
 import { buildPlmWorkbenchTeamViewShareUrl } from './plm/plmWorkbenchViewState'
@@ -356,6 +539,9 @@ const resourceType = ref<PlmCollaborativeAuditResourceType | ''>(DEFAULT_PLM_AUD
 const from = ref(DEFAULT_PLM_AUDIT_ROUTE_STATE.from)
 const to = ref(DEFAULT_PLM_AUDIT_ROUTE_STATE.to)
 const windowMinutes = ref(DEFAULT_PLM_AUDIT_ROUTE_STATE.windowMinutes)
+const auditSceneId = ref(DEFAULT_PLM_AUDIT_ROUTE_STATE.sceneId)
+const auditSceneName = ref(DEFAULT_PLM_AUDIT_ROUTE_STATE.sceneName)
+const auditSceneOwnerUserId = ref(DEFAULT_PLM_AUDIT_ROUTE_STATE.sceneOwnerUserId)
 
 const summary = ref<{
   windowMinutes: number
@@ -377,6 +563,39 @@ const defaultAuditTeamView = computed(
 )
 const defaultAuditTeamViewLabel = computed(() => defaultAuditTeamView.value?.name || '')
 const canSaveAuditTeamView = computed(() => Boolean(auditTeamViewName.value.trim()))
+const auditSceneContext = computed(() => {
+  return buildPlmAuditSceneContextBanner({
+    sceneId: auditSceneId.value,
+    sceneName: auditSceneName.value,
+    sceneOwnerUserId: auditSceneOwnerUserId.value,
+    action: action.value,
+    resourceType: resourceType.value,
+    semantic: resolvePlmAuditSceneSemantic({
+      sceneValue: buildPlmAuditSceneQueryValue(readCurrentRouteState()),
+      ownerValue: auditSceneOwnerUserId.value,
+      ownerContextActive: isPlmAuditSceneOwnerContextActive(readCurrentRouteState()),
+      sceneQueryContextActive: isPlmAuditSceneQueryContextActive(readCurrentRouteState()),
+    }),
+  }, tr)
+})
+const auditSceneOwnerContextActive = computed(() => isPlmAuditSceneOwnerContextActive(readCurrentRouteState()))
+const auditSceneQueryContextActive = computed(() => isPlmAuditSceneQueryContextActive(readCurrentRouteState()))
+const auditSceneToken = computed(() => buildPlmAuditSceneToken({
+  sceneValue: buildPlmAuditSceneQueryValue(readCurrentRouteState()),
+  ownerValue: auditSceneOwnerUserId.value,
+  ownerContextActive: auditSceneOwnerContextActive.value,
+  sceneQueryContextActive: auditSceneQueryContextActive.value,
+}, tr))
+const auditSceneInputToken = computed(() => buildPlmAuditSceneInputToken(auditSceneToken.value, tr))
+const auditTeamViewContextNote = computed(() => buildPlmAuditTeamViewContextNote(auditSceneToken.value, tr))
+const auditSceneSummaryCard = computed(() => buildPlmAuditSceneSummaryCard({
+  sceneId: auditSceneId.value,
+  sceneName: auditSceneName.value,
+  sceneOwnerUserId: auditSceneOwnerUserId.value,
+  ownerContextActive: auditSceneOwnerContextActive.value,
+  sceneQueryContextActive: auditSceneQueryContextActive.value,
+}, tr))
+const auditSceneFilterHighlight = computed(() => buildPlmAuditSceneFilterHighlight(auditSceneToken.value, tr))
 const canApplyAuditTeamView = computed(() => {
   const view = selectedAuditTeamView.value
   if (!view || view.isArchived) return false
@@ -415,6 +634,9 @@ function readCurrentRouteState(): PlmAuditRouteState {
     to: to.value,
     windowMinutes: windowMinutes.value,
     teamViewId: auditTeamViewKey.value,
+    sceneId: auditSceneId.value,
+    sceneName: auditSceneName.value,
+    sceneOwnerUserId: auditSceneOwnerUserId.value,
   }
 }
 
@@ -429,6 +651,9 @@ function applyRouteState(state: PlmAuditRouteState) {
   to.value = state.to
   windowMinutes.value = state.windowMinutes
   auditTeamViewKey.value = state.teamViewId
+  auditSceneId.value = state.sceneId
+  auditSceneName.value = state.sceneName
+  auditSceneOwnerUserId.value = state.sceneOwnerUserId
 }
 
 async function syncRouteState(nextState: PlmAuditRouteState, replace = false) {
@@ -440,6 +665,41 @@ async function syncRouteState(nextState: PlmAuditRouteState, replace = false) {
     name: 'plm-audit',
     query: nextQuery,
   })
+}
+
+async function clearAuditSceneContext() {
+  await syncRouteState({
+    ...readCurrentRouteState(),
+    sceneId: '',
+    sceneName: '',
+    sceneOwnerUserId: '',
+  })
+}
+
+async function applyAuditSceneOwnerContext() {
+  await syncRouteState(withPlmAuditSceneOwnerContext(readCurrentRouteState()))
+}
+
+async function restoreAuditSceneQuery() {
+  await syncRouteState(withPlmAuditSceneQueryContext(readCurrentRouteState()))
+}
+
+async function runAuditSceneTokenAction(actionKind: PlmAuditSceneTokenActionKind | null) {
+  if (actionKind === 'clear') {
+    await clearAuditSceneContext()
+    return
+  }
+  if (actionKind === 'owner') {
+    await applyAuditSceneOwnerContext()
+    return
+  }
+  if (actionKind === 'scene') {
+    await restoreAuditSceneQuery()
+  }
+}
+
+async function runAuditSceneSummaryAction(actionKind: 'owner' | 'scene' | null) {
+  await runAuditSceneTokenAction(actionKind)
 }
 
 function tr(en: string, zh: string): string {
@@ -455,12 +715,15 @@ function actionLabel(value: string): string {
   if (value === 'archive') return tr('Archive', '归档')
   if (value === 'restore') return tr('Restore', '恢复')
   if (value === 'delete') return tr('Delete', '删除')
+  if (value === 'set-default') return tr('Set default', '设为默认')
+  if (value === 'clear-default') return tr('Clear default', '取消默认')
   return value || '--'
 }
 
 function resourceTypeLabel(value: string): string {
   if (value === 'plm-team-preset-batch') return tr('Team preset batch', '团队预设批量')
   if (value === 'plm-team-view-batch') return tr('Team view batch', '团队视图批量')
+  if (value === 'plm-team-view-default') return tr('Team default scene', '团队默认场景')
   return value || '--'
 }
 
@@ -544,18 +807,32 @@ function buildAuditTeamViewShareUrl(view: PlmWorkbenchTeamView<'audit'>) {
 }
 
 function savedViewSummary(state: PlmAuditRouteState) {
-  const segments: string[] = []
-  if (state.q) segments.push(`${tr('Query', '查询')}: ${state.q}`)
-  if (state.actorId) segments.push(`${tr('Actor', '操作者')}: ${state.actorId}`)
-  if (state.kind) segments.push(`${tr('Kind', '类型')}: ${state.kind}`)
-  if (state.action) segments.push(`${tr('Action', '动作')}: ${actionLabel(state.action)}`)
-  if (state.resourceType) segments.push(`${tr('Resource', '资源')}: ${resourceTypeLabel(state.resourceType)}`)
-  segments.push(`${tr('Window', '窗口')}: ${state.windowMinutes} ${tr('minutes', '分钟')}`)
-  return segments.join(' · ') || tr('Default audit scope', '默认审计范围')
+  return buildPlmAuditSavedViewSummary(state, tr, actionLabel, resourceTypeLabel)
+}
+
+function savedViewContextBadge(view: PlmAuditSavedView) {
+  return buildPlmAuditSavedViewContextBadge(view.state, tr, readCurrentRouteState())
+}
+
+function buildSavedViewContextState(
+  view: PlmAuditSavedView,
+  actionKind: 'owner' | 'scene',
+) {
+  if (actionKind === 'owner') return withPlmAuditSceneOwnerContext(view.state)
+  return withPlmAuditSceneQueryContext(view.state)
 }
 
 function isSavedViewActive(view: PlmAuditSavedView) {
   return isPlmAuditRouteStateEqual(view.state, readCurrentRouteState())
+}
+
+function runSavedViewContextAction(
+  view: PlmAuditSavedView,
+  actionKind: 'owner' | 'scene',
+) {
+  const badge = savedViewContextBadge(view)
+  if (badge?.quickAction?.disabled) return
+  void syncRouteState(buildSavedViewContextState(view, actionKind))
 }
 
 function downloadCsvText(filename: string, csvText: string) {
@@ -919,6 +1196,32 @@ watch(
   gap: 8px;
 }
 
+.plm-audit__context {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 14px;
+}
+
+.plm-audit__context-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: #1e3a8a;
+  font-size: 12px;
+}
+
+.plm-audit__context-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .plm-audit__summary {
   flex-wrap: wrap;
 }
@@ -943,10 +1246,41 @@ watch(
   gap: 6px;
 }
 
+.plm-audit__summary-card--context {
+  min-width: 240px;
+}
+
+.plm-audit__summary-card--active {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.18);
+}
+
+.plm-audit__summary-card--owner {
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+}
+
+.plm-audit__summary-card--scene {
+  background: linear-gradient(180deg, #f0fdf4 0%, #ffffff 100%);
+}
+
+.plm-audit__button--inline {
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
 .plm-audit__summary-label,
 .plm-audit__muted {
   color: #64748b;
   font-size: 12px;
+}
+
+.plm-audit__summary-source,
+.plm-audit__saved-view-source {
+  color: #475569;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .plm-audit__summary-grid {
@@ -980,6 +1314,29 @@ watch(
   padding: 16px;
 }
 
+.plm-audit__filter-highlight {
+  display: flex;
+  flex: 1 1 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  background: #f8fbff;
+}
+
+.plm-audit__filter-highlight--scene {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.plm-audit__filter-highlight-value {
+  display: inline-flex;
+  margin-left: 8px;
+  font-weight: 700;
+}
+
 .plm-audit__team-views,
 .plm-audit__saved-views {
   display: flex;
@@ -999,6 +1356,35 @@ watch(
 .plm-audit__team-view-row {
   flex-wrap: wrap;
   align-items: center;
+}
+
+.plm-audit__team-view-context {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  background: #f8fbff;
+}
+
+.plm-audit__team-view-context--scene {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.plm-audit__team-view-context-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.plm-audit__team-view-context-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .plm-audit__saved-views-header {
@@ -1044,6 +1430,36 @@ watch(
   gap: 4px;
 }
 
+.plm-audit__saved-view-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.plm-audit__saved-view-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border: 1px solid #dbeafe;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.plm-audit__saved-view-badge--scene {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+  color: #15803d;
+}
+
+.plm-audit__saved-view-badge--active {
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.14);
+}
+
 .plm-audit__field {
   display: flex;
   flex: 1 1 180px;
@@ -1051,11 +1467,60 @@ watch(
   gap: 6px;
 }
 
+.plm-audit__field-token {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid #dbeafe;
+  border-radius: 10px;
+  background: #f8fbff;
+}
+
+.plm-audit__field-token--locked {
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.12);
+}
+
+.plm-audit__field-token--scene {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.plm-audit__field-token-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.plm-audit__field-token-value {
+  display: inline-flex;
+  font-weight: 700;
+}
+
+.plm-audit__field-token-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .plm-audit__field input,
 .plm-audit__field select {
   border: 1px solid #cbd5e1;
   border-radius: 10px;
   padding: 10px 12px;
+}
+
+.plm-audit__field--active span {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.plm-audit__field--active input,
+.plm-audit__field--active select {
+  border-color: #93c5fd;
+  background: #eff6ff;
 }
 
 .plm-audit__button {

--- a/apps/web/src/views/plmAuditQueryState.ts
+++ b/apps/web/src/views/plmAuditQueryState.ts
@@ -24,6 +24,9 @@ export interface PlmAuditRouteState {
   to: string
   windowMinutes: number
   teamViewId: string
+  sceneId: string
+  sceneName: string
+  sceneOwnerUserId: string
 }
 
 export const DEFAULT_PLM_AUDIT_ROUTE_STATE: PlmAuditRouteState = {
@@ -37,6 +40,9 @@ export const DEFAULT_PLM_AUDIT_ROUTE_STATE: PlmAuditRouteState = {
   to: '',
   windowMinutes: 180,
   teamViewId: '',
+  sceneId: '',
+  sceneName: '',
+  sceneOwnerUserId: '',
 }
 
 function readString(value: unknown) {
@@ -66,17 +72,26 @@ export function parsePlmAuditRouteState(query: LocationQuery): PlmAuditRouteStat
     actorId: readString(query.auditActor),
     kind: readString(query.auditKind),
     action:
-      action === 'archive' || action === 'restore' || action === 'delete'
+      action === 'archive'
+      || action === 'restore'
+      || action === 'delete'
+      || action === 'set-default'
+      || action === 'clear-default'
         ? action
         : '',
     resourceType:
-      resourceType === 'plm-team-preset-batch' || resourceType === 'plm-team-view-batch'
+      resourceType === 'plm-team-preset-batch'
+      || resourceType === 'plm-team-view-batch'
+      || resourceType === 'plm-team-view-default'
         ? resourceType
         : '',
     from: readString(query.auditFrom),
     to: readString(query.auditTo),
     windowMinutes: normalizeWindowMinutes(query.auditWindow),
     teamViewId: readString(query.auditTeamView),
+    sceneId: readString(query.auditSceneId),
+    sceneName: readString(query.auditSceneName),
+    sceneOwnerUserId: readString(query.auditSceneOwner),
   }
 }
 
@@ -95,6 +110,9 @@ export function buildPlmAuditRouteQuery(state: PlmAuditRouteState): LocationQuer
     query.auditWindow = String(state.windowMinutes)
   }
   if (state.teamViewId) query.auditTeamView = state.teamViewId
+  if (state.sceneId) query.auditSceneId = state.sceneId
+  if (state.sceneName) query.auditSceneName = state.sceneName
+  if (state.sceneOwnerUserId) query.auditSceneOwner = state.sceneOwnerUserId
 
   return query
 }
@@ -147,4 +165,7 @@ export function isPlmAuditRouteStateEqual(left: PlmAuditRouteState, right: PlmAu
     && left.to === right.to
     && left.windowMinutes === right.windowMinutes
     && left.teamViewId === right.teamViewId
+    && left.sceneId === right.sceneId
+    && left.sceneName === right.sceneName
+    && left.sceneOwnerUserId === right.sceneOwnerUserId
 }

--- a/apps/web/src/views/plmAuditSavedViewSummary.ts
+++ b/apps/web/src/views/plmAuditSavedViewSummary.ts
@@ -1,0 +1,93 @@
+import {
+  buildPlmAuditSceneQueryValue,
+  isPlmAuditSceneOwnerContextActive,
+  isPlmAuditSceneQueryContextActive,
+  withPlmAuditSceneOwnerContext,
+  withPlmAuditSceneQueryContext,
+} from './plmAuditSceneContext'
+import { buildPlmAuditSceneActionHint, buildPlmAuditSceneSourceCopy } from './plmAuditSceneCopy'
+import type { PlmAuditRouteState } from './plmAuditQueryState'
+import { buildPlmAuditSceneToken } from './plmAuditSceneToken'
+import type { PlmAuditSceneTokenActionKind } from './plmAuditSceneToken'
+
+export type PlmAuditSavedViewContextBadge = {
+  kind: 'owner' | 'scene'
+  sourceLabel: string
+  label: string
+  value: string
+  active: boolean
+  quickAction: {
+    kind: Exclude<PlmAuditSceneTokenActionKind, 'clear'>
+    label: string
+    disabled: boolean
+    hint: string
+  } | null
+}
+
+function isSameSceneContextTarget(
+  left: Pick<PlmAuditRouteState, 'q' | 'sceneId' | 'sceneName' | 'sceneOwnerUserId'>,
+  right: Pick<PlmAuditRouteState, 'q' | 'sceneId' | 'sceneName' | 'sceneOwnerUserId'>,
+) {
+  return left.q === right.q
+    && left.sceneId === right.sceneId
+    && left.sceneName === right.sceneName
+    && left.sceneOwnerUserId === right.sceneOwnerUserId
+}
+
+export function buildPlmAuditSavedViewContextBadge(
+  state: PlmAuditRouteState,
+  tr: (en: string, zh: string) => string,
+  currentState?: Pick<PlmAuditRouteState, 'q' | 'sceneId' | 'sceneName' | 'sceneOwnerUserId'>,
+): PlmAuditSavedViewContextBadge | null {
+  const token = buildPlmAuditSceneToken({
+    sceneValue: buildPlmAuditSceneQueryValue(state),
+    ownerValue: state.sceneOwnerUserId,
+    ownerContextActive: isPlmAuditSceneOwnerContextActive(state),
+    sceneQueryContextActive: isPlmAuditSceneQueryContextActive(state),
+  }, tr)
+
+  if (!token) return null
+
+  const primaryAction = token.actions.find((item) => item.emphasis === 'primary' && item.kind !== 'clear') ?? null
+  const ownerTarget = withPlmAuditSceneOwnerContext(state)
+  const sceneTarget = withPlmAuditSceneQueryContext(state)
+  const quickAction = primaryAction && primaryAction.kind !== 'clear'
+    ? {
+      kind: primaryAction.kind,
+      label: primaryAction.label,
+      disabled:
+        primaryAction.kind === 'owner'
+          ? Boolean(currentState && isSameSceneContextTarget(currentState, ownerTarget))
+          : Boolean(currentState && isSameSceneContextTarget(currentState, sceneTarget)),
+      hint:
+        buildPlmAuditSceneActionHint(primaryAction.kind, tr),
+    }
+    : null
+
+  return {
+    kind: token.kind,
+    sourceLabel: buildPlmAuditSceneSourceCopy('saved-view', tr).label,
+    label: token.label,
+    value: token.value,
+    active: token.active,
+    quickAction,
+  }
+}
+
+export function buildPlmAuditSavedViewSummary(
+  state: PlmAuditRouteState,
+  tr: (en: string, zh: string) => string,
+  actionLabel: (value: string) => string,
+  resourceTypeLabel: (value: string) => string,
+) {
+  const segments: string[] = []
+  if (state.sceneName) segments.push(`${tr('Scene', '场景')}: ${state.sceneName}`)
+  if (state.sceneOwnerUserId) segments.push(`Owner: ${state.sceneOwnerUserId}`)
+  if (state.q) segments.push(`${tr('Query', '查询')}: ${state.q}`)
+  if (state.actorId) segments.push(`${tr('Actor', '操作者')}: ${state.actorId}`)
+  if (state.kind) segments.push(`${tr('Kind', '类型')}: ${state.kind}`)
+  if (state.action) segments.push(`${tr('Action', '动作')}: ${actionLabel(state.action)}`)
+  if (state.resourceType) segments.push(`${tr('Resource', '资源')}: ${resourceTypeLabel(state.resourceType)}`)
+  segments.push(`${tr('Window', '窗口')}: ${state.windowMinutes} ${tr('minutes', '分钟')}`)
+  return segments.join(' · ') || tr('Default audit scope', '默认审计范围')
+}

--- a/apps/web/src/views/plmAuditSavedViews.ts
+++ b/apps/web/src/views/plmAuditSavedViews.ts
@@ -22,11 +22,37 @@ function isPlmAuditRouteState(value: unknown): value is PlmAuditRouteState {
     && typeof record.q === 'string'
     && typeof record.actorId === 'string'
     && typeof record.kind === 'string'
-    && (record.action === '' || record.action === 'archive' || record.action === 'restore' || record.action === 'delete')
-    && (record.resourceType === '' || record.resourceType === 'plm-team-preset-batch' || record.resourceType === 'plm-team-view-batch')
+    && (
+      record.action === ''
+      || record.action === 'archive'
+      || record.action === 'restore'
+      || record.action === 'delete'
+      || record.action === 'set-default'
+      || record.action === 'clear-default'
+    )
+    && (
+      record.resourceType === ''
+      || record.resourceType === 'plm-team-preset-batch'
+      || record.resourceType === 'plm-team-view-batch'
+      || record.resourceType === 'plm-team-view-default'
+    )
     && typeof record.from === 'string'
     && typeof record.to === 'string'
     && typeof record.windowMinutes === 'number'
+    && (record.teamViewId === undefined || typeof record.teamViewId === 'string')
+    && (record.sceneId === undefined || typeof record.sceneId === 'string')
+    && (record.sceneName === undefined || typeof record.sceneName === 'string')
+    && (record.sceneOwnerUserId === undefined || typeof record.sceneOwnerUserId === 'string')
+}
+
+function normalizePlmAuditRouteState(state: PlmAuditRouteState): PlmAuditRouteState {
+  return {
+    ...state,
+    teamViewId: state.teamViewId || '',
+    sceneId: state.sceneId || '',
+    sceneName: state.sceneName || '',
+    sceneOwnerUserId: state.sceneOwnerUserId || '',
+  }
 }
 
 function isPlmAuditSavedView(value: unknown): value is PlmAuditSavedView {
@@ -65,7 +91,13 @@ export function readPlmAuditSavedViews(storage?: Storage | null): PlmAuditSavedV
     if (!raw) return []
     const parsed = JSON.parse(raw) as unknown
     return Array.isArray(parsed)
-      ? parsed.filter(isPlmAuditSavedView).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      ? parsed
+        .filter(isPlmAuditSavedView)
+        .map((item) => ({
+          ...item,
+          state: normalizePlmAuditRouteState(item.state),
+        }))
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
       : []
   } catch {
     return []
@@ -85,7 +117,7 @@ export function savePlmAuditSavedView(name: string, state: PlmAuditRouteState, s
   const nextEntry: PlmAuditSavedView = {
     id: existing?.id ?? generateSavedViewId(),
     name: trimmedName,
-    state,
+    state: normalizePlmAuditRouteState(state),
     updatedAt: now,
   }
 

--- a/apps/web/src/views/plmAuditSceneContext.ts
+++ b/apps/web/src/views/plmAuditSceneContext.ts
@@ -1,0 +1,39 @@
+import type { PlmAuditRouteState } from './plmAuditQueryState'
+
+export function buildPlmAuditSceneQueryValue(state: Pick<PlmAuditRouteState, 'sceneId' | 'sceneName'>) {
+  return state.sceneId || state.sceneName || ''
+}
+
+export function isPlmAuditSceneOwnerContextActive(
+  state: Pick<PlmAuditRouteState, 'q' | 'sceneOwnerUserId'>,
+) {
+  return Boolean(state.sceneOwnerUserId) && state.q === state.sceneOwnerUserId
+}
+
+export function isPlmAuditSceneQueryContextActive(
+  state: Pick<PlmAuditRouteState, 'q' | 'sceneId' | 'sceneName'>,
+) {
+  const sceneQuery = buildPlmAuditSceneQueryValue(state)
+  return Boolean(sceneQuery) && state.q === sceneQuery
+}
+
+export function withPlmAuditSceneOwnerContext(state: PlmAuditRouteState): PlmAuditRouteState {
+  if (!state.sceneOwnerUserId) return state
+
+  return {
+    ...state,
+    page: 1,
+    q: state.sceneOwnerUserId,
+  }
+}
+
+export function withPlmAuditSceneQueryContext(state: PlmAuditRouteState): PlmAuditRouteState {
+  const nextQuery = buildPlmAuditSceneQueryValue(state)
+  if (!nextQuery) return state
+
+  return {
+    ...state,
+    page: 1,
+    q: nextQuery,
+  }
+}

--- a/apps/web/src/views/plmAuditSceneCopy.ts
+++ b/apps/web/src/views/plmAuditSceneCopy.ts
@@ -1,0 +1,261 @@
+export type PlmAuditSceneSurface = 'summary' | 'saved-view' | 'team-view'
+export type PlmAuditSceneKind = 'owner' | 'scene'
+export type PlmAuditSceneActionKind = 'owner' | 'scene' | 'clear'
+export type PlmAuditSceneSemantic = 'owner-context' | 'scene-context' | 'scene-owner' | 'scene-query'
+
+export type PlmAuditSceneSemanticInput = {
+  sceneValue: string
+  ownerValue: string
+  ownerContextActive: boolean
+  sceneQueryContextActive: boolean
+}
+
+export type PlmAuditSceneSemanticCopy = {
+  kind: PlmAuditSceneKind
+  label: string
+  description: string
+  active: boolean
+}
+
+export type PlmAuditSceneSourceCopy = {
+  label: string
+  description: string
+}
+
+export type PlmAuditSceneContextBannerInput = {
+  sceneId: string
+  sceneName: string
+  sceneOwnerUserId: string
+  action: string
+  resourceType: string
+  semantic: PlmAuditSceneSemantic | null
+}
+
+export type PlmAuditSceneContextBanner = {
+  title: string
+  sourceLabel: string
+  description: string
+  sceneId: string
+  sceneName: string
+  sceneOwnerUserId: string
+}
+
+export type PlmAuditSceneFilterHighlight = PlmAuditSceneSemanticCopy & {
+  sourceLabel: string
+  value: string
+  actions: Array<{
+    kind: PlmAuditSceneActionKind
+    label: string
+    emphasis: 'primary' | 'secondary'
+  }>
+}
+
+export function resolvePlmAuditSceneSemantic(
+  input: PlmAuditSceneSemanticInput,
+): PlmAuditSceneSemantic | null {
+  if (!input.sceneValue && !input.ownerValue) return null
+  if (input.ownerContextActive && input.ownerValue) return 'owner-context'
+  if (input.sceneQueryContextActive && input.sceneValue) return 'scene-context'
+  if (input.ownerValue) return 'scene-owner'
+  if (input.sceneValue) return 'scene-query'
+  return null
+}
+
+export function resolvePlmAuditSceneSemanticFromToken(
+  token: Pick<PlmAuditSceneSemanticCopy, 'kind' | 'active'>,
+): PlmAuditSceneSemantic {
+  if (token.kind === 'owner') {
+    return token.active ? 'owner-context' : 'scene-owner'
+  }
+  return token.active ? 'scene-context' : 'scene-query'
+}
+
+export function buildPlmAuditSceneSemanticCopy(
+  semantic: PlmAuditSceneSemantic,
+  tr: (en: string, zh: string) => string,
+): PlmAuditSceneSemanticCopy {
+  switch (semantic) {
+    case 'owner-context':
+      return {
+        kind: 'owner',
+        label: tr('Owner context', 'Owner 上下文'),
+        description: tr(
+          'Audit is currently focused on owner-related activity for this scene.',
+          '当前审计正在聚焦这个场景的 owner 相关活动。',
+        ),
+        active: true,
+      }
+    case 'scene-context':
+      return {
+        kind: 'scene',
+        label: tr('Scene query', '场景查询'),
+        description: tr(
+          'Audit is currently focused on the selected scene context.',
+          '当前审计正在聚焦所选场景上下文。',
+        ),
+        active: true,
+      }
+    case 'scene-owner':
+      return {
+        kind: 'owner',
+        label: tr('Scene owner', '场景 owner'),
+        description: tr(
+          'Use the owner as an audit shortcut for this recommended scene.',
+          '把这个推荐场景的 owner 作为审计快捷入口。',
+        ),
+        active: false,
+      }
+    case 'scene-query':
+      return {
+        kind: 'scene',
+        label: tr('Scene query', '场景查询'),
+        description: tr(
+          'Keep this audit view linked to the selected scene context.',
+          '让当前审计视图继续关联到所选场景上下文。',
+        ),
+        active: false,
+      }
+  }
+}
+
+export function buildPlmAuditSceneActionLabel(
+  action: PlmAuditSceneActionKind,
+  tr: (en: string, zh: string) => string,
+) {
+  switch (action) {
+    case 'owner':
+      return tr('Filter by owner', '按 owner 筛选')
+    case 'scene':
+      return tr('Restore scene query', '恢复场景查询')
+    case 'clear':
+      return tr('Clear context', '清除上下文')
+  }
+}
+
+export function buildPlmAuditSceneActionHint(
+  action: Exclude<PlmAuditSceneActionKind, 'clear'>,
+  tr: (en: string, zh: string) => string,
+) {
+  return action === 'owner'
+    ? tr('Current audit is already filtered by this scene owner.', '当前审计已按这个场景的 owner 过滤。')
+    : tr('Current audit is already using this scene query.', '当前审计已使用这个场景查询。')
+}
+
+export function buildPlmAuditSceneInputDescription(
+  semantic: PlmAuditSceneSemantic,
+  tr: (en: string, zh: string) => string,
+) {
+  switch (semantic) {
+    case 'owner-context':
+      return tr(
+        'Search is currently locked to the selected scene owner context.',
+        '当前搜索已锁定到所选场景的 owner 上下文。',
+      )
+    case 'scene-context':
+      return tr(
+        'Search is currently locked to the selected scene query.',
+        '当前搜索已锁定到所选场景查询。',
+      )
+    case 'scene-owner':
+      return tr(
+        'Use this token to pivot search to the scene owner when needed.',
+        '需要时可用这个 token 快速切到场景 owner 搜索。',
+      )
+    case 'scene-query':
+      return tr(
+        'Use this token to restore the selected scene query context.',
+        '可用这个 token 恢复所选场景查询上下文。',
+      )
+  }
+}
+
+export function buildPlmAuditSceneSourceCopy(
+  surface: PlmAuditSceneSurface,
+  tr: (en: string, zh: string) => string,
+): PlmAuditSceneSourceCopy {
+  if (surface === 'saved-view') {
+    return {
+      label: tr('Saved view context', '保存视图上下文'),
+      description: tr(
+        'This scene or owner context is stored with the local saved view.',
+        '这个场景或 owner 上下文会随本地保存视图一起保存。',
+      ),
+    }
+  }
+
+  if (surface === 'team-view') {
+    return {
+      label: tr('Local-only context', '仅本地上下文'),
+      description: tr(
+        'This scene or owner context is local to the current audit session and is not persisted in team views.',
+        '这个场景或 owner 上下文只属于当前审计会话，不会持久化进团队视图。',
+      ),
+    }
+  }
+
+  return {
+    label: tr('Local context', '本地上下文'),
+    description: tr(
+      'This summary reflects the current local scene or owner context.',
+      '这个汇总反映的是当前本地场景或 owner 上下文。',
+    ),
+  }
+}
+
+export function buildPlmAuditSceneContextBanner(
+  input: PlmAuditSceneContextBannerInput,
+  tr: (en: string, zh: string) => string,
+): PlmAuditSceneContextBanner | null {
+  if (!input.sceneId && !input.sceneName && !input.sceneOwnerUserId) return null
+
+  let description = tr('Opened from a recommended team scene card.', '来自推荐团队场景卡片。')
+  if (input.action === 'set-default' && input.resourceType === 'plm-team-view-default') {
+    description = tr('Opened from a recommended default-scene card.', '来自推荐团队默认场景卡片。')
+  } else if (input.semantic === 'owner-context') {
+    description = tr('Showing owner-related audit context for this scene.', '当前正在查看这个场景的 owner 相关审计上下文。')
+  }
+
+  return {
+    title: tr('Scene context', '场景上下文'),
+    sourceLabel: buildPlmAuditSceneSourceCopy('summary', tr).label,
+    description,
+    sceneId: input.sceneId,
+    sceneName: input.sceneName,
+    sceneOwnerUserId: input.sceneOwnerUserId,
+  }
+}
+
+export function buildPlmAuditSceneFilterHighlight(
+  token: {
+    kind: PlmAuditSceneKind
+    label: string
+    value: string
+    description: string
+    active: boolean
+    actions: Array<{
+      kind: PlmAuditSceneActionKind
+      label: string
+      emphasis: 'primary' | 'secondary'
+    }>
+  } | null,
+  tr: (en: string, zh: string) => string,
+): PlmAuditSceneFilterHighlight | null {
+  if (!token?.active) return null
+
+  return {
+    ...token,
+    sourceLabel: buildPlmAuditSceneSourceCopy('summary', tr).label,
+  }
+}
+
+export function buildPlmAuditTeamViewContextDescription(
+  active: boolean,
+  tr: (en: string, zh: string) => string,
+) {
+  return active
+    ? buildPlmAuditSceneSourceCopy('team-view', tr).description
+    : tr(
+      'This local context can be pivoted before applying or saving a team view, but team views still store route filters only.',
+      '这个本地上下文可在应用或保存团队视图前切换，但团队视图仍只保存路由过滤条件。',
+    )
+}

--- a/apps/web/src/views/plmAuditSceneInputToken.ts
+++ b/apps/web/src/views/plmAuditSceneInputToken.ts
@@ -1,0 +1,32 @@
+import {
+  buildPlmAuditSceneInputDescription,
+  resolvePlmAuditSceneSemanticFromToken,
+} from './plmAuditSceneCopy'
+import type { PlmAuditSceneToken } from './plmAuditSceneToken'
+
+export type PlmAuditSceneInputToken = {
+  kind: 'owner' | 'scene'
+  label: string
+  value: string
+  description: string
+  locked: boolean
+  actions: PlmAuditSceneToken['actions']
+}
+
+export function buildPlmAuditSceneInputToken(
+  token: PlmAuditSceneToken | null,
+  tr: (en: string, zh: string) => string,
+): PlmAuditSceneInputToken | null {
+  if (!token) return null
+
+  const semantic = resolvePlmAuditSceneSemanticFromToken(token)
+
+  return {
+    kind: token.kind,
+    label: token.label,
+    value: token.value,
+    description: buildPlmAuditSceneInputDescription(semantic, tr),
+    locked: token.active,
+    actions: token.actions,
+  }
+}

--- a/apps/web/src/views/plmAuditSceneSourceCopy.ts
+++ b/apps/web/src/views/plmAuditSceneSourceCopy.ts
@@ -1,0 +1,5 @@
+export {
+  buildPlmAuditSceneSourceCopy,
+  type PlmAuditSceneSourceCopy,
+  type PlmAuditSceneSurface as PlmAuditSceneSourceSurface,
+} from './plmAuditSceneCopy'

--- a/apps/web/src/views/plmAuditSceneSummary.ts
+++ b/apps/web/src/views/plmAuditSceneSummary.ts
@@ -1,0 +1,49 @@
+import { buildPlmAuditSceneQueryValue } from './plmAuditSceneContext'
+import { buildPlmAuditSceneSourceCopy } from './plmAuditSceneCopy'
+import { buildPlmAuditSceneToken } from './plmAuditSceneToken'
+
+export type PlmAuditSceneSummaryCard = {
+  kind: 'owner' | 'scene'
+  sourceLabel: string
+  label: string
+  value: string
+  description: string
+  action: 'owner' | 'scene' | null
+  actionLabel: string
+  active: boolean
+}
+
+export type PlmAuditSceneSummaryInput = {
+  sceneId: string
+  sceneName: string
+  sceneOwnerUserId: string
+  ownerContextActive: boolean
+  sceneQueryContextActive: boolean
+}
+
+export function buildPlmAuditSceneSummaryCard(
+  input: PlmAuditSceneSummaryInput,
+  tr: (en: string, zh: string) => string,
+): PlmAuditSceneSummaryCard | null {
+  const token = buildPlmAuditSceneToken({
+    sceneValue: buildPlmAuditSceneQueryValue(input),
+    ownerValue: input.sceneOwnerUserId,
+    ownerContextActive: input.ownerContextActive,
+    sceneQueryContextActive: input.sceneQueryContextActive,
+  }, tr)
+
+  if (!token) return null
+
+  const primaryAction = token.actions.find((item) => item.emphasis === 'primary') ?? null
+
+  return {
+    kind: token.kind,
+    sourceLabel: buildPlmAuditSceneSourceCopy('summary', tr).label,
+    label: token.label,
+    value: token.value,
+    description: token.description,
+    action: primaryAction?.kind === 'clear' ? null : (primaryAction?.kind ?? null),
+    actionLabel: primaryAction?.label ?? '',
+    active: token.active,
+  }
+}

--- a/apps/web/src/views/plmAuditSceneToken.ts
+++ b/apps/web/src/views/plmAuditSceneToken.ts
@@ -1,0 +1,70 @@
+import {
+  buildPlmAuditSceneActionLabel,
+  buildPlmAuditSceneSemanticCopy,
+  resolvePlmAuditSceneSemantic,
+  type PlmAuditSceneActionKind,
+} from './plmAuditSceneCopy'
+
+export type PlmAuditSceneTokenActionKind = PlmAuditSceneActionKind
+
+export type PlmAuditSceneTokenAction = {
+  kind: PlmAuditSceneTokenActionKind
+  label: string
+  emphasis: 'primary' | 'secondary'
+}
+
+export type PlmAuditSceneToken = {
+  kind: 'owner' | 'scene'
+  label: string
+  value: string
+  description: string
+  active: boolean
+  actions: PlmAuditSceneTokenAction[]
+}
+
+export type PlmAuditSceneTokenInput = {
+  sceneValue: string
+  ownerValue: string
+  ownerContextActive: boolean
+  sceneQueryContextActive: boolean
+}
+
+export function buildPlmAuditSceneToken(
+  input: PlmAuditSceneTokenInput,
+  tr: (en: string, zh: string) => string,
+): PlmAuditSceneToken | null {
+  const semantic = resolvePlmAuditSceneSemantic(input)
+  if (!semantic) return null
+
+  const copy = buildPlmAuditSceneSemanticCopy(semantic, tr)
+
+  const actions: PlmAuditSceneTokenAction[] = []
+  if (semantic === 'owner-context' && input.sceneValue) {
+    actions.push({
+      kind: 'scene',
+      label: buildPlmAuditSceneActionLabel('scene', tr),
+      emphasis: 'primary',
+    })
+  }
+  if ((semantic === 'scene-context' && input.ownerValue) || semantic === 'scene-owner') {
+    actions.push({
+      kind: 'owner',
+      label: buildPlmAuditSceneActionLabel('owner', tr),
+      emphasis: 'primary',
+    })
+  }
+  actions.push({
+    kind: 'clear',
+    label: buildPlmAuditSceneActionLabel('clear', tr),
+    emphasis: 'secondary',
+  })
+
+  return {
+    kind: copy.kind,
+    label: copy.label,
+    value: copy.kind === 'owner' ? input.ownerValue : input.sceneValue,
+    description: copy.description,
+    active: copy.active,
+    actions,
+  }
+}

--- a/apps/web/src/views/plmAuditTeamViewContext.ts
+++ b/apps/web/src/views/plmAuditTeamViewContext.ts
@@ -1,0 +1,34 @@
+import {
+  buildPlmAuditSceneSourceCopy,
+  buildPlmAuditTeamViewContextDescription,
+} from './plmAuditSceneCopy'
+import type { PlmAuditSceneToken } from './plmAuditSceneToken'
+
+export type PlmAuditTeamViewContextNote = {
+  kind: 'owner' | 'scene'
+  sourceLabel: string
+  label: string
+  value: string
+  description: string
+  localOnly: boolean
+  active: boolean
+  actions: PlmAuditSceneToken['actions']
+}
+
+export function buildPlmAuditTeamViewContextNote(
+  token: PlmAuditSceneToken | null,
+  tr: (en: string, zh: string) => string,
+): PlmAuditTeamViewContextNote | null {
+  if (!token) return null
+
+  return {
+    kind: token.kind,
+    sourceLabel: buildPlmAuditSceneSourceCopy('team-view', tr).label,
+    label: token.label,
+    value: token.value,
+    description: buildPlmAuditTeamViewContextDescription(token.active, tr),
+    localOnly: true,
+    active: token.active,
+    actions: token.actions,
+  }
+}

--- a/apps/web/tests/plmAuditQueryState.spec.ts
+++ b/apps/web/tests/plmAuditQueryState.spec.ts
@@ -21,6 +21,9 @@ describe('plmAuditQueryState', () => {
       auditFrom: '2026-03-11T15:00',
       auditTo: '2026-03-11T16:00',
       auditWindow: '720',
+      auditSceneId: 'scene-1',
+      auditSceneName: '采购团队场景',
+      auditSceneOwner: 'owner-a',
     })).toEqual({
       page: 3,
       q: 'documents',
@@ -32,6 +35,21 @@ describe('plmAuditQueryState', () => {
       to: '2026-03-11T16:00',
       windowMinutes: 720,
       teamViewId: '',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    })
+  })
+
+  it('accepts default-scene audit action and resource filters', () => {
+    expect(parsePlmAuditRouteState({
+      auditAction: 'set-default',
+      auditType: 'plm-team-view-default',
+      auditKind: 'workbench',
+    })).toMatchObject({
+      action: 'set-default',
+      resourceType: 'plm-team-view-default',
+      kind: 'workbench',
     })
   })
 
@@ -45,12 +63,18 @@ describe('plmAuditQueryState', () => {
       action: 'delete',
       windowMinutes: 60,
       teamViewId: 'audit-view-1',
+      sceneId: 'scene-2',
+      sceneName: 'BOM 巡检场景',
+      sceneOwnerUserId: 'owner-b',
     })).toEqual({
       auditPage: '2',
       auditQ: 'bom',
       auditAction: 'delete',
       auditWindow: '60',
       auditTeamView: 'audit-view-1',
+      auditSceneId: 'scene-2',
+      auditSceneName: 'BOM 巡检场景',
+      auditSceneOwner: 'owner-b',
     })
   })
 
@@ -78,6 +102,9 @@ describe('plmAuditQueryState', () => {
       to: '2026-03-11T16:00',
       windowMinutes: 720,
       teamViewId: 'audit-view-1',
+      sceneId: '',
+      sceneName: '',
+      sceneOwnerUserId: '',
     })
     expect(buildPlmAuditTeamViewState(state)).toEqual({
       page: 2,
@@ -97,6 +124,12 @@ describe('plmAuditQueryState', () => {
     expect(hasExplicitPlmAuditFilters({
       ...DEFAULT_PLM_AUDIT_ROUTE_STATE,
       teamViewId: 'audit-view-1',
+    })).toBe(false)
+    expect(hasExplicitPlmAuditFilters({
+      ...DEFAULT_PLM_AUDIT_ROUTE_STATE,
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
     })).toBe(false)
     expect(hasExplicitPlmAuditFilters({
       ...DEFAULT_PLM_AUDIT_ROUTE_STATE,

--- a/apps/web/tests/plmAuditSavedViewSummary.spec.ts
+++ b/apps/web/tests/plmAuditSavedViewSummary.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import type { PlmAuditRouteState } from '../src/views/plmAuditQueryState'
+import {
+  buildPlmAuditSavedViewContextBadge,
+  buildPlmAuditSavedViewSummary,
+} from '../src/views/plmAuditSavedViewSummary'
+
+function tr(en: string, zh: string) {
+  return `${en}|${zh}`
+}
+
+const sampleState: PlmAuditRouteState = {
+  page: 1,
+  q: '',
+  actorId: '',
+  kind: 'workbench',
+  action: 'set-default',
+  resourceType: 'plm-team-view-default',
+  from: '',
+  to: '',
+  windowMinutes: 180,
+  teamViewId: '',
+  sceneId: '',
+  sceneName: '',
+  sceneOwnerUserId: '',
+}
+
+describe('plmAuditSavedViewSummary', () => {
+  it('builds an owner-context badge when q is locked to the owner', () => {
+    expect(buildPlmAuditSavedViewContextBadge({
+      ...sampleState,
+      q: 'owner-a',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    }, tr)).toEqual({
+      kind: 'owner',
+      sourceLabel: 'Saved view context|保存视图上下文',
+      label: 'Owner context|Owner 上下文',
+      value: 'owner-a',
+      active: true,
+      quickAction: {
+        kind: 'scene',
+        label: 'Restore scene query|恢复场景查询',
+        disabled: false,
+        hint: 'Current audit is already using this scene query.|当前审计已使用这个场景查询。',
+      },
+    })
+  })
+
+  it('builds a scene-context badge when q is locked to the scene query', () => {
+    expect(buildPlmAuditSavedViewContextBadge({
+      ...sampleState,
+      q: 'scene-1',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    }, tr)).toEqual({
+      kind: 'scene',
+      sourceLabel: 'Saved view context|保存视图上下文',
+      label: 'Scene query|场景查询',
+      value: 'scene-1',
+      active: true,
+      quickAction: {
+        kind: 'owner',
+        label: 'Filter by owner|按 owner 筛选',
+        disabled: false,
+        hint: 'Current audit is already filtered by this scene owner.|当前审计已按这个场景的 owner 过滤。',
+      },
+    })
+  })
+
+  it('builds an owner shortcut badge with owner quick action when context is available but inactive', () => {
+    expect(buildPlmAuditSavedViewContextBadge({
+      ...sampleState,
+      q: 'documents',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    }, tr)).toEqual({
+      kind: 'owner',
+      sourceLabel: 'Saved view context|保存视图上下文',
+      label: 'Scene owner|场景 owner',
+      value: 'owner-a',
+      active: false,
+      quickAction: {
+        kind: 'owner',
+        label: 'Filter by owner|按 owner 筛选',
+        disabled: false,
+        hint: 'Current audit is already filtered by this scene owner.|当前审计已按这个场景的 owner 过滤。',
+      },
+    })
+  })
+
+  it('marks the quick action as disabled when current audit already matches the target context', () => {
+    expect(buildPlmAuditSavedViewContextBadge({
+      ...sampleState,
+      q: 'scene-1',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    }, tr, {
+      q: 'owner-a',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    })).toEqual({
+      kind: 'scene',
+      sourceLabel: 'Saved view context|保存视图上下文',
+      label: 'Scene query|场景查询',
+      value: 'scene-1',
+      active: true,
+      quickAction: {
+        kind: 'owner',
+        label: 'Filter by owner|按 owner 筛选',
+        disabled: true,
+        hint: 'Current audit is already filtered by this scene owner.|当前审计已按这个场景的 owner 过滤。',
+      },
+    })
+  })
+
+  it('builds a summary string that keeps scene and owner details', () => {
+    expect(buildPlmAuditSavedViewSummary({
+      ...sampleState,
+      q: 'scene-1',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    }, tr, (value) => value, (value) => value)).toContain('Scene|场景: 采购团队场景')
+  })
+})

--- a/apps/web/tests/plmAuditSavedViews.spec.ts
+++ b/apps/web/tests/plmAuditSavedViews.spec.ts
@@ -41,6 +41,9 @@ const sampleState: PlmAuditRouteState = {
   to: '',
   windowMinutes: 180,
   teamViewId: '',
+  sceneId: '',
+  sceneName: '',
+  sceneOwnerUserId: '',
 }
 
 describe('plmAuditSavedViews', () => {
@@ -85,4 +88,39 @@ describe('plmAuditSavedViews', () => {
     const next = deletePlmAuditSavedView(saved[0]!.id, storage)
     expect(next).toEqual([])
   })
+
+  it('keeps default-scene audit filters when saving and reading views', () => {
+    const storage = createMemoryStorage()
+
+    savePlmAuditSavedView('Workbench Defaults', {
+      ...sampleState,
+      kind: 'workbench',
+      action: 'set-default',
+      resourceType: 'plm-team-view-default',
+    }, storage)
+
+    expect(readPlmAuditSavedViews(storage)[0]?.state).toMatchObject({
+      kind: 'workbench',
+      action: 'set-default',
+      resourceType: 'plm-team-view-default',
+    })
+  })
+
+  it('keeps scene context when saving and reading views', () => {
+    const storage = createMemoryStorage()
+
+    savePlmAuditSavedView('Scene Context', {
+      ...sampleState,
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    }, storage)
+
+    expect(readPlmAuditSavedViews(storage)[0]?.state).toMatchObject({
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    })
+  })
+
 })

--- a/apps/web/tests/plmAuditSceneContext.spec.ts
+++ b/apps/web/tests/plmAuditSceneContext.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_PLM_AUDIT_ROUTE_STATE } from '../src/views/plmAuditQueryState'
+import {
+  buildPlmAuditSceneQueryValue,
+  isPlmAuditSceneQueryContextActive,
+  isPlmAuditSceneOwnerContextActive,
+  withPlmAuditSceneOwnerContext,
+  withPlmAuditSceneQueryContext,
+} from '../src/views/plmAuditSceneContext'
+
+describe('plmAuditSceneContext', () => {
+  it('prefers scene id when building the scene query value', () => {
+    expect(buildPlmAuditSceneQueryValue({
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+    })).toBe('scene-1')
+
+    expect(buildPlmAuditSceneQueryValue({
+      sceneId: '',
+      sceneName: '采购团队场景',
+    })).toBe('采购团队场景')
+  })
+
+  it('switches to owner context without dropping scene metadata', () => {
+    expect(withPlmAuditSceneOwnerContext({
+      ...DEFAULT_PLM_AUDIT_ROUTE_STATE,
+      page: 4,
+      q: 'scene-1',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    })).toMatchObject({
+      page: 1,
+      q: 'owner-a',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    })
+  })
+
+  it('can restore the scene query after switching to owner context', () => {
+    expect(withPlmAuditSceneQueryContext({
+      ...DEFAULT_PLM_AUDIT_ROUTE_STATE,
+      page: 2,
+      q: 'owner-a',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    })).toMatchObject({
+      page: 1,
+      q: 'scene-1',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+    })
+  })
+
+  it('detects when owner context is active', () => {
+    expect(isPlmAuditSceneOwnerContextActive({
+      q: 'owner-a',
+      sceneOwnerUserId: 'owner-a',
+    })).toBe(true)
+
+    expect(isPlmAuditSceneOwnerContextActive({
+      q: 'scene-1',
+      sceneOwnerUserId: 'owner-a',
+    })).toBe(false)
+  })
+
+  it('detects when scene query context is active', () => {
+    expect(isPlmAuditSceneQueryContextActive({
+      q: 'scene-1',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+    })).toBe(true)
+
+    expect(isPlmAuditSceneQueryContextActive({
+      q: 'owner-a',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+    })).toBe(false)
+  })
+})

--- a/apps/web/tests/plmAuditSceneCopy.spec.ts
+++ b/apps/web/tests/plmAuditSceneCopy.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPlmAuditSceneActionHint,
+  buildPlmAuditSceneActionLabel,
+  buildPlmAuditSceneContextBanner,
+  buildPlmAuditSceneFilterHighlight,
+  buildPlmAuditSceneInputDescription,
+  buildPlmAuditSceneSemanticCopy,
+  buildPlmAuditTeamViewContextDescription,
+  resolvePlmAuditSceneSemantic,
+  resolvePlmAuditSceneSemanticFromToken,
+} from '../src/views/plmAuditSceneCopy'
+
+function tr(en: string, zh: string) {
+  return `${en}|${zh}`
+}
+
+describe('plmAuditSceneCopy', () => {
+  it('resolves semantic from route state shape', () => {
+    expect(resolvePlmAuditSceneSemantic({
+      sceneValue: 'scene-1',
+      ownerValue: 'owner-a',
+      ownerContextActive: true,
+      sceneQueryContextActive: false,
+    })).toBe('owner-context')
+    expect(resolvePlmAuditSceneSemantic({
+      sceneValue: 'scene-1',
+      ownerValue: '',
+      ownerContextActive: false,
+      sceneQueryContextActive: false,
+    })).toBe('scene-query')
+  })
+
+  it('resolves semantic from token shape', () => {
+    expect(resolvePlmAuditSceneSemanticFromToken({ kind: 'owner', active: false })).toBe('scene-owner')
+    expect(resolvePlmAuditSceneSemanticFromToken({ kind: 'scene', active: true })).toBe('scene-context')
+  })
+
+  it('builds semantic copy and input description from the same contract', () => {
+    expect(buildPlmAuditSceneSemanticCopy('scene-owner', tr)).toEqual({
+      kind: 'owner',
+      label: 'Scene owner|场景 owner',
+      description: 'Use the owner as an audit shortcut for this recommended scene.|把这个推荐场景的 owner 作为审计快捷入口。',
+      active: false,
+    })
+    expect(buildPlmAuditSceneInputDescription('scene-owner', tr)).toBe(
+      'Use this token to pivot search to the scene owner when needed.|需要时可用这个 token 快速切到场景 owner 搜索。',
+    )
+  })
+
+  it('builds action labels and hints from the same contract', () => {
+    expect(buildPlmAuditSceneActionLabel('scene', tr)).toBe('Restore scene query|恢复场景查询')
+    expect(buildPlmAuditSceneActionLabel('clear', tr)).toBe('Clear context|清除上下文')
+    expect(buildPlmAuditSceneActionHint('owner', tr)).toBe(
+      'Current audit is already filtered by this scene owner.|当前审计已按这个场景的 owner 过滤。',
+    )
+  })
+
+  it('builds team-view descriptions from the shared contract', () => {
+    expect(buildPlmAuditTeamViewContextDescription(true, tr)).toBe(
+      'This scene or owner context is local to the current audit session and is not persisted in team views.|这个场景或 owner 上下文只属于当前审计会话，不会持久化进团队视图。',
+    )
+    expect(buildPlmAuditTeamViewContextDescription(false, tr)).toBe(
+      'This local context can be pivoted before applying or saving a team view, but team views still store route filters only.|这个本地上下文可在应用或保存团队视图前切换，但团队视图仍只保存路由过滤条件。',
+    )
+  })
+
+  it('builds context banner copy from the shared contract', () => {
+    expect(buildPlmAuditSceneContextBanner({
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+      action: 'set-default',
+      resourceType: 'plm-team-view-default',
+      semantic: 'owner-context',
+    }, tr)).toEqual({
+      title: 'Scene context|场景上下文',
+      sourceLabel: 'Local context|本地上下文',
+      description: 'Opened from a recommended default-scene card.|来自推荐团队默认场景卡片。',
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+    })
+  })
+
+  it('builds filter highlight copy from the shared contract', () => {
+    expect(buildPlmAuditSceneFilterHighlight({
+      kind: 'owner',
+      label: 'Owner context|Owner 上下文',
+      value: 'owner-a',
+      description: 'Audit is currently focused on owner-related activity for this scene.|当前审计正在聚焦这个场景的 owner 相关活动。',
+      active: true,
+      actions: [
+        { kind: 'scene', label: 'Restore scene query|恢复场景查询', emphasis: 'primary' },
+        { kind: 'clear', label: 'Clear context|清除上下文', emphasis: 'secondary' },
+      ],
+    }, tr)).toEqual({
+      kind: 'owner',
+      sourceLabel: 'Local context|本地上下文',
+      label: 'Owner context|Owner 上下文',
+      value: 'owner-a',
+      description: 'Audit is currently focused on owner-related activity for this scene.|当前审计正在聚焦这个场景的 owner 相关活动。',
+      active: true,
+      actions: [
+        { kind: 'scene', label: 'Restore scene query|恢复场景查询', emphasis: 'primary' },
+        { kind: 'clear', label: 'Clear context|清除上下文', emphasis: 'secondary' },
+      ],
+    })
+  })
+})

--- a/apps/web/tests/plmAuditSceneInputToken.spec.ts
+++ b/apps/web/tests/plmAuditSceneInputToken.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlmAuditSceneInputToken } from '../src/views/plmAuditSceneInputToken'
+import { buildPlmAuditSceneToken } from '../src/views/plmAuditSceneToken'
+
+function tr(en: string, zh: string) {
+  return `${en}|${zh}`
+}
+
+describe('plmAuditSceneInputToken', () => {
+  it('builds a locked owner input token when owner context is active', () => {
+    const token = buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: 'owner-a',
+      ownerContextActive: true,
+      sceneQueryContextActive: false,
+    }, tr)
+
+    expect(buildPlmAuditSceneInputToken(token, tr)).toEqual({
+      kind: 'owner',
+      label: 'Owner context|Owner 上下文',
+      value: 'owner-a',
+      description: 'Search is currently locked to the selected scene owner context.|当前搜索已锁定到所选场景的 owner 上下文。',
+      locked: true,
+      actions: [
+        {
+          kind: 'scene',
+          label: 'Restore scene query|恢复场景查询',
+          emphasis: 'primary',
+        },
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('builds a locked scene input token when scene query context is active', () => {
+    const token = buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: 'owner-a',
+      ownerContextActive: false,
+      sceneQueryContextActive: true,
+    }, tr)
+
+    expect(buildPlmAuditSceneInputToken(token, tr)).toEqual({
+      kind: 'scene',
+      label: 'Scene query|场景查询',
+      value: 'scene-1',
+      description: 'Search is currently locked to the selected scene query.|当前搜索已锁定到所选场景查询。',
+      locked: true,
+      actions: [
+        {
+          kind: 'owner',
+          label: 'Filter by owner|按 owner 筛选',
+          emphasis: 'primary',
+        },
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('builds an unlocked owner input token when owner shortcut is available', () => {
+    const token = buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: 'owner-a',
+      ownerContextActive: false,
+      sceneQueryContextActive: false,
+    }, tr)
+
+    expect(buildPlmAuditSceneInputToken(token, tr)).toEqual({
+      kind: 'owner',
+      label: 'Scene owner|场景 owner',
+      value: 'owner-a',
+      description: 'Use this token to pivot search to the scene owner when needed.|需要时可用这个 token 快速切到场景 owner 搜索。',
+      locked: false,
+      actions: [
+        {
+          kind: 'owner',
+          label: 'Filter by owner|按 owner 筛选',
+          emphasis: 'primary',
+        },
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('returns null without token input', () => {
+    expect(buildPlmAuditSceneInputToken(null, tr)).toBeNull()
+  })
+})

--- a/apps/web/tests/plmAuditSceneSourceCopy.spec.ts
+++ b/apps/web/tests/plmAuditSceneSourceCopy.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlmAuditSceneSourceCopy } from '../src/views/plmAuditSceneSourceCopy'
+
+function tr(en: string, zh: string) {
+  return `${en}|${zh}`
+}
+
+describe('plmAuditSceneSourceCopy', () => {
+  it('builds summary source copy', () => {
+    expect(buildPlmAuditSceneSourceCopy('summary', tr)).toEqual({
+      label: 'Local context|本地上下文',
+      description: 'This summary reflects the current local scene or owner context.|这个汇总反映的是当前本地场景或 owner 上下文。',
+    })
+  })
+
+  it('builds saved-view source copy', () => {
+    expect(buildPlmAuditSceneSourceCopy('saved-view', tr)).toEqual({
+      label: 'Saved view context|保存视图上下文',
+      description: 'This scene or owner context is stored with the local saved view.|这个场景或 owner 上下文会随本地保存视图一起保存。',
+    })
+  })
+
+  it('builds team-view source copy', () => {
+    expect(buildPlmAuditSceneSourceCopy('team-view', tr)).toEqual({
+      label: 'Local-only context|仅本地上下文',
+      description: 'This scene or owner context is local to the current audit session and is not persisted in team views.|这个场景或 owner 上下文只属于当前审计会话，不会持久化进团队视图。',
+    })
+  })
+})

--- a/apps/web/tests/plmAuditSceneSummary.spec.ts
+++ b/apps/web/tests/plmAuditSceneSummary.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlmAuditSceneSummaryCard } from '../src/views/plmAuditSceneSummary'
+
+function tr(en: string, zh: string) {
+  return `${en}|${zh}`
+}
+
+describe('plmAuditSceneSummary', () => {
+  it('builds an owner-context summary card when owner filtering is active', () => {
+    expect(buildPlmAuditSceneSummaryCard({
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+      ownerContextActive: true,
+      sceneQueryContextActive: false,
+    }, tr)).toEqual({
+      kind: 'owner',
+      sourceLabel: 'Local context|本地上下文',
+      label: 'Owner context|Owner 上下文',
+      value: 'owner-a',
+      description: 'Audit is currently focused on owner-related activity for this scene.|当前审计正在聚焦这个场景的 owner 相关活动。',
+      action: 'scene',
+      actionLabel: 'Restore scene query|恢复场景查询',
+      active: true,
+    })
+  })
+
+  it('builds an active scene-query card when scene context drives the current query', () => {
+    expect(buildPlmAuditSceneSummaryCard({
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+      ownerContextActive: false,
+      sceneQueryContextActive: true,
+    }, tr)).toEqual({
+      kind: 'scene',
+      sourceLabel: 'Local context|本地上下文',
+      label: 'Scene query|场景查询',
+      value: 'scene-1',
+      description: 'Audit is currently focused on the selected scene context.|当前审计正在聚焦所选场景上下文。',
+      action: 'owner',
+      actionLabel: 'Filter by owner|按 owner 筛选',
+      active: true,
+    })
+  })
+
+  it('builds an owner shortcut card when owner context is available but inactive', () => {
+    expect(buildPlmAuditSceneSummaryCard({
+      sceneId: 'scene-1',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: 'owner-a',
+      ownerContextActive: false,
+      sceneQueryContextActive: false,
+    }, tr)).toEqual({
+      kind: 'owner',
+      sourceLabel: 'Local context|本地上下文',
+      label: 'Scene owner|场景 owner',
+      value: 'owner-a',
+      description: 'Use the owner as an audit shortcut for this recommended scene.|把这个推荐场景的 owner 作为审计快捷入口。',
+      action: 'owner',
+      actionLabel: 'Filter by owner|按 owner 筛选',
+      active: false,
+    })
+  })
+
+  it('falls back to a scene-query summary when no owner is present', () => {
+    expect(buildPlmAuditSceneSummaryCard({
+      sceneId: '',
+      sceneName: '采购团队场景',
+      sceneOwnerUserId: '',
+      ownerContextActive: false,
+      sceneQueryContextActive: true,
+    }, tr)).toEqual({
+      kind: 'scene',
+      sourceLabel: 'Local context|本地上下文',
+      label: 'Scene query|场景查询',
+      value: '采购团队场景',
+      description: 'Audit is currently focused on the selected scene context.|当前审计正在聚焦所选场景上下文。',
+      action: null,
+      actionLabel: '',
+      active: true,
+    })
+  })
+
+  it('returns null when there is no scene context', () => {
+    expect(buildPlmAuditSceneSummaryCard({
+      sceneId: '',
+      sceneName: '',
+      sceneOwnerUserId: '',
+      ownerContextActive: false,
+      sceneQueryContextActive: false,
+    }, tr)).toBeNull()
+  })
+})

--- a/apps/web/tests/plmAuditSceneToken.spec.ts
+++ b/apps/web/tests/plmAuditSceneToken.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlmAuditSceneToken } from '../src/views/plmAuditSceneToken'
+
+function tr(en: string, zh: string) {
+  return `${en}|${zh}`
+}
+
+describe('plmAuditSceneToken', () => {
+  it('builds owner-active token with restore and clear actions', () => {
+    expect(buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: 'owner-a',
+      ownerContextActive: true,
+      sceneQueryContextActive: false,
+    }, tr)).toEqual({
+      kind: 'owner',
+      label: 'Owner context|Owner 上下文',
+      value: 'owner-a',
+      description: 'Audit is currently focused on owner-related activity for this scene.|当前审计正在聚焦这个场景的 owner 相关活动。',
+      active: true,
+      actions: [
+        {
+          kind: 'scene',
+          label: 'Restore scene query|恢复场景查询',
+          emphasis: 'primary',
+        },
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('builds scene-active token with owner pivot and clear actions', () => {
+    expect(buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: 'owner-a',
+      ownerContextActive: false,
+      sceneQueryContextActive: true,
+    }, tr)).toEqual({
+      kind: 'scene',
+      label: 'Scene query|场景查询',
+      value: 'scene-1',
+      description: 'Audit is currently focused on the selected scene context.|当前审计正在聚焦所选场景上下文。',
+      active: true,
+      actions: [
+        {
+          kind: 'owner',
+          label: 'Filter by owner|按 owner 筛选',
+          emphasis: 'primary',
+        },
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('builds inactive owner token with owner pivot and clear actions', () => {
+    expect(buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: 'owner-a',
+      ownerContextActive: false,
+      sceneQueryContextActive: false,
+    }, tr)).toEqual({
+      kind: 'owner',
+      label: 'Scene owner|场景 owner',
+      value: 'owner-a',
+      description: 'Use the owner as an audit shortcut for this recommended scene.|把这个推荐场景的 owner 作为审计快捷入口。',
+      active: false,
+      actions: [
+        {
+          kind: 'owner',
+          label: 'Filter by owner|按 owner 筛选',
+          emphasis: 'primary',
+        },
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('builds scene-only token with clear action', () => {
+    expect(buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: '',
+      ownerContextActive: false,
+      sceneQueryContextActive: false,
+    }, tr)).toEqual({
+      kind: 'scene',
+      label: 'Scene query|场景查询',
+      value: 'scene-1',
+      description: 'Keep this audit view linked to the selected scene context.|让当前审计视图继续关联到所选场景上下文。',
+      active: false,
+      actions: [
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('returns null without scene or owner context', () => {
+    expect(buildPlmAuditSceneToken({
+      sceneValue: '',
+      ownerValue: '',
+      ownerContextActive: false,
+      sceneQueryContextActive: false,
+    }, tr)).toBeNull()
+  })
+})

--- a/apps/web/tests/plmAuditTeamViewContext.spec.ts
+++ b/apps/web/tests/plmAuditTeamViewContext.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlmAuditSceneToken } from '../src/views/plmAuditSceneToken'
+import { buildPlmAuditTeamViewContextNote } from '../src/views/plmAuditTeamViewContext'
+
+function tr(en: string, zh: string) {
+  return `${en}|${zh}`
+}
+
+describe('plmAuditTeamViewContext', () => {
+  it('builds a local-only note for active owner context', () => {
+    const token = buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: 'owner-a',
+      ownerContextActive: true,
+      sceneQueryContextActive: false,
+    }, tr)
+
+    expect(buildPlmAuditTeamViewContextNote(token, tr)).toEqual({
+      kind: 'owner',
+      sourceLabel: 'Local-only context|仅本地上下文',
+      label: 'Owner context|Owner 上下文',
+      value: 'owner-a',
+      description: 'This scene or owner context is local to the current audit session and is not persisted in team views.|这个场景或 owner 上下文只属于当前审计会话，不会持久化进团队视图。',
+      localOnly: true,
+      active: true,
+      actions: [
+        {
+          kind: 'scene',
+          label: 'Restore scene query|恢复场景查询',
+          emphasis: 'primary',
+        },
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('builds a local-only note for inactive scene context', () => {
+    const token = buildPlmAuditSceneToken({
+      sceneValue: 'scene-1',
+      ownerValue: '',
+      ownerContextActive: false,
+      sceneQueryContextActive: false,
+    }, tr)
+
+    expect(buildPlmAuditTeamViewContextNote(token, tr)).toEqual({
+      kind: 'scene',
+      sourceLabel: 'Local-only context|仅本地上下文',
+      label: 'Scene query|场景查询',
+      value: 'scene-1',
+      description: 'This local context can be pivoted before applying or saving a team view, but team views still store route filters only.|这个本地上下文可在应用或保存团队视图前切换，但团队视图仍只保存路由过滤条件。',
+      localOnly: true,
+      active: false,
+      actions: [
+        {
+          kind: 'clear',
+          label: 'Clear context|清除上下文',
+          emphasis: 'secondary',
+        },
+      ],
+    })
+  })
+
+  it('returns null without scene token', () => {
+    expect(buildPlmAuditTeamViewContextNote(null, tr)).toBeNull()
+  })
+})

--- a/docs/development/plm-audit-collaboration-recut-development-20260320.md
+++ b/docs/development/plm-audit-collaboration-recut-development-20260320.md
@@ -1,0 +1,39 @@
+# PLM Audit Collaboration Recut Development
+
+Date: 2026-03-20
+Base: `origin/main` at `73dbbe5d0acb771b9eaca36fb9dac333cac47bc5`
+Branch: `recut/plm-audit-collab-main`
+
+## Scope
+
+Recut the first PLM audit collaboration slice from the legacy workbench branch onto current `main`.
+
+Included:
+
+- PLM audit scene context route/query state
+- PLM audit saved-view context summaries
+- PLM audit scene copy/token/banner/filter-highlight helpers
+- PLM audit team-view context note rendering
+- backend audit support for:
+  - `plm-team-view-default`
+  - `set-default`
+  - `clear-default`
+  - single-view default audit writes and list/export/summary handling
+- focused frontend and backend unit tests
+
+## Explicit exclusions
+
+This slice does not include:
+
+- recommended workbench scene cards
+- product/workbench shell rewrites
+- `lastDefaultSetAt` hydration
+- backend default-signal attachment queries
+- PLM product panel or scene catalog changes
+- OpenAPI, workflow, attendance, docs, or deployment changes outside this recut
+
+## Implementation notes
+
+- Frontend audit files were recovered from legacy commit `bcb189a68` and then aligned to current `main`.
+- `apps/web/src/services/plm/plmWorkbenchClient.ts` was updated only with the audit resource/action and metadata expansions required by the recut.
+- `packages/core-backend/src/routes/plm-workbench.ts` keeps the default-scene audit events but intentionally drops the later `attachPlmTeamViewDefaultSignals()` path so this slice remains independent from `lastDefaultSetAt` follow-up work.

--- a/docs/development/plm-audit-collaboration-recut-verification-20260320.md
+++ b/docs/development/plm-audit-collaboration-recut-verification-20260320.md
@@ -1,0 +1,31 @@
+# PLM Audit Collaboration Recut Verification
+
+Date: 2026-03-20
+Branch: `recut/plm-audit-collab-main`
+
+## Environment
+
+- Ran `CI=true pnpm install --ignore-scripts` in the recut worktree so `vitest` and `vue-tsc` binaries were available locally.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/plmAuditQueryState.spec.ts tests/plmAuditSavedViews.spec.ts tests/plmAuditSavedViewSummary.spec.ts tests/plmAuditSceneContext.spec.ts tests/plmAuditSceneCopy.spec.ts tests/plmAuditSceneInputToken.spec.ts tests/plmAuditSceneSourceCopy.spec.ts tests/plmAuditSceneSummary.spec.ts tests/plmAuditSceneToken.spec.ts tests/plmAuditTeamViewContext.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-workbench-routes.test.ts tests/unit/plm-workbench-audit-routes.test.ts
+pnpm --filter @metasheet/web build
+pnpm --filter @metasheet/core-backend build
+```
+
+## Results
+
+- frontend vitest: passed, `48/48`
+- backend vitest: passed, `32/32`
+- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`: passed
+- `pnpm --filter @metasheet/web build`: passed
+- `pnpm --filter @metasheet/core-backend build`: passed
+
+## Notes
+
+- The frontend vitest run reported `WebSocket server error: Port is already in use`, but the test process completed successfully and all targeted suites passed.
+- The frontend production build still emits the existing large-chunk warning for the main bundle. That warning predates this recut and did not block the build.

--- a/packages/core-backend/src/routes/plm-workbench.ts
+++ b/packages/core-backend/src/routes/plm-workbench.ts
@@ -49,14 +49,19 @@ interface PlmWorkbenchTeamViewConflictBuilder {
 
 type PlmTeamPresetBatchAction = 'archive' | 'restore' | 'delete'
 type PlmTeamViewBatchAction = 'archive' | 'restore' | 'delete'
-type PlmCollaborativeAuditResourceType = 'plm-team-preset-batch' | 'plm-team-view-batch'
+type PlmTeamViewDefaultAuditAction = 'set-default' | 'clear-default'
+type PlmCollaborativeAuditResourceType = 'plm-team-preset-batch' | 'plm-team-view-batch' | 'plm-team-view-default'
 const UUID_LIKE_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const PLM_COLLABORATIVE_AUDIT_RESOURCE_TYPES: PlmCollaborativeAuditResourceType[] = [
   'plm-team-preset-batch',
   'plm-team-view-batch',
+  'plm-team-view-default',
 ]
 
-type PlmCollaborativeAuditAction = PlmTeamPresetBatchAction | PlmTeamViewBatchAction
+type PlmCollaborativeAuditAction =
+  | PlmTeamPresetBatchAction
+  | PlmTeamViewBatchAction
+  | PlmTeamViewDefaultAuditAction
 
 interface PlmCollaborativeAuditEntry {
   id: string
@@ -173,7 +178,26 @@ function csvCell(value: unknown): string {
 function normalizePlmAuditResourceType(value: unknown): PlmCollaborativeAuditResourceType | null {
   if (typeof value !== 'string') return null
   const normalized = value.trim().toLowerCase()
-  if (normalized === 'plm-team-preset-batch' || normalized === 'plm-team-view-batch') {
+  if (
+    normalized === 'plm-team-preset-batch'
+    || normalized === 'plm-team-view-batch'
+    || normalized === 'plm-team-view-default'
+  ) {
+    return normalized
+  }
+  return null
+}
+
+function normalizePlmCollaborativeAuditAction(value: unknown): PlmCollaborativeAuditAction | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().toLowerCase()
+  if (
+    normalized === 'archive'
+    || normalized === 'restore'
+    || normalized === 'delete'
+    || normalized === 'set-default'
+    || normalized === 'clear-default'
+  ) {
     return normalized
   }
   return null
@@ -236,39 +260,15 @@ function buildPlmCollaborativeAuditWhere(paramsInput: PlmCollaborativeAuditWhere
   }
 }
 
-async function persistPlmCollaborativeBatchAudit(params: {
+async function persistPlmCollaborativeAuditEvent(params: {
+  route: string
   resourceType: PlmCollaborativeAuditResourceType
   action: PlmCollaborativeAuditAction
-  tenantId: string
   ownerUserId: string
-  requestedIds: string[]
-  processedIds: string[]
-  skippedIds: string[]
-  processedKinds?: string[]
+  resourceId: string
+  meta: Record<string, unknown>
 }) {
-  const resourceId =
-    params.processedIds[0]
-    || params.requestedIds[0]
-    || `${params.tenantId}:${params.resourceType}:${params.action}`
-
   try {
-    const route =
-      params.resourceType === 'plm-team-preset-batch'
-        ? '/api/plm-workbench/filter-presets/team/batch'
-        : '/api/plm-workbench/views/team/batch'
-    const meta = {
-      tenantId: params.tenantId,
-      ownerUserId: params.ownerUserId,
-      audit: params.resourceType,
-      requestedIds: params.requestedIds,
-      processedIds: params.processedIds,
-      skippedIds: params.skippedIds,
-      processedKinds: params.processedKinds ?? [],
-      requestedTotal: params.requestedIds.length,
-      processedTotal: params.processedIds.length,
-      skippedTotal: params.skippedIds.length,
-    }
-
     await pgQuery(
       `INSERT INTO operation_audit_logs (
         actor_id,
@@ -291,19 +291,61 @@ async function persistPlmCollaborativeBatchAudit(params: {
         'user',
         params.action,
         params.resourceType,
-        resourceId,
+        params.resourceId,
         null,
         null,
         null,
-        route,
+        params.route,
         200,
         0,
-        JSON.stringify(meta),
+        JSON.stringify(params.meta),
       ],
     )
   } catch (error: unknown) {
     logger.warn(`Failed to persist ${params.resourceType} audit event`, error as Error)
   }
+}
+
+async function persistPlmCollaborativeBatchAudit(params: {
+  resourceType: PlmCollaborativeAuditResourceType
+  action: PlmCollaborativeAuditAction
+  tenantId: string
+  ownerUserId: string
+  requestedIds: string[]
+  processedIds: string[]
+  skippedIds: string[]
+  processedKinds?: string[]
+}) {
+  const resourceId =
+    params.processedIds[0]
+    || params.requestedIds[0]
+    || `${params.tenantId}:${params.resourceType}:${params.action}`
+
+  const route =
+    params.resourceType === 'plm-team-preset-batch'
+      ? '/api/plm-workbench/filter-presets/team/batch'
+      : '/api/plm-workbench/views/team/batch'
+  const meta = {
+    tenantId: params.tenantId,
+    ownerUserId: params.ownerUserId,
+    audit: params.resourceType,
+    requestedIds: params.requestedIds,
+    processedIds: params.processedIds,
+    skippedIds: params.skippedIds,
+    processedKinds: params.processedKinds ?? [],
+    requestedTotal: params.requestedIds.length,
+    processedTotal: params.processedIds.length,
+    skippedTotal: params.skippedIds.length,
+  }
+
+  await persistPlmCollaborativeAuditEvent({
+    route,
+    resourceType: params.resourceType,
+    action: params.action,
+    ownerUserId: params.ownerUserId,
+    resourceId,
+    meta,
+  })
 }
 
 async function logPlmTeamPresetBatchAudit(params: {
@@ -374,6 +416,46 @@ async function logPlmTeamViewBatchAudit(params: {
   })
 }
 
+async function logPlmTeamViewDefaultAudit(params: {
+  action: PlmTeamViewDefaultAuditAction
+  tenantId: string
+  ownerUserId: string
+  viewId: string
+  kind: string
+  viewName: string
+}) {
+  logger.info('Processed PLM team view default action', {
+    audit: 'plm-team-view-default',
+    action: params.action,
+    tenantId: params.tenantId,
+    ownerUserId: params.ownerUserId,
+    viewId: params.viewId,
+    kind: params.kind,
+    viewName: params.viewName,
+    processedKinds: [params.kind],
+    processedTotal: 1,
+  })
+
+  await persistPlmCollaborativeAuditEvent({
+    route: '/api/plm-workbench/views/team/:id/default',
+    resourceType: 'plm-team-view-default',
+    action: params.action,
+    ownerUserId: params.ownerUserId,
+    resourceId: params.viewId,
+    meta: {
+      tenantId: params.tenantId,
+      ownerUserId: params.ownerUserId,
+      audit: 'plm-team-view-default',
+      kind: params.kind,
+      viewName: params.viewName,
+      processedKinds: [params.kind],
+      requestedTotal: 1,
+      processedTotal: 1,
+      skippedTotal: 0,
+    },
+  })
+}
+
 router.get(
   '/api/plm-workbench/audit-logs',
   authenticate,
@@ -388,7 +470,7 @@ router.get(
 
       const q = typeof req.query.q === 'string' ? req.query.q.trim() : ''
       const actorId = typeof req.query.actorId === 'string' ? req.query.actorId.trim() : ''
-      const action = normalizePlmTeamViewBatchAction(req.query.action)
+      const action = normalizePlmCollaborativeAuditAction(req.query.action)
       const resourceType = normalizePlmAuditResourceType(req.query.resourceType)
       const kind = typeof req.query.kind === 'string' ? req.query.kind.trim() : ''
       const from = parsePlmAuditDate(req.query.from)
@@ -463,7 +545,7 @@ router.get(
       const limit = Math.min(Math.max(rawLimit || 5000, 1), 10000)
       const q = typeof req.query.q === 'string' ? req.query.q.trim() : ''
       const actorId = typeof req.query.actorId === 'string' ? req.query.actorId.trim() : ''
-      const action = normalizePlmTeamViewBatchAction(req.query.action)
+      const action = normalizePlmCollaborativeAuditAction(req.query.action)
       const resourceType = normalizePlmAuditResourceType(req.query.resourceType)
       const kind = typeof req.query.kind === 'string' ? req.query.kind.trim() : ''
       const from = parsePlmAuditDate(req.query.from)
@@ -917,6 +999,15 @@ router.post(
           .executeTakeFirstOrThrow()
       })
 
+      await logPlmTeamViewDefaultAudit({
+        action: 'set-default',
+        tenantId,
+        ownerUserId: currentUserId,
+        viewId,
+        kind: String(view.kind || ''),
+        viewName: String(view.name || ''),
+      })
+
       return res.json({
         success: true,
         data: mapPlmWorkbenchTeamViewRow(saved as PlmWorkbenchTeamViewRowLike, currentUserId),
@@ -986,6 +1077,15 @@ router.delete(
         .where('id', '=', viewId)
         .returningAll()
         .executeTakeFirstOrThrow()
+
+      await logPlmTeamViewDefaultAudit({
+        action: 'clear-default',
+        tenantId,
+        ownerUserId: currentUserId,
+        viewId,
+        kind: String(view.kind || ''),
+        viewName: String(view.name || ''),
+      })
 
       return res.json({
         success: true,
@@ -1109,6 +1209,17 @@ router.post(
               return upsertView(trxAny, true)
             })
           : await upsertView(dbAny, requestedDefault)
+
+      if (requestedDefault === true) {
+        await logPlmTeamViewDefaultAudit({
+          action: 'set-default',
+          tenantId,
+          ownerUserId: currentUserId,
+          viewId: String(saved.id || ''),
+          kind,
+          viewName: name,
+        })
+      }
 
       return res.status(201).json({
         success: true,

--- a/packages/core-backend/tests/unit/plm-workbench-audit-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-workbench-audit-routes.test.ts
@@ -1,0 +1,300 @@
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const auditRouteMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  db: {
+    selectFrom: vi.fn(),
+    updateTable: vi.fn(),
+    insertInto: vi.fn(),
+    deleteFrom: vi.fn(),
+    transaction: vi.fn(),
+  },
+}))
+
+vi.mock('../../src/db/db', () => ({
+  db: auditRouteMocks.db,
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: {},
+  query: auditRouteMocks.query,
+}))
+
+vi.mock('../../src/audit/audit', () => ({
+  auditLog: vi.fn(async () => undefined),
+}))
+
+vi.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      id: 'dev-user',
+      tenantId: 'tenant-a',
+    } as never
+    next()
+  },
+}))
+
+vi.mock('../../src/middleware/validation', () => ({
+  validate: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}))
+
+vi.mock('../../src/types/validator', () => ({
+  loadValidators: () => {
+    const makeChain = () => {
+      const chain = ((
+        _req: express.Request,
+        _res: express.Response,
+        next: express.NextFunction,
+      ) => next()) as express.RequestHandler & Record<string, () => express.RequestHandler>
+
+      chain.optional = () => chain
+      chain.isString = () => chain
+      chain.notEmpty = () => chain
+      chain.exists = () => chain
+      chain.isObject = () => chain
+      return chain
+    }
+
+    return {
+      body: () => makeChain(),
+      param: () => makeChain(),
+      query: () => makeChain(),
+    }
+  },
+}))
+
+import plmWorkbenchRouter from '../../src/routes/plm-workbench'
+
+describe('plm-workbench audit routes', () => {
+  const app = express()
+  app.use(express.json())
+  app.use(plmWorkbenchRouter)
+
+  beforeEach(() => {
+    auditRouteMocks.query.mockReset()
+  })
+
+  it('lists collaborative batch audit logs with normalized metadata', async () => {
+    auditRouteMocks.query
+      .mockResolvedValueOnce({
+        rows: [{ c: 2 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'audit-1',
+            actor_id: 'owner-1',
+            actor_type: 'user',
+            action: 'archive',
+            resource_type: 'plm-team-preset-batch',
+            resource_id: 'preset-a',
+            request_id: 'req-1',
+            ip: '127.0.0.1',
+            user_agent: 'Vitest',
+            occurred_at: '2026-03-11T02:00:00.000Z',
+            meta: {
+              processedKinds: ['bom'],
+              processedTotal: 1,
+              skippedTotal: 0,
+            },
+          },
+        ],
+      })
+
+    const response = await request(app)
+      .get('/api/plm-workbench/audit-logs?page=1&pageSize=20&resourceType=plm-team-preset-batch&action=archive&q=bom')
+
+    expect(response.status).toBe(200)
+    expect(response.body.data).toMatchObject({
+      total: 2,
+      page: 1,
+      pageSize: 20,
+      items: [
+        {
+          id: 'audit-1',
+          action: 'archive',
+          resourceType: 'plm-team-preset-batch',
+          resourceId: 'preset-a',
+          actorId: 'owner-1',
+          meta: {
+            processedKinds: ['bom'],
+            processedTotal: 1,
+          },
+        },
+      ],
+    })
+    expect(auditRouteMocks.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('SELECT COUNT(*)::int AS c'),
+      expect.arrayContaining([
+        expect.arrayContaining(['plm-team-preset-batch', 'plm-team-view-batch', 'plm-team-view-default']),
+        'plm-team-preset-batch',
+        'archive',
+        '%bom%',
+      ]),
+    )
+  })
+
+  it('summarizes collaborative batch audit activity', async () => {
+    auditRouteMocks.query
+      .mockResolvedValueOnce({
+        rows: [
+          { action: 'archive', total: 3 },
+          { action: 'restore', total: 1 },
+          { action: 'set-default', total: 2 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { resource_type: 'plm-team-view-batch', total: 2 },
+          { resource_type: 'plm-team-preset-batch', total: 2 },
+          { resource_type: 'plm-team-view-default', total: 1 },
+        ],
+      })
+
+    const response = await request(app)
+      .get('/api/plm-workbench/audit-logs/summary?windowMinutes=120&limit=5')
+
+    expect(response.status).toBe(200)
+    expect(response.body.data).toEqual({
+      windowMinutes: 120,
+      actions: [
+        { action: 'archive', total: 3 },
+        { action: 'restore', total: 1 },
+        { action: 'set-default', total: 2 },
+      ],
+      resourceTypes: [
+        { resourceType: 'plm-team-view-batch', total: 2 },
+        { resourceType: 'plm-team-preset-batch', total: 2 },
+        { resourceType: 'plm-team-view-default', total: 1 },
+      ],
+    })
+    expect(auditRouteMocks.query).toHaveBeenCalledTimes(2)
+  })
+
+  it('exports collaborative batch audit logs as csv', async () => {
+    auditRouteMocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'audit-2',
+          actor_id: 'owner-1',
+          actor_type: 'user',
+          action: 'delete',
+          resource_type: 'plm-team-view-batch',
+          resource_id: 'view-a',
+          request_id: 'req-2',
+          ip: '127.0.0.1',
+          user_agent: 'Vitest',
+          route: '/api/plm-workbench/views/team/batch',
+          status_code: 200,
+          latency_ms: 0,
+          occurred_at: '2026-03-11T02:01:00.000Z',
+          meta: {
+            processedKinds: ['documents'],
+            requestedTotal: 1,
+            processedTotal: 1,
+            skippedTotal: 0,
+          },
+        },
+      ],
+    })
+
+    const response = await request(app)
+      .get('/api/plm-workbench/audit-logs/export.csv?resourceType=plm-team-view-batch&action=delete&kind=documents&limit=10')
+
+    expect(response.status).toBe(200)
+    expect(response.headers['content-type']).toContain('text/csv')
+    expect(response.headers['content-disposition']).toContain('plm-collaborative-audit-')
+    expect(response.text).toContain('occurredAt,id,actorId,actorType,action,resourceType')
+    expect(response.text).toContain('plm-team-view-batch')
+    expect(response.text).toContain('documents')
+    expect(auditRouteMocks.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM operation_audit_logs'),
+      expect.arrayContaining([
+        expect.arrayContaining(['plm-team-preset-batch', 'plm-team-view-batch', 'plm-team-view-default']),
+        'plm-team-view-batch',
+        'delete',
+        '%documents%',
+        10,
+      ]),
+    )
+  })
+
+  it('lists and exports default-scene audit activity', async () => {
+    auditRouteMocks.query
+      .mockResolvedValueOnce({
+        rows: [{ c: 1 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'audit-default-1',
+            actor_id: 'owner-1',
+            actor_type: 'user',
+            action: 'set-default',
+            resource_type: 'plm-team-view-default',
+            resource_id: 'scene-1',
+            request_id: 'req-1',
+            ip: '127.0.0.1',
+            user_agent: 'Vitest',
+            occurred_at: '2026-03-13T02:00:00.000Z',
+            meta: {
+              kind: 'workbench',
+              viewName: '采购团队场景',
+              processedKinds: ['workbench'],
+              processedTotal: 1,
+            },
+          },
+        ],
+      })
+
+    const response = await request(app)
+      .get('/api/plm-workbench/audit-logs?page=1&pageSize=20&resourceType=plm-team-view-default&action=set-default&kind=workbench')
+
+    expect(response.status).toBe(200)
+    expect(response.body.data.items[0]).toMatchObject({
+      action: 'set-default',
+      resourceType: 'plm-team-view-default',
+      meta: {
+        kind: 'workbench',
+        viewName: '采购团队场景',
+      },
+    })
+
+    auditRouteMocks.query.mockReset()
+    auditRouteMocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'audit-default-1',
+          actor_id: 'owner-1',
+          actor_type: 'user',
+          action: 'set-default',
+          resource_type: 'plm-team-view-default',
+          resource_id: 'scene-1',
+          request_id: 'req-1',
+          ip: '127.0.0.1',
+          user_agent: 'Vitest',
+          route: '/api/plm-workbench/views/team/:id/default',
+          status_code: 200,
+          latency_ms: 0,
+          occurred_at: '2026-03-13T02:00:00.000Z',
+          meta: {
+            kind: 'workbench',
+            viewName: '采购团队场景',
+            processedKinds: ['workbench'],
+            processedTotal: 1,
+          },
+        },
+      ],
+    })
+
+    const exportResponse = await request(app)
+      .get('/api/plm-workbench/audit-logs/export.csv?resourceType=plm-team-view-default&action=set-default&kind=workbench&limit=10')
+
+    expect(exportResponse.status).toBe(200)
+    expect(exportResponse.text).toContain('plm-team-view-default')
+    expect(exportResponse.text).toContain('采购团队场景')
+  })
+})

--- a/packages/core-backend/tests/unit/plm-workbench-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-workbench-routes.test.ts
@@ -161,10 +161,12 @@ describe('plm-workbench routes', () => {
         updated_at: '2026-03-09T00:11:00.000Z',
       },
     ])
-
     const response = await request(app).get('/api/plm-workbench/views/team?kind=documents')
 
     expect(response.status).toBe(200)
+    expect(response.body.data[0]).toMatchObject({
+      id: 'view-1',
+    })
     expect(response.body.metadata).toMatchObject({
       total: 2,
       tenantId: 'tenant-a',
@@ -1305,6 +1307,7 @@ describe('plm-workbench routes', () => {
       created_at: '2026-03-09T00:00:00.000Z',
       updated_at: '2026-03-09T00:20:00.000Z',
     })
+    pgMocks.query.mockResolvedValueOnce({ rows: [] })
 
     const response = await request(app).post('/api/plm-workbench/views/team/view-1/default')
 
@@ -1316,6 +1319,16 @@ describe('plm-workbench routes', () => {
       canManage: true,
     })
     expect(routeMocks.db.transaction).toHaveBeenCalledTimes(1)
+    expect(pgMocks.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('INSERT INTO operation_audit_logs'),
+      expect.arrayContaining([
+        'owner-1',
+        'set-default',
+        'plm-team-view-default',
+        'view-1',
+      ]),
+    )
   })
 
   it('rejects default changes from non-owners', async () => {
@@ -1366,6 +1379,7 @@ describe('plm-workbench routes', () => {
       created_at: '2026-03-09T00:00:00.000Z',
       updated_at: '2026-03-09T00:21:00.000Z',
     })
+    pgMocks.query.mockResolvedValueOnce({ rows: [] })
 
     const response = await request(app).delete('/api/plm-workbench/views/team/view-1/default')
 
@@ -1375,6 +1389,16 @@ describe('plm-workbench routes', () => {
       kind: 'approvals',
       isDefault: false,
     })
+    expect(pgMocks.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('INSERT INTO operation_audit_logs'),
+      expect.arrayContaining([
+        'owner-1',
+        'clear-default',
+        'plm-team-view-default',
+        'view-1',
+      ]),
+    )
   })
 
   it('rejects clearing default for archived team views', async () => {
@@ -1397,6 +1421,53 @@ describe('plm-workbench routes', () => {
 
     expect(response.status).toBe(409)
     expect(response.body.error).toContain('Archived PLM team views cannot clear the default')
+    expect(pgMocks.query).not.toHaveBeenCalled()
+  })
+
+  it('writes default-scene audit when saving a team view as default', async () => {
+    routeMocks.state.trxBuilder.execute.mockResolvedValueOnce(undefined)
+    routeMocks.state.trxBuilder.executeTakeFirstOrThrow.mockResolvedValueOnce({
+      id: 'view-save-default',
+      tenant_id: 'tenant-a',
+      owner_user_id: 'owner-1',
+      scope: 'team',
+      kind: 'workbench',
+      name: '采购团队场景',
+      name_key: '采购团队场景',
+      is_default: true,
+      state: JSON.stringify({ query: { productId: 'prod-100' } }),
+      created_at: '2026-03-09T00:00:00.000Z',
+      updated_at: '2026-03-09T00:22:00.000Z',
+    })
+    pgMocks.query.mockResolvedValueOnce({ rows: [] })
+
+    const response = await request(app)
+      .post('/api/plm-workbench/views/team')
+      .send({
+        kind: 'workbench',
+        name: '采购团队场景',
+        isDefault: true,
+        state: {
+          query: { productId: 'prod-100' },
+        },
+      })
+
+    expect(response.status).toBe(201)
+    expect(response.body.data).toMatchObject({
+      id: 'view-save-default',
+      kind: 'workbench',
+      isDefault: true,
+    })
+    expect(pgMocks.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('INSERT INTO operation_audit_logs'),
+      expect.arrayContaining([
+        'owner-1',
+        'set-default',
+        'plm-team-view-default',
+        'view-save-default',
+      ]),
+    )
   })
 
   it('rejects transferring archived team views', async () => {


### PR DESCRIPTION
## Summary
- recut the first PLM audit collaboration slice onto current `main`
- add audit scene context and saved-view context rendering on the frontend
- extend backend audit handling for default-scene events without pulling in later signal hydration work

## Included
- `PlmAuditView.vue` scene-context and saved-view context workflows
- audit route/query state and scene helper modules
- focused frontend audit helper tests
- backend `plm-workbench` audit support for:
  - `plm-team-view-default`
  - `set-default`
  - `clear-default`
  - audit list/export/summary coverage for those events
- backend route tests and recut development/verification docs

## Excluded
- recommended workbench scenes
- product/workbench shell rewrites
- `lastDefaultSetAt` hydration
- backend default-signal attachment queries
- OpenAPI, workflow, attendance, and deployment follow-up work

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/plmAuditQueryState.spec.ts tests/plmAuditSavedViews.spec.ts tests/plmAuditSavedViewSummary.spec.ts tests/plmAuditSceneContext.spec.ts tests/plmAuditSceneCopy.spec.ts tests/plmAuditSceneInputToken.spec.ts tests/plmAuditSceneSourceCopy.spec.ts tests/plmAuditSceneSummary.spec.ts tests/plmAuditSceneToken.spec.ts tests/plmAuditTeamViewContext.spec.ts`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-workbench-routes.test.ts tests/unit/plm-workbench-audit-routes.test.ts`
- `pnpm --filter @metasheet/web build`
- `pnpm --filter @metasheet/core-backend build`

## Notes
- local worktree needed `CI=true pnpm install --ignore-scripts` before validation so `vitest` and `vue-tsc` binaries were linked in the recut tree
- frontend vitest printed `WebSocket server error: Port is already in use`, but all targeted suites still passed
