### PR TITLE
fix(ci): restore missing directory migrations

### DIFF
--- a/docs/development/remote-deploy-missing-directory-migrations-20260328.md
+++ b/docs/development/remote-deploy-missing-directory-migrations-20260328.md
@@ -1,0 +1,34 @@
+# Remote Deploy Missing Directory Migrations
+
+## Problem
+
+`Build and Push Docker Images` on `main` now reaches the remote `migrate` stage, but the deploy fails with:
+
+`previously executed migration zzzz20260323120000_create_user_external_identities is missing`
+
+This is not a remote shell problem. The production database already recorded a directory migration chain that is absent from the current tracked repository state, so Kysely aborts before running any new migrations.
+
+## Design
+
+Use the smallest deploy-unblock that preserves migration history semantics:
+
+1. Restore the already-executed directory migration files to tracked source control under their original names.
+2. Restore the full contiguous executed chain that follows the first missing migration, not just the first file, so Kysely does not fail again on the next missing entry.
+3. Do not pull in the larger untracked directory runtime feature surface. This PR only restores migration source files required for migration history parity.
+
+## Scope
+
+Restore these tracked migrations:
+
+- `zzzz20260323120000_create_user_external_identities.ts`
+- `zzzz20260323133000_harden_user_external_identities.ts`
+- `zzzz20260324143000_create_user_external_auth_grants.ts`
+- `zzzz20260324150000_create_directory_sync_tables.ts`
+- `zzzz20260325100000_add_mobile_to_users_table.ts`
+- `zzzz20260327110000_create_directory_template_center_and_alerts.ts`
+
+## Why This Shape
+
+- Restoring same-name real schema migrations matches the remote database history and satisfies Kysely's missing-migration guard.
+- The files are idempotent and safe on fresh databases because they already use `ifNotExists`, helper guards, or additive DDL.
+- A noop placeholder would unblock history checks but would silently break fresh-database installs and later migrations that depend on these tables.

--- a/docs/development/remote-deploy-missing-directory-migrations-verification-20260328.md
+++ b/docs/development/remote-deploy-missing-directory-migrations-verification-20260328.md
@@ -1,0 +1,23 @@
+# Remote Deploy Missing Directory Migrations Verification
+
+## Verification
+
+Validated in clean worktree `codex/deploy-missing-directory-migrations-20260328`.
+
+Commands:
+
+```bash
+git diff --check
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-context.api.test.ts tests/integration/comments.api.test.ts --reporter=dot
+```
+
+## Expected Release Impact
+
+- Kysely migration discovery on deploy images will again include the directory migration names already recorded in the remote database.
+- Remote deploy should move past `failed to migrate` for `zzzz20260323120000_create_user_external_identities is missing`.
+
+## Out of Scope
+
+- This slice does not merge the larger untracked directory runtime feature set.
+- This slice does not claim the full directory feature is release-ready; it only restores migration history parity needed for deploy safety.

--- a/packages/core-backend/src/db/migrations/zzzz20260323120000_create_user_external_identities.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260323120000_create_user_external_identities.ts
@@ -1,0 +1,49 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const exists = await checkTableExists(db, 'user_external_identities')
+  if (!exists) {
+    await db.schema
+      .createTable('user_external_identities')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('provider', 'text', (col) => col.notNull())
+      .addColumn('external_key', 'text', (col) => col.notNull())
+      .addColumn('provider_user_id', 'text')
+      .addColumn('provider_union_id', 'text')
+      .addColumn('provider_open_id', 'text')
+      .addColumn('corp_id', 'text')
+      .addColumn('local_user_id', 'text', (col) => col.notNull())
+      .addColumn('profile', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('bound_by', 'text')
+      .addColumn('last_login_at', 'timestamptz')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_user_external_identities_provider_key
+    ON user_external_identities(provider, external_key)
+  `.execute(db)
+  await createIndexIfNotExists(
+    db,
+    'idx_user_external_identities_local_user',
+    'user_external_identities',
+    ['local_user_id', 'provider'],
+  )
+  await createIndexIfNotExists(
+    db,
+    'idx_user_external_identities_corp_provider',
+    'user_external_identities',
+    ['corp_id', 'provider'],
+  )
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('user_external_identities').ifExists().cascade().execute()
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260323133000_harden_user_external_identities.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260323133000_harden_user_external_identities.ts
@@ -1,0 +1,53 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { addForeignKeyIfNotExists, checkTableExists, createIndexIfNotExists, dropIndexIfExists } from './_patterns'
+
+const UNIQUE_INDEX = 'uq_user_external_identities_local_user_provider'
+const FK_NAME = 'fk_user_external_identities_local_user'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'user_external_identities')
+  if (!exists) return
+
+  await sql`
+    WITH ranked AS (
+      SELECT
+        id,
+        ROW_NUMBER() OVER (
+          PARTITION BY provider, local_user_id
+          ORDER BY updated_at DESC, created_at DESC, id DESC
+        ) AS rn
+      FROM user_external_identities
+    )
+    DELETE FROM user_external_identities target
+    USING ranked
+    WHERE target.id = ranked.id
+      AND ranked.rn > 1
+  `.execute(db)
+
+  await addForeignKeyIfNotExists(
+    db,
+    FK_NAME,
+    'user_external_identities',
+    'local_user_id',
+    'users',
+    'id',
+    {
+      onDelete: 'cascade',
+      onUpdate: 'cascade',
+    },
+  )
+
+  await createIndexIfNotExists(
+    db,
+    UNIQUE_INDEX,
+    'user_external_identities',
+    ['local_user_id', 'provider'],
+    { unique: true },
+  )
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await dropIndexIfExists(db, UNIQUE_INDEX)
+  await sql`ALTER TABLE user_external_identities DROP CONSTRAINT IF EXISTS ${sql.id(FK_NAME)}`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260324143000_create_user_external_auth_grants.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260324143000_create_user_external_auth_grants.ts
@@ -1,0 +1,52 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const exists = await checkTableExists(db, 'user_external_auth_grants')
+  if (!exists) {
+    await db.schema
+      .createTable('user_external_auth_grants')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('provider', 'text', (col) => col.notNull())
+      .addColumn('local_user_id', 'text', (col) => col.notNull())
+      .addColumn('enabled', 'boolean', (col) => col.notNull().defaultTo(true))
+      .addColumn('granted_by', 'text')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_user_external_auth_grants_provider_user
+    ON user_external_auth_grants(provider, local_user_id)
+  `.execute(db)
+  await createIndexIfNotExists(
+    db,
+    'idx_user_external_auth_grants_local_user',
+    'user_external_auth_grants',
+    ['local_user_id'],
+  )
+
+  await sql`
+    INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+    SELECT
+      'dingtalk',
+      local_user_id,
+      TRUE,
+      MAX(bound_by),
+      NOW(),
+      NOW()
+    FROM user_external_identities
+    WHERE provider = 'dingtalk'
+    GROUP BY local_user_id
+    ON CONFLICT (provider, local_user_id) DO NOTHING
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('user_external_auth_grants').ifExists().cascade().execute()
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260324150000_create_directory_sync_tables.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260324150000_create_directory_sync_tables.ts
@@ -1,0 +1,183 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const integrationsExists = await checkTableExists(db, 'directory_integrations')
+  if (!integrationsExists) {
+    await db.schema
+      .createTable('directory_integrations')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', (col) => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('provider', 'text', (col) => col.notNull().defaultTo('dingtalk'))
+      .addColumn('name', 'text', (col) => col.notNull())
+      .addColumn('status', 'text', (col) => col.notNull().defaultTo('active'))
+      .addColumn('corp_id', 'text', (col) => col.notNull())
+      .addColumn('config', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('sync_enabled', 'boolean', (col) => col.notNull().defaultTo(false))
+      .addColumn('schedule_cron', 'text')
+      .addColumn('default_deprovision_policy', 'text', (col) => col.notNull().defaultTo('mark_inactive'))
+      .addColumn('last_sync_at', 'timestamptz')
+      .addColumn('last_success_at', 'timestamptz')
+      .addColumn('last_cursor', 'jsonb')
+      .addColumn('last_error', 'text')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await createIndexIfNotExists(db, 'idx_directory_integrations_org', 'directory_integrations', 'org_id')
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_directory_integrations_org_provider_name
+    ON directory_integrations(org_id, provider, name)
+  `.execute(db)
+
+  const departmentsExists = await checkTableExists(db, 'directory_departments')
+  if (!departmentsExists) {
+    await db.schema
+      .createTable('directory_departments')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('integration_id', 'uuid', (col) => col.notNull().references('directory_integrations.id').onDelete('cascade'))
+      .addColumn('provider', 'text', (col) => col.notNull().defaultTo('dingtalk'))
+      .addColumn('external_department_id', 'text', (col) => col.notNull())
+      .addColumn('external_parent_department_id', 'text')
+      .addColumn('name', 'text', (col) => col.notNull())
+      .addColumn('full_path', 'text')
+      .addColumn('order_index', 'integer', (col) => col.notNull().defaultTo(0))
+      .addColumn('is_active', 'boolean', (col) => col.notNull().defaultTo(true))
+      .addColumn('raw', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('last_seen_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_directory_departments_integration_external
+    ON directory_departments(integration_id, external_department_id)
+  `.execute(db)
+  await createIndexIfNotExists(db, 'idx_directory_departments_integration', 'directory_departments', 'integration_id')
+
+  const accountsExists = await checkTableExists(db, 'directory_accounts')
+  if (!accountsExists) {
+    await db.schema
+      .createTable('directory_accounts')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('integration_id', 'uuid', (col) => col.notNull().references('directory_integrations.id').onDelete('cascade'))
+      .addColumn('provider', 'text', (col) => col.notNull().defaultTo('dingtalk'))
+      .addColumn('corp_id', 'text')
+      .addColumn('external_user_id', 'text', (col) => col.notNull())
+      .addColumn('union_id', 'text')
+      .addColumn('open_id', 'text')
+      .addColumn('external_key', 'text', (col) => col.notNull())
+      .addColumn('name', 'text', (col) => col.notNull())
+      .addColumn('nick', 'text')
+      .addColumn('email', 'text')
+      .addColumn('mobile', 'text')
+      .addColumn('job_number', 'text')
+      .addColumn('title', 'text')
+      .addColumn('avatar_url', 'text')
+      .addColumn('is_active', 'boolean', (col) => col.notNull().defaultTo(true))
+      .addColumn('deprovision_policy_override', 'text')
+      .addColumn('raw', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('last_seen_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_directory_accounts_integration_external_user
+    ON directory_accounts(integration_id, external_user_id)
+  `.execute(db)
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_directory_accounts_provider_external_key
+    ON directory_accounts(provider, external_key)
+  `.execute(db)
+  await createIndexIfNotExists(db, 'idx_directory_accounts_integration', 'directory_accounts', 'integration_id')
+  await createIndexIfNotExists(db, 'idx_directory_accounts_email', 'directory_accounts', 'email')
+  await createIndexIfNotExists(db, 'idx_directory_accounts_mobile', 'directory_accounts', 'mobile')
+
+  const accountDepartmentsExists = await checkTableExists(db, 'directory_account_departments')
+  if (!accountDepartmentsExists) {
+    await db.schema
+      .createTable('directory_account_departments')
+      .ifNotExists()
+      .addColumn('directory_account_id', 'uuid', (col) => col.notNull().references('directory_accounts.id').onDelete('cascade'))
+      .addColumn('directory_department_id', 'uuid', (col) => col.notNull().references('directory_departments.id').onDelete('cascade'))
+      .addColumn('is_primary', 'boolean', (col) => col.notNull().defaultTo(false))
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await sql`
+    DO $$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'directory_account_departments_pkey'
+          AND conrelid = 'directory_account_departments'::regclass
+      ) THEN
+        ALTER TABLE directory_account_departments
+        ADD PRIMARY KEY (directory_account_id, directory_department_id);
+      END IF;
+    END $$;
+  `.execute(db)
+
+  const linksExists = await checkTableExists(db, 'directory_account_links')
+  if (!linksExists) {
+    await db.schema
+      .createTable('directory_account_links')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('directory_account_id', 'uuid', (col) => col.notNull().references('directory_accounts.id').onDelete('cascade'))
+      .addColumn('local_user_id', 'text', (col) => col.references('users.id').onDelete('set null'))
+      .addColumn('link_status', 'text', (col) => col.notNull().defaultTo('pending'))
+      .addColumn('match_strategy', 'text')
+      .addColumn('reviewed_by', 'text')
+      .addColumn('review_note', 'text')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_directory_account_links_account
+    ON directory_account_links(directory_account_id)
+  `.execute(db)
+  await createIndexIfNotExists(db, 'idx_directory_account_links_user', 'directory_account_links', 'local_user_id')
+
+  const runsExists = await checkTableExists(db, 'directory_sync_runs')
+  if (!runsExists) {
+    await db.schema
+      .createTable('directory_sync_runs')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('integration_id', 'uuid', (col) => col.notNull().references('directory_integrations.id').onDelete('cascade'))
+      .addColumn('status', 'text', (col) => col.notNull().defaultTo('running'))
+      .addColumn('started_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('finished_at', 'timestamptz')
+      .addColumn('cursor_before', 'jsonb')
+      .addColumn('cursor_after', 'jsonb')
+      .addColumn('stats', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('error_message', 'text')
+      .addColumn('meta', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('triggered_by', 'text')
+      .addColumn('trigger_source', 'text', (col) => col.notNull().defaultTo('manual'))
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await createIndexIfNotExists(db, 'idx_directory_sync_runs_integration', 'directory_sync_runs', 'integration_id')
+  await createIndexIfNotExists(db, 'idx_directory_sync_runs_status', 'directory_sync_runs', 'status')
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('directory_sync_runs').ifExists().cascade().execute()
+  await db.schema.dropTable('directory_account_links').ifExists().cascade().execute()
+  await db.schema.dropTable('directory_account_departments').ifExists().cascade().execute()
+  await db.schema.dropTable('directory_accounts').ifExists().cascade().execute()
+  await db.schema.dropTable('directory_departments').ifExists().cascade().execute()
+  await db.schema.dropTable('directory_integrations').ifExists().cascade().execute()
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260325100000_add_mobile_to_users_table.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260325100000_add_mobile_to_users_table.ts
@@ -1,0 +1,10 @@
+import type { Kysely } from 'kysely'
+import { addColumnIfNotExists, dropColumnIfExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await addColumnIfNotExists(db, 'users', 'mobile', 'text')
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await dropColumnIfExists(db, 'users', 'mobile')
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260327110000_create_directory_template_center_and_alerts.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260327110000_create_directory_template_center_and_alerts.ts
@@ -1,0 +1,74 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const templateCentersExists = await checkTableExists(db, 'directory_template_centers')
+  if (!templateCentersExists) {
+    await db.schema
+      .createTable('directory_template_centers')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('integration_id', 'uuid', (col) => col.notNull().references('directory_integrations.id').onDelete('cascade'))
+      .addColumn('team_templates', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('import_history', 'jsonb', (col) => col.notNull().defaultTo(sql`'[]'::jsonb`))
+      .addColumn('import_presets', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('created_by', 'text')
+      .addColumn('updated_by', 'text')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_directory_template_centers_integration
+    ON directory_template_centers(integration_id)
+  `.execute(db)
+
+  const templateCenterVersionsExists = await checkTableExists(db, 'directory_template_center_versions')
+  if (!templateCenterVersionsExists) {
+    await db.schema
+      .createTable('directory_template_center_versions')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('center_id', 'uuid', (col) => col.notNull().references('directory_template_centers.id').onDelete('cascade'))
+      .addColumn('integration_id', 'uuid', (col) => col.notNull().references('directory_integrations.id').onDelete('cascade'))
+      .addColumn('snapshot', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('change_reason', 'text', (col) => col.notNull().defaultTo('manual_update'))
+      .addColumn('created_by', 'text')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await createIndexIfNotExists(db, 'idx_directory_template_center_versions_center', 'directory_template_center_versions', 'center_id')
+  await createIndexIfNotExists(db, 'idx_directory_template_center_versions_integration', 'directory_template_center_versions', 'integration_id')
+
+  const syncAlertsExists = await checkTableExists(db, 'directory_sync_alerts')
+  if (!syncAlertsExists) {
+    await db.schema
+      .createTable('directory_sync_alerts')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('integration_id', 'uuid', (col) => col.notNull().references('directory_integrations.id').onDelete('cascade'))
+      .addColumn('run_id', 'uuid', (col) => col.references('directory_sync_runs.id').onDelete('set null'))
+      .addColumn('level', 'text', (col) => col.notNull().defaultTo('error'))
+      .addColumn('code', 'text', (col) => col.notNull())
+      .addColumn('message', 'text', (col) => col.notNull())
+      .addColumn('details', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('sent_to_webhook', 'boolean', (col) => col.notNull().defaultTo(false))
+      .addColumn('acknowledged_at', 'timestamptz')
+      .addColumn('acknowledged_by', 'text')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+  await createIndexIfNotExists(db, 'idx_directory_sync_alerts_integration', 'directory_sync_alerts', 'integration_id')
+  await createIndexIfNotExists(db, 'idx_directory_sync_alerts_run', 'directory_sync_alerts', 'run_id')
+  await createIndexIfNotExists(db, 'idx_directory_sync_alerts_acknowledged', 'directory_sync_alerts', 'acknowledged_at')
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('directory_sync_alerts').ifExists().cascade().execute()
+  await db.schema.dropTable('directory_template_center_versions').ifExists().cascade().execute()
+  await db.schema.dropTable('directory_template_centers').ifExists().cascade().execute()
+}


### PR DESCRIPTION
## Summary
- restore the tracked directory migration chain already executed on the remote database
- unblock deploy images that currently fail Kysely missing-migration history checks
- add design and verification notes for this release-unblock slice

## Verification
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/comments.api.test.ts tests/integration/multitable-context.api.test.ts --reporter=dot`

## Context
Main deploy currently fails at migrate with:
`previously executed migration zzzz20260323120000_create_user_external_identities is missing`
