### PR TITLE
docs(release): record attendance onprem v2.7.2 package release

### DIFF
--- a/docs/development/attendance-onprem-v272-package-release-20260329.md
+++ b/docs/development/attendance-onprem-v272-package-release-20260329.md
@@ -1,0 +1,53 @@
+# Attendance On-Prem v2.7.2 Package Release
+
+Date: 2026-03-29
+
+## Goal
+
+Publish a patch release after the attendance admin navigation follow-up landed in `main`.
+
+The release should ship both a normal GitHub release tag and direct on-prem deployment assets.
+
+## Scope
+
+Operational release only. No product code changes are introduced in this slice.
+
+Artifacts produced:
+
+- `metasheet-attendance-onprem-v2.7.2.zip`
+- `metasheet-attendance-onprem-v2.7.2.tgz`
+- matching `.sha256` files
+- `SHA256SUMS-v2.7.2`
+- date-stamped `current` package variants for traceability
+
+## Release Basis
+
+Release target:
+
+- `main@b49746df8d1d80ca07940bac107f757837e1f402`
+
+Why patch:
+
+- the delta after `v2.7.1` is additive and corrective within attendance admin UX
+- it does not change the major or minor release contract
+
+## Packaging Choices
+
+### 1. Build from a clean worktree
+
+Packaging is performed from a dedicated worktree based on `origin/main` to avoid pollution from unrelated dirty files in the main checkout.
+
+### 2. Keep both traceable and user-friendly asset names
+
+The package build script emits a dated `current` bundle:
+
+- `metasheet-attendance-onprem-v2.7.2-20260329-current.*`
+
+The release also includes stable aliases for direct deployment:
+
+- `metasheet-attendance-onprem-v2.7.2.zip`
+- `metasheet-attendance-onprem-v2.7.2.tgz`
+
+## Claude Code Note
+
+Claude Code was actually invoked during this release continuation for a patch-bump sanity check. It did not return a timely consumable result, so the release decision was based on current tag history, merged scope after `v2.7.1`, and green mainline checks on the target commit.

--- a/docs/development/attendance-onprem-v272-package-release-verification-20260329.md
+++ b/docs/development/attendance-onprem-v272-package-release-verification-20260329.md
@@ -1,0 +1,34 @@
+# Attendance On-Prem v2.7.2 Package Release Verification
+
+Date: 2026-03-29
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web build
+pnpm --filter @metasheet/core-backend build
+PACKAGE_VERSION=2.7.2 PACKAGE_TAG=20260329-current INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 \
+  bash scripts/ops/attendance-onprem-package-build.sh
+gh release create v2.7.2 --target b49746df8d1d80ca07940bac107f757837e1f402 ...
+gh release view v2.7.2 --json tagName,url,publishedAt,assets
+```
+
+## What Was Verified
+
+- release tag `v2.7.2` was created
+- release target points at `main@b49746df8d1d80ca07940bac107f757837e1f402`
+- on-prem assets were uploaded in both dated and stable-name forms
+- stable-name archives have the same hashes as the dated `current` archives
+- mainline checks on the target commit were already green before release
+
+## Asset Expectations
+
+- `metasheet-attendance-onprem-v2.7.2.zip`
+- `metasheet-attendance-onprem-v2.7.2.tgz`
+- `metasheet-attendance-onprem-v2.7.2.zip.sha256`
+- `metasheet-attendance-onprem-v2.7.2.tgz.sha256`
+- `SHA256SUMS-v2.7.2`
+
+## Claude Code Note
+
+Claude Code was actually called during this continuation. It did not return a timely actionable release recommendation, so verification relies on local build/package outputs plus GitHub release state.


### PR DESCRIPTION
## Summary
- record the v2.7.2 attendance on-prem package release
- capture the clean-worktree packaging basis and uploaded asset set
- document the verification steps used to publish the release

## Verification
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/core-backend build
- PACKAGE_VERSION=2.7.2 PACKAGE_TAG=20260329-current INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 bash scripts/ops/attendance-onprem-package-build.sh
- gh release create v2.7.2 --target b49746df8d1d80ca07940bac107f757837e1f402 ...
- gh release view v2.7.2 --json tagName,url,publishedAt,assets