### PR TITLE
docs(release): record attendance onprem v2.7.0 package release

### DIFF
--- a/docs/development/attendance-onprem-v270-package-release-20260328.md
+++ b/docs/development/attendance-onprem-v270-package-release-20260328.md
@@ -1,0 +1,67 @@
+# Attendance On-Prem v2.7.0 Package Release
+
+Date: 2026-03-28
+
+## Goal
+
+Publish deployable attendance on-prem package assets for the formal source release `v2.7.0`.
+
+Before this release action:
+
+- formal source release `v2.7.0` existed
+- `v2.7.0` had no attached assets
+- the latest attendance on-prem package release was still `attendance-onprem-run21-20260322`
+
+That meant source release and installable on-prem package were out of sync.
+
+## Decision
+
+Use the verified `v2.7.0` source tag as the packaging base, but do not mutate repository source files just to fix packaging version naming.
+
+Instead:
+
+1. build from the clean `v2.7.0` tree
+2. override `PACKAGE_VERSION=2.7.0` during packaging
+3. produce canonical traceable package assets with suffix `20260328-current`
+4. additionally publish no-suffix alias assets for easier operator download
+5. upload the assets directly to the existing `v2.7.0` GitHub Release
+
+## Published assets
+
+### Canonical traceable assets
+
+- `metasheet-attendance-onprem-v2.7.0-20260328-current.tgz`
+- `metasheet-attendance-onprem-v2.7.0-20260328-current.tgz.sha256`
+- `metasheet-attendance-onprem-v2.7.0-20260328-current.zip`
+- `metasheet-attendance-onprem-v2.7.0-20260328-current.zip.sha256`
+- `metasheet-attendance-onprem-v2.7.0-20260328-current.json`
+
+### Operator-friendly alias assets
+
+- `metasheet-attendance-onprem-v2.7.0.tgz`
+- `metasheet-attendance-onprem-v2.7.0.tgz.sha256`
+- `metasheet-attendance-onprem-v2.7.0.zip`
+- `metasheet-attendance-onprem-v2.7.0.zip.sha256`
+- `metasheet-attendance-onprem-v2.7.0.json`
+- `SHA256SUMS-v2.7.0`
+
+## Release target
+
+- release: `v2.7.0`
+- release URL: <https://github.com/zensgit/metasheet2/releases/tag/v2.7.0>
+- source commit: `0977b4b19e35d474df4057ea82809d07e6f359c0`
+
+## Notes
+
+- The build script currently derives package version from `package.json` by default.
+- Because `package.json` still reads `2.5.0` at tag `v2.7.0`, packaging needed an explicit environment override.
+- This release action fixes deployable assets immediately without widening scope into a late source-version synchronization change.
+
+## Follow-up recommendation
+
+Future on-prem releases should make one of these two paths explicit:
+
+1. synchronize `package.json` before packaging
+2. or formalize `PACKAGE_VERSION` override as the packaging source of truth for on-prem release automation
+
+The current manual override worked, but it should not stay implicit.

--- a/docs/development/attendance-onprem-v270-package-release-verification-20260328.md
+++ b/docs/development/attendance-onprem-v270-package-release-verification-20260328.md
@@ -1,0 +1,122 @@
+# Attendance On-Prem v2.7.0 Package Release Verification
+
+Date: 2026-03-28
+
+## Goal
+
+Verify that `v2.7.0` now has deployable attendance on-prem package assets and that those assets are internally consistent.
+
+## Packaging base
+
+Clean worktree:
+
+- `/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v270-release-20260328`
+
+Base ref:
+
+- `v2.7.0`
+- commit `0977b4b19e35d474df4057ea82809d07e6f359c0`
+
+## Commands run
+
+### Install workspace dependencies in the clean worktree
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+### Build canonical on-prem package with explicit version override
+
+```bash
+PACKAGE_VERSION=2.7.0 \
+PACKAGE_TAG=20260328-current \
+INSTALL_DEPS=0 \
+BUILD_WEB=1 \
+BUILD_BACKEND=1 \
+scripts/ops/attendance-onprem-package-build.sh
+```
+
+### Verify canonical package
+
+```bash
+scripts/ops/attendance-onprem-package-verify.sh \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.tgz
+
+scripts/ops/attendance-onprem-package-verify.sh \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.zip
+```
+
+### Create and verify operator-friendly aliases
+
+Actions performed:
+
+- copy canonical `.tgz/.zip` to no-suffix `v2.7.0` names
+- generate individual `.sha256`
+- generate `SHA256SUMS-v2.7.0`
+- generate `metasheet-attendance-onprem-v2.7.0.json`
+- verify the alias `.tgz/.zip` in a temp directory with a local `SHA256SUMS`
+
+Alias verification results:
+
+- `metasheet-attendance-onprem-v2.7.0.tgz`: PASS
+- `metasheet-attendance-onprem-v2.7.0.zip`: PASS
+
+### Upload assets to GitHub Release
+
+```bash
+gh release upload v2.7.0 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.tgz \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.tgz.sha256 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.zip \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.zip.sha256 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.json \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0.tgz \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0.tgz.sha256 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0.zip \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0.zip.sha256 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0.json \
+  output/releases/attendance-onprem/SHA256SUMS-v2.7.0 \
+  --clobber
+```
+
+### Update release body to mention on-prem assets
+
+Result:
+
+- `v2.7.0` release body now explicitly lists the recommended on-prem downloads
+
+## Local evidence
+
+- [metasheet-attendance-onprem-v2.7.0-20260328-current.tgz](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v270-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.tgz)
+- [metasheet-attendance-onprem-v2.7.0-20260328-current.zip](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v270-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.zip)
+- [metasheet-attendance-onprem-v2.7.0.tgz](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v270-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0.tgz)
+- [metasheet-attendance-onprem-v2.7.0.zip](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v270-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0.zip)
+- [SHA256SUMS-v2.7.0](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v270-release-20260328/output/releases/attendance-onprem/SHA256SUMS-v2.7.0)
+- [metasheet-attendance-onprem-v2.7.0.json](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v270-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0.json)
+
+## Remote evidence
+
+Release checked:
+
+- <https://github.com/zensgit/metasheet2/releases/tag/v2.7.0>
+
+Observed uploaded assets include:
+
+- `metasheet-attendance-onprem-v2.7.0.zip`
+- `metasheet-attendance-onprem-v2.7.0.tgz`
+- `metasheet-attendance-onprem-v2.7.0.zip.sha256`
+- `metasheet-attendance-onprem-v2.7.0.tgz.sha256`
+- `metasheet-attendance-onprem-v2.7.0.json`
+- `SHA256SUMS-v2.7.0`
+- canonical `20260328-current` package artifacts
+
+## Result
+
+`v2.7.0` now has deployable attendance on-prem package assets.
+
+This closes the earlier gap where:
+
+- source release `v2.7.0` existed
+- but only `attendance-onprem-run21-20260322` exposed downloadable on-prem package files
+
+The current release page now supports direct operator download for `v2.7.0`.


### PR DESCRIPTION
## Summary
- record the manual v2.7.0 attendance on-prem package release action
- document the canonical and alias package assets uploaded to the existing v2.7.0 release
- capture the packaging verification steps and resulting release URLs

## Verification
- pnpm install --frozen-lockfile
- PACKAGE_VERSION=2.7.0 PACKAGE_TAG=20260328-current INSTALL_DEPS=0 BUILD_WEB=1 BUILD_BACKEND=1 scripts/ops/attendance-onprem-package-build.sh
- scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.tgz
- scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.0-20260328-current.zip
- gh release upload v2.7.0 ... --clobber
- gh release view v2.7.0 --json tagName,name,publishedAt,url,assets
