### PR TITLE
feat(attendance): add admin nav shortcuts

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -544,11 +544,19 @@
                   {{ adminFocusedMode ? tr('Current section', '当前区块') : tr('Browse sections', '浏览区块') }}
                 </span>
                 <strong>{{ activeAdminSectionContextLabel }}</strong>
-                <span>
+                <span class="attendance__admin-current-section-description">
                   {{
                     adminFocusedMode
                       ? tr('Choose another item on the left and the right pane will return here immediately.', '点击左侧其他区块后，右侧会立即回到这里。')
                       : tr('All sections are visible. Focus mode brings you back to the active block.', '当前显示全部区块；切回聚焦模式可回到当前区块。')
+                  }}
+                </span>
+                <span class="attendance__admin-current-section-hint">
+                  {{
+                    tr(
+                      'Quick switch: Alt+↑ previous · Alt+↓ next. This mode is remembered per workspace.',
+                      '快速切换：Alt+↑ 上一个 · Alt+↓ 下一个。系统会按当前工作区记住该模式。',
+                    )
                   }}
                 </span>
               </div>
@@ -4957,12 +4965,12 @@ const pluginErrorMessage = computed(() => pluginsError.value)
 
 const showAdmin = computed(() => props.mode === 'admin')
 const showOverview = computed(() => props.mode === 'overview')
-const adminFocusedMode = ref(true)
 
 const {
   adminActiveSectionId,
   adminCompactNavOpen,
   adminNavDefaultStorageScope,
+  adminFocusedMode,
   adminNavScopeFeedback,
   adminNavStorageScope,
   adminSectionFilter,
@@ -4998,6 +5006,8 @@ const {
   showAdmin,
   adminForbidden,
   adminFocusCurrentSectionOnly: adminFocusedMode,
+  previousAdminSectionId: computed(() => previousAdminSectionNavItem.value?.id ?? ''),
+  nextAdminSectionId: computed(() => nextAdminSectionNavItem.value?.id ?? ''),
   adminNavStorageScope,
   adminActiveSectionId,
   adminSectionNavItems,
@@ -12281,8 +12291,14 @@ const holidaySectionBindings = {
   font-size: 15px;
 }
 
-.attendance__admin-current-section-copy span:last-child {
+.attendance__admin-current-section-description {
   color: #64748b;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.attendance__admin-current-section-hint {
+  color: #1d4ed8;
   font-size: 12px;
   line-height: 1.45;
 }

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -5,6 +5,7 @@ export type TranslateFn = (en: string, zh: string) => string
 export const ADMIN_NAV_COLLAPSE_PREFS_STORAGE_KEY = 'metasheet_attendance_admin_nav_collapsed_groups'
 export const ADMIN_NAV_RECENTS_STORAGE_KEY = 'metasheet_attendance_admin_nav_recent_sections'
 export const ADMIN_NAV_LAST_SECTION_STORAGE_KEY = 'metasheet_attendance_admin_nav_last_section'
+export const ADMIN_NAV_FOCUS_MODE_STORAGE_KEY = 'metasheet_attendance_admin_nav_focused_mode'
 export const ADMIN_NAV_DEFAULT_STORAGE_SCOPE = 'default'
 const ADMIN_NAV_RECENT_LIMIT = 5
 
@@ -132,6 +133,27 @@ function persistLastAdminSection(scope: string, id: string): void {
   }
 }
 
+function loadAdminNavFocusedMode(scope: string): boolean {
+  if (typeof window === 'undefined') return true
+  try {
+    const raw = window.localStorage.getItem(resolveAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY, scope))
+    if (!raw) return true
+    const parsed = JSON.parse(raw)
+    return typeof parsed === 'boolean' ? parsed : true
+  } catch {
+    return true
+  }
+}
+
+function persistAdminNavFocusedMode(scope: string, focused: boolean): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(resolveAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY, scope), JSON.stringify(focused))
+  } catch {
+    // ignore storage write failures (private mode, quota).
+  }
+}
+
 export function useAttendanceAdminRail({
   tr,
   resolveStorageScope,
@@ -233,6 +255,7 @@ export function useAttendanceAdminRail({
   const adminNavStorageScope = computed(() => resolveStorageScope() ?? ADMIN_NAV_DEFAULT_STORAGE_SCOPE)
   const adminCollapsedGroupIds = ref<string[]>(loadAdminNavCollapsedGroups(adminNavStorageScope.value))
   const adminRecentSectionIds = ref<string[]>(loadAdminNavRecentSections(adminNavStorageScope.value))
+  const adminFocusedMode = ref(loadAdminNavFocusedMode(adminNavStorageScope.value))
   const isCompactAdminNav = ref(false)
   const adminCompactNavOpen = ref(false)
   const adminActiveSectionId = ref<string>(ATTENDANCE_ADMIN_SECTION_IDS.settings)
@@ -457,10 +480,15 @@ export function useAttendanceAdminRail({
     persistAdminNavRecentSections(adminNavStorageScope.value, Array.from(new Set(sectionIds)).slice(0, ADMIN_NAV_RECENT_LIMIT))
   })
 
+  watch(adminFocusedMode, focused => {
+    persistAdminNavFocusedMode(adminNavStorageScope.value, focused)
+  })
+
   watch(adminNavStorageScope, (scope, previousScope) => {
     if (scope === previousScope) return
     adminCollapsedGroupIds.value = loadAdminNavCollapsedGroups(scope)
     adminRecentSectionIds.value = loadAdminNavRecentSections(scope)
+    adminFocusedMode.value = loadAdminNavFocusedMode(scope)
     if (previousScope !== undefined) {
       setAdminNavScopeFeedback(scope)
     }
@@ -474,6 +502,7 @@ export function useAttendanceAdminRail({
     adminActiveSectionId,
     adminCompactNavOpen,
     adminNavDefaultStorageScope: ADMIN_NAV_DEFAULT_STORAGE_SCOPE,
+    adminFocusedMode,
     adminNavScopeFeedback,
     adminNavStorageScope,
     adminSectionFilter,

--- a/apps/web/src/views/attendance/useAttendanceAdminRailNavigation.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRailNavigation.ts
@@ -9,6 +9,8 @@ type UseAttendanceAdminRailNavigationOptions = {
   showAdmin: ReadonlyBoolRef
   adminForbidden: ReadonlyBoolRef
   adminFocusCurrentSectionOnly?: ReadonlyBoolRef
+  previousAdminSectionId?: ReadonlyStringRef
+  nextAdminSectionId?: ReadonlyStringRef
   adminNavStorageScope: ReadonlyStringRef
   adminActiveSectionId: Ref<string>
   adminSectionNavItems: ReadonlyItemsRef
@@ -22,6 +24,8 @@ export function useAttendanceAdminRailNavigation({
   showAdmin,
   adminForbidden,
   adminFocusCurrentSectionOnly,
+  previousAdminSectionId,
+  nextAdminSectionId,
   adminNavStorageScope,
   adminActiveSectionId,
   adminSectionNavItems,
@@ -35,6 +39,29 @@ export function useAttendanceAdminRailNavigation({
   let adminHashSyncReady = false
   let adminHashRestoreCompleted = false
   let adminHashRestorePending = false
+
+  function resolveAdminKeyboardTarget(direction: 'previous' | 'next'): string | null {
+    const candidate = direction === 'previous'
+      ? previousAdminSectionId?.value
+      : nextAdminSectionId?.value
+    return isKnownAdminSectionId(candidate) ? candidate : null
+  }
+
+  function isInteractiveAdminKeyboardTarget(target: EventTarget | null): boolean {
+    if (target instanceof HTMLElement) {
+      if (target.isContentEditable) return true
+      const tagName = target.tagName.toLowerCase()
+      if (tagName === 'input' || tagName === 'textarea' || tagName === 'select' || tagName === 'button') {
+        return true
+      }
+      if (target.closest('input, textarea, select, button, [contenteditable="true"]')) return true
+    }
+    const activeElement = typeof document !== 'undefined' ? document.activeElement : null
+    if (!(activeElement instanceof HTMLElement)) return false
+    if (activeElement.isContentEditable) return true
+    const tagName = activeElement.tagName.toLowerCase()
+    return tagName === 'input' || tagName === 'textarea' || tagName === 'select'
+  }
 
   function setAdminSectionRef(id: string, element: Element | null): void {
     if (element instanceof HTMLElement) {
@@ -173,6 +200,22 @@ export function useAttendanceAdminRailNavigation({
     target.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
 
+  function handleAdminSectionKeyboardNavigation(event: KeyboardEvent): void {
+    if (!showAdmin.value || adminForbidden.value) return
+    if (!event.altKey || event.metaKey || event.ctrlKey) return
+    if (event.defaultPrevented || isInteractiveAdminKeyboardTarget(event.target)) return
+    const direction = event.key === 'ArrowUp'
+      ? 'previous'
+      : event.key === 'ArrowDown'
+        ? 'next'
+        : null
+    if (!direction) return
+    const targetId = resolveAdminKeyboardTarget(direction)
+    if (!targetId) return
+    event.preventDefault()
+    scrollToAdminSection(targetId)
+  }
+
   function syncAdminNavViewportState(): void {
     if (typeof window === 'undefined') return
     const compact = window.innerWidth <= 768
@@ -191,6 +234,7 @@ export function useAttendanceAdminRailNavigation({
     syncAdminNavViewportState()
     if (typeof window !== 'undefined') {
       window.addEventListener('resize', syncAdminNavViewportState)
+      window.addEventListener('keydown', handleAdminSectionKeyboardNavigation)
     }
     if (showAdmin.value && !adminForbidden.value) {
       nextTick().then(() => restoreAdminSectionFromHash())
@@ -202,6 +246,7 @@ export function useAttendanceAdminRailNavigation({
     disconnectAdminSectionObserver()
     if (typeof window !== 'undefined') {
       window.removeEventListener('resize', syncAdminNavViewportState)
+      window.removeEventListener('keydown', handleAdminSectionKeyboardNavigation)
     }
   })
 

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -6,6 +6,7 @@ import { apiFetch } from '../src/utils/api'
 const ADMIN_NAV_COLLAPSE_PREFS_STORAGE_KEY = 'metasheet_attendance_admin_nav_collapsed_groups'
 const ADMIN_NAV_RECENTS_STORAGE_KEY = 'metasheet_attendance_admin_nav_recent_sections'
 const ADMIN_NAV_LAST_SECTION_STORAGE_KEY = 'metasheet_attendance_admin_nav_last_section'
+const ADMIN_NAV_FOCUS_MODE_STORAGE_KEY = 'metasheet_attendance_admin_nav_focused_mode'
 const ADMIN_NAV_DEFAULT_STORAGE_SCOPE = 'default'
 
 function scopedAdminNavStorageKey(baseKey: string, scope = ADMIN_NAV_DEFAULT_STORAGE_SCOPE): string {
@@ -246,6 +247,7 @@ describe('Attendance admin anchor navigation', () => {
     expect(currentSectionBar).toBeTruthy()
     expect(currentSectionBar?.textContent).toContain('Current section')
     expect(currentSectionBar?.textContent).toContain('Workspace · Settings')
+    expect(currentSectionBar?.textContent).toContain('Quick switch: Alt+↑ previous')
     expect(currentSectionBar?.querySelector('[data-admin-focus-toggle="true"]')?.textContent).toContain('Show all sections')
     expect(currentSectionBar?.querySelector('[data-admin-prev-section]')?.getAttribute('data-admin-prev-section-id')).toBe('')
     expect(currentSectionBar?.querySelector('[data-admin-next-section]')?.getAttribute('data-admin-next-section-id')).toBe('attendance-admin-user-access')
@@ -271,6 +273,32 @@ describe('Attendance admin anchor navigation', () => {
 
     expect(window.location.hash).toBe('#attendance-admin-settings')
     expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Workspace · Settings')
+  })
+
+  it('remembers focus-vs-show-all mode across remounts', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const toggle = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
+    expect(toggle).toBeTruthy()
+    toggle!.click()
+    await flushUi(2)
+
+    expect(window.localStorage.getItem(scopedAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY))).toBe('false')
+    expect(toggle?.textContent).toContain('Focus current section')
+
+    app.unmount()
+    container!.innerHTML = ''
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const nextToggle = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
+    expect(nextToggle?.textContent).toContain('Focus current section')
+    expect(container!.querySelector<HTMLElement>('#attendance-admin-settings')?.style.display).not.toBe('none')
+    expect(container!.querySelector<HTMLElement>('#attendance-admin-holidays')?.style.display).not.toBe('none')
   })
 
   it('restores the live user picker, structured rule builder, and holiday month calendar interactions', async () => {

--- a/apps/web/tests/useAttendanceAdminRail.spec.ts
+++ b/apps/web/tests/useAttendanceAdminRail.spec.ts
@@ -3,6 +3,7 @@ import { effectScope, nextTick, ref } from 'vue'
 import {
   ADMIN_NAV_COLLAPSE_PREFS_STORAGE_KEY,
   ADMIN_NAV_DEFAULT_STORAGE_SCOPE,
+  ADMIN_NAV_FOCUS_MODE_STORAGE_KEY,
   ADMIN_NAV_LAST_SECTION_STORAGE_KEY,
   ADMIN_NAV_RECENTS_STORAGE_KEY,
   ATTENDANCE_ADMIN_SECTION_IDS,
@@ -120,6 +121,38 @@ describe('useAttendanceAdminRail', () => {
     expect(rail.visibleRecentAdminSectionNavItems.value).toEqual([])
     expect(window.localStorage.getItem(scopedKey(ADMIN_NAV_RECENTS_STORAGE_KEY))).toBe('[]')
     expect(notifications.some(entry => entry.message.includes('Recent admin shortcuts cleared.'))).toBe(true)
+
+    scope.stop()
+  })
+
+  it('reloads and persists focused mode per org-scoped storage bucket', async () => {
+    window.localStorage.setItem(
+      scopedKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY, 'org-b'),
+      JSON.stringify(false),
+    )
+
+    const scopeRef = ref<string | undefined>(undefined)
+    const showAdmin = ref(true)
+    const scope = effectScope()
+    const rail = scope.run(() =>
+      useAttendanceAdminRail({
+        tr: (en: string) => en,
+        resolveStorageScope: () => scopeRef.value,
+        showAdmin,
+        notify: () => undefined,
+      }),
+    )!
+
+    await flushUi()
+    expect(rail.adminFocusedMode.value).toBe(true)
+
+    scopeRef.value = 'org-b'
+    await flushUi()
+    expect(rail.adminFocusedMode.value).toBe(false)
+
+    rail.adminFocusedMode.value = true
+    await flushUi()
+    expect(window.localStorage.getItem(scopedKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY, 'org-b'))).toBe('true')
 
     scope.stop()
   })

--- a/apps/web/tests/useAttendanceAdminRailNavigation.spec.ts
+++ b/apps/web/tests/useAttendanceAdminRailNavigation.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, nextTick, ref, type App } from 'vue'
+import { computed, createApp, defineComponent, nextTick, ref, type App } from 'vue'
 import type { AdminSectionNavItem } from '../src/views/attendance/useAttendanceAdminRail'
 import { useAttendanceAdminRailNavigation } from '../src/views/attendance/useAttendanceAdminRailNavigation'
 
@@ -64,12 +64,24 @@ describe('useAttendanceAdminRailNavigation', () => {
         const adminFocusCurrentSectionOnly = ref(options?.focused ?? false)
         const adminNavStorageScope = ref('default')
         const adminActiveSectionId = ref(items[0].id)
+        const previousAdminSectionId = computed(() => {
+          const activeIndex = items.findIndex(item => item.id === adminActiveSectionId.value)
+          if (activeIndex <= 0) return ''
+          return items[activeIndex - 1]?.id ?? ''
+        })
+        const nextAdminSectionId = computed(() => {
+          const activeIndex = items.findIndex(item => item.id === adminActiveSectionId.value)
+          if (activeIndex < 0 || activeIndex >= items.length - 1) return ''
+          return items[activeIndex + 1]?.id ?? ''
+        })
         const isCompactAdminNav = ref(false)
         const adminCompactNavOpen = ref(false)
         const { adminSectionBinding, scrollToAdminSection } = useAttendanceAdminRailNavigation({
           showAdmin,
           adminForbidden,
           adminFocusCurrentSectionOnly,
+          previousAdminSectionId,
+          nextAdminSectionId,
           adminNavStorageScope,
           adminActiveSectionId,
           adminSectionNavItems: ref(items),
@@ -90,6 +102,7 @@ describe('useAttendanceAdminRailNavigation', () => {
         <div>
           <button data-admin-anchor="attendance-admin-settings" type="button">Settings</button>
           <button data-admin-anchor="attendance-admin-approval-flows" type="button">Approval Flows</button>
+          <input data-keyboard-blocker type="text" />
           <div data-active-id>{{ adminActiveSectionId }}</div>
           <section v-bind="adminSectionBinding('attendance-admin-settings')">Settings section</section>
           <section v-bind="adminSectionBinding('attendance-admin-approval-flows')">Approval section</section>
@@ -146,5 +159,37 @@ describe('useAttendanceAdminRailNavigation', () => {
     expect(vm.adminCompactNavOpen).toBe(false)
     expect(vm.adminActiveSectionId).toBe('attendance-admin-approval-flows')
     expect(window.location.hash).toBe('#attendance-admin-approval-flows')
+  })
+
+  it('moves between sections with Alt+ArrowDown and Alt+ArrowUp', async () => {
+    const vm = mountHost()
+    await flushUi()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', altKey: true, bubbles: true }))
+    await flushUi()
+
+    expect(vm.adminActiveSectionId).toBe('attendance-admin-approval-flows')
+    expect(window.location.hash).toBe('#attendance-admin-approval-flows')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', altKey: true, bubbles: true }))
+    await flushUi()
+
+    expect(vm.adminActiveSectionId).toBe('attendance-admin-settings')
+    expect(window.location.hash).toBe('#attendance-admin-settings')
+  })
+
+  it('ignores keyboard navigation while an input is focused', async () => {
+    const vm = mountHost()
+    await flushUi()
+
+    const input = container!.querySelector<HTMLInputElement>('[data-keyboard-blocker]')
+    expect(input).toBeTruthy()
+    input!.focus()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', altKey: true, bubbles: true }))
+    await flushUi()
+
+    expect(vm.adminActiveSectionId).toBe('attendance-admin-settings')
+    expect(window.location.hash).toBe('')
   })
 })

--- a/docs/development/attendance-v271-admin-nav-shortcuts-design-20260329.md
+++ b/docs/development/attendance-v271-admin-nav-shortcuts-design-20260329.md
@@ -1,0 +1,78 @@
+# Attendance Admin Nav Shortcuts Design
+
+Date: 2026-03-29
+
+## Goal
+
+Extend the already-landed attendance admin navigation UX without adding left-rail clutter:
+
+- remember `focused` vs `show all` mode per workspace/org scope
+- add keyboard previous/next section switching
+- keep the interaction centered on the existing right-side sticky current-section bar
+
+## Scope
+
+Frontend only.
+
+Files in scope:
+
+- `apps/web/src/views/AttendanceView.vue`
+- `apps/web/src/views/attendance/useAttendanceAdminRail.ts`
+- `apps/web/src/views/attendance/useAttendanceAdminRailNavigation.ts`
+- focused tests under `apps/web/tests`
+
+## Design Choices
+
+### 1. Persist focus mode where other rail preferences already live
+
+`useAttendanceAdminRail.ts` already owns org-scoped local storage for:
+
+- collapsed groups
+- recent sections
+- last active section
+
+So the new `focused/show all` preference is stored there too, keyed by the same scoped storage model.
+
+This avoids introducing a second persistence seam in `AttendanceView.vue`.
+
+### 2. Put keyboard navigation in the navigation composable
+
+`useAttendanceAdminRailNavigation.ts` already owns:
+
+- section registration
+- hash sync
+- restore-from-hash
+- section scrolling
+
+Keyboard `Alt+ArrowUp` / `Alt+ArrowDown` is implemented there so it reuses the same `scrollToAdminSection()` path as click navigation.
+
+### 3. Do not steal keys from forms
+
+Attendance admin is form-heavy. Keyboard switching explicitly no-ops while the target or active element is:
+
+- `input`
+- `textarea`
+- `select`
+- `button`
+- `contentEditable`
+
+That keeps section switching from interfering with typing and inline editing.
+
+### 4. Surface the shortcut where the user is already looking
+
+The sticky current-section bar now includes the shortcut hint and continues to host:
+
+- previous/next pager
+- focus/show-all toggle
+
+No new control surface is added to the left rail.
+
+## Claude Code Note
+
+Claude Code was actually invoked during this slice. The useful boundary advice was:
+
+- persist focused/show-all in `useAttendanceAdminRail.ts`
+- place keyboard navigation in `useAttendanceAdminRailNavigation.ts`
+- keep the feature inside the right sticky current-section bar
+
+The final implementation follows that boundary.

--- a/docs/development/attendance-v271-admin-nav-shortcuts-verification-20260329.md
+++ b/docs/development/attendance-v271-admin-nav-shortcuts-verification-20260329.md
@@ -1,0 +1,35 @@
+# Attendance Admin Nav Shortcuts Verification
+
+Date: 2026-03-29
+
+## Commands
+
+```bash
+git diff --check
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web exec vitest run \
+  tests/attendance-admin-anchor-nav.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  tests/useAttendanceAdminRail.spec.ts \
+  tests/useAttendanceAdminRailNavigation.spec.ts \
+  --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Expected Coverage
+
+- current-section bar shows shortcut hint
+- focused/show-all mode persists per org-scoped storage bucket
+- `Alt+ArrowUp` / `Alt+ArrowDown` moves between sections
+- keyboard switching is ignored while an input is focused
+- existing admin rail and pager behavior stays green
+
+## Claude Code Note
+
+Claude Code was actually used for this slice. It did not generate the final patch, but it provided one useful implementation boundary:
+
+- keep persistence in `useAttendanceAdminRail.ts`
+- keep keyboard switching in `useAttendanceAdminRailNavigation.ts`
+- avoid re-expanding left-rail complexity
+
+Verification still relies on local tests, typecheck, and build output.


### PR DESCRIPTION
## Summary
- remember focused vs show-all attendance admin mode per org-scoped storage
- add Alt+ArrowUp / Alt+ArrowDown section switching inside the sticky current-section bar flow
- document the shortcut slice with design and verification notes

## Verification
- git diff --check
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts tests/useAttendanceAdminRail.spec.ts tests/useAttendanceAdminRailNavigation.spec.ts --watch=false
- pnpm --filter @metasheet/web build