### PR TITLE
fix(ci): checkout repo in storage workflow

### DIFF
--- a/.github/workflows/attendance-remote-storage-prod.yml
+++ b/.github/workflows/attendance-remote-storage-prod.yml
@@ -54,6 +54,9 @@ jobs:
       file_count: ${{ steps.remote_storage.outputs.file_count }}
       oldest_file_days: ${{ steps.remote_storage.outputs.oldest_file_days }}
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Remote storage check (with host sync logs)
         id: remote_storage
         continue-on-error: true

--- a/docs/development/attendance-remote-storage-workflow-checkout-20260327.md
+++ b/docs/development/attendance-remote-storage-workflow-checkout-20260327.md
@@ -1,0 +1,27 @@
+# Attendance Remote Storage Workflow Checkout
+
+## Background
+
+`#558` moved the storage health workflow to execute the current repository copy of `scripts/ops/attendance-check-storage.sh` on the remote host. The first post-merge validation run then failed earlier on the GitHub runner:
+
+```text
+scripts/ops/attendance-check-storage.sh: No such file or directory
+```
+
+## Root Cause
+
+`attendance-remote-storage-prod.yml` did not check out the repository before trying to read:
+
+```sh
+base64 < scripts/ops/attendance-check-storage.sh
+```
+
+That path only exists on the runner after `actions/checkout`.
+
+## Design
+
+Keep the fix minimal and storage-only:
+
+1. Add `actions/checkout@v4` to the `storage` job.
+2. Leave remote execution, summary logic, and host-sync behavior unchanged.
+3. Keep the workflow self-sufficient on the runner before it packages the latest storage check script.

--- a/docs/development/attendance-remote-storage-workflow-checkout-verification-20260327.md
+++ b/docs/development/attendance-remote-storage-workflow-checkout-verification-20260327.md
@@ -1,0 +1,34 @@
+# Attendance Remote Storage Workflow Checkout Verification
+
+## Scope
+
+Changed files:
+
+- `.github/workflows/attendance-remote-storage-prod.yml`
+- `docs/development/attendance-remote-storage-workflow-checkout-20260327.md`
+
+## Failure Baseline
+
+Manual workflow_dispatch run `23653849775` failed before SSH execution reached the remote host logic:
+
+```text
+/home/runner/work/_temp/...sh: line 18: scripts/ops/attendance-check-storage.sh: No such file or directory
+```
+
+This proved the previous storage-script-sync change needed a repository checkout on the GitHub runner.
+
+## Commands Run
+
+```sh
+git diff --check
+rg -n "Check out repository|actions/checkout@v4|storage_script_b64" .github/workflows/attendance-remote-storage-prod.yml
+```
+
+## Results
+
+- `git diff --check`: passed
+- workflow now checks out the repository before reading `scripts/ops/attendance-check-storage.sh`
+
+## Validation Conclusion
+
+This is the minimal runner-side fix needed to make the storage-script-sync path executable.


### PR DESCRIPTION
## Summary
- add actions/checkout to attendance remote storage workflow
- unblock the storage script sync path introduced in #558
- add design and verification notes for the runner-side missing-script failure

## Verification
- git diff --check
- rg -n Check out repository .github/workflows/attendance-remote-storage-prod.yml
- workflow_dispatch run 23653849775 showed the missing local script baseline
