### PR TITLE
feat(attendance): simplify admin section navigation

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -461,9 +461,6 @@
           <div class="attendance__admin-header">
             <h3>{{ tr('Admin Console', '管理控制台') }}</h3>
             <div class="attendance__admin-actions">
-              <button class="attendance__btn" type="button" @click="adminFocusedMode = !adminFocusedMode">
-                {{ adminFocusedMode ? tr('Show all sections', '显示全部区块') : tr('Focus current section', '仅显示当前区块') }}
-              </button>
               <button class="attendance__btn" :disabled="settingsLoading || ruleLoading" @click="loadAdminData">
                 {{ settingsLoading || ruleLoading ? tr('Loading...', '加载中...') : tr('Reload admin', '重载管理数据') }}
               </button>
@@ -490,33 +487,82 @@
             </button>
           </div>
           <div v-if="adminForbidden" class="attendance__empty">{{ tr('Admin permissions required to manage attendance settings.', '需要管理员权限才能管理考勤设置。') }}</div>
-          <div v-else class="attendance__admin-shell">
+          <template v-else>
+            <div v-if="visibleRecentAdminSectionNavItems.length > 0" class="attendance__admin-shortcuts">
+              <div class="attendance__admin-shortcuts-header">
+                <div class="attendance__admin-shortcuts-title">
+                  <strong>{{ tr('Recent', '最近访问') }}</strong>
+                  <span>{{ tr('Jump back without searching the left rail.', '不用再回左侧查找，直接跳转。') }}</span>
+                </div>
+                <button
+                  class="attendance__btn attendance__btn--inline"
+                  type="button"
+                  data-admin-shortcuts-clear="true"
+                  @click="clearRecentAdminSections"
+                >
+                  {{ tr('Clear', '清空') }}
+                </button>
+              </div>
+              <div class="attendance__admin-shortcuts-items">
+                <button
+                  v-for="item in visibleRecentAdminSectionNavItems"
+                  :key="`shortcut-${item.id}`"
+                  class="attendance__admin-shortcut"
+                  :class="{ 'attendance__admin-shortcut--active': adminActiveSectionId === item.id }"
+                  :data-admin-shortcut="item.id"
+                  type="button"
+                  @click="selectAdminSection(item.id)"
+                >
+                  {{ item.contextLabel }}
+                </button>
+              </div>
+            </div>
+            <div class="attendance__admin-shell">
             <AttendanceAdminRail
               :tr="tr"
-              :admin-section-nav-count-label="adminSectionNavCountLabel"
-              :admin-nav-storage-scope="adminNavStorageScope"
-              :admin-nav-default-storage-scope="adminNavDefaultStorageScope"
-              :admin-nav-scope-feedback="adminNavScopeFeedback"
               :active-admin-section-context-label="activeAdminSectionContextLabel"
               :is-compact-admin-nav="isCompactAdminNav"
               :admin-compact-nav-open="adminCompactNavOpen"
-              :admin-section-filter="adminSectionFilter"
-              :admin-section-filter-active="adminSectionFilterActive"
-              :all-admin-section-groups-expanded="allAdminSectionGroupsExpanded"
-              :all-admin-section-groups-collapsed="allAdminSectionGroupsCollapsed"
-              :visible-recent-admin-section-nav-items="visibleRecentAdminSectionNavItems"
               :visible-admin-section-nav-groups="visibleAdminSectionNavGroups"
               :admin-active-section-id="adminActiveSectionId"
               @update:compact-nav-open="adminCompactNavOpen = $event"
-              @update:section-filter="adminSectionFilter = $event"
-              @expand-all="expandAllAdminSectionGroups"
-              @collapse-all="collapseAllAdminSectionGroups"
-              @copy-current-link="copyCurrentAdminSectionLink"
-              @clear-recents="clearRecentAdminSections"
               @toggle-group="toggleAdminSectionGroup"
               @select-section="selectAdminSection"
             />
-            <div class="attendance__admin-content" :class="{ 'attendance__admin-content--focused': adminFocusedMode }">
+            <div
+              class="attendance__admin-content"
+              :class="{ 'attendance__admin-content--focused': adminFocusedMode }"
+              data-admin-content="true"
+            >
+            <div
+              class="attendance__admin-current-section"
+              :class="{ 'attendance__admin-current-section--expanded': !adminFocusedMode }"
+              data-admin-current-section="true"
+            >
+              <div class="attendance__admin-current-section-copy">
+                <span class="attendance__admin-current-section-eyebrow">
+                  {{ adminFocusedMode ? tr('Current section', '当前区块') : tr('Browse sections', '浏览区块') }}
+                </span>
+                <strong>{{ activeAdminSectionContextLabel }}</strong>
+                <span>
+                  {{
+                    adminFocusedMode
+                      ? tr('Choose another item on the left and the right pane will return here immediately.', '点击左侧其他区块后，右侧会立即回到这里。')
+                      : tr('All sections are visible. Focus mode brings you back to the active block.', '当前显示全部区块；切回聚焦模式可回到当前区块。')
+                  }}
+                </span>
+              </div>
+              <div class="attendance__admin-current-section-actions">
+                <button
+                  class="attendance__btn attendance__btn--inline"
+                  type="button"
+                  data-admin-focus-toggle="true"
+                  @click="adminFocusedMode = !adminFocusedMode"
+                >
+                  {{ adminFocusedMode ? tr('Show all sections', '显示全部区块') : tr('Focus current section', '仅显示当前区块') }}
+                </button>
+              </div>
+            </div>
             <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.settings)"
               class="attendance__admin-section"
@@ -3825,7 +3871,8 @@
               />
             </div>
             </div>
-          </div>
+            </div>
+          </template>
         </div>
       </section>
     </template>
@@ -4922,6 +4969,7 @@ const {
 } = useAttendanceAdminRailNavigation({
   showAdmin,
   adminForbidden,
+  adminFocusCurrentSectionOnly: adminFocusedMode,
   adminNavStorageScope,
   adminActiveSectionId,
   adminSectionNavItems,
@@ -12101,8 +12149,129 @@ const holidaySectionBindings = {
   align-items: start;
 }
 
+.attendance__admin-shortcuts {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  border: 1px solid #dbeafe;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+}
+
+.attendance__admin-shortcuts-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.attendance__admin-shortcuts-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.attendance__admin-shortcuts-title strong {
+  color: #1f2937;
+  font-size: 13px;
+}
+
+.attendance__admin-shortcuts-title span {
+  color: #6b7280;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.attendance__admin-shortcuts-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.attendance__admin-shortcut {
+  padding: 8px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #334155;
+  font-size: 12px;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.attendance__admin-shortcut:hover {
+  border-color: #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.attendance__admin-shortcut--active {
+  border-color: #93c5fd;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
 .attendance__admin-content {
   min-width: 0;
+}
+
+.attendance__admin-current-section {
+  position: sticky;
+  top: 12px;
+  z-index: 6;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  border: 1px solid #bfdbfe;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(10px);
+}
+
+.attendance__admin-current-section--expanded {
+  border-color: #dbeafe;
+}
+
+.attendance__admin-current-section-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.attendance__admin-current-section-copy strong {
+  color: #0f172a;
+  font-size: 15px;
+}
+
+.attendance__admin-current-section-copy span:last-child {
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.attendance__admin-current-section-eyebrow {
+  color: #2563eb;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.attendance__admin-current-section-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .attendance__admin-content--focused .attendance__admin-section + .attendance__admin-section {
@@ -12532,6 +12701,29 @@ const holidaySectionBindings = {
 
   .attendance__admin-shell {
     grid-template-columns: 1fr;
+  }
+
+  .attendance__admin-shortcuts-header {
+    flex-direction: column;
+  }
+
+  .attendance__admin-current-section {
+    top: 8px;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .attendance__admin-current-section-actions {
+    width: 100%;
+  }
+
+  .attendance__admin-shortcuts-items {
+    flex-direction: column;
+  }
+
+  .attendance__admin-shortcut {
+    width: 100%;
+    text-align: left;
   }
 
   .attendance__table--records {

--- a/apps/web/src/views/attendance/AttendanceAdminRail.vue
+++ b/apps/web/src/views/attendance/AttendanceAdminRail.vue
@@ -1,24 +1,7 @@
 <template>
   <aside class="attendance__admin-nav-panel">
     <div class="attendance__admin-nav-header">
-      <strong>{{ tr('Sections', '区块') }}</strong>
-      <div class="attendance__admin-nav-header-meta">
-        <span>{{ adminSectionNavCountLabel }}</span>
-        <span
-          v-if="adminNavStorageScope !== adminNavDefaultStorageScope"
-          class="attendance__admin-nav-scope-badge"
-          :title="tr('Navigation memory scoped to this org.', '当前导航记忆已关联到此组织。')"
-        >
-          {{ adminNavStorageScope }}
-        </span>
-      </div>
-    </div>
-    <div v-if="adminNavScopeFeedback" class="attendance__admin-nav-scope-note">
-      {{ adminNavScopeFeedback }}
-    </div>
-    <div class="attendance__admin-nav-current" :title="activeAdminSectionContextLabel">
-      <span>{{ tr('Current', '当前') }}</span>
-      <strong>{{ activeAdminSectionContextLabel }}</strong>
+      <strong>{{ tr('Jump to', '跳转区块') }}</strong>
     </div>
     <button
       v-if="isCompactAdminNav"
@@ -31,71 +14,6 @@
       <small>{{ activeAdminSectionContextLabel }}</small>
     </button>
     <template v-if="!isCompactAdminNav || adminCompactNavOpen">
-      <label class="attendance__field attendance__field--compact" for="attendance-admin-nav-filter">
-        <span>{{ tr('Quick find', '快速查找') }}</span>
-        <input
-          id="attendance-admin-nav-filter"
-          :value="adminSectionFilter"
-          type="text"
-          :placeholder="tr('Search sections', '搜索区块')"
-          @input="emit('update:sectionFilter', ($event.target as HTMLInputElement).value)"
-        />
-      </label>
-      <div class="attendance__admin-nav-actions">
-        <button
-          class="attendance__btn attendance__btn--inline"
-          type="button"
-          :disabled="adminSectionFilterActive || allAdminSectionGroupsExpanded"
-          @click="emit('expandAll')"
-        >
-          {{ tr('Expand all', '展开全部') }}
-        </button>
-        <button
-          class="attendance__btn attendance__btn--inline"
-          type="button"
-          :disabled="adminSectionFilterActive || allAdminSectionGroupsCollapsed"
-          @click="emit('collapseAll')"
-        >
-          {{ tr('Collapse all', '收起全部') }}
-        </button>
-        <button
-          class="attendance__btn attendance__btn--inline"
-          type="button"
-          @click="emit('copyCurrentLink')"
-        >
-          {{ tr('Copy current link', '复制当前链接') }}
-        </button>
-      </div>
-      <section v-if="visibleRecentAdminSectionNavItems.length > 0" class="attendance__admin-nav-recents">
-        <div class="attendance__admin-nav-recents-header">
-          <strong>{{ tr('Recent', '最近访问') }}</strong>
-          <div class="attendance__admin-nav-recents-meta">
-            <span>{{ `${visibleRecentAdminSectionNavItems.length}` }}</span>
-            <button
-              class="attendance__btn attendance__btn--inline"
-              type="button"
-              data-admin-recents-clear="true"
-              @click="emit('clearRecents')"
-            >
-              {{ tr('Clear', '清空') }}
-            </button>
-          </div>
-        </div>
-        <div class="attendance__admin-nav-recents-items">
-          <button
-            v-for="item in visibleRecentAdminSectionNavItems"
-            :key="`recent-${item.id}`"
-            class="attendance__admin-nav-link attendance__admin-nav-link--recent"
-            :class="{ 'attendance__admin-nav-link--active': adminActiveSectionId === item.id }"
-            :aria-current="adminActiveSectionId === item.id ? 'true' : undefined"
-            :data-admin-anchor-recent="item.id"
-            type="button"
-            @click="emit('selectSection', item.id)"
-          >
-            {{ item.contextLabel }}
-          </button>
-        </div>
-      </section>
       <nav class="attendance__admin-nav" :aria-label="tr('Attendance admin sections', '考勤管理区块')">
         <section
           v-for="group in visibleAdminSectionNavGroups"
@@ -111,7 +29,6 @@
           >
             <span class="attendance__admin-nav-group-title">{{ group.label }}</span>
             <span class="attendance__admin-nav-group-meta">
-              <span class="attendance__admin-nav-group-count">{{ group.countLabel }}</span>
               <span class="attendance__admin-nav-group-caret" aria-hidden="true">{{ group.expanded ? '▾' : '▸' }}</span>
             </span>
           </button>
@@ -145,23 +62,38 @@ import type {
   TranslateFn,
 } from './useAttendanceAdminRail'
 
-defineProps<{
+withDefaults(defineProps<{
   tr: TranslateFn
-  adminSectionNavCountLabel: string
-  adminNavStorageScope: string
-  adminNavDefaultStorageScope: string
-  adminNavScopeFeedback: string
-  activeAdminSectionContextLabel: string
-  isCompactAdminNav: boolean
-  adminCompactNavOpen: boolean
-  adminSectionFilter: string
-  adminSectionFilterActive: boolean
-  allAdminSectionGroupsExpanded: boolean
-  allAdminSectionGroupsCollapsed: boolean
-  visibleRecentAdminSectionNavItems: AdminSectionNavDisplayItem[]
-  visibleAdminSectionNavGroups: AdminSectionNavGroup[]
-  adminActiveSectionId: string
-}>()
+  adminSectionNavCountLabel?: string
+  adminNavStorageScope?: string
+  adminNavDefaultStorageScope?: string
+  adminNavScopeFeedback?: string
+  activeAdminSectionContextLabel?: string
+  isCompactAdminNav?: boolean
+  adminCompactNavOpen?: boolean
+  adminSectionFilter?: string
+  adminSectionFilterActive?: boolean
+  allAdminSectionGroupsExpanded?: boolean
+  allAdminSectionGroupsCollapsed?: boolean
+  visibleRecentAdminSectionNavItems?: AdminSectionNavDisplayItem[]
+  visibleAdminSectionNavGroups?: AdminSectionNavGroup[]
+  adminActiveSectionId?: string
+}>(), {
+  adminSectionNavCountLabel: '',
+  adminNavStorageScope: '',
+  adminNavDefaultStorageScope: '',
+  adminNavScopeFeedback: '',
+  activeAdminSectionContextLabel: '',
+  isCompactAdminNav: false,
+  adminCompactNavOpen: false,
+  adminSectionFilter: '',
+  adminSectionFilterActive: false,
+  allAdminSectionGroupsExpanded: false,
+  allAdminSectionGroupsCollapsed: false,
+  visibleRecentAdminSectionNavItems: () => [],
+  visibleAdminSectionNavGroups: () => [],
+  adminActiveSectionId: '',
+})
 
 const emit = defineEmits<{
   (event: 'update:compactNavOpen', value: boolean): void
@@ -226,110 +158,9 @@ const emit = defineEmits<{
 
 .attendance__admin-nav-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 12px;
   font-size: 12px;
   color: #6b7280;
-}
-
-.attendance__admin-nav-header-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
-.attendance__admin-nav-scope-badge {
-  max-width: 120px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: #e0e7ff;
-  color: #3730a3;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.attendance__admin-nav-scope-note {
-  margin-top: -4px;
-  padding: 8px 10px;
-  border-radius: 10px;
-  background: #eef6ff;
-  color: #1d4ed8;
-  font-size: 12px;
-  line-height: 1.4;
-}
-
-.attendance__admin-nav-current {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 8px 10px;
-  border: 1px solid #dbeafe;
-  border-radius: 10px;
-  background: #f8fbff;
-  color: #6b7280;
-  font-size: 12px;
-}
-
-.attendance__admin-nav-current strong {
-  color: #1f2937;
-  font-size: 13px;
-  line-height: 1.4;
-}
-
-.attendance__field--compact {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.attendance__field--compact span {
-  font-size: 12px;
-}
-
-.attendance__admin-nav-actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.attendance__admin-nav-recents {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-  border: 1px solid #dbeafe;
-  border-radius: 12px;
-  background: #f8fbff;
-}
-
-.attendance__admin-nav-recents-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  color: #1e3a8a;
-  font-size: 12px;
-}
-
-.attendance__admin-nav-recents-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.attendance__admin-nav-recents-items {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.attendance__admin-nav-link--recent {
-  background: #ffffff;
 }
 
 .attendance__admin-nav-toggle {
@@ -391,14 +222,9 @@ const emit = defineEmits<{
 .attendance__admin-nav-group-meta {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
   color: #6b7280;
   font-size: 11px;
-}
-
-.attendance__admin-nav-group-count {
-  min-width: 28px;
-  text-align: right;
 }
 
 .attendance__admin-nav-group-caret {

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -175,6 +175,25 @@ export function useAttendanceAdminRail({
       ],
     },
     {
+      id: 'scheduling',
+      label: tr('Scheduling', '排班执行'),
+      itemIds: [
+        ATTENDANCE_ADMIN_SECTION_IDS.rotationRules,
+        ATTENDANCE_ADMIN_SECTION_IDS.rotationAssignments,
+        ATTENDANCE_ADMIN_SECTION_IDS.shifts,
+        ATTENDANCE_ADMIN_SECTION_IDS.assignments,
+        ATTENDANCE_ADMIN_SECTION_IDS.holidays,
+      ],
+    },
+    {
+      id: 'organization',
+      label: tr('Organization', '组织分组'),
+      itemIds: [
+        ATTENDANCE_ADMIN_SECTION_IDS.attendanceGroups,
+        ATTENDANCE_ADMIN_SECTION_IDS.groupMembers,
+      ],
+    },
+    {
       id: 'policies',
       label: tr('Policies', '规则策略'),
       itemIds: [
@@ -188,14 +207,6 @@ export function useAttendanceAdminRail({
       ],
     },
     {
-      id: 'organization',
-      label: tr('Organization', '组织分组'),
-      itemIds: [
-        ATTENDANCE_ADMIN_SECTION_IDS.attendanceGroups,
-        ATTENDANCE_ADMIN_SECTION_IDS.groupMembers,
-      ],
-    },
-    {
       id: 'data-payroll',
       label: tr('Data & Payroll', '数据与计薪'),
       itemIds: [
@@ -203,17 +214,6 @@ export function useAttendanceAdminRail({
         ATTENDANCE_ADMIN_SECTION_IDS.importBatches,
         ATTENDANCE_ADMIN_SECTION_IDS.payrollTemplates,
         ATTENDANCE_ADMIN_SECTION_IDS.payrollCycles,
-      ],
-    },
-    {
-      id: 'scheduling',
-      label: tr('Scheduling', '排班执行'),
-      itemIds: [
-        ATTENDANCE_ADMIN_SECTION_IDS.rotationRules,
-        ATTENDANCE_ADMIN_SECTION_IDS.rotationAssignments,
-        ATTENDANCE_ADMIN_SECTION_IDS.shifts,
-        ATTENDANCE_ADMIN_SECTION_IDS.assignments,
-        ATTENDANCE_ADMIN_SECTION_IDS.holidays,
       ],
     },
   ])

--- a/apps/web/src/views/attendance/useAttendanceAdminRailNavigation.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRailNavigation.ts
@@ -8,6 +8,7 @@ type ReadonlyItemsRef = Readonly<Ref<AdminSectionNavItem[]> | ComputedRef<AdminS
 type UseAttendanceAdminRailNavigationOptions = {
   showAdmin: ReadonlyBoolRef
   adminForbidden: ReadonlyBoolRef
+  adminFocusCurrentSectionOnly?: ReadonlyBoolRef
   adminNavStorageScope: ReadonlyStringRef
   adminActiveSectionId: Ref<string>
   adminSectionNavItems: ReadonlyItemsRef
@@ -20,6 +21,7 @@ type UseAttendanceAdminRailNavigationOptions = {
 export function useAttendanceAdminRailNavigation({
   showAdmin,
   adminForbidden,
+  adminFocusCurrentSectionOnly,
   adminNavStorageScope,
   adminActiveSectionId,
   adminSectionNavItems,
@@ -150,19 +152,24 @@ export function useAttendanceAdminRailNavigation({
     await nextTick()
     const link = resolveActiveAdminNavLink(id)
     if (!(link instanceof HTMLElement)) return
-    link.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'nearest' })
+    link.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'nearest' })
   }
 
   function scrollToAdminSection(id: string): void {
     if (typeof document === 'undefined') return
     const target = adminSectionElements.get(id) ?? document.getElementById(id)
     if (!(target instanceof HTMLElement)) return
+    const content = target.closest<HTMLElement>('[data-admin-content="true"]')
     adminActiveSectionId.value = id
     adminHashSyncReady = true
     syncAdminSectionHash(id)
     if (isCompactAdminNav.value) {
       adminCompactNavOpen.value = false
     }
+    if (content instanceof HTMLElement) {
+      content.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+    if (adminFocusCurrentSectionOnly?.value) return
     target.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
 

--- a/apps/web/tests/AttendanceAdminRail.spec.ts
+++ b/apps/web/tests/AttendanceAdminRail.spec.ts
@@ -86,13 +86,16 @@ describe('AttendanceAdminRail', () => {
     mountRail()
     await flushUi()
 
-    expect(container!.querySelector('.attendance__admin-nav-current')?.textContent).toContain('Workspace · Settings')
+    expect(container!.querySelector('.attendance__admin-nav-header')?.textContent).toContain('Jump to')
     expect(container!.querySelector('.attendance__admin-nav-group-title')?.textContent).toContain('Workspace')
-    expect(container!.querySelector('[data-admin-anchor-recent="attendance-admin-approval-flows"]')?.textContent).toContain('Policies · Approval Flows')
-    expect(container!.querySelector('[data-admin-recents-clear="true"]')).toBeTruthy()
+    expect(container!.querySelector('[data-admin-anchor="attendance-admin-settings"]')?.textContent).toContain('Settings')
+    expect(container!.querySelector('.attendance__admin-nav-current')).toBeNull()
+    expect(container!.querySelector('#attendance-admin-nav-filter')).toBeNull()
+    expect(container!.querySelector('.attendance__admin-nav-actions')).toBeNull()
+    expect(container!.querySelector('[data-admin-anchor-recent]')).toBeNull()
   })
 
-  it('emits interaction events for the extracted rail surface', async () => {
+  it('emits interaction events for compact toggle, grouped sections, and item selection', async () => {
     const handlers = mountRail({ isCompactAdminNav: true, adminCompactNavOpen: true })
     await flushUi()
 
@@ -102,27 +105,11 @@ describe('AttendanceAdminRail', () => {
     await flushUi()
     expect(handlers['onUpdate:compactNavOpen']).toHaveBeenCalledWith(false)
 
-    const filter = container!.querySelector<HTMLInputElement>('#attendance-admin-nav-filter')!
-    filter.value = 'pay'
-    filter.dispatchEvent(new Event('input', { bubbles: true }))
-    await flushUi()
-    expect(handlers['onUpdate:sectionFilter']).toHaveBeenCalledWith('pay')
-
     container!.querySelector<HTMLButtonElement>('.attendance__admin-nav-group-header')!.click()
     container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-settings"]')!.click()
-    container!.querySelector<HTMLButtonElement>('[data-admin-anchor-recent="attendance-admin-approval-flows"]')!.click()
-    container!.querySelector<HTMLButtonElement>('[data-admin-recents-clear="true"]')!.click()
-    container!.querySelectorAll<HTMLButtonElement>('.attendance__admin-nav-actions .attendance__btn')[0]!.click()
-    container!.querySelectorAll<HTMLButtonElement>('.attendance__admin-nav-actions .attendance__btn')[1]!.click()
-    container!.querySelectorAll<HTMLButtonElement>('.attendance__admin-nav-actions .attendance__btn')[2]!.click()
     await flushUi()
 
     expect(handlers.onToggleGroup).toHaveBeenCalledWith('workspace')
     expect(handlers.onSelectSection).toHaveBeenCalledWith('attendance-admin-settings')
-    expect(handlers.onSelectSection).toHaveBeenCalledWith('attendance-admin-approval-flows')
-    expect(handlers.onClearRecents).toHaveBeenCalled()
-    expect(handlers.onExpandAll).toHaveBeenCalled()
-    expect(handlers.onCollapseAll).toHaveBeenCalled()
-    expect(handlers.onCopyCurrentLink).toHaveBeenCalled()
   })
 })

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -122,7 +122,7 @@ describe('Attendance admin anchor navigation', () => {
       item => item.textContent?.trim() || '',
     )
 
-    expect(groupLabels).toEqual(['Workspace', 'Policies', 'Organization', 'Data & Payroll', 'Scheduling'])
+    expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Data & Payroll'])
     expect(labels).toHaveLength(22)
     expect(labels).toEqual(
       expect.arrayContaining([
@@ -137,8 +137,10 @@ describe('Attendance admin anchor navigation', () => {
     )
     expect(labels).not.toContain('Holiday overrides')
     expect(labels).not.toContain('Template Versions')
-    expect(container!.querySelector('.attendance__admin-nav-scope-badge')).toBeNull()
-    expect(container!.querySelector('.attendance__admin-nav-current')?.textContent).toContain('Workspace · Settings')
+    expect(container!.querySelector('.attendance__admin-nav-current')).toBeNull()
+    expect(container!.querySelector('#attendance-admin-nav-filter')).toBeNull()
+    expect(container!.querySelector('.attendance__admin-nav-actions')).toBeNull()
+    expect(container!.querySelector('[data-admin-anchor-recent]')).toBeNull()
   })
 
   it('collapses and expands admin anchor groups', async () => {
@@ -183,7 +185,7 @@ describe('Attendance admin anchor navigation', () => {
     expect(container!.querySelector('[data-admin-anchor="attendance-admin-approval-flows"]')).toBeNull()
   })
 
-  it('scrolls to the selected anchor target, keeps the rail item visible, and marks it active', async () => {
+  it('scrolls the focused right content back to the top region, keeps the rail item visible, and marks it active', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
     await flushUi()
@@ -197,12 +199,13 @@ describe('Attendance admin anchor navigation', () => {
 
     expect(scrollIntoViewSpy).toHaveBeenCalled()
     const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
-    expect(scrolledTargets.some(target => target.id === 'attendance-admin-import-batches')).toBe(true)
+    expect(scrolledTargets.some(target => target.id === 'attendance-admin-import-batches')).toBe(false)
+    expect(scrolledTargets.some(target => target.dataset.adminContent === 'true')).toBe(true)
     expect(scrolledTargets.some(target => target.dataset.adminAnchor === 'attendance-admin-import-batches')).toBe(true)
     expect(window.location.hash).toBe('#attendance-admin-import-batches')
     expect(button?.getAttribute('aria-current')).toBe('true')
     expect(button?.classList.contains('attendance__admin-nav-link--active')).toBe(true)
-    expect(container!.querySelector('.attendance__admin-nav-current')?.textContent).toContain('Data & Payroll · Import batches')
+    expect(container!.querySelector('[data-admin-shortcut="attendance-admin-import-batches"]')?.textContent).toContain('Data & Payroll · Import batches')
   })
 
   it('focuses the right pane on the active admin section by default and can reveal all sections on demand', async () => {
@@ -225,14 +228,25 @@ describe('Attendance admin anchor navigation', () => {
     expect(settingsSection?.style.display).toBe('none')
     expect(holidaysSection?.style.display).not.toBe('none')
 
-    const revealAllButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('.attendance__admin-header .attendance__btn'))
-      .find(button => button.textContent?.includes('Show all sections'))
+    const revealAllButton = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
     expect(revealAllButton).toBeTruthy()
     revealAllButton!.click()
     await flushUi(2)
 
     expect(settingsSection?.style.display).not.toBe('none')
     expect(holidaysSection?.style.display).not.toBe('none')
+  })
+
+  it('renders a sticky current-section bar in the right pane', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const currentSectionBar = container!.querySelector<HTMLElement>('[data-admin-current-section="true"]')
+    expect(currentSectionBar).toBeTruthy()
+    expect(currentSectionBar?.textContent).toContain('Current section')
+    expect(currentSectionBar?.textContent).toContain('Workspace · Settings')
+    expect(currentSectionBar?.querySelector('[data-admin-focus-toggle="true"]')?.textContent).toContain('Show all sections')
   })
 
   it('restores the live user picker, structured rule builder, and holiday month calendar interactions', async () => {
@@ -339,26 +353,26 @@ describe('Attendance admin anchor navigation', () => {
     expect(importSection!.querySelector('.attendance__template-guide')).toBeTruthy()
   })
 
-  it('filters anchor items with the quick-find input', async () => {
+  it('surfaces recent shortcuts at the top of the admin content instead of inside the left rail', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
     await flushUi()
 
-    const input = container!.querySelector<HTMLInputElement>('#attendance-admin-nav-filter')
-    expect(input).toBeTruthy()
-    input!.value = 'payroll'
-    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    const payrollTemplates = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-payroll-templates"]')
+    const payrollCycles = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-payroll-cycles"]')
+    expect(payrollTemplates).toBeTruthy()
+    expect(payrollCycles).toBeTruthy()
+
+    payrollTemplates!.click()
+    await flushUi(2)
+    payrollCycles!.click()
     await flushUi(2)
 
-    const labels = Array.from(container!.querySelectorAll('.attendance__admin-nav-link')).map(
+    const labels = Array.from(container!.querySelectorAll('[data-admin-shortcut]')).map(
       item => item.textContent?.trim() || '',
     )
-    const groupLabels = Array.from(container!.querySelectorAll('.attendance__admin-nav-group-title')).map(
-      item => item.textContent?.trim() || '',
-    )
-    expect(groupLabels).toEqual(['Data & Payroll'])
-    expect(labels).toEqual(['Payroll Templates', 'Payroll Cycles'])
-    expect(container!.textContent).toContain('2/22 items')
+    expect(labels).toEqual(['Data & Payroll · Payroll Cycles', 'Data & Payroll · Payroll Templates'])
+    expect(container!.querySelector('[data-admin-anchor-recent]')).toBeNull()
   })
 
   it('restores the hashed admin anchor on first load', async () => {
@@ -378,46 +392,17 @@ describe('Attendance admin anchor navigation', () => {
     expect(window.location.hash).toBe('#attendance-admin-approval-flows')
   })
 
-  it('supports expand all and collapse all controls', async () => {
+  it('does not render the removed left-rail clutter controls', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
     await flushUi()
 
-    const controls = Array.from(container!.querySelectorAll<HTMLButtonElement>('.attendance__admin-nav-actions .attendance__btn'))
-    const expandAll = controls.find(button => button.textContent?.includes('Expand all'))
-    const collapseAll = controls.find(button => button.textContent?.includes('Collapse all'))
-    expect(expandAll).toBeTruthy()
-    expect(collapseAll).toBeTruthy()
-
-    collapseAll!.click()
-    await flushUi(2)
-    expect(container!.querySelector('[data-admin-anchor="attendance-admin-approval-flows"]')).toBeNull()
-    expect(container!.querySelector('[data-admin-anchor-group="policies"] [aria-expanded="false"]')).toBeTruthy()
-
-    expandAll!.click()
-    await flushUi(2)
-    expect(container!.querySelector('[data-admin-anchor="attendance-admin-approval-flows"]')).toBeTruthy()
-    expect(container!.querySelector('[data-admin-anchor-group="policies"] [aria-expanded="true"]')).toBeTruthy()
-  })
-
-  it('copies the current admin section deep link', async () => {
-    app = createApp(AttendanceView, { mode: 'admin' })
-    app.mount(container!)
-    await flushUi()
-
-    const target = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-import-batches"]')
-    target!.click()
-    await flushUi(2)
-
-    const copyButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('.attendance__admin-nav-actions .attendance__btn'))
-      .find(button => button.textContent?.includes('Copy current link'))
-    expect(copyButton).toBeTruthy()
-    copyButton!.click()
-    await flushUi(2)
-
-    expect(clipboardWriteTextSpy).toHaveBeenCalledTimes(1)
-    expect(clipboardWriteTextSpy.mock.calls[0]?.[0]).toContain('#attendance-admin-import-batches')
-    expect(container!.textContent).toContain('Current admin section link copied.')
+    expect(container!.querySelector('#attendance-admin-nav-filter')).toBeNull()
+    expect(container!.querySelector('.attendance__admin-nav-actions')).toBeNull()
+    expect(container!.textContent).not.toContain('Quick find')
+    expect(container!.textContent).not.toContain('Expand all')
+    expect(container!.textContent).not.toContain('Collapse all')
+    expect(container!.textContent).not.toContain('Copy current link')
   })
 
   it('tracks recent admin sections as operators move across the console', async () => {
@@ -435,7 +420,7 @@ describe('Attendance admin anchor navigation', () => {
     approvalFlows!.click()
     await flushUi(2)
 
-    const labels = Array.from(container!.querySelectorAll('[data-admin-anchor-recent]')).map(
+    const labels = Array.from(container!.querySelectorAll('[data-admin-shortcut]')).map(
       item => item.textContent?.trim() || '',
     )
     expect(labels).toEqual(['Policies · Approval Flows', 'Data & Payroll · Import batches'])
@@ -461,7 +446,7 @@ describe('Attendance admin anchor navigation', () => {
     app.mount(container!)
     await flushUi()
 
-    const labels = Array.from(container!.querySelectorAll('[data-admin-anchor-recent]')).map(
+    const labels = Array.from(container!.querySelectorAll('[data-admin-shortcut]')).map(
       item => item.textContent?.trim() || '',
     )
     expect(labels).toEqual(['Policies · Approval Flows', 'Data & Payroll · Import batches'])
@@ -479,12 +464,12 @@ describe('Attendance admin anchor navigation', () => {
     approvalFlows!.click()
     await flushUi(2)
 
-    const clearButton = container!.querySelector<HTMLButtonElement>('[data-admin-recents-clear="true"]')
+    const clearButton = container!.querySelector<HTMLButtonElement>('[data-admin-shortcuts-clear="true"]')
     expect(clearButton).toBeTruthy()
     clearButton!.click()
     await flushUi(2)
 
-    expect(container!.querySelector('[data-admin-anchor-recent]')).toBeNull()
+    expect(container!.querySelector('[data-admin-shortcut]')).toBeNull()
     expect(window.localStorage.getItem(scopedAdminNavStorageKey(ADMIN_NAV_RECENTS_STORAGE_KEY))).toBe('[]')
     expect(container!.textContent).toContain('Recent admin shortcuts cleared.')
   })
@@ -529,16 +514,13 @@ describe('Attendance admin anchor navigation', () => {
     vm.orgId = 'org-b'
     await flushUi(3)
 
-    const labels = Array.from(container!.querySelectorAll('[data-admin-anchor-recent]')).map(
+    const labels = Array.from(container!.querySelectorAll('[data-admin-shortcut]')).map(
       item => item.textContent?.trim() || '',
     )
     expect(labels).toEqual(['Data & Payroll · Payroll Cycles', 'Data & Payroll · Import batches'])
-    expect(container!.querySelector('.attendance__admin-nav-scope-badge')?.textContent?.trim()).toBe('org-b')
-    expect(container!.textContent).toContain('Switched to navigation memory for org-b.')
     expect(scrollIntoViewSpy).toHaveBeenCalled()
     const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
     expect(scrolledTargets.some(target => target.id === 'attendance-admin-payroll-cycles')).toBe(true)
-    expect(container!.querySelector('.attendance__admin-nav-current')?.textContent).toContain('Data & Payroll · Payroll Cycles')
   })
 
   it('collapses the grouped rail behind a toggle on narrow screens', async () => {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -312,7 +312,7 @@ describe('Attendance admin regressions', () => {
     app.mount(container!)
     await flushUi()
 
-    const toggle = container!.querySelector<HTMLButtonElement>('.attendance__admin-actions .attendance__btn')
+    const toggle = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
     expect(toggle?.textContent).toContain('Show all sections')
 
     toggle!.click()
@@ -334,7 +334,7 @@ describe('Attendance admin regressions', () => {
     expect(toggle?.textContent).toContain('Show all sections')
     expect(window.getComputedStyle(settings!).display).toBe('none')
     expect(window.getComputedStyle(groupMembers!).display).not.toBe('none')
-    expect(container!.querySelector('.attendance__admin-nav-current')?.textContent).toContain('Organization · Group members')
+    expect(container!.querySelector('[data-admin-shortcut="attendance-admin-group-members"]')?.textContent).toContain('Organization · Group members')
     expect(container!.textContent).toContain('User picker')
     expect(container!.textContent).toContain('Append selected user')
   })
@@ -360,7 +360,7 @@ describe('Attendance admin regressions', () => {
     expect(visibleEditButton).toBeTruthy()
     expect(window.getComputedStyle(leaveTypeSection!).display).toBe('none')
 
-    const toggle = container!.querySelector<HTMLButtonElement>('.attendance__admin-header .attendance__admin-actions .attendance__btn')
+    const toggle = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
     expect(toggle?.textContent).toContain('Show all sections')
     toggle!.click()
     await flushUi(2)

--- a/apps/web/tests/useAttendanceAdminRailNavigation.spec.ts
+++ b/apps/web/tests/useAttendanceAdminRailNavigation.spec.ts
@@ -52,7 +52,7 @@ describe('useAttendanceAdminRailNavigation', () => {
     container = null
   })
 
-  function mountHost() {
+  function mountHost(options?: { focused?: boolean }) {
     const items: AdminSectionNavItem[] = [
       { id: 'attendance-admin-settings', label: 'Settings' },
       { id: 'attendance-admin-approval-flows', label: 'Approval Flows' },
@@ -61,6 +61,7 @@ describe('useAttendanceAdminRailNavigation', () => {
       setup() {
         const showAdmin = ref(true)
         const adminForbidden = ref(false)
+        const adminFocusCurrentSectionOnly = ref(options?.focused ?? false)
         const adminNavStorageScope = ref('default')
         const adminActiveSectionId = ref(items[0].id)
         const isCompactAdminNav = ref(false)
@@ -68,6 +69,7 @@ describe('useAttendanceAdminRailNavigation', () => {
         const { adminSectionBinding, scrollToAdminSection } = useAttendanceAdminRailNavigation({
           showAdmin,
           adminForbidden,
+          adminFocusCurrentSectionOnly,
           adminNavStorageScope,
           adminActiveSectionId,
           adminSectionNavItems: ref(items),
@@ -109,6 +111,26 @@ describe('useAttendanceAdminRailNavigation', () => {
     const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
     expect(scrolledTargets.some(target => target.id === 'attendance-admin-approval-flows')).toBe(true)
     expect(scrolledTargets.some(target => target.dataset.adminAnchor === 'attendance-admin-approval-flows')).toBe(true)
+  })
+
+  it('scrolls only the content pane in focused mode when selecting a section', async () => {
+    const vm = mountHost({ focused: true })
+    await flushUi()
+
+    const content = document.createElement('div')
+    content.dataset.adminContent = 'true'
+    const target = document.getElementById('attendance-admin-approval-flows')
+    expect(target).toBeTruthy()
+    content.appendChild(target!)
+    container!.appendChild(content)
+    scrollIntoViewSpy.mockClear()
+
+    vm.scrollToAdminSection('attendance-admin-approval-flows')
+    await flushUi()
+
+    const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
+    expect(scrolledTargets.some(element => element.dataset.adminContent === 'true')).toBe(true)
+    expect(scrolledTargets.some(element => element.id === 'attendance-admin-approval-flows')).toBe(false)
   })
 
   it('closes compact nav after selecting a section', async () => {

--- a/docs/development/attendance-v271-admin-nav-ux-design-20260329.md
+++ b/docs/development/attendance-v271-admin-nav-ux-design-20260329.md
@@ -1,0 +1,81 @@
+# Attendance v2.7.1 Admin Nav UX Design
+
+## Goal
+
+Reduce friction in the attendance admin console when operators jump between deep sections such as `Shifts`.
+
+The current pain points were:
+
+1. The left rail carried too much chrome before the actual section links.
+2. `Shifts` and other scheduling sections sat too low in the rail.
+3. After selecting a left-rail section, operators could still feel stranded in the old scroll position.
+
+## Scope
+
+This slice stays entirely in the attendance admin shell:
+
+1. Simplify the left rail into a plain grouped directory.
+2. Move recent shortcuts out of the rail and into the top of the admin content area.
+3. Bring the scheduling group higher in the rail ordering.
+4. Make section selection bring the right content back to the top region immediately.
+5. Keep the current section and focus toggle visible inside the right pane itself.
+
+## UX Changes
+
+### Left Rail
+
+Removed from the left rail:
+
+- section count
+- current section summary
+- quick-find input
+- expand all
+- collapse all
+- copy current link
+- embedded recents block
+
+The rail now acts as a cleaner jump list with grouped headings only.
+
+### Recent Access
+
+Recent shortcuts still use the existing persisted recents model, but now render at the top of the admin content area as compact jump chips. This keeps high-value revisits visible without pushing the primary directory downward.
+
+### Current Section Bar
+
+The right pane now renders a sticky current-section bar above the content body.
+
+It shows:
+
+- the active section context label
+- a short usage hint
+- the focused/show-all toggle in the same place operators are already looking
+
+This shortens the interaction loop: operators no longer need to scroll back to the top header just to change the visibility mode.
+
+### Group Ordering
+
+The group order is now:
+
+1. Workspace
+2. Scheduling
+3. Organization
+4. Policies
+5. Data & Payroll
+
+This moves `Shifts` and related scheduling actions significantly closer to the top.
+
+### Scroll Behavior
+
+When a section is selected:
+
+1. the active rail link is centered into view in the left rail
+2. the right content container is scrolled back into the top region in focused mode
+3. the target section is only scrolled into place when operators reveal all sections
+
+This avoids a double-scroll fight in focused mode while keeping section-level navigation intact in expanded mode.
+
+## Non-goals
+
+- No backend/API changes
+- No change to focused-mode semantics
+- No removal of the underlying recents/collapse persistence model

--- a/docs/development/attendance-v271-admin-nav-ux-verification-20260329.md
+++ b/docs/development/attendance-v271-admin-nav-ux-verification-20260329.md
@@ -1,0 +1,48 @@
+# Attendance v2.7.1 Admin Nav UX Verification
+
+## Commands
+
+```bash
+git diff --check
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+cd apps/web && ../../node_modules/.bin/vitest run tests/AttendanceAdminRail.spec.ts tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts tests/useAttendanceAdminRailNavigation.spec.ts --watch=false
+cd apps/web && ./node_modules/.bin/vite build
+```
+
+## Focused Test Result
+
+The admin-nav focused suite passed:
+
+- `tests/AttendanceAdminRail.spec.ts`
+- `tests/attendance-admin-anchor-nav.spec.ts`
+- `tests/attendance-admin-regressions.spec.ts`
+- `tests/useAttendanceAdminRailNavigation.spec.ts`
+
+Observed result:
+
+- `4 files`
+- `27 tests passed`
+
+The updated coverage locks:
+
+- left rail renders as a lean grouped directory
+- recent shortcuts render at the top of the admin content area
+- a sticky current-section bar renders in the right pane and owns the focus/show-all toggle
+- focused-mode section selection scrolls the content container without a second target scroll override
+- grouped navigation still works in compact mode
+- focused-mode admin flows and existing Run21 regressions stay intact
+
+## Type And Build Result
+
+- `vue-tsc --noEmit` passed
+- `vite build` passed
+
+## Claude Code Review
+
+Claude Code was actually invoked in this slice as a scoped UI review assistant.
+
+Its useful recommendation was to add a sticky breadcrumb-like current-section bar inside the right pane rather than re-expanding the left rail. The final implementation adopted that part, but intentionally skipped arrow-based prev/next navigation to keep the slice smaller and lower-risk.
+
+## Environment Note
+
+`pnpm exec vitest` in this worktree intermittently hit a local Vite config temp-file `ENOSPC` issue even though the filesystem still had free space. The verification command therefore used the same checked-in workspace binaries directly from `apps/web/node_modules/.bin`, and the tests completed successfully.


### PR DESCRIPTION
## Summary
- simplify the attendance admin left rail by removing low-value chrome and keeping only grouped section navigation
- move recent admin shortcuts to the top of the page content so they stay reachable without left-rail scrolling
- make section selection bring the right content area back to the top region and move Scheduling higher in the rail order

## Verification
- git diff --check
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- cd apps/web && ../../node_modules/.bin/vitest run tests/AttendanceAdminRail.spec.ts tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts tests/useAttendanceAdminRailNavigation.spec.ts --watch=false
- cd apps/web && ./node_modules/.bin/vite build

## Design / Verification Docs
- docs/development/attendance-v271-admin-nav-ux-design-20260329.md
- docs/development/attendance-v271-admin-nav-ux-verification-20260329.md
