### PR TITLE
fix(ci): harden storage compose exec

### DIFF
--- a/docs/development/attendance-remote-storage-compose-exec-fix-20260327.md
+++ b/docs/development/attendance-remote-storage-compose-exec-fix-20260327.md
@@ -1,0 +1,45 @@
+# Attendance Remote Storage Compose Exec Fix
+
+## Context
+
+After the deploy chain was fully recovered, a separate production workflow still failed:
+
+- `Attendance Remote Storage Health (Prod)`
+
+The remote storage log shows the actual storage check reaches the fallback path that execs into the backend container, then fails with:
+
+- `unknown shorthand flag: 'f' in -f`
+
+That means the script is no longer failing on storage capacity itself. It is failing while composing the Docker CLI invocation for backend exec.
+
+## Root cause
+
+`scripts/ops/attendance-check-storage.sh` resolves the compose command as either:
+
+- `docker compose`
+- `docker-compose`
+
+but later feeds that string through a single `eval ... "${COMPOSE_CMD} -f ... exec ..."` path.
+
+In the failing production run, that string-based execution degraded into a plain `docker -f ...` parse path, which Docker rejects.
+
+## Goal
+
+Keep the storage check behavior the same, but make backend exec deterministic across both compose variants.
+
+## Design
+
+Replace the string-based `eval` execution path with explicit command branches:
+
+- if `COMPOSE_CMD == "docker compose"`:
+  - run `docker compose -f "$COMPOSE_FILE" exec -T backend sh -lc "$cmd"`
+- if `COMPOSE_CMD == "docker-compose"`:
+  - run `docker-compose -f "$COMPOSE_FILE" exec -T backend sh -lc "$cmd"`
+
+If neither variant matches, fail fast with an explicit unsupported-compose error.
+
+## Why this is the right slice
+
+- It only changes the backend-exec transport in the storage workflow helper.
+- It does not change thresholds, parsing, metrics, or storage policy.
+- It removes the same class of string-wrapper ambiguity that already caused earlier deploy issues.

--- a/docs/development/attendance-remote-storage-compose-exec-fix-verification-20260327.md
+++ b/docs/development/attendance-remote-storage-compose-exec-fix-verification-20260327.md
@@ -1,0 +1,50 @@
+# Attendance Remote Storage Compose Exec Fix Verification
+
+## Source evidence
+
+Failing run:
+
+- `Attendance Remote Storage Health (Prod) #23629425244`
+
+Artifact used:
+
+- `output/playwright/ga/23629425244/attendance-remote-storage-prod-23629425244-1/storage.log`
+
+Observed failure:
+
+- `unknown shorthand flag: 'f' in -f`
+- `[attendance-storage] ERROR: Failed to compute storage metrics via backend exec (rc=125).`
+
+## Commands run
+
+### Passed
+
+```bash
+git diff --check
+```
+
+```bash
+bash -n scripts/ops/attendance-check-storage.sh
+```
+
+```bash
+rg -n "docker compose -f|docker-compose -f|unsupported compose command" \
+  scripts/ops/attendance-check-storage.sh
+```
+
+### Evidence inspected
+
+```bash
+sed -n '1,220p' output/playwright/ga/23629425244/attendance-remote-storage-prod-23629425244-1/storage.log
+```
+
+## Conclusion
+
+The failing path was not storage pressure. It was the backend exec wrapper.
+
+The patch removes the string-`eval` compose execution path and replaces it with explicit command branches for:
+
+- `docker compose`
+- `docker-compose`
+
+This is the minimal fix needed to move the workflow back to real storage-health evaluation.

--- a/scripts/ops/attendance-check-storage.sh
+++ b/scripts/ops/attendance-check-storage.sh
@@ -193,7 +193,15 @@ function run_cmd() {
     tmp_err="$(mktemp 2>/dev/null || echo "/tmp/attendance-storage-err-$$")"
     out=""
     set +e
-    out="$(eval "${COMPOSE_CMD} -f \"${COMPOSE_FILE}\" exec -T backend sh -lc \"\$cmd\" < /dev/null" 2>"$tmp_err")"
+    if [[ "$COMPOSE_CMD" == "docker compose" ]]; then
+      out="$(docker compose -f "$COMPOSE_FILE" exec -T backend sh -lc "$cmd" < /dev/null 2>"$tmp_err")"
+    elif [[ "$COMPOSE_CMD" == "docker-compose" ]]; then
+      out="$(docker-compose -f "$COMPOSE_FILE" exec -T backend sh -lc "$cmd" < /dev/null 2>"$tmp_err")"
+    else
+      echo "[attendance-storage] ERROR: unsupported compose command: ${COMPOSE_CMD}" >&2
+      rm -f "$tmp_err" || true
+      return 125
+    fi
     rc=$?
     set -e
     if [[ "$rc" != "0" ]]; then


### PR DESCRIPTION
## Summary
- replace the eval-based backend exec wrapper in `attendance-check-storage.sh`
- branch explicitly on `docker compose` vs `docker-compose`
- add design / verification MD for the production storage health failure

## Why
`Attendance Remote Storage Health (Prod)` currently fails after falling back to backend exec with:

- `unknown shorthand flag: 'f' in -f`

That is a compose transport bug, not a real storage threshold failure.

## Verify
- `git diff --check`
- `bash -n scripts/ops/attendance-check-storage.sh`
- `rg -n "docker compose -f|docker-compose -f|unsupported compose command" scripts/ops/attendance-check-storage.sh`
- Claude Code boundary review => `SAFE_MINIMAL_UNBLOCK`
