### PR TITLE
feat(dingtalk): add directory sync admin slice

### DIFF
--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -134,6 +134,12 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'User Management', requiresAuth: true }
   },
   {
+    path: '/admin/directory',
+    name: AppRouteNames.DIRECTORY_MANAGEMENT,
+    component: () => import('../views/DirectoryManagementView.vue'),
+    meta: { title: 'Directory Management', titleZh: '目录同步', requiresAuth: true }
+  },
+  {
     path: '/admin/roles',
     name: 'role-management',
     component: () => import('../views/RoleManagementView.vue'),

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -75,6 +75,7 @@ export const AppRouteNames = {
   USER_PROFILE: 'user-profile',
   USER_SETTINGS: 'user-settings',
   USER_MANAGEMENT: 'user-management',
+  DIRECTORY_MANAGEMENT: 'directory-management',
 
   // Permission routes
   PERMISSION_MANAGEMENT: 'permission-management',
@@ -140,6 +141,7 @@ export interface AppRouteParams {
   'multitable-comment-inbox': Record<string, never>
   'user-settings': Record<string, never>
   'user-management': Record<string, never>
+  'directory-management': Record<string, never>
   'permission-management': Record<string, never>
   'role-management': Record<string, never>
   'admin-dashboard': Record<string, never>

--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -1,0 +1,659 @@
+<template>
+  <section class="directory-admin">
+    <header class="directory-admin__header">
+      <div>
+        <h1>目录同步</h1>
+        <p>管理钉钉组织目录集成，执行连通性测试，并手动触发同步。</p>
+      </div>
+
+      <div class="directory-admin__actions">
+        <router-link class="directory-admin__link" to="/admin/users">用户管理</router-link>
+        <router-link class="directory-admin__link" to="/admin/roles">角色管理</router-link>
+        <router-link class="directory-admin__link" to="/admin/audit">管理审计</router-link>
+        <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="loading" @click="void loadIntegrations()">
+          {{ loading ? '刷新中...' : '刷新列表' }}
+        </button>
+        <button class="directory-admin__button" type="button" @click="resetDraft()">新建集成</button>
+      </div>
+    </header>
+
+    <p v-if="status" class="directory-admin__status" :class="{ 'directory-admin__status--error': statusTone === 'error' }">
+      {{ status }}
+    </p>
+
+    <div class="directory-admin__layout">
+      <aside class="directory-admin__panel directory-admin__panel--list">
+        <div class="directory-admin__section-head">
+          <div>
+            <h2>集成列表</h2>
+            <p class="directory-admin__hint">当前仅支持钉钉目录拉取与手动同步。</p>
+          </div>
+        </div>
+
+        <div v-if="integrations.length === 0" class="directory-admin__empty">暂无目录集成</div>
+        <button
+          v-for="integration in integrations"
+          :key="integration.id"
+          class="directory-admin__item"
+          :class="{ 'directory-admin__item--active': selectedIntegrationId === integration.id }"
+          type="button"
+          @click="selectIntegration(integration.id)"
+        >
+          <strong>{{ integration.name }}</strong>
+          <span>{{ integration.corpId }}</span>
+          <small>
+            账号 {{ integration.stats.accountCount }} / 部门 {{ integration.stats.departmentCount }} / 待确认 {{ integration.stats.pendingLinkCount }}
+          </small>
+          <small>
+            最近同步：{{ formatDateTime(integration.lastSyncAt) }} · {{ integration.stats.lastRunStatus || '未运行' }}
+          </small>
+        </button>
+      </aside>
+
+      <section class="directory-admin__panel directory-admin__panel--detail">
+        <div class="directory-admin__section-head">
+          <div>
+            <h2>{{ selectedIntegration ? '编辑集成' : '创建集成' }}</h2>
+            <p class="directory-admin__hint">`appSecret` 在更新时可留空，系统会继续使用已保存的值。</p>
+          </div>
+          <div class="directory-admin__summary" v-if="selectedIntegration">
+            <span class="directory-admin__badge">{{ selectedIntegration.status }}</span>
+            <span class="directory-admin__badge" :class="{ 'directory-admin__badge--inactive': !selectedIntegration.syncEnabled }">
+              {{ selectedIntegration.syncEnabled ? '已启用同步' : '仅手动同步' }}
+            </span>
+            <span class="directory-admin__badge">已链接 {{ selectedIntegration.stats.linkedCount }}</span>
+          </div>
+        </div>
+
+        <div class="directory-admin__form-grid">
+          <label class="directory-admin__field">
+            <span>集成名称</span>
+            <input v-model.trim="draft.name" class="directory-admin__input" type="text" placeholder="例如 DingTalk CN" />
+          </label>
+          <label class="directory-admin__field">
+            <span>Corp ID</span>
+            <input v-model.trim="draft.corpId" class="directory-admin__input" type="text" placeholder="dingxxxx" />
+          </label>
+          <label class="directory-admin__field">
+            <span>App Key</span>
+            <input v-model.trim="draft.appKey" class="directory-admin__input" type="text" placeholder="填写企业应用 appKey" />
+          </label>
+          <label class="directory-admin__field">
+            <span>App Secret</span>
+            <input v-model.trim="draft.appSecret" class="directory-admin__input" type="password" placeholder="创建必填，更新可留空" />
+          </label>
+          <label class="directory-admin__field">
+            <span>根部门 ID</span>
+            <input v-model.trim="draft.rootDepartmentId" class="directory-admin__input" type="text" placeholder="默认 1" />
+          </label>
+          <label class="directory-admin__field">
+            <span>Base URL</span>
+            <input v-model.trim="draft.baseUrl" class="directory-admin__input" type="text" placeholder="默认 https://oapi.dingtalk.com" />
+          </label>
+          <label class="directory-admin__field">
+            <span>Page Size</span>
+            <input v-model.number="draft.pageSize" class="directory-admin__input" type="number" min="1" max="100" />
+          </label>
+          <label class="directory-admin__field">
+            <span>状态</span>
+            <select v-model="draft.status" class="directory-admin__input">
+              <option value="active">active</option>
+              <option value="paused">paused</option>
+            </select>
+          </label>
+          <label class="directory-admin__field">
+            <span>Schedule Cron</span>
+            <input v-model.trim="draft.scheduleCron" class="directory-admin__input" type="text" placeholder="一期可留空" />
+          </label>
+          <label class="directory-admin__field">
+            <span>停权策略</span>
+            <select v-model="draft.defaultDeprovisionPolicy" class="directory-admin__input">
+              <option value="mark_inactive">mark_inactive</option>
+              <option value="manual_review">manual_review</option>
+            </select>
+          </label>
+          <label class="directory-admin__toggle">
+            <input v-model="draft.syncEnabled" type="checkbox" />
+            <span>保存后允许自动同步</span>
+          </label>
+        </div>
+
+        <footer class="directory-admin__footer">
+          <button class="directory-admin__button" type="button" :disabled="busy || !canSave" @click="void saveIntegration()">
+            {{ busy ? '处理中...' : selectedIntegration ? '保存变更' : '创建集成' }}
+          </button>
+          <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy" @click="void testIntegration()">
+            测试连通性
+          </button>
+          <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy || !selectedIntegration" @click="void syncIntegration()">
+            手动同步
+          </button>
+        </footer>
+
+        <section v-if="selectedIntegration" class="directory-admin__section">
+          <h3>当前概览</h3>
+          <div class="directory-admin__chips">
+            <span class="directory-admin__chip">部门 {{ selectedIntegration.stats.departmentCount }}</span>
+            <span class="directory-admin__chip">账号 {{ selectedIntegration.stats.accountCount }}</span>
+            <span class="directory-admin__chip">待确认 {{ selectedIntegration.stats.pendingLinkCount }}</span>
+            <span class="directory-admin__chip">已链接 {{ selectedIntegration.stats.linkedCount }}</span>
+            <span class="directory-admin__chip">上次成功 {{ formatDateTime(selectedIntegration.lastSuccessAt) }}</span>
+          </div>
+          <p v-if="selectedIntegration.lastError" class="directory-admin__status directory-admin__status--error">
+            最近错误：{{ selectedIntegration.lastError }}
+          </p>
+        </section>
+
+        <section v-if="testResult" class="directory-admin__section">
+          <h3>连通性测试</h3>
+          <div class="directory-admin__chips">
+            <span class="directory-admin__chip">部门样本 {{ testResult.departmentSampleCount }}</span>
+            <span class="directory-admin__chip">用户样本 {{ testResult.userSampleCount }}</span>
+            <span class="directory-admin__chip">Root {{ testResult.rootDepartmentId }}</span>
+          </div>
+          <p class="directory-admin__hint">
+            部门：{{ testResult.sampledDepartments.map((item) => item.name).join('，') || '无' }}
+          </p>
+          <p class="directory-admin__hint">
+            用户：{{ testResult.sampledUsers.map((item) => item.name).join('，') || '无' }}
+          </p>
+        </section>
+
+        <section v-if="selectedIntegration" class="directory-admin__section">
+          <div class="directory-admin__section-head">
+            <div>
+              <h3>运行记录</h3>
+              <p class="directory-admin__hint">展示最近同步执行结果与聚合统计。</p>
+            </div>
+            <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="loadingRuns" @click="void loadRuns(selectedIntegration.id)">
+              {{ loadingRuns ? '刷新中...' : '刷新记录' }}
+            </button>
+          </div>
+          <div v-if="runs.length === 0" class="directory-admin__empty">暂无运行记录</div>
+          <article v-for="run in runs" :key="run.id" class="directory-admin__run">
+            <div class="directory-admin__run-head">
+              <strong>{{ run.status }}</strong>
+              <small>{{ formatDateTime(run.startedAt) }} → {{ formatDateTime(run.finishedAt) }}</small>
+            </div>
+            <p class="directory-admin__hint">
+              账号 {{ readNumericStat(run.stats, 'accountsSynced') }} / 部门 {{ readNumericStat(run.stats, 'departmentsSynced') }} /
+              待确认 {{ readNumericStat(run.stats, 'pendingCount') }} / 已链接 {{ readNumericStat(run.stats, 'linkedCount') }}
+            </p>
+            <p v-if="run.errorMessage" class="directory-admin__status directory-admin__status--error">{{ run.errorMessage }}</p>
+          </article>
+        </section>
+      </section>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { apiFetch } from '../utils/api'
+
+type DirectoryIntegration = {
+  id: string
+  name: string
+  corpId: string
+  status: string
+  syncEnabled: boolean
+  scheduleCron: string | null
+  defaultDeprovisionPolicy: string
+  lastSyncAt: string | null
+  lastSuccessAt: string | null
+  lastError: string | null
+  config: {
+    appKey: string
+    appSecretConfigured: boolean
+    rootDepartmentId: string
+    baseUrl: string | null
+    pageSize: number
+  }
+  stats: {
+    departmentCount: number
+    accountCount: number
+    pendingLinkCount: number
+    linkedCount: number
+    lastRunStatus: string | null
+  }
+}
+
+type DirectoryRun = {
+  id: string
+  status: string
+  startedAt: string
+  finishedAt: string | null
+  stats: Record<string, unknown>
+  errorMessage: string | null
+}
+
+type TestResult = {
+  rootDepartmentId: string
+  departmentSampleCount: number
+  sampledDepartments: Array<{ id: string; name: string }>
+  userSampleCount: number
+  sampledUsers: Array<{ userId: string; name: string }>
+}
+
+type DirectoryDraft = {
+  name: string
+  corpId: string
+  appKey: string
+  appSecret: string
+  rootDepartmentId: string
+  baseUrl: string
+  pageSize: number
+  status: string
+  scheduleCron: string
+  defaultDeprovisionPolicy: string
+  syncEnabled: boolean
+}
+
+const integrations = ref<DirectoryIntegration[]>([])
+const runs = ref<DirectoryRun[]>([])
+const selectedIntegrationId = ref('')
+const loading = ref(false)
+const loadingRuns = ref(false)
+const busy = ref(false)
+const status = ref('')
+const statusTone = ref<'info' | 'error'>('info')
+const testResult = ref<TestResult | null>(null)
+
+const draft = reactive<DirectoryDraft>({
+  name: '',
+  corpId: '',
+  appKey: '',
+  appSecret: '',
+  rootDepartmentId: '1',
+  baseUrl: '',
+  pageSize: 50,
+  status: 'active',
+  scheduleCron: '',
+  defaultDeprovisionPolicy: 'mark_inactive',
+  syncEnabled: false,
+})
+
+const selectedIntegration = computed(() =>
+  integrations.value.find((integration) => integration.id === selectedIntegrationId.value) ?? null,
+)
+
+const canSave = computed(() =>
+  draft.name.trim().length > 0 &&
+  draft.corpId.trim().length > 0 &&
+  draft.appKey.trim().length > 0 &&
+  (selectedIntegration.value !== null || draft.appSecret.trim().length > 0),
+)
+
+function setStatus(message: string, tone: 'info' | 'error' = 'info') {
+  status.value = message
+  statusTone.value = tone
+}
+
+function resetDraft() {
+  selectedIntegrationId.value = ''
+  testResult.value = null
+  runs.value = []
+  draft.name = ''
+  draft.corpId = ''
+  draft.appKey = ''
+  draft.appSecret = ''
+  draft.rootDepartmentId = '1'
+  draft.baseUrl = ''
+  draft.pageSize = 50
+  draft.status = 'active'
+  draft.scheduleCron = ''
+  draft.defaultDeprovisionPolicy = 'mark_inactive'
+  draft.syncEnabled = false
+}
+
+function applyIntegrationToDraft(integration: DirectoryIntegration) {
+  draft.name = integration.name
+  draft.corpId = integration.corpId
+  draft.appKey = integration.config.appKey
+  draft.appSecret = ''
+  draft.rootDepartmentId = integration.config.rootDepartmentId
+  draft.baseUrl = integration.config.baseUrl ?? ''
+  draft.pageSize = integration.config.pageSize
+  draft.status = integration.status
+  draft.scheduleCron = integration.scheduleCron ?? ''
+  draft.defaultDeprovisionPolicy = integration.defaultDeprovisionPolicy
+  draft.syncEnabled = integration.syncEnabled
+}
+
+function selectIntegration(integrationId: string) {
+  selectedIntegrationId.value = integrationId
+  testResult.value = null
+  const integration = integrations.value.find((item) => item.id === integrationId)
+  if (!integration) return
+  applyIntegrationToDraft(integration)
+  void loadRuns(integrationId)
+}
+
+function readApiError(payload: unknown, fallback: string): string {
+  const error = payload && typeof payload === 'object' ? (payload as { error?: { message?: unknown } }).error : undefined
+  return typeof error?.message === 'string' && error.message.trim().length > 0 ? error.message : fallback
+}
+
+async function readJson(response: Response): Promise<any> {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+async function loadIntegrations() {
+  loading.value = true
+  try {
+    const response = await apiFetch('/api/admin/directory/integrations')
+    const payload = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(payload, '加载目录集成失败'))
+
+    integrations.value = Array.isArray(payload?.data?.items) ? payload.data.items : []
+    if (!selectedIntegrationId.value && integrations.value.length > 0) {
+      selectIntegration(integrations.value[0].id)
+    } else if (selectedIntegrationId.value) {
+      const current = integrations.value.find((item) => item.id === selectedIntegrationId.value)
+      if (current) applyIntegrationToDraft(current)
+    }
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '加载目录集成失败', 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+function buildPayload() {
+  return {
+    name: draft.name.trim(),
+    corpId: draft.corpId.trim(),
+    appKey: draft.appKey.trim(),
+    appSecret: draft.appSecret.trim(),
+    rootDepartmentId: draft.rootDepartmentId.trim() || '1',
+    baseUrl: draft.baseUrl.trim(),
+    pageSize: Number(draft.pageSize || 50),
+    status: draft.status,
+    scheduleCron: draft.scheduleCron.trim(),
+    defaultDeprovisionPolicy: draft.defaultDeprovisionPolicy,
+    syncEnabled: draft.syncEnabled,
+  }
+}
+
+async function saveIntegration() {
+  busy.value = true
+  try {
+    const payload = buildPayload()
+    const path = selectedIntegration.value
+      ? `/api/admin/directory/integrations/${selectedIntegration.value.id}`
+      : '/api/admin/directory/integrations'
+    const method = selectedIntegration.value ? 'PUT' : 'POST'
+    const response = await apiFetch(path, {
+      method,
+      body: JSON.stringify(payload),
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '保存目录集成失败'))
+
+    const integration = body?.data?.integration as DirectoryIntegration | undefined
+    setStatus(selectedIntegration.value ? '目录集成已更新' : '目录集成已创建')
+    testResult.value = null
+    await loadIntegrations()
+    if (integration?.id) selectIntegration(integration.id)
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '保存目录集成失败', 'error')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function testIntegration() {
+  busy.value = true
+  try {
+    const response = await apiFetch('/api/admin/directory/integrations/test', {
+      method: 'POST',
+      body: JSON.stringify(buildPayload()),
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '目录连通性测试失败'))
+    testResult.value = body?.data ?? null
+    setStatus('目录连通性测试通过')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '目录连通性测试失败', 'error')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function syncIntegration() {
+  if (!selectedIntegration.value) return
+  busy.value = true
+  try {
+    const response = await apiFetch(`/api/admin/directory/integrations/${selectedIntegration.value.id}/sync`, {
+      method: 'POST',
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '目录同步失败'))
+    setStatus('目录同步已完成')
+    await Promise.all([
+      loadIntegrations(),
+      loadRuns(selectedIntegration.value.id),
+    ])
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '目录同步失败', 'error')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function loadRuns(integrationId: string) {
+  loadingRuns.value = true
+  try {
+    const response = await apiFetch(`/api/admin/directory/integrations/${integrationId}/runs?page=1&pageSize=10`)
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '加载同步记录失败'))
+    runs.value = Array.isArray(body?.data?.items) ? body.data.items : []
+  } catch (error) {
+    runs.value = []
+    setStatus(error instanceof Error ? error.message : '加载同步记录失败', 'error')
+  } finally {
+    loadingRuns.value = false
+  }
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return '未记录'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function readNumericStat(stats: Record<string, unknown>, key: string): number {
+  const value = stats[key]
+  if (typeof value === 'number') return value
+  if (typeof value === 'string' && value.trim().length > 0 && !Number.isNaN(Number(value))) return Number(value)
+  return 0
+}
+
+onMounted(() => {
+  void loadIntegrations()
+})
+</script>
+
+<style scoped>
+.directory-admin {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+}
+
+.directory-admin__header,
+.directory-admin__section-head,
+.directory-admin__footer,
+.directory-admin__actions,
+.directory-admin__run-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.directory-admin__layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  gap: 20px;
+}
+
+.directory-admin__panel {
+  border: 1px solid #d8dee8;
+  border-radius: 18px;
+  background: #fff;
+  padding: 20px;
+  box-shadow: 0 14px 40px rgba(15, 23, 42, 0.06);
+}
+
+.directory-admin__panel--list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.directory-admin__panel--detail {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.directory-admin__item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid #d8dee8;
+  border-radius: 14px;
+  background: #f8fafc;
+  text-align: left;
+  cursor: pointer;
+}
+
+.directory-admin__item--active {
+  border-color: #2563eb;
+  background: #eff6ff;
+}
+
+.directory-admin__form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.directory-admin__field,
+.directory-admin__toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.directory-admin__toggle {
+  justify-content: flex-end;
+}
+
+.directory-admin__input {
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.directory-admin__button,
+.directory-admin__link {
+  border: 1px solid #1d4ed8;
+  border-radius: 999px;
+  padding: 9px 16px;
+  background: #1d4ed8;
+  color: #fff;
+  text-decoration: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.directory-admin__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.directory-admin__button--secondary,
+.directory-admin__link {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.directory-admin__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.directory-admin__chips,
+.directory-admin__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.directory-admin__chip,
+.directory-admin__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #0f172a;
+  font-size: 13px;
+}
+
+.directory-admin__badge--inactive {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.directory-admin__status {
+  margin: 0;
+  color: #0f766e;
+}
+
+.directory-admin__status--error {
+  color: #b91c1c;
+}
+
+.directory-admin__hint,
+.directory-admin__item small {
+  margin: 0;
+  color: #475569;
+}
+
+.directory-admin__empty {
+  color: #64748b;
+}
+
+.directory-admin__run {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 14px;
+  background: #f8fafc;
+}
+
+@media (max-width: 960px) {
+  .directory-admin__layout,
+  .directory-admin__form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -9,6 +9,7 @@
       <div class="user-admin__actions">
         <router-link class="user-admin__link" to="/admin/roles">角色管理</router-link>
         <router-link class="user-admin__link" to="/admin/permissions">权限管理</router-link>
+        <router-link class="user-admin__link" to="/admin/directory">目录同步</router-link>
         <router-link class="user-admin__link" to="/admin/audit">管理审计</router-link>
         <input
           v-model.trim="search"

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import DirectoryManagementView from '../src/views/DirectoryManagementView.vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function createJsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  }
+}
+
+describe('DirectoryManagementView', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('loads integrations and recent runs on mount', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'dir-1',
+              name: 'DingTalk CN',
+              corpId: 'dingcorp',
+              status: 'active',
+              syncEnabled: true,
+              scheduleCron: null,
+              defaultDeprovisionPolicy: 'mark_inactive',
+              lastSyncAt: '2026-04-08T01:00:00.000Z',
+              lastSuccessAt: '2026-04-08T01:00:00.000Z',
+              lastError: null,
+              config: {
+                appKey: 'ding-app-key',
+                appSecretConfigured: true,
+                rootDepartmentId: '1',
+                baseUrl: null,
+                pageSize: 50,
+              },
+              stats: {
+                departmentCount: 12,
+                accountCount: 98,
+                pendingLinkCount: 4,
+                linkedCount: 88,
+                lastRunStatus: 'completed',
+              },
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'run-1',
+              status: 'completed',
+              startedAt: '2026-04-08T01:00:00.000Z',
+              finishedAt: '2026-04-08T01:05:00.000Z',
+              stats: {
+                departmentsSynced: 12,
+                accountsSynced: 98,
+                pendingCount: 4,
+                linkedCount: 88,
+              },
+              errorMessage: null,
+            },
+          ],
+        },
+      }))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenNthCalledWith(1, '/api/admin/directory/integrations')
+    expect(apiFetchMock).toHaveBeenNthCalledWith(2, '/api/admin/directory/integrations/dir-1/runs?page=1&pageSize=10')
+    expect(container?.textContent).toContain('DingTalk CN')
+    expect(container?.textContent).toContain('账号 98')
+    expect(container?.textContent).toContain('completed')
+  })
+
+  it('posts manual sync and refreshes the selected integration', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'dir-1',
+              name: 'DingTalk CN',
+              corpId: 'dingcorp',
+              status: 'active',
+              syncEnabled: true,
+              scheduleCron: null,
+              defaultDeprovisionPolicy: 'mark_inactive',
+              lastSyncAt: '2026-04-08T01:00:00.000Z',
+              lastSuccessAt: '2026-04-08T01:00:00.000Z',
+              lastError: null,
+              config: {
+                appKey: 'ding-app-key',
+                appSecretConfigured: true,
+                rootDepartmentId: '1',
+                baseUrl: null,
+                pageSize: 50,
+              },
+              stats: {
+                departmentCount: 12,
+                accountCount: 98,
+                pendingLinkCount: 4,
+                linkedCount: 88,
+                lastRunStatus: 'completed',
+              },
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          integration: { id: 'dir-1' },
+          run: { id: 'run-2', status: 'completed' },
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'dir-1',
+              name: 'DingTalk CN',
+              corpId: 'dingcorp',
+              status: 'active',
+              syncEnabled: true,
+              scheduleCron: null,
+              defaultDeprovisionPolicy: 'mark_inactive',
+              lastSyncAt: '2026-04-08T02:00:00.000Z',
+              lastSuccessAt: '2026-04-08T02:00:00.000Z',
+              lastError: null,
+              config: {
+                appKey: 'ding-app-key',
+                appSecretConfigured: true,
+                rootDepartmentId: '1',
+                baseUrl: null,
+                pageSize: 50,
+              },
+              stats: {
+                departmentCount: 13,
+                accountCount: 99,
+                pendingLinkCount: 3,
+                linkedCount: 89,
+                lastRunStatus: 'completed',
+              },
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'run-2',
+              status: 'completed',
+              startedAt: '2026-04-08T02:00:00.000Z',
+              finishedAt: '2026-04-08T02:05:00.000Z',
+              stats: {
+                departmentsSynced: 13,
+                accountsSynced: 99,
+                pendingCount: 3,
+                linkedCount: 89,
+              },
+              errorMessage: null,
+            },
+          ],
+        },
+      }))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const buttons = Array.from(container!.querySelectorAll('button'))
+    const syncButton = buttons.find((button) => button.textContent?.includes('手动同步'))
+    expect(syncButton).toBeTruthy()
+
+    syncButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/integrations/dir-1/sync',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(container?.textContent).toContain('目录同步已完成')
+    expect(container?.textContent).toContain('账号 99')
+  })
+})

--- a/docs/development/dingtalk-pr2-directory-sync-design-20260408.md
+++ b/docs/development/dingtalk-pr2-directory-sync-design-20260408.md
@@ -1,0 +1,176 @@
+# DingTalk PR2 Directory Sync Design
+
+Date: 2026-04-08
+Branch: `codex/dingtalk-pr2-directory-sync-20260408`
+Scope: DingTalk directory integration CRUD, manual sync, sync runs/history, minimal admin UI
+
+## Goal
+
+PR2 adds a usable DingTalk directory integration slice on top of PR1 login foundation without importing the historical featureline wholesale.
+
+The target for this slice is:
+
+- create and update DingTalk directory integrations
+- test DingTalk app credentials and root department reachability
+- manually run a directory sync
+- persist departments, accounts, account-department membership, and link suggestions
+- expose recent sync runs to admins
+- provide a minimal admin UI at `/admin/directory`
+
+## Why not reuse the historical branch directly
+
+The historical DingTalk directory branch contains a much larger surface:
+
+- deprovision ledgers
+- alert acknowledgement workflows
+- template center
+- scheduler and alerting combinations
+- auth helper rewrites
+- large frontend shell changes
+
+Current main already has the required tables for directory sync. Pulling the full historical branch into current main would create unnecessary conflicts in `auth.ts`, router types, admin shell code, and generated OpenAPI artifacts.
+
+This PR deliberately keeps the write set narrow:
+
+- backend:
+  - `packages/core-backend/src/integrations/dingtalk/client.ts`
+  - `packages/core-backend/src/directory/directory-sync.ts`
+  - `packages/core-backend/src/routes/admin-directory.ts`
+  - `packages/core-backend/src/index.ts`
+- frontend:
+  - `apps/web/src/views/DirectoryManagementView.vue`
+  - `apps/web/src/router/appRoutes.ts`
+  - `apps/web/src/router/types.ts`
+  - `apps/web/src/views/UserManagementView.vue`
+
+## Backend design
+
+### DingTalk client extension
+
+`packages/core-backend/src/integrations/dingtalk/client.ts` is extended from PR1 OAuth support to also cover directory APIs:
+
+- app access token
+- list sub-departments
+- list users in a department
+- fetch user detail
+
+This keeps DingTalk HTTP normalization in one place instead of duplicating it in attendance, auth, and directory modules.
+
+### Directory service
+
+`packages/core-backend/src/directory/directory-sync.ts` is the backend core for PR2.
+
+Responsibilities:
+
+- list integrations with lightweight stats
+- create and update integration config
+- test credentials against DingTalk APIs
+- execute manual sync
+- persist sync run history
+
+The service uses existing tables from current main:
+
+- `directory_integrations`
+- `directory_departments`
+- `directory_accounts`
+- `directory_account_departments`
+- `directory_account_links`
+- `directory_sync_runs`
+
+No new migration is introduced in PR2.
+
+### Sync flow
+
+Manual sync performs the following steps:
+
+1. Load the integration and create a `directory_sync_runs` row with `running`.
+2. Fetch the DingTalk app access token.
+3. Walk departments from the configured root department.
+4. List department users page by page.
+5. Enrich unique users with DingTalk user detail.
+6. Upsert departments and accounts.
+7. Rebuild account-to-department membership.
+8. Generate link suggestions:
+   - `linked` if an existing `user_external_identities` record matches the DingTalk external key
+   - `pending` if email or mobile matches a local user
+   - `unmatched` if no local candidate exists
+9. Mark stale accounts and departments inactive.
+10. Complete the sync run with aggregated stats.
+
+On failure:
+
+- `directory_integrations.last_error` is updated
+- the run is marked `failed`
+- the service attempts to persist a lightweight `directory_sync_alerts` row when that table exists
+
+### Security and access
+
+The route layer requires an authenticated platform admin.
+
+Access is allowed when either condition is true:
+
+- request user already carries an admin claim
+- RBAC `isAdmin(userId)` fallback returns true
+
+PR2 intentionally does not add a new fine-grained `directory:*` permission family yet. This keeps the rollout aligned with the existing admin model.
+
+## API surface
+
+Mounted under `/api/admin/directory`.
+
+Endpoints:
+
+- `GET /integrations`
+- `POST /integrations`
+- `PUT /integrations/:integrationId`
+- `POST /integrations/test`
+- `POST /integrations/:integrationId/sync`
+- `GET /integrations/:integrationId/runs`
+
+PR2 keeps testing separate from saved integrations so admins can validate credentials before creating the record.
+
+## Frontend design
+
+`apps/web/src/views/DirectoryManagementView.vue` provides a minimal admin console.
+
+Included:
+
+- integration list
+- create/update form
+- credential test action
+- manual sync action
+- sync stats summary
+- recent run list
+
+Intentionally excluded from PR2:
+
+- full org tree explorer
+- account-by-account manual link review
+- deprovision ledger UI
+- alert acknowledgement UI
+- scheduler editing UX beyond raw cron text
+
+The page is routed at `/admin/directory` and linked from the existing user admin page for discoverability.
+
+## Non-goals
+
+PR2 does not include:
+
+- automatic scheduled execution
+- DingTalk deprovision rollback workflows
+- directory-driven local user creation
+- OpenAPI contract generation
+- deep admin shell redesign
+
+These remain better candidates for a later PR after the minimal sync slice is stable in a real tenant.
+
+## Claude parallel role
+
+Claude was used in a parallel review role during PR2 planning.
+
+Its output was used to validate two implementation constraints:
+
+- keep the minimal file set instead of replaying the historical featureline
+- expect the biggest merge risks around `auth.ts`, router types, and large generated artifacts
+
+Claude did not own the core implementation. The service, routes, UI, and tests in this PR were implemented directly in the current branch.

--- a/docs/development/dingtalk-pr2-directory-sync-verification-20260408.md
+++ b/docs/development/dingtalk-pr2-directory-sync-verification-20260408.md
@@ -1,0 +1,98 @@
+# DingTalk PR2 Directory Sync Verification
+
+Date: 2026-04-08
+Branch: `codex/dingtalk-pr2-directory-sync-20260408`
+
+## Scope verified
+
+This verification covers the PR2 minimal directory sync slice:
+
+- backend compileability
+- frontend type-check
+- admin directory route behavior
+- directory management view load and manual sync flow
+
+It does not cover live DingTalk tenant validation.
+
+## Commands run
+
+### Static verification
+
+```bash
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web type-check
+```
+
+Result:
+
+- backend build: passed
+- frontend type-check: passed
+
+### Targeted tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts
+```
+
+Result:
+
+- backend unit test file: passed, `4/4`
+- frontend spec file: passed, `2/2`
+
+## Verified files
+
+Backend:
+
+- `packages/core-backend/src/integrations/dingtalk/client.ts`
+- `packages/core-backend/src/directory/directory-sync.ts`
+- `packages/core-backend/src/routes/admin-directory.ts`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/tests/unit/admin-directory-routes.test.ts`
+
+Frontend:
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/router/types.ts`
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+Docs:
+
+- `docs/development/dingtalk-pr2-directory-sync-design-20260408.md`
+- `docs/development/dingtalk-pr2-directory-sync-verification-20260408.md`
+
+## What the tests cover
+
+Backend route test coverage:
+
+- unauthenticated request rejection
+- admin access through direct admin role
+- RBAC admin fallback path
+- sync route delegation and JSON payload shape
+
+Frontend view coverage:
+
+- integration list loads on mount
+- selected integration triggers run-history loading
+- manual sync button calls the correct API and refreshes UI state
+
+## Known gaps
+
+- no live DingTalk tenant verification yet
+- no backend unit coverage for the full `directory-sync.ts` persistence path
+- no scheduler test because scheduled execution is still out of scope for this PR
+- no OpenAPI regeneration in this PR
+
+## Notes from parallel review
+
+Claude was used as a parallel reviewer for PR2 scope only.
+
+Useful conclusions from the review:
+
+- historical directory featureline is too large to merge directly
+- current PR should stay focused on the minimal service, route, and UI path
+- high-conflict files from the historical branch include `auth.ts` and router typing, so this PR intentionally avoids reworking those areas
+
+These review notes matched the implementation direction used in this branch.

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -14,6 +14,8 @@ const AUTH_WHITELIST = [
   '/api/auth/refresh',
   '/api/auth/refresh-token',
   '/api/auth/dev-token',
+  '/api/auth/dingtalk/launch',
+  '/api/auth/dingtalk/callback',
   '/api/plugins',
   '/api/v2/hello',
   '/api/v2/rpc-test',

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1,0 +1,943 @@
+import { Logger } from '../core/logger'
+import { query, transaction } from '../db/pg'
+import {
+  fetchDingTalkAppAccessToken,
+  getDingTalkUserDetail,
+  listDingTalkDepartments,
+  listDingTalkDepartmentUsers,
+  type DingTalkDepartment,
+  type DingTalkDirectoryUser,
+} from '../integrations/dingtalk/client'
+
+const logger = new Logger('DirectorySync')
+const DEFAULT_ORG_ID = 'default'
+const DEFAULT_PROVIDER = 'dingtalk'
+const DEFAULT_ROOT_DEPARTMENT_ID = '1'
+const DEFAULT_PAGE_SIZE = 50
+
+type JsonRecord = Record<string, unknown>
+
+type DirectoryIntegrationConfig = {
+  appKey: string
+  appSecret: string
+  rootDepartmentId: string
+  baseUrl?: string
+  pageSize?: number
+}
+
+type DirectoryIntegrationRow = {
+  id: string
+  org_id: string
+  provider: string
+  name: string
+  status: string
+  corp_id: string
+  config: JsonRecord | string | null
+  sync_enabled: boolean
+  schedule_cron: string | null
+  default_deprovision_policy: string
+  last_sync_at: string | null
+  last_success_at: string | null
+  last_error: string | null
+  created_at: string
+  updated_at: string
+  department_count?: number
+  account_count?: number
+  pending_link_count?: number
+  linked_count?: number
+  last_run_status?: string | null
+}
+
+type DirectoryRunRow = {
+  id: string
+  integration_id: string
+  status: string
+  started_at: string
+  finished_at: string | null
+  stats: JsonRecord | string | null
+  error_message: string | null
+  triggered_by: string | null
+  trigger_source: string
+  created_at: string
+  updated_at: string
+}
+
+type DirectoryDepartmentRow = {
+  id: string
+  external_department_id: string
+}
+
+type DirectoryAccountRow = {
+  id: string
+  external_user_id: string
+  external_key: string
+  email: string | null
+  mobile: string | null
+}
+
+type DirectoryAccountLinkRow = {
+  directory_account_id: string
+  local_user_id: string | null
+  link_status: string
+  match_strategy: string | null
+}
+
+type ExternalIdentityRow = {
+  external_key: string
+  local_user_id: string
+}
+
+type LocalUserRow = {
+  id: string
+  email?: string | null
+  mobile?: string | null
+}
+
+export type DirectoryIntegrationSummary = {
+  id: string
+  orgId: string
+  provider: string
+  name: string
+  status: string
+  corpId: string
+  syncEnabled: boolean
+  scheduleCron: string | null
+  defaultDeprovisionPolicy: string
+  lastSyncAt: string | null
+  lastSuccessAt: string | null
+  lastError: string | null
+  createdAt: string
+  updatedAt: string
+  config: {
+    appKey: string
+    appSecretConfigured: boolean
+    rootDepartmentId: string
+    baseUrl: string | null
+    pageSize: number
+  }
+  stats: {
+    departmentCount: number
+    accountCount: number
+    pendingLinkCount: number
+    linkedCount: number
+    lastRunStatus: string | null
+  }
+}
+
+export type DirectoryIntegrationInput = {
+  name: string
+  corpId: string
+  appKey: string
+  appSecret?: string
+  rootDepartmentId?: string
+  baseUrl?: string
+  pageSize?: number
+  syncEnabled?: boolean
+  scheduleCron?: string | null
+  defaultDeprovisionPolicy?: string
+  status?: string
+}
+
+export type DirectoryIntegrationTestResult = {
+  corpId: string
+  rootDepartmentId: string
+  appKey: string
+  departmentSampleCount: number
+  sampledDepartments: Array<{ id: string; name: string }>
+  userSampleCount: number
+  sampledUsers: Array<{ userId: string; name: string }>
+}
+
+export type DirectorySyncRunSummary = {
+  id: string
+  integrationId: string
+  status: string
+  startedAt: string
+  finishedAt: string | null
+  stats: JsonRecord
+  errorMessage: string | null
+  triggeredBy: string | null
+  triggerSource: string
+  createdAt: string
+  updatedAt: string
+}
+
+function parseJsonRecord(value: JsonRecord | string | null | undefined): JsonRecord {
+  if (!value) return {}
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return parsed && typeof parsed === 'object' ? parsed as JsonRecord : {}
+    } catch {
+      return {}
+    }
+  }
+  return value
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function normalizeOptionalText(value: unknown): string | null {
+  const text = normalizeText(value)
+  return text.length > 0 ? text : null
+}
+
+function normalizePageSize(value: unknown): number {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return DEFAULT_PAGE_SIZE
+  return Math.min(Math.max(Math.trunc(numeric), 1), 100)
+}
+
+function parseIntegrationConfig(row: Pick<DirectoryIntegrationRow, 'config'>): DirectoryIntegrationConfig {
+  const config = parseJsonRecord(row.config)
+  const appKey = normalizeText(config.appKey)
+  const appSecret = normalizeText(config.appSecret)
+  const rootDepartmentId = normalizeText(config.rootDepartmentId) || DEFAULT_ROOT_DEPARTMENT_ID
+  const baseUrl = normalizeOptionalText(config.baseUrl) ?? undefined
+  const pageSize = normalizePageSize(config.pageSize)
+  return { appKey, appSecret, rootDepartmentId, baseUrl, pageSize }
+}
+
+function summarizeIntegration(row: DirectoryIntegrationRow): DirectoryIntegrationSummary {
+  const config = parseIntegrationConfig(row)
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    provider: row.provider,
+    name: row.name,
+    status: row.status,
+    corpId: row.corp_id,
+    syncEnabled: Boolean(row.sync_enabled),
+    scheduleCron: row.schedule_cron,
+    defaultDeprovisionPolicy: row.default_deprovision_policy,
+    lastSyncAt: row.last_sync_at,
+    lastSuccessAt: row.last_success_at,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    config: {
+      appKey: config.appKey,
+      appSecretConfigured: Boolean(config.appSecret),
+      rootDepartmentId: config.rootDepartmentId,
+      baseUrl: config.baseUrl ?? null,
+      pageSize: config.pageSize,
+    },
+    stats: {
+      departmentCount: Number(row.department_count ?? 0),
+      accountCount: Number(row.account_count ?? 0),
+      pendingLinkCount: Number(row.pending_link_count ?? 0),
+      linkedCount: Number(row.linked_count ?? 0),
+      lastRunStatus: row.last_run_status ?? null,
+    },
+  }
+}
+
+function summarizeRun(row: DirectoryRunRow): DirectorySyncRunSummary {
+  return {
+    id: row.id,
+    integrationId: row.integration_id,
+    status: row.status,
+    startedAt: row.started_at,
+    finishedAt: row.finished_at,
+    stats: parseJsonRecord(row.stats),
+    errorMessage: row.error_message,
+    triggeredBy: row.triggered_by,
+    triggerSource: row.trigger_source,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function readErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) return error.message
+  return fallback
+}
+
+function normalizeIntegrationInput(
+  input: DirectoryIntegrationInput,
+  current?: DirectoryIntegrationConfig,
+): DirectoryIntegrationInput & Required<Pick<DirectoryIntegrationInput, 'name' | 'corpId' | 'appKey' | 'appSecret' | 'rootDepartmentId' | 'defaultDeprovisionPolicy' | 'status'>> {
+  const name = normalizeText(input.name)
+  const corpId = normalizeText(input.corpId)
+  const appKey = normalizeText(input.appKey)
+  const appSecret = normalizeText(input.appSecret) || current?.appSecret || ''
+  const rootDepartmentId = normalizeText(input.rootDepartmentId) || current?.rootDepartmentId || DEFAULT_ROOT_DEPARTMENT_ID
+  const defaultDeprovisionPolicy = normalizeText(input.defaultDeprovisionPolicy) || 'mark_inactive'
+  const status = normalizeText(input.status) || 'active'
+
+  if (!name) throw new Error('Integration name is required')
+  if (!corpId) throw new Error('corpId is required')
+  if (!appKey) throw new Error('appKey is required')
+  if (!appSecret) throw new Error('appSecret is required')
+
+  return {
+    ...input,
+    name,
+    corpId,
+    appKey,
+    appSecret,
+    rootDepartmentId,
+    baseUrl: normalizeOptionalText(input.baseUrl) ?? current?.baseUrl,
+    pageSize: normalizePageSize(input.pageSize ?? current?.pageSize),
+    syncEnabled: input.syncEnabled ?? false,
+    scheduleCron: normalizeOptionalText(input.scheduleCron),
+    defaultDeprovisionPolicy,
+    status,
+  }
+}
+
+async function getIntegrationRow(integrationId: string): Promise<DirectoryIntegrationRow | null> {
+  const result = await query<DirectoryIntegrationRow>(
+    `SELECT id, org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron,
+            default_deprovision_policy, last_sync_at, last_success_at, last_error, created_at, updated_at
+     FROM directory_integrations
+     WHERE id = $1 AND provider = $2`,
+    [integrationId, DEFAULT_PROVIDER],
+  )
+  return result.rows[0] ?? null
+}
+
+export async function listDirectoryIntegrations(orgId = DEFAULT_ORG_ID): Promise<DirectoryIntegrationSummary[]> {
+  const result = await query<DirectoryIntegrationRow>(
+    `SELECT i.id, i.org_id, i.provider, i.name, i.status, i.corp_id, i.config, i.sync_enabled, i.schedule_cron,
+            i.default_deprovision_policy, i.last_sync_at, i.last_success_at, i.last_error, i.created_at, i.updated_at,
+            COALESCE((SELECT COUNT(*)::int FROM directory_departments d WHERE d.integration_id = i.id AND d.is_active = true), 0) AS department_count,
+            COALESCE((SELECT COUNT(*)::int FROM directory_accounts a WHERE a.integration_id = i.id AND a.is_active = true), 0) AS account_count,
+            COALESCE((
+              SELECT COUNT(*)::int
+              FROM directory_account_links l
+              JOIN directory_accounts a ON a.id = l.directory_account_id
+              WHERE a.integration_id = i.id AND l.link_status = 'pending'
+            ), 0) AS pending_link_count,
+            COALESCE((
+              SELECT COUNT(*)::int
+              FROM directory_account_links l
+              JOIN directory_accounts a ON a.id = l.directory_account_id
+              WHERE a.integration_id = i.id AND l.link_status = 'linked'
+            ), 0) AS linked_count,
+            (
+              SELECT r.status
+              FROM directory_sync_runs r
+              WHERE r.integration_id = i.id
+              ORDER BY r.started_at DESC
+              LIMIT 1
+            ) AS last_run_status
+     FROM directory_integrations i
+     WHERE i.org_id = $1 AND i.provider = $2
+     ORDER BY i.updated_at DESC`,
+    [orgId, DEFAULT_PROVIDER],
+  )
+
+  return result.rows.map(summarizeIntegration)
+}
+
+export async function createDirectoryIntegration(input: DirectoryIntegrationInput): Promise<DirectoryIntegrationSummary> {
+  const normalized = normalizeIntegrationInput(input)
+  const result = await query<DirectoryIntegrationRow>(
+    `INSERT INTO directory_integrations (
+       org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron,
+       default_deprovision_policy, created_at, updated_at
+     )
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, NOW(), NOW())
+     RETURNING id, org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron,
+               default_deprovision_policy, last_sync_at, last_success_at, last_error, created_at, updated_at`,
+    [
+      DEFAULT_ORG_ID,
+      DEFAULT_PROVIDER,
+      normalized.name,
+      normalized.status,
+      normalized.corpId,
+      JSON.stringify({
+        appKey: normalized.appKey,
+        appSecret: normalized.appSecret,
+        rootDepartmentId: normalized.rootDepartmentId,
+        baseUrl: normalized.baseUrl ?? null,
+        pageSize: normalized.pageSize,
+      }),
+      Boolean(normalized.syncEnabled),
+      normalized.scheduleCron,
+      normalized.defaultDeprovisionPolicy,
+    ],
+  )
+
+  return summarizeIntegration(result.rows[0])
+}
+
+export async function updateDirectoryIntegration(
+  integrationId: string,
+  input: DirectoryIntegrationInput,
+): Promise<DirectoryIntegrationSummary | null> {
+  const current = await getIntegrationRow(integrationId)
+  if (!current) return null
+
+  const currentConfig = parseIntegrationConfig(current)
+  const normalized = normalizeIntegrationInput(input, currentConfig)
+  const result = await query<DirectoryIntegrationRow>(
+    `UPDATE directory_integrations
+     SET name = $2,
+         status = $3,
+         corp_id = $4,
+         config = $5::jsonb,
+         sync_enabled = $6,
+         schedule_cron = $7,
+         default_deprovision_policy = $8,
+         updated_at = NOW()
+     WHERE id = $1
+     RETURNING id, org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron,
+               default_deprovision_policy, last_sync_at, last_success_at, last_error, created_at, updated_at`,
+    [
+      integrationId,
+      normalized.name,
+      normalized.status,
+      normalized.corpId,
+      JSON.stringify({
+        appKey: normalized.appKey,
+        appSecret: normalized.appSecret,
+        rootDepartmentId: normalized.rootDepartmentId,
+        baseUrl: normalized.baseUrl ?? null,
+        pageSize: normalized.pageSize,
+      }),
+      Boolean(normalized.syncEnabled),
+      normalized.scheduleCron,
+      normalized.defaultDeprovisionPolicy,
+    ],
+  )
+
+  return summarizeIntegration(result.rows[0])
+}
+
+export async function testDirectoryIntegration(input: DirectoryIntegrationInput): Promise<DirectoryIntegrationTestResult> {
+  const normalized = normalizeIntegrationInput(input)
+  const accessToken = await fetchDingTalkAppAccessToken({
+    appKey: normalized.appKey,
+    appSecret: normalized.appSecret,
+    baseUrl: normalized.baseUrl ?? undefined,
+  })
+
+  const departments = await listDingTalkDepartments(
+    accessToken,
+    normalized.rootDepartmentId,
+    { baseUrl: normalized.baseUrl ?? undefined },
+  )
+  const firstDepartmentId = departments[0]?.id ?? normalized.rootDepartmentId
+  const { users } = await listDingTalkDepartmentUsers(
+    accessToken,
+    firstDepartmentId,
+    0,
+    Math.min(normalized.pageSize ?? DEFAULT_PAGE_SIZE, 5),
+    { baseUrl: normalized.baseUrl ?? undefined },
+  )
+
+  return {
+    corpId: normalized.corpId,
+    rootDepartmentId: normalized.rootDepartmentId,
+    appKey: normalized.appKey,
+    departmentSampleCount: departments.length,
+    sampledDepartments: departments.slice(0, 5).map((department) => ({ id: department.id, name: department.name })),
+    userSampleCount: users.length,
+    sampledUsers: users.slice(0, 5).map((user) => ({ userId: user.userId, name: user.name })),
+  }
+}
+
+async function fetchAllDepartments(config: DirectoryIntegrationConfig, integrationName: string): Promise<Map<string, DingTalkDepartment>> {
+  const accessToken = await fetchDingTalkAppAccessToken({
+    appKey: config.appKey,
+    appSecret: config.appSecret,
+    baseUrl: config.baseUrl,
+  })
+  const departments = new Map<string, DingTalkDepartment>()
+  departments.set(config.rootDepartmentId, {
+    id: config.rootDepartmentId,
+    parentId: null,
+    name: integrationName,
+    order: 0,
+    source: { syntheticRoot: true },
+  })
+
+  const queue = [config.rootDepartmentId]
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current) continue
+    const children = await listDingTalkDepartments(accessToken, current, { baseUrl: config.baseUrl })
+    for (const child of children) {
+      const existing = departments.get(child.id)
+      departments.set(child.id, existing ? { ...existing, ...child } : child)
+      if (!existing) queue.push(child.id)
+    }
+  }
+
+  return departments
+}
+
+function mergeDepartmentIds(primary: string[], secondary: string[]): string[] {
+  return Array.from(new Set([...primary, ...secondary].filter(Boolean)))
+}
+
+async function fetchAllUsers(
+  config: DirectoryIntegrationConfig,
+  departmentMap: Map<string, DingTalkDepartment>,
+): Promise<Map<string, DingTalkDirectoryUser>> {
+  const accessToken = await fetchDingTalkAppAccessToken({
+    appKey: config.appKey,
+    appSecret: config.appSecret,
+    baseUrl: config.baseUrl,
+  })
+  const users = new Map<string, DingTalkDirectoryUser>()
+  const pageSize = config.pageSize ?? DEFAULT_PAGE_SIZE
+
+  for (const departmentId of departmentMap.keys()) {
+    let cursor = 0
+    let hasMore = true
+    while (hasMore) {
+      const response = await listDingTalkDepartmentUsers(
+        accessToken,
+        departmentId,
+        cursor,
+        pageSize,
+        { baseUrl: config.baseUrl },
+      )
+      for (const summary of response.users) {
+        const existing = users.get(summary.userId)
+        if (!existing) {
+          const detail = await getDingTalkUserDetail(accessToken, summary.userId, { baseUrl: config.baseUrl })
+          users.set(summary.userId, {
+            ...detail,
+            departmentIds: mergeDepartmentIds(detail.departmentIds, summary.departmentIds),
+          })
+          continue
+        }
+        users.set(summary.userId, {
+          ...existing,
+          departmentIds: mergeDepartmentIds(existing.departmentIds, summary.departmentIds),
+        })
+      }
+      if (!response.hasMore || response.nextCursor === null) {
+        hasMore = false
+      } else {
+        cursor = response.nextCursor
+      }
+    }
+  }
+
+  return users
+}
+
+function buildDepartmentPathMap(departments: Map<string, DingTalkDepartment>): Map<string, string> {
+  const cache = new Map<string, string>()
+
+  const walk = (departmentId: string): string => {
+    if (cache.has(departmentId)) return cache.get(departmentId) ?? ''
+    const department = departments.get(departmentId)
+    if (!department) return ''
+    if (!department.parentId || !departments.has(department.parentId)) {
+      cache.set(departmentId, department.name)
+      return department.name
+    }
+    const parentPath = walk(department.parentId)
+    const fullPath = parentPath ? `${parentPath} / ${department.name}` : department.name
+    cache.set(departmentId, fullPath)
+    return fullPath
+  }
+
+  for (const departmentId of departments.keys()) {
+    walk(departmentId)
+  }
+
+  return cache
+}
+
+async function markSyncFailure(integrationId: string, runId: string, message: string): Promise<void> {
+  await query(
+    `UPDATE directory_integrations
+     SET last_sync_at = NOW(),
+         last_error = $2,
+         updated_at = NOW()
+     WHERE id = $1`,
+    [integrationId, message],
+  )
+  await query(
+    `UPDATE directory_sync_runs
+     SET status = 'failed',
+         finished_at = NOW(),
+         error_message = $2,
+         updated_at = NOW()
+     WHERE id = $1`,
+    [runId, message],
+  )
+  try {
+    await query(
+      `INSERT INTO directory_sync_alerts (integration_id, run_id, level, code, message, details, created_at, updated_at)
+       VALUES ($1, $2, 'error', 'sync_failed', $3, '{}'::jsonb, NOW(), NOW())`,
+      [integrationId, runId, message],
+    )
+  } catch (error) {
+    logger.warn(`Failed to persist directory alert: ${readErrorMessage(error, 'unknown error')}`)
+  }
+}
+
+async function loadMatchMaps(externalKeys: string[], emails: string[], mobiles: string[]) {
+  const [externalIdentities, emailUsers, mobileUsers] = await Promise.all([
+    externalKeys.length > 0
+      ? query<ExternalIdentityRow>(
+        `SELECT external_key, local_user_id
+         FROM user_external_identities
+         WHERE provider = $1 AND external_key = ANY($2::text[])`,
+        [DEFAULT_PROVIDER, externalKeys],
+      )
+      : Promise.resolve({ rows: [] } as Awaited<ReturnType<typeof query<ExternalIdentityRow>>>),
+    emails.length > 0
+      ? query<LocalUserRow>(
+        `SELECT id, email
+         FROM users
+         WHERE lower(email) = ANY($1::text[])`,
+        [emails],
+      )
+      : Promise.resolve({ rows: [] } as Awaited<ReturnType<typeof query<LocalUserRow>>>),
+    mobiles.length > 0
+      ? query<LocalUserRow>(
+        `SELECT id, mobile
+         FROM users
+         WHERE mobile = ANY($1::text[])`,
+        [mobiles],
+      )
+      : Promise.resolve({ rows: [] } as Awaited<ReturnType<typeof query<LocalUserRow>>>),
+  ])
+
+  return {
+    externalIdentityMap: new Map(externalIdentities.rows.map((row) => [row.external_key, row.local_user_id])),
+    emailMap: new Map(
+      emailUsers.rows
+        .map((row) => [normalizeText(row.email).toLowerCase(), row.id] as const)
+        .filter(([email]) => email.length > 0),
+    ),
+    mobileMap: new Map(
+      mobileUsers.rows
+        .map((row) => [normalizeText(row.mobile), row.id] as const)
+        .filter(([mobile]) => mobile.length > 0),
+    ),
+  }
+}
+
+export async function syncDirectoryIntegration(
+  integrationId: string,
+  triggeredBy: string,
+): Promise<{ integration: DirectoryIntegrationSummary; run: DirectorySyncRunSummary }> {
+  const integration = await getIntegrationRow(integrationId)
+  if (!integration) throw new Error('Directory integration not found')
+
+  const config = parseIntegrationConfig(integration)
+  const runResult = await query<DirectoryRunRow>(
+    `INSERT INTO directory_sync_runs (
+       integration_id, status, started_at, stats, meta, triggered_by, trigger_source, created_at, updated_at
+     )
+     VALUES ($1, 'running', NOW(), '{}'::jsonb, '{}'::jsonb, $2, 'manual', NOW(), NOW())
+     RETURNING id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at`,
+    [integrationId, triggeredBy],
+  )
+  const runId = runResult.rows[0].id
+
+  try {
+    const departments = await fetchAllDepartments(config, integration.name)
+    const departmentPathMap = buildDepartmentPathMap(departments)
+    const users = await fetchAllUsers(config, departments)
+    const syncTimestamp = new Date().toISOString()
+
+    await transaction(async (client) => {
+      for (const department of departments.values()) {
+        await client.query(
+          `INSERT INTO directory_departments (
+             integration_id, provider, external_department_id, external_parent_department_id, name,
+             full_path, order_index, is_active, raw, last_seen_at, created_at, updated_at
+           )
+           VALUES ($1, $2, $3, $4, $5, $6, $7, true, $8::jsonb, $9, NOW(), NOW())
+           ON CONFLICT (integration_id, external_department_id)
+           DO UPDATE SET
+             external_parent_department_id = EXCLUDED.external_parent_department_id,
+             name = EXCLUDED.name,
+             full_path = EXCLUDED.full_path,
+             order_index = EXCLUDED.order_index,
+             is_active = true,
+             raw = EXCLUDED.raw,
+             last_seen_at = EXCLUDED.last_seen_at,
+             updated_at = NOW()`,
+          [
+            integrationId,
+            DEFAULT_PROVIDER,
+            department.id,
+            department.parentId,
+            department.name,
+            departmentPathMap.get(department.id) ?? department.name,
+            department.order,
+            JSON.stringify(department.source),
+            syncTimestamp,
+          ],
+        )
+      }
+
+      const userList = Array.from(users.values())
+      for (const user of userList) {
+        const externalKey = normalizeText(user.unionId || user.openId || user.userId)
+        await client.query(
+          `INSERT INTO directory_accounts (
+             integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key,
+             name, nick, email, mobile, job_number, title, avatar_url, is_active, raw, last_seen_at, created_at, updated_at
+           )
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, true, $15::jsonb, $16, NOW(), NOW())
+           ON CONFLICT (integration_id, external_user_id)
+           DO UPDATE SET
+             union_id = EXCLUDED.union_id,
+             open_id = EXCLUDED.open_id,
+             external_key = EXCLUDED.external_key,
+             name = EXCLUDED.name,
+             nick = EXCLUDED.nick,
+             email = EXCLUDED.email,
+             mobile = EXCLUDED.mobile,
+             job_number = EXCLUDED.job_number,
+             title = EXCLUDED.title,
+             avatar_url = EXCLUDED.avatar_url,
+             is_active = true,
+             raw = EXCLUDED.raw,
+             last_seen_at = EXCLUDED.last_seen_at,
+             updated_at = NOW()`,
+          [
+            integrationId,
+            DEFAULT_PROVIDER,
+            integration.corp_id,
+            user.userId,
+            normalizeOptionalText(user.unionId),
+            normalizeOptionalText(user.openId),
+            externalKey,
+            user.name,
+            normalizeOptionalText(user.nick),
+            normalizeOptionalText(user.email),
+            normalizeOptionalText(user.mobile),
+            normalizeOptionalText(user.jobNumber),
+            normalizeOptionalText(user.title),
+            normalizeOptionalText(user.avatarUrl),
+            JSON.stringify(user.source),
+            syncTimestamp,
+          ],
+        )
+      }
+
+      await client.query(
+        `UPDATE directory_departments
+         SET is_active = false, updated_at = NOW()
+         WHERE integration_id = $1 AND last_seen_at < $2`,
+        [integrationId, syncTimestamp],
+      )
+      await client.query(
+        `UPDATE directory_accounts
+         SET is_active = false, updated_at = NOW()
+         WHERE integration_id = $1 AND last_seen_at < $2`,
+        [integrationId, syncTimestamp],
+      )
+
+      const [departmentRows, accountRows] = await Promise.all([
+        client.query(
+          `SELECT id, external_department_id
+           FROM directory_departments
+           WHERE integration_id = $1`,
+          [integrationId],
+        ),
+        client.query(
+          `SELECT id, external_user_id, external_key, email, mobile
+           FROM directory_accounts
+           WHERE integration_id = $1`,
+          [integrationId],
+        ),
+      ])
+
+      const departmentIdMap = new Map<string, string>()
+      for (const row of departmentRows.rows as DirectoryDepartmentRow[]) {
+        departmentIdMap.set(row.external_department_id, row.id)
+      }
+
+      const accountIdMap = new Map<string, DirectoryAccountRow>()
+      for (const row of accountRows.rows as DirectoryAccountRow[]) {
+        accountIdMap.set(row.external_user_id, row)
+      }
+
+      await client.query(
+        `DELETE FROM directory_account_departments
+         WHERE directory_account_id IN (
+           SELECT id FROM directory_accounts WHERE integration_id = $1
+         )`,
+        [integrationId],
+      )
+
+      for (const user of users.values()) {
+        const account = accountIdMap.get(user.userId)
+        if (!account) continue
+        for (const departmentId of user.departmentIds) {
+          const directoryDepartmentId = departmentIdMap.get(departmentId)
+          if (!directoryDepartmentId) continue
+          await client.query(
+            `INSERT INTO directory_account_departments (
+               directory_account_id, directory_department_id, is_primary, created_at
+             )
+             VALUES ($1, $2, $3, NOW())
+             ON CONFLICT (directory_account_id, directory_department_id)
+             DO UPDATE SET is_primary = EXCLUDED.is_primary`,
+            [account.id, directoryDepartmentId, departmentId === user.departmentIds[0]],
+          )
+        }
+      }
+
+      const externalKeys = Array.from(new Set(Array.from(accountIdMap.values()).map((account) => account.external_key).filter(Boolean)))
+      const emails = Array.from(new Set(
+        Array.from(accountIdMap.values())
+          .map((account) => normalizeText(account.email).toLowerCase())
+          .filter(Boolean),
+      ))
+      const mobiles = Array.from(new Set(
+        Array.from(accountIdMap.values())
+          .map((account) => normalizeText(account.mobile))
+          .filter(Boolean),
+      ))
+      const { externalIdentityMap, emailMap, mobileMap } = await loadMatchMaps(externalKeys, emails, mobiles)
+
+      const existingLinksResult = await client.query(
+        `SELECT directory_account_id, local_user_id, link_status, match_strategy
+         FROM directory_account_links
+         WHERE directory_account_id = ANY($1::uuid[])`,
+        [Array.from(accountIdMap.values()).map((account) => account.id)],
+      )
+      const existingLinks = new Map(
+        (existingLinksResult.rows as DirectoryAccountLinkRow[]).map((row) => [row.directory_account_id, row]),
+      )
+
+      let linkedCount = 0
+      let pendingCount = 0
+      let unmatchedCount = 0
+      for (const account of accountIdMap.values()) {
+        const existing = existingLinks.get(account.id)
+        let localUserId: string | null = existing?.local_user_id ?? null
+        let linkStatus = existing?.link_status ?? 'pending'
+        let matchStrategy = existing?.match_strategy ?? null
+
+        if (!(existing && existing.link_status === 'linked' && existing.local_user_id)) {
+          const externalIdentityUserId = externalIdentityMap.get(account.external_key)
+          if (externalIdentityUserId) {
+            localUserId = externalIdentityUserId
+            linkStatus = 'linked'
+            matchStrategy = 'external_identity'
+          } else {
+            const emailUserId = normalizeText(account.email).toLowerCase() ? emailMap.get(normalizeText(account.email).toLowerCase()) : undefined
+            const mobileUserId = normalizeText(account.mobile) ? mobileMap.get(normalizeText(account.mobile)) : undefined
+            if (emailUserId) {
+              localUserId = emailUserId
+              linkStatus = 'pending'
+              matchStrategy = 'email'
+            } else if (mobileUserId) {
+              localUserId = mobileUserId
+              linkStatus = 'pending'
+              matchStrategy = 'mobile'
+            } else {
+              localUserId = null
+              linkStatus = 'unmatched'
+              matchStrategy = 'none'
+            }
+          }
+        }
+
+        if (linkStatus === 'linked') linkedCount += 1
+        else if (linkStatus === 'pending') pendingCount += 1
+        else unmatchedCount += 1
+
+        await client.query(
+          `INSERT INTO directory_account_links (
+             directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at
+           )
+           VALUES ($1, $2, $3, $4, NOW(), NOW())
+           ON CONFLICT (directory_account_id)
+           DO UPDATE SET
+             local_user_id = EXCLUDED.local_user_id,
+             link_status = EXCLUDED.link_status,
+             match_strategy = EXCLUDED.match_strategy,
+             updated_at = NOW()`,
+          [account.id, localUserId, linkStatus, matchStrategy],
+        )
+      }
+
+      const stats = {
+        departmentsSynced: departments.size,
+        accountsSynced: users.size,
+        linkedCount,
+        pendingCount,
+        unmatchedCount,
+      }
+
+      await client.query(
+        `UPDATE directory_integrations
+         SET last_sync_at = NOW(),
+             last_success_at = NOW(),
+             last_error = NULL,
+             updated_at = NOW()
+         WHERE id = $1`,
+        [integrationId],
+      )
+      await client.query(
+        `UPDATE directory_sync_runs
+         SET status = 'completed',
+             finished_at = NOW(),
+             stats = $2::jsonb,
+             updated_at = NOW()
+         WHERE id = $1`,
+        [runId, JSON.stringify(stats)],
+      )
+    })
+
+    const [updatedIntegration, updatedRun] = await Promise.all([
+      getIntegrationRow(integrationId),
+      query<DirectoryRunRow>(
+        `SELECT id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at
+         FROM directory_sync_runs
+         WHERE id = $1`,
+        [runId],
+      ),
+    ])
+
+    if (!updatedIntegration || !updatedRun.rows[0]) {
+      throw new Error('Directory sync completed but summary reload failed')
+    }
+
+    return {
+      integration: summarizeIntegration(updatedIntegration),
+      run: summarizeRun(updatedRun.rows[0]),
+    }
+  } catch (error) {
+    const message = readErrorMessage(error, 'Directory sync failed')
+    await markSyncFailure(integrationId, runId, message)
+    throw error
+  }
+}
+
+export async function listDirectorySyncRuns(
+  integrationId: string,
+  pagination: { limit: number; offset: number },
+): Promise<{ items: DirectorySyncRunSummary[]; total: number }> {
+  const [totalResult, rowsResult] = await Promise.all([
+    query<{ total: number }>(
+      `SELECT COUNT(*)::int AS total
+       FROM directory_sync_runs
+       WHERE integration_id = $1`,
+      [integrationId],
+    ),
+    query<DirectoryRunRow>(
+      `SELECT id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at
+       FROM directory_sync_runs
+       WHERE integration_id = $1
+       ORDER BY started_at DESC
+       LIMIT $2 OFFSET $3`,
+      [integrationId, pagination.limit, pagination.offset],
+    ),
+  ])
+
+  return {
+    items: rowsResult.rows.map(summarizeRun),
+    total: Number(totalResult.rows[0]?.total ?? 0),
+  }
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -90,6 +90,7 @@ import { kanbanRouter } from './routes/kanban'
 import { viewsRouter } from './routes/views'
 import { initAdminRoutes } from './routes/admin-routes'
 import { adminUsersRouter } from './routes/admin-users'
+import { adminDirectoryRouter } from './routes/admin-directory'
 import workflowRouter from './routes/workflow'
 import workflowDesignerRouter from './routes/workflow-designer'
 import plmWorkbenchRouter from './routes/plm-workbench'
@@ -864,6 +865,7 @@ export class MetaSheetServer {
       snapshotService: this.snapshotService,
     }))
     this.app.use(adminUsersRouter())
+    this.app.use('/api/admin/directory', adminDirectoryRouter())
 
     // V2 测试端点
     this.app.get('/api/v2/hello', (req, res) => {

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -24,6 +24,47 @@ export interface DingTalkCurrentUserProfile {
   avatarUrl?: string
 }
 
+export interface DingTalkDirectoryConfig {
+  appKey: string
+  appSecret: string
+  baseUrl?: string
+}
+
+export interface DingTalkDepartment {
+  id: string
+  parentId: string | null
+  name: string
+  order: number
+  source: Record<string, unknown>
+}
+
+export interface DingTalkDepartmentUserSummary {
+  userId: string
+  name: string
+  unionId?: string
+  mobile?: string
+  email?: string
+  title?: string
+  avatarUrl?: string
+  departmentIds: string[]
+  source: Record<string, unknown>
+}
+
+export interface DingTalkDirectoryUser {
+  userId: string
+  name: string
+  nick?: string
+  unionId?: string
+  openId?: string
+  mobile?: string
+  email?: string
+  jobNumber?: string
+  title?: string
+  avatarUrl?: string
+  departmentIds: string[]
+  source: Record<string, unknown>
+}
+
 class DingTalkRequestError extends Error {
   statusCode: number
   responseBody: Record<string, unknown> | null
@@ -87,6 +128,51 @@ async function requestDingTalkJson(
   }
 
   return payload ?? {}
+}
+
+function readNumericField(payload: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = payload[key]
+    if (typeof value === 'number') return value
+    if (typeof value === 'string' && value.trim().length > 0 && !Number.isNaN(Number(value))) {
+      return Number(value)
+    }
+  }
+  return null
+}
+
+function readNestedPayload(payload: Record<string, unknown>, key = 'result'): Record<string, unknown> {
+  const nested = payload[key]
+  return nested && typeof nested === 'object' ? nested as Record<string, unknown> : {}
+}
+
+function normalizeDingTalkApiPayload(payload: Record<string, unknown>, fallbackError: string): Record<string, unknown> {
+  const errcode = readNumericField(payload, 'errcode', 'code')
+  if (errcode !== null && errcode !== 0) {
+    throw new Error(normalizeErrorMessage(payload, fallbackError))
+  }
+  return payload
+}
+
+function normalizeDirectoryBaseUrl(baseUrl?: string): string {
+  const normalized = typeof baseUrl === 'string' && baseUrl.trim().length > 0
+    ? baseUrl.trim()
+    : 'https://oapi.dingtalk.com'
+  return normalized.replace(/\/+$/, '')
+}
+
+async function requestDingTalkDirectoryJson(
+  path: string,
+  init: RequestInit,
+  fallbackError: string,
+  baseUrl?: string,
+): Promise<Record<string, unknown>> {
+  const payload = await requestDingTalkJson(
+    `${normalizeDirectoryBaseUrl(baseUrl)}${path}`,
+    init,
+    fallbackError,
+  )
+  return normalizeDingTalkApiPayload(payload, fallbackError)
 }
 
 export function readDingTalkOauthConfig(): DingTalkOauthConfig {
@@ -205,6 +291,180 @@ export async function fetchDingTalkCurrentUser(accessToken: string): Promise<Din
         : typeof payload.avatar_url === 'string'
           ? payload.avatar_url
           : undefined,
+  }
+}
+
+export async function fetchDingTalkAppAccessToken(config: DingTalkDirectoryConfig): Promise<string> {
+  const baseUrl = normalizeDirectoryBaseUrl(config.baseUrl)
+  const payload = await requestDingTalkDirectoryJson(
+    `/gettoken?appkey=${encodeURIComponent(config.appKey)}&appsecret=${encodeURIComponent(config.appSecret)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+    'Failed to obtain DingTalk app access token',
+    baseUrl,
+  )
+
+  const token = typeof payload.access_token === 'string'
+    ? payload.access_token
+    : typeof payload.accessToken === 'string'
+      ? payload.accessToken
+      : ''
+
+  if (!token) {
+    throw new Error(normalizeErrorMessage(payload, 'Failed to obtain DingTalk app access token'))
+  }
+
+  return token
+}
+
+export async function listDingTalkDepartments(
+  accessToken: string,
+  rootDepartmentId: string,
+  config?: { baseUrl?: string },
+): Promise<DingTalkDepartment[]> {
+  const payload = await requestDingTalkDirectoryJson(
+    `/topapi/v2/department/listsub?access_token=${encodeURIComponent(accessToken)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        dept_id: Number.isNaN(Number(rootDepartmentId)) ? rootDepartmentId : Number(rootDepartmentId),
+      }),
+    },
+    'Failed to list DingTalk departments',
+    config?.baseUrl,
+  )
+
+  const result = readNestedPayload(payload)
+  const rawList = Array.isArray(result.list) ? result.list : []
+  return rawList
+    .map((entry) => (entry && typeof entry === 'object' ? entry as Record<string, unknown> : null))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    .map((entry) => ({
+      id: String(entry.dept_id ?? entry.id ?? '').trim(),
+      parentId:
+        entry.parent_id === null || entry.parent_id === undefined
+          ? null
+          : String(entry.parent_id).trim() || null,
+      name: String(entry.name ?? '').trim(),
+      order: readNumericField(entry, 'order', 'order_index') ?? 0,
+      source: entry,
+    }))
+    .filter((entry) => entry.id.length > 0 && entry.name.length > 0)
+}
+
+export async function listDingTalkDepartmentUsers(
+  accessToken: string,
+  departmentId: string,
+  cursor: number,
+  size: number,
+  config?: { baseUrl?: string },
+): Promise<{ users: DingTalkDepartmentUserSummary[]; nextCursor: number | null; hasMore: boolean }> {
+  const payload = await requestDingTalkDirectoryJson(
+    `/topapi/v2/user/list?access_token=${encodeURIComponent(accessToken)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        dept_id: Number.isNaN(Number(departmentId)) ? departmentId : Number(departmentId),
+        cursor,
+        size,
+        contain_access_limit: false,
+        language: 'zh_CN',
+      }),
+    },
+    'Failed to list DingTalk department users',
+    config?.baseUrl,
+  )
+
+  const result = readNestedPayload(payload)
+  const rawList = Array.isArray(result.list) ? result.list : []
+  const users = rawList
+    .map((entry) => (entry && typeof entry === 'object' ? entry as Record<string, unknown> : null))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    .map((entry) => {
+      const departmentIds = Array.isArray(entry.dept_id_list)
+        ? entry.dept_id_list.map((item) => String(item ?? '').trim()).filter(Boolean)
+        : [departmentId]
+
+      return {
+        userId: String(entry.userid ?? entry.userId ?? '').trim(),
+        name: String(entry.name ?? '').trim(),
+        unionId: typeof entry.unionid === 'string' ? entry.unionid : typeof entry.unionId === 'string' ? entry.unionId : undefined,
+        mobile: typeof entry.mobile === 'string' ? entry.mobile : undefined,
+        email: typeof entry.email === 'string' ? entry.email : undefined,
+        title: typeof entry.title === 'string' ? entry.title : undefined,
+        avatarUrl:
+          typeof entry.avatar === 'string'
+            ? entry.avatar
+            : typeof entry.avatarUrl === 'string'
+              ? entry.avatarUrl
+              : undefined,
+        departmentIds,
+        source: entry,
+      }
+    })
+    .filter((entry) => entry.userId.length > 0 && entry.name.length > 0)
+
+  return {
+    users,
+    nextCursor: readNumericField(result, 'next_cursor', 'nextCursor'),
+    hasMore: Boolean(result.has_more),
+  }
+}
+
+export async function getDingTalkUserDetail(
+  accessToken: string,
+  userId: string,
+  config?: { baseUrl?: string },
+): Promise<DingTalkDirectoryUser> {
+  const payload = await requestDingTalkDirectoryJson(
+    `/topapi/v2/user/get?access_token=${encodeURIComponent(accessToken)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userid: userId,
+        language: 'zh_CN',
+      }),
+    },
+    'Failed to read DingTalk user detail',
+    config?.baseUrl,
+  )
+
+  const result = readNestedPayload(payload)
+  const departmentIds = Array.isArray(result.dept_id_list)
+    ? result.dept_id_list.map((item) => String(item ?? '').trim()).filter(Boolean)
+    : []
+
+  const resolvedUserId = String(result.userid ?? result.userId ?? userId).trim()
+  const name = String(result.name ?? '').trim()
+  if (!resolvedUserId || !name) {
+    throw new Error('Failed to resolve DingTalk user detail')
+  }
+
+  return {
+    userId: resolvedUserId,
+    name,
+    nick: typeof result.nick === 'string' ? result.nick : undefined,
+    unionId: typeof result.unionid === 'string' ? result.unionid : typeof result.unionId === 'string' ? result.unionId : undefined,
+    openId: typeof result.openId === 'string' ? result.openId : typeof result.open_id === 'string' ? result.open_id : undefined,
+    mobile: typeof result.mobile === 'string' ? result.mobile : undefined,
+    email: typeof result.email === 'string' ? result.email : undefined,
+    jobNumber: typeof result.job_number === 'string' ? result.job_number : typeof result.jobNumber === 'string' ? result.jobNumber : undefined,
+    title: typeof result.title === 'string' ? result.title : undefined,
+    avatarUrl:
+      typeof result.avatar === 'string'
+        ? result.avatar
+        : typeof result.avatarUrl === 'string'
+          ? result.avatarUrl
+          : undefined,
+    departmentIds,
+    source: result,
   }
 }
 

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -1,0 +1,141 @@
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { isAdmin as isRbacAdmin } from '../rbac/service'
+import { jsonError, jsonOk, parsePagination } from '../util/response'
+import {
+  createDirectoryIntegration,
+  listDirectoryIntegrations,
+  listDirectorySyncRuns,
+  syncDirectoryIntegration,
+  testDirectoryIntegration,
+  updateDirectoryIntegration,
+} from '../directory/directory-sync'
+
+function readErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) return error.message
+  return fallback
+}
+
+function getRequestUserId(req: Request): string {
+  const raw = req.user as Record<string, unknown> | undefined
+  const userId = raw?.id ?? raw?.userId ?? raw?.sub
+  return typeof userId === 'string' ? userId.trim() : ''
+}
+
+function hasLegacyAdminClaim(req: Request): boolean {
+  const raw = req.user as Record<string, unknown> | undefined
+  if (!raw) return false
+  if (raw.role === 'admin') return true
+  if (Array.isArray(raw.roles) && raw.roles.includes('admin')) return true
+  if (Array.isArray(raw.permissions) && raw.permissions.includes('*:*')) return true
+  if (Array.isArray(raw.perms) && raw.perms.includes('*:*')) return true
+  return false
+}
+
+async function ensurePlatformAdmin(req: Request, res: Response): Promise<string | null> {
+  const userId = getRequestUserId(req)
+  if (!userId) {
+    jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')
+    return null
+  }
+
+  if (hasLegacyAdminClaim(req) || await isRbacAdmin(userId)) {
+    return userId
+  }
+
+  jsonError(res, 403, 'FORBIDDEN', 'Admin access required')
+  return null
+}
+
+export function adminDirectoryRouter(): Router {
+  const router = Router()
+
+  router.get('/integrations', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const items = await listDirectoryIntegrations()
+      jsonOk(res, { items })
+    } catch (error) {
+      jsonError(res, 500, 'DIRECTORY_LIST_FAILED', readErrorMessage(error, 'Failed to load directory integrations'))
+    }
+  })
+
+  router.post('/integrations', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const integration = await createDirectoryIntegration(req.body as Record<string, unknown> as never)
+      jsonOk(res, { integration })
+    } catch (error) {
+      jsonError(res, 400, 'DIRECTORY_CREATE_FAILED', readErrorMessage(error, 'Failed to create directory integration'))
+    }
+  })
+
+  router.put('/integrations/:integrationId', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const integration = await updateDirectoryIntegration(req.params.integrationId, req.body as Record<string, unknown> as never)
+      if (!integration) {
+        jsonError(res, 404, 'DIRECTORY_NOT_FOUND', 'Directory integration not found')
+        return
+      }
+      jsonOk(res, { integration })
+    } catch (error) {
+      jsonError(res, 400, 'DIRECTORY_UPDATE_FAILED', readErrorMessage(error, 'Failed to update directory integration'))
+    }
+  })
+
+  router.post('/integrations/test', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const result = await testDirectoryIntegration(req.body as Record<string, unknown> as never)
+      jsonOk(res, result)
+    } catch (error) {
+      jsonError(res, 400, 'DIRECTORY_TEST_FAILED', readErrorMessage(error, 'Failed to test directory integration'))
+    }
+  })
+
+  router.post('/integrations/:integrationId/sync', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const result = await syncDirectoryIntegration(req.params.integrationId, adminUserId)
+      jsonOk(res, result)
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to sync directory integration')
+      jsonError(res, /not found/i.test(message) ? 404 : 500, 'DIRECTORY_SYNC_FAILED', message)
+    }
+  })
+
+  router.get('/integrations/:integrationId/runs', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const { page, pageSize, offset } = parsePagination(req.query as Record<string, unknown>, {
+        defaultPage: 1,
+        defaultPageSize: 20,
+        maxPageSize: 100,
+      })
+      const result = await listDirectorySyncRuns(req.params.integrationId, { limit: pageSize, offset })
+      jsonOk(res, {
+        items: result.items,
+        total: result.total,
+        page,
+        pageSize,
+      })
+    } catch (error) {
+      jsonError(res, 500, 'DIRECTORY_RUNS_FAILED', readErrorMessage(error, 'Failed to load sync runs'))
+    }
+  })
+
+  return router
+}

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -1,0 +1,188 @@
+import type { Request, Response } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const rbacMocks = vi.hoisted(() => ({
+  isRbacAdmin: vi.fn(),
+}))
+
+const directoryMocks = vi.hoisted(() => ({
+  listDirectoryIntegrations: vi.fn(),
+  createDirectoryIntegration: vi.fn(),
+  updateDirectoryIntegration: vi.fn(),
+  testDirectoryIntegration: vi.fn(),
+  syncDirectoryIntegration: vi.fn(),
+  listDirectorySyncRuns: vi.fn(),
+}))
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: rbacMocks.isRbacAdmin,
+}))
+
+vi.mock('../../src/directory/directory-sync', () => ({
+  listDirectoryIntegrations: directoryMocks.listDirectoryIntegrations,
+  createDirectoryIntegration: directoryMocks.createDirectoryIntegration,
+  updateDirectoryIntegration: directoryMocks.updateDirectoryIntegration,
+  testDirectoryIntegration: directoryMocks.testDirectoryIntegration,
+  syncDirectoryIntegration: directoryMocks.syncDirectoryIntegration,
+  listDirectorySyncRuns: directoryMocks.listDirectorySyncRuns,
+}))
+
+import { adminDirectoryRouter } from '../../src/routes/admin-directory'
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    headersSent: false,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      this.headersSent = true
+      return this
+    },
+  } as Response & {
+    statusCode: number
+    body: unknown
+    headersSent: boolean
+  }
+}
+
+async function invokeRoute(
+  method: 'get' | 'post' | 'put',
+  path: string,
+  options: {
+    params?: Record<string, string>
+    query?: Record<string, unknown>
+    body?: Record<string, unknown>
+    user?: Record<string, unknown>
+  } = {},
+) {
+  const router = adminDirectoryRouter()
+  const layer = router.stack.find((entry) => entry.route?.path === path && entry.route?.methods?.[method])
+  if (!layer?.route?.stack) throw new Error(`Route ${method.toUpperCase()} ${path} not found`)
+
+  const req = {
+    method: method.toUpperCase(),
+    url: path,
+    params: options.params ?? {},
+    query: options.query ?? {},
+    body: options.body ?? {},
+    user: options.user,
+  } as unknown as Request
+
+  const res = createMockResponse()
+
+  for (const routeLayer of layer.route.stack) {
+    await new Promise<void>((resolve, reject) => {
+      try {
+        const maybePromise = routeLayer.handle(req, res, (error?: unknown) => {
+          if (error) reject(error)
+          else resolve()
+        })
+        if (maybePromise && typeof maybePromise.then === 'function') {
+          Promise.resolve(maybePromise).then(() => resolve()).catch(reject)
+        } else if (routeLayer.handle.length < 3) {
+          resolve()
+        }
+      } catch (error) {
+        reject(error)
+      }
+    })
+  }
+
+  return res
+}
+
+describe('adminDirectoryRouter', () => {
+  beforeEach(() => {
+    rbacMocks.isRbacAdmin.mockReset()
+    directoryMocks.listDirectoryIntegrations.mockReset()
+    directoryMocks.createDirectoryIntegration.mockReset()
+    directoryMocks.updateDirectoryIntegration.mockReset()
+    directoryMocks.testDirectoryIntegration.mockReset()
+    directoryMocks.syncDirectoryIntegration.mockReset()
+    directoryMocks.listDirectorySyncRuns.mockReset()
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    const response = await invokeRoute('get', '/integrations')
+    expect(response.statusCode).toBe(401)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'UNAUTHENTICATED',
+      },
+    })
+  })
+
+  it('lists integrations for admin users', async () => {
+    directoryMocks.listDirectoryIntegrations.mockResolvedValue([
+      { id: 'dir-1', name: 'DingTalk CN' },
+    ])
+
+    const response = await invokeRoute('get', '/integrations', {
+      user: {
+        id: 'admin-1',
+        role: 'admin',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.listDirectoryIntegrations).toHaveBeenCalledTimes(1)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        items: [{ id: 'dir-1', name: 'DingTalk CN' }],
+      },
+    })
+  })
+
+  it('delegates sync to the directory service and returns its payload', async () => {
+    directoryMocks.syncDirectoryIntegration.mockResolvedValue({
+      integration: { id: 'dir-1', name: 'DingTalk CN' },
+      run: { id: 'run-1', status: 'completed' },
+    })
+
+    const response = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      user: {
+        id: 'admin-1',
+        role: 'admin',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.syncDirectoryIntegration).toHaveBeenCalledWith('dir-1', 'admin-1')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        integration: { id: 'dir-1' },
+        run: { id: 'run-1', status: 'completed' },
+      },
+    })
+  })
+
+  it('supports admin checks via RBAC fallback', async () => {
+    rbacMocks.isRbacAdmin.mockResolvedValue(true)
+    directoryMocks.listDirectorySyncRuns.mockResolvedValue({
+      items: [{ id: 'run-1', status: 'completed' }],
+      total: 1,
+    })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/runs', {
+      params: { integrationId: 'dir-1' },
+      query: { page: '1', pageSize: '10' },
+      user: {
+        id: 'user-2',
+        role: 'user',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(rbacMocks.isRbacAdmin).toHaveBeenCalledWith('user-2')
+    expect(directoryMocks.listDirectorySyncRuns).toHaveBeenCalledWith('dir-1', { limit: 10, offset: 0 })
+  })
+})

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { isWhitelisted } from '../../src/auth/jwt-middleware'
+
+describe('jwt auth whitelist', () => {
+  it('allows DingTalk launch without a bearer token', () => {
+    expect(isWhitelisted('/api/auth/dingtalk/launch')).toBe(true)
+    expect(isWhitelisted('/api/auth/dingtalk/launch?redirect=%2Fdashboard')).toBe(true)
+  })
+
+  it('allows DingTalk callback without a bearer token', () => {
+    expect(isWhitelisted('/api/auth/dingtalk/callback')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add the minimal DingTalk directory integration/admin slice on top of PR1
- support integration CRUD, credential test, manual sync, and recent run history
- add a minimal admin UI at `/admin/directory`
- keep the write set narrow instead of replaying the historical featureline wholesale

## Review Order
- review after `#725`
- stacked base: `#725`
- stacked follow-up: `#724`

## Scope
- extend the shared DingTalk client with directory API support
- add `directory-sync.ts` service and `admin-directory.ts` routes
- mount admin directory APIs in the backend
- add `DirectoryManagementView.vue` and router/admin entry wiring
- reuse existing current-main directory tables without new migrations

## Verification
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts`
- `pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts`

## Docs
- `docs/development/dingtalk-pr2-directory-sync-design-20260408.md`
- `docs/development/dingtalk-pr2-directory-sync-verification-20260408.md`

## Known Risks
- no live DingTalk tenant validation yet
- no deep persistence-path unit coverage for `directory-sync.ts`
- still uses existing admin gate instead of a dedicated `directory:*` permission family

## Merge Readiness
- current status: keep as draft; branch refreshed onto latest PR1 head and current stacked merge state is CLEAN
- upstream status: `#725` has merged to `main`; this PR has now been retargeted to `main` and rebased onto the merge commit
- gate status: this PR still only becomes merge-eligible after `#725` merges and this PR is retargeted to `main`
- retarget rule: this PR is now `main`-based; wait for full GitHub checks on the retargeted head, then decide when to move it out of draft
- prepared review focus after retarget: directory sync CRUD, manual sync runs, recent history, and admin route behavior
- latest stacked refresh: rebased onto the newest `#725` branch head; local validation rerun and branch force-pushed as `0959febdb`


