### PR TITLE
feat(attendance-ui): add timezone selectors with offset labels

### DIFF
--- a/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
@@ -135,7 +135,11 @@
       </label>
       <label class="attendance__field" for="attendance-holiday-sync-auto-tz">
         <span>{{ tr('Auto sync timezone', '自动同步时区') }}</span>
-        <input id="attendance-holiday-sync-auto-tz" v-model="settingsForm.holidaySyncAutoTimezone" name="holidaySyncAutoTimezone" type="text" :placeholder="tr('Asia/Shanghai', 'Asia/Shanghai')" />
+        <select id="attendance-holiday-sync-auto-tz" v-model="settingsForm.holidaySyncAutoTimezone" name="holidaySyncAutoTimezone">
+          <option v-for="timezone in holidaySyncTimezoneOptions" :key="timezone.value" :value="timezone.value">
+            {{ timezone.label }}
+          </option>
+        </select>
       </label>
       <label class="attendance__field attendance__field--checkbox" for="attendance-holiday-sync-index">
         <span>{{ tr('Append day index', '追加节假日序号') }}</span>
@@ -178,6 +182,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, type Ref } from 'vue'
+import { buildTimezoneOptionEntries } from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -254,6 +259,7 @@ const holidaySyncLastRun = props.config.holidaySyncLastRun
 const holidaySyncLoading = props.config.holidaySyncLoading
 const saveSettings = () => props.config.saveSettings()
 const settingsForm = props.config.settingsForm
+const holidaySyncTimezoneOptions = computed(() => buildTimezoneOptionEntries(settingsForm.holidaySyncAutoTimezone))
 const settingsLoading = props.config.settingsLoading
 const syncHolidays = () => props.config.syncHolidays()
 const syncHolidaysForYears = (years: number[]) => props.config.syncHolidaysForYears(years)

--- a/apps/web/src/views/attendance/AttendanceImportWorkflowSection.vue
+++ b/apps/web/src/views/attendance/AttendanceImportWorkflowSection.vue
@@ -245,12 +245,15 @@
       </label>
       <label class="attendance__field" for="attendance-import-group-timezone">
         <span>{{ tr('Group timezone (optional)', '分组时区（可选）') }}</span>
-        <input
+        <select
           id="attendance-import-group-timezone"
           v-model="importGroupTimezone"
-          type="text"
-          placeholder="Asia/Shanghai"
-        />
+        >
+          <option value="">{{ tr('(Optional) Use import timezone', '（可选）沿用导入时区') }}</option>
+          <option v-for="timezone in importGroupTimezoneOptions" :key="timezone.value" :value="timezone.value">
+            {{ timezone.label }}
+          </option>
+        </select>
       </label>
       <label class="attendance__field" for="attendance-import-user">
         <span>{{ tr('User ID', '用户 ID') }}</span>
@@ -264,12 +267,15 @@
       </label>
       <label class="attendance__field" for="attendance-import-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
-        <input
+        <select
           id="attendance-import-timezone"
           name="importTimezone"
           v-model="importForm.timezone"
-          type="text"
-        />
+        >
+          <option v-for="timezone in importTimezoneOptions" :key="timezone.value" :value="timezone.value">
+            {{ timezone.label }}
+          </option>
+        </select>
       </label>
       <label class="attendance__field attendance__field--full" for="attendance-import-payload">
         <span>{{ tr('Payload (JSON)', '负载（JSON）') }}</span>
@@ -464,6 +470,10 @@
 
 <script setup lang="ts">
 import { computed, type ComputedRef, type Ref } from 'vue'
+import {
+  buildTimezoneOptionEntries,
+  formatTimezoneOptionLabel,
+} from './attendanceTimezones'
 import type {
   AttendanceImportCommitLane,
   AttendanceImportFormState,
@@ -578,6 +588,8 @@ const importGroupAutoCreate = props.workflow.importGroupAutoCreate
 const importGroupAutoAssign = props.workflow.importGroupAutoAssign
 const importGroupRuleSetId = props.workflow.importGroupRuleSetId
 const importGroupTimezone = props.workflow.importGroupTimezone
+const importTimezoneOptions = computed(() => buildTimezoneOptionEntries(importForm.timezone))
+const importGroupTimezoneOptions = computed(() => buildTimezoneOptionEntries(importGroupTimezone.value))
 const importScalabilityHint = props.workflow.importScalabilityHint
 const importPreviewTask = props.workflow.importPreviewTask
 const importAsyncJob = props.workflow.importAsyncJob
@@ -665,7 +677,8 @@ const importGroupSyncSummary = computed(() => {
   }
   const timezone = importGroupTimezone.value.trim()
   if (timezone) {
-    segments.push(tr(`timezone ${timezone}`, `时区 ${timezone}`))
+    const timezoneLabel = formatTimezoneOptionLabel(timezone)
+    segments.push(tr(`timezone ${timezoneLabel}`, `时区 ${timezoneLabel}`))
   }
 
   return segments.length > 0

--- a/apps/web/src/views/attendance/AttendancePayrollAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendancePayrollAdminSection.vue
@@ -25,8 +25,8 @@
           v-model="payrollTemplateForm.timezone"
           name="payrollTemplateTimezone"
         >
-          <option v-for="timezone in payrollTemplateTimezones" :key="timezone" :value="timezone">
-            {{ timezone }}
+          <option v-for="timezone in payrollTemplateTimezones" :key="timezone.value" :value="timezone.value">
+            {{ timezone.label }}
           </option>
         </select>
       </label>
@@ -125,7 +125,7 @@
         <tbody>
           <tr v-for="item in payrollTemplates" :key="item.id">
             <td>{{ item.name }}</td>
-            <td>{{ item.timezone }}</td>
+            <td>{{ formatTimezoneOptionLabel(item.timezone) }}</td>
             <td>{{ item.startDay }}</td>
             <td>{{ item.endDay }}</td>
             <td>{{ item.endMonthOffset }}</td>
@@ -383,7 +383,10 @@ import type {
   AttendancePayrollSummary,
   AttendancePayrollTemplate,
 } from './useAttendanceAdminPayroll'
-import { buildTimezoneOptions } from './attendanceTimezones'
+import {
+  buildTimezoneOptionEntries,
+  formatTimezoneOptionLabel,
+} from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -471,7 +474,7 @@ const payrollCycleSummary = props.payroll.payrollCycleSummary
 const payrollTemplateForm = props.payroll.payrollTemplateForm
 const payrollCycleForm = props.payroll.payrollCycleForm
 const payrollCycleGenerateForm = props.payroll.payrollCycleGenerateForm
-const payrollTemplateTimezones = computed(() => buildTimezoneOptions(payrollTemplateForm.timezone))
+const payrollTemplateTimezones = computed(() => buildTimezoneOptionEntries(payrollTemplateForm.timezone))
 const payrollTemplateName = props.payroll.payrollTemplateName
 const resetPayrollTemplateForm = () => props.payroll.resetPayrollTemplateForm()
 const editPayrollTemplate = (item: AttendancePayrollTemplate) => props.payroll.editPayrollTemplate(item)

--- a/apps/web/src/views/attendance/AttendanceRulesAndGroupsSection.vue
+++ b/apps/web/src/views/attendance/AttendanceRulesAndGroupsSection.vue
@@ -68,7 +68,7 @@
           </div>
           <div class="attendance__rule-builder-summary">
             <span>{{ tr('Source', '来源') }}: <strong>{{ ruleBuilderSource || '--' }}</strong></span>
-            <span>{{ tr('Timezone', '时区') }}: <strong>{{ ruleBuilderTimezone || '--' }}</strong></span>
+            <span>{{ tr('Timezone', '时区') }}: <strong>{{ ruleBuilderTimezoneLabel || '--' }}</strong></span>
             <span>{{ tr('Working days', '工作日') }}: <strong>{{ formatWorkingDays(ruleBuilderWorkingDays) }}</strong></span>
           </div>
         </div>
@@ -85,12 +85,14 @@
           </label>
           <label class="attendance__field" for="attendance-rule-builder-timezone">
             <span>{{ tr('Timezone', '时区') }}</span>
-            <input
+            <select
               id="attendance-rule-builder-timezone"
               v-model="ruleBuilderTimezone"
-              type="text"
-              :placeholder="tr('Asia/Shanghai', 'Asia/Shanghai')"
-            />
+            >
+              <option v-for="timezone in ruleBuilderTimezoneOptions" :key="timezone.value" :value="timezone.value">
+                {{ timezone.label }}
+              </option>
+            </select>
           </label>
           <label class="attendance__field" for="attendance-rule-builder-start">
             <span>{{ tr('Work start time', '上班时间') }}</span>
@@ -677,8 +679,8 @@
       <label class="attendance__field" for="attendance-group-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
         <select id="attendance-group-timezone" v-model="attendanceGroupForm.timezone">
-          <option v-for="timezone in attendanceGroupTimezones" :key="timezone" :value="timezone">
-            {{ timezone }}
+          <option v-for="timezone in attendanceGroupTimezones" :key="timezone.value" :value="timezone.value">
+            {{ timezone.label }}
           </option>
         </select>
       </label>
@@ -724,7 +726,7 @@
           <tr v-for="item in attendanceGroups" :key="item.id">
             <td>{{ item.name }}</td>
             <td>{{ item.code || '-' }}</td>
-            <td>{{ item.timezone }}</td>
+            <td>{{ formatTimezoneOptionLabel(item.timezone) }}</td>
             <td>{{ resolveRuleSetName(item.ruleSetId) }}</td>
             <td class="attendance__table-actions">
               <button class="attendance__btn" @click="editAttendanceGroup(item)">{{ tr('Edit', '编辑') }}</button>
@@ -843,7 +845,10 @@ import type {
   AttendanceRuleTemplateVersion,
 } from './useAttendanceAdminRulesAndGroups'
 import AttendanceUserPickerField from './AttendanceUserPickerField.vue'
-import { buildTimezoneOptions } from './attendanceTimezones'
+import {
+  buildTimezoneOptionEntries,
+  formatTimezoneOptionLabel,
+} from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -987,7 +992,7 @@ const tr = props.tr
 const formatDateTime = props.formatDateTime
 const attendanceGroupEditingId = props.rules.attendanceGroupEditingId
 const attendanceGroupForm = props.rules.attendanceGroupForm
-const attendanceGroupTimezones = computed(() => buildTimezoneOptions(attendanceGroupForm.timezone))
+const attendanceGroupTimezones = computed(() => buildTimezoneOptionEntries(attendanceGroupForm.timezone))
 const attendanceGroupLoading = props.rules.attendanceGroupLoading
 const attendanceGroupMemberGroupId = props.rules.attendanceGroupMemberGroupId
 const attendanceGroupMemberLoading = props.rules.attendanceGroupMemberLoading
@@ -1041,6 +1046,8 @@ const localRuleSetPreviewEventsText = ref('[]')
 const localRuleSetPreviewResult = ref<RuleSetPreviewResult | null>(null)
 const ruleBuilderSource = props.rules.ruleBuilderSource ?? localRuleBuilderSource
 const ruleBuilderTimezone = props.rules.ruleBuilderTimezone ?? localRuleBuilderTimezone
+const ruleBuilderTimezoneOptions = computed(() => buildTimezoneOptionEntries(ruleBuilderTimezone.value))
+const ruleBuilderTimezoneLabel = computed(() => formatTimezoneOptionLabel(ruleBuilderTimezone.value))
 const ruleBuilderWorkStartTime = props.rules.ruleBuilderWorkStartTime ?? localRuleBuilderWorkStartTime
 const ruleBuilderWorkEndTime = props.rules.ruleBuilderWorkEndTime ?? localRuleBuilderWorkEndTime
 const ruleBuilderLateGraceMinutes = props.rules.ruleBuilderLateGraceMinutes ?? localRuleBuilderLateGraceMinutes

--- a/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
@@ -13,7 +13,11 @@
       </label>
       <label class="attendance__field" for="attendance-rule-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
-        <input id="attendance-rule-timezone" v-model="ruleForm.timezone" name="ruleTimezone" type="text" />
+        <select id="attendance-rule-timezone" v-model="ruleForm.timezone" name="ruleTimezone">
+          <option v-for="timezone in ruleTimezoneOptions" :key="timezone.value" :value="timezone.value">
+            {{ timezone.label }}
+          </option>
+        </select>
       </label>
       <label class="attendance__field" for="attendance-rule-start">
         <span>{{ tr('Work start', '上班时间') }}</span>
@@ -63,12 +67,15 @@
       </label>
       <label class="attendance__field" for="attendance-rotation-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
-        <input
+        <select
           id="attendance-rotation-timezone"
           v-model="rotationRuleForm.timezone"
           name="rotationTimezone"
-          type="text"
-        />
+        >
+          <option v-for="timezone in rotationRuleTimezoneOptions" :key="timezone.value" :value="timezone.value">
+            {{ timezone.label }}
+          </option>
+        </select>
       </label>
       <label class="attendance__field attendance__field--full" for="attendance-rotation-sequence">
         <span>{{ tr('Shift sequence (IDs)', '班次序列（ID）') }}</span>
@@ -138,7 +145,7 @@
         <tbody>
           <tr v-for="rule in rotationRules" :key="rule.id">
             <td>{{ rule.name }}</td>
-            <td>{{ rule.timezone }}</td>
+            <td>{{ formatTimezoneOptionLabel(rule.timezone) }}</td>
             <td>{{ rule.shiftSequence.join(', ') }}</td>
             <td>{{ rule.isActive ? tr('Yes', '是') : tr('No', '否') }}</td>
             <td class="attendance__table-actions">
@@ -291,7 +298,11 @@
       </label>
       <label class="attendance__field" for="attendance-shift-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
-        <input id="attendance-shift-timezone" v-model="shiftForm.timezone" name="shiftTimezone" type="text" />
+        <select id="attendance-shift-timezone" v-model="shiftForm.timezone" name="shiftTimezone">
+          <option v-for="timezone in shiftTimezoneOptions" :key="timezone.value" :value="timezone.value">
+            {{ timezone.label }}
+          </option>
+        </select>
       </label>
       <label class="attendance__field" for="attendance-shift-start">
         <span>{{ tr('Work start', '上班开始') }}</span>
@@ -378,7 +389,7 @@
         <tbody>
           <tr v-for="shift in shifts" :key="shift.id">
             <td>{{ shift.name }}</td>
-            <td>{{ shift.timezone }}</td>
+            <td>{{ formatTimezoneOptionLabel(shift.timezone) }}</td>
             <td>{{ formatShiftSchedule(shift) }}</td>
             <td>{{ shift.isOvernight ? tr('Yes', '是') : tr('No', '否') }}</td>
             <td>{{ shift.workingDays.join(',') }}</td>
@@ -509,6 +520,10 @@ import type {
   AttendanceShift,
 } from './useAttendanceAdminScheduling'
 import AttendanceUserPickerField from './AttendanceUserPickerField.vue'
+import {
+  buildTimezoneOptionEntries,
+  formatTimezoneOptionLabel,
+} from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -614,6 +629,7 @@ const props = defineProps<{
 const tr = props.tr
 const loadRule = () => props.scheduling.loadRule()
 const ruleForm = props.scheduling.ruleForm
+const ruleTimezoneOptions = computed(() => buildTimezoneOptionEntries(ruleForm.timezone))
 const ruleLoading = props.scheduling.ruleLoading
 const saveRule = () => props.scheduling.saveRule()
 const rotationRules = props.scheduling.rotationRules
@@ -621,6 +637,7 @@ const rotationRuleLoading = props.scheduling.rotationRuleLoading
 const rotationRuleSaving = props.scheduling.rotationRuleSaving
 const rotationRuleEditingId = props.scheduling.rotationRuleEditingId
 const rotationRuleForm = props.scheduling.rotationRuleForm
+const rotationRuleTimezoneOptions = computed(() => buildTimezoneOptionEntries(rotationRuleForm.timezone))
 const resetRotationRuleForm = () => props.scheduling.resetRotationRuleForm()
 const editRotationRule = (rule: AttendanceRotationRule) => props.scheduling.editRotationRule(rule)
 const loadRotationRules = () => props.scheduling.loadRotationRules()
@@ -641,6 +658,7 @@ const shiftLoading = props.scheduling.shiftLoading
 const shiftSaving = props.scheduling.shiftSaving
 const shiftEditingId = props.scheduling.shiftEditingId
 const shiftForm = props.scheduling.shiftForm
+const shiftTimezoneOptions = computed(() => buildTimezoneOptionEntries(shiftForm.timezone))
 const resetShiftForm = () => props.scheduling.resetShiftForm()
 const editShift = (shift: AttendanceShift) => props.scheduling.editShift(shift)
 const loadShifts = () => props.scheduling.loadShifts()

--- a/apps/web/src/views/attendance/attendanceTimezones.ts
+++ b/apps/web/src/views/attendance/attendanceTimezones.ts
@@ -13,6 +13,11 @@ const FALLBACK_TIMEZONES = [
 
 let cachedSupportedTimezones: string[] | null = null
 
+export interface TimezoneOptionEntry {
+  value: string
+  label: string
+}
+
 function loadSupportedTimezones(): string[] {
   if (cachedSupportedTimezones) return cachedSupportedTimezones
 
@@ -39,4 +44,47 @@ export function buildTimezoneOptions(currentValue?: string | null): string[] {
     options.unshift(normalized)
   }
   return options
+}
+
+export function formatTimezoneOffsetLabel(timezone?: string | null, date = new Date()): string {
+  const normalized = typeof timezone === 'string' ? timezone.trim() : ''
+  if (!normalized) return ''
+
+  try {
+    const timeZoneName = new Intl.DateTimeFormat('en-US', {
+      timeZone: normalized,
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'shortOffset',
+    })
+      .formatToParts(date)
+      .find((part) => part.type === 'timeZoneName')
+      ?.value
+
+    if (!timeZoneName) return ''
+    if (timeZoneName === 'GMT' || timeZoneName === 'UTC') return 'UTC+00:00'
+
+    const match = timeZoneName.match(/^(?:GMT|UTC)([+-])(\d{1,2})(?::?(\d{2}))?$/)
+    if (!match) return ''
+
+    const [, sign, hours, minutes = '00'] = match
+    return `UTC${sign}${hours.padStart(2, '0')}:${minutes.padStart(2, '0')}`
+  } catch {
+    return ''
+  }
+}
+
+export function formatTimezoneOptionLabel(timezone?: string | null, date = new Date()): string {
+  const normalized = typeof timezone === 'string' ? timezone.trim() : ''
+  if (!normalized) return ''
+
+  const offsetLabel = formatTimezoneOffsetLabel(normalized, date)
+  return offsetLabel ? `${normalized} (${offsetLabel})` : normalized
+}
+
+export function buildTimezoneOptionEntries(currentValue?: string | null): TimezoneOptionEntry[] {
+  return buildTimezoneOptions(currentValue).map((value) => ({
+    value,
+    label: formatTimezoneOptionLabel(value),
+  }))
 }

--- a/apps/web/tests/AttendanceImportWorkflowSection.spec.ts
+++ b/apps/web/tests/AttendanceImportWorkflowSection.spec.ts
@@ -218,7 +218,12 @@ describe('AttendanceImportWorkflowSection', () => {
     expect(container!.textContent).toContain('Import will queue an async job because 240 rows meet the async threshold (200).')
     expect(container!.textContent).toContain('Mapping profile: DingTalk (2 required fields)')
     expect(container!.textContent).toContain('User map: 18 entries ready · key empNo · source 工号, 姓名')
-    expect(container!.textContent).toContain('Group sync: auto-create groups · rule set Ops Rules · timezone Asia/Shanghai')
+    expect(container!.textContent).toContain('Group sync: auto-create groups · rule set Ops Rules · timezone Asia/Shanghai (UTC+08:00)')
+    const importTimezone = container!.querySelector<HTMLSelectElement>('#attendance-import-timezone')
+    const importGroupTimezone = container!.querySelector<HTMLSelectElement>('#attendance-import-group-timezone')
+    expect(importTimezone).toBeTruthy()
+    expect(importGroupTimezone).toBeTruthy()
+    expect(importTimezone!.selectedOptions[0]?.textContent).toContain('Asia/Shanghai (UTC+08:00)')
   })
 
   it('shows manual-plan fallbacks when mapping, user map, and group sync are unset', async () => {

--- a/apps/web/tests/AttendanceRulesAndGroupsSection.spec.ts
+++ b/apps/web/tests/AttendanceRulesAndGroupsSection.spec.ts
@@ -273,7 +273,7 @@ describe('AttendanceRulesAndGroupsSection', () => {
     expect(builderRows()).toHaveLength(1)
 
     const sourceInput = container!.querySelector<HTMLInputElement>('#attendance-rule-builder-source')
-    const timezoneInput = container!.querySelector<HTMLInputElement>('#attendance-rule-builder-timezone')
+    const timezoneInput = container!.querySelector<HTMLSelectElement>('#attendance-rule-builder-timezone')
     const startInput = container!.querySelector<HTMLInputElement>('#attendance-rule-builder-start')
     const endInput = container!.querySelector<HTMLInputElement>('#attendance-rule-builder-end')
     const lateInput = container!.querySelector<HTMLInputElement>('#attendance-rule-builder-late-grace')
@@ -284,11 +284,12 @@ describe('AttendanceRulesAndGroupsSection', () => {
     expect(endInput).toBeTruthy()
     expect(lateInput).toBeTruthy()
     expect(earlyInput).toBeTruthy()
+    expect(timezoneInput!.selectedOptions[0]?.textContent).toContain('UTC')
 
     sourceInput!.value = 'csv'
     sourceInput!.dispatchEvent(new Event('input', { bubbles: true }))
     timezoneInput!.value = 'Europe/London'
-    timezoneInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    timezoneInput!.dispatchEvent(new Event('change', { bubbles: true }))
     startInput!.value = '08:30'
     startInput!.dispatchEvent(new Event('input', { bubbles: true }))
     endInput!.value = '17:30'
@@ -330,6 +331,7 @@ describe('AttendanceRulesAndGroupsSection', () => {
         workingDays: [1, 2, 3, 4, 5, 6],
       },
     })
+    expect(container!.textContent).toContain('Timezone: Europe/London (UTC')
 
     expect(JSON.parse(rules.ruleSetPreviewEventsText!.value)).toEqual([
       {
@@ -427,5 +429,28 @@ describe('AttendanceRulesAndGroupsSection', () => {
     previewButton!.click()
 
     expect(previewRuleSet).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows timezone options with UTC offset labels for groups and the rule builder', async () => {
+    const rules = createBindings()
+
+    app = createApp(AttendanceRulesAndGroupsSection, {
+      tr,
+      formatDateTime,
+      rules,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const ruleBuilderTimezone = container!.querySelector<HTMLSelectElement>('#attendance-rule-builder-timezone')
+    const attendanceGroupTimezone = container!.querySelector<HTMLSelectElement>('#attendance-group-timezone')
+
+    expect(ruleBuilderTimezone).toBeTruthy()
+    expect(attendanceGroupTimezone).toBeTruthy()
+    expect(ruleBuilderTimezone!.selectedOptions[0]?.textContent).toContain('Asia/Shanghai (UTC+08:00)')
+    expect(Array.from(attendanceGroupTimezone!.querySelectorAll('option')).map((option) => option.textContent)).toContain(
+      'Asia/Shanghai (UTC+08:00)',
+    )
+    expect(container!.textContent).toContain('Asia/Shanghai (UTC+08:00)')
   })
 })

--- a/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
+++ b/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
@@ -359,4 +359,27 @@ describe('AttendanceSchedulingAdminSection', () => {
     expect(container!.textContent).toContain('Schedule')
     expect(container!.textContent).toContain('22:00 → 06:00 · Overnight')
   })
+
+  it('renders timezone selectors with UTC offset labels across scheduling forms', async () => {
+    const scheduling = createSchedulingBindings()
+
+    app = createApp(AttendanceSchedulingAdminSection, {
+      tr,
+      scheduling,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const defaultRuleTimezone = container!.querySelector<HTMLSelectElement>('#attendance-rule-timezone')
+    const rotationTimezone = container!.querySelector<HTMLSelectElement>('#attendance-rotation-timezone')
+    const shiftTimezone = container!.querySelector<HTMLSelectElement>('#attendance-shift-timezone')
+
+    expect(defaultRuleTimezone).toBeTruthy()
+    expect(rotationTimezone).toBeTruthy()
+    expect(shiftTimezone).toBeTruthy()
+    expect(defaultRuleTimezone!.selectedOptions[0]?.textContent).toContain('UTC+00:00')
+    expect(rotationTimezone!.selectedOptions[0]?.textContent).toContain('UTC+00:00')
+    expect(shiftTimezone!.selectedOptions[0]?.textContent).toContain('UTC+00:00')
+    expect(container!.textContent).toContain('UTC (UTC+00:00)')
+  })
 })

--- a/apps/web/tests/attendanceTimezones.spec.ts
+++ b/apps/web/tests/attendanceTimezones.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTimezoneOptionEntries,
+  formatTimezoneOffsetLabel,
+  formatTimezoneOptionLabel,
+} from '../src/views/attendance/attendanceTimezones'
+
+describe('attendanceTimezones', () => {
+  it('formats UTC offsets for supported timezones', () => {
+    expect(formatTimezoneOffsetLabel('UTC')).toBe('UTC+00:00')
+    expect(formatTimezoneOffsetLabel('Asia/Shanghai')).toBe('UTC+08:00')
+  })
+
+  it('builds timezone labels with UTC offsets', () => {
+    expect(formatTimezoneOptionLabel('Asia/Shanghai')).toBe('Asia/Shanghai (UTC+08:00)')
+
+    const options = buildTimezoneOptionEntries('Asia/Shanghai')
+    const selected = options.find((item) => item.value === 'Asia/Shanghai')
+    expect(selected).toEqual({
+      value: 'Asia/Shanghai',
+      label: 'Asia/Shanghai (UTC+08:00)',
+    })
+  })
+})

--- a/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
+++ b/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
@@ -226,4 +226,33 @@ describe('AttendanceHolidayRuleSection', () => {
     expect(container!.querySelector('.attendance__table-cell--holiday-name input')).toBeTruthy()
     expect(container!.querySelector('.attendance__override-field input[placeholder="单休办公,白班"]')).toBeTruthy()
   })
+
+  it('shows the auto-sync timezone as a select with UTC offset labels', async () => {
+    const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
+
+    const config = {
+      addHolidayOverride: vi.fn(),
+      holidaySyncLastRun: { value: null },
+      holidaySyncLoading: { value: false },
+      removeHolidayOverride: vi.fn(),
+      saveSettings: vi.fn(),
+      settingsForm,
+      settingsLoading: { value: false },
+      syncHolidays: vi.fn(),
+      syncHolidaysForYears: vi.fn(),
+    } as HolidayConfig
+
+    app = createApp(AttendanceHolidayRuleSection, {
+      attendanceGroupOptions: [],
+      config,
+      formatDateTime,
+      tr,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const timezoneSelect = container!.querySelector<HTMLSelectElement>('#attendance-holiday-sync-auto-tz')
+    expect(timezoneSelect).toBeTruthy()
+    expect(timezoneSelect!.selectedOptions[0]?.textContent).toContain('Asia/Shanghai (UTC+08:00)')
+  })
 })

--- a/docs/development/attendance-timezone-selector-design-20260323.md
+++ b/docs/development/attendance-timezone-selector-design-20260323.md
@@ -1,0 +1,66 @@
+# Attendance Timezone Selector Design 2026-03-23
+
+## Background
+
+Several attendance admin forms still required operators to type raw IANA timezones such as `Asia/Shanghai` or `Europe/London`.
+
+That created two usability issues:
+
+1. Operators had to remember exact timezone identifiers.
+2. The UI did not show the effective UTC offset, so it was hard to confirm whether the selected timezone was `UTC+8`, `UTC+0`, or another offset.
+
+## Goal
+
+Replace raw timezone text inputs in the main attendance admin flows with shared selectors that:
+
+1. Use existing IANA timezone values as the stored payload.
+2. Show the current UTC offset in the option label.
+3. Keep existing API payloads unchanged.
+
+## Scope
+
+This change updates the following attendance admin surfaces:
+
+1. Rule set structured builder in `AttendanceRulesAndGroupsSection.vue`
+2. Attendance group timezone selector in `AttendanceRulesAndGroupsSection.vue`
+3. Default rule / rotation rule / shift timezone fields in `AttendanceSchedulingAdminSection.vue`
+4. Holiday sync auto timezone in `AttendanceHolidayRuleSection.vue`
+5. Import timezone and optional group timezone in `AttendanceImportWorkflowSection.vue`
+6. Payroll template timezone labels in `AttendancePayrollAdminSection.vue`
+
+## Shared Design
+
+The shared timezone utility now exposes:
+
+1. `formatTimezoneOffsetLabel(timezone)` to normalize the runtime offset into `UTC±HH:MM`
+2. `formatTimezoneOptionLabel(timezone)` to render labels such as `Asia/Shanghai (UTC+08:00)`
+3. `buildTimezoneOptionEntries(currentValue)` to produce `{ value, label }` option lists
+
+The stored value remains the raw timezone identifier, for example `Asia/Shanghai`.
+Only the rendered label changes.
+
+## UX Decision
+
+The selector is intentionally not grouped by region or filtered yet.
+
+Reason:
+
+1. The repository already has a shared timezone source based on `Intl.supportedValuesOf('timeZone')`.
+2. Switching from free text to select already removes the main operator error.
+3. Adding region grouping or search would be a second-step enhancement and should be done only if the current flat selector proves too large in production.
+
+## Compatibility
+
+This change is backward compatible:
+
+1. Existing saved timezone strings still render correctly.
+2. Unknown custom values still remain selectable because the current value is injected into the option list when needed.
+3. API payloads and server-side validation do not change.
+
+## Out of Scope
+
+This change does not:
+
+1. Rework backend timezone handling
+2. Add fuzzy timezone search
+3. Reorganize all settings screens outside the attendance admin flow

--- a/docs/development/attendance-timezone-selector-verification-20260323.md
+++ b/docs/development/attendance-timezone-selector-verification-20260323.md
@@ -1,0 +1,49 @@
+# Attendance Timezone Selector Verification 2026-03-23
+
+## Scope Verified
+
+Verified that attendance admin timezone fields now use selectors with UTC offset labels and continue to write raw timezone identifiers into the bound form state.
+
+## Commands
+
+Executed in `/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-run20-field-compat-20260320`:
+
+1. `pnpm --filter @metasheet/web exec vitest run tests/attendanceTimezones.spec.ts tests/AttendanceRulesAndGroupsSection.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/AttendanceImportWorkflowSection.spec.ts --watch=false`
+2. `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
+3. `pnpm --filter @metasheet/web build`
+
+## Results
+
+### Vitest
+
+Passed:
+
+1. `tests/attendanceTimezones.spec.ts`
+2. `tests/AttendanceRulesAndGroupsSection.spec.ts`
+3. `tests/AttendanceSchedulingAdminSection.spec.ts`
+4. `tests/useAttendanceHolidayRuleSection.spec.ts`
+5. `tests/AttendanceImportWorkflowSection.spec.ts`
+
+Summary:
+
+1. `5` files passed
+2. `15` tests passed
+
+### Type Check
+
+`vue-tsc --noEmit` passed.
+
+### Production Build
+
+`pnpm --filter @metasheet/web build` passed.
+
+The existing Vite chunk-size warning remains, but it is unrelated to this change.
+
+## Behavior Verified
+
+1. Rule builder timezone field is now a selector and renders labels like `Asia/Shanghai (UTC+08:00)`.
+2. Attendance group timezone selector renders the same labeled options.
+3. Scheduling admin timezone selectors for default rules, rotation rules, and shifts show `UTC±HH:MM`.
+4. Holiday sync auto timezone is now a selector instead of a raw text input.
+5. Import timezone and optional group timezone are selectors and the import plan summary shows the labeled timezone.
+6. Stored values remain raw IANA timezone identifiers such as `Asia/Shanghai`.


### PR DESCRIPTION
## Summary
- replace raw attendance timezone text inputs with selectors in rules, scheduling, holiday sync, and import flows
- show `UTC±HH:MM` labels so operators can confirm the effective offset before saving
- add shared timezone label helpers plus focused design and verification docs

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendanceTimezones.spec.ts tests/AttendanceRulesAndGroupsSection.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/AttendanceImportWorkflowSection.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`

## Docs
- `docs/development/attendance-timezone-selector-design-20260323.md`
- `docs/development/attendance-timezone-selector-verification-20260323.md`