### PR TITLE
fix(release): harden onprem api base packaging

### DIFF
--- a/apps/web/src/utils/api.ts
+++ b/apps/web/src/utils/api.ts
@@ -26,6 +26,21 @@ export interface ApiFetchOptions extends RequestInit {
   suppressUnauthorizedRedirect?: boolean
 }
 
+function resolveWindowOrigin(): string {
+  if (typeof window === 'undefined') return ''
+  const origin = window?.location?.origin
+  return typeof origin === 'string' && origin.trim().length > 0 ? origin.trim() : ''
+}
+
+function isLoopbackUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return ['127.0.0.1', 'localhost', '::1', '[::1]'].includes(url.hostname)
+  } catch {
+    return false
+  }
+}
+
 /**
  * Get the API base URL from environment or default to relative path
  */
@@ -39,13 +54,16 @@ export function getApiBase(): string {
   }
 
   const apiUrl = envValue('VITE_API_URL') || envValue('VITE_API_BASE')
-  if (apiUrl) return apiUrl
-
-  if (typeof window !== 'undefined') {
-    const origin = window?.location?.origin
-    if (typeof origin === 'string' && origin.trim().length > 0) {
-      return origin
+  const browserOrigin = resolveWindowOrigin()
+  if (apiUrl) {
+    if (browserOrigin && isLoopbackUrl(apiUrl) && !isLoopbackUrl(browserOrigin)) {
+      return browserOrigin
     }
+    return apiUrl
+  }
+
+  if (browserOrigin) {
+    return browserOrigin
   }
 
   return 'http://localhost:8900'

--- a/apps/web/tests/utils/api.test.ts
+++ b/apps/web/tests/utils/api.test.ts
@@ -40,6 +40,17 @@ describe('API Utils', () => {
       expect(getApiBase()).toBe('https://api-base.example.com')
     })
 
+    it('ignores loopback VITE API env on non-loopback browser origins', () => {
+      vi.stubEnv('VITE_API_URL', '')
+      vi.stubEnv('VITE_API_BASE', 'http://127.0.0.1:7778')
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'http://192.168.1.222' },
+        writable: true,
+        configurable: true,
+      })
+      expect(getApiBase()).toBe('http://192.168.1.222')
+    })
+
     it('falls back to location.origin', () => {
       vi.unstubAllEnvs()
       Object.defineProperty(window, 'location', {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,12 +5,14 @@ import { resolve } from 'path'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const envDir = process.env.METASHEET_ENV_DIR?.trim() || process.cwd()
+  const env = loadEnv(mode, envDir, '')
   const apiBase = env.VITE_API_URL || env.VITE_API_BASE || 'http://127.0.0.1:7778'
   const portValue = Number(env.VITE_PORT)
   const serverPort = Number.isFinite(portValue) && portValue > 0 ? portValue : 8899
 
   return {
+    envDir,
     plugins: [vue()],
     server: {
       port: serverPort,

--- a/docs/development/attendance-v272-onprem-api-base-hotfix-design-20260330.md
+++ b/docs/development/attendance-v272-onprem-api-base-hotfix-design-20260330.md
@@ -1,0 +1,48 @@
+# Attendance v2.7.2 On-Prem API Base Hotfix
+
+## Problem
+
+`attendance-onprem-run22-20260330` shipped a frontend bundle that embedded `VITE_API_BASE=http://127.0.0.1:7778`.
+
+In production browsers this forced login and all other API calls to the operator's own loopback interface instead of the deployed MetaSheet host, which made the package unusable and required rollback to `v2.7.1`.
+
+## Root Cause
+
+Two independent gaps aligned:
+
+1. `apps/web/src/utils/api.ts` trusted `VITE_API_URL` / `VITE_API_BASE` unconditionally in production.
+2. `scripts/ops/attendance-onprem-package-build.sh` defaulted to reusing existing `apps/web/dist` and `packages/core-backend/dist`, so a package build could ship stale artifacts without forcing a fresh build.
+
+Because local development env files contained loopback API settings, a production package could inherit those settings and publish them into the bundle.
+
+## Design
+
+The fix is intentionally small and release-focused:
+
+1. Harden `getApiBase()` in `apps/web/src/utils/api.ts`.
+   - If the baked API origin is a loopback host and the browser origin is not loopback, use `window.location.origin`.
+   - Keep explicit non-loopback env values untouched.
+   - Keep `http://localhost:8900` only as the final no-window fallback.
+
+2. Make Vite env loading overridable.
+   - `apps/web/vite.config.ts` now honors `METASHEET_ENV_DIR`.
+   - This allows the on-prem packaging flow to build with an isolated empty env directory instead of inheriting developer `.env.local`.
+
+3. Force fresh on-prem package builds.
+   - `scripts/ops/attendance-onprem-package-build.sh` now defaults `BUILD_WEB=1` and `BUILD_BACKEND=1`.
+   - The web build runs with an isolated temporary env directory.
+
+4. Add a package verify guard.
+   - `scripts/ops/attendance-onprem-package-verify.sh` now fails if the built frontend bundle embeds loopback `VITE_API_URL` / `VITE_API_BASE`.
+
+## Scope
+
+Changed files:
+
+- `apps/web/src/utils/api.ts`
+- `apps/web/tests/utils/api.test.ts`
+- `apps/web/vite.config.ts`
+- `scripts/ops/attendance-onprem-package-build.sh`
+- `scripts/ops/attendance-onprem-package-verify.sh`
+
+No backend runtime behavior changes were made.

--- a/docs/development/attendance-v272-onprem-api-base-hotfix-verification-20260330.md
+++ b/docs/development/attendance-v272-onprem-api-base-hotfix-verification-20260330.md
@@ -1,0 +1,81 @@
+# Attendance v2.7.2 On-Prem API Base Hotfix Verification
+
+## Verified Risk
+
+Before the fix, the shipped `run22` package contained:
+
+- `VITE_API_BASE:"http://127.0.0.1:7778"`
+
+inside `apps/web/dist/assets/index-Dxtdj0_0.js`, which matches the rollback report from the deployment environment.
+
+## Commands Run
+
+### Frontend regression checks
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/utils/api.test.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+- `tests/utils/api.test.ts`: `16 passed`
+- `vue-tsc`: clean
+
+### Script syntax
+
+```bash
+bash -n scripts/ops/attendance-onprem-package-build.sh
+bash -n scripts/ops/attendance-onprem-package-verify.sh
+```
+
+Result:
+
+- both passed
+
+### Poisoned env reproduction guard
+
+A temporary `apps/web/.env.local` containing:
+
+```bash
+VITE_API_BASE=http://127.0.0.1:7778
+```
+
+was created on purpose during verification.
+
+Then the build was run with an isolated env dir:
+
+```bash
+METASHEET_ENV_DIR="$(mktemp -d)" pnpm --filter @metasheet/web build
+```
+
+Post-build inspection result:
+
+- built `index-B8YJB_dG.js`
+- `loopback_idx = -1`
+- `localhost_idx = -1`
+
+which means the bundle no longer embedded the loopback API base.
+
+### End-to-end on-prem package verification
+
+```bash
+PACKAGE_VERSION=2.7.2 PACKAGE_TAG=run22-hotfix-check OUTPUT_DIR=output/releases/attendance-onprem-hotfix-check bash scripts/ops/attendance-onprem-package-build.sh
+VERIFY_NO_GITHUB_LINKS=0 bash scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem-hotfix-check/metasheet-attendance-onprem-v2.7.2-run22-hotfix-check.zip
+```
+
+Result:
+
+- package build succeeded
+- package verify succeeded
+- extracted zip bundle inspection also reported:
+  - `loopback_idx = -1`
+  - `localhost_idx = -1`
+
+## Conclusion
+
+This hotfix closes the exact rollback cause:
+
+- production frontend bundles no longer inherit loopback API env by default during on-prem packaging
+- runtime API resolution now degrades safely to the deployed browser origin when a loopback env slips into a non-loopback page
+- package verification now blocks this class of release regression before publish

--- a/scripts/ops/attendance-onprem-package-build.sh
+++ b/scripts/ops/attendance-onprem-package-build.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/output/releases/attendance-onprem}"
 INSTALL_DEPS="${INSTALL_DEPS:-0}"
-BUILD_WEB="${BUILD_WEB:-0}"
-BUILD_BACKEND="${BUILD_BACKEND:-0}"
+BUILD_WEB="${BUILD_WEB:-1}"
+BUILD_BACKEND="${BUILD_BACKEND:-1}"
 PACKAGE_PREFIX="${PACKAGE_PREFIX:-metasheet-attendance-onprem}"
 PACKAGE_VERSION="${PACKAGE_VERSION:-$(node -p "require('./package.json').version" 2>/dev/null || echo unknown)}"
 PACKAGE_TAG="${PACKAGE_TAG:-$(date +%Y%m%d-%H%M%S)}"
@@ -68,6 +68,14 @@ function run() {
   "$@"
 }
 
+function build_web_dist() {
+  local env_dir
+  env_dir="$(mktemp -d)"
+  trap 'rm -rf "$env_dir"' RETURN
+  info "Using isolated env dir for web build: ${env_dir}"
+  run env METASHEET_ENV_DIR="$env_dir" pnpm --filter @metasheet/web build
+}
+
 function hash_value() {
   local file="$1"
   if command -v sha256sum >/dev/null 2>&1; then
@@ -113,7 +121,7 @@ if [[ "$INSTALL_DEPS" == "1" ]]; then
 fi
 
 if [[ "$BUILD_WEB" == "1" ]]; then
-  run pnpm --filter @metasheet/web build
+  build_web_dist
 fi
 
 if [[ "$BUILD_BACKEND" == "1" ]]; then

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -159,6 +159,10 @@ if [[ "$VERIFY_NO_GITHUB_LINKS" == "1" ]]; then
   verify_no_github_links "$pkg_root"
 fi
 
+if rg -n 'VITE_API_(URL|BASE):"http://(127\.0\.0\.1|localhost)' "${pkg_root}/apps/web/dist" >/dev/null 2>&1; then
+  die "Frontend bundle embeds loopback VITE_API_* config; rebuild package with isolated web env"
+fi
+
 info "Package verify OK"
 info "  package: ${PACKAGE_FILE}"
 info "  root: ${pkg_root}"


### PR DESCRIPTION
## Summary
- harden frontend API base resolution so baked loopback env values fall back to the deployed browser origin on non-loopback sites
- let the web build use an isolated env directory for release packaging and make on-prem packaging rebuild fresh web/backend artifacts by default
- fail package verification when a frontend bundle embeds loopback `VITE_API_URL` / `VITE_API_BASE`

## Design
- /Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-v272-loopback-hotfix-20260330/docs/development/attendance-v272-onprem-api-base-hotfix-design-20260330.md

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/utils/api.test.ts --watch=false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- bash -n scripts/ops/attendance-onprem-package-build.sh
- bash -n scripts/ops/attendance-onprem-package-verify.sh
- created a temporary poisoned `apps/web/.env.local` with `VITE_API_BASE=http://127.0.0.1:7778`
- `METASHEET_ENV_DIR=$(mktemp -d) pnpm --filter @metasheet/web build`
- `PACKAGE_VERSION=2.7.2 PACKAGE_TAG=run22-hotfix-check OUTPUT_DIR=output/releases/attendance-onprem-hotfix-check bash scripts/ops/attendance-onprem-package-build.sh`
- `VERIFY_NO_GITHUB_LINKS=0 bash scripts/ops/attendance-onprem-package-verify.sh output/releases/attendance-onprem-hotfix-check/metasheet-attendance-onprem-v2.7.2-run22-hotfix-check.zip`
- /Users/huazhou/Downloads/Github/metasheet2/.worktrees/attendance-v272-loopback-hotfix-20260330/docs/development/attendance-v272-onprem-api-base-hotfix-verification-20260330.md