### PR TITLE
feat(attendance): improve admin holiday and import guidance

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -604,6 +604,8 @@ const {
   revokeProvisioningRoleBatch,
   searchProvisionUsers,
   selectProvisionUser,
+  addProvisionUserToBatch,
+  syncProvisionUserId,
 } = useAttendanceAdminProvisioning({ adminForbidden, tr })
 const {
   auditLogActionPrefix,
@@ -1014,9 +1016,11 @@ const {
   editRotationAssignment,
   editRotationRule,
   editShift,
+  holidayRange,
   holidayEditingId,
   holidayForm,
   holidayLoading,
+  holidayTotal,
   holidays,
   holidaySaving,
   loadAssignments,
@@ -1085,6 +1089,7 @@ const {
   importPreviewTask,
   importProfileId,
   importScalabilityHint,
+  importTemplateGuide,
   importUserMapCount,
   importUserMapError,
   importUserMapFileName,
@@ -1096,6 +1101,7 @@ const {
   resumeImportAsyncJobPolling,
   runImport,
   selectedImportProfile,
+  selectedImportProfileGuide,
 } = useAttendanceAdminImportWorkflow({
   adminForbidden,
   apiFetch,
@@ -1134,6 +1140,7 @@ const importWorkflowSectionBindings = {
   importPreviewTask,
   importProfileId,
   importScalabilityHint,
+  importTemplateGuide,
   importUserMapCount,
   importUserMapError,
   importUserMapFileName,
@@ -1145,6 +1152,7 @@ const importWorkflowSectionBindings = {
   resumeImportAsyncJobPolling,
   runImport,
   selectedImportProfile,
+  selectedImportProfileGuide,
 }
 const importBatchesSectionBindings = {
   exportImportBatchItemsCsv,
@@ -1351,8 +1359,10 @@ const provisioningSectionBindings = {
   provisionUserProfile,
   revokeProvisioningRole,
   revokeProvisioningRoleBatch,
+  addProvisionUserToBatch,
   searchProvisionUsers,
   selectProvisionUser,
+  syncProvisionUserId,
 }
 const auditLogsSectionBindings = {
   auditLogActionPrefix,
@@ -1402,6 +1412,8 @@ const holidayDataSectionBindings = {
   holidayEditingId,
   holidayForm,
   holidayLoading,
+  holidayRange,
+  holidayTotal,
   holidays,
   holidaySaving,
   loadHolidays,

--- a/apps/web/src/views/attendance/AttendanceHolidayDataSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayDataSection.vue
@@ -2,9 +2,39 @@
   <div class="attendance__admin-section">
     <div class="attendance__admin-section-header">
       <h4>{{ tr('Holidays', '节假日') }}</h4>
-      <button class="attendance__btn" :disabled="holidayLoading" @click="loadHolidays">
-        {{ holidayLoading ? tr('Loading...', '加载中...') : tr('Reload holidays', '重载节假日') }}
-      </button>
+      <div class="attendance__admin-actions">
+        <span class="attendance__section-meta">
+          {{ tr('Showing', '当前显示') }} {{ holidayTotal }} {{ tr('holiday(s)', '个节假日') }}
+        </span>
+        <button class="attendance__btn" :disabled="holidayLoading" @click="loadHolidays">
+          {{ holidayLoading ? tr('Loading...', '加载中...') : tr('Reload holidays', '重载节假日') }}
+        </button>
+      </div>
+    </div>
+    <div class="attendance__admin-grid">
+      <label class="attendance__field" for="attendance-holiday-range-from">
+        <span>{{ tr('List from', '列表起始') }}</span>
+        <input
+          id="attendance-holiday-range-from"
+          v-model="holidayRange.from"
+          name="holidayRangeFrom"
+          type="date"
+        />
+      </label>
+      <label class="attendance__field" for="attendance-holiday-range-to">
+        <span>{{ tr('List to', '列表结束') }}</span>
+        <input
+          id="attendance-holiday-range-to"
+          v-model="holidayRange.to"
+          name="holidayRangeTo"
+          type="date"
+        />
+      </label>
+      <div class="attendance__field attendance__field--full">
+        <small class="attendance__field-hint">
+          {{ tr('The holiday list now uses its own date range, so synced holidays are not limited by the overview page range.', '节假日列表现在使用独立日期范围，不再受总览页面日期范围限制。') }}
+        </small>
+      </div>
     </div>
     <div class="attendance__admin-grid">
       <label class="attendance__field" for="attendance-holiday-date">
@@ -13,7 +43,7 @@
       </label>
       <label class="attendance__field" for="attendance-holiday-name">
         <span>{{ tr('Name', '名称') }}</span>
-        <input id="attendance-holiday-name" v-model="holidayForm.name" name="holidayName" type="text" :placeholder="tr('Optional', '可选')" />
+        <input id="attendance-holiday-name" v-model="holidayForm.name" name="holidayName" type="text" :placeholder="tr('Required holiday name', '必填节假日名称')" />
       </label>
       <label class="attendance__field attendance__field--checkbox" for="attendance-holiday-working">
         <span>{{ tr('Working day override', '工作日覆盖') }}</span>
@@ -70,9 +100,14 @@ interface HolidayFormState {
 
 interface HolidayDataBindings {
   holidays: Ref<AttendanceHoliday[]>
+  holidayTotal: Ref<number>
   holidayLoading: Ref<boolean>
   holidaySaving: Ref<boolean>
   holidayEditingId: Ref<string | null>
+  holidayRange: {
+    from: string
+    to: string
+  }
   holidayForm: HolidayFormState
   resetHolidayForm: () => MaybePromise<void>
   editHoliday: (holiday: AttendanceHoliday) => MaybePromise<void>
@@ -90,9 +125,11 @@ const props = defineProps<{
 const tr = props.tr
 const formatDate = props.formatDate
 const holidays = props.holiday.holidays
+const holidayTotal = props.holiday.holidayTotal
 const holidayLoading = props.holiday.holidayLoading
 const holidaySaving = props.holiday.holidaySaving
 const holidayEditingId = props.holiday.holidayEditingId
+const holidayRange = props.holiday.holidayRange
 const holidayForm = props.holiday.holidayForm
 const resetHolidayForm = () => props.holiday.resetHolidayForm()
 const editHoliday = (holiday: AttendanceHoliday) => props.holiday.editHoliday(holiday)
@@ -107,7 +144,10 @@ const deleteHoliday = (id: string) => props.holiday.deleteHoliday(id)
 .attendance__admin-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
 .attendance__admin-actions, .attendance__table-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 .attendance__field { display: flex; flex-direction: column; gap: 6px; }
+.attendance__field--full { grid-column: 1 / -1; }
 .attendance__field--checkbox { justify-content: flex-end; }
+.attendance__field-hint { color: #666; font-size: 12px; }
+.attendance__section-meta { color: #555; font-size: 12px; align-self: center; }
 .attendance__btn { padding: 8px 14px; border-radius: 6px; border: 1px solid #d0d0d0; background: #fff; cursor: pointer; }
 .attendance__btn--primary { background: #1976d2; border-color: #1976d2; color: #fff; }
 .attendance__btn--danger { color: #c62828; }

--- a/apps/web/src/views/attendance/AttendanceImportWorkflowSection.vue
+++ b/apps/web/src/views/attendance/AttendanceImportWorkflowSection.vue
@@ -6,6 +6,101 @@
         {{ importLoading ? tr('Loading...', '加载中...') : tr('Load template', '加载模板') }}
       </button>
     </div>
+    <div v-if="importTemplateGuide" class="attendance__template-guide">
+      <div class="attendance__template-guide-header">
+        <strong>{{ tr('Template guide', '模板说明') }}</strong>
+        <span>
+          {{ tr('Source', '来源') }}: <code>{{ importTemplateGuide.source }}</code>
+          · {{ tr('Mode', '模式') }}: <code>{{ importTemplateGuide.mode }}</code>
+        </span>
+      </div>
+      <div class="attendance__template-guide-grid">
+        <div class="attendance__template-guide-card">
+          <div class="attendance__template-guide-title">{{ tr('Suggested CSV header', '建议 CSV 表头') }}</div>
+          <code class="attendance__template-code">{{ importTemplateGuide.sampleHeader || tr('(no header guidance yet)', '（暂无表头指导）') }}</code>
+          <small class="attendance__field-hint">
+            {{ tr('Use this header order when you export or hand-edit CSV rows.', '导出或手工编辑 CSV 行时，请按这个表头顺序。') }}
+          </small>
+        </div>
+        <div class="attendance__template-guide-card">
+          <div class="attendance__template-guide-title">{{ tr('Required fields', '必填字段') }}</div>
+          <div v-if="importTemplateGuide.requiredFields.length" class="attendance__template-chip-list">
+            <span v-for="field in importTemplateGuide.requiredFields" :key="field" class="attendance__template-chip">
+              {{ field }}
+            </span>
+          </div>
+          <small v-else class="attendance__field-hint">
+            {{ tr('No required fields were declared in the template response.', '模板响应中未声明必填字段。') }}
+          </small>
+        </div>
+        <div class="attendance__template-guide-card">
+          <div class="attendance__template-guide-title">{{ tr('Template columns', '模板列') }}</div>
+          <div v-if="importTemplateGuide.columns.length" class="attendance__template-chip-list">
+            <span v-for="column in importTemplateGuide.columns" :key="column" class="attendance__template-chip">
+              {{ column }}
+            </span>
+          </div>
+          <small v-else class="attendance__field-hint">
+            {{ tr('The template response did not declare explicit source columns.', '模板响应未声明明确的源列。') }}
+          </small>
+        </div>
+        <div class="attendance__template-guide-card attendance__template-guide-card--full">
+          <div class="attendance__template-guide-title">{{ tr('Field meanings', '字段说明') }}</div>
+          <table class="attendance__template-table">
+            <thead>
+              <tr>
+                <th>{{ tr('Field', '字段') }}</th>
+                <th>{{ tr('Meaning', '含义') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in importTemplateGuide.fieldGuides" :key="item.field">
+                <td><code>{{ item.field }}</code></td>
+                <td>
+                  {{ tr(item.meaningEn, item.meaningZh) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-if="selectedImportProfileGuide" class="attendance__template-guide-card attendance__template-guide-card--full">
+          <div class="attendance__template-guide-title">
+            {{ tr('Selected mapping profile', '已选映射配置') }}: {{ selectedImportProfileGuide.name }}
+          </div>
+          <small v-if="selectedImportProfileGuide.description" class="attendance__field-hint">
+            {{ selectedImportProfileGuide.description }}
+          </small>
+          <small v-if="selectedImportProfileGuide.requiredFields.length" class="attendance__field-hint">
+            {{ tr('Profile required fields', '配置必填字段') }}: {{ selectedImportProfileGuide.requiredFields.join(', ') }}
+          </small>
+          <div v-if="selectedImportProfileGuide.userMapKeyField || selectedImportProfileGuide.userMapSourceFields?.length" class="attendance__field-hint">
+            <span v-if="selectedImportProfileGuide.userMapKeyField">
+              {{ tr('User map key field', '用户映射键字段') }}: <code>{{ selectedImportProfileGuide.userMapKeyField }}</code>
+            </span>
+            <span v-if="selectedImportProfileGuide.userMapSourceFields?.length">
+              {{ selectedImportProfileGuide.userMapKeyField ? ' · ' : '' }}
+              {{ tr('User map source fields', '用户映射源字段') }}: <code>{{ selectedImportProfileGuide.userMapSourceFields.join(', ') }}</code>
+            </span>
+          </div>
+          <table v-if="selectedImportProfileGuide.mappingEntries.length" class="attendance__template-table">
+            <thead>
+              <tr>
+                <th>{{ tr('Target field', '目标字段') }}</th>
+                <th>{{ tr('Meaning', '含义') }}</th>
+                <th>{{ tr('Source field', '源字段') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in selectedImportProfileGuide.mappingEntries" :key="item.targetField">
+                <td><code>{{ item.targetField }}</code></td>
+                <td>{{ tr(item.meaningEn, item.meaningZh) }}</td>
+                <td><code>{{ item.sourceField }}</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
     <div class="attendance__admin-grid">
       <label class="attendance__field" for="attendance-import-rule-set">
         <span>{{ tr('Rule set', '规则集') }}</span>
@@ -333,6 +428,8 @@ import type {
   AttendanceImportMode,
   AttendanceImportPreviewItem,
   AttendanceImportPreviewTask,
+  AttendanceImportProfileGuide,
+  AttendanceImportTemplateGuide,
 } from './useAttendanceAdminImportWorkflow'
 import type { AttendanceRuleSet } from './useAttendanceAdminRulesAndGroups'
 
@@ -346,6 +443,8 @@ interface ImportWorkflowBindings {
   importProfileId: Ref<string>
   importMappingProfiles: Ref<AttendanceImportMappingProfile[]>
   selectedImportProfile: ComputedRef<AttendanceImportMappingProfile | null>
+  importTemplateGuide: ComputedRef<AttendanceImportTemplateGuide | null>
+  selectedImportProfileGuide: ComputedRef<AttendanceImportProfileGuide | null>
   importCsvFileName: Ref<string>
   importCsvHeaderRow: Ref<string>
   importCsvDelimiter: Ref<string>
@@ -402,6 +501,8 @@ const importMode = props.workflow.importMode
 const importProfileId = props.workflow.importProfileId
 const importMappingProfiles = props.workflow.importMappingProfiles
 const selectedImportProfile = props.workflow.selectedImportProfile
+const importTemplateGuide = props.workflow.importTemplateGuide
+const selectedImportProfileGuide = props.workflow.selectedImportProfileGuide
 const importCsvFileName = props.workflow.importCsvFileName
 const importCsvHeaderRow = props.workflow.importCsvHeaderRow
 const importCsvDelimiter = props.workflow.importCsvDelimiter
@@ -479,6 +580,91 @@ const formatPolicyList = props.formatPolicyList
 
 .attendance__field-hint--error {
   color: #c0392b;
+}
+
+.attendance__template-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid #dfe6ef;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #f8fbff 0%, #fff 100%);
+}
+
+.attendance__template-guide-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: #4b5563;
+}
+
+.attendance__template-guide-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.attendance__template-guide-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.attendance__template-guide-card--full {
+  grid-column: 1 / -1;
+}
+
+.attendance__template-guide-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.attendance__template-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.attendance__template-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #e8eef9;
+  color: #17324f;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.attendance__template-code {
+  padding: 8px 10px;
+  border: 1px solid #d0d7e2;
+  border-radius: 8px;
+  background: #fff;
+  color: #111827;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.attendance__template-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.attendance__template-table th,
+.attendance__template-table td {
+  padding: 8px;
+  border-top: 1px solid #e5e7eb;
+  text-align: left;
+  vertical-align: top;
 }
 
 .attendance__btn {

--- a/apps/web/src/views/attendance/AttendanceProvisioningSection.vue
+++ b/apps/web/src/views/attendance/AttendanceProvisioningSection.vue
@@ -28,7 +28,7 @@
     </div>
     <div class="attendance__admin-actions">
       <button class="attendance__btn" :disabled="provisionSearchLoading" @click="searchProvisionUsers(1)">
-        {{ provisionSearchLoading ? tr('Searching...', '搜索中...') : tr('Search', '搜索') }}
+        {{ provisionSearchLoading ? tr('Searching...', '搜索中...') : tr('Search users', '搜索用户') }}
       </button>
       <button
         class="attendance__btn"
@@ -64,7 +64,8 @@
             <td>{{ user.name || '--' }}</td>
             <td><code>{{ user.id.slice(0, 8) }}</code></td>
             <td class="attendance__table-actions">
-              <button class="attendance__btn" @click="selectProvisionUser(user)">{{ tr('Select', '选择') }}</button>
+              <button class="attendance__btn" @click="selectProvisionUser(user)">{{ tr('Use for access', '用于授权') }}</button>
+              <button class="attendance__btn" @click="addProvisionUserToBatch(user)">{{ tr('Add to batch', '加入批量') }}</button>
             </td>
           </tr>
         </tbody>
@@ -72,19 +73,17 @@
     </div>
     <p v-else-if="provisionSearchHasSearched" class="attendance__empty">{{ tr('No users found.', '未找到用户。') }}</p>
     <div class="attendance__admin-grid">
-      <label class="attendance__field attendance__field--full" for="attendance-provision-user-id">
-        <span>{{ tr('User ID (UUID)', '用户 ID（UUID）') }}</span>
-        <input
-          id="attendance-provision-user-id"
-          v-model="provisionForm.userId"
-          name="provisionUserId"
-          type="text"
-          :placeholder="tr('e.g. 0cdf4a9c-4fe1-471b-be08-854b683dc930', '例如 0cdf4a9c-4fe1-471b-be08-854b683dc930')"
-        />
-        <small v-if="provisionUserProfile" class="attendance__field-hint">
-          {{ tr('Selected', '已选择') }}: {{ provisionUserProfile.email }}{{ provisionUserProfile.name ? ` (${provisionUserProfile.name})` : '' }}
-        </small>
-      </label>
+      <AttendanceUserPickerField
+        :model-value="provisionForm.userId"
+        @update:modelValue="handleProvisionUserIdChange"
+        :tr="tr"
+        :label="tr('User', '用户')"
+        name="provisionUserId"
+        :help-text="tr('Search by email, name, or user ID, then pick a user before loading or changing roles.', '按邮箱、姓名或用户 ID 搜索，然后选中用户再加载或调整角色。')"
+        :search-placeholder="tr('Search users for provisioning', '搜索授权用户')"
+        :full-width="true"
+        input-id="attendance-provision-user-id"
+      />
       <label class="attendance__field" for="attendance-provision-role">
         <span>{{ tr('Role template', '角色模板') }}</span>
         <select id="attendance-provision-role" v-model="provisionForm.role" name="provisionRole">
@@ -94,6 +93,15 @@
         </select>
       </label>
     </div>
+    <p v-if="provisionForm.userId" class="attendance__field-hint">
+      {{ tr('Current user', '当前用户') }}:
+      <template v-if="provisionUserProfile">
+        {{ provisionUserProfile.email }}{{ provisionUserProfile.name ? ` (${provisionUserProfile.name})` : '' }}
+      </template>
+      <template v-else>
+        <code>{{ provisionForm.userId }}</code>
+      </template>
+    </p>
     <p v-if="provisionStatusMessage" class="attendance__status" :class="{ 'attendance__status--error': provisionStatusKind === 'error' }">
       {{ provisionStatusMessage }}
     </p>
@@ -210,6 +218,7 @@
 
 <script setup lang="ts">
 import type { Ref } from 'vue'
+import AttendanceUserPickerField from './AttendanceUserPickerField.vue'
 
 type Translate = (en: string, zh: string) => string
 type ProvisionRole = 'employee' | 'approver' | 'admin'
@@ -286,6 +295,8 @@ interface ProvisioningBindings {
   revokeProvisioningRoleBatch: () => MaybePromise<void>
   searchProvisionUsers: (page: number) => MaybePromise<void>
   selectProvisionUser: (user: ProvisionSearchItem) => MaybePromise<void>
+  addProvisionUserToBatch: (user: ProvisionSearchItem) => void
+  syncProvisionUserId: (userId: string) => void
 }
 
 const props = defineProps<{
@@ -333,7 +344,9 @@ const provisionUserProfile = props.provisioning.provisionUserProfile
 const revokeProvisioningRole = () => props.provisioning.revokeProvisioningRole()
 const revokeProvisioningRoleBatch = () => props.provisioning.revokeProvisioningRoleBatch()
 const searchProvisionUsers = (page: number) => props.provisioning.searchProvisionUsers(page)
+const handleProvisionUserIdChange = (userId: string) => props.provisioning.syncProvisionUserId(userId)
 const selectProvisionUser = (user: ProvisionSearchItem) => props.provisioning.selectProvisionUser(user)
+const addProvisionUserToBatch = (user: ProvisionSearchItem) => props.provisioning.addProvisionUserToBatch(user)
 </script>
 
 <style scoped>

--- a/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
@@ -75,6 +75,26 @@
           type="text"
           :placeholder="tr('shiftId1, shiftId2', '班次ID1, 班次ID2')"
         />
+        <small class="attendance__field-hint">
+          {{ tr('Separate shift IDs with commas. Use the quick append buttons below to build the sequence in order, and repeat a shift if the cycle needs duplicates.', '请用英文逗号分隔班次 ID。可用下方快捷按钮按顺序拼接，如需重复班次可重复点击。') }}
+        </small>
+        <div v-if="shifts.length > 0" class="attendance__sequence-builder">
+          <span class="attendance__field-hint">{{ tr('Quick append from existing shifts', '从已有班次快捷拼接') }}</span>
+          <div class="attendance__sequence-builder-actions">
+            <button
+              v-for="shift in shifts"
+              :key="shift.id"
+              class="attendance__btn attendance__btn--inline"
+              type="button"
+              @click="appendShiftToRotationSequence(shift.id)"
+            >
+              {{ shift.name }} · {{ shift.id }}
+            </button>
+          </div>
+        </div>
+        <small v-if="rotationSequencePreviewText" class="attendance__field-hint">
+          {{ tr('Current sequence', '当前序列') }}: {{ rotationSequencePreviewText }}
+        </small>
       </label>
       <label class="attendance__field attendance__field--checkbox" for="attendance-rotation-rule-active">
         <span>{{ tr('Active', '启用') }}</span>
@@ -446,7 +466,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Ref } from 'vue'
+import { computed, type Ref } from 'vue'
 import type {
   AttendanceAssignmentItem,
   AttendanceRotationAssignmentItem,
@@ -600,6 +620,27 @@ const editAssignment = (item: AttendanceAssignmentItem) => props.scheduling.edit
 const loadAssignments = () => props.scheduling.loadAssignments()
 const saveAssignment = () => props.scheduling.saveAssignment()
 const deleteAssignment = (id: string) => props.scheduling.deleteAssignment(id)
+
+function parseShiftSequence(value: string): string[] {
+  return value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function appendShiftToRotationSequence(shiftId: string) {
+  const current = parseShiftSequence(rotationRuleForm.shiftSequence)
+  rotationRuleForm.shiftSequence = [...current, shiftId].join(', ')
+}
+
+const rotationSequencePreviewText = computed(() => {
+  const sequence = parseShiftSequence(rotationRuleForm.shiftSequence)
+  if (sequence.length === 0) return ''
+  return sequence.map((shiftId) => {
+    const shift = shifts.value.find(item => item.id === shiftId)
+    return shift ? `${shift.name} (${shiftId})` : shiftId
+  }).join(' → ')
+})
 </script>
 
 <style scoped>
@@ -635,6 +676,11 @@ const deleteAssignment = (id: string) => props.scheduling.deleteAssignment(id)
   gap: 6px;
 }
 
+.attendance__field-hint {
+  color: #666;
+  font-size: 12px;
+}
+
 .attendance__field--full {
   grid-column: 1 / -1;
 }
@@ -664,6 +710,23 @@ const deleteAssignment = (id: string) => props.scheduling.deleteAssignment(id)
 .attendance__btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.attendance__btn--inline {
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
+.attendance__sequence-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.attendance__sequence-builder-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .attendance__table-wrapper {

--- a/apps/web/src/views/attendance/useAttendanceAdminImportWorkflow.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminImportWorkflow.ts
@@ -77,6 +77,37 @@ export interface AttendanceImportMappingProfile {
   payloadExample?: Record<string, any>
 }
 
+export interface AttendanceImportFieldGuide {
+  field: string
+  meaningEn: string
+  meaningZh: string
+}
+
+export interface AttendanceImportProfileMappingGuide {
+  targetField: string
+  sourceField: string
+  meaningEn: string
+  meaningZh: string
+}
+
+export interface AttendanceImportTemplateGuide {
+  source: string
+  mode: AttendanceImportMode
+  columns: string[]
+  requiredFields: string[]
+  sampleHeader: string
+  fieldGuides: AttendanceImportFieldGuide[]
+}
+
+export interface AttendanceImportProfileGuide {
+  name: string
+  description?: string
+  requiredFields: string[]
+  mappingEntries: AttendanceImportProfileMappingGuide[]
+  userMapKeyField?: string
+  userMapSourceFields?: string[]
+}
+
 export interface AttendanceImportJob {
   id: string
   orgId?: string
@@ -448,6 +479,304 @@ function buildImportPerfSuffix(input: {
   }
 }
 
+const ATTENDANCE_IMPORT_FIELD_MEANINGS: Record<string, { en: string; zh: string }> = {
+  source: {
+    en: 'Import source that selects the parser and mapping path.',
+    zh: '导入来源，用于选择解析器和映射路径。',
+  },
+  mode: {
+    en: 'Import behavior. override replaces matching user/date rows; merge keeps existing values when new fields are missing.',
+    zh: '导入行为。override 会覆盖同用户同日期记录；merge 在缺少新字段时保留已有值。',
+  },
+  columns: {
+    en: 'Source column names or column definitions used by the template.',
+    zh: '模板使用的源列名或列定义。',
+  },
+  mapping: {
+    en: 'Source-to-attendance field mapping used when parsing each row.',
+    zh: '解析每一行时使用的源字段到考勤字段映射。',
+  },
+  data: {
+    en: 'Structured row data keyed by the source columns.',
+    zh: '按源列组织的结构化行数据。',
+  },
+  rows: {
+    en: 'Inline rows included directly in the payload.',
+    zh: '直接写入载荷的行数据。',
+  },
+  entries: {
+    en: 'Alternate inline row array used by some import sources.',
+    zh: '某些导入来源使用的另一种行数组。',
+  },
+  userId: {
+    en: 'Target attendance user ID.',
+    zh: '考勤目标用户 ID。',
+  },
+  workDate: {
+    en: 'Attendance date for the imported record.',
+    zh: '导入记录对应的考勤日期。',
+  },
+  firstInAt: {
+    en: 'First clock-in timestamp for the day.',
+    zh: '当天第一次打卡时间。',
+  },
+  lastOutAt: {
+    en: 'Last clock-out timestamp for the day.',
+    zh: '当天最后一次打卡时间。',
+  },
+  workMinutes: {
+    en: 'Total worked minutes after the import rules are applied.',
+    zh: '套用导入规则后得到的工作分钟数。',
+  },
+  lateMinutes: {
+    en: 'Minutes counted as late arrival.',
+    zh: '计为迟到的分钟数。',
+  },
+  earlyLeaveMinutes: {
+    en: 'Minutes counted as early leave.',
+    zh: '计为早退的分钟数。',
+  },
+  leaveMinutes: {
+    en: 'Minutes counted as leave time.',
+    zh: '计为请假时间的分钟数。',
+  },
+  overtimeMinutes: {
+    en: 'Minutes counted as overtime.',
+    zh: '计为加班的分钟数。',
+  },
+  status: {
+    en: 'Attendance status produced by the import engine.',
+    zh: '导入引擎生成的考勤状态。',
+  },
+  isWorkday: {
+    en: 'Whether the imported date is treated as a workday.',
+    zh: '导入日期是否被视为工作日。',
+  },
+  warnings: {
+    en: 'Warning messages generated while importing the row.',
+    zh: '导入该行时生成的警告信息。',
+  },
+  appliedPolicies: {
+    en: 'Policies that were applied to compute the result.',
+    zh: '用于计算结果的规则。',
+  },
+  userGroups: {
+    en: 'User groups associated with the imported record.',
+    zh: '与导入记录关联的用户分组。',
+  },
+  orgId: {
+    en: 'Organization that owns the import.',
+    zh: '导入所属的组织。',
+  },
+  timezone: {
+    en: 'Timezone used to interpret dates and clock-in or clock-out timestamps.',
+    zh: '用于解析日期和上下班打卡时间的时区。',
+  },
+  ruleSetId: {
+    en: 'Rule set applied while evaluating imported attendance data.',
+    zh: '导入考勤数据时使用的规则集。',
+  },
+  mappingProfileId: {
+    en: 'Saved mapping profile selected for this payload.',
+    zh: '此载荷选中的已保存映射配置。',
+  },
+  csvText: {
+    en: 'Raw CSV text to upload or preview.',
+    zh: '用于上传或预览的原始 CSV 文本。',
+  },
+  csvFileId: {
+    en: 'Uploaded CSV file reference returned by the server.',
+    zh: '服务端返回的已上传 CSV 文件引用。',
+  },
+  csvOptions: {
+    en: 'CSV parsing options such as header row and delimiter.',
+    zh: 'CSV 解析选项，例如表头行和分隔符。',
+  },
+  userMap: {
+    en: 'Lookup table used to resolve imported values to users.',
+    zh: '用于把导入值解析为用户的查找表。',
+  },
+  userMapKeyField: {
+    en: 'Key field in the user map, such as employee number.',
+    zh: '用户映射中的键字段，例如工号。',
+  },
+  userMapSourceFields: {
+    en: 'Source fields that can be used to match the user map key.',
+    zh: '用于匹配用户映射键的源字段。',
+  },
+  groupSync: {
+    en: 'Optional group creation and member assignment settings.',
+    zh: '可选的分组创建和成员分配设置。',
+  },
+  commitToken: {
+    en: 'Short-lived token required for preview and commit requests.',
+    zh: '预览和提交请求所需的短期令牌。',
+  },
+}
+
+const ATTENDANCE_IMPORT_FIELD_ORDER = [
+  'source',
+  'mode',
+  'columns',
+  'mapping',
+  'data',
+  'rows',
+  'entries',
+  'csvText',
+  'csvFileId',
+  'csvOptions',
+  'userId',
+  'orgId',
+  'timezone',
+  'ruleSetId',
+  'mappingProfileId',
+  'userMap',
+  'userMapKeyField',
+  'userMapSourceFields',
+  'groupSync',
+  'commitToken',
+]
+
+function humanizeAttendanceImportField(field: string): string {
+  return String(field)
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function describeAttendanceImportField(field: string): AttendanceImportFieldGuide {
+  const normalized = String(field || '').trim()
+  const known = ATTENDANCE_IMPORT_FIELD_MEANINGS[normalized]
+  if (known) {
+    return {
+      field: normalized,
+      meaningEn: known.en,
+      meaningZh: known.zh,
+    }
+  }
+  const humanized = humanizeAttendanceImportField(normalized) || normalized
+  return {
+    field: normalized,
+    meaningEn: `Field "${humanized}".`,
+    meaningZh: `字段“${humanized}”。`,
+  }
+}
+
+function extractTemplateColumns(columns: unknown): string[] {
+  if (!Array.isArray(columns)) return []
+  const values: string[] = []
+  for (const column of columns) {
+    if (typeof column === 'string') {
+      const text = column.trim()
+      if (text) values.push(text)
+      continue
+    }
+    if (!column || typeof column !== 'object') continue
+    const candidate = (
+      (column as Record<string, unknown>).header
+      ?? (column as Record<string, unknown>).sourceField
+      ?? (column as Record<string, unknown>).source
+      ?? (column as Record<string, unknown>).name
+      ?? (column as Record<string, unknown>).field
+      ?? (column as Record<string, unknown>).key
+      ?? (column as Record<string, unknown>).targetField
+      ?? (column as Record<string, unknown>).label
+    )
+    if (typeof candidate === 'string') {
+      const text = candidate.trim()
+      if (text) values.push(text)
+    }
+  }
+  return Array.from(new Set(values))
+}
+
+function extractRequiredFields(payloadExample: Record<string, any>, profile?: AttendanceImportMappingProfile | null): string[] {
+  const required = Array.isArray(payloadExample.requiredFields)
+    ? payloadExample.requiredFields
+    : []
+  const profileRequired = Array.isArray(profile?.requiredFields)
+    ? profile?.requiredFields
+    : []
+  return Array.from(new Set([
+    ...required,
+    ...profileRequired,
+  ].map(item => String(item).trim()).filter(Boolean)))
+}
+
+function extractMappingSource(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (!value || typeof value !== 'object') return String(value ?? '').trim()
+
+  const node = value as Record<string, unknown>
+  const candidate = (
+    node.header
+    ?? node.sourceField
+    ?? node.source
+    ?? node.name
+    ?? node.field
+    ?? node.key
+    ?? node.label
+    ?? node.value
+  )
+  if (typeof candidate === 'string') return candidate.trim()
+  if (Array.isArray(candidate)) return candidate.map(item => String(item).trim()).filter(Boolean).join(', ')
+  return JSON.stringify(value)
+}
+
+function buildAttendanceImportTemplateGuide(
+  payloadExample: Record<string, any>,
+  profile?: AttendanceImportMappingProfile | null,
+): AttendanceImportTemplateGuide | null {
+  if (!payloadExample || typeof payloadExample !== 'object') return null
+
+  const columns = extractTemplateColumns(payloadExample.columns)
+  const requiredFields = extractRequiredFields(payloadExample, profile)
+  const sampleHeader = columns.length > 0
+    ? columns.join(',')
+    : requiredFields.join(',')
+  const fieldOrder = [
+    ...ATTENDANCE_IMPORT_FIELD_ORDER,
+    ...Object.keys(payloadExample).filter(field => !ATTENDANCE_IMPORT_FIELD_ORDER.includes(field)).sort(),
+  ]
+  const fieldGuides = Array.from(new Set(fieldOrder))
+    .filter(field => Object.prototype.hasOwnProperty.call(payloadExample, field))
+    .map(field => describeAttendanceImportField(field))
+
+  return {
+    source: typeof payloadExample.source === 'string' && payloadExample.source.trim() ? payloadExample.source.trim() : 'attendance',
+    mode: payloadExample.mode === 'merge' ? 'merge' : 'override',
+    columns,
+    requiredFields,
+    sampleHeader,
+    fieldGuides,
+  }
+}
+
+function buildAttendanceImportProfileGuide(
+  profile: AttendanceImportMappingProfile | null,
+): AttendanceImportProfileGuide | null {
+  if (!profile) return null
+  const mappingEntries = profile.mapping && typeof profile.mapping === 'object' && !Array.isArray(profile.mapping)
+    ? Object.entries(profile.mapping).map(([targetField, sourceValue]) => ({
+      targetField,
+      sourceField: extractMappingSource(sourceValue),
+      ...describeAttendanceImportField(targetField),
+    }))
+    : []
+
+  return {
+    name: profile.name,
+    description: profile.description,
+    requiredFields: Array.isArray(profile.requiredFields)
+      ? Array.from(new Set(profile.requiredFields.map(item => String(item).trim()).filter(Boolean)))
+      : [],
+    mappingEntries,
+    userMapKeyField: profile.userMapKeyField,
+    userMapSourceFields: profile.userMapSourceFields,
+  }
+}
+
 export function useAttendanceAdminImportWorkflow({
   tr,
   defaultTimezone,
@@ -527,6 +856,14 @@ export function useAttendanceAdminImportWorkflow({
     const commitAsync = importThresholds.commitAsyncThreshold.toLocaleString()
     return `Auto mode: preview >= ${previewChunk} rows may use chunked preview (${previewChunkSize}/chunk); preview >= ${previewAsync} rows queues async preview; import >= ${commitAsync} rows queues async import.`
   })
+
+  const importTemplateGuide = computed(() => {
+    const payloadExample = parseAttendanceImportJsonConfig(importForm.payload)
+    if (!payloadExample) return null
+    return buildAttendanceImportTemplateGuide(payloadExample, selectedImportProfile.value)
+  })
+
+  const selectedImportProfileGuide = computed(() => buildAttendanceImportProfileGuide(selectedImportProfile.value))
 
   const importAsyncJobTelemetryText = computed(() => {
     const job = importAsyncJob.value
@@ -1645,6 +1982,8 @@ export function useAttendanceAdminImportWorkflow({
     importMode,
     importMappingProfiles,
     selectedImportProfile,
+    importTemplateGuide,
+    selectedImportProfileGuide,
     importCsvFile,
     importCsvFileName,
     importCsvFileId,

--- a/apps/web/src/views/attendance/useAttendanceAdminProvisioning.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminProvisioning.ts
@@ -315,6 +315,29 @@ export function useAttendanceAdminProvisioning({ adminForbidden, tr }: UseAttend
     void loadProvisioningUser()
   }
 
+  function syncProvisionUserId(userId: string) {
+    if (provisionForm.userId === userId) return
+    provisionForm.userId = userId
+    provisionHasLoaded.value = false
+    provisionStatusMessage.value = ''
+    provisionStatusKind.value = 'info'
+    provisionUserProfile.value = null
+    provisionPermissions.value = []
+    provisionRoles.value = []
+    provisionUserIsAdmin.value = false
+  }
+
+  function addProvisionUserToBatch(user: AttendanceAdminUserSearchItem) {
+    const userId = user.id.trim()
+    if (!userId) return
+
+    const { valid, invalid } = parseAttendanceAdminUserIdList(provisionBatchUserIdsText.value)
+    if (valid.includes(userId) || invalid.includes(userId)) return
+
+    const nextValue = provisionBatchUserIdsText.value.trimEnd()
+    provisionBatchUserIdsText.value = nextValue ? `${nextValue}\n${userId}` : userId
+  }
+
   async function fetchProvisioningUser(userId: string) {
     provisionRoles.value = []
     const response = await apiFetch(`/api/permissions/user/${encodeURIComponent(userId)}`)
@@ -810,5 +833,7 @@ export function useAttendanceAdminProvisioning({ adminForbidden, tr }: UseAttend
     revokeProvisioningRoleBatch,
     searchProvisionUsers,
     selectProvisionUser,
+    addProvisionUserToBatch,
+    syncProvisionUserId,
   }
 }

--- a/apps/web/src/views/attendance/useAttendanceAdminScheduling.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminScheduling.ts
@@ -93,6 +93,14 @@ function toDateInput(date: Date): string {
   return date.toISOString().slice(0, 10)
 }
 
+function startOfYear(date: Date): Date {
+  return new Date(date.getFullYear(), 0, 1)
+}
+
+function endOfYear(date: Date): Date {
+  return new Date(date.getFullYear(), 11, 31)
+}
+
 function buildQuery(params: Record<string, string | undefined>): URLSearchParams {
   const query = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
@@ -194,9 +202,15 @@ export function useAttendanceAdminScheduling({
   })
 
   const holidays = ref<AttendanceHoliday[]>([])
+  const holidayTotal = ref(0)
   const holidayLoading = ref(false)
   const holidaySaving = ref(false)
   const holidayEditingId = ref<string | null>(null)
+  const initialRange = getDateRange()
+  const holidayRange = reactive({
+    from: initialRange.from || toDateInput(startOfYear(today)),
+    to: initialRange.to || toDateInput(endOfYear(today)),
+  })
   const holidayForm = reactive({
     date: toDateInput(today),
     name: '',
@@ -655,7 +669,10 @@ export function useAttendanceAdminScheduling({
   async function loadHolidays() {
     holidayLoading.value = true
     try {
-      const range = getDateRange()
+      const range = {
+        from: holidayRange.from || getDateRange().from,
+        to: holidayRange.to || getDateRange().to,
+      }
       const query = buildQuery({
         from: range.from,
         to: range.to,
@@ -666,12 +683,13 @@ export function useAttendanceAdminScheduling({
         adminForbidden.value = true
         return
       }
-      const data = await readJson(response) as { ok?: boolean; data?: { items?: AttendanceHoliday[] }; error?: { message?: string } } | null
+      const data = await readJson(response) as { ok?: boolean; data?: { items?: AttendanceHoliday[]; total?: number }; error?: { message?: string } } | null
       if (!response.ok || !data?.ok) {
         throw new Error(data?.error?.message || tr('Failed to load holidays', '加载节假日失败'))
       }
       adminForbidden.value = false
       holidays.value = data.data?.items || []
+      holidayTotal.value = Number(data.data?.total ?? holidays.value.length) || holidays.value.length
     } catch (error) {
       setStatus(extractErrorMessage(error, tr('Failed to load holidays', '加载节假日失败')), 'error')
     } finally {
@@ -686,9 +704,12 @@ export function useAttendanceAdminScheduling({
       if (!holidayForm.date) {
         throw new Error(tr('Holiday date is required', '节假日日期为必填项'))
       }
+      if (!holidayForm.name.trim()) {
+        throw new Error(tr('Holiday name is required', '节假日名称为必填项'))
+      }
       const payload = {
         date: holidayForm.date,
-        name: holidayForm.name.trim().length > 0 ? holidayForm.name.trim() : null,
+        name: holidayForm.name.trim(),
         isWorkingDay: holidayForm.isWorkingDay,
         orgId: getOrgId(),
       }
@@ -780,9 +801,11 @@ export function useAttendanceAdminScheduling({
     saveAssignment,
     deleteAssignment,
     holidays,
+    holidayTotal,
     holidayLoading,
     holidaySaving,
     holidayEditingId,
+    holidayRange,
     holidayForm,
     resetHolidayForm,
     editHoliday,

--- a/apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts
+++ b/apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts
@@ -65,7 +65,19 @@ describe('useAttendanceAdminImportWorkflow', () => {
               columns: ['userId'],
             },
             mappingProfiles: [
-              { id: 'profile-a', name: 'DingTalk', source: 'dingtalk_csv' },
+              {
+                id: 'profile-a',
+                name: 'DingTalk',
+                source: 'dingtalk_csv',
+                description: 'Maps DingTalk CSV headers to attendance fields.',
+                requiredFields: ['userId', 'workDate'],
+                userMapKeyField: 'empNo',
+                userMapSourceFields: ['工号', '姓名'],
+                mapping: {
+                  userId: '工号',
+                  workDate: '日期',
+                },
+              },
             ],
           },
         })
@@ -81,8 +93,85 @@ describe('useAttendanceAdminImportWorkflow', () => {
       mode: 'merge',
       columns: ['userId'],
     })
+    expect(workflow.importTemplateGuide.value).toEqual({
+      source: 'dingtalk_csv',
+      mode: 'merge',
+      columns: ['userId'],
+      requiredFields: [],
+      sampleHeader: 'userId',
+      fieldGuides: [
+        { field: 'source', meaningEn: 'Import source that selects the parser and mapping path.', meaningZh: '导入来源，用于选择解析器和映射路径。' },
+        { field: 'mode', meaningEn: 'Import behavior. override replaces matching user/date rows; merge keeps existing values when new fields are missing.', meaningZh: '导入行为。override 会覆盖同用户同日期记录；merge 在缺少新字段时保留已有值。' },
+        { field: 'columns', meaningEn: 'Source column names or column definitions used by the template.', meaningZh: '模板使用的源列名或列定义。' },
+      ],
+    })
     expect(workflow.importMappingProfiles.value.map((item) => item.id)).toEqual(['profile-a'])
     expect(setStatus).toHaveBeenCalledWith('Import template loaded.', 'info', undefined)
+  })
+
+  it('builds a selected profile guide with readable field meanings', async () => {
+    const { workflow } = createWorkflow({
+      apiFetch: vi.fn(async () => jsonResponse(200, {
+        ok: true,
+        data: {
+          payloadExample: {
+            source: 'dingtalk_csv',
+            mode: 'override',
+            columns: ['userId', 'workDate', 'firstInAt'],
+          },
+          mappingProfiles: [
+            {
+              id: 'profile-a',
+              name: 'DingTalk',
+              source: 'dingtalk_csv',
+              description: 'Maps DingTalk CSV headers to attendance fields.',
+              requiredFields: ['userId', 'workDate'],
+              userMapKeyField: 'empNo',
+              userMapSourceFields: ['工号', '姓名'],
+              mapping: {
+                userId: '工号',
+                workDate: '日期',
+                firstInAt: '上班打卡',
+              },
+            },
+          ],
+        },
+      })),
+    })
+
+    await workflow.loadImportTemplate()
+    workflow.importProfileId.value = 'profile-a'
+
+    expect(workflow.selectedImportProfileGuide.value).toEqual({
+      name: 'DingTalk',
+      description: 'Maps DingTalk CSV headers to attendance fields.',
+      requiredFields: ['userId', 'workDate'],
+      userMapKeyField: 'empNo',
+      userMapSourceFields: ['工号', '姓名'],
+      mappingEntries: [
+        {
+          field: 'userId',
+          targetField: 'userId',
+          sourceField: '工号',
+          meaningEn: 'Target attendance user ID.',
+          meaningZh: '考勤目标用户 ID。',
+        },
+        {
+          field: 'workDate',
+          targetField: 'workDate',
+          sourceField: '日期',
+          meaningEn: 'Attendance date for the imported record.',
+          meaningZh: '导入记录对应的考勤日期。',
+        },
+        {
+          field: 'firstInAt',
+          targetField: 'firstInAt',
+          sourceField: '上班打卡',
+          meaningEn: 'First clock-in timestamp for the day.',
+          meaningZh: '当天第一次打卡时间。',
+        },
+      ],
+    })
   })
 
   it('applies the selected mapping profile into the payload', () => {

--- a/apps/web/tests/useAttendanceAdminProvisioning.spec.ts
+++ b/apps/web/tests/useAttendanceAdminProvisioning.spec.ts
@@ -121,4 +121,64 @@ describe('useAttendanceAdminProvisioning', () => {
     expect(provisioning.provisionBatchUnchangedIds.value).toEqual([])
     expect(adminForbidden.value).toBe(false)
   })
+
+  it('clears stale single-user access state when the selected user changes', () => {
+    const adminForbidden = ref(false)
+    const provisioning = useAttendanceAdminProvisioning({ adminForbidden, tr })
+
+    provisioning.provisionForm.userId = '11111111-1111-4111-8111-111111111111'
+    provisioning.provisionPermissions.value = ['attendance:read']
+    provisioning.provisionRoles.value = ['employee']
+    provisioning.provisionUserIsAdmin.value = true
+    provisioning.provisionUserProfile.value = {
+      id: provisioning.provisionForm.userId,
+      email: 'alice@example.com',
+      name: 'Alice',
+    }
+    provisioning.provisionHasLoaded.value = true
+
+    provisioning.syncProvisionUserId('22222222-2222-4222-8222-222222222222')
+
+    expect(provisioning.provisionHasLoaded.value).toBe(false)
+    expect(provisioning.provisionUserProfile.value).toBeNull()
+    expect(provisioning.provisionPermissions.value).toEqual([])
+    expect(provisioning.provisionRoles.value).toEqual([])
+    expect(provisioning.provisionUserIsAdmin.value).toBe(false)
+    expect(adminForbidden.value).toBe(false)
+  })
+
+  it('adds searched users to the batch UUID list without duplicating ids', () => {
+    const adminForbidden = ref(false)
+    const provisioning = useAttendanceAdminProvisioning({ adminForbidden, tr })
+    const validA = '11111111-1111-4111-8111-111111111111'
+    const validB = '22222222-2222-4222-8222-222222222222'
+
+    provisioning.provisionBatchUserIdsText.value = `${validA}\nlegacy-note`
+
+    provisioning.addProvisionUserToBatch({
+      id: validA,
+      email: 'alice@example.com',
+      name: 'Alice',
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-20T00:00:00.000Z',
+    })
+    expect(provisioning.provisionBatchUserIdsText.value).toBe(`${validA}\nlegacy-note`)
+
+    provisioning.addProvisionUserToBatch({
+      id: validB,
+      email: 'bob@example.com',
+      name: 'Bob',
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-20T00:00:00.000Z',
+    })
+
+    expect(provisioning.provisionBatchUserIdsText.value).toBe(`${validA}\nlegacy-note\n${validB}`)
+    expect(adminForbidden.value).toBe(false)
+  })
 })

--- a/apps/web/tests/useAttendanceAdminScheduling.spec.ts
+++ b/apps/web/tests/useAttendanceAdminScheduling.spec.ts
@@ -176,6 +176,57 @@ describe('useAttendanceAdminScheduling', () => {
     expect(scheduling.holidays.value[0]?.id).toBe('holiday-1')
   })
 
+  it('uses the holiday module range instead of the overview range once the admin changes it', async () => {
+    const adminForbidden = ref(false)
+    const apiFetch = vi.fn().mockResolvedValue(jsonResponse(200, {
+      ok: true,
+      data: {
+        items: [
+          { id: 'holiday-2', date: '2026-01-01', name: 'New Year', isWorkingDay: false },
+        ],
+        total: 12,
+      },
+    }))
+
+    const scheduling = useAttendanceAdminScheduling({
+      adminForbidden,
+      apiFetch,
+      defaultTimezone: 'UTC',
+      getOrgId: () => 'org-3',
+      getDateRange: () => ({ from: '2026-03-01', to: '2026-03-31' }),
+    })
+
+    scheduling.holidayRange.from = '2026-01-01'
+    scheduling.holidayRange.to = '2026-12-31'
+
+    await scheduling.loadHolidays()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/holidays?from=2026-01-01&to=2026-12-31&orgId=org-3')
+    expect(scheduling.holidayTotal.value).toBe(12)
+    expect(scheduling.holidays.value[0]?.id).toBe('holiday-2')
+  })
+
+  it('requires a holiday name before saving', async () => {
+    const adminForbidden = ref(false)
+    const setStatus = vi.fn()
+    const apiFetch = vi.fn()
+
+    const scheduling = useAttendanceAdminScheduling({
+      adminForbidden,
+      apiFetch,
+      defaultTimezone: 'UTC',
+      setStatus,
+    })
+
+    scheduling.holidayForm.date = '2026-03-15'
+    scheduling.holidayForm.name = '   '
+
+    await scheduling.saveHoliday()
+
+    expect(apiFetch).not.toHaveBeenCalled()
+    expect(setStatus).toHaveBeenCalledWith('Holiday name is required', 'error')
+  })
+
   it('marks admin forbidden and shows the direct 403 message for holiday saves', async () => {
     const adminForbidden = ref(false)
     const setStatus = vi.fn()
@@ -189,6 +240,7 @@ describe('useAttendanceAdminScheduling', () => {
     })
 
     scheduling.holidayForm.date = '2026-03-15'
+    scheduling.holidayForm.name = 'Spring Festival'
 
     await scheduling.saveHoliday()
 


### PR DESCRIPTION
## Summary
- decouple the holiday admin table from the overview date range and add inline holiday-name validation
- surface import template guides and mapping-profile field explanations from the existing template API
- reduce manual UUID entry in provisioning and add shift-sequence helpers for rotation rules

## Testing
- pnpm --filter @metasheet/web exec vitest run tests/useAttendanceAdminScheduling.spec.ts tests/useAttendanceAdminImportWorkflow.spec.ts tests/useAttendanceAdminProvisioning.spec.ts
- pnpm --filter @metasheet/web build
