### PR TITLE
fix(ci): sync storage script to remote host

### DIFF
--- a/.github/workflows/attendance-remote-storage-prod.yml
+++ b/.github/workflows/attendance-remote-storage-prod.yml
@@ -86,6 +86,7 @@ jobs:
 
           mkdir -p output/storage
           storage_log="output/storage/storage.log"
+          storage_script_b64="$(base64 < scripts/ops/attendance-check-storage.sh | tr -d '\n')"
 
           remote_cmds=(
             "set -euo pipefail"
@@ -96,6 +97,7 @@ jobs:
             "MAX_FS_USED_PCT=\"${MAX_FS_USED_PCT}\""
             "MAX_UPLOAD_DIR_GB=\"${MAX_UPLOAD_DIR_GB}\""
             "MAX_OLDEST_FILE_DAYS=\"${MAX_OLDEST_FILE_DAYS}\""
+            "STORAGE_SCRIPT_B64=\"${storage_script_b64}\""
             'if [[ "${DEPLOY_PATH}" == /* ]]; then'
               '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
             'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
@@ -138,15 +140,19 @@ jobs:
             "echo \"=== HOST SYNC END ===\""
             "echo \"=== ATTENDANCE STORAGE START ===\""
             "storage_rc=0"
+            'storage_script_path="$(mktemp /tmp/attendance-check-storage.XXXXXX.sh)"'
+            'printf "%s" "${STORAGE_SCRIPT_B64}" | base64 -d > "${storage_script_path}"'
+            'chmod +x "${storage_script_path}"'
             'if [[ "$host_sync_rc" != "0" ]]; then'
               '  echo "[attendance-storage][skip] host sync failed: rc=$host_sync_rc"'
               '  storage_rc="$host_sync_rc"'
             "else"
               "  set +e"
-              "  COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE}\" ENV_FILE=\"docker/app.env\" MAX_FS_USED_PCT=\"${MAX_FS_USED_PCT}\" MAX_UPLOAD_DIR_GB=\"${MAX_UPLOAD_DIR_GB}\" MAX_OLDEST_FILE_DAYS=\"${MAX_OLDEST_FILE_DAYS}\" scripts/ops/attendance-check-storage.sh"
+              "  COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE}\" ENV_FILE=\"docker/app.env\" MAX_FS_USED_PCT=\"${MAX_FS_USED_PCT}\" MAX_UPLOAD_DIR_GB=\"${MAX_UPLOAD_DIR_GB}\" MAX_OLDEST_FILE_DAYS=\"${MAX_OLDEST_FILE_DAYS}\" \"${storage_script_path}\""
               '  storage_rc=$?'
               "  set -e"
             "fi"
+            'rm -f "${storage_script_path}" || true'
             "echo \"=== ATTENDANCE STORAGE END ===\""
             'if [[ "$storage_rc" != "0" ]]; then exit "$storage_rc"; fi'
             "if [[ \"${DRILL_FAIL}\" == \"true\" ]]; then echo \"[storage][drill] intentional failure after storage check\"; exit 97; fi"

--- a/docs/development/attendance-remote-storage-script-sync-20260327.md
+++ b/docs/development/attendance-remote-storage-script-sync-20260327.md
@@ -1,0 +1,51 @@
+# Attendance Remote Storage Script Sync
+
+## Background
+
+After `#556` fixed `attendance-check-storage.sh` in the repository and `#557` fixed summary false negatives, a manual validation run of `Attendance Remote Storage Health (Prod)` still failed on `main`.
+
+Observed evidence from run `23653446366`:
+
+- host sync reported `DEPLOY_PATH is not a git repo`
+- the remote job continued with existing files
+- storage then failed with:
+
+```text
+unknown shorthand flag: 'f' in -f
+[attendance-storage] ERROR: Failed to compute storage metrics via backend exec (rc=125).
+```
+
+This means the workflow was still executing an old copy of `scripts/ops/attendance-check-storage.sh` on the remote host.
+
+## Root Cause
+
+The workflow already tolerates non-git deploy roots:
+
+- if `DEPLOY_PATH` is not a git repo, host sync is skipped and the workflow continues
+
+That fallback is safe for checks whose remote script has not changed, but it becomes stale as soon as the repository script is fixed and the remote host keeps an older copy.
+
+## Design
+
+Keep the fix storage-only and workflow-local:
+
+1. Do not change global host-sync policy.
+2. Do not require the deploy host to become a git repo.
+3. Before building `remote_cmds`, base64-encode the current repository copy of `scripts/ops/attendance-check-storage.sh`.
+4. On the remote host, write that payload to a temporary executable file in `/tmp`.
+5. Execute the temporary script instead of `scripts/ops/attendance-check-storage.sh`.
+6. Remove the temporary file after the check finishes.
+
+## Why This Scope
+
+This is the smallest unblock for the only remaining known failing attendance prod check:
+
+- `Preflight`: already green
+- `Metrics`: already green
+- `Storage`: blocked specifically by stale remote script execution
+
+## Expected Outcome
+
+- remote storage checks always run the current repository implementation
+- non-git deploy roots stop masking repository-side storage fixes
+- no behavior change for preflight or metrics workflows

--- a/docs/development/attendance-remote-storage-script-sync-verification-20260327.md
+++ b/docs/development/attendance-remote-storage-script-sync-verification-20260327.md
@@ -1,0 +1,48 @@
+# Attendance Remote Storage Script Sync Verification
+
+## Scope
+
+Changed file:
+
+- `.github/workflows/attendance-remote-storage-prod.yml`
+
+Design reference:
+
+- [`attendance-remote-storage-script-sync-20260327.md`](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-remote-followup-20260327/docs/development/attendance-remote-storage-script-sync-20260327.md)
+
+## Failure Baseline
+
+Validated against manual run `23653446366`:
+
+- `Attendance Remote Preflight (Prod)`: success
+- `Attendance Remote Metrics (Prod)`: success
+- `Attendance Remote Storage Health (Prod)`: failure
+
+Storage failure evidence:
+
+- host sync fell back with `DEPLOY_PATH is not a git repo`
+- storage executed a stale remote script copy
+- log still contained the pre-`#556` compose exec bug:
+
+```text
+unknown shorthand flag: 'f' in -f
+[attendance-storage] ERROR: Failed to compute storage metrics via backend exec (rc=125).
+```
+
+## Commands Run
+
+```sh
+git diff --check
+rg -n "storage_script_b64|storage_script_path|attendance-check-storage" .github/workflows/attendance-remote-storage-prod.yml
+claude -p "Review this minimal unblock..."
+```
+
+## Results
+
+- `git diff --check`: passed
+- workflow now embeds the current repo copy of `attendance-check-storage.sh` and executes it via a remote temp file
+- Claude Code: used to confirm this is a storage-only minimal unblock for stale non-git hosts
+
+## Validation Conclusion
+
+This patch closes the remaining known gap between repository fixes and non-git remote hosts for the storage health workflow without broadening host-sync behavior.


### PR DESCRIPTION
## Summary
- sync the current repository copy of attendance-check-storage.sh to the remote host before executing the storage health check
- keep the fix scoped to attendance remote storage on non-git deploy roots
- add design and verification notes for the stale-script failure mode

## Verification
- git diff --check
- rg -n storage_script_b64 .github/workflows/attendance-remote-storage-prod.yml
- workflow_dispatch baseline run 23653446366 showed the stale remote script failure mode
