### PR TITLE
fix(ci): reset stale db containers

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -130,7 +130,7 @@ jobs:
             'echo "[deploy] compose_cmd=${COMPOSE_CMD}"'
             'echo "[deploy] image_owner=${DEPLOY_IMAGE_OWNER}"'
             'echo "[deploy] image_tag=${DEPLOY_IMAGE_TAG}"'
-            'for CONTAINER_NAME in metasheet-backend metasheet-web; do'
+            'for CONTAINER_NAME in metasheet-postgres metasheet-redis metasheet-backend metasheet-web; do'
             '  if docker ps -a --format "{{.Names}}" | grep -Fxq "${CONTAINER_NAME}"; then'
             '    echo "[deploy][warn] removing existing container ${CONTAINER_NAME} before recreate"'
             '    docker rm -f "${CONTAINER_NAME}"'

--- a/docs/development/remote-deploy-reset-db-containers-20260327.md
+++ b/docs/development/remote-deploy-reset-db-containers-20260327.md
@@ -1,0 +1,48 @@
+# Remote Deploy Reset DB Containers
+
+Date: 2026-03-27
+
+## Problem
+
+After resolving path, non-git host, compose-command, image-coordinate, backend/web fixed-container, and db-dependency sequencing blockers,
+mainline run `23597784889` still failed at deploy start with:
+
+- `Cannot create container for service redis: Conflict`
+- `Cannot create container for service postgres: Conflict`
+
+The deploy path already reset `metasheet-backend` and `metasheet-web`, but the stateful services still kept
+their fixed-name legacy containers around.
+
+## Design
+
+Extend the existing stale-container reset loop to include:
+
+- `metasheet-postgres`
+- `metasheet-redis`
+
+Keep the same guarded behavior:
+
+1. Check container existence first.
+2. Remove only the known fixed-name containers.
+3. Continue with the existing deploy sequence.
+
+Apply this in:
+
+- the remote deploy workflow
+- the manual production deploy helper
+
+## Scope
+
+Updated files:
+
+- `.github/workflows/docker-build.yml`
+- `scripts/ops/deploy-attendance-prod.sh`
+
+## Expected Effect
+
+Deploy should move beyond:
+
+- `postgres` container-name conflict
+- `redis` container-name conflict
+
+If a later failure still occurs, it should now be a real runtime readiness or migrate/smoke issue rather than stale fixed-name DB containers.

--- a/docs/development/remote-deploy-reset-db-containers-verification-20260327.md
+++ b/docs/development/remote-deploy-reset-db-containers-verification-20260327.md
@@ -1,0 +1,72 @@
+# Remote Deploy Reset DB Containers Verification
+
+Date: 2026-03-27
+
+## Trigger
+
+Follow-up failure after merge commit `5d11160b9ba212dec7bfa0efb982bfcc2679e05f`:
+
+- workflow: `Build and Push Docker Images`
+- run: `23597784889`
+
+Artifact evidence:
+
+- `output/playwright/ga/23597784889/deploy-logs-23597784889-1/deploy.log`
+- `output/playwright/ga/23597784889/deploy-logs-23597784889-1/step-summary.md`
+
+The logs proved:
+
+- backend/web container reset logic worked
+- deploy now explicitly tried to start `postgres` and `redis`
+- the new failure was the same fixed-name conflict pattern, just on `metasheet-postgres` and `metasheet-redis`
+
+## Verification Performed
+
+### 1. Diff integrity
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- pass
+
+### 2. Shell syntax
+
+Command:
+
+```bash
+bash -n scripts/ops/deploy-attendance-prod.sh
+```
+
+Result:
+
+- pass
+
+### 3. Reset markers present
+
+Command:
+
+```bash
+rg -n "metasheet-postgres|metasheet-redis|removing existing container|docker rm -f" \
+  .github/workflows/docker-build.yml \
+  scripts/ops/deploy-attendance-prod.sh
+```
+
+Result:
+
+- workflow reset loop now includes postgres and redis
+- manual helper reset loop now includes postgres and redis
+- reset remains scoped to the four known fixed-name app containers only
+
+## What Was Not Verified
+
+- No new remote rerun has been executed yet from this branch.
+- This verification proves the extended stale-container reset logic, not that later migrate/smoke stages have already passed.
+
+## Expected Next Step
+
+Merge this slice, rerun `Build and Push Docker Images`, and confirm deploy moves beyond stale `postgres` / `redis` container conflicts.

--- a/scripts/ops/deploy-attendance-prod.sh
+++ b/scripts/ops/deploy-attendance-prod.sh
@@ -38,7 +38,7 @@ info "Compose cmd: ${COMPOSE_CMD}"
 info "Image owner: ${DEPLOY_IMAGE_OWNER}"
 info "Image tag:   ${DEPLOY_IMAGE_TAG}"
 
-for container_name in metasheet-backend metasheet-web; do
+for container_name in metasheet-postgres metasheet-redis metasheet-backend metasheet-web; do
   if docker ps -a --format '{{.Names}}' | grep -Fxq "${container_name}"; then
     info "Removing existing container before recreate: ${container_name}"
     docker rm -f "${container_name}"


### PR DESCRIPTION
## Summary
- extend the existing fixed-name container reset loop to postgres and redis
- align the manual attendance deploy helper with the same reset scope
- document the release-unblock slice and focused verification

## Verification
- git diff --check
- bash -n scripts/ops/deploy-attendance-prod.sh
- rg -n "metasheet-postgres|metasheet-redis|removing existing container|docker rm -f" .github/workflows/docker-build.yml scripts/ops/deploy-attendance-prod.sh
- Claude Code decision: SAFE_MINIMAL_UNBLOCK