### PR TITLE
fix(attendance): tighten run24 admin focus

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -591,26 +591,21 @@
             >
             <div
               class="attendance__admin-current-section"
-              :class="{ 'attendance__admin-current-section--expanded': !adminFocusedMode }"
               data-admin-current-section="true"
             >
               <div class="attendance__admin-current-section-copy">
                 <span class="attendance__admin-current-section-eyebrow">
-                  {{ adminFocusedMode ? tr('Current section', '当前区块') : tr('Browse sections', '浏览区块') }}
+                  {{ tr('Current section', '当前区块') }}
                 </span>
                 <strong>{{ activeAdminSectionContextLabel }}</strong>
                 <span class="attendance__admin-current-section-description">
-                  {{
-                    adminFocusedMode
-                      ? tr('Choose another item on the left and the right pane will return here immediately.', '点击左侧其他区块后，右侧会立即回到这里。')
-                      : tr('All sections are visible. Focus mode brings you back to the active block.', '当前显示全部区块；切回聚焦模式可回到当前区块。')
-                  }}
+                  {{ tr('Choose another item on the left and the right pane will return here immediately.', '点击左侧其他区块后，右侧会立即回到这里。') }}
                 </span>
                 <span class="attendance__admin-current-section-hint">
                   {{
                     tr(
-                      'Quick switch: Alt+↑ previous · Alt+↓ next. This mode is remembered per workspace.',
-                      '快速切换：Alt+↑ 上一个 · Alt+↓ 下一个。系统会按当前工作区记住该模式。',
+                      'Quick switch: Alt+↑ previous · Alt+↓ next.',
+                      '快速切换：Alt+↑ 上一个 · Alt+↓ 下一个。',
                     )
                   }}
                 </span>
@@ -652,14 +647,6 @@
                     </optgroup>
                   </select>
                 </label>
-                <button
-                  class="attendance__btn attendance__btn--inline"
-                  type="button"
-                  data-admin-focus-toggle="true"
-                  @click="adminFocusedMode = !adminFocusedMode"
-                >
-                  {{ adminFocusedMode ? tr('Show all sections', '显示全部区块') : tr('Focus current section', '仅显示当前区块') }}
-                </button>
                 <button
                   class="attendance__btn attendance__btn--inline attendance__admin-current-section-nav"
                   :class="{ 'attendance__admin-current-section-nav--disabled': !nextAdminSectionNavItem }"
@@ -12419,8 +12406,16 @@ const holidaySectionBindings = {
 
 .attendance__table-actions {
   display: flex;
+  align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.attendance__table td.attendance__table-actions {
+  width: 1%;
+  min-width: max-content;
+  height: auto;
+  vertical-align: middle;
 }
 
 .attendance__table-actions .attendance__btn {
@@ -12653,10 +12648,6 @@ const holidaySectionBindings = {
   backdrop-filter: blur(10px);
 }
 
-.attendance__admin-current-section--expanded {
-  border-color: #dbeafe;
-}
-
 .attendance__admin-current-section-copy {
   display: flex;
   flex-direction: column;
@@ -12756,6 +12747,13 @@ const holidaySectionBindings = {
   gap: 12px;
 }
 
+.attendance__rule-builder > .attendance__admin-section-header,
+.attendance__rule-builder-preview > .attendance__admin-section-header,
+.attendance__preview-builder > .attendance__admin-section-header {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
 .attendance__template-guide {
   padding: 16px;
   border: 1px solid #d9e2ec;
@@ -12839,6 +12837,10 @@ const holidaySectionBindings = {
   gap: 10px 16px;
   color: #4b5563;
   font-size: 12px;
+}
+
+.attendance__rule-builder-summary {
+  margin-left: auto;
 }
 
 .attendance__rule-builder-summary strong,
@@ -13203,6 +13205,17 @@ const holidaySectionBindings = {
 
   .attendance__table--records {
     min-width: 100%;
+  }
+
+  .attendance__rule-builder-summary {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .attendance__rule-builder > .attendance__admin-section-header,
+  .attendance__rule-builder-preview > .attendance__admin-section-header,
+  .attendance__preview-builder > .attendance__admin-section-header {
+    flex-direction: column;
   }
 
   .attendance__table-actions .attendance__btn,

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -134,15 +134,9 @@ function persistLastAdminSection(scope: string, id: string): void {
 }
 
 function loadAdminNavFocusedMode(scope: string): boolean {
-  if (typeof window === 'undefined') return true
-  try {
-    const raw = window.localStorage.getItem(resolveAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY, scope))
-    if (!raw) return true
-    const parsed = JSON.parse(raw)
-    return typeof parsed === 'boolean' ? parsed : true
-  } catch {
-    return true
-  }
+  void scope
+  // The all-sections mode is retired. Always normalize back to focused mode.
+  return true
 }
 
 function persistAdminNavFocusedMode(scope: string, focused: boolean): void {
@@ -501,7 +495,7 @@ export function useAttendanceAdminRail({
 
   watch(adminFocusedMode, focused => {
     persistAdminNavFocusedMode(adminNavStorageScope.value, focused)
-  })
+  }, { immediate: true })
 
   watch(adminNavStorageScope, (scope, previousScope) => {
     if (scope === previousScope) return

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -209,7 +209,9 @@ describe('Attendance admin anchor navigation', () => {
     expect(container!.querySelector('[data-admin-shortcut="attendance-admin-import-batches"]')?.textContent).toContain('Data & Payroll · Import batches')
   })
 
-  it('focuses the right pane on the active admin section by default and can reveal all sections on demand', async () => {
+  it('keeps the right pane focused on the active admin section and ignores legacy show-all preferences', async () => {
+    window.localStorage.setItem(scopedAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY), JSON.stringify(false))
+
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
     await flushUi()
@@ -228,14 +230,8 @@ describe('Attendance admin anchor navigation', () => {
 
     expect(settingsSection?.style.display).toBe('none')
     expect(holidaysSection?.style.display).not.toBe('none')
-
-    const revealAllButton = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
-    expect(revealAllButton).toBeTruthy()
-    revealAllButton!.click()
-    await flushUi(2)
-
-    expect(settingsSection?.style.display).not.toBe('none')
-    expect(holidaysSection?.style.display).not.toBe('none')
+    expect(container!.querySelector('[data-admin-focus-toggle="true"]')).toBeNull()
+    expect(window.localStorage.getItem(scopedAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY))).toBe('true')
   })
 
   it('renders a sticky current-section bar in the right pane', async () => {
@@ -249,7 +245,7 @@ describe('Attendance admin anchor navigation', () => {
     expect(currentSectionBar?.textContent).toContain('Workspace · Settings')
     expect(currentSectionBar?.textContent).toContain('Quick switch: Alt+↑ previous')
     expect(currentSectionBar?.querySelector('[data-admin-quick-jump="true"]')).toBeTruthy()
-    expect(currentSectionBar?.querySelector('[data-admin-focus-toggle="true"]')?.textContent).toContain('Show all sections')
+    expect(currentSectionBar?.querySelector('[data-admin-focus-toggle="true"]')).toBeNull()
     expect(currentSectionBar?.querySelector('[data-admin-prev-section]')?.getAttribute('data-admin-prev-section-id')).toBe('')
     expect(currentSectionBar?.querySelector('[data-admin-next-section]')?.getAttribute('data-admin-next-section-id')).toBe('attendance-admin-user-access')
   })
@@ -293,18 +289,15 @@ describe('Attendance admin anchor navigation', () => {
     expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Scheduling · Shifts')
   })
 
-  it('remembers focus-vs-show-all mode across remounts', async () => {
+  it('normalizes legacy show-all storage back to focused mode across remounts', async () => {
+    window.localStorage.setItem(scopedAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY), JSON.stringify(false))
+
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
     await flushUi()
 
-    const toggle = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
-    expect(toggle).toBeTruthy()
-    toggle!.click()
-    await flushUi(2)
-
-    expect(window.localStorage.getItem(scopedAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY))).toBe('false')
-    expect(toggle?.textContent).toContain('Focus current section')
+    expect(container!.querySelector('[data-admin-focus-toggle="true"]')).toBeNull()
+    expect(window.localStorage.getItem(scopedAdminNavStorageKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY))).toBe('true')
 
     app.unmount()
     container!.innerHTML = ''
@@ -313,10 +306,9 @@ describe('Attendance admin anchor navigation', () => {
     app.mount(container!)
     await flushUi()
 
-    const nextToggle = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
-    expect(nextToggle?.textContent).toContain('Focus current section')
+    expect(container!.querySelector('[data-admin-focus-toggle="true"]')).toBeNull()
     expect(container!.querySelector<HTMLElement>('#attendance-admin-settings')?.style.display).not.toBe('none')
-    expect(container!.querySelector<HTMLElement>('#attendance-admin-holidays')?.style.display).not.toBe('none')
+    expect(container!.querySelector<HTMLElement>('#attendance-admin-holidays')?.style.display).toBe('none')
   })
 
   it('restores the live user picker, structured rule builder, and holiday month calendar interactions', async () => {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -307,31 +307,24 @@ describe('Attendance admin regressions', () => {
     container = null
   })
 
-  it('focuses the clicked admin section after toggling show-all', async () => {
+  it('keeps the clicked admin section focused and retires the show-all toggle', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
     await flushUi()
-
-    const toggle = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
-    expect(toggle?.textContent).toContain('Show all sections')
-
-    toggle!.click()
-    await flushUi(2)
-    expect(toggle?.textContent).toContain('Focus current section')
 
     const settings = container!.querySelector<HTMLElement>('#attendance-admin-settings')
     const groupMembers = container!.querySelector<HTMLElement>('#attendance-admin-group-members')
     expect(settings).toBeTruthy()
     expect(groupMembers).toBeTruthy()
     expect(window.getComputedStyle(settings!).display).not.toBe('none')
-    expect(window.getComputedStyle(groupMembers!).display).not.toBe('none')
+    expect(window.getComputedStyle(groupMembers!).display).toBe('none')
 
     const groupMembersNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-group-members"]')
     expect(groupMembersNav).toBeTruthy()
     groupMembersNav!.click()
     await flushUi(2)
 
-    expect(toggle?.textContent).toContain('Show all sections')
+    expect(container!.querySelector('[data-admin-focus-toggle="true"]')).toBeNull()
     expect(window.getComputedStyle(settings!).display).toBe('none')
     expect(window.getComputedStyle(groupMembers!).display).not.toBe('none')
     expect(container!.querySelector('[data-admin-shortcut="attendance-admin-group-members"]')?.textContent).toContain('Organization · Group members')
@@ -358,17 +351,11 @@ describe('Attendance admin regressions', () => {
     expect(ruleSetSection).toBeTruthy()
     expect(window.getComputedStyle(ruleSetSection!).display).not.toBe('none')
     expect(visibleEditButton).toBeTruthy()
+    expect(container!.querySelector('[data-admin-focus-toggle="true"]')).toBeNull()
     expect(window.getComputedStyle(leaveTypeSection!).display).toBe('none')
-
-    const toggle = container!.querySelector<HTMLButtonElement>('[data-admin-focus-toggle="true"]')
-    expect(toggle?.textContent).toContain('Show all sections')
-    toggle!.click()
-    await flushUi(2)
-
-    const leaveTypeEditButton = Array.from(leaveTypeSection!.querySelectorAll<HTMLButtonElement>('button'))
-      .find(button => button.textContent?.includes('Edit'))
-    expect(window.getComputedStyle(leaveTypeSection!).display).not.toBe('none')
-    expect(leaveTypeEditButton).toBeTruthy()
+    const actionCell = visibleEditButton?.closest('td')
+    expect(actionCell).toBeTruthy()
+    expect(actionCell?.classList.contains('attendance__table-actions')).toBe(true)
   })
 
   it('restores the run21 holiday calendar, rule builder, and import template guidance', async () => {
@@ -450,6 +437,14 @@ describe('Attendance admin regressions', () => {
     expect(container!.textContent).toContain('Selected version')
     expect(container!.textContent).toContain('ops-admin')
     expect(container!.textContent).toContain('Night Shift')
+
+    const dataPayrollHeader = Array.from(container!.querySelectorAll<HTMLButtonElement>('.attendance__admin-nav-group-header'))
+      .find(button => button.textContent?.includes('Data & Payroll'))
+    expect(dataPayrollHeader).toBeTruthy()
+    if (dataPayrollHeader!.getAttribute('aria-expanded') === 'false') {
+      dataPayrollHeader!.click()
+      await flushUi(2)
+    }
 
     const importBatchesNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-import-batches"]')
     expect(importBatchesNav).toBeTruthy()

--- a/docs/development/attendance-run24-ui-followup-design-20260330.md
+++ b/docs/development/attendance-run24-ui-followup-design-20260330.md
@@ -1,0 +1,41 @@
+# Attendance Run24 UI Follow-up Design
+
+## Scope
+
+This slice closes the two operator-facing regressions confirmed during `attendance-onprem-run24-20260330` validation:
+
+1. Retire the `Show all sections` admin-console mode so the right pane always stays focused on the active section.
+2. Fix attendance admin action cells whose `td.attendance__table-actions` could collapse to `0x0` in the deployed browser, hiding `Edit` buttons even though the handlers still worked.
+
+It also hardens the structured rule builder header layout so the summary badges and preview actions wrap instead of squeezing the form on narrower desktop widths.
+
+## Design
+
+### 1. Remove the operator-facing show-all toggle
+
+- Keep `adminFocusedMode` as the only supported runtime mode.
+- Normalize any old persisted `false` value back to `true`.
+- Remove the `Show all sections` / `Focus current section` toggle button from the current-section bar.
+- Update the current-section copy so it no longer references a retired all-sections mode.
+
+### 2. Fix admin table action-cell sizing at the cell level
+
+- Keep `.attendance__table-actions` as a flex container for both `td` and non-table wrappers.
+- Add a table-cell-specific rule for `.attendance__table td.attendance__table-actions`:
+  - `width: 1%`
+  - `min-width: max-content`
+  - `height: auto`
+  - `vertical-align: middle`
+- This anchors the width on the `td` itself instead of relying on child button min-size.
+
+### 3. Harden structured rule builder layout
+
+- Make the top-level rule-builder headers wrap.
+- Let the summary chip row fall below the title block instead of compressing controls.
+- On narrower widths, stack the rule-builder and preview headers vertically.
+
+## Non-goals
+
+- No new import/report pages.
+- No change to attendance API behavior.
+- No attempt to reintroduce an alternate “show all sections” mode behind another control.

--- a/docs/development/attendance-run24-ui-followup-verification-20260330.md
+++ b/docs/development/attendance-run24-ui-followup-verification-20260330.md
@@ -1,0 +1,30 @@
+# Attendance Run24 UI Follow-up Verification
+
+## Commands
+
+```bash
+git diff --check
+pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+```
+
+## Expectations
+
+- Admin console no longer renders a `data-admin-focus-toggle` control.
+- Legacy local-storage `focused_mode=false` is normalized back to focused mode.
+- The active section still scrolls into view and recent shortcuts still work.
+- Action-cell `td` elements expose a non-collapsing `min-width`.
+- Structured rule builder and preview headers wrap without squeezing content.
+
+## Results
+
+- `git diff --check`: pass
+- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false`: pass (`26/26`)
+- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`: pass
+- `pnpm --filter @metasheet/web build`: pass
+
+## Notes
+
+- The DOM-level regression tests lock the retired `data-admin-focus-toggle` out of the UI and verify that legacy local-storage values are normalized back to focused mode.
+- jsdom does not compute real browser layout for the action-cell width collapse, so the button-column fix is validated here through the scoped CSS change plus the focused regression suite. Final confirmation still belongs to browser smoke on the deployed package.


### PR DESCRIPTION
## Summary
- retire the operator-facing `Show all sections` toggle and normalize legacy admin-nav focus preferences back to focused mode
- fix attendance action-cell sizing at the table-cell level so admin `Edit` buttons no longer collapse in deployed browsers
- harden the structured rule builder header layout and lock the focused-mode behavior with frontend regression tests

## Verification
- `git diff --check`
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`