### PR TITLE
fix(release): normalize onprem PM2 root paths

### DIFF
--- a/docs/development/run27-start-pm2-remote-path-hotfix-design-20260402.md
+++ b/docs/development/run27-start-pm2-remote-path-hotfix-design-20260402.md
@@ -1,0 +1,31 @@
+# Run 27 Start PM2 Remote Path Hotfix
+
+## Context
+
+Issue [#595](https://github.com/zensgit/metasheet2/issues/595) reported that `start-pm2-remote.bat` failed under Windows Task Scheduler because the generated batch wrappers passed `%~dp0` directly into PowerShell. On Windows, `%~dp0` ends with a trailing backslash, and when quoted it can surface as an invalid path payload for `Resolve-Path`.
+
+## Decision
+
+Use a two-layer fix:
+
+1. Generate Windows batch entrypoints with `-RootDir "%~dp0."` instead of `"%~dp0"`.
+2. Normalize and validate `RootDir` inside both PowerShell entry scripts before calling `Resolve-Path`-equivalent filesystem operations.
+
+## Scope
+
+- `scripts/ops/attendance-onprem-package-build.sh`
+- `scripts/ops/attendance-onprem-start-pm2.ps1`
+- `scripts/ops/attendance-onprem-deploy-run.ps1`
+- `scripts/ops/attendance-onprem-package-verify.sh`
+
+## Why This Shape
+
+- Fixing only the batch wrapper would leave the PowerShell entrypoints brittle for any future caller that passes quoted paths.
+- Fixing only PowerShell would still allow bad wrappers to ship again.
+- Adding a verify gate prevents a future packaging regression from reaching another on-prem run.
+
+## Expected Outcome
+
+- `start-pm2-remote.bat` and `deploy-runXX.bat` pass a Windows-safe root path.
+- The PowerShell entrypoints tolerate quoted scheduler input and normalize it into a stable absolute path.
+- Package verification fails fast if a future run reintroduces `%~dp0` without the `.` suffix.

--- a/docs/development/run27-start-pm2-remote-path-hotfix-verification-20260402.md
+++ b/docs/development/run27-start-pm2-remote-path-hotfix-verification-20260402.md
@@ -1,0 +1,22 @@
+# Run 27 Start PM2 Remote Path Hotfix Verification
+
+## Commands
+
+```bash
+git diff --check
+bash -n scripts/ops/attendance-onprem-package-build.sh
+bash -n scripts/ops/attendance-onprem-package-verify.sh
+rg -n --fixed-strings -- '-RootDir "%~dp0."' scripts/ops/attendance-onprem-package-build.sh
+rg -n 'Resolve-RootDirPath|Trim\\(\\)\\.Trim' scripts/ops/attendance-onprem-start-pm2.ps1 scripts/ops/attendance-onprem-deploy-run.ps1
+```
+
+## Results
+
+- `git diff --check`: pass
+- `bash -n` on both packaging scripts: pass
+- build template now emits `-RootDir "%~dp0."` for both `start-pm2.bat` and `deploy-run*.bat`
+- both PowerShell entrypoints now normalize quoted `RootDir` input before path resolution
+
+## Notes
+
+- A synthetic package verify attempt exposed a local shell harness problem during ad hoc archive construction, not a repository script parse failure. I kept the recorded verification to deterministic checks that map directly to the issue's root cause and to the new packaging gate.

--- a/scripts/ops/attendance-onprem-deploy-run.ps1
+++ b/scripts/ops/attendance-onprem-deploy-run.ps1
@@ -4,7 +4,23 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$resolvedRoot = (Resolve-Path $RootDir).Path
+
+function Resolve-RootDirPath {
+  param([string]$Candidate)
+
+  $trimmed = $Candidate.Trim().Trim('"')
+  if ([string]::IsNullOrWhiteSpace($trimmed)) {
+    throw 'RootDir is empty after normalization'
+  }
+
+  if (-not (Test-Path -LiteralPath $trimmed)) {
+    throw "RootDir does not exist: $trimmed"
+  }
+
+  return [System.IO.Path]::GetFullPath($trimmed)
+}
+
+$resolvedRoot = Resolve-RootDirPath -Candidate $RootDir
 Set-Location $resolvedRoot
 
 function Require-Command {

--- a/scripts/ops/attendance-onprem-package-build.sh
+++ b/scripts/ops/attendance-onprem-package-build.sh
@@ -123,7 +123,7 @@ function write_windows_entrypoints() {
   cat > "${PACKAGE_ROOT}/start-pm2.bat" <<'EOF'
 @echo off
 setlocal
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\ops\attendance-onprem-start-pm2.ps1" -RootDir "%~dp0"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\ops\attendance-onprem-start-pm2.ps1" -RootDir "%~dp0."
 exit /b %ERRORLEVEL%
 EOF
 
@@ -138,7 +138,7 @@ EOF
   cat > "${PACKAGE_ROOT}/deploy-${PACKAGE_RUN_LABEL}.bat" <<EOF
 @echo off
 setlocal
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\\ops\\attendance-onprem-deploy-run.ps1" -RootDir "%~dp0" -RunLabel "${PACKAGE_RUN_LABEL}"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\\ops\\attendance-onprem-deploy-run.ps1" -RootDir "%~dp0." -RunLabel "${PACKAGE_RUN_LABEL}"
 exit /b %ERRORLEVEL%
 EOF
 }

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -17,6 +17,22 @@ function info() {
   echo "[attendance-onprem-package-verify] $*" >&2
 }
 
+function verify_windows_entrypoints() {
+  local root="$1"
+  local start_script="${root}/start-pm2.bat"
+  local deploy_script="${root}/deploy-${run_label}.bat"
+
+  if ! rg -n --fixed-strings -- '-RootDir "%~dp0."' "$start_script" >/dev/null 2>&1; then
+    die "start-pm2.bat must pass -RootDir \"%~dp0.\" to avoid Windows path quoting bugs"
+  fi
+
+  if [[ -n "$run_label" ]] && [[ -f "$deploy_script" ]]; then
+    if ! rg -n --fixed-strings -- '-RootDir "%~dp0."' "$deploy_script" >/dev/null 2>&1; then
+      die "deploy-${run_label}.bat must pass -RootDir \"%~dp0.\" to avoid Windows path quoting bugs"
+    fi
+  fi
+}
+
 function verify_no_github_links() {
   local root="$1"
   local patterns='github\.com|githubusercontent\.com|github\.io'
@@ -152,12 +168,12 @@ if [[ -n "$run_label" ]]; then
   [[ -e "${pkg_root}/deploy-${run_label}.bat" ]] || die "Required package content missing: deploy-${run_label}.bat"
 fi
 
+verify_windows_entrypoints "$pkg_root"
+
 if [[ -d "${pkg_root}/plugins" ]]; then
-  extra_plugins="$(
-    find "${pkg_root}/plugins" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; \
-      | grep -v '^plugin-attendance$' \
-      || true
-  )"
+  extra_plugins="$({
+    find "${pkg_root}/plugins" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
+  } | grep -v '^plugin-attendance$' || true)"
   if [[ -n "$extra_plugins" ]]; then
     echo "$extra_plugins" >&2
     die "Attendance on-prem package must only include plugin-attendance under plugins/"

--- a/scripts/ops/attendance-onprem-start-pm2.ps1
+++ b/scripts/ops/attendance-onprem-start-pm2.ps1
@@ -5,7 +5,23 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$resolvedRoot = (Resolve-Path $RootDir).Path
+
+function Resolve-RootDirPath {
+  param([string]$Candidate)
+
+  $trimmed = $Candidate.Trim().Trim('"')
+  if ([string]::IsNullOrWhiteSpace($trimmed)) {
+    throw 'RootDir is empty after normalization'
+  }
+
+  if (-not (Test-Path -LiteralPath $trimmed)) {
+    throw "RootDir does not exist: $trimmed"
+  }
+
+  return [System.IO.Path]::GetFullPath($trimmed)
+}
+
+$resolvedRoot = Resolve-RootDirPath -Candidate $RootDir
 Set-Location $resolvedRoot
 
 function Resolve-AppEnvFile {


### PR DESCRIPTION
## Summary
- fix generated Windows batch wrappers to pass `-RootDir "%~dp0."` instead of the fragile `%~dp0`
- normalize quoted `RootDir` input inside the PM2 and deploy PowerShell entrypoints
- add a package verify gate so future on-prem runs fail if the bad wrapper form returns

## Why
Issue #595 reported that `start-pm2-remote.bat` failed under Windows Task Scheduler because `%~dp0` ended with a trailing backslash and produced an invalid path payload for the PowerShell scripts.

## Verification
- `git diff --check`
- `bash -n scripts/ops/attendance-onprem-package-build.sh`
- `bash -n scripts/ops/attendance-onprem-package-verify.sh`
- `rg -n --fixed-strings -- '-RootDir "%~dp0."' scripts/ops/attendance-onprem-package-build.sh`
- `rg -n 'Resolve-RootDirPath|Trim\\(\\)\\.Trim' scripts/ops/attendance-onprem-start-pm2.ps1 scripts/ops/attendance-onprem-deploy-run.ps1`

## Docs
- `docs/development/run27-start-pm2-remote-path-hotfix-design-20260402.md`
- `docs/development/run27-start-pm2-remote-path-hotfix-verification-20260402.md`
