### PR TITLE
feat(attendance): add admin section pager

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -554,12 +554,38 @@
               </div>
               <div class="attendance__admin-current-section-actions">
                 <button
+                  class="attendance__btn attendance__btn--inline attendance__admin-current-section-nav"
+                  :class="{ 'attendance__admin-current-section-nav--disabled': !previousAdminSectionNavItem }"
+                  type="button"
+                  data-admin-prev-section
+                  :data-admin-prev-section-id="previousAdminSectionNavItem?.id || ''"
+                  :disabled="!previousAdminSectionNavItem"
+                  :title="previousAdminSectionNavItem?.contextLabel || ''"
+                  @click="previousAdminSectionNavItem && selectAdminSection(previousAdminSectionNavItem.id)"
+                >
+                  <span class="attendance__admin-current-section-nav-direction">{{ tr('Prev', '上一个') }}</span>
+                  <strong>{{ previousAdminSectionNavItem?.label || tr('Start', '起点') }}</strong>
+                </button>
+                <button
                   class="attendance__btn attendance__btn--inline"
                   type="button"
                   data-admin-focus-toggle="true"
                   @click="adminFocusedMode = !adminFocusedMode"
                 >
                   {{ adminFocusedMode ? tr('Show all sections', '显示全部区块') : tr('Focus current section', '仅显示当前区块') }}
+                </button>
+                <button
+                  class="attendance__btn attendance__btn--inline attendance__admin-current-section-nav"
+                  :class="{ 'attendance__admin-current-section-nav--disabled': !nextAdminSectionNavItem }"
+                  type="button"
+                  data-admin-next-section
+                  :data-admin-next-section-id="nextAdminSectionNavItem?.id || ''"
+                  :disabled="!nextAdminSectionNavItem"
+                  :title="nextAdminSectionNavItem?.contextLabel || ''"
+                  @click="nextAdminSectionNavItem && selectAdminSection(nextAdminSectionNavItem.id)"
+                >
+                  <span class="attendance__admin-current-section-nav-direction">{{ tr('Next', '下一个') }}</span>
+                  <strong>{{ nextAdminSectionNavItem?.label || tr('End', '终点') }}</strong>
                 </button>
               </div>
             </div>
@@ -4951,6 +4977,8 @@ const {
   expandAllAdminSectionGroups,
   isCompactAdminNav,
   isKnownAdminSectionId,
+  nextAdminSectionNavItem,
+  previousAdminSectionNavItem,
   readLastAdminSection,
   collapseAllAdminSectionGroups,
   toggleAdminSectionGroup,
@@ -12270,8 +12298,33 @@ const holidaySectionBindings = {
 .attendance__admin-current-section-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   flex-shrink: 0;
+}
+
+.attendance__admin-current-section-nav {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  min-width: 112px;
+}
+
+.attendance__admin-current-section-nav strong {
+  font-size: 12px;
+}
+
+.attendance__admin-current-section-nav-direction {
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.attendance__admin-current-section-nav--disabled {
+  opacity: 0.62;
 }
 
 .attendance__admin-content--focused .attendance__admin-section + .attendance__admin-section {

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -364,6 +364,22 @@ export function useAttendanceAdminRail({
   })
 
   const visibleAdminSectionNavItems = computed(() => visibleAdminSectionNavGroups.value.flatMap(group => group.items))
+  const orderedAdminSectionNavItems = computed<AdminSectionNavDisplayItem[]>(() => {
+    return adminSectionNavGroups.value.flatMap(group => {
+      return group.itemIds
+        .map(id => adminSectionItemMap.value.get(id))
+        .filter((item): item is AdminSectionNavItem => Boolean(item))
+        .map(item => {
+          const groupLabel = adminSectionGroupLabelByItemId.value.get(item.id) ?? null
+          const contextLabel = formatAdminSectionContextLabel(item)
+          return {
+            ...item,
+            groupLabel,
+            contextLabel,
+          }
+        })
+    })
+  })
   const visibleRecentAdminSectionNavItems = computed<AdminSectionNavDisplayItem[]>(() => {
     const query = adminSectionFilterQuery.value
     return adminRecentSectionIds.value
@@ -383,6 +399,19 @@ export function useAttendanceAdminRail({
   const activeAdminSectionContextLabel = computed(() => {
     const activeItem = adminSectionItemMap.value.get(adminActiveSectionId.value)
     return formatAdminSectionContextLabel(activeItem)
+  })
+  const activeAdminSectionOrderedIndex = computed(() => {
+    return orderedAdminSectionNavItems.value.findIndex(item => item.id === adminActiveSectionId.value)
+  })
+  const previousAdminSectionNavItem = computed<AdminSectionNavDisplayItem | null>(() => {
+    const activeIndex = activeAdminSectionOrderedIndex.value
+    if (activeIndex <= 0) return null
+    return orderedAdminSectionNavItems.value[activeIndex - 1] ?? null
+  })
+  const nextAdminSectionNavItem = computed<AdminSectionNavDisplayItem | null>(() => {
+    const activeIndex = activeAdminSectionOrderedIndex.value
+    if (activeIndex < 0 || activeIndex >= orderedAdminSectionNavItems.value.length - 1) return null
+    return orderedAdminSectionNavItems.value[activeIndex + 1] ?? null
   })
   const allAdminSectionGroupsExpanded = computed(() => adminCollapsedGroupIds.value.length === 0)
   const allAdminSectionGroupsCollapsed = computed(() => {
@@ -459,6 +488,9 @@ export function useAttendanceAdminRail({
     expandAllAdminSectionGroups,
     isCompactAdminNav,
     isKnownAdminSectionId,
+    nextAdminSectionNavItem,
+    orderedAdminSectionNavItems,
+    previousAdminSectionNavItem,
     readLastAdminSection,
     collapseAllAdminSectionGroups,
     toggleAdminSectionGroup,

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -247,6 +247,30 @@ describe('Attendance admin anchor navigation', () => {
     expect(currentSectionBar?.textContent).toContain('Current section')
     expect(currentSectionBar?.textContent).toContain('Workspace · Settings')
     expect(currentSectionBar?.querySelector('[data-admin-focus-toggle="true"]')?.textContent).toContain('Show all sections')
+    expect(currentSectionBar?.querySelector('[data-admin-prev-section]')?.getAttribute('data-admin-prev-section-id')).toBe('')
+    expect(currentSectionBar?.querySelector('[data-admin-next-section]')?.getAttribute('data-admin-next-section-id')).toBe('attendance-admin-user-access')
+  })
+
+  it('lets operators move to the previous and next section from the current-section bar', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const nextButton = container!.querySelector<HTMLButtonElement>('[data-admin-next-section]')
+    expect(nextButton?.getAttribute('data-admin-next-section-id')).toBe('attendance-admin-user-access')
+    nextButton!.click()
+    await flushUi(2)
+
+    expect(window.location.hash).toBe('#attendance-admin-user-access')
+    expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Workspace · User Access')
+    expect(container!.querySelector('[data-admin-prev-section]')?.getAttribute('data-admin-prev-section-id')).toBe('attendance-admin-settings')
+
+    const previousButton = container!.querySelector<HTMLButtonElement>('[data-admin-prev-section]')
+    previousButton!.click()
+    await flushUi(2)
+
+    expect(window.location.hash).toBe('#attendance-admin-settings')
+    expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Workspace · Settings')
   })
 
   it('restores the live user picker, structured rule builder, and holiday month calendar interactions', async () => {

--- a/docs/development/attendance-v271-admin-nav-pager-design-20260329.md
+++ b/docs/development/attendance-v271-admin-nav-pager-design-20260329.md
@@ -1,0 +1,55 @@
+# Attendance v2.7.1 Admin Nav Pager Design
+
+## Goal
+
+Reduce the number of times operators must return to the left rail when moving through nearby attendance admin sections.
+
+The previous slice already:
+
+1. simplified the left rail,
+2. moved recent shortcuts to the top of the right pane,
+3. added a sticky current-section bar.
+
+This follow-up adds lightweight adjacent navigation inside that current-section bar.
+
+## Scope
+
+This slice stays in the attendance admin shell only:
+
+1. expose a stable previous/next section relationship,
+2. render previous/next controls inside the sticky current-section bar,
+3. keep the existing focused/show-all toggle in the same bar.
+
+## UX Changes
+
+### Current Section Pager
+
+The sticky current-section bar now includes:
+
+- a previous section button,
+- the existing focused/show-all toggle,
+- a next section button.
+
+The buttons use adjacent section labels so operators can step through the admin console without returning to the left rail after every change.
+
+### Stable Navigation Order
+
+The pager uses a stable section order derived from the canonical admin section definitions rather than from the visible left-rail order.
+
+That avoids coupling the pager to compact-mode behavior, where the active group is intentionally floated toward the top of the left rail.
+
+### Interaction Model
+
+Pager clicks reuse the existing `selectAdminSection()` flow. That means they preserve:
+
+- focused-mode semantics,
+- hash sync,
+- recent-section tracking,
+- right-pane top reset behavior.
+
+## Non-goals
+
+- No backend or API changes
+- No change to left-rail structure
+- No arrow-key shortcuts or carousel behavior
+- No cross-group search UI

--- a/docs/development/attendance-v271-admin-nav-pager-verification-20260329.md
+++ b/docs/development/attendance-v271-admin-nav-pager-verification-20260329.md
@@ -1,0 +1,47 @@
+# Attendance v2.7.1 Admin Nav Pager Verification
+
+## Commands
+
+```bash
+git diff --check
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+cd apps/web && /Users/huazhou/Downloads/Github/metasheet2/node_modules/.bin/vitest run tests/AttendanceAdminRail.spec.ts tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts tests/useAttendanceAdminRailNavigation.spec.ts --watch=false
+cd apps/web && ./node_modules/.bin/vite build
+```
+
+## Focused Test Result
+
+The admin navigation suite passed:
+
+- `tests/AttendanceAdminRail.spec.ts`
+- `tests/attendance-admin-anchor-nav.spec.ts`
+- `tests/attendance-admin-regressions.spec.ts`
+- `tests/useAttendanceAdminRailNavigation.spec.ts`
+
+Observed result:
+
+- `4 files`
+- `28 tests passed`
+
+The updated coverage locks:
+
+- the sticky current-section bar still renders in the right pane,
+- the current-section bar exposes adjacent previous/next navigation,
+- pager clicks update the active section and hash through the existing selection flow,
+- focused-mode and reveal-all behavior still work,
+- the simplified left rail remains unchanged.
+
+## Type And Build Result
+
+- `vue-tsc --noEmit` passed
+- `vite build` passed
+
+## Claude Code Review
+
+Claude Code was actually invoked in this slice as a scoped UI review assistant.
+
+Its useful recommendation was to keep the pager inside the existing sticky current-section bar instead of re-expanding the left rail. The final implementation follows that boundary, while still using a stable canonical order for adjacent-section traversal.
+
+## Environment Note
+
+This worktree temporarily linked `node_modules` from the main workspace only for verification. The links were removed before commit so they do not become part of the patch.


### PR DESCRIPTION
## Summary
- add lightweight previous/next section switching inside the sticky attendance admin current-section bar
- keep the pager aligned with the stable admin section order without reintroducing left-rail complexity
- preserve the existing focused/show-all toggle and current-section context in the same right-pane control surface

## Verification
- git diff --check
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- cd apps/web && /Users/huazhou/Downloads/Github/metasheet2/node_modules/.bin/vitest run tests/AttendanceAdminRail.spec.ts tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts tests/useAttendanceAdminRailNavigation.spec.ts --watch=false
- cd apps/web && ./node_modules/.bin/vite build

## Design / Verification Docs
- docs/development/attendance-v271-admin-nav-pager-design-20260329.md
- docs/development/attendance-v271-admin-nav-pager-verification-20260329.md
