### PR TITLE
fix(ci): start deploy db deps

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -147,6 +147,7 @@ jobs:
             'if [[ "$preflight_rc" != "0" ]]; then exit "$preflight_rc"; fi'
             "echo \"=== DEPLOY START ===\""
             'if [[ "${DRILL_FAIL_STAGE:-none}" == "deploy" ]]; then echo "[deploy][drill] intentional failure at deploy stage"; exit 91; fi'
+            'eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" up -d postgres redis"'
             'eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" pull backend web"'
             'eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${DEPLOY_COMPOSE_FILE}\" up -d --no-deps --force-recreate backend web"'
             "echo \"=== DEPLOY END ===\""

--- a/docs/development/remote-deploy-start-db-deps-20260326.md
+++ b/docs/development/remote-deploy-start-db-deps-20260326.md
@@ -1,0 +1,43 @@
+# Remote Deploy Start DB Dependencies
+
+Date: 2026-03-26
+
+## Problem
+
+After resolving path, non-git host, compose-command, image-coordinate, and fixed-container blockers,
+mainline run `23597386632` advanced through deploy and then failed during migration with:
+
+- `getaddrinfo ENOTFOUND postgres`
+
+That means the backend container was up, but the compose network did not currently provide a running
+`postgres` service for DNS resolution during the migration step.
+
+## Design
+
+Before pulling/recreating `backend` and `web`, explicitly start the stateful dependencies:
+
+- `postgres`
+- `redis`
+
+Do this in:
+
+- the remote deploy workflow
+- the manual production deploy helper
+
+This is a narrow sequencing fix. It does not alter compose topology, service names, migration commands, or smoke logic.
+
+## Scope
+
+Updated files:
+
+- `.github/workflows/docker-build.yml`
+- `scripts/ops/deploy-attendance-prod.sh`
+
+## Expected Effect
+
+Deploy should move past:
+
+- backend/web recreate
+- migration hostname resolution
+
+If a later failure still occurs, it should now be a real DB readiness/auth/runtime issue rather than missing compose dependencies.

--- a/docs/development/remote-deploy-start-db-deps-verification-20260326.md
+++ b/docs/development/remote-deploy-start-db-deps-verification-20260326.md
@@ -1,0 +1,72 @@
+# Remote Deploy Start DB Dependencies Verification
+
+Date: 2026-03-26
+
+## Trigger
+
+Follow-up failure after merge commit `927dbec52d999c6862f48af71eee1dc72dd22fc1`:
+
+- workflow: `Build and Push Docker Images`
+- run: `23597386632`
+
+Artifact evidence:
+
+- `output/playwright/ga/23597386632/deploy-logs-23597386632-1/deploy.log`
+- `output/playwright/ga/23597386632/deploy-logs-23597386632-1/step-summary.md`
+
+The logs proved:
+
+- deploy stage passed end-to-end
+- migrate then failed because backend could not resolve `postgres`
+- this is consistent with missing compose dependency startup before migration
+
+## Verification Performed
+
+### 1. Diff integrity
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- pass
+
+### 2. Shell syntax
+
+Command:
+
+```bash
+bash -n scripts/ops/deploy-attendance-prod.sh
+```
+
+Result:
+
+- pass
+
+### 3. Dependency startup markers present
+
+Command:
+
+```bash
+rg -n "up -d postgres redis|ENOTFOUND postgres|DEPLOY START" \
+  .github/workflows/docker-build.yml \
+  scripts/ops/deploy-attendance-prod.sh
+```
+
+Result:
+
+- workflow now starts `postgres redis` before backend/web pull+recreate
+- manual helper uses the same ordering
+- migration sequencing now matches the actual compose dependency graph
+
+## What Was Not Verified
+
+- No new remote rerun has been executed yet from this branch.
+- This verification proves dependency startup sequencing, not that later migrate/smoke stages have already passed.
+
+## Expected Next Step
+
+Merge this slice, rerun `Build and Push Docker Images`, and confirm deploy moves beyond `ENOTFOUND postgres`.

--- a/scripts/ops/deploy-attendance-prod.sh
+++ b/scripts/ops/deploy-attendance-prod.sh
@@ -47,6 +47,7 @@ done
 
 run "${ROOT_DIR}/scripts/ops/attendance-preflight.sh"
 
+eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" up -d postgres redis"
 eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" pull backend web"
 eval "IMAGE_OWNER=\"${DEPLOY_IMAGE_OWNER}\" IMAGE_TAG=\"${DEPLOY_IMAGE_TAG}\" ${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" up -d"
 


### PR DESCRIPTION
## Summary
- start postgres and redis before recreating backend/web during remote deploy
- align the manual attendance deploy helper with the same sequencing
- document the release-unblock slice and focused verification

## Verification
- git diff --check
- bash -n scripts/ops/deploy-attendance-prod.sh
- rg -n "up -d postgres redis|ENOTFOUND postgres|DEPLOY START" .github/workflows/docker-build.yml scripts/ops/deploy-attendance-prod.sh
- Claude Code was used earlier in this release-unblock chain; this slice follows the same minimal operational boundary, but the CLI hit its daily limit before returning a new one-line decision