### PR TITLE
fix(ci): escape remote storage script path

### DIFF
--- a/.github/workflows/attendance-remote-storage-prod.yml
+++ b/.github/workflows/attendance-remote-storage-prod.yml
@@ -151,7 +151,7 @@ jobs:
               '  storage_rc="$host_sync_rc"'
             "else"
               "  set +e"
-              "  COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE}\" ENV_FILE=\"docker/app.env\" MAX_FS_USED_PCT=\"${MAX_FS_USED_PCT}\" MAX_UPLOAD_DIR_GB=\"${MAX_UPLOAD_DIR_GB}\" MAX_OLDEST_FILE_DAYS=\"${MAX_OLDEST_FILE_DAYS}\" \"${storage_script_path}\""
+              "  COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE}\" ENV_FILE=\"docker/app.env\" MAX_FS_USED_PCT=\"${MAX_FS_USED_PCT}\" MAX_UPLOAD_DIR_GB=\"${MAX_UPLOAD_DIR_GB}\" MAX_OLDEST_FILE_DAYS=\"${MAX_OLDEST_FILE_DAYS}\" \"\${storage_script_path}\""
               '  storage_rc=$?'
               "  set -e"
             "fi"

--- a/docs/development/attendance-remote-storage-script-path-escape-20260328.md
+++ b/docs/development/attendance-remote-storage-script-path-escape-20260328.md
@@ -1,0 +1,29 @@
+# Attendance Remote Storage Script Path Escape
+
+## Background
+
+After `#559` added repository checkout, the next validation run of `Attendance Remote Storage Health (Prod)` still failed before the remote storage script executed.
+
+Observed runner-side error from run `23672540066`:
+
+```text
+line 88: storage_script_path: unbound variable
+```
+
+## Root Cause
+
+The workflow builds `remote_cmds` under `set -u`. One command entry used:
+
+```sh
+" ... \"${storage_script_path}\""
+```
+
+Because that array entry is double-quoted on the runner, `${storage_script_path}` was expanded locally while the variable only exists later on the remote host.
+
+## Design
+
+Keep the fix to a single interpolation boundary:
+
+1. Preserve all current storage-script-sync behavior.
+2. Escape the reference as `\"\${storage_script_path}\"` so it survives local interpolation.
+3. Let the variable expand only on the remote host, after the temp file has been created.

--- a/docs/development/attendance-remote-storage-script-path-escape-verification-20260328.md
+++ b/docs/development/attendance-remote-storage-script-path-escape-verification-20260328.md
@@ -1,0 +1,34 @@
+# Attendance Remote Storage Script Path Escape Verification
+
+## Scope
+
+Changed files:
+
+- `.github/workflows/attendance-remote-storage-prod.yml`
+- `docs/development/attendance-remote-storage-script-path-escape-20260328.md`
+
+## Failure Baseline
+
+Manual run `23672540066` failed on the GitHub runner with:
+
+```text
+line 88: storage_script_path: unbound variable
+```
+
+This happened before the remote command block could finish and therefore `storage_rc` never reached `$GITHUB_OUTPUT`.
+
+## Commands Run
+
+```sh
+git diff --check
+rg -n '\\$\\{storage_script_path\\}|storage_script_path' .github/workflows/attendance-remote-storage-prod.yml
+```
+
+## Results
+
+- `git diff --check`: passed
+- the execution line now preserves `${storage_script_path}` for remote expansion instead of local runner expansion
+
+## Validation Conclusion
+
+This is the minimal interpolation fix required to make the remote temp-script execution path actually runnable under `set -u`.


### PR DESCRIPTION
## Summary
- escape the remote storage temp-script path reference so it expands on the remote host instead of the runner
- keep the fix to a single interpolation boundary in attendance remote storage workflow
- add design and verification notes for the unbound-variable failure mode

## Verification
- git diff --check
- rg -n storage_script_path .github/workflows/attendance-remote-storage-prod.yml
- claude -p minimal review
