### PR TITLE
feat(attendance): infer request type from record timeline

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -5718,20 +5718,36 @@ function recordTimelineInlineMessage(recordId: string): string {
   return ''
 }
 
+function inferRequestTypeFromRecordTimeline(items: AttendancePunchEvent[]): string {
+  let hasCheckIn = false
+  let hasCheckOut = false
+  for (const item of items) {
+    if (item.eventType === 'check_in') hasCheckIn = true
+    else if (item.eventType === 'check_out') hasCheckOut = true
+    if (hasCheckIn && hasCheckOut) break
+  }
+  if (hasCheckIn && !hasCheckOut) return 'missed_check_out'
+  if (hasCheckOut && !hasCheckIn) return 'missed_check_in'
+  return 'time_correction'
+}
+
 function resolveRecordTimelineRequestDraft(record: AttendanceRecord): {
+  requestType: string
   requestedInAt: string
   requestedOutAt: string
 } {
   const items = recordTimelineItems(record.id)
+  const requestType = inferRequestTypeFromRecordTimeline(items)
   const checkIn = items.find(item => item.eventType === 'check_in')
   const checkOut = [...items].reverse().find(item => item.eventType === 'check_out')
   const requestedInAtSource = checkIn?.occurredAt
-    ?? record.first_in_at
+    ?? (requestType === 'missed_check_in' ? null : record.first_in_at)
     ?? null
   const requestedOutAtSource = checkOut?.occurredAt
-    ?? record.last_out_at
+    ?? (requestType === 'missed_check_out' ? null : record.last_out_at)
     ?? null
   return {
+    requestType,
     requestedInAt: requestedInAtSource ? formatDateTimeLocal(new Date(requestedInAtSource)) : '',
     requestedOutAt: requestedOutAtSource ? formatDateTimeLocal(new Date(requestedOutAtSource)) : '',
   }
@@ -5740,7 +5756,7 @@ function resolveRecordTimelineRequestDraft(record: AttendanceRecord): {
 async function prefillRequestFromRecordTimeline(record: AttendanceRecord): Promise<void> {
   const draft = resolveRecordTimelineRequestDraft(record)
   requestForm.workDate = record.work_date
-  requestForm.requestType = 'time_correction'
+  requestForm.requestType = draft.requestType
   requestForm.requestedInAt = draft.requestedInAt
   requestForm.requestedOutAt = draft.requestedOutAt
   setStatus(

--- a/apps/web/tests/attendance-record-timeline.spec.ts
+++ b/apps/web/tests/attendance-record-timeline.spec.ts
@@ -66,9 +66,29 @@ const baseRecord = {
   meta: {},
 }
 
-function installAttendanceMock(options?: { timelineStatus?: number }): string[] {
+function installAttendanceMock(options?: { timelineStatus?: number; timelineItems?: Array<Record<string, unknown>> }): string[] {
   const timelineCalls: string[] = []
   const timelineStatus = options?.timelineStatus ?? 200
+  const timelineItems = options?.timelineItems ?? [
+    {
+      id: 'evt-2',
+      userId: 'user-1',
+      workDate: '2026-03-28',
+      eventType: 'check_out',
+      occurredAt: '2026-03-28T18:05:00+08:00',
+      source: 'terminal',
+      timezone: 'Asia/Shanghai',
+    },
+    {
+      id: 'evt-1',
+      userId: 'user-1',
+      workDate: '2026-03-28',
+      eventType: 'check_in',
+      occurredAt: '2026-03-28T09:01:00+08:00',
+      source: 'terminal',
+      timezone: 'Asia/Shanghai',
+    },
+  ]
   vi.mocked(apiFetch).mockImplementation(async (input) => {
     const url = String(input)
     if (url.includes('/api/attendance/summary?')) {
@@ -109,27 +129,8 @@ function installAttendanceMock(options?: { timelineStatus?: number }): string[] 
       return jsonResponse(200, {
         ok: true,
         data: {
-          items: [
-            {
-              id: 'evt-2',
-              userId: 'user-1',
-              workDate: '2026-03-28',
-              eventType: 'check_out',
-              occurredAt: '2026-03-28T18:05:00+08:00',
-              source: 'terminal',
-              timezone: 'Asia/Shanghai',
-            },
-            {
-              id: 'evt-1',
-              userId: 'user-1',
-              workDate: '2026-03-28',
-              eventType: 'check_in',
-              occurredAt: '2026-03-28T09:01:00+08:00',
-              source: 'terminal',
-              timezone: 'Asia/Shanghai',
-            },
-          ],
-          total: 2,
+          items: timelineItems,
+          total: timelineItems.length,
         },
       })
     }
@@ -235,5 +236,37 @@ describe('Attendance record timeline', () => {
     expect(requestedOutInput?.value).toBe(toLocalDateTimeValue('2026-03-28T18:05:00+08:00'))
     expect(container?.textContent).toContain('Request form updated from record timeline.')
     expect(scrollIntoView).toHaveBeenCalled()
+  })
+
+  it('infers missed check-out when the loaded timeline only has a check-in event', async () => {
+    installAttendanceMock({
+      timelineItems: [
+        {
+          id: 'evt-1',
+          userId: 'user-1',
+          workDate: '2026-03-28',
+          eventType: 'check_in',
+          occurredAt: '2026-03-28T09:01:00+08:00',
+          source: 'terminal',
+          timezone: 'Asia/Shanghai',
+        },
+      ],
+    })
+    app = createApp(AttendanceView)
+    app.mount(container!)
+    await flushUi()
+
+    findButton(container!, 'Details').click()
+    await flushUi()
+    findButton(container!, 'Use in request form').click()
+    await flushUi()
+
+    const requestTypeSelect = container!.querySelector<HTMLSelectElement>('#attendance-request-type')
+    const requestedInInput = container!.querySelector<HTMLInputElement>('#attendance-request-in')
+    const requestedOutInput = container!.querySelector<HTMLInputElement>('#attendance-request-out')
+
+    expect(requestTypeSelect?.value).toBe('missed_check_out')
+    expect(requestedInInput?.value).toBe(toLocalDateTimeValue('2026-03-28T09:01:00+08:00'))
+    expect(requestedOutInput?.value).toBe('')
   })
 })

--- a/docs/development/attendance-record-timeline-requesttype-design-20260329.md
+++ b/docs/development/attendance-record-timeline-requesttype-design-20260329.md
@@ -1,0 +1,50 @@
+# Attendance Record Timeline Request Type Design
+
+## Goal
+
+Make the record-timeline request bridge smarter without expanding scope beyond the existing request form.
+
+The previous bridge slice always prefills `time_correction`. That is safe, but it still leaves obvious single-sided punch gaps under-optimized:
+
+- only `check_in` present
+- only `check_out` present
+
+This slice infers the narrowest correct request type from the loaded raw punch timeline.
+
+## Scope
+
+1. Keep the feature inside the existing record timeline bridge.
+2. Infer request type from the loaded punch-event mix.
+3. Leave the missing side blank when the inferred request type is a single-sided correction.
+4. Keep `time_correction` for two-sided or ambiguous cases.
+
+## Design
+
+### 1. Small deterministic inference rule
+
+The inference is intentionally simple:
+
+- `check_in` only -> `missed_check_out`
+- `check_out` only -> `missed_check_in`
+- both or ambiguous -> `time_correction`
+
+This avoids heuristic overreach while still removing the most common manual form toggle.
+
+### 2. Missing-side fields stay empty
+
+When the inferred request type is one-sided, the bridge must not backfill the missing side from the summary record row.
+
+Otherwise the form would say “missed check-out” while still pre-populating a `requestedOutAt`, which is semantically wrong.
+
+### 3. Keep fallback behavior for two-sided correction
+
+For `time_correction`, the bridge may still fall back to the summary row's `first_in_at / last_out_at` when the raw event list is incomplete.
+
+That preserves the previous convenience for the general correction case.
+
+## Non-goals
+
+- No backend changes
+- No anomaly-specific inference
+- No auto-submission or approval logic
+- No new request types

--- a/docs/development/attendance-record-timeline-requesttype-verification-20260329.md
+++ b/docs/development/attendance-record-timeline-requesttype-verification-20260329.md
@@ -1,0 +1,41 @@
+# Attendance Record Timeline Request Type Verification
+
+## Commands
+
+```bash
+git diff --check
+pnpm --filter @metasheet/web exec vitest run tests/attendance-record-timeline.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+```
+
+## Focused Test Result
+
+The record timeline spec now covers:
+
+- lazy-load and cached reopen behavior
+- unsupported-endpoint inline fallback
+- bridge to the request form
+- request-type inference for one-sided timelines
+
+Observed result:
+
+- `4 passed`
+
+## Typecheck / Build
+
+- `vue-tsc --noEmit` passed
+- `@metasheet/web build` passed
+
+## Behavioral Summary
+
+Verified outcomes for this slice:
+
+- timelines with only `check_in` now prefill `missed_check_out`
+- timelines with only `check_out` would analogously prefill `missed_check_in`
+- one-sided inferred requests leave the missing timestamp blank
+- two-sided timelines still use `time_correction`
+
+## Claude Code Status
+
+Claude Code remained callable in this environment through `/usr/local/bin/node` plus the local CLI package. Its long-running review prompt still did not return a timely boundary conclusion, so this slice was accepted on the basis of focused tests and local verification.


### PR DESCRIPTION
## Summary
- infer the narrowest request type from the loaded raw punch timeline before prefilling the existing request form
- keep one-sided inferred requests semantically clean by leaving the missing timestamp blank
- document the inference slice with focused design and verification notes

## Design
- /Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-record-timeline-requesttype-20260329/docs/development/attendance-record-timeline-requesttype-design-20260329.md

## Verification
- git diff --check
- pnpm --filter @metasheet/web exec vitest run tests/attendance-record-timeline.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/web build
- /Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-record-timeline-requesttype-20260329/docs/development/attendance-record-timeline-requesttype-verification-20260329.md