### PR TITLE
fix(ci): prevent attendance summary pipefail failures

### DIFF
--- a/.github/workflows/attendance-remote-metrics-prod.yml
+++ b/.github/workflows/attendance-remote-metrics-prod.yml
@@ -232,8 +232,12 @@ jobs:
               awk '
                 /^=== HOST SYNC START ===$/ { printing=1; next }
                 /^=== HOST SYNC END ===$/ { printing=0 }
-                printing { print }
-              ' "$metrics_log" | head -n 80
+                printing {
+                  print
+                  count++
+                  if (count >= 80) exit
+                }
+              ' "$metrics_log"
             )"
 
             if [[ -z "${host_sync_block}" ]]; then
@@ -274,13 +278,18 @@ jobs:
               awk '
                 /^=== ATTENDANCE METRICS START ===$/ { printing=1; next }
                 /^=== ATTENDANCE METRICS END ===$/ { printing=0; after=1; next }
-                printing { print; next }
+                printing {
+                  print
+                  count++
+                  if (count >= 120) exit
+                  next
+                }
                 after {
                   print
                   count++
                   if (count >= 20) exit
                 }
-              ' "$metrics_log" | head -n 140
+              ' "$metrics_log"
             )"
 
             if [[ -z "${metrics_block}" ]]; then

--- a/.github/workflows/attendance-remote-preflight-prod.yml
+++ b/.github/workflows/attendance-remote-preflight-prod.yml
@@ -184,8 +184,12 @@ jobs:
               awk '
                 /^=== HOST SYNC START ===$/ { printing=1; next }
                 /^=== HOST SYNC END ===$/ { printing=0 }
-                printing { print }
-              ' "$preflight_log" | head -n 80
+                printing {
+                  print
+                  count++
+                  if (count >= 80) exit
+                }
+              ' "$preflight_log"
             )"
 
             if [[ -z "${host_sync_block}" ]]; then
@@ -228,7 +232,12 @@ jobs:
               awk '
                 /^=== ATTENDANCE PREFLIGHT START ===$/ { printing=1; next }
                 /^=== ATTENDANCE PREFLIGHT END ===$/ { printing=0; after=1; next }
-                printing { print; next }
+                printing {
+                  print
+                  count++
+                  if (count >= 120) exit
+                  next
+                }
                 after {
                   # Include a small post-block tail to capture "Preflight OK" even when
                   # stdout/stderr interleaving moves it after the END marker.
@@ -236,7 +245,7 @@ jobs:
                   count++
                   if (count >= 20) exit
                 }
-              ' "$preflight_log" | head -n 140
+              ' "$preflight_log"
             )"
 
             if [[ -z "${preflight_block}" ]]; then

--- a/.github/workflows/attendance-remote-storage-prod.yml
+++ b/.github/workflows/attendance-remote-storage-prod.yml
@@ -269,8 +269,12 @@ jobs:
               awk '
                 /^=== HOST SYNC START ===$/ { printing=1; next }
                 /^=== HOST SYNC END ===$/ { printing=0 }
-                printing { print }
-              ' "$storage_log" | head -n 80
+                printing {
+                  print
+                  count++
+                  if (count >= 80) exit
+                }
+              ' "$storage_log"
             )"
 
             if [[ -z "${host_sync_block}" ]]; then
@@ -311,13 +315,18 @@ jobs:
               awk '
                 /^=== ATTENDANCE STORAGE START ===$/ { printing=1; next }
                 /^=== ATTENDANCE STORAGE END ===$/ { printing=0; after=1; next }
-                printing { print; next }
+                printing {
+                  print
+                  count++
+                  if (count >= 120) exit
+                  next
+                }
                 after {
                   print
                   count++
                   if (count >= 20) exit
                 }
-              ' "$storage_log" | head -n 140
+              ' "$storage_log"
             )"
 
             if [[ -z "${storage_block}" ]]; then

--- a/docs/development/attendance-remote-summary-pipefail-fix-20260327.md
+++ b/docs/development/attendance-remote-summary-pipefail-fix-20260327.md
@@ -1,0 +1,48 @@
+# Attendance Remote Summary Pipefail Fix
+
+## Background
+
+After `#556` fixed the real storage exec bug, three attendance prod remote workflows still showed red in GitHub Actions even when the remote probe itself had already completed successfully:
+
+- `Attendance Remote Preflight (Prod)`
+- `Attendance Remote Metrics (Prod)`
+- `Attendance Remote Storage Health (Prod)`
+
+The failing step was the local `Write step summary ...` step, not the remote SSH check. The failure mode was `exit code 141`, which matches `SIGPIPE` from `head` when used in a pipeline under `set -euo pipefail`.
+
+## Root Cause
+
+Each summary step captured log snippets with command substitutions shaped like:
+
+```sh
+block="$(
+  awk '...' "$log_file" | head -n 80
+)"
+```
+
+Under `set -euo pipefail`, `head` exiting after it consumed enough lines caused the upstream `awk` to terminate on a broken pipe. That non-zero pipeline status then failed the entire summary step even though:
+
+- the remote command had already returned `0`
+- the workflow outputs already contained the correct remote exit code
+- only the GitHub step summary rendering path was broken
+
+## Design
+
+Keep the fix scoped to summary rendering only:
+
+1. Do not touch remote SSH commands, runbook links, or failure semantics of the remote checks.
+2. Remove `head` from the command substitutions that extract summary snippets.
+3. Move the line cap into the single `awk` program itself.
+
+Applied caps:
+
+- host sync blocks: first `80` lines
+- main preflight / metrics / storage blocks:
+  - first `120` lines inside the block
+  - plus up to `20` post-block tail lines for interleaved success text
+
+## Expected Outcome
+
+- successful remote probes no longer fail the workflow on summary rendering
+- failed remote probes still surface as failures through the existing `*_RC` outputs
+- storage summary is proactively protected from the same false-negative pattern

--- a/docs/development/attendance-remote-summary-pipefail-fix-verification-20260327.md
+++ b/docs/development/attendance-remote-summary-pipefail-fix-verification-20260327.md
@@ -1,0 +1,45 @@
+# Attendance Remote Summary Pipefail Fix Verification
+
+## Scope
+
+Changed files:
+
+- `.github/workflows/attendance-remote-preflight-prod.yml`
+- `.github/workflows/attendance-remote-metrics-prod.yml`
+- `.github/workflows/attendance-remote-storage-prod.yml`
+
+Design reference:
+
+- [`attendance-remote-summary-pipefail-fix-20260327.md`](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-remote-followup-20260327/docs/development/attendance-remote-summary-pipefail-fix-20260327.md)
+
+## Evidence
+
+Historical failure evidence that motivated this fix:
+
+- preflight log showed `PREFLIGHT_RC: 0` while the `Write step summary` step failed with `exit code 141`
+- metrics log showed `METRICS_RC: 0` while the `Write step summary` step failed with `exit code 141`
+- the failure came from `awk ... | head -n ...` under `set -euo pipefail`
+
+This patch removes that pipeline shape from all three affected summary steps.
+
+## Commands Run
+
+```sh
+git diff --check
+rg -n "head -n" .github/workflows/attendance-remote-preflight-prod.yml .github/workflows/attendance-remote-metrics-prod.yml .github/workflows/attendance-remote-storage-prod.yml
+claude -p "You are reviewing a minimal GitHub Actions fix in metasheet2..."
+```
+
+## Results
+
+- `git diff --check`: passed
+- `rg -n "head -n" ...`: no matches in the three updated workflows
+- Claude Code: `safe, minimal fix that eliminates the SIGPIPE/exit-141 under set -euo pipefail`
+
+## Validation Conclusion
+
+This is a safe summary-only unblock:
+
+- no remote command behavior changed
+- no threshold or probe contract changed
+- only the local log-snippet extraction path was hardened against `pipefail` false negatives


### PR DESCRIPTION
## Summary
- remove pipefail-sensitive log snippet pipelines from attendance remote summary steps
- keep the fix scoped to local step-summary rendering for preflight, metrics, and storage workflows
- add design and verification notes for the exit-141 false-negative pattern

## Verification
- git diff --check
- rg -n head -n on the three updated workflows returned no matches
- claude -p minimal-unblock review
