### PR TITLE
fix(attendance): harden second-round import/export compatibility

### DIFF
--- a/docs/development/attendance-v271-round2-import-export-compat-design-20260329.md
+++ b/docs/development/attendance-v271-round2-import-export-compat-design-20260329.md
@@ -1,0 +1,86 @@
+# Attendance v2.7.1 Round 2 Import/Export Compatibility Design
+
+Date: 2026-03-29
+
+## Context
+
+Second-round `v2.7.1` feedback narrowed the remaining runtime gaps to:
+
+1. CSV upload -> prepare -> commit could still end with `No rows to import` even when the file looked structurally valid.
+2. `/api/attendance/payroll-cycles/:id/export` returned `404` while `/api/attendance/payroll-cycles/:id/summary/export` worked.
+
+The reported CSV example used API-style column names such as `workDate` and `1_on_duty_user_check_time`, plus slash dates like `2026/3/26`.
+
+## Goals
+
+- Make the upload channel use the same notion of “valid data row” as preview/commit.
+- Accept common CSV date variants such as `YYYY/M/D`.
+- Keep CSV imports compatible when callers use API-style required columns under the default admin flow.
+- Add a narrow compatibility alias for payroll-cycle CSV export without changing existing canonical routes.
+
+## Non-Goals
+
+- No new punch-event detail API in this slice.
+- No further admin UI work in this slice.
+- No change to the canonical payroll summary/export contract; the alias only reduces client breakage.
+
+## Design
+
+### 1. Upload validation uses parsed non-empty rows
+
+`/api/attendance/import/upload` previously derived `rowCount` from physical line count. That could diverge from preview/commit, which parse CSV rows and ignore blank data rows.
+
+The upload route now calls the same CSV row iterator used by import processing and:
+
+- validates the header as before
+- counts parsed non-empty data rows
+- rejects files that only contain a header row plus empty lines
+- stores the parsed `rowCount` in upload metadata and response
+
+This closes the “upload says 1 row, commit says no rows” class of drift for header-only or visually empty CSV files.
+
+### 2. CSV workDate normalization accepts non-zero-padded slash dates
+
+`normalizeCsvWorkDate()` now accepts `YYYY/M/D` and normalizes it to `YYYY-MM-DD`.
+
+Examples:
+
+- `2026/3/26` -> `2026-03-26`
+- `2026/03/26` -> `2026-03-26`
+
+### 3. Required-field lookup accepts canonical aliases
+
+`resolveRequiredFieldValue()` now checks a small alias table so the default daily-summary admin path also recognizes API-style equivalents for required punch/date fields.
+
+Examples:
+
+- `日期` can be satisfied by `workDate`
+- `上班1打卡时间` can be satisfied by `1_on_duty_user_check_time`
+- `下班1打卡时间` can be satisfied by `1_off_duty_user_check_time`
+
+This keeps the current default import profile usable for API-column CSV uploads without forcing callers to know an extra profile flag.
+
+### 4. Payroll-cycle export compatibility alias
+
+Runtime now exposes:
+
+- canonical: `/api/attendance/payroll-cycles/:id/summary/export`
+- compatibility alias: `/api/attendance/payroll-cycles/:id/export`
+
+Both routes share the same handler and produce identical CSV output.
+
+## Minimal Working CSV Example
+
+This API-style CSV is now accepted by the default upload -> preview -> commit flow:
+
+```csv
+workDate,userId,1_on_duty_user_check_time,1_off_duty_user_check_time,attend_result
+2026/3/26,user-001,2026-03-26T09:00:00+08:00,2026-03-26T18:00:00+08:00,Normal
+```
+
+The canonical template endpoints remain:
+
+- `GET /api/attendance/import/template`
+- `GET /api/attendance/import/template.csv`
+- `GET /api/attendance/import/template.csv?profileId=dingtalk_api_columns`
+

--- a/docs/development/attendance-v271-round2-import-export-compat-verification-20260329.md
+++ b/docs/development/attendance-v271-round2-import-export-compat-verification-20260329.md
@@ -1,0 +1,52 @@
+# Attendance v2.7.1 Round 2 Import/Export Compatibility Verification
+
+Date: 2026-03-29
+
+## Scope Verified
+
+- upload-channel CSV row counting matches parsed non-empty rows
+- API-style CSV imports with slash dates no longer fail the default admin path
+- payroll-cycle export compatibility alias returns the same CSV as the canonical summary/export route
+- OpenAPI source/dist include the new export alias
+
+## Commands
+
+```bash
+git diff --check
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "rejects uploaded CSV files that only contain a header row after parser normalization|accepts uploaded API-column CSV imports with slash dates through required-field aliases|supports approval flow, rule set, and payroll cycle item lookup while keeping missing item semantics stable" --reporter=dot
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm exec tsx packages/openapi/tools/build.ts
+```
+
+## Results
+
+- `git diff --check`: passed
+- focused integration suite: `3 passed`
+- backend TypeScript compile: passed
+- OpenAPI rebuild: passed
+
+## Focused Assertions
+
+### Header-only uploads
+
+Valid-looking headers followed only by empty row content are rejected during upload with `400 VALIDATION_ERROR` instead of surviving until commit and failing later.
+
+### API-column CSV compatibility
+
+The following import shape now succeeds without requiring an explicit profile override:
+
+```csv
+workDate,userId,1_on_duty_user_check_time,1_off_duty_user_check_time,attend_result
+2026/3/26,user-001,2026-03-26T09:00:00+08:00,2026-03-26T18:00:00+08:00,Normal
+```
+
+The preview result normalizes `workDate` to `2026-03-26`, and commit imports the row instead of skipping it as “missing required”.
+
+### Payroll cycle export alias
+
+`GET /api/attendance/payroll-cycles/:id/export` now returns `200` and the raw CSV matches `GET /api/attendance/payroll-cycles/:id/summary/export` byte-for-byte.
+
+## Residual Notes
+
+- The earlier “edit buttons 0x0” report still looks like a focused-mode locator mismatch unless reproduced in a real browser against the active section.
+- `/metrics/prom` was not changed in this slice; the product route remains `/metrics/prom`.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1940,6 +1940,22 @@ describe('Attendance Plugin Integration', () => {
     })
     expect(invalidPayrollCycleUpdateRes.status).toBe(400)
     expect((invalidPayrollCycleUpdateRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('VALIDATION_ERROR')
+
+    const payrollCycleExportAliasRes = await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${payrollCycleId}/export`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(payrollCycleExportAliasRes.status).toBe(200)
+    expect(payrollCycleExportAliasRes.raw).toContain('cycle_id,cycle_name,start_date,end_date,metric,value')
+
+    const payrollCycleSummaryExportRes = await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${payrollCycleId}/summary/export`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(payrollCycleSummaryExportRes.status).toBe(200)
+    expect(payrollCycleSummaryExportRes.raw).toBe(payrollCycleExportAliasRes.raw)
   })
 
   it('rejects invalid CSV upload payloads with 400 before creating upload handles', async () => {
@@ -1967,6 +1983,33 @@ describe('Attendance Plugin Integration', () => {
     expect(body.ok).toBe(false)
     expect(body.error?.code).toBe('VALIDATION_ERROR')
     expect(String(body.error?.message ?? '')).toMatch(/header|data row/i)
+  })
+
+  it('rejects uploaded CSV files that only contain a header row after parser normalization', async () => {
+    if (!baseUrl) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=attendance-header-only-csv&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const headerOnlyCsv = 'workDate,userId,1_on_duty_user_check_time,1_off_duty_user_check_time\n,,,\n'
+    const uploadRes = await requestJson(`${baseUrl}/api/attendance/import/upload?orgId=default&filename=header-only.csv`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'text/csv',
+      },
+      body: headerOnlyCsv,
+    })
+
+    expect(uploadRes.status).toBe(400)
+    const body = (uploadRes.body as { ok?: boolean; error?: { code?: string; message?: string } } | undefined) ?? {}
+    expect(body.ok).toBe(false)
+    expect(body.error?.code).toBe('VALIDATION_ERROR')
+    expect(String(body.error?.message ?? '')).toMatch(/non-empty data row/i)
   })
 
   it('keeps /api/health public for probes', async () => {
@@ -4789,6 +4832,111 @@ describe('Attendance Plugin Integration', () => {
       })
       expect(rollbackRes.status).toBe(200)
     }
+  })
+
+  it('accepts uploaded API-column CSV imports with slash dates through required-field aliases', async () => {
+    if (!baseUrl) return
+    if (!importUploadDir) return
+
+    const runSuffix = Date.now().toString(36)
+    const requesterId = `attendance-api-csv-${runSuffix}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(requesterId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const orgId = 'default'
+    const csvText = [
+      'workDate,userId,1_on_duty_user_check_time,1_off_duty_user_check_time,attend_result',
+      `2026/3/26,${requesterId},2026-03-26T09:00:00+08:00,2026-03-26T18:00:00+08:00,Normal`,
+      '',
+    ].join('\n')
+
+    const uploadRes = await requestJson(`${baseUrl}/api/attendance/import/upload?orgId=${encodeURIComponent(orgId)}&filename=api-columns.csv`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'text/csv',
+      },
+      body: csvText,
+    })
+    expect(uploadRes.status).toBe(201)
+    const fileId = (uploadRes.body as { data?: { fileId?: string; rowCount?: number } } | undefined)?.data?.fileId
+    const rowCount = (uploadRes.body as { data?: { rowCount?: number } } | undefined)?.data?.rowCount
+    expect(rowCount).toBe(1)
+    expect(typeof fileId).toBe('string')
+    if (!fileId) return
+
+    const preparePreviewRes = await requestJson(`${baseUrl}/api/attendance/import/prepare`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    })
+    expect(preparePreviewRes.status).toBe(200)
+    const previewCommitToken = (preparePreviewRes.body as { data?: { commitToken?: string } } | undefined)?.data?.commitToken
+    expect(previewCommitToken).toBeTruthy()
+    if (!previewCommitToken) return
+
+    const previewRes = await requestJson(`${baseUrl}/api/attendance/import/preview`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        orgId,
+        fileId,
+        timezone: 'Asia/Shanghai',
+        commitToken: previewCommitToken,
+      }),
+    })
+    expect(previewRes.status).toBe(200)
+    const previewItems = (previewRes.body as { data?: { items?: Array<{ userId?: string; workDate?: string; warnings?: string[] }> } } | undefined)?.data?.items ?? []
+    expect(previewItems[0]?.userId).toBe(requesterId)
+    expect(previewItems[0]?.workDate).toBe('2026-03-26')
+    expect(previewItems[0]?.warnings ?? []).not.toContain('Missing required: 日期')
+
+    const prepareCommitRes = await requestJson(`${baseUrl}/api/attendance/import/prepare`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    })
+    expect(prepareCommitRes.status).toBe(200)
+    const commitToken = (prepareCommitRes.body as { data?: { commitToken?: string } } | undefined)?.data?.commitToken
+    expect(commitToken).toBeTruthy()
+    if (!commitToken) return
+
+    const commitRes = await requestJson(`${baseUrl}/api/attendance/import/commit`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        orgId,
+        fileId,
+        timezone: 'Asia/Shanghai',
+        commitToken,
+        returnItems: false,
+      }),
+    })
+    expect(commitRes.status).toBe(200)
+    const commitData = (commitRes.body as { data?: { imported?: number; failedRows?: number; skipped?: unknown[] } } | undefined)?.data
+    expect(commitData?.imported).toBe(1)
+    expect(commitData?.failedRows).toBe(0)
+
+    const csvPath = path.join(importUploadDir, orgId, `${fileId}.csv`)
+    const metaPath = path.join(importUploadDir, orgId, `${fileId}.json`)
+    await expect(fs.stat(csvPath)).rejects.toBeTruthy()
+    await expect(fs.stat(metaPath)).rejects.toBeTruthy()
   })
 
   it('routes high-scale csvFileId imports to async endpoints and preserves upload for async lanes', async () => {

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -7465,6 +7465,37 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/attendance/payroll-cycles/{id}/export:
+    x-plugin: plugin-attendance
+    get:
+      summary: Export payroll cycle summary (CSV compatibility alias)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: userId
+          schema:
+            type: string
+        - in: query
+          name: orgId
+          schema:
+            type: string
+      responses:
+        '200':
+          description: CSV export
+          content:
+            text/csv:
+              schema:
+                type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/audit-logs:
     get:
       summary: Admin-only audit log query

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -11730,6 +11730,59 @@
         }
       }
     },
+    "/api/attendance/payroll-cycles/{id}/export": {
+      "x-plugin": "plugin-attendance",
+      "get": {
+        "summary": "Export payroll cycle summary (CSV compatibility alias)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "userId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "orgId",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV export",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
     "/api/audit-logs": {
       "get": {
         "summary": "Admin-only audit log query",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -7465,6 +7465,37 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/attendance/payroll-cycles/{id}/export:
+    x-plugin: plugin-attendance
+    get:
+      summary: Export payroll cycle summary (CSV compatibility alias)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: userId
+          schema:
+            type: string
+        - in: query
+          name: orgId
+          schema:
+            type: string
+      responses:
+        '200':
+          description: CSV export
+          content:
+            text/csv:
+              schema:
+                type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/audit-logs:
     get:
       summary: Admin-only audit log query

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -3688,3 +3688,29 @@ paths:
                 type: string
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/attendance/payroll-cycles/{id}/export:
+    x-plugin: plugin-attendance
+    get:
+      summary: Export payroll cycle summary (CSV compatibility alias)
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: userId
+          schema: { type: string }
+        - in: query
+          name: orgId
+          schema: { type: string }
+      responses:
+        '200':
+          description: CSV export
+          content:
+            text/csv:
+              schema:
+                type: string
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -234,6 +234,15 @@ const IMPORT_MAPPING_PROFILES = [
   },
 ]
 
+const IMPORT_REQUIRED_FIELD_ALIASES = {
+  '日期': ['workDate', 'date'],
+  workDate: ['日期', 'date'],
+  '上班1打卡时间': ['1_on_duty_user_check_time', 'firstInAt', 'clockIn1'],
+  '下班1打卡时间': ['1_off_duty_user_check_time', 'lastOutAt', 'clockOut1'],
+  '上班2打卡时间': ['2_on_duty_user_check_time', 'clockIn2'],
+  '下班2打卡时间': ['2_off_duty_user_check_time', 'clockOut2'],
+}
+
 function findImportProfile(profileId) {
   if (!profileId) return null
   return IMPORT_MAPPING_PROFILES.find((profile) => profile.id === profileId) ?? null
@@ -1604,7 +1613,10 @@ function normalizeCsvWorkDate(value) {
     const [yy, mm, dd] = cleaned.split('-')
     return `20${yy}-${mm}-${dd}`
   }
-  if (/^\d{4}\/\d{2}\/\d{2}$/.test(cleaned)) return cleaned.replace(/\//g, '-')
+  if (/^\d{4}[/-]\d{1,2}[/-]\d{1,2}$/.test(cleaned)) {
+    const [yyyy, mm, dd] = cleaned.split(/[/-]/)
+    return `${yyyy}-${String(mm).padStart(2, '0')}-${String(dd).padStart(2, '0')}`
+  }
   return null
 }
 
@@ -2064,6 +2076,18 @@ async function validateImportUploadCsvOrThrow({ csvPath, csvOptions }) {
       'CSV header must include a work date column and at least one user or attendance column'
     )
   }
+  const rowScan = await iterateImportRowsFromCsvFileAsync({
+    csvPath,
+    csvOptions,
+    maxRows: Number.MAX_SAFE_INTEGER,
+  })
+  if (rowScan.rowCount <= 0) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'CSV must include at least 1 non-empty data row')
+  }
+  return {
+    rowCount: rowScan.rowCount,
+    warnings: rowScan.warnings,
+  }
 }
 
 function buildRowsFromCsv({ csvText, csvOptions, maxRows }) {
@@ -2208,6 +2232,12 @@ function resolveRequiredFieldValue(row, field) {
   if (!row || !field) return undefined
   if (row.fields && row.fields[field] !== undefined) return row.fields[field]
   if (row[field] !== undefined) return row[field]
+  const aliases = IMPORT_REQUIRED_FIELD_ALIASES[field]
+  if (!Array.isArray(aliases)) return undefined
+  for (const alias of aliases) {
+    if (row.fields && row.fields[alias] !== undefined) return row.fields[alias]
+    if (row[alias] !== undefined) return row[alias]
+  }
   return undefined
 }
 
@@ -12616,18 +12646,8 @@ module.exports = {
 	          await fsp.mkdir(paths.dir, { recursive: true })
 	          const meter = new ImportUploadMeter(ATTENDANCE_IMPORT_UPLOAD_MAX_BYTES)
 	          await pipeline(req, meter, fs.createWriteStream(paths.csvPath))
-
-	          const endedWithNewline = meter.lastByte === 10
-	          const lines = meter.bytes === 0 ? 0 : meter.newlines + (endedWithNewline ? 0 : 1)
-	          const rowCount = Math.max(0, lines - 1) // header row excluded
-
-	          if (rowCount <= 0) {
-	            await deleteImportUpload({ orgId, fileId })
-	            res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'CSV must include at least 1 data row' } })
-	            return
-	          }
-
-	          await validateImportUploadCsvOrThrow({ csvPath: paths.csvPath })
+	          const validation = await validateImportUploadCsvOrThrow({ csvPath: paths.csvPath })
+	          const rowCount = validation.rowCount
 
 	          const meta = {
 	            fileId,
@@ -16853,10 +16873,7 @@ module.exports = {
       })
     )
 
-    context.api.http.addRoute(
-      'GET',
-      '/api/attendance/payroll-cycles/:id/summary/export',
-      withPermission('attendance:read', async (req, res) => {
+    const handlePayrollCycleSummaryExport = async (req, res) => {
         const schema = z.object({
           userId: z.string().optional(),
           orgId: z.string().optional(),
@@ -16915,7 +16932,18 @@ module.exports = {
           logger.error('Attendance payroll cycle summary export failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to export payroll summary' } })
         }
-      })
+      }
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/payroll-cycles/:id/summary/export',
+      withPermission('attendance:read', handlePayrollCycleSummaryExport)
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/payroll-cycles/:id/export',
+      withPermission('attendance:read', handlePayrollCycleSummaryExport)
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- align CSV upload row counting with parsed non-empty import rows
- accept slash-date API-column CSV uploads through required-field aliases
- add /api/attendance/payroll-cycles/:id/export as a compatibility alias to summary/export
- record design and verification for the second-round v2.7.1 follow-up slice

## Verification
- git diff --check
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "rejects uploaded CSV files that only contain a header row after parser normalization|accepts uploaded API-column CSV imports with slash dates through required-field aliases|supports approval flow, rule set, and payroll cycle item lookup while keeping missing item semantics stable" --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- pnpm exec tsx packages/openapi/tools/build.ts
