### PR TITLE
feat(attendance-ui): group timezone selectors

### DIFF
--- a/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
@@ -136,9 +136,15 @@
       <label class="attendance__field" for="attendance-holiday-sync-auto-tz">
         <span>{{ tr('Auto sync timezone', '自动同步时区') }}</span>
         <select id="attendance-holiday-sync-auto-tz" v-model="settingsForm.holidaySyncAutoTimezone" name="holidaySyncAutoTimezone">
-          <option v-for="timezone in holidaySyncTimezoneOptions" :key="timezone.value" :value="timezone.value">
-            {{ timezone.label }}
-          </option>
+          <optgroup
+            v-for="group in holidaySyncTimezoneOptionGroups"
+            :key="group.id"
+            :label="tr(group.labelEn, group.labelZh)"
+          >
+            <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+              {{ timezone.label }}
+            </option>
+          </optgroup>
         </select>
       </label>
       <label class="attendance__field attendance__field--checkbox" for="attendance-holiday-sync-index">
@@ -182,7 +188,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, type Ref } from 'vue'
-import { buildTimezoneOptionEntries } from './attendanceTimezones'
+import { buildTimezoneOptionGroups } from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -259,7 +265,7 @@ const holidaySyncLastRun = props.config.holidaySyncLastRun
 const holidaySyncLoading = props.config.holidaySyncLoading
 const saveSettings = () => props.config.saveSettings()
 const settingsForm = props.config.settingsForm
-const holidaySyncTimezoneOptions = computed(() => buildTimezoneOptionEntries(settingsForm.holidaySyncAutoTimezone))
+const holidaySyncTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(settingsForm.holidaySyncAutoTimezone))
 const settingsLoading = props.config.settingsLoading
 const syncHolidays = () => props.config.syncHolidays()
 const syncHolidaysForYears = (years: number[]) => props.config.syncHolidaysForYears(years)

--- a/apps/web/src/views/attendance/AttendanceImportWorkflowSection.vue
+++ b/apps/web/src/views/attendance/AttendanceImportWorkflowSection.vue
@@ -250,9 +250,15 @@
           v-model="importGroupTimezone"
         >
           <option value="">{{ tr('(Optional) Use import timezone', '（可选）沿用导入时区') }}</option>
-          <option v-for="timezone in importGroupTimezoneOptions" :key="timezone.value" :value="timezone.value">
-            {{ timezone.label }}
-          </option>
+          <optgroup
+            v-for="group in importGroupTimezoneOptionGroups"
+            :key="group.id"
+            :label="tr(group.labelEn, group.labelZh)"
+          >
+            <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+              {{ timezone.label }}
+            </option>
+          </optgroup>
         </select>
       </label>
       <label class="attendance__field" for="attendance-import-user">
@@ -272,9 +278,15 @@
           name="importTimezone"
           v-model="importForm.timezone"
         >
-          <option v-for="timezone in importTimezoneOptions" :key="timezone.value" :value="timezone.value">
-            {{ timezone.label }}
-          </option>
+          <optgroup
+            v-for="group in importTimezoneOptionGroups"
+            :key="group.id"
+            :label="tr(group.labelEn, group.labelZh)"
+          >
+            <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+              {{ timezone.label }}
+            </option>
+          </optgroup>
         </select>
       </label>
       <label class="attendance__field attendance__field--full" for="attendance-import-payload">
@@ -471,7 +483,7 @@
 <script setup lang="ts">
 import { computed, type ComputedRef, type Ref } from 'vue'
 import {
-  buildTimezoneOptionEntries,
+  buildTimezoneOptionGroups,
   formatTimezoneOptionLabel,
 } from './attendanceTimezones'
 import type {
@@ -588,8 +600,8 @@ const importGroupAutoCreate = props.workflow.importGroupAutoCreate
 const importGroupAutoAssign = props.workflow.importGroupAutoAssign
 const importGroupRuleSetId = props.workflow.importGroupRuleSetId
 const importGroupTimezone = props.workflow.importGroupTimezone
-const importTimezoneOptions = computed(() => buildTimezoneOptionEntries(importForm.timezone))
-const importGroupTimezoneOptions = computed(() => buildTimezoneOptionEntries(importGroupTimezone.value))
+const importTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(importForm.timezone))
+const importGroupTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(importGroupTimezone.value))
 const importScalabilityHint = props.workflow.importScalabilityHint
 const importPreviewTask = props.workflow.importPreviewTask
 const importAsyncJob = props.workflow.importAsyncJob

--- a/apps/web/src/views/attendance/AttendancePayrollAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendancePayrollAdminSection.vue
@@ -25,9 +25,15 @@
           v-model="payrollTemplateForm.timezone"
           name="payrollTemplateTimezone"
         >
-          <option v-for="timezone in payrollTemplateTimezones" :key="timezone.value" :value="timezone.value">
-            {{ timezone.label }}
-          </option>
+          <optgroup
+            v-for="group in payrollTemplateTimezoneOptionGroups"
+            :key="group.id"
+            :label="tr(group.labelEn, group.labelZh)"
+          >
+            <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+              {{ timezone.label }}
+            </option>
+          </optgroup>
         </select>
       </label>
       <label class="attendance__field" for="attendance-payroll-template-start">
@@ -384,7 +390,7 @@ import type {
   AttendancePayrollTemplate,
 } from './useAttendanceAdminPayroll'
 import {
-  buildTimezoneOptionEntries,
+  buildTimezoneOptionGroups,
   formatTimezoneOptionLabel,
 } from './attendanceTimezones'
 
@@ -474,7 +480,7 @@ const payrollCycleSummary = props.payroll.payrollCycleSummary
 const payrollTemplateForm = props.payroll.payrollTemplateForm
 const payrollCycleForm = props.payroll.payrollCycleForm
 const payrollCycleGenerateForm = props.payroll.payrollCycleGenerateForm
-const payrollTemplateTimezones = computed(() => buildTimezoneOptionEntries(payrollTemplateForm.timezone))
+const payrollTemplateTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(payrollTemplateForm.timezone))
 const payrollTemplateName = props.payroll.payrollTemplateName
 const resetPayrollTemplateForm = () => props.payroll.resetPayrollTemplateForm()
 const editPayrollTemplate = (item: AttendancePayrollTemplate) => props.payroll.editPayrollTemplate(item)

--- a/apps/web/src/views/attendance/AttendanceRulesAndGroupsSection.vue
+++ b/apps/web/src/views/attendance/AttendanceRulesAndGroupsSection.vue
@@ -89,9 +89,15 @@
               id="attendance-rule-builder-timezone"
               v-model="ruleBuilderTimezone"
             >
-              <option v-for="timezone in ruleBuilderTimezoneOptions" :key="timezone.value" :value="timezone.value">
-                {{ timezone.label }}
-              </option>
+              <optgroup
+                v-for="group in ruleBuilderTimezoneOptionGroups"
+                :key="group.id"
+                :label="tr(group.labelEn, group.labelZh)"
+              >
+                <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+                  {{ timezone.label }}
+                </option>
+              </optgroup>
             </select>
           </label>
           <label class="attendance__field" for="attendance-rule-builder-start">
@@ -679,9 +685,15 @@
       <label class="attendance__field" for="attendance-group-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
         <select id="attendance-group-timezone" v-model="attendanceGroupForm.timezone">
-          <option v-for="timezone in attendanceGroupTimezones" :key="timezone.value" :value="timezone.value">
-            {{ timezone.label }}
-          </option>
+          <optgroup
+            v-for="group in attendanceGroupTimezoneGroups"
+            :key="group.id"
+            :label="tr(group.labelEn, group.labelZh)"
+          >
+            <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+              {{ timezone.label }}
+            </option>
+          </optgroup>
         </select>
       </label>
       <label class="attendance__field" for="attendance-group-rule-set">
@@ -846,7 +858,7 @@ import type {
 } from './useAttendanceAdminRulesAndGroups'
 import AttendanceUserPickerField from './AttendanceUserPickerField.vue'
 import {
-  buildTimezoneOptionEntries,
+  buildTimezoneOptionGroups,
   formatTimezoneOptionLabel,
 } from './attendanceTimezones'
 
@@ -992,7 +1004,7 @@ const tr = props.tr
 const formatDateTime = props.formatDateTime
 const attendanceGroupEditingId = props.rules.attendanceGroupEditingId
 const attendanceGroupForm = props.rules.attendanceGroupForm
-const attendanceGroupTimezones = computed(() => buildTimezoneOptionEntries(attendanceGroupForm.timezone))
+const attendanceGroupTimezoneGroups = computed(() => buildTimezoneOptionGroups(attendanceGroupForm.timezone))
 const attendanceGroupLoading = props.rules.attendanceGroupLoading
 const attendanceGroupMemberGroupId = props.rules.attendanceGroupMemberGroupId
 const attendanceGroupMemberLoading = props.rules.attendanceGroupMemberLoading
@@ -1046,7 +1058,7 @@ const localRuleSetPreviewEventsText = ref('[]')
 const localRuleSetPreviewResult = ref<RuleSetPreviewResult | null>(null)
 const ruleBuilderSource = props.rules.ruleBuilderSource ?? localRuleBuilderSource
 const ruleBuilderTimezone = props.rules.ruleBuilderTimezone ?? localRuleBuilderTimezone
-const ruleBuilderTimezoneOptions = computed(() => buildTimezoneOptionEntries(ruleBuilderTimezone.value))
+const ruleBuilderTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(ruleBuilderTimezone.value))
 const ruleBuilderTimezoneLabel = computed(() => formatTimezoneOptionLabel(ruleBuilderTimezone.value))
 const ruleBuilderWorkStartTime = props.rules.ruleBuilderWorkStartTime ?? localRuleBuilderWorkStartTime
 const ruleBuilderWorkEndTime = props.rules.ruleBuilderWorkEndTime ?? localRuleBuilderWorkEndTime

--- a/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
@@ -14,9 +14,15 @@
       <label class="attendance__field" for="attendance-rule-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
         <select id="attendance-rule-timezone" v-model="ruleForm.timezone" name="ruleTimezone">
-          <option v-for="timezone in ruleTimezoneOptions" :key="timezone.value" :value="timezone.value">
-            {{ timezone.label }}
-          </option>
+          <optgroup
+            v-for="group in ruleTimezoneOptionGroups"
+            :key="group.id"
+            :label="tr(group.labelEn, group.labelZh)"
+          >
+            <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+              {{ timezone.label }}
+            </option>
+          </optgroup>
         </select>
       </label>
       <label class="attendance__field" for="attendance-rule-start">
@@ -72,9 +78,15 @@
           v-model="rotationRuleForm.timezone"
           name="rotationTimezone"
         >
-          <option v-for="timezone in rotationRuleTimezoneOptions" :key="timezone.value" :value="timezone.value">
-            {{ timezone.label }}
-          </option>
+          <optgroup
+            v-for="group in rotationRuleTimezoneOptionGroups"
+            :key="group.id"
+            :label="tr(group.labelEn, group.labelZh)"
+          >
+            <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+              {{ timezone.label }}
+            </option>
+          </optgroup>
         </select>
       </label>
       <label class="attendance__field attendance__field--full" for="attendance-rotation-sequence">
@@ -299,9 +311,15 @@
       <label class="attendance__field" for="attendance-shift-timezone">
         <span>{{ tr('Timezone', '时区') }}</span>
         <select id="attendance-shift-timezone" v-model="shiftForm.timezone" name="shiftTimezone">
-          <option v-for="timezone in shiftTimezoneOptions" :key="timezone.value" :value="timezone.value">
-            {{ timezone.label }}
-          </option>
+          <optgroup
+            v-for="group in shiftTimezoneOptionGroups"
+            :key="group.id"
+            :label="tr(group.labelEn, group.labelZh)"
+          >
+            <option v-for="timezone in group.options" :key="timezone.value" :value="timezone.value">
+              {{ timezone.label }}
+            </option>
+          </optgroup>
         </select>
       </label>
       <label class="attendance__field" for="attendance-shift-start">
@@ -521,7 +539,7 @@ import type {
 } from './useAttendanceAdminScheduling'
 import AttendanceUserPickerField from './AttendanceUserPickerField.vue'
 import {
-  buildTimezoneOptionEntries,
+  buildTimezoneOptionGroups,
   formatTimezoneOptionLabel,
 } from './attendanceTimezones'
 
@@ -629,7 +647,7 @@ const props = defineProps<{
 const tr = props.tr
 const loadRule = () => props.scheduling.loadRule()
 const ruleForm = props.scheduling.ruleForm
-const ruleTimezoneOptions = computed(() => buildTimezoneOptionEntries(ruleForm.timezone))
+const ruleTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(ruleForm.timezone))
 const ruleLoading = props.scheduling.ruleLoading
 const saveRule = () => props.scheduling.saveRule()
 const rotationRules = props.scheduling.rotationRules
@@ -637,7 +655,7 @@ const rotationRuleLoading = props.scheduling.rotationRuleLoading
 const rotationRuleSaving = props.scheduling.rotationRuleSaving
 const rotationRuleEditingId = props.scheduling.rotationRuleEditingId
 const rotationRuleForm = props.scheduling.rotationRuleForm
-const rotationRuleTimezoneOptions = computed(() => buildTimezoneOptionEntries(rotationRuleForm.timezone))
+const rotationRuleTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(rotationRuleForm.timezone))
 const resetRotationRuleForm = () => props.scheduling.resetRotationRuleForm()
 const editRotationRule = (rule: AttendanceRotationRule) => props.scheduling.editRotationRule(rule)
 const loadRotationRules = () => props.scheduling.loadRotationRules()
@@ -658,7 +676,7 @@ const shiftLoading = props.scheduling.shiftLoading
 const shiftSaving = props.scheduling.shiftSaving
 const shiftEditingId = props.scheduling.shiftEditingId
 const shiftForm = props.scheduling.shiftForm
-const shiftTimezoneOptions = computed(() => buildTimezoneOptionEntries(shiftForm.timezone))
+const shiftTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(shiftForm.timezone))
 const resetShiftForm = () => props.scheduling.resetShiftForm()
 const editShift = (shift: AttendanceShift) => props.scheduling.editShift(shift)
 const loadShifts = () => props.scheduling.loadShifts()

--- a/apps/web/src/views/attendance/attendanceTimezones.ts
+++ b/apps/web/src/views/attendance/attendanceTimezones.ts
@@ -18,6 +18,46 @@ export interface TimezoneOptionEntry {
   label: string
 }
 
+export interface TimezoneOptionGroupEntry {
+  id: string
+  labelEn: string
+  labelZh: string
+  options: TimezoneOptionEntry[]
+}
+
+const COMMON_TIMEZONES = [
+  'UTC',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Asia/Singapore',
+  'Asia/Hong_Kong',
+  'Asia/Seoul',
+  'Europe/London',
+  'Europe/Paris',
+  'America/New_York',
+  'America/Los_Angeles',
+]
+
+const TIMEZONE_GROUPS: Array<{
+  id: string
+  labelEn: string
+  labelZh: string
+}> = [
+  { id: 'common', labelEn: 'Common timezones', labelZh: '常用时区' },
+  { id: 'Asia', labelEn: 'Asia', labelZh: '亚洲' },
+  { id: 'Europe', labelEn: 'Europe', labelZh: '欧洲' },
+  { id: 'America', labelEn: 'Americas', labelZh: '美洲' },
+  { id: 'Pacific', labelEn: 'Pacific', labelZh: '太平洋' },
+  { id: 'Australia', labelEn: 'Australia', labelZh: '澳洲' },
+  { id: 'Africa', labelEn: 'Africa', labelZh: '非洲' },
+  { id: 'Atlantic', labelEn: 'Atlantic', labelZh: '大西洋' },
+  { id: 'Indian', labelEn: 'Indian Ocean', labelZh: '印度洋' },
+  { id: 'Antarctica', labelEn: 'Antarctica', labelZh: '南极洲' },
+  { id: 'Arctic', labelEn: 'Arctic', labelZh: '北极' },
+  { id: 'Etc', labelEn: 'Etc / UTC', labelZh: 'Etc / UTC' },
+  { id: 'custom', labelEn: 'Other / custom', labelZh: '其他 / 自定义' },
+]
+
 function loadSupportedTimezones(): string[] {
   if (cachedSupportedTimezones) return cachedSupportedTimezones
 
@@ -37,8 +77,31 @@ function loadSupportedTimezones(): string[] {
   return cachedSupportedTimezones
 }
 
+function resolveLocalTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || ''
+  } catch {
+    return ''
+  }
+}
+
+function normalizeTimezoneValue(value?: string | null): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function resolveTimezoneGroupId(timezone: string): string {
+  if (!timezone) return 'custom'
+  if (timezone === 'UTC') return 'common'
+
+  const [region] = timezone.split('/')
+  if (TIMEZONE_GROUPS.some((item) => item.id === region)) {
+    return region
+  }
+  return 'custom'
+}
+
 export function buildTimezoneOptions(currentValue?: string | null): string[] {
-  const normalized = typeof currentValue === 'string' ? currentValue.trim() : ''
+  const normalized = normalizeTimezoneValue(currentValue)
   const options = [...loadSupportedTimezones()]
   if (normalized && !options.includes(normalized)) {
     options.unshift(normalized)
@@ -75,7 +138,7 @@ export function formatTimezoneOffsetLabel(timezone?: string | null, date = new D
 }
 
 export function formatTimezoneOptionLabel(timezone?: string | null, date = new Date()): string {
-  const normalized = typeof timezone === 'string' ? timezone.trim() : ''
+  const normalized = normalizeTimezoneValue(timezone)
   if (!normalized) return ''
 
   const offsetLabel = formatTimezoneOffsetLabel(normalized, date)
@@ -87,4 +150,51 @@ export function buildTimezoneOptionEntries(currentValue?: string | null): Timezo
     value,
     label: formatTimezoneOptionLabel(value),
   }))
+}
+
+export function buildTimezoneOptionGroups(currentValue?: string | null): TimezoneOptionGroupEntry[] {
+  const options = buildTimezoneOptions(currentValue)
+  const normalizedCurrent = normalizeTimezoneValue(currentValue)
+  const localTimezone = normalizeTimezoneValue(resolveLocalTimezone())
+  const optionSet = new Set(options)
+
+  const commonOrder = Array.from(new Set([
+    normalizedCurrent,
+    localTimezone,
+    ...COMMON_TIMEZONES,
+  ].filter(Boolean)))
+
+  const commonSet = new Set(commonOrder.filter((item) => optionSet.has(item)))
+  const groups = new Map<string, string[]>()
+
+  if (commonSet.size > 0) {
+    groups.set('common', commonOrder.filter((item) => commonSet.has(item)))
+  }
+
+  for (const option of options) {
+    if (commonSet.has(option)) continue
+    const groupId = resolveTimezoneGroupId(option)
+    const group = groups.get(groupId)
+    if (group) {
+      group.push(option)
+      continue
+    }
+    groups.set(groupId, [option])
+  }
+
+  return TIMEZONE_GROUPS
+    .map((group) => {
+      const entries = groups.get(group.id) ?? []
+      if (entries.length === 0) return null
+      return {
+        id: group.id,
+        labelEn: group.labelEn,
+        labelZh: group.labelZh,
+        options: entries.map((value) => ({
+          value,
+          label: formatTimezoneOptionLabel(value),
+        })),
+      }
+    })
+    .filter((group): group is TimezoneOptionGroupEntry => Boolean(group))
 }

--- a/apps/web/tests/AttendanceImportWorkflowSection.spec.ts
+++ b/apps/web/tests/AttendanceImportWorkflowSection.spec.ts
@@ -224,6 +224,8 @@ describe('AttendanceImportWorkflowSection', () => {
     expect(importTimezone).toBeTruthy()
     expect(importGroupTimezone).toBeTruthy()
     expect(importTimezone!.selectedOptions[0]?.textContent).toContain('Asia/Shanghai (UTC+08:00)')
+    expect(Array.from(importTimezone!.querySelectorAll('optgroup')).map((group) => group.label)).toContain('Common timezones')
+    expect(Array.from(importGroupTimezone!.querySelectorAll('optgroup')).map((group) => group.label)).toContain('Asia')
   })
 
   it('shows manual-plan fallbacks when mapping, user map, and group sync are unset', async () => {

--- a/apps/web/tests/AttendanceRulesAndGroupsSection.spec.ts
+++ b/apps/web/tests/AttendanceRulesAndGroupsSection.spec.ts
@@ -448,9 +448,11 @@ describe('AttendanceRulesAndGroupsSection', () => {
     expect(ruleBuilderTimezone).toBeTruthy()
     expect(attendanceGroupTimezone).toBeTruthy()
     expect(ruleBuilderTimezone!.selectedOptions[0]?.textContent).toContain('Asia/Shanghai (UTC+08:00)')
+    expect(Array.from(ruleBuilderTimezone!.querySelectorAll('optgroup')).map((group) => group.label)).toContain('Common timezones')
     expect(Array.from(attendanceGroupTimezone!.querySelectorAll('option')).map((option) => option.textContent)).toContain(
       'Asia/Shanghai (UTC+08:00)',
     )
+    expect(Array.from(attendanceGroupTimezone!.querySelectorAll('optgroup')).map((group) => group.label)).toContain('Asia')
     expect(container!.textContent).toContain('Asia/Shanghai (UTC+08:00)')
   })
 })

--- a/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
+++ b/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
@@ -380,6 +380,8 @@ describe('AttendanceSchedulingAdminSection', () => {
     expect(defaultRuleTimezone!.selectedOptions[0]?.textContent).toContain('UTC+00:00')
     expect(rotationTimezone!.selectedOptions[0]?.textContent).toContain('UTC+00:00')
     expect(shiftTimezone!.selectedOptions[0]?.textContent).toContain('UTC+00:00')
+    expect(Array.from(defaultRuleTimezone!.querySelectorAll('optgroup')).map((group) => group.label)).toContain('Common timezones')
+    expect(Array.from(rotationTimezone!.querySelectorAll('optgroup')).map((group) => group.label)).toContain('Asia')
     expect(container!.textContent).toContain('UTC (UTC+00:00)')
   })
 })

--- a/apps/web/tests/attendanceTimezones.spec.ts
+++ b/apps/web/tests/attendanceTimezones.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildTimezoneOptionEntries,
+  buildTimezoneOptionGroups,
   formatTimezoneOffsetLabel,
   formatTimezoneOptionLabel,
 } from '../src/views/attendance/attendanceTimezones'
@@ -20,5 +21,15 @@ describe('attendanceTimezones', () => {
       value: 'Asia/Shanghai',
       label: 'Asia/Shanghai (UTC+08:00)',
     })
+  })
+
+  it('groups timezone options into common and regional buckets', () => {
+    const groups = buildTimezoneOptionGroups('America/New_York')
+
+    expect(groups[0]?.id).toBe('common')
+    expect(groups[0]?.labelEn).toBe('Common timezones')
+    expect(groups[0]?.options.some((item) => item.value === 'America/New_York')).toBe(true)
+    expect(groups.some((group) => group.id === 'Asia')).toBe(true)
+    expect(groups.some((group) => group.id === 'Europe')).toBe(true)
   })
 })

--- a/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
+++ b/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
@@ -254,5 +254,6 @@ describe('AttendanceHolidayRuleSection', () => {
     const timezoneSelect = container!.querySelector<HTMLSelectElement>('#attendance-holiday-sync-auto-tz')
     expect(timezoneSelect).toBeTruthy()
     expect(timezoneSelect!.selectedOptions[0]?.textContent).toContain('Asia/Shanghai (UTC+08:00)')
+    expect(Array.from(timezoneSelect!.querySelectorAll('optgroup')).map((group) => group.label)).toContain('常用时区')
   })
 })

--- a/docs/development/attendance-timezone-selector-groups-design-20260323.md
+++ b/docs/development/attendance-timezone-selector-groups-design-20260323.md
@@ -1,0 +1,73 @@
+# Attendance Timezone Selector Groups Design 2026-03-23
+
+## Background
+
+The attendance admin timezone selectors already moved away from raw text input, but the first version still rendered one long flat option list.
+
+That solved validation issues, but it left two UX problems:
+
+1. Operators still had to scan a very long list to find common timezones.
+2. The selector did not visually separate high-frequency timezones from the full IANA catalog.
+
+## Goal
+
+Upgrade the shared attendance timezone selector model so that:
+
+1. Common timezones appear first.
+2. The full timezone list is grouped by region.
+3. Existing saved values still render correctly.
+4. Stored payloads remain unchanged and continue to use raw IANA timezone strings.
+
+## Scope
+
+This update applies to the attendance admin selectors already introduced in the previous timezone-selector change:
+
+1. Rule set builder timezone
+2. Attendance group timezone
+3. Default rule timezone
+4. Rotation rule timezone
+5. Shift timezone
+6. Holiday sync auto timezone
+7. Import timezone
+8. Optional import group timezone
+9. Payroll template timezone
+
+## Shared Design
+
+The shared timezone utility now exposes grouped options in addition to the existing flat label formatter:
+
+1. `buildTimezoneOptionGroups(currentValue)`
+2. `formatTimezoneOptionLabel(timezone)`
+3. `formatTimezoneOffsetLabel(timezone)`
+
+The grouped builder has three behaviors:
+
+1. Promote current value and browser-local timezone into the leading common bucket when possible.
+2. Keep a curated `Common timezones` group for the most frequent attendance admin cases.
+3. Bucket remaining options by IANA region such as `Asia`, `Europe`, and `Americas`.
+
+## UX Decision
+
+The grouped selector stays as native `<select>` plus `<optgroup>`.
+
+Reason:
+
+1. It keeps keyboard and browser accessibility behavior intact.
+2. It avoids introducing a larger combobox/search component across several admin forms.
+3. It is a low-risk second-step improvement on top of the existing selector rollout.
+
+## Compatibility
+
+This update remains backward compatible:
+
+1. Saved timezone values are still raw identifiers such as `Asia/Shanghai`.
+2. Unknown current values are still injected into the option list and grouped under `Other / custom`.
+3. API payloads and server-side validation do not change.
+
+## Out of Scope
+
+This change does not:
+
+1. Add fuzzy timezone search
+2. Infer timezone from organization profile
+3. Rework backend timezone semantics

--- a/docs/development/attendance-timezone-selector-groups-verification-20260323.md
+++ b/docs/development/attendance-timezone-selector-groups-verification-20260323.md
@@ -1,0 +1,50 @@
+# Attendance Timezone Selector Groups Verification 2026-03-23
+
+## Scope Verified
+
+Verified that attendance admin timezone selectors now render grouped options with a leading common-timezone bucket, while still persisting raw IANA timezone values.
+
+## Commands
+
+Executed in `/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-run20-field-compat-20260320`:
+
+1. `pnpm --filter @metasheet/web exec vitest run tests/attendanceTimezones.spec.ts tests/AttendanceRulesAndGroupsSection.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/AttendanceImportWorkflowSection.spec.ts --watch=false`
+2. `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
+3. `pnpm --filter @metasheet/web build`
+
+## Results
+
+### Vitest
+
+Passed:
+
+1. `tests/attendanceTimezones.spec.ts`
+2. `tests/AttendanceRulesAndGroupsSection.spec.ts`
+3. `tests/AttendanceSchedulingAdminSection.spec.ts`
+4. `tests/useAttendanceHolidayRuleSection.spec.ts`
+5. `tests/AttendanceImportWorkflowSection.spec.ts`
+
+Summary:
+
+1. `5` files passed
+2. `16` tests passed
+
+### Type Check
+
+`vue-tsc --noEmit` passed.
+
+### Production Build
+
+`pnpm --filter @metasheet/web build` passed.
+
+The existing Vite chunk-size warning remains unrelated to this selector grouping change.
+
+## Behavior Verified
+
+1. Shared timezone options are grouped into `Common timezones` plus regional buckets.
+2. Rule set builder and attendance group selectors render grouped options.
+3. Scheduling selectors for default rules, rotation rules, and shifts render grouped options.
+4. Holiday sync auto timezone renders grouped options.
+5. Import timezone and group timezone render grouped options.
+6. The selected option labels still show `UTC±HH:MM`.
+7. Stored values remain raw timezone strings such as `UTC` and `Asia/Shanghai`.


### PR DESCRIPTION
## Summary
- group attendance timezone selectors into a leading common bucket plus regional optgroups
- keep UTC offset labels and raw IANA payload values unchanged
- refresh design and verification docs for the grouped-selector follow-up

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendanceTimezones.spec.ts tests/AttendanceRulesAndGroupsSection.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/AttendanceImportWorkflowSection.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`

## Docs
- `docs/development/attendance-timezone-selector-groups-design-20260323.md`
- `docs/development/attendance-timezone-selector-groups-verification-20260323.md`