### PR TITLE
docs(attendance): add timezone selector post-merge status

### DIFF
--- a/docs/development/attendance-timezone-selector-design-20260323.md
+++ b/docs/development/attendance-timezone-selector-design-20260323.md
@@ -64,3 +64,13 @@ This change does not:
 1. Rework backend timezone handling
 2. Add fuzzy timezone search
 3. Reorganize all settings screens outside the attendance admin flow
+
+## Post-Merge Status
+
+This design shipped to `main` on `2026-03-23`.
+
+1. Pull request: `#542 feat(attendance-ui): add timezone selectors with offset labels`
+2. Merge commit: `8fba63dcfe08490bb728f2f230079498072f2a8a`
+3. The post-merge `main` workflow chain for this commit completed without red jobs.
+
+That means the selector-based timezone UX described in this document is no longer a branch-only proposal. It is the current `main` behavior baseline.

--- a/docs/development/attendance-timezone-selector-verification-20260323.md
+++ b/docs/development/attendance-timezone-selector-verification-20260323.md
@@ -47,3 +47,51 @@ The existing Vite chunk-size warning remains, but it is unrelated to this change
 4. Holiday sync auto timezone is now a selector instead of a raw text input.
 5. Import timezone and optional group timezone are selectors and the import plan summary shows the labeled timezone.
 6. Stored values remain raw IANA timezone identifiers such as `Asia/Shanghai`.
+
+## Post-Merge GitHub Status
+
+As of `2026-03-23 15:57:45 CST`, the change is merged and the relevant GitHub workflows for merge commit `8fba63dcfe08490bb728f2f230079498072f2a8a` have completed with no failed jobs.
+
+### Pull Request
+
+1. Pull request: `#542`
+2. Merge commit: `8fba63dcfe08490bb728f2f230079498072f2a8a`
+
+### Main Push Workflows
+
+1. `Phase 5 Production Flags Guard on: push`
+   `guard` succeeded
+2. `Observability E2E on: push`
+   `e2e` succeeded
+3. `Plugin System Tests on: push`
+   `test (18.x)` succeeded
+   `test (20.x)` succeeded
+   `coverage` skipped
+4. `Build and Push Docker Images on: push`
+   `build` succeeded
+   `deploy` succeeded
+5. `Deploy to Production on: push`
+   `test` succeeded
+   `build-and-push` skipped
+   `deploy` skipped
+6. `.github/workflows/monitoring-alert.yml on: push`
+   `test` succeeded
+
+### PR Validation Workflows
+
+1. `Phase 5 PR Validation (External Metrics Gate) on: pull_request`
+   `pr-validate` succeeded
+2. `Attendance Gate Contract Matrix on: pull_request`
+   `contracts (strict)` succeeded
+   `contracts (dashboard)` succeeded
+   `contracts (openapi)` succeeded
+3. `Plugin System Tests on: pull_request`
+   `test (18.x)` succeeded
+   `test (20.x)` succeeded
+   `coverage` succeeded
+4. `Observability E2E on: pull_request`
+   `e2e` succeeded
+5. `Observability Strict on: pull_request`
+   `Strict E2E with Enhanced Gates` skipped
+
+The skipped jobs above were non-blocking in GitHub and did not prevent merge or post-merge deployment completion.


### PR DESCRIPTION
## Summary
- refresh the timezone selector design and verification docs after PR #542 merged to main
- record the merge commit and the final GitHub workflow outcomes for commit `8fba63dcfe08490bb728f2f230079498072f2a8a`
- clarify which skipped jobs were non-blocking in the final merge/deploy path

## Verification
- docs-only change
- verified GitHub status for commit `8fba63dcfe08490bb728f2f230079498072f2a8a` on the public checks page

## Docs
- `docs/development/attendance-timezone-selector-design-20260323.md`
- `docs/development/attendance-timezone-selector-verification-20260323.md`