### PR TITLE
fix(attendance): align admin claim fallback

### DIFF
--- a/docs/development/attendance-v271-admin-claim-alignment-design-20260329.md
+++ b/docs/development/attendance-v271-admin-claim-alignment-design-20260329.md
@@ -1,0 +1,46 @@
+# Attendance v2.7.1 Admin Claim Alignment Design
+
+## Problem
+
+Attendance admin routes inside `plugin-attendance` use a custom `withPermission()` guard that only checks RBAC tables through `isAdmin(userId)` and `userHasPermission(userId, permission)`.
+
+That diverges from the core RBAC middleware, which trusts the already-authenticated request user first:
+
+- admin role on `req.user`
+- resolved wildcard permissions such as `*:*`
+- request-scoped permission lists already attached by auth middleware
+
+The gap shows up immediately in local/dev sessions:
+
+- `/api/auth/me` returns a valid admin snapshot with `permissions: ["*:*"]`
+- `/api/admin/users` succeeds
+- but attendance admin routes like `/api/attendance/settings` still return `403 FORBIDDEN`
+
+This makes the admin console appear permission-blocked even though the authenticated session is effectively an admin session.
+
+## Scope
+
+Smallest safe slice:
+
+1. Align `plugin-attendance` permission checks with the core RBAC semantics.
+2. Keep database-backed permission fallback intact.
+3. Do not change attendance resource schemas or UI structure.
+
+## Change
+
+Add request-user permission helpers inside `plugin-attendance`:
+
+- normalize permission arrays from `req.user.permissions` and `req.user.perms`
+- treat `role=admin` or `roles[]` containing `admin` as admin
+- accept `*:*` and `<resource>:*` wildcard permissions
+
+Then update `withPermission()` so it:
+
+1. trusts the authenticated request user first
+2. falls back to database RBAC only when request claims do not already authorize the action
+
+## Expected Outcome
+
+- Dev/admin sessions that already resolve as admin in core auth can open attendance admin routes without being blocked by plugin-local RBAC drift.
+- The previously reported “edit button invisible” report can be rechecked against the actual admin console instead of a permission-blocked shell.
+- Existing DB-backed RBAC flows remain unchanged.

--- a/docs/development/attendance-v271-admin-claim-alignment-verification-20260329.md
+++ b/docs/development/attendance-v271-admin-claim-alignment-verification-20260329.md
@@ -1,0 +1,52 @@
+# Attendance v2.7.1 Admin Claim Alignment Verification
+
+## Commands
+
+```bash
+git diff --check
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "honors authenticated admin claims for attendance admin routes when RBAC_BYPASS is disabled" --reporter=dot
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+## Focused Integration Result
+
+`attendance-plugin.test.ts` now locks this behavior:
+
+- when `RBAC_BYPASS=false`
+- and the caller uses a dev token with authenticated admin claims / wildcard permissions
+- attendance admin routes such as:
+  - `GET /api/attendance/settings`
+  - `GET /api/attendance/groups`
+
+return `200` instead of `403`.
+
+Observed result:
+
+- `1 passed`
+
+## Browser Verification
+
+Using the local verification worktree with backend on `http://localhost:7778` and frontend on `http://127.0.0.1:8899`:
+
+1. Injected a valid dev token into local storage.
+2. Opened `/attendance?tab=admin`.
+3. Confirmed `GET /api/attendance/settings` returns `200`.
+4. Navigated to the `请假类型` admin section.
+5. Measured the first visible `编辑` button.
+
+Observed button geometry:
+
+- width: `56.6640625`
+- height: `36.5`
+- display: `block`
+- opacity: `1`
+- visibility: `visible`
+
+This means the active-section edit button is not zero-sized on the current code after the permission guard is aligned. The earlier “26 buttons width/height=0” report is consistent with either:
+
+- querying buttons in hidden inactive sections while focused mode is on
+- or checking a permission-blocked admin shell instead of the loaded section content
+
+## Residual Risk
+
+This slice aligns `withPermission()` with core RBAC semantics. It does not introduce a new attendance API surface and does not change DB-backed permission resolution order once request claims are insufficient.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1026,6 +1026,45 @@ describe('Attendance Plugin Integration', () => {
     }
   })
 
+  it('honors authenticated admin claims for attendance admin routes when RBAC_BYPASS is disabled', async () => {
+    if (!baseUrl) return
+
+    const originalRbacBypass = process.env.RBAC_BYPASS
+    process.env.RBAC_BYPASS = 'false'
+
+    try {
+      const testUserId = `attendance-admin-claims-${Date.now().toString(36)}`
+      const tokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=admin&perms=*:*`
+      )
+      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      expect(token).toBeTruthy()
+      if (!token) return
+
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      expect(settingsRes.status).toBe(200)
+      const settingsBody = settingsRes.body as { ok?: boolean; data?: Record<string, unknown> } | undefined
+      expect(settingsBody?.ok).toBe(true)
+      expect(settingsBody?.data).toBeTruthy()
+
+      const groupsRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      expect(groupsRes.status).toBe(200)
+      const groupsBody = groupsRes.body as { ok?: boolean; data?: { items?: unknown[] } } | undefined
+      expect(groupsBody?.ok).toBe(true)
+      expect(Array.isArray(groupsBody?.data?.items)).toBe(true)
+    } finally {
+      process.env.RBAC_BYPASS = originalRbacBypass
+    }
+  })
+
   it('serves attendance import templates as JSON and CSV', async () => {
     if (!baseUrl) return
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -6555,6 +6555,35 @@ function createRbacHelpers(db, logger) {
     }
   }
 
+  function normalizePermissionCodes(value) {
+    if (!Array.isArray(value)) return []
+    return value
+      .map((item) => String(item ?? '').trim())
+      .filter(Boolean)
+  }
+
+  function hasPermissionCode(permissionCodes, permissionCode) {
+    if (permissionCodes.includes(permissionCode) || permissionCodes.includes('*:*')) return true
+    const resource = permissionCode.split(':')[0]
+    return resource ? permissionCodes.includes(`${resource}:*`) : false
+  }
+
+  function requestUserIsAdmin(user) {
+    if (!user || typeof user !== 'object') return false
+    if (String(user.role || '').trim() === 'admin') return true
+    return normalizePermissionCodes(user.roles).includes('admin')
+  }
+
+  function requestUserHasPermission(user, permission) {
+    if (!user || typeof user !== 'object') return false
+    if (requestUserIsAdmin(user)) return true
+    const permissionCodes = Array.from(new Set([
+      ...normalizePermissionCodes(user.permissions),
+      ...normalizePermissionCodes(user.perms),
+    ]))
+    return hasPermissionCode(permissionCodes, permission)
+  }
+
   function withPermission(permission, handler) {
     return async (req, res, next) => {
       const userId = getUserId(req)
@@ -6569,6 +6598,10 @@ function createRbacHelpers(db, logger) {
       }
 
       try {
+        if (requestUserHasPermission(req.user, permission)) {
+          await handler(req, res, next)
+          return
+        }
         const admin = await isAdmin(userId)
         if (!admin) {
           const allowed = await userHasPermission(userId, permission)


### PR DESCRIPTION
## Summary
- align plugin-attendance admin permission fallback with core RBAC request-claim semantics
- add focused integration coverage for attendance admin routes with RBAC_BYPASS disabled
- record design and verification evidence for the admin-claim alignment slice

## Verification
- git diff --check
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "honors authenticated admin claims for attendance admin routes when RBAC_BYPASS is disabled" --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- Browser verification: attendance admin settings loaded with 200 and active leave-type edit button measured at 56.66 x 36.5

## Docs
- docs/development/attendance-v271-admin-claim-alignment-design-20260329.md
- docs/development/attendance-v271-admin-claim-alignment-verification-20260329.md