### PR TITLE
fix(ci): pin deploy image coordinates

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -69,6 +69,8 @@ jobs:
           DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
+          DEPLOY_IMAGE_OWNER: zensgit
+          DEPLOY_IMAGE_TAG: ${{ github.sha }}
           DRILL_FAIL_STAGE: ${{ github.event.inputs.drill_fail_stage || 'none' }}
         run: |
           set -euo pipefail
@@ -78,6 +80,8 @@ jobs:
           ssh_opts="-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
           DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"
+          DEPLOY_IMAGE_OWNER="${DEPLOY_IMAGE_OWNER:-zensgit}"
+          DEPLOY_IMAGE_TAG="${DEPLOY_IMAGE_TAG:-${GITHUB_SHA}}"
           DRILL_FAIL_STAGE="${DRILL_FAIL_STAGE:-none}"
           mkdir -p output/deploy
           deploy_log="output/deploy/deploy.log"
@@ -85,6 +89,8 @@ jobs:
             "set -euo pipefail"
             "DEPLOY_PATH=\"${DEPLOY_PATH:-metasheet2}\""
             "DEPLOY_COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}\""
+            "DEPLOY_IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER:-zensgit}\""
+            "DEPLOY_IMAGE_TAG=\"${DEPLOY_IMAGE_TAG:-${GITHUB_SHA}}\""
             "DRILL_FAIL_STAGE=\"${DRILL_FAIL_STAGE:-none}\""
             'if [[ "${DEPLOY_PATH}" == /* ]]; then'
             '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
@@ -122,6 +128,8 @@ jobs:
             '  exit 125'
             'fi'
             'echo "[deploy] compose_cmd=${COMPOSE_CMD}"'
+            'echo "[deploy] image_owner=${DEPLOY_IMAGE_OWNER}"'
+            'echo "[deploy] image_tag=${DEPLOY_IMAGE_TAG}"'
             "# Preflight: validate production env/compose/nginx before (re)deploying containers."
             "echo \"=== ATTENDANCE PREFLIGHT START ===\""
             "preflight_rc=0"
@@ -133,8 +141,8 @@ jobs:
             'if [[ "$preflight_rc" != "0" ]]; then exit "$preflight_rc"; fi'
             "echo \"=== DEPLOY START ===\""
             'if [[ "${DRILL_FAIL_STAGE:-none}" == "deploy" ]]; then echo "[deploy][drill] intentional failure at deploy stage"; exit 91; fi'
-            'eval "${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" pull backend web"'
-            'eval "${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" up -d --no-deps --force-recreate backend web"'
+            'eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" pull backend web"'
+            'eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" up -d --no-deps --force-recreate backend web"'
             "echo \"=== DEPLOY END ===\""
             "# Ensure DB schema is up to date before smoke checks."
             "echo \"=== MIGRATE START ===\""

--- a/docs/development/remote-deploy-image-owner-tag-override-20260326.md
+++ b/docs/development/remote-deploy-image-owner-tag-override-20260326.md
@@ -1,0 +1,45 @@
+# Remote Deploy Image Owner/Tag Override
+
+Date: 2026-03-26
+
+## Problem
+
+After merging the deploy path, non-git host, and compose-command fixes, mainline run `23594571570`
+advanced into the actual `pull` step and failed with:
+
+- `Head "https://ghcr.io/v2/local/metasheet2-backend/manifests/current": denied`
+- `Head "https://ghcr.io/v2/local/metasheet2-web/manifests/current": denied`
+
+The repository compose file defaults to:
+
+- `IMAGE_OWNER=zensgit`
+- `IMAGE_TAG=latest`
+
+but the remote host environment was overriding those values to `local/current`.
+
+## Design
+
+Pin the deploy workflow to the images that the same workflow just built:
+
+1. Set `DEPLOY_IMAGE_OWNER=zensgit`.
+2. Set `DEPLOY_IMAGE_TAG=${GITHUB_SHA}`.
+3. Export those values into the remote shell.
+4. Prefix the compose `pull` / `up` commands with `IMAGE_OWNER=... IMAGE_TAG=...`.
+
+Also align the manual production helper script with the same explicit owner/tag override mechanism.
+
+## Scope
+
+Updated files:
+
+- `.github/workflows/docker-build.yml`
+- `scripts/ops/deploy-attendance-prod.sh`
+
+## Expected Effect
+
+The remote host should stop inheriting stale `local/current` image coordinates and instead pull:
+
+- `ghcr.io/zensgit/metasheet2-backend:${GITHUB_SHA}`
+- `ghcr.io/zensgit/metasheet2-web:${GITHUB_SHA}`
+
+If deploy still fails after this change, the next blocker will be registry authentication or some later pull/runtime step, not compose variable drift.

--- a/docs/development/remote-deploy-image-owner-tag-override-verification-20260326.md
+++ b/docs/development/remote-deploy-image-owner-tag-override-verification-20260326.md
@@ -1,0 +1,74 @@
+# Remote Deploy Image Owner/Tag Override Verification
+
+Date: 2026-03-26
+
+## Trigger
+
+Follow-up failure after merge commit `2c7b1557e09cd67a4d03e00d2e75326b58391257`:
+
+- workflow: `Build and Push Docker Images`
+- run: `23594571570`
+
+Artifact evidence:
+
+- `output/playwright/ga/23594571570/deploy-logs-23594571570-1/deploy.log`
+- `output/playwright/ga/23594571570/deploy-logs-23594571570-1/step-summary.md`
+
+The logs proved:
+
+- path resolution worked
+- non-git host fallback worked
+- compose command fallback worked (`compose_cmd=docker-compose`)
+- deploy still failed because compose pulled `ghcr.io/local/...:current`
+
+## Verification Performed
+
+### 1. Diff integrity
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- pass
+
+### 2. Shell syntax
+
+Command:
+
+```bash
+bash -n scripts/ops/deploy-attendance-prod.sh
+```
+
+Result:
+
+- pass
+
+### 3. Override markers present
+
+Command:
+
+```bash
+rg -n "DEPLOY_IMAGE_OWNER|DEPLOY_IMAGE_TAG|image_owner=|image_tag=|IMAGE_OWNER=|IMAGE_TAG=" \
+  .github/workflows/docker-build.yml \
+  scripts/ops/deploy-attendance-prod.sh
+```
+
+Result:
+
+- workflow now exports explicit owner/tag into the remote shell
+- deploy log will now show the effective owner/tag
+- compose `pull` / `up` are now pinned to the workflow-built image coordinates
+- manual helper script supports the same explicit override path
+
+## What Was Not Verified
+
+- No new remote rerun has been executed yet from this branch.
+- This verification proves the owner/tag override logic, not that the target host already has valid GHCR credentials for those images.
+
+## Expected Next Step
+
+Merge this slice, rerun `Build and Push Docker Images`, and confirm deploy moves past stale `local/current` image selection.

--- a/scripts/ops/deploy-attendance-prod.sh
+++ b/scripts/ops/deploy-attendance-prod.sh
@@ -28,21 +28,25 @@ function resolve_compose_cmd() {
 
 COMPOSE_CMD="$(resolve_compose_cmd || true)"
 [[ -n "$COMPOSE_CMD" ]] || { echo "[deploy-attendance-prod] ERROR: neither 'docker compose' nor 'docker-compose' is available" >&2; exit 125; }
+DEPLOY_IMAGE_OWNER="${DEPLOY_IMAGE_OWNER:-zensgit}"
+DEPLOY_IMAGE_TAG="${DEPLOY_IMAGE_TAG:-latest}"
 
 info "Starting production deploy (attendance)"
 info "Compose: ${COMPOSE_FILE}"
 info "Env:     ${ENV_FILE}"
 info "Compose cmd: ${COMPOSE_CMD}"
+info "Image owner: ${DEPLOY_IMAGE_OWNER}"
+info "Image tag:   ${DEPLOY_IMAGE_TAG}"
 
 run "${ROOT_DIR}/scripts/ops/attendance-preflight.sh"
 
-eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" pull backend web"
-eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" up -d"
+eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" pull backend web"
+eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" up -d"
 
 info "Running DB migrations inside backend container"
 eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" exec -T backend node packages/core-backend/dist/src/db/migrate.js"
 
 info "Restarting web (nginx) to ensure it picks up the latest config and resolves backend via Docker DNS"
-eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" restart web"
+eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" restart web"
 
 info "Deploy complete"


### PR DESCRIPTION
## Summary
- pin remote deploy to the workflow-built image owner/tag instead of inheriting host IMAGE_OWNER/IMAGE_TAG
- align the manual attendance deploy helper with the same explicit owner/tag override path
- document the release-unblock slice and focused verification

## Verification
- git diff --check
- bash -n scripts/ops/deploy-attendance-prod.sh
- rg -n "DEPLOY_IMAGE_OWNER|DEPLOY_IMAGE_TAG|image_owner=|image_tag=|IMAGE_OWNER=|IMAGE_TAG=" .github/workflows/docker-build.yml scripts/ops/deploy-attendance-prod.sh
- Claude Code decision: SAFE_MINIMAL_UNBLOCK