### PR TITLE
feat(attendance): surface workday decision context

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -441,6 +441,7 @@ interface AttendanceRecord {
   early_leave_minutes: number
   status: string
   is_workday?: boolean
+  workday_context?: AttendanceWorkdayContext | null
   meta?: Record<string, any>
 }
 
@@ -457,6 +458,7 @@ interface AttendanceAnomaly {
   leaveMinutes?: number
   overtimeMinutes?: number
   warnings: string[]
+  workdayContext?: AttendanceWorkdayContext | null
   state: 'open' | 'pending'
   request?: {
     id: string
@@ -496,6 +498,22 @@ interface AttendanceImportPreviewItem {
   warnings?: string[]
   appliedPolicies?: string[]
   userGroups?: string[]
+}
+
+interface AttendanceWorkdayContext {
+  storedIsWorkday: boolean
+  resolvedIsWorkday: boolean
+  matchesStored: boolean
+  source: 'rule' | 'shift' | 'rotation'
+  sourceName?: string | null
+  weekday?: number
+  workingDays?: number[]
+  holiday?: {
+    id?: string | null
+    name?: string | null
+    isWorkingDay?: boolean
+    type?: string | null
+  } | null
 }
 
 interface CalendarDay {
@@ -901,6 +919,66 @@ const holidayMap = computed(() => {
   return map
 })
 
+function formatWorkdayWeekday(weekday: number | undefined): string {
+  if (!Number.isInteger(weekday) || weekday == null || weekday < 0 || weekday > 6) return tr('Unknown day', '未知星期')
+  return isZh.value
+    ? ['周日', '周一', '周二', '周三', '周四', '周五', '周六'][weekday]
+    : ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][weekday]
+}
+
+function formatWorkingDaysList(days: number[] | undefined): string {
+  if (!Array.isArray(days) || days.length === 0) return tr('No working days configured', '未配置工作日')
+  return days
+    .map((day) => formatWorkdayWeekday(day))
+    .join(isZh.value ? '、' : ', ')
+}
+
+function buildWorkdayTooltipLines(context: AttendanceWorkdayContext | null | undefined): string[] {
+  if (!context) return []
+
+  const resolvedLabel = context.resolvedIsWorkday
+    ? tr('Working day', '工作日')
+    : tr('Rest day', '休息日')
+  const sourceLabel = context.source === 'rotation'
+    ? tr('Rotation', '轮班')
+    : context.source === 'shift'
+      ? tr('Shift', '班次')
+      : tr('Default rule', '默认规则')
+  const lines = [
+    tr(`Workday decision: ${resolvedLabel}`, `工作日判定：${resolvedLabel}`),
+    context.sourceName
+      ? tr(`Source: ${sourceLabel} · ${context.sourceName}`, `来源：${sourceLabel} · ${context.sourceName}`)
+      : tr(`Source: ${sourceLabel}`, `来源：${sourceLabel}`),
+    tr(`Configured days: ${formatWorkingDaysList(context.workingDays)}`, `配置工作日：${formatWorkingDaysList(context.workingDays)}`),
+  ]
+
+  if (context.weekday != null) {
+    lines.push(tr(`Date weekday: ${formatWorkdayWeekday(context.weekday)}`, `当天星期：${formatWorkdayWeekday(context.weekday)}`))
+  }
+
+  if (context.holiday) {
+    const holidayLabel = context.holiday.isWorkingDay
+      ? tr('working-day override', '调班工作日')
+      : tr('holiday/rest override', '节假日/休息日覆盖')
+    lines.push(
+      context.holiday.name
+        ? tr(`Holiday override: ${context.holiday.name} (${holidayLabel})`, `节假日覆盖：${context.holiday.name}（${holidayLabel}）`)
+        : tr(`Holiday override: ${holidayLabel}`, `节假日覆盖：${holidayLabel}`)
+    )
+  }
+
+  if (!context.matchesStored) {
+    lines.push(
+      tr(
+        `Stored record differs: stored=${context.storedIsWorkday ? 'working day' : 'rest day'}`,
+        `记录值不同：存量记录=${context.storedIsWorkday ? '工作日' : '休息日'}`
+      )
+    )
+  }
+
+  return lines
+}
+
 const calendarDays = computed<CalendarDay[]>(() => {
   const year = calendarMonth.value.getFullYear()
   const month = calendarMonth.value.getMonth()
@@ -934,6 +1012,10 @@ const calendarDays = computed<CalendarDay[]>(() => {
       tooltip = holidayName ? `${key} · ${holidayName}` : `${key} · ${tr('Holiday', '休息日')}`
     } else if (record && status === 'off' && holidayName) {
       tooltip = `${key} · ${holidayName} · ${record.work_minutes} min`
+    }
+    const workdayTooltipLines = buildWorkdayTooltipLines(record?.workday_context)
+    if (workdayTooltipLines.length > 0) {
+      tooltip = `${tooltip}\n${workdayTooltipLines.join('\n')}`
     }
     return {
       key,

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1827,6 +1827,171 @@ describe('Attendance Plugin Integration', () => {
     expect(lastOutAtIso.startsWith(`${workDate}T18:00:00`)).toBe(true)
   })
 
+  it('exposes workday context for holiday overrides and shift schedules on attendance records', async () => {
+    if (!baseUrl) return
+
+    const userId = `attendance-workday-context-${Date.now().toString(36)}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const pickFutureWeekday = (targetDay: number): string => {
+      const cursor = new Date('2029-03-01T00:00:00.000Z')
+      for (let attempt = 0; attempt < 60; attempt += 1) {
+        if (cursor.getUTCDay() === targetDay) return cursor.toISOString().slice(0, 10)
+        cursor.setUTCDate(cursor.getUTCDate() + 1)
+      }
+      throw new Error(`Unable to reserve future weekday ${targetDay}`)
+    }
+
+    const sundayDate = pickFutureWeekday(0)
+    const wednesdayDate = pickFutureWeekday(3)
+    const rangeFrom = sundayDate < wednesdayDate ? sundayDate : wednesdayDate
+    const rangeTo = sundayDate > wednesdayDate ? sundayDate : wednesdayDate
+    const shiftName = `Sunday Shift ${Date.now().toString(36)}`
+
+    const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: shiftName,
+        timezone: 'UTC',
+        workStartTime: '09:00',
+        workEndTime: '18:00',
+        workingDays: [0],
+      }),
+    })
+    expect(shiftRes.status).toBe(201)
+    const shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+    expect(shiftId).toBeTruthy()
+
+    const assignmentRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId,
+        shiftId,
+        startDate: sundayDate,
+        endDate: sundayDate,
+        isActive: true,
+      }),
+    })
+    expect(assignmentRes.status).toBe(201)
+
+    const holidayName = `Midweek Holiday ${Date.now().toString(36)}`
+    const holidayRes = await requestJson(`${baseUrl}/api/attendance/holidays`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        date: wednesdayDate,
+        name: holidayName,
+        isWorkingDay: false,
+      }),
+    })
+    expect([201, 409]).toContain(holidayRes.status)
+
+    const prepareRes = await requestJson(`${baseUrl}/api/attendance/import/prepare`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    })
+    expect(prepareRes.status).toBe(200)
+    const commitToken = (prepareRes.body as { data?: { commitToken?: string } } | undefined)?.data?.commitToken
+    expect(commitToken).toBeTruthy()
+    if (!commitToken) return
+
+    const importRes = await requestJson(`${baseUrl}/api/attendance/import/commit`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId,
+        timezone: 'UTC',
+        rows: [
+          {
+            workDate: sundayDate,
+            fields: {
+              firstInAt: `${sundayDate}T09:00:00Z`,
+              lastOutAt: `${sundayDate}T18:00:00Z`,
+              status: 'normal',
+            },
+          },
+          {
+            workDate: wednesdayDate,
+            fields: {
+              firstInAt: `${wednesdayDate}T09:00:00Z`,
+              lastOutAt: `${wednesdayDate}T18:00:00Z`,
+              status: 'off',
+            },
+          },
+        ],
+        mode: 'override',
+        commitToken,
+      }),
+    })
+    expect(importRes.status).toBe(200)
+
+    const recordsRes = await requestJson(
+      `${baseUrl}/api/attendance/records?from=${encodeURIComponent(rangeFrom)}&to=${encodeURIComponent(rangeTo)}&userId=${encodeURIComponent(userId)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    )
+    expect(recordsRes.status).toBe(200)
+    const items = (recordsRes.body as { data?: { items?: any[] } } | undefined)?.data?.items ?? []
+    expect(Array.isArray(items)).toBe(true)
+
+    const sundayRecord = items.find((row) => String(row?.work_date ?? '').slice(0, 10) === sundayDate)
+    expect(sundayRecord).toBeTruthy()
+    expect(sundayRecord?.is_workday).toBe(true)
+    expect(sundayRecord?.workday_context).toMatchObject({
+      storedIsWorkday: true,
+      resolvedIsWorkday: true,
+      matchesStored: true,
+      source: 'shift',
+      sourceName: shiftName,
+      weekday: 0,
+      workingDays: [0],
+      holiday: null,
+    })
+
+    const wednesdayRecord = items.find((row) => String(row?.work_date ?? '').slice(0, 10) === wednesdayDate)
+    expect(wednesdayRecord).toBeTruthy()
+    expect(wednesdayRecord?.is_workday).toBe(false)
+    expect(wednesdayRecord?.workday_context).toMatchObject({
+      storedIsWorkday: false,
+      resolvedIsWorkday: false,
+      matchesStored: true,
+      source: 'rule',
+      weekday: 3,
+      workingDays: [1, 2, 3, 4, 5],
+      holiday: {
+        isWorkingDay: false,
+        type: 'holiday',
+      },
+    })
+    expect(typeof wednesdayRecord?.workday_context?.holiday?.name).toBe('string')
+  })
+
   it('keeps existing records after rolling back a later update batch', async () => {
     if (!baseUrl) return
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -2189,8 +2189,8 @@ function mapAssignmentRow(row) {
     orgId: row.org_id ?? DEFAULT_ORG_ID,
     userId: row.user_id,
     shiftId: row.shift_id,
-    startDate: row.start_date,
-    endDate: row.end_date ?? null,
+    startDate: normalizeDateOnly(row.start_date) ?? row.start_date,
+    endDate: normalizeDateOnly(row.end_date) ?? row.end_date ?? null,
     isActive: row.is_active ?? true,
   }
 }
@@ -2559,8 +2559,8 @@ function mapRotationAssignmentRow(row) {
     orgId: row.org_id ?? DEFAULT_ORG_ID,
     userId: row.user_id,
     rotationRuleId: row.rotation_rule_id,
-    startDate: row.start_date,
-    endDate: row.end_date ?? null,
+    startDate: normalizeDateOnly(row.start_date) ?? row.start_date,
+    endDate: normalizeDateOnly(row.end_date) ?? row.end_date ?? null,
     isActive: row.is_active ?? true,
   }
 }
@@ -4534,6 +4534,79 @@ function resolveWorkContextFromPrefetch(options) {
     holiday,
     isWorkingDay,
     source: rotationInfo ? 'rotation' : assignmentInfo ? 'shift' : 'rule',
+  }
+}
+
+async function buildWorkContextPrefetch(db, options) {
+  const { orgId, userIds, workDates, defaultRule } = options
+  const normalizedUserIds = Array.from(new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean)))
+  const normalizedWorkDates = Array.from(
+    new Set(
+      (Array.isArray(workDates) ? workDates : [])
+        .map((value) => normalizeDateOnly(value) ?? (typeof value === 'string' ? value.slice(0, 10) : null))
+        .filter(Boolean)
+    )
+  ).sort()
+
+  const resolvedDefaultRule = defaultRule ?? await loadDefaultRule(db, orgId)
+  if (!normalizedWorkDates.length || !normalizedUserIds.length) {
+    return {
+      defaultRule: resolvedDefaultRule,
+      prefetched: {
+        holidaysByDate: new Map(),
+        shiftAssignmentsByUser: new Map(),
+        rotationAssignmentsByUser: new Map(),
+        rotationShiftsById: new Map(),
+      },
+    }
+  }
+
+  const fromDate = normalizedWorkDates[0]
+  const toDate = normalizedWorkDates[normalizedWorkDates.length - 1]
+  const [holidaysByDate, shiftAssignmentsByUser, rotationPrefetch] = await Promise.all([
+    loadHolidayMapByDates(db, orgId, normalizedWorkDates),
+    loadShiftAssignmentMapForUsersRange(db, orgId, normalizedUserIds, fromDate, toDate),
+    loadRotationAssignmentMapForUsersRange(db, orgId, normalizedUserIds, fromDate, toDate),
+  ])
+
+  return {
+    defaultRule: resolvedDefaultRule,
+    prefetched: {
+      holidaysByDate,
+      shiftAssignmentsByUser,
+      rotationAssignmentsByUser: rotationPrefetch.assignmentsByUser,
+      rotationShiftsById: rotationPrefetch.shiftsById,
+    },
+  }
+}
+
+function buildWorkdayContextSummary(options) {
+  const { workDate, storedIsWorkday, resolvedContext } = options
+  if (!resolvedContext || !workDate) return null
+
+  const sourceName = resolvedContext.source === 'rotation'
+    ? resolvedContext.rotation?.name ?? resolvedContext.rule?.name ?? null
+    : resolvedContext.rule?.name ?? null
+  const holiday = resolvedContext.holiday
+    ? {
+        id: resolvedContext.holiday.id ?? null,
+        name: resolvedContext.holiday.name ?? null,
+        isWorkingDay: resolvedContext.holiday.isWorkingDay === true,
+        type: resolvedContext.holiday.type ?? (resolvedContext.holiday.isWorkingDay === true ? 'working_day_override' : 'holiday'),
+      }
+    : null
+  const normalizedStored = storedIsWorkday !== false
+  const normalizedResolved = resolvedContext.isWorkingDay !== false
+
+  return {
+    storedIsWorkday: normalizedStored,
+    resolvedIsWorkday: normalizedResolved,
+    matchesStored: normalizedStored === normalizedResolved,
+    source: resolvedContext.source ?? 'rule',
+    sourceName,
+    weekday: getWeekdayFromDateKey(workDate),
+    workingDays: Array.isArray(resolvedContext.rule?.workingDays) ? [...resolvedContext.rule.workingDays] : [...DEFAULT_RULE.workingDays],
+    holiday,
   }
 }
 
@@ -8529,12 +8602,31 @@ module.exports = {
             [targetUserId, orgId, from, to, pageSize, offset]
           )
 
+          const workContextPrefetch = await buildWorkContextPrefetch(db, {
+            orgId,
+            userIds: [targetUserId],
+            workDates: rows.map((row) => row.work_date),
+          })
           const approvedMap = await loadApprovedMinutesRange(db, orgId, targetUserId, from, to)
           const records = rows.map((row) => {
+            const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
             const meta = normalizeMetadata(row.meta)
-            const approved = approvedMap.get(row.work_date) ?? { leaveMinutes: 0, overtimeMinutes: 0 }
+            const approved = approvedMap.get(workDate) ?? { leaveMinutes: 0, overtimeMinutes: 0 }
+            const resolvedContext = resolveWorkContextFromPrefetch({
+              orgId,
+              userId: targetUserId,
+              workDate,
+              defaultRule: workContextPrefetch.defaultRule,
+              prefetched: workContextPrefetch.prefetched,
+            })
             return {
               ...row,
+              work_date: workDate,
+              workday_context: buildWorkdayContextSummary({
+                workDate,
+                storedIsWorkday: row.is_workday,
+                resolvedContext,
+              }),
               meta: {
                 ...meta,
                 leave_minutes: approved.leaveMinutes,
@@ -8674,6 +8766,12 @@ module.exports = {
 	            [targetUserId, orgId, from, to, excludedStatuses, pageSize, offset]
 	          )
 
+	          const workContextPrefetch = await buildWorkContextPrefetch(db, {
+	            orgId,
+	            userIds: [targetUserId],
+	            workDates: rows.map((row) => row.work_date),
+	          })
+
 	          const requestRows = await db.query(
 	            `SELECT id, work_date, request_type, status
 	             FROM attendance_requests
@@ -8683,7 +8781,7 @@ module.exports = {
 	          )
 	          const requestByDate = new Map()
 	          for (const row of requestRows) {
-	            const workDate = row.work_date
+	            const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
 	            const entry = requestByDate.get(workDate) ?? {
 	              hasPending: false,
 	              pending: null,
@@ -8704,16 +8802,24 @@ module.exports = {
 
 	          const approvedMap = await loadApprovedMinutesRange(db, orgId, targetUserId, from, to)
 	          const items = rows.map((row) => {
+	            const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
 	            const meta = normalizeMetadata(row.meta)
-	            const approved = approvedMap.get(row.work_date) ?? { leaveMinutes: 0, overtimeMinutes: 0 }
+	            const approved = approvedMap.get(workDate) ?? { leaveMinutes: 0, overtimeMinutes: 0 }
 	            const warnings = extractWarnings(meta)
-	            const requestSummary = requestByDate.get(row.work_date) ?? { hasPending: false, pending: null, latest: null }
+	            const requestSummary = requestByDate.get(workDate) ?? { hasPending: false, pending: null, latest: null }
 	            const suggestedRequestType = suggestRequestType(row)
 	            const state = requestSummary.hasPending ? 'pending' : 'open'
+	            const resolvedContext = resolveWorkContextFromPrefetch({
+	              orgId,
+	              userId: targetUserId,
+	              workDate,
+	              defaultRule: workContextPrefetch.defaultRule,
+	              prefetched: workContextPrefetch.prefetched,
+	            })
 
 	            return {
 	              recordId: row.id,
-	              workDate: row.work_date,
+	              workDate,
 	              status: row.status,
 	              isWorkday: row.is_workday,
 	              firstInAt: row.first_in_at,
@@ -8724,6 +8830,11 @@ module.exports = {
 	              leaveMinutes: approved.leaveMinutes,
 	              overtimeMinutes: approved.overtimeMinutes,
 	              warnings,
+	              workdayContext: buildWorkdayContextSummary({
+	                workDate,
+	                storedIsWorkday: row.is_workday,
+	                resolvedContext,
+	              }),
 	              state,
 	              request: requestSummary.pending ?? requestSummary.latest,
 	              suggestedRequestType,


### PR DESCRIPTION
## Summary
- expose workday decision context on attendance records and anomalies so deployed environments can explain why a date is treated as a workday or rest day
- normalize date-only fields on record and assignment paths to avoid timezone drift in work_date/startDate/endDate comparisons
- surface the context in the attendance calendar tooltip and cover the behavior with focused integration tests

## Verification
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "exposes workday context for holiday overrides and shift schedules on attendance records|supports import commit merge mode \(keeps earliest firstInAt and latest lastOutAt\)"
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build