### PR TITLE
docs(attendance): refresh post-release design verification

### DIFF
--- a/docs/development/attendance-release-candidate-design-20260322.md
+++ b/docs/development/attendance-release-candidate-design-20260322.md
@@ -3,6 +3,12 @@
 Date: 2026-03-22
 Branch: `codex/attendance-run20-followup-20260320`
 PR: `#536`
+Merged main commit: `796be28e7de27bd07efed118e79e1fe25e09953e`
+
+Release note:
+
+- published from `main` via `Build and Push Docker Images` run `#23401465080`
+- deploy completed successfully at `2026-03-22T10:54:34Z`
 
 ## Goal
 

--- a/docs/development/attendance-release-candidate-design-verification-20260322.md
+++ b/docs/development/attendance-release-candidate-design-verification-20260322.md
@@ -3,6 +3,7 @@
 Date: 2026-03-22
 Branch: `codex/attendance-run20-followup-20260320`
 PR: `#536`
+Merged main commit: `796be28e7de27bd07efed118e79e1fe25e09953e`
 Runtime verification baseline head: `2edb62ab42f994f51b979caa8bacbd1ed2ea9d8e`
 
 ## 1. Release Candidate Overview
@@ -185,22 +186,31 @@ GitHub checks for runtime baseline head `2edb62ab42f994f51b979caa8bacbd1ed2ea9d8
 
 `Strict E2E with Enhanced Gates` was skipped, not failed.
 
-## 6. Release Gate
+## 6. Release And Publication Outcome
 
-As of 2026-03-22, the remaining release blocker is no longer code or CI.
+As of 2026-03-22, this branch has already crossed the release gate and been published through the repository's auto-deploy path.
 
-Observed PR state:
+Observed final state:
 
-- `state = open`
-- `mergeable = true`
-- `mergeStateStatus = BLOCKED`
-- `reviewDecision = REVIEW_REQUIRED`
+- `PR #536` merged into `main` at `2026-03-22T10:51:09Z`
+- merge commit: `796be28e7de27bd07efed118e79e1fe25e09953e`
+- publication workflow:
+  - `Build and Push Docker Images`
+  - run: `#23401465080`
+  - result: `success`
+  - deploy completed at `2026-03-22T10:54:34Z`
+- companion workflow on the same push:
+  - `Deploy to Production`
+  - run: `#23401465079`
+  - result: `success`
+  - `build-and-push` and `deploy` jobs were skipped, so this was not the live deploy path
 
 This means:
 
-1. The branch is technically ready as a release candidate.
-2. The remaining blocker is review/approval and merge, not implementation quality gates.
-3. The version can be updated and published once the PR receives approval, merges into `main`, and the release/deploy action is triggered on the merged head.
+1. The branch cleared the PR-level release candidate gate.
+2. The merged `main` commit has already been built, pushed, and remotely deployed.
+3. The release is live through the repository's standard main-branch deployment path.
+4. No new semver tag was minted during this flow; the root package version remains `2.5.0`.
 
 ## 7. Out Of Scope For This Release
 
@@ -213,17 +223,18 @@ The following items are intentionally left for the next phase:
 
 ## 8. Recommendation
 
-Do not expand feature scope further on this RC branch.
+Do not continue feature expansion on this already-published line without opening a new follow-up branch.
 
 The correct next action is:
 
-1. obtain PR approval
-2. merge `#536`
-3. update and publish the version from `main`
+1. treat `796be28e7de27bd07efed118e79e1fe25e09953e` as the released mainline state
+2. open a new follow-up branch only for post-release fixes or next-scope enhancements
+3. cut a semantic tag only if release bookkeeping requires a named artifact beyond the successful main deployment
 
-This branch is now strong enough to release on the basis of:
+This release is justified on the basis of:
 
 - explainable rule simulation
 - operator-grade import triage
 - safer rollback and retry flows
 - validated frontend and backend guardrails
+- successful main-branch deployment

--- a/docs/development/attendance-release-candidate-verification-20260322.md
+++ b/docs/development/attendance-release-candidate-verification-20260322.md
@@ -3,7 +3,7 @@
 Date: 2026-03-22
 Branch: `codex/attendance-run20-followup-20260320`
 PR: `#536`
-Current PR head: `8af3a4e72a99b7ec9ecca898d10a374e5ce413e3`
+Merged main commit: `796be28e7de27bd07efed118e79e1fe25e09953e`
 Runtime verification baseline head: `2edb62ab42f994f51b979caa8bacbd1ed2ea9d8e`
 
 ## Scope
@@ -64,38 +64,49 @@ Non-failing skipped check:
 
 - `Strict E2E with Enhanced Gates`
 
-## PR Gate Status
+## Merge And Publication Outcome
 
-Observed PR status on 2026-03-22:
+Observed final release path on 2026-03-22:
 
-- `state = open`
-- `mergeable = true`
-- `mergeStateStatus = BLOCKED`
-- `reviewDecision = REVIEW_REQUIRED`
+- `PR #536` merged into `main` at `2026-03-22T10:51:09Z`
+- merge commit: `796be28e7de27bd07efed118e79e1fe25e09953e`
+- auto-deploy workflow:
+  - `Build and Push Docker Images`
+  - run: `#23401465080`
+  - result: `success`
+  - build job completed at `2026-03-22T10:53:23Z`
+  - deploy job completed at `2026-03-22T10:54:34Z`
+- non-publishing workflow result on the same push:
+  - `Deploy to Production`
+  - run: `#23401465079`
+  - result: `success`
+  - `build-and-push` and `deploy` jobs were skipped on push-to-main, so this was not the publishing path
 
 Interpretation:
 
-1. Code and CI are no longer the release blocker.
-2. The remaining blocker is review approval and merge.
-3. After approval and merge into `main`, version update and publication can proceed immediately.
+1. The attendance RC is no longer only a release candidate; it has been merged and published through the repo's main-branch auto-deploy path.
+2. The effective publishing workflow for this release was `.github/workflows/docker-build.yml`, not `.github/workflows/deploy.yml`.
+3. No new semver tag was cut during this publication; root package version remains `2.5.0`.
 
 ## Working Tree Status
 
-At the time this verification note was recorded:
+At the time this verification note was refreshed:
 
 - current branch is `codex/attendance-run20-followup-20260320`
-- PR head is `ahead 21` relative to `origin/main`
+- `origin/main` includes merge commit `796be28e7de27bd07efed118e79e1fe25e09953e`
 - working tree is clean except untracked `node_modules` paths
 
 ## Verification Conclusion
 
-This attendance branch qualifies as a release candidate.
+This attendance line has cleared release-candidate validation and has now been published from `main`.
 
-Release readiness is supported by:
+Publication confidence is supported by:
 
 - targeted frontend test coverage for the new rule and batch console behaviors
 - successful type-check and production build
 - successful backend type-check and focused regression tests
-- green GitHub checks on the current PR head
+- green GitHub checks on the verified PR head
+- successful merge into `main`
+- successful `Build and Push Docker Images` deploy run on the merged main commit
 
-The remaining action before version update and publication is review approval and merge of `#536`.
+No further release gate remains for this change set. The only remaining follow-up would be optional version/tag housekeeping if the team wants a named release artifact beyond the existing `main` deployment.


### PR DESCRIPTION
## Summary
- refresh the attendance release-candidate design docs to reflect the merged main commit
- record the successful Build and Push Docker Images deployment run and publication timestamps
- clarify that this was a main-branch auto-deploy publication without a new semver tag

## Verification
- docs only
- verified GitHub Actions run 23401465080 succeeded on merged main commit 796be28e7de27bd07efed118e79e1fe25e09953e