### PR TITLE
docs(release): record attendance onprem v2.7.1 package release

### DIFF
--- a/docs/development/attendance-onprem-v271-package-release-20260328.md
+++ b/docs/development/attendance-onprem-v271-package-release-20260328.md
@@ -1,0 +1,75 @@
+# Attendance On-Prem v2.7.1 Package Release
+
+Date: 2026-03-28
+
+## Goal
+
+Publish a formal `v2.7.1` hotfix release that includes deployable attendance on-prem package assets.
+
+This release exists because `v2.7.0` was already formally published, but the attendance admin hotfixes from PR `#567` landed afterward on `main`. Those hotfixes needed a new semver release instead of being folded back into `v2.7.0`.
+
+## Packaging base
+
+- source branch: `main`
+- source commit: `9a958a5a1c0fdb1a53171b5727a9d62d51e3e201`
+- merge source: PR `#567` `fix(attendance): restore admin console regressions`
+
+## Decision
+
+Use the merged `main` hotfix commit as the release target and publish `v2.7.1` as a patch release.
+
+For packaging:
+
+1. build from a clean worktree at `main@9a958a5a1`
+2. override `PACKAGE_VERSION=2.7.1` during on-prem packaging
+3. produce canonical traceable artifacts with suffix `20260328-current`
+4. additionally publish no-suffix operator-friendly aliases
+5. create a new GitHub Release `v2.7.1` instead of mutating `v2.7.0`
+
+## Hotfix scope
+
+`v2.7.1` packages the attendance admin fixes that restored or hardened:
+
+- focused right-pane section rendering with show-all toggle
+- Run21-facing admin UX slices:
+  - user picker
+  - import field guide
+  - holiday month calendar
+  - structured rule builder
+- create payload compatibility for approval flow and rule set admin routes
+- reduced unauthenticated login flash
+- attendance id semantics:
+  - malformed id -> `400`
+  - valid-but-missing id -> `404`
+- regenerated OpenAPI artifacts for `GET /api/attendance/rotation-rules/{id}`
+
+## Published assets
+
+### Canonical traceable assets
+
+- `metasheet-attendance-onprem-v2.7.1-20260328-current.tgz`
+- `metasheet-attendance-onprem-v2.7.1-20260328-current.tgz.sha256`
+- `metasheet-attendance-onprem-v2.7.1-20260328-current.zip`
+- `metasheet-attendance-onprem-v2.7.1-20260328-current.zip.sha256`
+- `metasheet-attendance-onprem-v2.7.1-20260328-current.json`
+
+### Operator-friendly alias assets
+
+- `metasheet-attendance-onprem-v2.7.1.tgz`
+- `metasheet-attendance-onprem-v2.7.1.tgz.sha256`
+- `metasheet-attendance-onprem-v2.7.1.zip`
+- `metasheet-attendance-onprem-v2.7.1.zip.sha256`
+- `metasheet-attendance-onprem-v2.7.1.json`
+- `SHA256SUMS-v2.7.1`
+
+## Release target
+
+- release: `v2.7.1`
+- release URL: <https://github.com/zensgit/metasheet2/releases/tag/v2.7.1>
+- target commit: `9a958a5a1c0fdb1a53171b5727a9d62d51e3e201`
+
+## Notes
+
+- The build script still derives the package version from `package.json` by default.
+- `package.json` on the release commit still does not equal `2.7.1`, so packaging needed the explicit `PACKAGE_VERSION=2.7.1` override.
+- This keeps the hotfix release narrow: no extra source-version synchronization change was mixed into the shipping release.

--- a/docs/development/attendance-onprem-v271-package-release-verification-20260328.md
+++ b/docs/development/attendance-onprem-v271-package-release-verification-20260328.md
@@ -1,0 +1,121 @@
+# Attendance On-Prem v2.7.1 Package Release Verification
+
+Date: 2026-03-28
+
+## Goal
+
+Verify that `v2.7.1` was released from the merged attendance hotfix commit and that the attached on-prem package assets are internally consistent.
+
+## Packaging base
+
+Clean worktree:
+
+- `/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v271-release-20260328`
+
+Base ref:
+
+- `main`
+- commit `9a958a5a1c0fdb1a53171b5727a9d62d51e3e201`
+
+## Commands run
+
+### Install workspace dependencies
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+### Build canonical on-prem package with explicit version override
+
+```bash
+PACKAGE_VERSION=2.7.1 \
+PACKAGE_TAG=20260328-current \
+INSTALL_DEPS=0 \
+BUILD_WEB=1 \
+BUILD_BACKEND=1 \
+scripts/ops/attendance-onprem-package-build.sh
+```
+
+### Verify canonical package artifacts
+
+```bash
+scripts/ops/attendance-onprem-package-verify.sh \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.tgz
+
+scripts/ops/attendance-onprem-package-verify.sh \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.zip
+```
+
+### Create operator-friendly aliases and verify them
+
+Actions performed:
+
+- copy canonical `.tgz/.zip/.json` to no-suffix `v2.7.1` names
+- generate per-file `.sha256`
+- generate `SHA256SUMS-v2.7.1`
+- update alias json metadata
+- verify alias `.tgz/.zip` in a temp directory with `SHA256SUMS-v2.7.1` copied locally as `SHA256SUMS`
+
+Alias verification results:
+
+- `metasheet-attendance-onprem-v2.7.1.tgz`: PASS
+- `metasheet-attendance-onprem-v2.7.1.zip`: PASS
+
+### Create GitHub Release
+
+```bash
+gh release create v2.7.1 \
+  --target 9a958a5a1c0fdb1a53171b5727a9d62d51e3e201 \
+  --title 'v2.7.1' \
+  --notes-file /tmp/metasheet-v271-release-notes.md \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.tgz \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.tgz.sha256 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.zip \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.zip.sha256 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.json \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1.tgz \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1.tgz.sha256 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1.zip \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1.zip.sha256 \
+  output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1.json \
+  output/releases/attendance-onprem/SHA256SUMS-v2.7.1
+```
+
+## Local evidence
+
+- [metasheet-attendance-onprem-v2.7.1-20260328-current.tgz](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v271-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.tgz)
+- [metasheet-attendance-onprem-v2.7.1-20260328-current.zip](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v271-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.zip)
+- [metasheet-attendance-onprem-v2.7.1.tgz](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v271-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1.tgz)
+- [metasheet-attendance-onprem-v2.7.1.zip](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v271-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1.zip)
+- [SHA256SUMS-v2.7.1](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v271-release-20260328/output/releases/attendance-onprem/SHA256SUMS-v2.7.1)
+- [metasheet-attendance-onprem-v2.7.1.json](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-onprem-v271-release-20260328/output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1.json)
+
+## Remote evidence
+
+Release checked:
+
+- <https://github.com/zensgit/metasheet2/releases/tag/v2.7.1>
+
+Observed uploaded assets include:
+
+- `metasheet-attendance-onprem-v2.7.1.zip`
+- `metasheet-attendance-onprem-v2.7.1.tgz`
+- `metasheet-attendance-onprem-v2.7.1.zip.sha256`
+- `metasheet-attendance-onprem-v2.7.1.tgz.sha256`
+- `metasheet-attendance-onprem-v2.7.1.json`
+- `SHA256SUMS-v2.7.1`
+- canonical `20260328-current` package artifacts
+
+Observed release metadata:
+
+- published at: `2026-03-28T14:38:31Z`
+- target commit: `9a958a5a1c0fdb1a53171b5727a9d62d51e3e201`
+
+## Result
+
+`v2.7.1` is now formally published and has deployable attendance on-prem package assets attached.
+
+This release closes the gap between:
+
+- merged attendance admin hotfix code on `main`
+- and a formally downloadable, operator-ready on-prem package for that hotfix line


### PR DESCRIPTION
## Summary
- record the formal `v2.7.1` attendance hotfix release decision and packaging base
- capture the exact local build, verify, alias, upload, and release-create commands used for the on-prem package publish
- link the final release assets and target commit for future operator traceability

## Verification
- `pnpm install --frozen-lockfile`
- `PACKAGE_VERSION=2.7.1 PACKAGE_TAG=20260328-current INSTALL_DEPS=0 BUILD_WEB=1 BUILD_BACKEND=1 scripts/ops/attendance-onprem-package-build.sh`
- `scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.tgz`
- `scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem/metasheet-attendance-onprem-v2.7.1-20260328-current.zip`
- alias asset verification in a temp directory with `SHA256SUMS-v2.7.1` copied locally as `SHA256SUMS`
- `gh release create v2.7.1 ...`
- `gh release view v2.7.1 --json tagName,publishedAt,targetCommitish,url,assets`
- `gh run list --limit 20 --json databaseId,workflowName,event,headBranch,headSha,status,conclusion,url,createdAt | jq '[.[] | select(.headBranch=="v2.7.1" or .headSha=="9a958a5a1c0fdb1a53171b5727a9d62d51e3e201")]'`

## Design / Verification Docs
- `docs/development/attendance-onprem-v271-package-release-20260328.md`
- `docs/development/attendance-onprem-v271-package-release-verification-20260328.md`
