### PR TITLE
feat(attendance): add admin quick jump

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -574,6 +574,29 @@
                   <span class="attendance__admin-current-section-nav-direction">{{ tr('Prev', '上一个') }}</span>
                   <strong>{{ previousAdminSectionNavItem?.label || tr('Start', '起点') }}</strong>
                 </button>
+                <label class="attendance__admin-current-section-jump">
+                  <span>{{ tr('Quick jump', '快速跳转') }}</span>
+                  <select
+                    class="attendance__admin-current-section-select"
+                    :value="resolvedAdminSectionId()"
+                    data-admin-quick-jump="true"
+                    @change="handleAdminQuickJumpChange"
+                  >
+                    <optgroup
+                      v-for="group in adminQuickJumpGroups"
+                      :key="group.label"
+                      :label="group.label"
+                    >
+                      <option
+                        v-for="item in group.items"
+                        :key="item.id"
+                        :value="item.id"
+                      >
+                        {{ item.label }}
+                      </option>
+                    </optgroup>
+                  </select>
+                </label>
                 <button
                   class="attendance__btn attendance__btn--inline"
                   type="button"
@@ -4986,6 +5009,7 @@ const {
   isCompactAdminNav,
   isKnownAdminSectionId,
   nextAdminSectionNavItem,
+  orderedAdminSectionNavItems,
   previousAdminSectionNavItem,
   readLastAdminSection,
   collapseAllAdminSectionGroups,
@@ -5023,6 +5047,20 @@ function resolvedAdminSectionId(): string {
     : ATTENDANCE_ADMIN_SECTION_IDS.settings
 }
 
+const adminQuickJumpGroups = computed(() => {
+  const groups = new Map<string, { label: string; items: typeof orderedAdminSectionNavItems.value }>()
+  for (const item of orderedAdminSectionNavItems.value) {
+    const groupLabel = item.groupLabel ?? tr('Sections', '区块')
+    const existing = groups.get(groupLabel)
+    if (existing) {
+      existing.items.push(item)
+      continue
+    }
+    groups.set(groupLabel, { label: groupLabel, items: [item] })
+  }
+  return Array.from(groups.values())
+})
+
 function shouldShowAdminSection(id: string): boolean {
   return !adminFocusedMode.value || resolvedAdminSectionId() === id
 }
@@ -5033,6 +5071,12 @@ function selectAdminSection(id: string): void {
   void nextTick(() => {
     scrollToAdminSection(id)
   })
+}
+
+function handleAdminQuickJumpChange(event: Event): void {
+  const value = event.target instanceof HTMLSelectElement ? event.target.value : ''
+  if (!isKnownAdminSectionId(value)) return
+  selectAdminSection(value)
 }
 
 const statusCode = computed(() => statusMeta.value?.code || '')
@@ -12319,6 +12363,29 @@ const holidaySectionBindings = {
   flex-shrink: 0;
 }
 
+.attendance__admin-current-section-jump {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 164px;
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.attendance__admin-current-section-select {
+  min-width: 164px;
+  padding: 7px 10px;
+  border: 1px solid #bfdbfe;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 13px;
+  font-weight: 500;
+}
+
 .attendance__admin-current-section-nav {
   display: inline-flex;
   flex-direction: column;
@@ -12784,6 +12851,11 @@ const holidaySectionBindings = {
 
   .attendance__admin-current-section-actions {
     width: 100%;
+  }
+
+  .attendance__admin-current-section-jump,
+  .attendance__admin-current-section-select {
+    min-width: 100%;
   }
 
   .attendance__admin-shortcuts-items {

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -248,6 +248,7 @@ describe('Attendance admin anchor navigation', () => {
     expect(currentSectionBar?.textContent).toContain('Current section')
     expect(currentSectionBar?.textContent).toContain('Workspace · Settings')
     expect(currentSectionBar?.textContent).toContain('Quick switch: Alt+↑ previous')
+    expect(currentSectionBar?.querySelector('[data-admin-quick-jump="true"]')).toBeTruthy()
     expect(currentSectionBar?.querySelector('[data-admin-focus-toggle="true"]')?.textContent).toContain('Show all sections')
     expect(currentSectionBar?.querySelector('[data-admin-prev-section]')?.getAttribute('data-admin-prev-section-id')).toBe('')
     expect(currentSectionBar?.querySelector('[data-admin-next-section]')?.getAttribute('data-admin-next-section-id')).toBe('attendance-admin-user-access')
@@ -273,6 +274,23 @@ describe('Attendance admin anchor navigation', () => {
 
     expect(window.location.hash).toBe('#attendance-admin-settings')
     expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Workspace · Settings')
+  })
+
+  it('lets operators jump directly to a deep section from the current-section bar selector', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
+    expect(jumpSelect).toBeTruthy()
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(22)
+
+    jumpSelect!.value = 'attendance-admin-shifts'
+    jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    expect(window.location.hash).toBe('#attendance-admin-shifts')
+    expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Scheduling · Shifts')
   })
 
   it('remembers focus-vs-show-all mode across remounts', async () => {

--- a/docs/development/attendance-v271-admin-nav-quickjump-design-20260329.md
+++ b/docs/development/attendance-v271-admin-nav-quickjump-design-20260329.md
@@ -1,0 +1,66 @@
+# Attendance Admin Quick Jump Design
+
+Date: 2026-03-29
+
+## Goal
+
+After landing:
+
+- simplified left rail
+- sticky current-section bar
+- previous/next pager
+- focus-mode persistence
+- keyboard previous/next shortcuts
+
+the next small UX slice is a direct quick-jump control inside the same right-side current-section bar.
+
+This is meant to solve the remaining "班次 / Shifts is still too far away" problem without reintroducing left-rail clutter.
+
+## Scope
+
+Frontend only.
+
+Files:
+
+- `apps/web/src/views/AttendanceView.vue`
+- `apps/web/tests/attendance-admin-anchor-nav.spec.ts`
+
+## Design
+
+### Keep navigation surfaces consolidated
+
+The quick jump is added to the existing sticky current-section bar, not to the left rail.
+
+That keeps all fast navigation tools in one place:
+
+- previous
+- next
+- focus/show-all
+- direct jump
+
+### Reuse canonical section order
+
+The control is built from `orderedAdminSectionNavItems`, which already defines the stable canonical order used by the pager.
+
+Items are rendered as grouped native `<select>` optgroups, preserving existing section grouping without creating a second navigation taxonomy.
+
+### Reuse existing selection flow
+
+The select change handler only calls `selectAdminSection()`.
+
+That means it automatically inherits:
+
+- focused-mode reset to current section
+- hash sync
+- scroll-to-section behavior
+- recent-section tracking
+
+## Why this slice
+
+It is higher value than more left-rail work because it directly reduces the cost of reaching deep sections, especially when the operator already knows the target section name.
+
+It is smaller and safer than introducing a command palette or new floating navigation UI.
+
+## Claude Code Note
+
+Claude Code was invoked again during this continuation. It did not return a timely consumable answer for this slice, so the implementation boundary here was chosen from the already-landed navigation architecture and local code review.

--- a/docs/development/attendance-v271-admin-nav-quickjump-verification-20260329.md
+++ b/docs/development/attendance-v271-admin-nav-quickjump-verification-20260329.md
@@ -1,0 +1,28 @@
+# Attendance Admin Quick Jump Verification
+
+Date: 2026-03-29
+
+## Commands
+
+```bash
+git diff --check
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web exec vitest run \
+  tests/attendance-admin-anchor-nav.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  tests/useAttendanceAdminRail.spec.ts \
+  tests/useAttendanceAdminRailNavigation.spec.ts \
+  --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## What This Verifies
+
+- sticky current-section bar still renders correctly
+- quick-jump select is present in the current-section bar
+- selecting a deep section updates the hash and current-section label
+- earlier pager / focus-mode / keyboard shortcut flows remain green
+
+## Claude Code Note
+
+Claude Code was actually invoked during this continuation, but it did not return a timely actionable result for this slice. Final verification relies on local tests, typecheck, and build output.


### PR DESCRIPTION
## Summary
- add a compact grouped quick-jump select to the sticky attendance admin current-section bar
- drive quick jump through the existing selectAdminSection flow so hash, focus mode, recents, and scroll behavior stay aligned
- document the slice with design and verification notes

## Verification
- git diff --check
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts tests/useAttendanceAdminRail.spec.ts tests/useAttendanceAdminRailNavigation.spec.ts --watch=false
- pnpm --filter @metasheet/web build