### PR TITLE
fix(attendance): complete admin lookup routes

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -976,6 +976,110 @@ describe('Attendance Plugin Integration', () => {
     }
   })
 
+  it('supports shift and overtime rule lookup by id and rejects malformed ids with 400', async () => {
+    if (!baseUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const testUserId = `attendance-lookup-${runSuffix}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: `Lookup Shift ${runSuffix}`,
+        timezone: 'Asia/Shanghai',
+        workStartTime: '09:00',
+        workEndTime: '18:00',
+        workingDays: [1, 2, 3, 4, 5],
+      }),
+    })
+    expect(shiftRes.status).toBe(201)
+    const shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+    expect(shiftId).toBeTruthy()
+    if (!shiftId) return
+
+    const shiftLookupRes = await requestJson(`${baseUrl}/api/attendance/shifts/${shiftId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(shiftLookupRes.status).toBe(200)
+    const shiftLookupBody = shiftLookupRes.body as { data?: { id?: string; name?: string } } | undefined
+    expect(shiftLookupBody?.data?.id).toBe(shiftId)
+    expect(shiftLookupBody?.data?.name).toBe(`Lookup Shift ${runSuffix}`)
+
+    const overtimeRes = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: `Lookup Overtime ${runSuffix}`,
+        minMinutes: 30,
+        roundingMinutes: 15,
+        maxMinutesPerDay: 180,
+        requiresApproval: true,
+      }),
+    })
+    expect(overtimeRes.status).toBe(201)
+    const overtimeRuleId = (overtimeRes.body as { data?: { id?: string } } | undefined)?.data?.id
+    expect(overtimeRuleId).toBeTruthy()
+    if (!overtimeRuleId) return
+
+    const overtimeLookupRes = await requestJson(`${baseUrl}/api/attendance/overtime-rules/${overtimeRuleId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(overtimeLookupRes.status).toBe(200)
+    const overtimeLookupBody = overtimeLookupRes.body as { data?: { id?: string; name?: string } } | undefined
+    expect(overtimeLookupBody?.data?.id).toBe(overtimeRuleId)
+    expect(overtimeLookupBody?.data?.name).toBe(`Lookup Overtime ${runSuffix}`)
+
+    const invalidEndpoints = [
+      'groups/nonexistent-id',
+      'leave-types/fake',
+      'payroll-templates/not-a-uuid',
+      'shifts/not-a-uuid',
+      'overtime-rules/not-a-uuid',
+    ]
+
+    for (const apiPath of invalidEndpoints) {
+      const invalidRes = await requestJson(`${baseUrl}/api/attendance/${apiPath}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      expect(invalidRes.status).toBe(400)
+      const invalidBody = invalidRes.body as { error?: { code?: string } } | undefined
+      expect(invalidBody?.error?.code).toBe('VALIDATION_ERROR')
+    }
+
+    const missingShiftRes = await requestJson(`${baseUrl}/api/attendance/shifts/${randomUuidV4()}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(missingShiftRes.status).toBe(404)
+
+    const missingOvertimeRes = await requestJson(`${baseUrl}/api/attendance/overtime-rules/${randomUuidV4()}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(missingOvertimeRes.status).toBe(404)
+  })
+
   it('keeps /api/health public for probes', async () => {
     if (!baseUrl) return
 

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -3072,6 +3072,34 @@ paths:
           $ref: '#/components/responses/Forbidden'
   /api/attendance/shifts/{id}:
     x-plugin: plugin-attendance
+    get:
+      summary: Get attendance shift
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/AttendanceShift'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     put:
       summary: Update attendance shift
       security:
@@ -4402,6 +4430,34 @@ paths:
           $ref: '#/components/responses/Forbidden'
   /api/attendance/overtime-rules/{id}:
     x-plugin: plugin-attendance
+    get:
+      summary: Get overtime rule
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/AttendanceOvertimeRule'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     put:
       summary: Update overtime rule
       security:
@@ -4560,6 +4616,20 @@ paths:
               required:
                 - name
                 - requestType
+            examples:
+              missedCheckIn:
+                summary: Approval flow for missed check-in requests
+                value:
+                  name: 补卡审批
+                  requestType: missed_check_in
+                  steps:
+                    - name: 直属主管
+                      approverUserIds:
+                        - manager-user-001
+                    - name: 人事复核
+                      approverRoleIds:
+                        - attendance-admin
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -4732,6 +4802,17 @@ paths:
               required:
                 - name
                 - shiftSequence
+            examples:
+              standardCycle:
+                summary: Rotation rule with ordered shift ids
+                value:
+                  name: 四班两倒
+                  timezone: Asia/Shanghai
+                  shiftSequence:
+                    - 11111111-1111-4111-8111-111111111111
+                    - 22222222-2222-4222-8222-222222222222
+                    - 33333333-3333-4333-8333-333333333333
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -4905,6 +4986,15 @@ paths:
                 - userId
                 - rotationRuleId
                 - startDate
+            examples:
+              activeAssignment:
+                summary: Assign one user to a rotation rule
+                value:
+                  userId: attendance-user-001
+                  rotationRuleId: 44444444-4444-4444-8444-444444444444
+                  startDate: '2026-03-20'
+                  endDate: null
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -5088,6 +5178,35 @@ paths:
                   type: string
               required:
                 - name
+            examples:
+              orgDefault:
+                summary: Org-wide default rule set
+                value:
+                  name: 默认规则集
+                  description: 标准工作日与节假日配置
+                  version: 1
+                  scope: org
+                  isDefault: true
+                  config:
+                    source: manual
+                    rule:
+                      timezone: Asia/Shanghai
+                      workStartTime: '09:00'
+                      workEndTime: '18:00'
+                      workingDays:
+                        - 1
+                        - 2
+                        - 3
+                        - 4
+                        - 5
+                    policies:
+                      rules:
+                        - name: holiday-no-work
+                          when:
+                            isHoliday: true
+                          then:
+                            setWorkMinutes: 0
+                            setStatus: 'off'
       responses:
         '201':
           description: Created

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -4686,6 +4686,53 @@
     },
     "/api/attendance/shifts/{id}": {
       "x-plugin": "plugin-attendance",
+      "get": {
+        "summary": "Get attendance shift",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/AttendanceShift"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
       "put": {
         "summary": "Update attendance shift",
         "security": [
@@ -6852,6 +6899,53 @@
     },
     "/api/attendance/overtime-rules/{id}": {
       "x-plugin": "plugin-attendance",
+      "get": {
+        "summary": "Get overtime rule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/AttendanceOvertimeRule"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
       "put": {
         "summary": "Update overtime rule",
         "security": [
@@ -7108,6 +7202,30 @@
                   "name",
                   "requestType"
                 ]
+              },
+              "examples": {
+                "missedCheckIn": {
+                  "summary": "Approval flow for missed check-in requests",
+                  "value": {
+                    "name": "补卡审批",
+                    "requestType": "missed_check_in",
+                    "steps": [
+                      {
+                        "name": "直属主管",
+                        "approverUserIds": [
+                          "manager-user-001"
+                        ]
+                      },
+                      {
+                        "name": "人事复核",
+                        "approverRoleIds": [
+                          "attendance-admin"
+                        ]
+                      }
+                    ],
+                    "isActive": true
+                  }
+                }
               }
             }
           }
@@ -7391,6 +7509,21 @@
                   "name",
                   "shiftSequence"
                 ]
+              },
+              "examples": {
+                "standardCycle": {
+                  "summary": "Rotation rule with ordered shift ids",
+                  "value": {
+                    "name": "四班两倒",
+                    "timezone": "Asia/Shanghai",
+                    "shiftSequence": [
+                      "11111111-1111-4111-8111-111111111111",
+                      "22222222-2222-4222-8222-222222222222",
+                      "33333333-3333-4333-8333-333333333333"
+                    ],
+                    "isActive": true
+                  }
+                }
               }
             }
           }
@@ -7671,6 +7804,18 @@
                   "rotationRuleId",
                   "startDate"
                 ]
+              },
+              "examples": {
+                "activeAssignment": {
+                  "summary": "Assign one user to a rotation rule",
+                  "value": {
+                    "userId": "attendance-user-001",
+                    "rotationRuleId": "44444444-4444-4444-8444-444444444444",
+                    "startDate": "2026-03-20",
+                    "endDate": null,
+                    "isActive": true
+                  }
+                }
               }
             }
           }
@@ -7969,6 +8114,47 @@
                 "required": [
                   "name"
                 ]
+              },
+              "examples": {
+                "orgDefault": {
+                  "summary": "Org-wide default rule set",
+                  "value": {
+                    "name": "默认规则集",
+                    "description": "标准工作日与节假日配置",
+                    "version": 1,
+                    "scope": "org",
+                    "isDefault": true,
+                    "config": {
+                      "source": "manual",
+                      "rule": {
+                        "timezone": "Asia/Shanghai",
+                        "workStartTime": "09:00",
+                        "workEndTime": "18:00",
+                        "workingDays": [
+                          1,
+                          2,
+                          3,
+                          4,
+                          5
+                        ]
+                      },
+                      "policies": {
+                        "rules": [
+                          {
+                            "name": "holiday-no-work",
+                            "when": {
+                              "isHoliday": true
+                            },
+                            "then": {
+                              "setWorkMinutes": 0,
+                              "setStatus": "off"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
               }
             }
           }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -3072,6 +3072,34 @@ paths:
           $ref: '#/components/responses/Forbidden'
   /api/attendance/shifts/{id}:
     x-plugin: plugin-attendance
+    get:
+      summary: Get attendance shift
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/AttendanceShift'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     put:
       summary: Update attendance shift
       security:
@@ -4402,6 +4430,34 @@ paths:
           $ref: '#/components/responses/Forbidden'
   /api/attendance/overtime-rules/{id}:
     x-plugin: plugin-attendance
+    get:
+      summary: Get overtime rule
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/AttendanceOvertimeRule'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     put:
       summary: Update overtime rule
       security:
@@ -4560,6 +4616,20 @@ paths:
               required:
                 - name
                 - requestType
+            examples:
+              missedCheckIn:
+                summary: Approval flow for missed check-in requests
+                value:
+                  name: 补卡审批
+                  requestType: missed_check_in
+                  steps:
+                    - name: 直属主管
+                      approverUserIds:
+                        - manager-user-001
+                    - name: 人事复核
+                      approverRoleIds:
+                        - attendance-admin
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -4732,6 +4802,17 @@ paths:
               required:
                 - name
                 - shiftSequence
+            examples:
+              standardCycle:
+                summary: Rotation rule with ordered shift ids
+                value:
+                  name: 四班两倒
+                  timezone: Asia/Shanghai
+                  shiftSequence:
+                    - 11111111-1111-4111-8111-111111111111
+                    - 22222222-2222-4222-8222-222222222222
+                    - 33333333-3333-4333-8333-333333333333
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -4905,6 +4986,15 @@ paths:
                 - userId
                 - rotationRuleId
                 - startDate
+            examples:
+              activeAssignment:
+                summary: Assign one user to a rotation rule
+                value:
+                  userId: attendance-user-001
+                  rotationRuleId: 44444444-4444-4444-8444-444444444444
+                  startDate: '2026-03-20'
+                  endDate: null
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -5088,6 +5178,35 @@ paths:
                   type: string
               required:
                 - name
+            examples:
+              orgDefault:
+                summary: Org-wide default rule set
+                value:
+                  name: 默认规则集
+                  description: 标准工作日与节假日配置
+                  version: 1
+                  scope: org
+                  isDefault: true
+                  config:
+                    source: manual
+                    rule:
+                      timezone: Asia/Shanghai
+                      workStartTime: '09:00'
+                      workEndTime: '18:00'
+                      workingDays:
+                        - 1
+                        - 2
+                        - 3
+                        - 4
+                        - 5
+                    policies:
+                      rules:
+                        - name: holiday-no-work
+                          when:
+                            isHoliday: true
+                          then:
+                            setWorkMinutes: 0
+                            setStatus: 'off'
       responses:
         '201':
           description: Created

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -627,6 +627,27 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
   /api/attendance/shifts/{id}:
     x-plugin: plugin-attendance
+    get:
+      summary: Get attendance shift
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data: { $ref: '#/components/schemas/AttendanceShift' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
     put:
       summary: Update attendance shift
       security: [ { bearerAuth: [] } ]
@@ -1593,6 +1614,27 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
   /api/attendance/overtime-rules/{id}:
     x-plugin: plugin-attendance
+    get:
+      summary: Get overtime rule
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data: { $ref: '#/components/schemas/AttendanceOvertimeRule' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
     put:
       summary: Update overtime rule
       security: [ { bearerAuth: [] } ]
@@ -1709,6 +1751,18 @@ paths:
                 isActive: { type: boolean }
                 orgId: { type: string }
               required: [name, requestType]
+            examples:
+              missedCheckIn:
+                summary: Approval flow for missed check-in requests
+                value:
+                  name: 补卡审批
+                  requestType: missed_check_in
+                  steps:
+                    - name: 直属主管
+                      approverUserIds: [manager-user-001]
+                    - name: 人事复核
+                      approverRoleIds: [attendance-admin]
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -1837,6 +1891,17 @@ paths:
                 isActive: { type: boolean }
                 orgId: { type: string }
               required: [name, shiftSequence]
+            examples:
+              standardCycle:
+                summary: Rotation rule with ordered shift ids
+                value:
+                  name: 四班两倒
+                  timezone: Asia/Shanghai
+                  shiftSequence:
+                    - 11111111-1111-4111-8111-111111111111
+                    - 22222222-2222-4222-8222-222222222222
+                    - 33333333-3333-4333-8333-333333333333
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -1961,6 +2026,15 @@ paths:
                 isActive: { type: boolean }
                 orgId: { type: string }
               required: [userId, rotationRuleId, startDate]
+            examples:
+              activeAssignment:
+                summary: Assign one user to a rotation rule
+                value:
+                  userId: attendance-user-001
+                  rotationRuleId: 44444444-4444-4444-8444-444444444444
+                  startDate: '2026-03-20'
+                  endDate: null
+                  isActive: true
       responses:
         '201':
           description: Created
@@ -2094,6 +2168,30 @@ paths:
                 isDefault: { type: boolean }
                 orgId: { type: string }
               required: [name]
+            examples:
+              orgDefault:
+                summary: Org-wide default rule set
+                value:
+                  name: 默认规则集
+                  description: 标准工作日与节假日配置
+                  version: 1
+                  scope: org
+                  isDefault: true
+                  config:
+                    source: manual
+                    rule:
+                      timezone: Asia/Shanghai
+                      workStartTime: '09:00'
+                      workEndTime: '18:00'
+                      workingDays: [1, 2, 3, 4, 5]
+                    policies:
+                      rules:
+                        - name: holiday-no-work
+                          when:
+                            isHoliday: true
+                          then:
+                            setWorkMinutes: 0
+                            setStatus: off
       responses:
         '201':
           description: Created

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -632,6 +632,19 @@ function normalizeDateOnlyStrict(value) {
   return date.toISOString().slice(0, 10) === normalized ? normalized : null
 }
 
+function normalizeUuidString(value) {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  if (!normalized) return null
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(normalized)
+    ? normalized
+    : null
+}
+
+function respondInvalidUuid(res, fieldName = 'id') {
+  res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `${fieldName} must be a UUID` } })
+}
+
 function isValidTimeZoneIdentifier(value) {
   const zone = typeof value === 'string' ? value.trim() : ''
   if (!zone) return false
@@ -9763,7 +9776,11 @@ module.exports = {
       '/api/attendance/leave-types/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const leaveTypeId = req.params.id
+        const leaveTypeId = normalizeUuidString(req.params.id)
+        if (!leaveTypeId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -9860,7 +9877,11 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const leaveTypeId = req.params.id
+        const leaveTypeId = normalizeUuidString(req.params.id)
+        if (!leaveTypeId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const existingRows = await db.query(
@@ -9936,7 +9957,11 @@ module.exports = {
       '/api/attendance/leave-types/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const leaveTypeId = req.params.id
+        const leaveTypeId = normalizeUuidString(req.params.id)
+        if (!leaveTypeId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -10027,6 +10052,35 @@ module.exports = {
     )
 
     context.api.http.addRoute(
+      'GET',
+      '/api/attendance/overtime-rules/:id',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const overtimeRuleId = normalizeUuidString(req.params.id)
+        if (!overtimeRuleId) {
+          respondInvalidUuid(res)
+          return
+        }
+
+        try {
+          const rule = await loadOvertimeRule(db, orgId, { id: overtimeRuleId })
+          if (!rule) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Overtime rule not found' } })
+            return
+          }
+          res.json({ ok: true, data: rule })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance overtime rule lookup failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load overtime rule' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
       'POST',
       '/api/attendance/overtime-rules',
       withPermission('attendance:admin', async (req, res) => {
@@ -10093,7 +10147,11 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const overtimeRuleId = req.params.id
+        const overtimeRuleId = normalizeUuidString(req.params.id)
+        if (!overtimeRuleId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const existingRows = await db.query(
@@ -10161,7 +10219,11 @@ module.exports = {
       '/api/attendance/overtime-rules/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const overtimeRuleId = req.params.id
+        const overtimeRuleId = normalizeUuidString(req.params.id)
+        if (!overtimeRuleId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -15025,7 +15087,11 @@ module.exports = {
       '/api/attendance/payroll-templates/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const templateId = req.params.id
+        const templateId = normalizeUuidString(req.params.id)
+        if (!templateId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -15134,7 +15200,11 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const templateId = req.params.id
+        const templateId = normalizeUuidString(req.params.id)
+        if (!templateId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const existingRows = await db.query(
@@ -15218,7 +15288,11 @@ module.exports = {
       '/api/attendance/payroll-templates/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const templateId = req.params.id
+        const templateId = normalizeUuidString(req.params.id)
+        if (!templateId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -15855,7 +15929,11 @@ module.exports = {
       '/api/attendance/groups/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const groupId = req.params.id
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -15960,7 +16038,11 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const groupId = req.params.id
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
         const existingRows = await db.query(
           'SELECT * FROM attendance_groups WHERE id = $1 AND org_id = $2',
           [groupId, orgId]
@@ -16030,7 +16112,11 @@ module.exports = {
       '/api/attendance/groups/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const groupId = req.params.id
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
         try {
           const rows = await db.query(
             'DELETE FROM attendance_groups WHERE id = $1 AND org_id = $2 RETURNING id',
@@ -16231,6 +16317,35 @@ module.exports = {
     )
 
     context.api.http.addRoute(
+      'GET',
+      '/api/attendance/shifts/:id',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const shiftId = normalizeUuidString(req.params.id)
+        if (!shiftId) {
+          respondInvalidUuid(res)
+          return
+        }
+
+        try {
+          const shift = await loadShiftById(db, orgId, shiftId)
+          if (!shift) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Shift not found' } })
+            return
+          }
+          res.json({ ok: true, data: shift })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance shift lookup failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load shift' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
       'POST',
       '/api/attendance/shifts',
       withPermission('attendance:admin', async (req, res) => {
@@ -16296,7 +16411,11 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const shiftId = req.params.id
+        const shiftId = normalizeUuidString(req.params.id)
+        if (!shiftId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const existingRows = await db.query(
@@ -16370,7 +16489,11 @@ module.exports = {
       '/api/attendance/shifts/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const shiftId = req.params.id
+        const shiftId = normalizeUuidString(req.params.id)
+        if (!shiftId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(


### PR DESCRIPTION
## Summary
- add missing GET by id routes for attendance shifts and overtime rules
- return 400 VALIDATION_ERROR for malformed UUID ids on attendance admin lookup/update/delete routes
- document approval flow, rotation rule, rotation assignment, and rule set create payloads with concrete OpenAPI examples

## Verification
- node --check plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "supports shift and overtime rule lookup by id and rejects malformed ids with 400|registers attendance routes and lists plugin"
- pnpm --filter @metasheet/core-backend build
- pnpm exec tsx packages/openapi/tools/build.ts
- node scripts/ops/attendance-validate-openapi-import-contract.mjs packages/openapi/dist/openapi.json packages/openapi/src/paths/attendance.yml