### PR TITLE
fix(ci): resolve home-relative deploy paths

### DIFF
--- a/.github/workflows/attendance-remote-docker-gc-prod.yml
+++ b/.github/workflows/attendance-remote-docker-gc-prod.yml
@@ -59,7 +59,22 @@ jobs:
             "DEPLOY_PATH=\"${DEPLOY_PATH}\""
             "PRUNE=\"${PRUNE}\""
             "SKIP_HOST_SYNC=\"${SKIP_HOST_SYNC}\""
-            "cd \"${DEPLOY_PATH}\""
+            'if [[ "${DEPLOY_PATH}" == /* ]]; then'
+              '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
+            'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"'
+            "else"
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"'
+            "fi"
+            'if [[ ! -d "$DEPLOY_REPO_PATH" ]]; then'
+              '  echo "[host-sync][error] DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})"'
+              '  echo "[host-sync][error] pwd=$(pwd)"'
+              '  echo "[host-sync][error] home=${HOME}"'
+              '  ls -la "${HOME}" || true'
+              '  exit 1'
+            "fi"
+            'cd "$DEPLOY_REPO_PATH"'
+            'echo "[host-sync] repo_path=${DEPLOY_REPO_PATH}"'
             "echo \"=== HOST SYNC START ===\""
             "host_sync_rc=0"
             "host_sync_attempts=3"
@@ -72,6 +87,7 @@ jobs:
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
+              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-env-reconcile-prod.yml
+++ b/.github/workflows/attendance-remote-env-reconcile-prod.yml
@@ -67,7 +67,22 @@ jobs:
             "DEPLOY_COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE}\""
             "CSV_MAX_ROWS=\"${CSV_MAX_ROWS}\""
             "SKIP_HOST_SYNC=\"${SKIP_HOST_SYNC}\""
-            "cd \"${DEPLOY_PATH}\""
+            'if [[ "${DEPLOY_PATH}" == /* ]]; then'
+              '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
+            'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"'
+            "else"
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"'
+            "fi"
+            'if [[ ! -d "$DEPLOY_REPO_PATH" ]]; then'
+              '  echo "[host-sync][error] DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})"'
+              '  echo "[host-sync][error] pwd=$(pwd)"'
+              '  echo "[host-sync][error] home=${HOME}"'
+              '  ls -la "${HOME}" || true'
+              '  exit 1'
+            "fi"
+            'cd "$DEPLOY_REPO_PATH"'
+            'echo "[host-sync] repo_path=${DEPLOY_REPO_PATH}"'
             "echo \"=== HOST SYNC START ===\""
             "host_sync_rc=0"
             "host_sync_attempts=3"
@@ -80,6 +95,7 @@ jobs:
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
+              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-metrics-prod.yml
+++ b/.github/workflows/attendance-remote-metrics-prod.yml
@@ -82,7 +82,22 @@ jobs:
             "SKIP_HOST_SYNC=\"${SKIP_HOST_SYNC}\""
             "METRICS_URL=\"${METRICS_URL}\""
             "MAX_TIME=\"${MAX_TIME}\""
-            "cd \"${DEPLOY_PATH}\""
+            'if [[ "${DEPLOY_PATH}" == /* ]]; then'
+              '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
+            'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"'
+            "else"
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"'
+            "fi"
+            'if [[ ! -d "$DEPLOY_REPO_PATH" ]]; then'
+              '  echo "[host-sync][error] DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})"'
+              '  echo "[host-sync][error] pwd=$(pwd)"'
+              '  echo "[host-sync][error] home=${HOME}"'
+              '  ls -la "${HOME}" || true'
+              '  exit 1'
+            "fi"
+            'cd "$DEPLOY_REPO_PATH"'
+            'echo "[host-sync] repo_path=${DEPLOY_REPO_PATH}"'
             "echo \"=== HOST SYNC START ===\""
             "host_sync_rc=0"
             "host_sync_attempts=3"
@@ -95,6 +110,7 @@ jobs:
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
+              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-preflight-prod.yml
+++ b/.github/workflows/attendance-remote-preflight-prod.yml
@@ -67,7 +67,22 @@ jobs:
             "DEPLOY_COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE}\""
             "DRILL_FAIL=\"${DRILL_FAIL}\""
             "SKIP_HOST_SYNC=\"${SKIP_HOST_SYNC}\""
-            "cd \"${DEPLOY_PATH}\""
+            'if [[ "${DEPLOY_PATH}" == /* ]]; then'
+              '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
+            'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"'
+            "else"
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"'
+            "fi"
+            'if [[ ! -d "$DEPLOY_REPO_PATH" ]]; then'
+              '  echo "[host-sync][error] DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})"'
+              '  echo "[host-sync][error] pwd=$(pwd)"'
+              '  echo "[host-sync][error] home=${HOME}"'
+              '  ls -la "${HOME}" || true'
+              '  exit 1'
+            "fi"
+            'cd "$DEPLOY_REPO_PATH"'
+            'echo "[host-sync] repo_path=${DEPLOY_REPO_PATH}"'
             "echo \"=== HOST SYNC START ===\""
             "host_sync_rc=0"
             "host_sync_attempts=3"
@@ -80,6 +95,7 @@ jobs:
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
+              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-storage-prod.yml
+++ b/.github/workflows/attendance-remote-storage-prod.yml
@@ -96,7 +96,22 @@ jobs:
             "MAX_FS_USED_PCT=\"${MAX_FS_USED_PCT}\""
             "MAX_UPLOAD_DIR_GB=\"${MAX_UPLOAD_DIR_GB}\""
             "MAX_OLDEST_FILE_DAYS=\"${MAX_OLDEST_FILE_DAYS}\""
-            "cd \"${DEPLOY_PATH}\""
+            'if [[ "${DEPLOY_PATH}" == /* ]]; then'
+              '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
+            'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"'
+            "else"
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"'
+            "fi"
+            'if [[ ! -d "$DEPLOY_REPO_PATH" ]]; then'
+              '  echo "[host-sync][error] DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})"'
+              '  echo "[host-sync][error] pwd=$(pwd)"'
+              '  echo "[host-sync][error] home=${HOME}"'
+              '  ls -la "${HOME}" || true'
+              '  exit 1'
+            "fi"
+            'cd "$DEPLOY_REPO_PATH"'
+            'echo "[host-sync] repo_path=${DEPLOY_REPO_PATH}"'
             "echo \"=== HOST SYNC START ===\""
             "host_sync_rc=0"
             "host_sync_attempts=3"
@@ -109,6 +124,7 @@ jobs:
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
+              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-upload-cleanup-prod.yml
+++ b/.github/workflows/attendance-remote-upload-cleanup-prod.yml
@@ -102,7 +102,22 @@ jobs:
             "MAX_DELETE_GB=\"${MAX_DELETE_GB}\""
             "DELETE=\"${DELETE}\""
             "CONFIRM_DELETE=\"${CONFIRM_DELETE}\""
-            "cd \"${DEPLOY_PATH}\""
+            'if [[ "${DEPLOY_PATH}" == /* ]]; then'
+              '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
+            'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"'
+            "else"
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"'
+            "fi"
+            'if [[ ! -d "$DEPLOY_REPO_PATH" ]]; then'
+              '  echo "[host-sync][error] DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})"'
+              '  echo "[host-sync][error] pwd=$(pwd)"'
+              '  echo "[host-sync][error] home=${HOME}"'
+              '  ls -la "${HOME}" || true'
+              '  exit 1'
+            "fi"
+            'cd "$DEPLOY_REPO_PATH"'
+            'echo "[host-sync] repo_path=${DEPLOY_REPO_PATH}"'
             "echo \"=== HOST SYNC START ===\""
             "host_sync_rc=0"
             "host_sync_attempts=3"
@@ -115,6 +130,7 @@ jobs:
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
+              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -86,9 +86,24 @@ jobs:
             "DEPLOY_PATH=\"${DEPLOY_PATH:-metasheet2}\""
             "DEPLOY_COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}\""
             "DRILL_FAIL_STAGE=\"${DRILL_FAIL_STAGE:-none}\""
-            "cd \"${DEPLOY_PATH}\""
+            'if [[ "${DEPLOY_PATH}" == /* ]]; then'
+            '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
+            'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
+            '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"'
+            'else'
+            '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"'
+            'fi'
+            'if [[ ! -d "$DEPLOY_REPO_PATH" ]]; then'
+            '  echo "[deploy][error] DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})" >&2'
+            '  echo "[deploy][error] pwd=$(pwd)" >&2'
+            '  echo "[deploy][error] home=${HOME}" >&2'
+            '  ls -la "${HOME}" >&2 || true'
+            '  exit 1'
+            'fi'
+            'cd "$DEPLOY_REPO_PATH"'
+            'echo "[deploy] repo_path=${DEPLOY_REPO_PATH}"'
             "# Keep host-mounted config (e.g. docker/nginx.conf) in sync with main."
-            "git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo \"[deploy][error] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH}\" >&2; exit 1; }"
+            'git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "[deploy][error] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})" >&2; echo "[deploy][error] pwd=$(pwd)" >&2; ls -la >&2 || true; exit 1; }'
             "git fetch origin main"
             "git checkout main"
             "git merge --ff-only origin/main"

--- a/docs/development/remote-deploy-path-home-resolution-20260326.md
+++ b/docs/development/remote-deploy-path-home-resolution-20260326.md
@@ -1,0 +1,48 @@
+# Remote Deploy Path Home Resolution
+
+Date: 2026-03-26
+
+## Problem
+
+`main` merge commit `1aa41d700e6f2c134fc739d67320a14bc4468159` triggered `Build and Push Docker Images` run `23592951330`.
+The build job succeeded, but the remote deploy job failed before preflight/migrate/smoke:
+
+- `Remote deploy failed: rc=1`
+- `[deploy][error] DEPLOY_PATH is not a git repo: metasheet2`
+
+The current workflows assume `DEPLOY_PATH=metasheet2` can be passed directly to `cd`. That is fragile because:
+
+1. docs already describe the default as home-relative;
+2. non-interactive SSH shells should not rely on the current working directory;
+3. the old failure string did not expose the resolved path or host cwd, so operators had to re-run just to learn basic context.
+
+The same path assumption existed in the mainline deploy workflow and six attendance remote maintenance workflows.
+
+## Design
+
+Apply one uniform remote-path contract to every SSH workflow that syncs/deploys a repo:
+
+1. If `DEPLOY_PATH` is absolute, use it unchanged.
+2. If `DEPLOY_PATH` starts with `~/`, expand it against `$HOME`.
+3. Otherwise resolve it as `$HOME/$DEPLOY_PATH`.
+4. Fail early if the resolved directory does not exist.
+5. After `cd`, log the resolved repo path.
+6. If `git rev-parse --is-inside-work-tree` fails, print the resolved path, `pwd`, and `ls -la` diagnostics before exiting.
+
+This keeps the current secret contract backward-compatible while making the implicit "home-relative" rule explicit in code.
+
+## Scope
+
+Updated workflows:
+
+- `.github/workflows/docker-build.yml`
+- `.github/workflows/attendance-remote-preflight-prod.yml`
+- `.github/workflows/attendance-remote-storage-prod.yml`
+- `.github/workflows/attendance-remote-metrics-prod.yml`
+- `.github/workflows/attendance-remote-env-reconcile-prod.yml`
+- `.github/workflows/attendance-remote-upload-cleanup-prod.yml`
+- `.github/workflows/attendance-remote-docker-gc-prod.yml`
+
+## Claude Code Note
+
+Claude Code was used to sanity-check the fix boundary. Its recommendation matched the chosen approach: resolve `DEPLOY_PATH` to an absolute path early and emit `pwd/ls` diagnostics on repo-check failure.

--- a/docs/development/remote-deploy-path-home-resolution-verification-20260326.md
+++ b/docs/development/remote-deploy-path-home-resolution-verification-20260326.md
@@ -1,0 +1,89 @@
+# Remote Deploy Path Home Resolution Verification
+
+Date: 2026-03-26
+
+## Trigger
+
+Blocked release status after merged PR `#547`:
+
+- workflow: `Build and Push Docker Images`
+- run: `23592951330`
+- failing job: `deploy`
+- failure excerpt:
+  - `Remote deploy failed: rc=1`
+  - `[deploy][error] DEPLOY_PATH is not a git repo: metasheet2`
+
+Downloaded artifact evidence:
+
+- `output/playwright/ga/23592951330/deploy.log`
+- `output/playwright/ga/23592951330/step-summary.md`
+
+## Verification Performed
+
+### 1. Workflow diff integrity
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- pass
+
+### 2. Target workflows all contain the new resolver/diagnostics contract
+
+Command:
+
+```bash
+rg -n "DEPLOY_REPO_PATH|repo_path=|DEPLOY_PATH missing|not a git repo at" \
+  .github/workflows/docker-build.yml \
+  .github/workflows/attendance-remote-preflight-prod.yml \
+  .github/workflows/attendance-remote-storage-prod.yml \
+  .github/workflows/attendance-remote-metrics-prod.yml \
+  .github/workflows/attendance-remote-env-reconcile-prod.yml \
+  .github/workflows/attendance-remote-upload-cleanup-prod.yml \
+  .github/workflows/attendance-remote-docker-gc-prod.yml
+```
+
+Result:
+
+- all 7 workflows contain the new `DEPLOY_REPO_PATH` resolution
+- all 7 workflows now log resolved repo path
+- all 7 workflows emit failure diagnostics for missing/non-repo targets
+
+### 3. Resolution semantics
+
+Command:
+
+```bash
+bash -lc 'for p in metasheet2 ~/metasheet2 /srv/metasheet2; do
+  DEPLOY_PATH="$p"
+  if [[ "$DEPLOY_PATH" == /* ]]; then
+    DEPLOY_REPO_PATH="$DEPLOY_PATH"
+  elif [[ "$DEPLOY_PATH" == ~/* ]]; then
+    DEPLOY_REPO_PATH="$HOME/${DEPLOY_PATH#~/}"
+  else
+    DEPLOY_REPO_PATH="$HOME/${DEPLOY_PATH}"
+  fi
+  printf "%s -> %s\n" "$DEPLOY_PATH" "$DEPLOY_REPO_PATH"
+done'
+```
+
+Result:
+
+- `metasheet2 -> $HOME/metasheet2`
+- `~/metasheet2 -> $HOME/metasheet2`
+- `/srv/metasheet2 -> /srv/metasheet2`
+
+This matches the intended contract.
+
+## What Was Not Verified
+
+- No remote rerun was executed in this worktree.
+- This verification proves the workflow contract change and diagnostics improvement, not that the target host has already been repaired.
+
+## Expected Next Step
+
+Re-run the failed workflow after merging this fix. If the host path is correct, deploy should continue past repo validation; if not, the new logs will expose the resolved path and host directory contents immediately.


### PR DESCRIPTION
## Summary
- resolve remote `DEPLOY_PATH` explicitly against `$HOME` when the secret/default is home-relative
- add missing-path and non-repo diagnostics to the main deploy workflow and attendance remote maintenance workflows
- document the design and verification for the current mainline deploy failure

## Why
`Build and Push Docker Images` run `23592951330` failed in the remote deploy step before preflight/migrate/smoke with:
- `Remote deploy failed: rc=1`
- `[deploy][error] DEPLOY_PATH is not a git repo: metasheet2`

This PR makes the implicit home-relative contract explicit in code and upgrades the failure logs so operators can see the resolved path, `pwd`, and directory listing on the first failed run.

## Verify
- `git diff --check`
- `rg -n "DEPLOY_REPO_PATH|repo_path=|DEPLOY_PATH missing|not a git repo at" .github/workflows/docker-build.yml .github/workflows/attendance-remote-preflight-prod.yml .github/workflows/attendance-remote-storage-prod.yml .github/workflows/attendance-remote-metrics-prod.yml .github/workflows/attendance-remote-env-reconcile-prod.yml .github/workflows/attendance-remote-upload-cleanup-prod.yml .github/workflows/attendance-remote-docker-gc-prod.yml`
- `bash -lc 'for p in metasheet2 ~/metasheet2 /srv/metasheet2; do DEPLOY_PATH="$p"; if [[ "$DEPLOY_PATH" == /* ]]; then DEPLOY_REPO_PATH="$DEPLOY_PATH"; elif [[ "$DEPLOY_PATH" == ~/* ]]; then DEPLOY_REPO_PATH="$HOME/${DEPLOY_PATH#~/}"; else DEPLOY_REPO_PATH="$HOME/${DEPLOY_PATH}"; fi; printf "%s -> %s\n" "$DEPLOY_PATH" "$DEPLOY_REPO_PATH"; done'`

## Docs
- `docs/development/remote-deploy-path-home-resolution-20260326.md`
- `docs/development/remote-deploy-path-home-resolution-verification-20260326.md`
