### PR TITLE
fix(ci): reset stale deploy containers

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -130,6 +130,12 @@ jobs:
             'echo "[deploy] compose_cmd=${COMPOSE_CMD}"'
             'echo "[deploy] image_owner=${DEPLOY_IMAGE_OWNER}"'
             'echo "[deploy] image_tag=${DEPLOY_IMAGE_TAG}"'
+            'for CONTAINER_NAME in metasheet-backend metasheet-web; do'
+            '  if docker ps -a --format "{{.Names}}" | grep -Fxq "${CONTAINER_NAME}"; then'
+            '    echo "[deploy][warn] removing existing container ${CONTAINER_NAME} before recreate"'
+            '    docker rm -f "${CONTAINER_NAME}"'
+            '  fi'
+            'done'
             "# Preflight: validate production env/compose/nginx before (re)deploying containers."
             "echo \"=== ATTENDANCE PREFLIGHT START ===\""
             "preflight_rc=0"

--- a/docs/development/remote-deploy-container-name-conflict-reset-20260326.md
+++ b/docs/development/remote-deploy-container-name-conflict-reset-20260326.md
@@ -1,0 +1,45 @@
+# Remote Deploy Container Name Conflict Reset
+
+Date: 2026-03-26
+
+## Problem
+
+After fixing path resolution, non-git host fallback, compose-command fallback, and image owner/tag drift,
+mainline run `23594905975` advanced into a real image pull and then failed with:
+
+- `Cannot create container for service backend: Conflict`
+- `The container name "/metasheet-backend" is already in use`
+
+This means the remote host still has an existing container with the fixed `container_name`, and legacy
+`docker-compose` is not removing it cleanly before recreate.
+
+## Design
+
+Before running compose `pull` / `up`, explicitly remove any existing fixed-name app containers:
+
+- `metasheet-backend`
+- `metasheet-web`
+
+Do this in:
+
+- the remote deploy workflow
+- the manual production deploy helper
+
+This is a narrow operational reset. It does not change compose topology, container names, images, or migration logic.
+
+## Scope
+
+Updated files:
+
+- `.github/workflows/docker-build.yml`
+- `scripts/ops/deploy-attendance-prod.sh`
+
+## Expected Effect
+
+Deploy should move past fixed-name container conflicts and continue into:
+
+- compose up
+- migration
+- smoke
+
+If deploy still fails after this slice, the next blocker will be later runtime/registry behavior, not stale fixed-name containers.

--- a/docs/development/remote-deploy-container-name-conflict-reset-verification-20260326.md
+++ b/docs/development/remote-deploy-container-name-conflict-reset-verification-20260326.md
@@ -1,0 +1,74 @@
+# Remote Deploy Container Name Conflict Reset Verification
+
+Date: 2026-03-26
+
+## Trigger
+
+Follow-up failure after merge commit `738c6ffb2743d9c2bb22281ec9f4a9fac7892b7f`:
+
+- workflow: `Build and Push Docker Images`
+- run: `23594905975`
+
+Artifact evidence:
+
+- `output/playwright/ga/23594905975/deploy-logs-23594905975-1/deploy.log`
+- `output/playwright/ga/23594905975/deploy-logs-23594905975-1/step-summary.md`
+
+The logs proved:
+
+- path resolution worked
+- non-git host fallback worked
+- compose command fallback worked
+- image owner/tag override worked
+- deploy then failed on fixed container-name reuse (`/metasheet-backend`)
+
+## Verification Performed
+
+### 1. Diff integrity
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- pass
+
+### 2. Shell syntax
+
+Command:
+
+```bash
+bash -n scripts/ops/deploy-attendance-prod.sh
+```
+
+Result:
+
+- pass
+
+### 3. Reset markers present
+
+Command:
+
+```bash
+rg -n "removing existing container|docker rm -f|metasheet-backend|metasheet-web" \
+  .github/workflows/docker-build.yml \
+  scripts/ops/deploy-attendance-prod.sh
+```
+
+Result:
+
+- workflow now removes stale fixed-name app containers before recreate
+- manual helper does the same
+- reset scope is constrained to the two app containers only
+
+## What Was Not Verified
+
+- No new remote rerun has been executed yet from this branch.
+- This verification proves the stale-container reset logic, not that later migrate/smoke stages have already passed.
+
+## Expected Next Step
+
+Merge this slice, rerun `Build and Push Docker Images`, and confirm deploy moves beyond the stale container conflict.

--- a/scripts/ops/deploy-attendance-prod.sh
+++ b/scripts/ops/deploy-attendance-prod.sh
@@ -38,6 +38,13 @@ info "Compose cmd: ${COMPOSE_CMD}"
 info "Image owner: ${DEPLOY_IMAGE_OWNER}"
 info "Image tag:   ${DEPLOY_IMAGE_TAG}"
 
+for container_name in metasheet-backend metasheet-web; do
+  if docker ps -a --format '{{.Names}}' | grep -Fxq "${container_name}"; then
+    info "Removing existing container before recreate: ${container_name}"
+    docker rm -f "${container_name}"
+  fi
+done
+
 run "${ROOT_DIR}/scripts/ops/attendance-preflight.sh"
 
 eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" pull backend web"


### PR DESCRIPTION
## Summary
- remove stale fixed-name app containers before compose recreate on the remote host
- align the manual attendance deploy helper with the same reset step
- document the release-unblock slice and focused verification

## Verification
- git diff --check
- bash -n scripts/ops/deploy-attendance-prod.sh
- rg -n "removing existing container|docker rm -f|metasheet-backend|metasheet-web" .github/workflows/docker-build.yml scripts/ops/deploy-attendance-prod.sh
- Claude Code assessment: scoped/idempotent fix for legacy docker-compose fixed-name conflicts