### PR TITLE
fix(ci): allow deploy on non-git hosts

### DIFF
--- a/.github/workflows/attendance-remote-docker-gc-prod.yml
+++ b/.github/workflows/attendance-remote-docker-gc-prod.yml
@@ -81,13 +81,17 @@ jobs:
             'if [[ "${SKIP_HOST_SYNC}" == "true" ]]; then'
               '  echo "[host-sync] skipped (skip_host_sync=true)"'
               '  host_sync_rc=0'
+            'elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then'
+              '  echo "[host-sync][warn] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH}); continuing with existing files"'
+              '  pwd'
+              '  ls -la || true'
+              '  host_sync_rc=0'
             "else"
               "  set +e"
               '  for attempt in $(seq 1 "$host_sync_attempts"); do'
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
-              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-env-reconcile-prod.yml
+++ b/.github/workflows/attendance-remote-env-reconcile-prod.yml
@@ -89,13 +89,17 @@ jobs:
             'if [[ "${SKIP_HOST_SYNC}" == "true" ]]; then'
               '  echo "[host-sync] skipped (skip_host_sync=true)"'
               '  host_sync_rc=0'
+            'elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then'
+              '  echo "[host-sync][warn] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH}); continuing with existing files"'
+              '  pwd'
+              '  ls -la || true'
+              '  host_sync_rc=0'
             "else"
               "  set +e"
               '  for attempt in $(seq 1 "$host_sync_attempts"); do'
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
-              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-metrics-prod.yml
+++ b/.github/workflows/attendance-remote-metrics-prod.yml
@@ -104,13 +104,17 @@ jobs:
             'if [[ "${SKIP_HOST_SYNC}" == "true" ]]; then'
               '  echo "[host-sync] skipped (skip_host_sync=true)"'
               '  host_sync_rc=0'
+            'elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then'
+              '  echo "[host-sync][warn] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH}); continuing with existing files"'
+              '  pwd'
+              '  ls -la || true'
+              '  host_sync_rc=0'
             "else"
               "  set +e"
               '  for attempt in $(seq 1 "$host_sync_attempts"); do'
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
-              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-preflight-prod.yml
+++ b/.github/workflows/attendance-remote-preflight-prod.yml
@@ -89,13 +89,17 @@ jobs:
             'if [[ "${SKIP_HOST_SYNC}" == "true" ]]; then'
               '  echo "[host-sync] skipped (skip_host_sync=true)"'
               '  host_sync_rc=0'
+            'elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then'
+              '  echo "[host-sync][warn] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH}); continuing with existing files"'
+              '  pwd'
+              '  ls -la || true'
+              '  host_sync_rc=0'
             "else"
               "  set +e"
               '  for attempt in $(seq 1 "$host_sync_attempts"); do'
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
-              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-storage-prod.yml
+++ b/.github/workflows/attendance-remote-storage-prod.yml
@@ -118,13 +118,17 @@ jobs:
             'if [[ "${SKIP_HOST_SYNC}" == "true" ]]; then'
               '  echo "[host-sync] skipped (skip_host_sync=true)"'
               '  host_sync_rc=0'
+            'elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then'
+              '  echo "[host-sync][warn] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH}); continuing with existing files"'
+              '  pwd'
+              '  ls -la || true'
+              '  host_sync_rc=0'
             "else"
               "  set +e"
               '  for attempt in $(seq 1 "$host_sync_attempts"); do'
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
-              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/attendance-remote-upload-cleanup-prod.yml
+++ b/.github/workflows/attendance-remote-upload-cleanup-prod.yml
@@ -124,13 +124,17 @@ jobs:
             'if [[ "${SKIP_HOST_SYNC}" == "true" ]]; then'
               '  echo "[host-sync] skipped (skip_host_sync=true)"'
               '  host_sync_rc=0'
+            'elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then'
+              '  echo "[host-sync][warn] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH}); continuing with existing files"'
+              '  pwd'
+              '  ls -la || true'
+              '  host_sync_rc=0'
             "else"
               "  set +e"
               '  for attempt in $(seq 1 "$host_sync_attempts"); do'
               '    git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git fetch origin main && git checkout main && git pull --ff-only origin main'
               '    host_sync_rc=$?'
               '    echo "[host-sync] attempt=$attempt rc=$host_sync_rc"'
-              '    if [[ "$host_sync_rc" != "0" && "$attempt" == "1" ]]; then echo "[host-sync][error] not a git repo at ${DEPLOY_REPO_PATH}" ; pwd ; ls -la || true; fi'
               '    if [[ "$host_sync_rc" == "0" ]]; then break; fi'
               '    if [[ "$attempt" -lt "$host_sync_attempts" ]]; then sleep $((attempt * 2)); fi'
               '  done'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -103,10 +103,16 @@ jobs:
             'cd "$DEPLOY_REPO_PATH"'
             'echo "[deploy] repo_path=${DEPLOY_REPO_PATH}"'
             "# Keep host-mounted config (e.g. docker/nginx.conf) in sync with main."
-            'git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "[deploy][error] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})" >&2; echo "[deploy][error] pwd=$(pwd)" >&2; ls -la >&2 || true; exit 1; }'
-            "git fetch origin main"
-            "git checkout main"
-            "git merge --ff-only origin/main"
+            'if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then'
+            '  echo "[deploy] git sync=enabled"'
+            '  git fetch origin main'
+            '  git checkout main'
+            '  git merge --ff-only origin/main'
+            'else'
+            '  echo "[deploy][warn] DEPLOY_PATH is not a git repo: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH}); continuing with existing files"'
+            '  echo "[deploy][warn] pwd=$(pwd)"'
+            '  ls -la || true'
+            'fi'
             "# Preflight: validate production env/compose/nginx before (re)deploying containers."
             "echo \"=== ATTENDANCE PREFLIGHT START ===\""
             "preflight_rc=0"

--- a/docs/development/remote-deploy-nongit-host-fallback-20260326.md
+++ b/docs/development/remote-deploy-nongit-host-fallback-20260326.md
@@ -1,0 +1,52 @@
+# Remote Deploy Non-Git Host Fallback
+
+Date: 2026-03-26
+
+## Problem
+
+After merging `#548`, mainline deploy run `23593684257` still failed.
+The new diagnostics showed that the path resolution fix worked:
+
+- resolved path: `/home/mainuser/metasheet2`
+- current directory after `cd`: `/home/mainuser/metasheet2`
+
+But the host directory is not a git repository:
+
+- `[deploy][error] DEPLOY_PATH is not a git repo: metasheet2 (resolved: /home/mainuser/metasheet2)`
+
+The directory already contains the deployment files needed for runtime operations:
+
+- `docker-compose.app.yml`
+- `docker/app.env`
+- `docker/nginx.conf`
+- `scripts/ops/*`
+
+So the remaining blocker is not path discovery; it is the hard requirement that the deploy host must also be a git checkout.
+
+## Design
+
+Treat git sync as an optional host-sync optimization instead of a hard runtime prerequisite.
+
+Rules:
+
+1. Missing deploy directory remains a hard error.
+2. If the directory exists and is a git repo, keep the existing fetch/checkout/pull behavior.
+3. If the directory exists but is not a git repo, emit a warning, print `pwd` and `ls -la`, and continue with the existing deployment files.
+
+This keeps the logs explicit while unblocking hosts that are managed as deployment bundles rather than live git checkouts.
+
+## Scope
+
+Updated workflows:
+
+- `.github/workflows/docker-build.yml`
+- `.github/workflows/attendance-remote-preflight-prod.yml`
+- `.github/workflows/attendance-remote-storage-prod.yml`
+- `.github/workflows/attendance-remote-metrics-prod.yml`
+- `.github/workflows/attendance-remote-env-reconcile-prod.yml`
+- `.github/workflows/attendance-remote-upload-cleanup-prod.yml`
+- `.github/workflows/attendance-remote-docker-gc-prod.yml`
+
+## Claude Code Note
+
+Claude Code was used again after the first fix. Its smallest safe unblock recommendation was consistent with this direction: if the host already has deploy artifacts and does not need source checkout semantics, stop treating remote git operations as the only valid sync mechanism.

--- a/docs/development/remote-deploy-nongit-host-fallback-verification-20260326.md
+++ b/docs/development/remote-deploy-nongit-host-fallback-verification-20260326.md
@@ -1,0 +1,83 @@
+# Remote Deploy Non-Git Host Fallback Verification
+
+Date: 2026-03-26
+
+## Trigger
+
+Follow-up failure after `#548`:
+
+- workflow: `Build and Push Docker Images`
+- run: `23593684257`
+- merge commit under test: `848bc728f4a9133b810033ff08fb30e837d10b4f`
+
+New diagnostic evidence from:
+
+- `output/playwright/ga/23593684257/deploy-logs-23593684257-1/deploy.log`
+- `output/playwright/ga/23593684257/deploy-logs-23593684257-1/step-summary.md`
+
+confirmed:
+
+- path resolution now works
+- target directory exists
+- the hard blocker is only the missing `.git` directory
+
+## Verification Performed
+
+### 1. Diff integrity
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- pass
+
+### 2. Fallback/warn behavior present in all target workflows
+
+Command:
+
+```bash
+rg -n "continuing with existing files|git sync=enabled|DEPLOY_PATH is not a git repo" \
+  .github/workflows/docker-build.yml \
+  .github/workflows/attendance-remote-preflight-prod.yml \
+  .github/workflows/attendance-remote-storage-prod.yml \
+  .github/workflows/attendance-remote-metrics-prod.yml \
+  .github/workflows/attendance-remote-env-reconcile-prod.yml \
+  .github/workflows/attendance-remote-upload-cleanup-prod.yml \
+  .github/workflows/attendance-remote-docker-gc-prod.yml
+```
+
+Result:
+
+- all 7 workflows now contain the non-git-host fallback messaging
+
+### 3. Shell syntax
+
+Command:
+
+```bash
+git diff -- .github/workflows/docker-build.yml \
+  .github/workflows/attendance-remote-preflight-prod.yml \
+  .github/workflows/attendance-remote-storage-prod.yml \
+  .github/workflows/attendance-remote-metrics-prod.yml \
+  .github/workflows/attendance-remote-env-reconcile-prod.yml \
+  .github/workflows/attendance-remote-upload-cleanup-prod.yml \
+  .github/workflows/attendance-remote-docker-gc-prod.yml
+```
+
+Result:
+
+- reviewed focused workflow diff
+- no trailing whitespace / patch-shape issues
+
+## What Was Not Verified
+
+- No new mainline rerun was executed yet from this branch.
+- This verification proves the workflow behavior change, not that the remote host has already completed a successful deploy with it.
+
+## Expected Next Step
+
+Merge this fallback fix, re-run `Build and Push Docker Images`, and confirm the deploy job moves past the former git-repo gate into preflight/deploy/migrate/smoke.


### PR DESCRIPTION
## Summary
- allow the SSH deploy workflows to continue when `DEPLOY_PATH` exists but is not a git repo
- keep missing deploy directories as hard errors
- document the second-stage root cause and verification after run `23593684257`

## Why
After merging `#548`, `Build and Push Docker Images` run `23593684257` still failed.
The new logs showed path resolution was fixed, but `/home/mainuser/metasheet2` is not a git repository even though it already contains the runtime deploy files.

This PR changes git sync from a hard prerequisite into a warning-only host-sync optimization.

## Verify
- `git diff --check`
- `rg -n "continuing with existing files|git sync=enabled|DEPLOY_PATH is not a git repo" .github/workflows/docker-build.yml .github/workflows/attendance-remote-preflight-prod.yml .github/workflows/attendance-remote-storage-prod.yml .github/workflows/attendance-remote-metrics-prod.yml .github/workflows/attendance-remote-env-reconcile-prod.yml .github/workflows/attendance-remote-upload-cleanup-prod.yml .github/workflows/attendance-remote-docker-gc-prod.yml`

## Docs
- `docs/development/remote-deploy-nongit-host-fallback-20260326.md`
- `docs/development/remote-deploy-nongit-host-fallback-verification-20260326.md`
