### PR TITLE
fix(ci): add compose command fallback

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -113,6 +113,15 @@ jobs:
             '  echo "[deploy][warn] pwd=$(pwd)"'
             '  ls -la || true'
             'fi'
+            'if docker compose version >/dev/null 2>&1; then'
+            '  COMPOSE_CMD="docker compose"'
+            'elif command -v docker-compose >/dev/null 2>&1; then'
+            '  COMPOSE_CMD="docker-compose"'
+            'else'
+            '  echo "[deploy][error] neither '\''docker compose'\'' nor '\''docker-compose'\'' is available" >&2'
+            '  exit 125'
+            'fi'
+            'echo "[deploy] compose_cmd=${COMPOSE_CMD}"'
             "# Preflight: validate production env/compose/nginx before (re)deploying containers."
             "echo \"=== ATTENDANCE PREFLIGHT START ===\""
             "preflight_rc=0"
@@ -124,14 +133,14 @@ jobs:
             'if [[ "$preflight_rc" != "0" ]]; then exit "$preflight_rc"; fi'
             "echo \"=== DEPLOY START ===\""
             'if [[ "${DRILL_FAIL_STAGE:-none}" == "deploy" ]]; then echo "[deploy][drill] intentional failure at deploy stage"; exit 91; fi'
-            "docker compose -f \"${DEPLOY_COMPOSE_FILE}\" pull backend web"
-            "docker compose -f \"${DEPLOY_COMPOSE_FILE}\" up -d --no-deps --force-recreate backend web"
+            'eval "${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" pull backend web"'
+            'eval "${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" up -d --no-deps --force-recreate backend web"'
             "echo \"=== DEPLOY END ===\""
             "# Ensure DB schema is up to date before smoke checks."
             "echo \"=== MIGRATE START ===\""
             'if [[ "${DRILL_FAIL_STAGE:-none}" == "migrate" ]]; then echo "[deploy][drill] intentional failure at migrate stage"; exit 92; fi'
             "# Important: redirect stdin so docker compose exec can't consume the rest of this bash -s script."
-            "docker compose -f \"${DEPLOY_COMPOSE_FILE}\" exec -T backend node packages/core-backend/dist/src/db/migrate.js < /dev/null"
+            'eval "${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" exec -T backend node packages/core-backend/dist/src/db/migrate.js < /dev/null"'
             "echo \"=== MIGRATE END ===\""
             "# Post-deploy smoke checks"
             "echo \"=== SMOKE START ===\""

--- a/docs/development/remote-deploy-compose-command-fallback-20260326.md
+++ b/docs/development/remote-deploy-compose-command-fallback-20260326.md
@@ -1,0 +1,46 @@
+# Remote Deploy Compose Command Fallback
+
+Date: 2026-03-26
+
+## Problem
+
+After merging `#549`, mainline deploy run `23594097419` moved past:
+
+- path resolution
+- non-git host sync fallback
+- attendance preflight
+
+and then failed at deploy start with:
+
+- `unknown shorthand flag: 'f' in -f`
+- remote exit code `125`
+
+That failure pattern means the host does not support `docker compose ...` subcommands, and likely only exposes legacy `docker-compose`.
+
+## Design
+
+Introduce a compose-command compatibility layer:
+
+1. Prefer `docker compose` when available.
+2. Fall back to `docker-compose` when the plugin form is unavailable.
+3. Keep a hard error only when neither command exists.
+
+Apply this in:
+
+- the main remote deploy workflow, because it directly invokes compose pull/up/exec
+- the attendance ops scripts that execute compose backend commands on the host
+
+This is a narrow operational compatibility fix; it does not change container targets, compose files, migration commands, or smoke behavior.
+
+## Scope
+
+Updated files:
+
+- `.github/workflows/docker-build.yml`
+- `scripts/ops/deploy-attendance-prod.sh`
+- `scripts/ops/attendance-check-storage.sh`
+- `scripts/ops/attendance-clean-uploads.sh`
+
+## Claude Code Note
+
+Claude Code was used earlier in this release-unblock chain for boundary checks. This slice continues the same pattern: move the deploy blocker forward without widening product/runtime scope.

--- a/docs/development/remote-deploy-compose-command-fallback-verification-20260326.md
+++ b/docs/development/remote-deploy-compose-command-fallback-verification-20260326.md
@@ -1,0 +1,79 @@
+# Remote Deploy Compose Command Fallback Verification
+
+Date: 2026-03-26
+
+## Trigger
+
+Follow-up failure after `#549`:
+
+- workflow: `Build and Push Docker Images`
+- run: `23594097419`
+- merge commit under test: `0c70e2d8217bb85e493c5bb1a1b8cd081f51d9c3`
+
+Artifact evidence:
+
+- `output/playwright/ga/23594097419/deploy-logs-23594097419-1/deploy.log`
+- `output/playwright/ga/23594097419/deploy-logs-23594097419-1/step-summary.md`
+
+The logs proved:
+
+- path resolution worked
+- non-git host fallback worked
+- attendance preflight passed
+- deploy then failed specifically on `docker compose -f ...`
+
+## Verification Performed
+
+### 1. Shell syntax
+
+Command:
+
+```bash
+bash -n \
+  scripts/ops/deploy-attendance-prod.sh \
+  scripts/ops/attendance-check-storage.sh \
+  scripts/ops/attendance-clean-uploads.sh
+```
+
+Result:
+
+- pass
+
+### 2. Diff integrity
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- pass
+
+### 3. Fallback markers present
+
+Command:
+
+```bash
+rg -n "COMPOSE_CMD|docker-compose|docker compose version|compose backend exec requested" \
+  .github/workflows/docker-build.yml \
+  scripts/ops/deploy-attendance-prod.sh \
+  scripts/ops/attendance-check-storage.sh \
+  scripts/ops/attendance-clean-uploads.sh
+```
+
+Result:
+
+- workflow deploy path now detects `docker compose` vs `docker-compose`
+- attendance helper scripts now detect the same fallback
+- backend exec paths now fail clearly only when neither compose form exists
+
+## What Was Not Verified
+
+- No new remote rerun has been executed yet from this branch.
+- This verification proves the compatibility logic and script syntax, not that the target host has already completed a full successful deploy.
+
+## Expected Next Step
+
+Merge this slice, rerun `Build and Push Docker Images`, and confirm deploy moves past the compose-command compatibility gate into pull/up/migrate/smoke execution.

--- a/scripts/ops/attendance-check-storage.sh
+++ b/scripts/ops/attendance-check-storage.sh
@@ -22,6 +22,18 @@ function info() {
   echo "[attendance-storage] $*" >&2
 }
 
+function resolve_compose_cmd() {
+  if docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose"
+    return 0
+  fi
+  return 1
+}
+
 function get_env_value() {
   local key="$1"
   if [[ ! -f "$ENV_FILE" ]]; then
@@ -76,6 +88,11 @@ info "Compose:   ${COMPOSE_FILE}"
 info "Env file:  ${ENV_FILE}"
 info "Upload dir (container): ${UPLOAD_DIR}"
 info "Thresholds: max_fs_used_pct=${MAX_FS_USED_PCT} max_upload_dir_gb=${MAX_UPLOAD_DIR_GB} max_oldest_file_days=${MAX_OLDEST_FILE_DAYS}"
+
+COMPOSE_CMD="$(resolve_compose_cmd || true)"
+if [[ -z "$COMPOSE_CMD" ]]; then
+  warn "Neither 'docker compose' nor 'docker-compose' is available"
+fi
 
 volume_line="$(
   grep -E "^[[:space:]]*-[[:space:]]*[^#]*:[[:space:]]*${UPLOAD_DIR}([[:space:]]|$|:)" "$COMPOSE_FILE" \
@@ -171,11 +188,12 @@ function run_cmd() {
     #
     # Also, hide noisy docker compose warnings on stderr (e.g. "version is obsolete") by only
     # emitting stderr when the exec fails.
+    [[ -n "$COMPOSE_CMD" ]] || die "docker compose backend exec requested, but no compose command is available"
     local tmp_err out rc
     tmp_err="$(mktemp 2>/dev/null || echo "/tmp/attendance-storage-err-$$")"
     out=""
     set +e
-    out="$(docker compose -f "$COMPOSE_FILE" exec -T backend sh -lc "$cmd" < /dev/null 2>"$tmp_err")"
+    out="$(eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" exec -T backend sh -lc \"\$cmd\" < /dev/null" 2>"$tmp_err")"
     rc=$?
     set -e
     if [[ "$rc" != "0" ]]; then

--- a/scripts/ops/attendance-clean-uploads.sh
+++ b/scripts/ops/attendance-clean-uploads.sh
@@ -24,6 +24,18 @@ function info() {
   echo "[attendance-clean-uploads] $*" >&2
 }
 
+function resolve_compose_cmd() {
+  if docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose"
+    return 0
+  fi
+  return 1
+}
+
 function is_integer() {
   [[ "${1:-}" =~ ^[0-9]+$ ]]
 }
@@ -87,6 +99,11 @@ info "Compose:   ${COMPOSE_FILE}"
 info "Env file:  ${ENV_FILE}"
 info "Upload dir (container): ${UPLOAD_DIR}"
 info "Params: max_file_age_days=${MAX_FILE_AGE_DAYS} delete=${DELETE} confirm_delete=${CONFIRM_DELETE} max_delete_files=${MAX_DELETE_FILES} max_delete_gb=${MAX_DELETE_GB}"
+
+COMPOSE_CMD="$(resolve_compose_cmd || true)"
+if [[ -z "$COMPOSE_CMD" ]]; then
+  warn "Neither 'docker compose' nor 'docker-compose' is available"
+fi
 
 volume_line="$(
   grep -E "^[[:space:]]*-[[:space:]]*[^#]*:[[:space:]]*${UPLOAD_DIR}([[:space:]]|$|:)" "$COMPOSE_FILE" \
@@ -166,11 +183,12 @@ fi
 function run_cmd() {
   local cmd="$1"
   if [[ "$use_backend_exec" == "true" ]]; then
+    [[ -n "$COMPOSE_CMD" ]] || die "docker compose backend exec requested, but no compose command is available"
     local tmp_err out rc
     tmp_err="$(mktemp 2>/dev/null || echo "/tmp/attendance-clean-uploads-err-$$")"
     out=""
     set +e
-    out="$(docker compose -f "$COMPOSE_FILE" exec -T backend sh -lc "$cmd" < /dev/null 2>"$tmp_err")"
+    out="$(eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" exec -T backend sh -lc \"\$cmd\" < /dev/null" 2>"$tmp_err")"
     rc=$?
     set -e
     if [[ "$rc" != "0" ]]; then

--- a/scripts/ops/deploy-attendance-prod.sh
+++ b/scripts/ops/deploy-attendance-prod.sh
@@ -14,20 +14,35 @@ function run() {
   "$@"
 }
 
+function resolve_compose_cmd() {
+  if docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose"
+    return 0
+  fi
+  return 1
+}
+
+COMPOSE_CMD="$(resolve_compose_cmd || true)"
+[[ -n "$COMPOSE_CMD" ]] || { echo "[deploy-attendance-prod] ERROR: neither 'docker compose' nor 'docker-compose' is available" >&2; exit 125; }
+
 info "Starting production deploy (attendance)"
 info "Compose: ${COMPOSE_FILE}"
 info "Env:     ${ENV_FILE}"
+info "Compose cmd: ${COMPOSE_CMD}"
 
 run "${ROOT_DIR}/scripts/ops/attendance-preflight.sh"
 
-run docker compose -f "${COMPOSE_FILE}" pull backend web
-run docker compose -f "${COMPOSE_FILE}" up -d
+eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" pull backend web"
+eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" up -d"
 
 info "Running DB migrations inside backend container"
-run docker compose -f "${COMPOSE_FILE}" exec -T backend node packages/core-backend/dist/src/db/migrate.js
+eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" exec -T backend node packages/core-backend/dist/src/db/migrate.js"
 
 info "Restarting web (nginx) to ensure it picks up the latest config and resolves backend via Docker DNS"
-run docker compose -f "${COMPOSE_FILE}" restart web
+eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" restart web"
 
 info "Deploy complete"
-


### PR DESCRIPTION
## Summary
- add docker compose vs docker-compose fallback in the remote deploy workflow
- add the same fallback to attendance deploy/storage/upload ops scripts that exec compose on the host
- document the release-unblock slice and focused verification

## Verification
- git diff --check
- bash -n scripts/ops/deploy-attendance-prod.sh scripts/ops/attendance-check-storage.sh scripts/ops/attendance-clean-uploads.sh
- rg -n "COMPOSE_CMD|docker-compose|docker compose version|compose backend exec requested" .github/workflows/docker-build.yml scripts/ops/deploy-attendance-prod.sh scripts/ops/attendance-check-storage.sh scripts/ops/attendance-clean-uploads.sh
- Claude Code decision: SAFE_MINIMAL_UNBLOCK