### PR TITLE
feat(dingtalk): add oauth login foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ JWT_EXPIRES_IN=2h
 # DINGTALK_CLIENT_SECRET=dingtalk-app-secret
 # DINGTALK_REDIRECT_URI=https://app.example.com/login/dingtalk/callback
 # DINGTALK_CORP_ID=dingtalk-corp-id
-# DINGTALK_AUTH_AUTO_LINK_EMAIL=1
+# DINGTALK_AUTH_AUTO_LINK_EMAIL=0
 # DINGTALK_AUTH_AUTO_PROVISION=0
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,14 @@ JWT_EXPIRES_IN=2h
 # IMPORTANT: Generate a strong secret for production using:
 # node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
 
+# DingTalk OAuth (optional)
+# DINGTALK_CLIENT_ID=dingtalk-app-key
+# DINGTALK_CLIENT_SECRET=dingtalk-app-secret
+# DINGTALK_REDIRECT_URI=https://app.example.com/login/dingtalk/callback
+# DINGTALK_CORP_ID=dingtalk-corp-id
+# DINGTALK_AUTH_AUTO_LINK_EMAIL=1
+# DINGTALK_AUTH_AUTO_PROVISION=0
+
 # =============================================================================
 # REDIS CACHE (Optional)
 # =============================================================================

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -34,7 +34,7 @@ export const appRoutes: RouteRecordRaw[] = [
     path: ROUTE_PATHS.DINGTALK_AUTH_CALLBACK,
     name: AppRouteNames.DINGTALK_AUTH_CALLBACK,
     component: DingTalkAuthCallbackView,
-    meta: { title: 'DingTalk Sign In', titleZh: '钉钉登录', hideNavbar: true, requiresAuth: false }
+    meta: { title: 'DingTalk Sign In', titleZh: '钉钉登录', hideNavbar: true, requiresAuth: false, requiresGuest: true }
   },
   {
     path: '/accept-invite',

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -13,6 +13,7 @@ import MultitableCommentInboxView from '../views/MultitableCommentInboxView.vue'
 import PluginManagerView from '../views/PluginManagerView.vue'
 import PluginViewHost from '../views/PluginViewHost.vue'
 import AttendanceExperienceView from '../views/attendance/AttendanceExperienceView.vue'
+import DingTalkAuthCallbackView from '../views/DingTalkAuthCallbackView.vue'
 import HomeRedirect from '../views/HomeRedirect.vue'
 import LoginView from '../views/LoginView.vue'
 
@@ -28,6 +29,12 @@ export const appRoutes: RouteRecordRaw[] = [
     name: 'login',
     component: LoginView,
     meta: { title: 'Sign In', hideNavbar: true, requiresGuest: true }
+  },
+  {
+    path: ROUTE_PATHS.DINGTALK_AUTH_CALLBACK,
+    name: AppRouteNames.DINGTALK_AUTH_CALLBACK,
+    component: DingTalkAuthCallbackView,
+    meta: { title: 'DingTalk Sign In', titleZh: '钉钉登录', hideNavbar: true, requiresAuth: false }
   },
   {
     path: '/accept-invite',

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -37,6 +37,7 @@ import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router'
 export const AppRouteNames = {
   // Auth routes
   LOGIN: 'login',
+  DINGTALK_AUTH_CALLBACK: 'dingtalk-auth-callback',
   REGISTER: 'register',
   FORGOT_PASSWORD: 'forgot-password',
   RESET_PASSWORD: 'reset-password',
@@ -121,6 +122,7 @@ export interface AppRouteParams {
 
   // Routes without params
   'login': Record<string, never>
+  'dingtalk-auth-callback': Record<string, never>
   'register': Record<string, never>
   'forgot-password': Record<string, never>
   'dashboard': Record<string, never>
@@ -190,6 +192,12 @@ export interface AppRouteQuery {
 
   // Login redirect
   'login': {
+    redirect?: string
+  }
+
+  'dingtalk-auth-callback': {
+    code?: string
+    state?: string
     redirect?: string
   }
 
@@ -358,6 +366,7 @@ export function createTypedNavigation<Name extends AppRouteNamesType>(
 export const ROUTE_PATHS = {
   // Auth
   LOGIN: '/login',
+  DINGTALK_AUTH_CALLBACK: '/login/dingtalk/callback',
   REGISTER: '/register',
   FORGOT_PASSWORD: '/forgot-password',
   RESET_PASSWORD: '/reset-password/:token',

--- a/apps/web/src/views/DingTalkAuthCallbackView.vue
+++ b/apps/web/src/views/DingTalkAuthCallbackView.vue
@@ -111,6 +111,24 @@ function persistAuthContext(user: AuthUserPayload | null, features: AuthFeatureP
 }
 
 async function handleCallback(): Promise<void> {
+  const existingToken = auth.getToken()
+  if (existingToken) {
+    const currentSession = await auth.bootstrapSession()
+    if (currentSession.ok) {
+      let fallbackPath = resolveHomePath()
+      try {
+        await loadProductFeatures()
+        fallbackPath = resolveHomePath()
+      } catch {
+        // Keep authenticated users on their current session even if feature probing fails.
+      }
+
+      const redirectPath = normalizePostLoginRedirect(route.query.redirect)
+      await router.replace(redirectPath || fallbackPath)
+      return
+    }
+  }
+
   const code = typeof route.query.code === 'string' ? route.query.code : ''
   const state = typeof route.query.state === 'string' ? route.query.state : ''
 

--- a/apps/web/src/views/DingTalkAuthCallbackView.vue
+++ b/apps/web/src/views/DingTalkAuthCallbackView.vue
@@ -1,0 +1,254 @@
+<template>
+  <section class="dingtalk-callback">
+    <div v-if="loading" class="dingtalk-callback__loading">
+      <div class="dingtalk-callback__spinner" />
+      <p>{{ text.loading }}</p>
+    </div>
+
+    <div v-else-if="errorMessage" class="dingtalk-callback__error">
+      <p class="dingtalk-callback__error-text">{{ errorMessage }}</p>
+      <button class="dingtalk-callback__button" type="button" @click="void returnToLogin()">
+        {{ text.backToLogin }}
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuth } from '../composables/useAuth'
+import { useLocale } from '../composables/useLocale'
+import { useFeatureFlags } from '../stores/featureFlags'
+import { normalizePostLoginRedirect } from '../utils/authRedirect'
+import { apiFetch } from '../utils/api'
+import { readErrorMessage } from '../utils/error'
+
+interface AuthUserPayload {
+  role?: unknown
+  roles?: unknown
+  permissions?: unknown
+}
+
+interface AuthFeaturePayload {
+  mode?: unknown
+  attendance?: unknown
+  workflow?: unknown
+  attendanceAdmin?: unknown
+  attendanceImport?: unknown
+  plm?: unknown
+}
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuth()
+const { isZh } = useLocale()
+const { loadProductFeatures, resolveHomePath } = useFeatureFlags()
+
+const loading = ref(true)
+const errorMessage = ref('')
+
+const text = computed(() => {
+  if (isZh.value) {
+    return {
+      loading: '正在验证钉钉登录，请稍候...',
+      backToLogin: '返回登录',
+      missingCode: '缺少授权码参数',
+      missingToken: '登录成功但未获取到令牌',
+      failed: '钉钉登录失败，请稍后重试。',
+    }
+  }
+  return {
+    loading: 'Completing DingTalk sign-in...',
+    backToLogin: 'Back to Sign In',
+    missingCode: 'Missing authorization code',
+    missingToken: 'Sign-in succeeded but no token was returned',
+    failed: 'DingTalk sign-in failed. Please try again.',
+  }
+})
+
+function extractUserRoles(user: AuthUserPayload | null): string[] {
+  if (!user) return []
+  if (Array.isArray(user.roles)) {
+    return user.roles.filter((item): item is string => typeof item === 'string')
+  }
+  if (typeof user.role === 'string' && user.role.trim().length > 0) {
+    return [user.role.trim()]
+  }
+  return []
+}
+
+function extractUserPermissions(user: AuthUserPayload | null): string[] {
+  if (!user) return []
+  if (!Array.isArray(user.permissions)) return []
+  return user.permissions.filter((item): item is string => typeof item === 'string')
+}
+
+function persistAuthContext(user: AuthUserPayload | null, features: AuthFeaturePayload | null): void {
+  if (typeof localStorage === 'undefined') return
+
+  const roles = extractUserRoles(user)
+  const permissions = extractUserPermissions(user)
+
+  if (roles.length > 0) {
+    localStorage.setItem('user_roles', JSON.stringify(roles))
+  } else {
+    localStorage.removeItem('user_roles')
+  }
+
+  if (permissions.length > 0) {
+    localStorage.setItem('user_permissions', JSON.stringify(permissions))
+  } else {
+    localStorage.removeItem('user_permissions')
+  }
+
+  if (features && typeof features === 'object') {
+    localStorage.setItem('metasheet_features', JSON.stringify(features))
+    if (typeof features.mode === 'string' && features.mode.trim().length > 0) {
+      localStorage.setItem('metasheet_product_mode', features.mode)
+    }
+  }
+}
+
+async function handleCallback(): Promise<void> {
+  const code = typeof route.query.code === 'string' ? route.query.code : ''
+  const state = typeof route.query.state === 'string' ? route.query.state : ''
+
+  if (!code) {
+    loading.value = false
+    errorMessage.value = text.value.missingCode
+    return
+  }
+
+  try {
+    const response = await apiFetch('/api/auth/dingtalk/callback', {
+      method: 'POST',
+      body: JSON.stringify({ code, state }),
+      suppressUnauthorizedRedirect: true,
+    })
+    const payload = await response.json().catch(() => null)
+
+    if (!response.ok || !payload?.success) {
+      loading.value = false
+      errorMessage.value = readErrorMessage(payload, text.value.failed)
+      return
+    }
+
+    const token = typeof payload?.data?.token === 'string' ? payload.data.token : ''
+    if (!token) {
+      loading.value = false
+      errorMessage.value = text.value.missingToken
+      return
+    }
+
+    auth.setToken(token)
+    persistAuthContext(
+      (payload?.data?.user ?? null) as AuthUserPayload | null,
+      (payload?.data?.features ?? null) as AuthFeaturePayload | null,
+    )
+    auth.primeSession({
+      success: true,
+      data: {
+        user: payload?.data?.user ?? null,
+        features: payload?.data?.features ?? null,
+      },
+    })
+
+    let fallbackPath = resolveHomePath()
+    try {
+      await loadProductFeatures(true, { skipSessionProbe: true })
+      fallbackPath = resolveHomePath()
+    } catch {
+      // Keep the login successful even when feature probing temporarily fails.
+    }
+
+    const redirectPath =
+      normalizePostLoginRedirect(payload?.data?.redirectPath) ||
+      normalizePostLoginRedirect(route.query.redirect)
+    await router.replace(redirectPath || fallbackPath)
+  } catch (error) {
+    loading.value = false
+    errorMessage.value = readErrorMessage(error, text.value.failed)
+  }
+}
+
+async function returnToLogin(): Promise<void> {
+  await router.replace({ name: 'login' }).catch(() => undefined)
+}
+
+onMounted(() => {
+  void handleCallback()
+})
+</script>
+
+<style scoped>
+.dingtalk-callback {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: linear-gradient(160deg, #f3f6fb 0%, #eef5ff 40%, #f9fcff 100%);
+}
+
+.dingtalk-callback__loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.dingtalk-callback__loading p {
+  margin: 0;
+  color: #475569;
+  font-size: 16px;
+}
+
+.dingtalk-callback__spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid #dbeafe;
+  border-top-color: #0f7ae5;
+  border-radius: 50%;
+  animation: dingtalk-spin 0.8s linear infinite;
+}
+
+@keyframes dingtalk-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.dingtalk-callback__error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  max-width: 420px;
+  text-align: center;
+}
+
+.dingtalk-callback__error-text {
+  margin: 0;
+  padding: 14px 20px;
+  border-radius: 10px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 15px;
+}
+
+.dingtalk-callback__button {
+  appearance: none;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 20px;
+  background: #2070d8;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dingtalk-callback__button:hover {
+  background: #1558ac;
+}
+</style>

--- a/apps/web/src/views/LoginView.vue
+++ b/apps/web/src/views/LoginView.vue
@@ -48,18 +48,35 @@
         <button class="login-submit" type="submit" :disabled="submitting">
           {{ submitting ? text.submitting : text.submit }}
         </button>
+
+        <div v-if="dingtalkAvailable" class="login-divider">
+          <span>{{ text.alternative }}</span>
+        </div>
+
+        <button
+          v-if="dingtalkAvailable"
+          class="login-dingtalk"
+          type="button"
+          :disabled="dingtalkSubmitting"
+          @click="onLaunchDingTalk"
+        >
+          {{ dingtalkSubmitting ? text.dingtalkSubmitting : text.dingtalkSubmit }}
+        </button>
+
+        <p v-if="dingtalkErrorMessage" class="login-error">{{ dingtalkErrorMessage }}</p>
       </form>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useLocale } from '../composables/useLocale'
 import { useFeatureFlags } from '../stores/featureFlags'
 import { normalizePostLoginRedirect } from '../utils/authRedirect'
 import { apiFetch, clearStoredAuthState } from '../utils/api'
+import { readErrorMessage } from '../utils/error'
 
 interface AuthUserPayload {
   role?: unknown
@@ -85,6 +102,9 @@ const email = ref('')
 const password = ref('')
 const submitting = ref(false)
 const errorMessage = ref('')
+const dingtalkAvailable = ref(false)
+const dingtalkSubmitting = ref(false)
+const dingtalkErrorMessage = ref('')
 
 const text = computed(() => {
   if (isZh.value) {
@@ -98,8 +118,13 @@ const text = computed(() => {
       passwordPlaceholder: '请输入密码',
       submit: '登录',
       submitting: '登录中...',
+      alternative: '或者',
+      dingtalkSubmit: '使用钉钉登录',
+      dingtalkSubmitting: '跳转到钉钉中...',
       failed: '登录失败，请检查账号或密码。',
       networkError: '登录失败，请稍后再试。',
+      dingtalkUnavailable: '钉钉登录暂不可用，请稍后重试。',
+      dingtalkMissingUrl: '未获取到钉钉登录地址。',
     }
   }
   return {
@@ -112,8 +137,13 @@ const text = computed(() => {
     passwordPlaceholder: 'Enter password',
     submit: 'Sign in',
     submitting: 'Signing in...',
+    alternative: 'or',
+    dingtalkSubmit: 'Continue with DingTalk',
+    dingtalkSubmitting: 'Redirecting to DingTalk...',
     failed: 'Sign-in failed. Check your email or password.',
     networkError: 'Sign-in failed. Please try again.',
+    dingtalkUnavailable: 'DingTalk login is unavailable right now.',
+    dingtalkMissingUrl: 'No DingTalk login URL was returned.',
   }
 })
 
@@ -210,6 +240,54 @@ async function onSubmit(): Promise<void> {
     submitting.value = false
   }
 }
+
+async function probeDingTalkLogin(): Promise<void> {
+  try {
+    const response = await apiFetch('/api/auth/dingtalk/launch', {
+      method: 'GET',
+      suppressUnauthorizedRedirect: true,
+    })
+    dingtalkAvailable.value = response.ok
+  } catch {
+    dingtalkAvailable.value = false
+  }
+}
+
+async function onLaunchDingTalk(): Promise<void> {
+  dingtalkErrorMessage.value = ''
+  dingtalkSubmitting.value = true
+
+  try {
+    const redirectPath = normalizePostLoginRedirect(route.query.redirect)
+    const query = redirectPath ? `?redirect=${encodeURIComponent(redirectPath)}` : ''
+    const response = await apiFetch(`/api/auth/dingtalk/launch${query}`, {
+      method: 'GET',
+      suppressUnauthorizedRedirect: true,
+    })
+    const payload = await response.json().catch(() => null)
+
+    if (!response.ok || !payload?.success) {
+      dingtalkErrorMessage.value = readErrorMessage(payload, text.value.dingtalkUnavailable)
+      return
+    }
+
+    const launchUrl = typeof payload?.data?.url === 'string' ? payload.data.url : ''
+    if (!launchUrl) {
+      dingtalkErrorMessage.value = text.value.dingtalkMissingUrl
+      return
+    }
+
+    window.location.href = launchUrl
+  } catch (error) {
+    dingtalkErrorMessage.value = readErrorMessage(error, text.value.dingtalkUnavailable)
+  } finally {
+    dingtalkSubmitting.value = false
+  }
+}
+
+onMounted(() => {
+  void probeDingTalkLogin()
+})
 </script>
 
 <style scoped>
@@ -330,6 +408,38 @@ async function onSubmit(): Promise<void> {
 }
 
 .login-submit:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.login-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #6b7c93;
+  font-size: 12px;
+}
+
+.login-divider::before,
+.login-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #d9e4f2;
+}
+
+.login-dingtalk {
+  border: 1px solid #0089ff;
+  border-radius: 8px;
+  padding: 10px 14px;
+  background: #f3f9ff;
+  color: #0067c7;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.login-dingtalk:disabled {
   opacity: 0.6;
   cursor: default;
 }

--- a/apps/web/src/views/LoginView.vue
+++ b/apps/web/src/views/LoginView.vue
@@ -243,7 +243,7 @@ async function onSubmit(): Promise<void> {
 
 async function probeDingTalkLogin(): Promise<void> {
   try {
-    const response = await apiFetch('/api/auth/dingtalk/launch', {
+    const response = await apiFetch('/api/auth/dingtalk/launch?probe=1', {
       method: 'GET',
       suppressUnauthorizedRedirect: true,
     })

--- a/apps/web/tests/LoginView.spec.ts
+++ b/apps/web/tests/LoginView.spec.ts
@@ -6,6 +6,19 @@ const mocks = vi.hoisted(() => ({
   resolveHomePath: vi.fn(() => '/attendance'),
   routerReplace: vi.fn().mockResolvedValue(undefined),
   apiFetch: vi.fn(async (path: string) => {
+    if (path === '/api/auth/dingtalk/launch?probe=1') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: {
+            available: true,
+          },
+        }),
+      }
+    }
+
     if (path === '/api/auth/login') {
       return {
         ok: true,
@@ -130,7 +143,12 @@ describe('LoginView', () => {
     submitButton?.click()
     await flushUi(8)
 
-    expect(mocks.apiFetch).toHaveBeenCalledTimes(1)
+    expect(mocks.apiFetch).toHaveBeenCalledTimes(2)
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(
+      1,
+      '/api/auth/dingtalk/launch?probe=1',
+      expect.objectContaining({ method: 'GET', suppressUnauthorizedRedirect: true }),
+    )
     expect(mocks.apiFetch).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({ method: 'POST' }))
     expect(window.localStorage.getItem('auth_token')).toBe('login-token')
     expect(window.localStorage.getItem('user_roles')).toBe(JSON.stringify(['admin']))
@@ -139,5 +157,21 @@ describe('LoginView', () => {
     expect(mocks.loadProductFeatures).toHaveBeenCalledWith(true, { skipSessionProbe: true })
     expect(mocks.resolveHomePath).toHaveBeenCalled()
     expect(mocks.routerReplace).toHaveBeenCalledWith('/attendance')
+  })
+
+  it('uses the probe flag when checking DingTalk availability on mount', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp(LoginViewComponent)
+    app.mount(container)
+    await flushUi()
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith(
+      '/api/auth/dingtalk/launch?probe=1',
+      expect.objectContaining({ method: 'GET', suppressUnauthorizedRedirect: true }),
+    )
+    const dingtalkButton = container?.querySelector('.login-dingtalk')
+    expect(dingtalkButton).not.toBeNull()
   })
 })

--- a/apps/web/tests/dingtalk-auth-callback.spec.ts
+++ b/apps/web/tests/dingtalk-auth-callback.spec.ts
@@ -5,6 +5,8 @@ import DingTalkAuthCallbackView from '../src/views/DingTalkAuthCallbackView.vue'
 const apiFetchMock = vi.fn()
 const setTokenMock = vi.fn()
 const primeSessionMock = vi.fn()
+const getTokenMock = vi.fn()
+const bootstrapSessionMock = vi.fn()
 const loadProductFeaturesMock = vi.fn()
 const resolveHomePathMock = vi.fn(() => '/attendance')
 const replaceMock = vi.fn(() => Promise.resolve())
@@ -24,6 +26,8 @@ vi.mock('../src/composables/useLocale', () => ({
 
 vi.mock('../src/composables/useAuth', () => ({
   useAuth: () => ({
+    getToken: getTokenMock,
+    bootstrapSession: bootstrapSessionMock,
     setToken: setTokenMock,
     primeSession: primeSessionMock,
   }),
@@ -60,6 +64,8 @@ describe('DingTalkAuthCallbackView', () => {
 
   beforeEach(() => {
     apiFetchMock.mockReset()
+    getTokenMock.mockReset()
+    bootstrapSessionMock.mockReset()
     setTokenMock.mockReset()
     primeSessionMock.mockReset()
     loadProductFeaturesMock.mockReset()
@@ -67,6 +73,8 @@ describe('DingTalkAuthCallbackView', () => {
     resolveHomePathMock.mockReturnValue('/attendance')
     replaceMock.mockReset()
     replaceMock.mockResolvedValue(undefined)
+    getTokenMock.mockReturnValue(null)
+    bootstrapSessionMock.mockResolvedValue({ ok: false, status: 401, payload: null })
     routeState.query.code = 'auth-code'
     routeState.query.state = 'state-1'
 
@@ -135,5 +143,29 @@ describe('DingTalkAuthCallbackView', () => {
 
     expect(apiFetchMock).not.toHaveBeenCalled()
     expect(container?.textContent).toContain('缺少授权码参数')
+  })
+
+  it('keeps an existing authenticated session instead of overwriting it via callback', async () => {
+    getTokenMock.mockReturnValue('existing-token')
+    bootstrapSessionMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      payload: {
+        data: {
+          user: {
+            id: 'user-1',
+          },
+        },
+      },
+    })
+    loadProductFeaturesMock.mockResolvedValue(undefined)
+
+    app = createApp(DingTalkAuthCallbackView)
+    app.mount(container!)
+    await flushUi(6)
+
+    expect(apiFetchMock).not.toHaveBeenCalled()
+    expect(setTokenMock).not.toHaveBeenCalled()
+    expect(replaceMock).toHaveBeenCalledWith('/attendance')
   })
 })

--- a/apps/web/tests/dingtalk-auth-callback.spec.ts
+++ b/apps/web/tests/dingtalk-auth-callback.spec.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, ref, type App } from 'vue'
+import DingTalkAuthCallbackView from '../src/views/DingTalkAuthCallbackView.vue'
+
+const apiFetchMock = vi.fn()
+const setTokenMock = vi.fn()
+const primeSessionMock = vi.fn()
+const loadProductFeaturesMock = vi.fn()
+const resolveHomePathMock = vi.fn(() => '/attendance')
+const replaceMock = vi.fn(() => Promise.resolve())
+
+const routeState = {
+  query: {
+    code: 'auth-code',
+    state: 'state-1',
+  },
+}
+
+vi.mock('../src/composables/useLocale', () => ({
+  useLocale: () => ({
+    isZh: ref(true),
+  }),
+}))
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    setToken: setTokenMock,
+    primeSession: primeSessionMock,
+  }),
+}))
+
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({
+    loadProductFeatures: loadProductFeaturesMock,
+    resolveHomePath: resolveHomePathMock,
+  }),
+}))
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}))
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('DingTalkAuthCallbackView', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    setTokenMock.mockReset()
+    primeSessionMock.mockReset()
+    loadProductFeaturesMock.mockReset()
+    resolveHomePathMock.mockReset()
+    resolveHomePathMock.mockReturnValue('/attendance')
+    replaceMock.mockReset()
+    replaceMock.mockResolvedValue(undefined)
+    routeState.query.code = 'auth-code'
+    routeState.query.state = 'state-1'
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('stores the returned token and redirects to the backend-provided path', async () => {
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          token: 'jwt-dingtalk-token',
+          redirectPath: '/workflows',
+          user: {
+            id: 'user-1',
+            email: 'manager@example.com',
+            role: 'admin',
+            permissions: ['attendance:admin'],
+          },
+          features: {
+            attendance: true,
+            workflow: true,
+            attendanceAdmin: true,
+            attendanceImport: true,
+            plm: false,
+            mode: 'platform',
+          },
+        },
+      }),
+    })
+    loadProductFeaturesMock.mockResolvedValue(undefined)
+
+    app = createApp(DingTalkAuthCallbackView)
+    app.mount(container!)
+    await flushUi(6)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/auth/dingtalk/callback',
+      expect.objectContaining({
+        method: 'POST',
+        suppressUnauthorizedRedirect: true,
+      }),
+    )
+    expect(setTokenMock).toHaveBeenCalledWith('jwt-dingtalk-token')
+    expect(primeSessionMock).toHaveBeenCalled()
+    expect(replaceMock).toHaveBeenCalledWith('/workflows')
+  })
+
+  it('shows an inline error when the callback is missing the code query param', async () => {
+    routeState.query.code = ''
+    routeState.query.state = ''
+
+    app = createApp(DingTalkAuthCallbackView)
+    app.mount(container!)
+    await flushUi(4)
+
+    expect(apiFetchMock).not.toHaveBeenCalled()
+    expect(container?.textContent).toContain('缺少授权码参数')
+  })
+})

--- a/docs/development/dingtalk-pr1-corpid-rollout-20260410.md
+++ b/docs/development/dingtalk-pr1-corpid-rollout-20260410.md
@@ -14,12 +14,13 @@ That is the correct runtime behavior, but it introduces a rollout requirement fo
 
 Before enabling `DINGTALK_CORP_ID` in any shared environment:
 
-1. run the one-time backfill script
-2. confirm there are no legacy rows with:
+1. run the one-time backfill dry-run and export candidate rows
+2. review the exported candidates and create a manual allowlist
+3. confirm there are no legacy rows with:
    - `provider = 'dingtalk'`
    - `corp_id IS NULL`
    - `provider_open_id IS NULL`
-3. confirm there are no conflicts for the target corp-scoped key:
+4. confirm there are no conflicts for the target corp-scoped key:
    - `external_key = <corpId>:<provider_open_id>`
 
 ## Script
@@ -27,7 +28,7 @@ Before enabling `DINGTALK_CORP_ID` in any shared environment:
 Use:
 
 ```bash
-scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId>
+scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId> --export-file /tmp/dingtalk-corpid-candidates.csv
 ```
 
 Dry-run output reports:
@@ -37,20 +38,27 @@ Dry-run output reports:
 - `conflict_rows`
 - `apply_rows`
 
-The script refuses to proceed if:
+Apply only after manual review and allowlist creation:
+
+```bash
+scripts/ops/backfill-dingtalk-corp-identities.sh \
+  --corp-id <corpId> \
+  --allowlist-file /tmp/dingtalk-corpid-allowlist.txt \
+  --apply
+```
+
+The allowlist file contains one `user_external_identities.id` per line. Empty lines and `#` comments are ignored.
+
+The script refuses to apply if:
 
 - any legacy row is missing `provider_open_id`
 - any target corp-scoped `external_key` would collide
-
-Apply only after dry-run is clean:
-
-```bash
-scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId> --apply
-```
+- the allowlist contains unknown ids
+- the allowlist contains ids that are not eligible legacy DingTalk candidates
 
 ## Expected Data Rewrite
 
-For each eligible legacy DingTalk binding:
+For each allowlisted eligible legacy DingTalk binding:
 
 - `corp_id = <target corp id>`
 - `external_key = <corpId>:<provider_open_id>`
@@ -58,9 +66,9 @@ For each eligible legacy DingTalk binding:
 
 ## Verification
 
-After `--apply`, rerun dry-run and expect:
+After `--apply`, rerun dry-run and expect the reviewed subset to be cleared:
 
-- `candidate_rows=0`
+- no remaining reviewed ids in the exported candidate set
 - `missing_open_id_rows=0`
 - `conflict_rows=0`
 

--- a/docs/development/dingtalk-pr1-corpid-rollout-20260410.md
+++ b/docs/development/dingtalk-pr1-corpid-rollout-20260410.md
@@ -1,0 +1,67 @@
+# DingTalk PR1 CorpId Rollout Gate
+
+Date: 2026-04-10
+PR: `#725`
+Branch: `codex/dingtalk-pr1-foundation-login-20260408`
+
+## Purpose
+
+`DINGTALK_CORP_ID` makes DingTalk identity lookup strict by requiring corp-scoped external keys and corp-matched fallback rows.
+
+That is the correct runtime behavior, but it introduces a rollout requirement for legacy `user_external_identities` rows written before corp scoping was enforced.
+
+## Required Precondition
+
+Before enabling `DINGTALK_CORP_ID` in any shared environment:
+
+1. run the one-time backfill script
+2. confirm there are no legacy rows with:
+   - `provider = 'dingtalk'`
+   - `corp_id IS NULL`
+   - `provider_open_id IS NULL`
+3. confirm there are no conflicts for the target corp-scoped key:
+   - `external_key = <corpId>:<provider_open_id>`
+
+## Script
+
+Use:
+
+```bash
+scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId>
+```
+
+Dry-run output reports:
+
+- `candidate_rows`
+- `missing_open_id_rows`
+- `conflict_rows`
+- `apply_rows`
+
+The script refuses to proceed if:
+
+- any legacy row is missing `provider_open_id`
+- any target corp-scoped `external_key` would collide
+
+Apply only after dry-run is clean:
+
+```bash
+scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId> --apply
+```
+
+## Expected Data Rewrite
+
+For each eligible legacy DingTalk binding:
+
+- `corp_id = <target corp id>`
+- `external_key = <corpId>:<provider_open_id>`
+- `updated_at = now()`
+
+## Verification
+
+After `--apply`, rerun dry-run and expect:
+
+- `candidate_rows=0`
+- `missing_open_id_rows=0`
+- `conflict_rows=0`
+
+Only after that should `DINGTALK_CORP_ID` be enabled in runtime configuration.

--- a/docs/development/dingtalk-pr1-foundation-login-design-20260408.md
+++ b/docs/development/dingtalk-pr1-foundation-login-design-20260408.md
@@ -1,0 +1,187 @@
+# DingTalk PR1 Foundation + Login Design
+
+Date: 2026-04-08
+Branch: `codex/dingtalk-pr1-foundation-login-20260408`
+
+## Scope
+
+This PR1 slice restores the minimum DingTalk login foundation on top of current `origin/main` without replaying the older featureline wholesale.
+
+Included:
+
+- Shared DingTalk backend client for OAuth token exchange and current-user lookup
+- Redis-first OAuth state store with in-memory fallback
+- Backend launch/callback endpoints under `/api/auth/dingtalk/*`
+- Frontend DingTalk login entry on the login page
+- Frontend DingTalk callback route and callback view
+- Unit tests for OAuth state handling, auth routes, and callback page behavior
+
+Explicitly excluded from PR1:
+
+- Directory sync UI and sync jobs
+- Attendance DingTalk productionization
+- DingTalk notification/webhook delivery
+- Admin grant management UI
+- Live DingTalk smoke scripts and ops rollout assets
+
+## Why This Is Not a Cherry-pick
+
+The historical DingTalk rollout branch contains a much larger surface than PR1 and drifts heavily from current `main`, especially around:
+
+- `packages/core-backend/src/routes/auth.ts`
+- `packages/core-backend/src/auth/AuthService.ts`
+- frontend router composition
+- unrelated PLM/multitable/workflow churn
+
+To avoid replaying stale conflicts, PR1 ports only the minimum DingTalk login files and grafts them onto the current auth/session stack.
+
+## Backend Design
+
+### Shared DingTalk client
+
+File:
+
+- `packages/core-backend/src/integrations/dingtalk/client.ts`
+
+Responsibilities:
+
+- Read DingTalk OAuth config from env
+- Exchange auth code for user access token
+- Fetch current DingTalk user profile from `/contact/users/me`
+- Normalize DingTalk error handling
+
+Supported env aliases:
+
+- `DINGTALK_CLIENT_ID` or `DINGTALK_APP_KEY`
+- `DINGTALK_CLIENT_SECRET` or `DINGTALK_APP_SECRET`
+- `DINGTALK_REDIRECT_URI`
+- `DINGTALK_CORP_ID` optional
+
+### OAuth state store
+
+File:
+
+- `packages/core-backend/src/auth/dingtalk-oauth.ts`
+
+State handling rules:
+
+- State TTL is 5 minutes
+- Redis is preferred when `REDIS_URL` or `REDIS_HOST` is configured
+- Memory fallback is used when Redis is unavailable
+- State is one-time use
+- Redirect path is stored inside the state record so the frontend does not have to trust query echoing from DingTalk
+
+### Local user resolution policy
+
+PR1 resolves local users using current mainline tables instead of the old `users.dingtalk_open_id` approach.
+
+Primary tables:
+
+- `user_external_identities`
+- `user_external_auth_grants`
+
+Resolution order:
+
+1. Existing external identity by `external_key`, `provider_open_id`, or `provider_union_id`
+2. Email match if `DINGTALK_AUTH_AUTO_LINK_EMAIL=1` (default enabled)
+3. Auto-provision if `DINGTALK_AUTH_AUTO_PROVISION=1` (default disabled)
+
+Behavior details:
+
+- Existing disabled grants block login
+- Successful email-link and auto-provision paths create a grant row if missing
+- External identity rows are upserted and `last_login_at` is refreshed
+
+This keeps PR1 compatible with the current schema and leaves space for PR2 admin grant management.
+
+### Auth route integration
+
+File:
+
+- `packages/core-backend/src/routes/auth.ts`
+
+New endpoints:
+
+- `GET /api/auth/dingtalk/launch`
+- `POST /api/auth/dingtalk/callback`
+
+Launch flow:
+
+- Validate DingTalk config
+- Normalize optional in-app redirect path
+- Generate state with embedded redirect payload
+- Return the final DingTalk authorize URL
+
+Callback flow:
+
+- Validate `code` and `state`
+- Exchange DingTalk auth code for DingTalk user profile
+- Resolve or provision local user
+- Load current permissions
+- Issue a normal MetaSheet session-backed JWT
+- Return `user`, `token`, `features`, and `redirectPath`
+
+Session behavior intentionally reuses existing MetaSheet session semantics:
+
+- `sid` is generated locally
+- `createUserSession(...)` is called
+- `users.last_login_at` is updated
+
+This means DingTalk login plugs into the current session center instead of bypassing it.
+
+## Frontend Design
+
+### Login page entry
+
+File:
+
+- `apps/web/src/views/LoginView.vue`
+
+Behavior:
+
+- Probe `/api/auth/dingtalk/launch` on mount
+- Show DingTalk login button only when the backend reports availability
+- Pass the safe post-login redirect to the launch endpoint
+- Redirect the browser to DingTalk when launch succeeds
+
+### Callback route
+
+Files:
+
+- `apps/web/src/router/types.ts`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/views/DingTalkAuthCallbackView.vue`
+
+Behavior:
+
+- Route path: `/login/dingtalk/callback`
+- Read `code` and `state` from the query string
+- POST them to `/api/auth/dingtalk/callback`
+- Persist token, roles, permissions, feature flags
+- Prime frontend auth session state
+- Redirect to backend-provided `redirectPath` or resolved home fallback
+
+## Config
+
+Added to `.env.example`:
+
+- `DINGTALK_CLIENT_ID`
+- `DINGTALK_CLIENT_SECRET`
+- `DINGTALK_REDIRECT_URI`
+- `DINGTALK_CORP_ID`
+- `DINGTALK_AUTH_AUTO_LINK_EMAIL`
+- `DINGTALK_AUTH_AUTO_PROVISION`
+
+Recommended production defaults:
+
+- `DINGTALK_AUTH_AUTO_LINK_EMAIL=1` only if your email domain is already authoritative inside DingTalk
+- `DINGTALK_AUTH_AUTO_PROVISION=0` until PR2 directory/admin flows are live
+
+## Risks Left for PR2
+
+- No admin-facing grant management yet
+- No live DingTalk env smoke validation in this slice
+- No directory sync or account review UI yet
+- No DingTalk-specific observability counters or dashboards in this slice
+
+Those are deferred to keep PR1 narrow and mergeable.

--- a/docs/development/dingtalk-pr1-foundation-login-verification-20260408.md
+++ b/docs/development/dingtalk-pr1-foundation-login-verification-20260408.md
@@ -1,0 +1,118 @@
+# DingTalk PR1 Foundation + Login Verification
+
+Date: 2026-04-08
+Branch: `codex/dingtalk-pr1-foundation-login-20260408`
+
+## What Was Verified
+
+This verification pass covers the PR1 login slice only:
+
+- backend DingTalk OAuth state handling
+- backend auth route integration
+- frontend DingTalk callback page flow
+- backend package build
+- frontend package type-check
+
+## Automated Verification
+
+### Backend unit tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/dingtalk-oauth-state-store.test.ts
+```
+
+Result:
+
+- Passed
+- `13/13` tests green
+
+Covered:
+
+- existing auth login feature payload behavior
+- session-center auth regressions
+- DingTalk launch URL generation
+- DingTalk callback token/session issuance
+- invalid or expired OAuth state rejection
+- Redis-backed state consumption
+- in-memory fallback when Redis is unavailable
+
+### Frontend callback test
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-auth-callback.spec.ts
+```
+
+Result:
+
+- Passed
+- `2/2` tests green
+
+Covered:
+
+- callback page stores the returned token and redirects to backend-provided path
+- callback page shows an inline error when the `code` query param is missing
+
+### Backend build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+- Passed
+
+### Frontend type-check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result:
+
+- Passed
+
+## Manual Validation Notes
+
+Not yet executed in this slice:
+
+- Real DingTalk browser login against a configured enterprise tenant
+- Callback validation through a public HTTPS redirect URI
+- Email auto-link behavior against production-like user data
+- Auto-provision behavior with `DINGTALK_AUTH_AUTO_PROVISION=1`
+
+Reason:
+
+- No live DingTalk tenant credentials or callback endpoint were provided during this implementation pass
+
+## Functional Outcome
+
+The branch now supports:
+
+- backend launch URL generation for DingTalk login
+- redirect-safe OAuth state creation and validation
+- DingTalk callback exchange into a normal MetaSheet session-backed JWT
+- frontend DingTalk login button discovery
+- frontend callback handling and post-login redirect
+
+## Residual Risks
+
+- Email auto-link is enabled by default; this should be reviewed before production rollout if tenant email authority is weak
+- No admin UI yet exists to explicitly grant or revoke DingTalk login
+- No live DingTalk smoke script was added in this PR1 slice
+- No observability dashboards or alert rules were brought over yet
+
+## Recommended Next Checks Before Merge
+
+1. Run one real DingTalk login against a staging tenant.
+2. Confirm callback URI exactly matches the configured DingTalk application.
+3. Decide whether `DINGTALK_AUTH_AUTO_LINK_EMAIL` should stay enabled in staging/production.
+4. Keep `DINGTALK_AUTH_AUTO_PROVISION=0` until directory/admin controls are merged.

--- a/docs/development/dingtalk-pr1-review-design-20260409.md
+++ b/docs/development/dingtalk-pr1-review-design-20260409.md
@@ -1,0 +1,78 @@
+# DingTalk PR1 Review Design
+
+Date: 2026-04-09
+PR: `#725`
+Branch: `codex/dingtalk-pr1-foundation-login-20260408`
+
+## Scope
+
+This review pass covers only the PR1 DingTalk login foundation:
+
+- backend launch/callback routing
+- DingTalk OAuth state storage
+- local-user resolution and auto-provision behavior
+- login page launch flow
+- callback page session handoff
+
+Out of scope:
+
+- PR2 directory sync behavior
+- PR3 attendance, robot notifications, delegated admin controls
+- production rollout and tenant-side configuration changes
+
+## Review Gates
+
+PR1 stays on the existing public contract:
+
+- `GET /api/auth/dingtalk/launch`
+- `POST /api/auth/dingtalk/callback`
+- `/login/dingtalk/callback`
+
+This review only fixes blocking correctness or security issues found inside those flows.
+
+## Review Findings
+
+### 1. Launch probing consumed real OAuth state
+
+The login page mounted by probing `GET /api/auth/dingtalk/launch`, which created and stored a real one-time state on every page visit. Under repeated login page traffic this could churn Redis or in-memory state capacity and evict legitimate pending logins.
+
+Design response:
+
+- keep the route path unchanged
+- add a lightweight `probe=1` mode on `/api/auth/dingtalk/launch`
+- update the login page probe to use that mode
+
+### 2. Redis `multi().exec()` tuple errors were treated as success
+
+The state store only handled thrown Redis errors. It did not inspect per-command `[error, result]` tuples returned by `exec()`, so partial command failures could be treated as successful persistence or successful validation.
+
+Design response:
+
+- inspect `exec()` results in both write and validation paths
+- invalidate the Redis client on tuple errors
+- fall back to in-memory storage on write failures
+- fail closed on validation failures
+
+### 3. Auto-provision could reuse an existing email when auto-link was disabled
+
+`createProvisionedUser()` used `INSERT ... ON CONFLICT (email) DO UPDATE`, which let the provisioning path silently reuse an existing local account by email. That bypassed the intended distinction between explicit email linking and account provisioning.
+
+Design response:
+
+- remove the email upsert behavior from provisioning
+- reject provisioning when a local account already exists with the same email
+- preserve the existing explicit email-link path as the only place where email reuse can happen
+
+### 4. Logged-in sessions could be overwritten from the callback page
+
+The callback view accepted a DingTalk callback even when a valid local session already existed in the browser, which allowed token replacement in the current tab.
+
+Design response:
+
+- mark the callback route as guest-only in route metadata
+- add a defensive callback-view guard that keeps the current authenticated session and redirects home instead of exchanging the DingTalk callback
+
+## Non-Blocking Notes
+
+- Duplicate auth payload helpers between `LoginView.vue` and `DingTalkAuthCallbackView.vue` remain a refactor candidate, but they are not blocking for PR1 merge.
+- `DINGTALK_AUTH_AUTO_LINK_EMAIL` remains a configuration choice. The stricter production policy is handled later in the stack by explicit-grant controls.

--- a/docs/development/dingtalk-pr1-review-design-20260409.md
+++ b/docs/development/dingtalk-pr1-review-design-20260409.md
@@ -108,6 +108,34 @@ Design response:
 - when `corpId` is configured, require `identity.corp_id = configuredCorpId` on the fallback path
 - do not change the callback contract; only tighten internal user-resolution semantics
 
+### 8. Callback status codes conflated local policy rejection with DingTalk upstream failure
+
+The callback route previously mapped every `exchangeCodeForUser()` failure to `502`. That hid local admission denials behind an upstream-failure status and made it impossible for clients or operators to distinguish:
+
+- DingTalk transport or token-exchange failures
+- local user disabled / inactive rejections
+- explicit grant-denied rejections
+- auto-provision email conflicts
+
+Design response:
+
+- introduce a dedicated local policy error type inside the DingTalk OAuth module
+- keep DingTalk upstream request errors mapped to `502`
+- map local admission denials to `403`
+- map auto-provision email conflicts to `409`
+- preserve the existing public route path and response body shape
+
+### 9. Enabling `DINGTALK_CORP_ID` requires a rollout gate for legacy bindings
+
+The corp-scoped fallback fix is intentionally strict. Once `DINGTALK_CORP_ID` is enabled, legacy `user_external_identities` rows written before corp scoping may stop matching if they only contain bare `provider_open_id` / `provider_union_id` values and `corp_id IS NULL`.
+
+Design response:
+
+- treat corp-scoped lookup hardening as correct-by-default behavior
+- do not weaken the runtime lookup to auto-accept ambiguous legacy rows
+- require a one-time rollout backfill before enabling `DINGTALK_CORP_ID` in production
+- document the backfill requirement and verification gate in the PR1 review docs
+
 ## Non-Blocking Notes
 
 - Duplicate auth payload helpers between `LoginView.vue` and `DingTalkAuthCallbackView.vue` remain a refactor candidate, but they are not blocking for PR1 merge.

--- a/docs/development/dingtalk-pr1-review-design-20260409.md
+++ b/docs/development/dingtalk-pr1-review-design-20260409.md
@@ -134,6 +134,7 @@ Design response:
 - treat corp-scoped lookup hardening as correct-by-default behavior
 - do not weaken the runtime lookup to auto-accept ambiguous legacy rows
 - require a one-time rollout backfill before enabling `DINGTALK_CORP_ID` in production
+- export candidate rows first and require a manual allowlist for apply
 - document the backfill requirement and verification gate in the PR1 review docs
 
 ### 10. Email auto-link remained enabled by default
@@ -155,6 +156,7 @@ Design response:
 - keep `DingTalkRequestError` mapped to `502`
 - keep local policy errors on their explicit `403` / `409` codes
 - map all other unexpected callback failures to `500`
+- return a generic client-facing error string for the `500` path and keep the detailed error only in server logs
 - preserve the existing route path and response body shape
 
 ## Non-Blocking Notes

--- a/docs/development/dingtalk-pr1-review-design-20260409.md
+++ b/docs/development/dingtalk-pr1-review-design-20260409.md
@@ -72,6 +72,31 @@ Design response:
 - mark the callback route as guest-only in route metadata
 - add a defensive callback-view guard that keeps the current authenticated session and redirects home instead of exchanging the DingTalk callback
 
+### 5. DingTalk login could bypass disabled or inactive local-user gates
+
+The PR1 user-resolution path only selected `id`, `email`, `name`, and `role` from `users`. It did not read or enforce `is_active`, so a DingTalk-linked account that had been disabled in the local system could still receive a fresh session from `/api/auth/dingtalk/callback`.
+
+Design response:
+
+- extend resolved local-user rows to include `is_active`
+- enforce the same deny rule already used by password login and token verification:
+  - `role === 'disabled'`
+  - `is_active === false`
+- apply the check to both external-identity matches and email auto-link matches before grant evaluation or identity upsert
+- keep the existing public error string: `DingTalk login is disabled for this user`
+
+### 6. Auto-provision did not satisfy the current `users` schema
+
+PR1 kept `DINGTALK_AUTH_AUTO_PROVISION` as a supported code path, but the implementation inserted into `users` without `password_hash`. The current schema requires `password_hash TEXT NOT NULL`, so the first real auto-provision attempt would fail at the database layer.
+
+Design response:
+
+- keep auto-provision support in PR1
+- do not change the schema in this fix
+- generate a random one-time secret server-side and hash it with the existing bcrypt runtime configuration
+- write that hash into `users.password_hash` during auto-provision
+- do not expose any generated password to the caller; the hash only satisfies the current local-auth schema
+
 ## Non-Blocking Notes
 
 - Duplicate auth payload helpers between `LoginView.vue` and `DingTalkAuthCallbackView.vue` remain a refactor candidate, but they are not blocking for PR1 merge.

--- a/docs/development/dingtalk-pr1-review-design-20260409.md
+++ b/docs/development/dingtalk-pr1-review-design-20260409.md
@@ -1,6 +1,6 @@
 # DingTalk PR1 Review Design
 
-Date: 2026-04-09
+Date: 2026-04-10
 PR: `#725`
 Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 
@@ -18,7 +18,7 @@ Out of scope:
 
 - PR2 directory sync behavior
 - PR3 attendance, robot notifications, delegated admin controls
-- production rollout and tenant-side configuration changes
+- production feature expansion beyond PR1 login
 
 ## Review Gates
 
@@ -136,7 +136,28 @@ Design response:
 - require a one-time rollout backfill before enabling `DINGTALK_CORP_ID` in production
 - document the backfill requirement and verification gate in the PR1 review docs
 
+### 10. Email auto-link remained enabled by default
+
+The runtime still treated `DINGTALK_AUTH_AUTO_LINK_EMAIL` as enabled when the environment variable was unset. That would let PR1 on its own auto-link DingTalk identities to existing local accounts by email before the later explicit-grant controls from PR3 are merged.
+
+Design response:
+
+- change the runtime fallback for `DINGTALK_AUTH_AUTO_LINK_EMAIL` from enabled to disabled
+- keep explicit opt-in behavior unchanged when the environment variable is set to a truthy value
+- update `.env.example` so the documented default matches the safer runtime behavior
+
+### 11. Unknown local callback failures still looked like DingTalk upstream outages
+
+The callback route already split local policy denials from DingTalk transport failures, but every other unexpected local failure still returned `502`. That would misclassify local database, session, or permission-loading faults as DingTalk upstream issues.
+
+Design response:
+
+- keep `DingTalkRequestError` mapped to `502`
+- keep local policy errors on their explicit `403` / `409` codes
+- map all other unexpected callback failures to `500`
+- preserve the existing route path and response body shape
+
 ## Non-Blocking Notes
 
 - Duplicate auth payload helpers between `LoginView.vue` and `DingTalkAuthCallbackView.vue` remain a refactor candidate, but they are not blocking for PR1 merge.
-- `DINGTALK_AUTH_AUTO_LINK_EMAIL` remains a configuration choice. The stricter production policy is handled later in the stack by explicit-grant controls.
+- `DINGTALK_AUTH_AUTO_LINK_EMAIL` remains a configuration choice, but it is now safe-by-default and must be explicitly enabled.

--- a/docs/development/dingtalk-pr1-review-design-20260409.md
+++ b/docs/development/dingtalk-pr1-review-design-20260409.md
@@ -97,6 +97,17 @@ Design response:
 - write that hash into `users.password_hash` during auto-provision
 - do not expose any generated password to the caller; the hash only satisfies the current local-auth schema
 
+### 7. Corp-scoped identity lookups could fall back to a bare open id
+
+When `DINGTALK_CORP_ID` is configured, PR1 writes external identities using a corp-scoped key (`corpId:openId`). However, the fallback lookup still accepted bare `provider_open_id` / `provider_union_id` matches with no corp guard. That could let a stale row from another corp or a legacy binding without the current corp key resolve the wrong local user.
+
+Design response:
+
+- keep `external_key` as the primary lookup key
+- when `corpId` is not configured, preserve the legacy bare `openId` / `unionId` fallback
+- when `corpId` is configured, require `identity.corp_id = configuredCorpId` on the fallback path
+- do not change the callback contract; only tighten internal user-resolution semantics
+
 ## Non-Blocking Notes
 
 - Duplicate auth payload helpers between `LoginView.vue` and `DingTalkAuthCallbackView.vue` remain a refactor candidate, but they are not blocking for PR1 merge.

--- a/docs/development/dingtalk-pr1-review-development-20260409.md
+++ b/docs/development/dingtalk-pr1-review-development-20260409.md
@@ -1,0 +1,61 @@
+# DingTalk PR1 Review Development
+
+Date: 2026-04-09
+PR: `#725`
+Branch: `codex/dingtalk-pr1-foundation-login-20260408`
+
+## Review Outcome
+
+This pass found and fixed four blocking issues inside the PR1 login foundation:
+
+1. login-page probing created real OAuth state
+2. Redis `exec()` tuple errors were ignored
+3. auto-provision reused existing emails through upsert
+4. the callback page could overwrite an already authenticated browser session
+
+## Code Changes
+
+### Backend
+
+- [dingtalk-oauth.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/src/auth/dingtalk-oauth.ts)
+  - validate Redis `exec()` result tuples on write and read
+  - fail over to memory when Redis write tuples contain errors
+  - reject auto-provision when an existing local user already owns the same email
+
+- [auth.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/src/routes/auth.ts)
+  - add `probe=1` handling to `GET /dingtalk/launch`
+  - keep the launch path unchanged for real OAuth starts
+
+### Frontend
+
+- [LoginView.vue](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/src/views/LoginView.vue)
+  - switch DingTalk availability probing to `/api/auth/dingtalk/launch?probe=1`
+
+- [DingTalkAuthCallbackView.vue](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/src/views/DingTalkAuthCallbackView.vue)
+  - refuse to replace an already valid authenticated session
+
+- [appRoutes.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/src/router/appRoutes.ts)
+  - mark the DingTalk callback route as `requiresGuest`
+
+## Test Additions
+
+- [auth-login-routes.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/tests/unit/auth-login-routes.test.ts)
+  - probe mode does not generate OAuth state
+
+- [dingtalk-oauth-state-store.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts)
+  - Redis tuple-error fallback
+  - provisioning rejection on existing-email conflict
+
+- [LoginView.spec.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/tests/LoginView.spec.ts)
+  - probe path uses `?probe=1`
+
+- [dingtalk-auth-callback.spec.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/tests/dingtalk-auth-callback.spec.ts)
+  - authenticated session is preserved instead of being overwritten
+
+## PR Handling
+
+After these fixes:
+
+- PR1 remains `Ready for review`
+- downstream stack order remains unchanged
+- no PR2 or PR3 code was touched

--- a/docs/development/dingtalk-pr1-review-development-20260409.md
+++ b/docs/development/dingtalk-pr1-review-development-20260409.md
@@ -6,7 +6,7 @@ Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 
 ## Review Outcome
 
-This review sequence now covers seven blocking issues inside the PR1 login foundation.
+This review sequence now covers nine blocking issues inside the PR1 login foundation.
 
 The earlier pass fixed:
 
@@ -20,6 +20,8 @@ This follow-up pass fixed:
 5. DingTalk login could still admit disabled or inactive local users
 6. auto-provision did not write `users.password_hash` even though the current schema requires it
 7. corp-scoped external identities could still fall back to a bare `openId` / `unionId` lookup and hit the wrong local user
+8. callback status codes hid local policy denials behind `502`
+9. corp-scoped rollout had no explicit backfill gate for legacy bindings
 
 ## Execution Context
 
@@ -47,6 +49,8 @@ This follow-up was implemented from a new detached worktree rooted at remote PR1
   - add `probe=1` handling to `GET /dingtalk/launch`
   - keep the launch path unchanged for real OAuth starts
   - preserve disabled-user callback failures as explicit API errors
+  - map local DingTalk login policy errors to `403` / `409`
+  - keep upstream DingTalk transport or token-exchange failures mapped to `502`
 
 ### Frontend
 
@@ -79,6 +83,11 @@ This follow-up was implemented from a new detached worktree rooted at remote PR1
 - [dingtalk-auth-callback.spec.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/tests/dingtalk-auth-callback.spec.ts)
   - authenticated session is preserved instead of being overwritten
 
+- [auth-login-routes.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/tests/unit/auth-login-routes.test.ts)
+  - disabled or inactive local-user rejections return `403`
+  - upstream DingTalk request failures remain `502`
+  - auto-provision email conflicts return `409`
+
 ## PR Handling
 
 After these fixes:
@@ -86,3 +95,13 @@ After these fixes:
 - PR1 remains `Ready for review`
 - downstream stack order remains unchanged
 - no PR2 or PR3 code was touched
+
+## Rollout Note
+
+Before enabling `DINGTALK_CORP_ID` in production, legacy `user_external_identities` rows should be backfilled so existing DingTalk bindings remain corp-scoped.
+
+The minimum backfill expectation is:
+
+1. set `corp_id` on existing DingTalk identity rows that belong to the target tenant
+2. rewrite `external_key` to the corp-scoped form `corpId:provider_open_id`
+3. verify that no ambiguous bare `provider_open_id` / `provider_union_id` rows remain for active production identities

--- a/docs/development/dingtalk-pr1-review-development-20260409.md
+++ b/docs/development/dingtalk-pr1-review-development-20260409.md
@@ -6,12 +6,28 @@ Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 
 ## Review Outcome
 
-This pass found and fixed four blocking issues inside the PR1 login foundation:
+This review sequence now covers six blocking issues inside the PR1 login foundation.
+
+The earlier pass fixed:
 
 1. login-page probing created real OAuth state
 2. Redis `exec()` tuple errors were ignored
 3. auto-provision reused existing emails through upsert
 4. the callback page could overwrite an already authenticated browser session
+
+This follow-up pass fixed:
+
+5. DingTalk login could still admit disabled or inactive local users
+6. auto-provision did not write `users.password_hash` even though the current schema requires it
+
+## Execution Context
+
+The existing PR1 worktrees were not safe to reuse:
+
+- the original PR1 worktree already contained unrelated `jwt-middleware` changes
+- the refresh worktree was detached and had local `node_modules` churn
+
+This follow-up was implemented from a new detached worktree rooted at remote PR1 head `75be0891a`, then pushed directly back to `origin/codex/dingtalk-pr1-foundation-login-20260408`.
 
 ## Code Changes
 
@@ -21,10 +37,14 @@ This pass found and fixed four blocking issues inside the PR1 login foundation:
   - validate Redis `exec()` result tuples on write and read
   - fail over to memory when Redis write tuples contain errors
   - reject auto-provision when an existing local user already owns the same email
+  - include `is_active` in resolved local-user rows
+  - reject external-identity and email-link logins when the local user is disabled or inactive
+  - generate a bcrypt `password_hash` for auto-provisioned users and persist it with the new local account
 
 - [auth.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/src/routes/auth.ts)
   - add `probe=1` handling to `GET /dingtalk/launch`
   - keep the launch path unchanged for real OAuth starts
+  - preserve disabled-user callback failures as explicit API errors
 
 ### Frontend
 
@@ -41,10 +61,14 @@ This pass found and fixed four blocking issues inside the PR1 login foundation:
 
 - [auth-login-routes.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/tests/unit/auth-login-routes.test.ts)
   - probe mode does not generate OAuth state
+  - disabled/inactive local-user failures are surfaced back through `/api/auth/dingtalk/callback`
 
 - [dingtalk-oauth-state-store.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts)
   - Redis tuple-error fallback
   - provisioning rejection on existing-email conflict
+  - external-identity login rejection for inactive local users
+  - email-link rejection for disabled local users
+  - auto-provision writes a bcrypt `password_hash`
 
 - [LoginView.spec.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/tests/LoginView.spec.ts)
   - probe path uses `?probe=1`

--- a/docs/development/dingtalk-pr1-review-development-20260409.md
+++ b/docs/development/dingtalk-pr1-review-development-20260409.md
@@ -1,12 +1,12 @@
 # DingTalk PR1 Review Development
 
-Date: 2026-04-09
+Date: 2026-04-10
 PR: `#725`
 Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 
 ## Review Outcome
 
-This review sequence now covers nine blocking issues inside the PR1 login foundation.
+This review sequence now covers eleven blocking issues inside the PR1 login foundation.
 
 The earlier pass fixed:
 
@@ -14,79 +14,61 @@ The earlier pass fixed:
 2. Redis `exec()` tuple errors were ignored
 3. auto-provision reused existing emails through upsert
 4. the callback page could overwrite an already authenticated browser session
-
-This follow-up pass fixed:
-
 5. DingTalk login could still admit disabled or inactive local users
 6. auto-provision did not write `users.password_hash` even though the current schema requires it
 7. corp-scoped external identities could still fall back to a bare `openId` / `unionId` lookup and hit the wrong local user
 8. callback status codes hid local policy denials behind `502`
 9. corp-scoped rollout had no explicit backfill gate for legacy bindings
 
+This follow-up pass fixed:
+
+10. email auto-link stayed enabled by default when the env var was unset
+11. unexpected local callback failures were still being reported as `502`
+
 ## Execution Context
 
 The existing PR1 worktrees were not safe to reuse:
 
 - the original PR1 worktree already contained unrelated `jwt-middleware` changes
-- the refresh worktree was detached and had local `node_modules` churn
+- the refresh worktrees were detached and already used for prior fix rounds
 
-This follow-up was implemented from a new detached worktree rooted at remote PR1 head `75be0891a`, then pushed directly back to `origin/codex/dingtalk-pr1-foundation-login-20260408`.
+This follow-up was implemented from a new detached worktree rooted at remote PR1 head `5a97e80c9`, then pushed directly back to `origin/codex/dingtalk-pr1-foundation-login-20260408`.
 
 ## Code Changes
 
 ### Backend
 
-- [dingtalk-oauth.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/src/auth/dingtalk-oauth.ts)
-  - validate Redis `exec()` result tuples on write and read
-  - fail over to memory when Redis write tuples contain errors
-  - reject auto-provision when an existing local user already owns the same email
-  - include `is_active` in resolved local-user rows
-  - reject external-identity and email-link logins when the local user is disabled or inactive
-  - generate a bcrypt `password_hash` for auto-provisioned users and persist it with the new local account
-  - when `corpId` is configured, require `identity.corp_id` to match on any fallback `provider_open_id` / `provider_union_id` lookup
+- `packages/core-backend/src/auth/dingtalk-oauth.ts`
+  - default `DINGTALK_AUTH_AUTO_LINK_EMAIL` to disabled unless explicitly enabled
+  - keep the earlier disabled/inactive-user gate, hashed auto-provision, and corp-scoped fallback hardening
 
-- [auth.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/src/routes/auth.ts)
-  - add `probe=1` handling to `GET /dingtalk/launch`
-  - keep the launch path unchanged for real OAuth starts
-  - preserve disabled-user callback failures as explicit API errors
-  - map local DingTalk login policy errors to `403` / `409`
-  - keep upstream DingTalk transport or token-exchange failures mapped to `502`
+- `packages/core-backend/src/routes/auth.ts`
+  - keep local DingTalk policy errors on `403` / `409`
+  - keep upstream DingTalk request failures on `502`
+  - map unexpected local callback failures to `500`
 
-### Frontend
+### Configuration
 
-- [LoginView.vue](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/src/views/LoginView.vue)
-  - switch DingTalk availability probing to `/api/auth/dingtalk/launch?probe=1`
+- `.env.example`
+  - change the DingTalk auto-link example from `1` to `0`
 
-- [DingTalkAuthCallbackView.vue](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/src/views/DingTalkAuthCallbackView.vue)
-  - refuse to replace an already valid authenticated session
+### Tests
 
-- [appRoutes.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/src/router/appRoutes.ts)
-  - mark the DingTalk callback route as `requiresGuest`
+- `packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts`
+  - verify email auto-link stays off when the env var is unset
+  - keep explicit email-link tests by enabling the env flag inside the test
 
-## Test Additions
+- `packages/core-backend/tests/unit/auth-login-routes.test.ts`
+  - verify unexpected local callback failures now return `500`
 
-- [auth-login-routes.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/tests/unit/auth-login-routes.test.ts)
-  - probe mode does not generate OAuth state
-  - disabled/inactive local-user failures are surfaced back through `/api/auth/dingtalk/callback`
+### Ops / Rollout
 
-- [dingtalk-oauth-state-store.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts)
-  - Redis tuple-error fallback
-  - provisioning rejection on existing-email conflict
-  - external-identity login rejection for inactive local users
-  - corp-scoped identity fallback stays bound to the configured `corpId`
-  - email-link rejection for disabled local users
-  - auto-provision writes a bcrypt `password_hash`
+- `scripts/ops/backfill-dingtalk-corp-identities.sh`
+  - add a dry-run-by-default corpId backfill helper for legacy DingTalk identities
+  - refuse to apply when `provider_open_id` is missing or corp-scoped `external_key` conflicts exist
 
-- [LoginView.spec.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/tests/LoginView.spec.ts)
-  - probe path uses `?probe=1`
-
-- [dingtalk-auth-callback.spec.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/apps/web/tests/dingtalk-auth-callback.spec.ts)
-  - authenticated session is preserved instead of being overwritten
-
-- [auth-login-routes.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/tests/unit/auth-login-routes.test.ts)
-  - disabled or inactive local-user rejections return `403`
-  - upstream DingTalk request failures remain `502`
-  - auto-provision email conflicts return `409`
+- `docs/development/dingtalk-pr1-corpid-rollout-20260410.md`
+  - document the rollout gate and execution order for enabling `DINGTALK_CORP_ID`
 
 ## PR Handling
 
@@ -94,14 +76,14 @@ After these fixes:
 
 - PR1 remains `Ready for review`
 - downstream stack order remains unchanged
-- no PR2 or PR3 code was touched
+- no PR2 or PR3 code is touched
 
 ## Rollout Note
 
-Before enabling `DINGTALK_CORP_ID` in production, legacy `user_external_identities` rows should be backfilled so existing DingTalk bindings remain corp-scoped.
+Before enabling `DINGTALK_CORP_ID` in production:
 
-The minimum backfill expectation is:
-
-1. set `corp_id` on existing DingTalk identity rows that belong to the target tenant
-2. rewrite `external_key` to the corp-scoped form `corpId:provider_open_id`
-3. verify that no ambiguous bare `provider_open_id` / `provider_union_id` rows remain for active production identities
+1. dry-run `scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId>`
+2. resolve any reported `missing_open_id_rows` or `conflict_rows`
+3. run `--apply`
+4. rerun dry-run and confirm the candidate count is zero
+5. only then enable `DINGTALK_CORP_ID`

--- a/docs/development/dingtalk-pr1-review-development-20260409.md
+++ b/docs/development/dingtalk-pr1-review-development-20260409.md
@@ -6,7 +6,7 @@ Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 
 ## Review Outcome
 
-This review sequence now covers six blocking issues inside the PR1 login foundation.
+This review sequence now covers seven blocking issues inside the PR1 login foundation.
 
 The earlier pass fixed:
 
@@ -19,6 +19,7 @@ This follow-up pass fixed:
 
 5. DingTalk login could still admit disabled or inactive local users
 6. auto-provision did not write `users.password_hash` even though the current schema requires it
+7. corp-scoped external identities could still fall back to a bare `openId` / `unionId` lookup and hit the wrong local user
 
 ## Execution Context
 
@@ -40,6 +41,7 @@ This follow-up was implemented from a new detached worktree rooted at remote PR1
   - include `is_active` in resolved local-user rows
   - reject external-identity and email-link logins when the local user is disabled or inactive
   - generate a bcrypt `password_hash` for auto-provisioned users and persist it with the new local account
+  - when `corpId` is configured, require `identity.corp_id` to match on any fallback `provider_open_id` / `provider_union_id` lookup
 
 - [auth.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/dingtalk-phase1-20260408/packages/core-backend/src/routes/auth.ts)
   - add `probe=1` handling to `GET /dingtalk/launch`
@@ -67,6 +69,7 @@ This follow-up was implemented from a new detached worktree rooted at remote PR1
   - Redis tuple-error fallback
   - provisioning rejection on existing-email conflict
   - external-identity login rejection for inactive local users
+  - corp-scoped identity fallback stays bound to the configured `corpId`
   - email-link rejection for disabled local users
   - auto-provision writes a bcrypt `password_hash`
 

--- a/docs/development/dingtalk-pr1-review-development-20260409.md
+++ b/docs/development/dingtalk-pr1-review-development-20260409.md
@@ -6,7 +6,7 @@ Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 
 ## Review Outcome
 
-This review sequence now covers eleven blocking issues inside the PR1 login foundation.
+This review sequence now covers thirteen blocking issues inside the PR1 login foundation.
 
 The earlier pass fixed:
 
@@ -24,6 +24,8 @@ This follow-up pass fixed:
 
 10. email auto-link stayed enabled by default when the env var was unset
 11. unexpected local callback failures were still being reported as `502`
+12. unknown local `500` callback failures still leaked internal error strings back to clients
+13. the corpId backfill script still assumed whole-database single-corp apply instead of a manual allowlist gate
 
 ## Execution Context
 
@@ -32,7 +34,7 @@ The existing PR1 worktrees were not safe to reuse:
 - the original PR1 worktree already contained unrelated `jwt-middleware` changes
 - the refresh worktrees were detached and already used for prior fix rounds
 
-This follow-up was implemented from a new detached worktree rooted at remote PR1 head `5a97e80c9`, then pushed directly back to `origin/codex/dingtalk-pr1-foundation-login-20260408`.
+This follow-up was implemented from a new detached worktree rooted at remote PR1 head `20cdabd19`, then pushed directly back to `origin/codex/dingtalk-pr1-foundation-login-20260408`.
 
 ## Code Changes
 
@@ -46,6 +48,7 @@ This follow-up was implemented from a new detached worktree rooted at remote PR1
   - keep local DingTalk policy errors on `403` / `409`
   - keep upstream DingTalk request failures on `502`
   - map unexpected local callback failures to `500`
+  - keep the `500` response body generic instead of exposing the raw internal error string
 
 ### Configuration
 
@@ -65,7 +68,9 @@ This follow-up was implemented from a new detached worktree rooted at remote PR1
 
 - `scripts/ops/backfill-dingtalk-corp-identities.sh`
   - add a dry-run-by-default corpId backfill helper for legacy DingTalk identities
-  - refuse to apply when `provider_open_id` is missing or corp-scoped `external_key` conflicts exist
+  - export candidate rows for manual review
+  - require a manual allowlist for `--apply`
+  - refuse to apply when `provider_open_id` is missing, corp-scoped `external_key` conflicts exist, or the allowlist includes ineligible ids
 
 - `docs/development/dingtalk-pr1-corpid-rollout-20260410.md`
   - document the rollout gate and execution order for enabling `DINGTALK_CORP_ID`
@@ -82,8 +87,9 @@ After these fixes:
 
 Before enabling `DINGTALK_CORP_ID` in production:
 
-1. dry-run `scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId>`
-2. resolve any reported `missing_open_id_rows` or `conflict_rows`
-3. run `--apply`
-4. rerun dry-run and confirm the candidate count is zero
-5. only then enable `DINGTALK_CORP_ID`
+1. export candidates with `scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId> --export-file <path>`
+2. manually review the candidate export and prepare an allowlist file of approved `user_external_identities.id` values
+3. resolve any reported `missing_open_id_rows` or `conflict_rows`
+4. run `--apply` with `--allowlist-file`
+5. rerun dry-run/export and confirm the reviewed rows are no longer candidates
+6. only then enable `DINGTALK_CORP_ID`

--- a/docs/development/dingtalk-pr1-review-development-20260409.md
+++ b/docs/development/dingtalk-pr1-review-development-20260409.md
@@ -36,6 +36,8 @@ The existing PR1 worktrees were not safe to reuse:
 
 This follow-up was implemented from a new detached worktree rooted at remote PR1 head `20cdabd19`, then pushed directly back to `origin/codex/dingtalk-pr1-foundation-login-20260408`.
 
+A final minimal refresh was then rebased onto the latest `origin/main`, producing refreshed PR1 head `a4751ee22` with no code-scope expansion.
+
 ## Code Changes
 
 ### Backend

--- a/docs/development/dingtalk-pr1-review-verification-20260409.md
+++ b/docs/development/dingtalk-pr1-review-verification-20260409.md
@@ -33,15 +33,15 @@ bash -n scripts/ops/backfill-dingtalk-corp-identities.sh
 - local policy rejections return `403`
 - auto-provision email conflicts return `409`
 - DingTalk upstream request failures remain mapped to `502`
-- unexpected local callback failures now return `500`
+- unexpected local callback failures now return `500` with a generic client-facing error message
 
 ## Rollout Gate
 
 The corp-scoped identity hardening is intentionally strict. Before enabling `DINGTALK_CORP_ID` in production, rollout must include a one-time backfill of legacy DingTalk identity rows. Use:
 
 ```bash
-scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId>
-scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId> --apply
+scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId> --export-file /tmp/dingtalk-corpid-candidates.csv
+scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId> --allowlist-file /tmp/dingtalk-corpid-allowlist.txt --apply
 ```
 
 The rollout note is documented in `docs/development/dingtalk-pr1-corpid-rollout-20260410.md`.

--- a/docs/development/dingtalk-pr1-review-verification-20260409.md
+++ b/docs/development/dingtalk-pr1-review-verification-20260409.md
@@ -1,6 +1,6 @@
 # DingTalk PR1 Review Verification
 
-Date: 2026-04-09
+Date: 2026-04-10
 PR: `#725`
 Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 
@@ -10,14 +10,14 @@ Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 pnpm install --offline --frozen-lockfile
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/dingtalk-oauth-state-store.test.ts
 pnpm --filter @metasheet/core-backend build
+bash -n scripts/ops/backfill-dingtalk-corp-identities.sh
 ```
 
 ## Results
 
-- backend unit tests: passed (`23/23`)
+- backend unit tests: passed (`25/25`)
 - `@metasheet/core-backend` build: passed
-
-The frontend callback and login-page validations from the earlier PR1 review pass remain unchanged; this follow-up only touched backend helper and route behavior.
+- corpId backfill script shell parse check: passed
 
 ## Verified Behaviors
 
@@ -27,17 +27,21 @@ The frontend callback and login-page validations from the earlier PR1 review pas
 - callback view preserves an already authenticated browser session
 - external-identity logins are rejected when the linked local user is inactive
 - corp-scoped identity fallbacks are now pinned to the configured `corpId`
+- email auto-link stays off unless `DINGTALK_AUTH_AUTO_LINK_EMAIL` is explicitly enabled
 - email auto-link is rejected when the matched local user is disabled
 - auto-provision writes a bcrypt `password_hash`, so the current `users` schema no longer rejects the insert
-- local policy rejections now return `403` instead of masquerading as DingTalk upstream `502`
-- auto-provision email conflicts now return `409`
+- local policy rejections return `403`
+- auto-provision email conflicts return `409`
 - DingTalk upstream request failures remain mapped to `502`
+- unexpected local callback failures now return `500`
 
 ## Rollout Gate
 
-The corp-scoped identity hardening is intentionally strict. Before enabling `DINGTALK_CORP_ID` in production, rollout must include a one-time backfill of legacy DingTalk identity rows so existing bindings are rewritten to:
+The corp-scoped identity hardening is intentionally strict. Before enabling `DINGTALK_CORP_ID` in production, rollout must include a one-time backfill of legacy DingTalk identity rows. Use:
 
-- `corp_id = <target corp id>`
-- `external_key = <corpId>:<provider_open_id>`
+```bash
+scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId>
+scripts/ops/backfill-dingtalk-corp-identities.sh --corp-id <corpId> --apply
+```
 
-Without that backfill, older bindings that only relied on bare `provider_open_id` / `provider_union_id` may stop matching once corp-scoped lookup is enabled.
+The rollout note is documented in `docs/development/dingtalk-pr1-corpid-rollout-20260410.md`.

--- a/docs/development/dingtalk-pr1-review-verification-20260409.md
+++ b/docs/development/dingtalk-pr1-review-verification-20260409.md
@@ -7,18 +7,17 @@ Branch: `codex/dingtalk-pr1-foundation-login-20260408`
 ## Commands
 
 ```bash
+pnpm install --offline --frozen-lockfile
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/dingtalk-oauth-state-store.test.ts
-pnpm --filter @metasheet/web exec vitest run tests/dingtalk-auth-callback.spec.ts tests/LoginView.spec.ts --watch=false
 pnpm --filter @metasheet/core-backend build
-pnpm --filter @metasheet/web type-check
 ```
 
 ## Results
 
-- backend unit tests: passed (`16/16`)
-- frontend unit tests: passed (`6/6`)
+- backend unit tests: passed (`20/20`)
 - `@metasheet/core-backend` build: passed
-- `@metasheet/web` type-check: passed
+
+The frontend callback and login-page validations from the earlier PR1 review pass remain unchanged; this follow-up only touched backend helper and route behavior.
 
 ## Verified Behaviors
 
@@ -26,3 +25,6 @@ pnpm --filter @metasheet/web type-check
 - Redis tuple errors no longer masquerade as successful state persistence
 - provisioning refuses to reuse an existing local email when auto-link is disabled
 - callback view preserves an already authenticated browser session
+- external-identity logins are rejected when the linked local user is inactive
+- email auto-link is rejected when the matched local user is disabled
+- auto-provision writes a bcrypt `password_hash`, so the current `users` schema no longer rejects the insert

--- a/docs/development/dingtalk-pr1-review-verification-20260409.md
+++ b/docs/development/dingtalk-pr1-review-verification-20260409.md
@@ -1,0 +1,28 @@
+# DingTalk PR1 Review Verification
+
+Date: 2026-04-09
+PR: `#725`
+Branch: `codex/dingtalk-pr1-foundation-login-20260408`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/dingtalk-oauth-state-store.test.ts
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-auth-callback.spec.ts tests/LoginView.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web type-check
+```
+
+## Results
+
+- backend unit tests: passed (`16/16`)
+- frontend unit tests: passed (`6/6`)
+- `@metasheet/core-backend` build: passed
+- `@metasheet/web` type-check: passed
+
+## Verified Behaviors
+
+- login-page DingTalk probing no longer allocates real OAuth state
+- Redis tuple errors no longer masquerade as successful state persistence
+- provisioning refuses to reuse an existing local email when auto-link is disabled
+- callback view preserves an already authenticated browser session

--- a/docs/development/dingtalk-pr1-review-verification-20260409.md
+++ b/docs/development/dingtalk-pr1-review-verification-20260409.md
@@ -14,7 +14,7 @@ pnpm --filter @metasheet/core-backend build
 
 ## Results
 
-- backend unit tests: passed (`20/20`)
+- backend unit tests: passed (`21/21`)
 - `@metasheet/core-backend` build: passed
 
 The frontend callback and login-page validations from the earlier PR1 review pass remain unchanged; this follow-up only touched backend helper and route behavior.
@@ -26,5 +26,6 @@ The frontend callback and login-page validations from the earlier PR1 review pas
 - provisioning refuses to reuse an existing local email when auto-link is disabled
 - callback view preserves an already authenticated browser session
 - external-identity logins are rejected when the linked local user is inactive
+- corp-scoped identity fallbacks are now pinned to the configured `corpId`
 - email auto-link is rejected when the matched local user is disabled
 - auto-provision writes a bcrypt `password_hash`, so the current `users` schema no longer rejects the insert

--- a/docs/development/dingtalk-pr1-review-verification-20260409.md
+++ b/docs/development/dingtalk-pr1-review-verification-20260409.md
@@ -14,7 +14,7 @@ pnpm --filter @metasheet/core-backend build
 
 ## Results
 
-- backend unit tests: passed (`21/21`)
+- backend unit tests: passed (`23/23`)
 - `@metasheet/core-backend` build: passed
 
 The frontend callback and login-page validations from the earlier PR1 review pass remain unchanged; this follow-up only touched backend helper and route behavior.
@@ -29,3 +29,15 @@ The frontend callback and login-page validations from the earlier PR1 review pas
 - corp-scoped identity fallbacks are now pinned to the configured `corpId`
 - email auto-link is rejected when the matched local user is disabled
 - auto-provision writes a bcrypt `password_hash`, so the current `users` schema no longer rejects the insert
+- local policy rejections now return `403` instead of masquerading as DingTalk upstream `502`
+- auto-provision email conflicts now return `409`
+- DingTalk upstream request failures remain mapped to `502`
+
+## Rollout Gate
+
+The corp-scoped identity hardening is intentionally strict. Before enabling `DINGTALK_CORP_ID` in production, rollout must include a one-time backfill of legacy DingTalk identity rows so existing bindings are rewritten to:
+
+- `corp_id = <target corp id>`
+- `external_key = <corpId>:<provider_open_id>`
+
+Without that backfill, older bindings that only relied on bare `provider_open_id` / `provider_union_id` may stop matching once corp-scoped lookup is enabled.

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -205,10 +205,16 @@ async function writeStateToRedis(state: string, record: StateRecord): Promise<bo
     await trimRedisStateIndex(client)
 
     const ttlMs = Math.max(record.expiresAt - Date.now() + STATE_REDIS_RETENTION_MS, STATE_REDIS_RETENTION_MS)
-    await client.multi()
+    const results = await client.multi()
       .set(stateRedisKey(state), JSON.stringify(record), 'PX', ttlMs)
       .zadd(STATE_REDIS_INDEX_KEY, record.expiresAt, state)
       .exec()
+
+    if (!results || results.some(([error]) => error)) {
+      logRedisFallback('Redis state write failed', results)
+      await invalidateRedisStateClient(client)
+      return false
+    }
     return true
   } catch (error) {
     logRedisFallback('Redis state write failed', error)
@@ -227,6 +233,12 @@ async function validateStateFromRedis(state: string): Promise<StateValidationRes
       .del(stateRedisKey(state))
       .zrem(STATE_REDIS_INDEX_KEY, state)
       .exec()
+
+    if (!results || results.some(([error]) => error)) {
+      logRedisFallback('Redis state validation failed', results)
+      await invalidateRedisStateClient(client)
+      return null
+    }
 
     const statePayload = results?.[0]?.[1]
     if (typeof statePayload !== 'string') {
@@ -413,20 +425,38 @@ async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUse
   const email = dtUser.email || `dingtalk_${dtUser.openId}@placeholder.local`
   const name = dtUser.nick || 'DingTalk User'
 
-  const result = await query<LocalUserRow>(
-    `INSERT INTO users (id, email, name, role, created_at, updated_at)
-     VALUES ($1, $2, $3, 'user', NOW(), NOW())
-     ON CONFLICT (email)
-     DO UPDATE SET name = COALESCE(NULLIF(EXCLUDED.name, ''), users.name), updated_at = NOW()
-     RETURNING id, email, COALESCE(name, '') AS name, COALESCE(role, 'user') AS role`,
-    [userId, email, name],
-  )
-
-  const row = result.rows[0]
-  if (!row) {
-    throw new Error('Failed to create local user for DingTalk login')
+  if (dtUser.email) {
+    const existingUser = await findUserByEmail(dtUser.email)
+    if (existingUser) {
+      throw new Error('Refusing to auto-provision DingTalk user because a local account already exists with the same email')
+    }
   }
-  return row
+
+  try {
+    const result = await query<LocalUserRow>(
+      `INSERT INTO users (id, email, name, role, created_at, updated_at)
+       VALUES ($1, $2, $3, 'user', NOW(), NOW())
+       RETURNING id, email, COALESCE(name, '') AS name, COALESCE(role, 'user') AS role`,
+      [userId, email, name],
+    )
+
+    const row = result.rows[0]
+    if (!row) {
+      throw new Error('Failed to create local user for DingTalk login')
+    }
+    return row
+  } catch (error) {
+    if (
+      dtUser.email &&
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === '23505'
+    ) {
+      throw new Error('Refusing to auto-provision DingTalk user because a local account already exists with the same email')
+    }
+    throw error
+  }
 }
 
 async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: LocalUserRow; isNewUser: boolean }> {

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -91,7 +91,7 @@ function parseBooleanEnv(name: string, fallback: boolean): boolean {
 }
 
 function shouldAutoLinkEmail(): boolean {
-  return parseBooleanEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', true)
+  return parseBooleanEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', false)
 }
 
 function shouldAutoProvision(): boolean {

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -407,6 +407,7 @@ async function findUserByEmail(email: string): Promise<LocalUserRow | null> {
 
 async function findIdentityUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow | null> {
   try {
+    const config = readDingTalkOauthConfig()
     const result = await query<LocalUserRow>(
       `SELECT u.id,
               u.email,
@@ -418,12 +419,25 @@ async function findIdentityUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow 
        WHERE identity.provider = $1
          AND (
            identity.external_key = $2
-           OR identity.provider_open_id = $3
-           OR ($4 <> '' AND identity.provider_union_id = $4)
+           OR (
+             $5 = ''
+             AND (
+               identity.provider_open_id = $3
+               OR ($4 <> '' AND identity.provider_union_id = $4)
+             )
+           )
+           OR (
+             $5 <> ''
+             AND identity.corp_id = $5
+             AND (
+               identity.provider_open_id = $3
+               OR ($4 <> '' AND identity.provider_union_id = $4)
+             )
+           )
          )
        ORDER BY identity.updated_at DESC
        LIMIT 1`,
-      [PROVIDER, buildExternalKey(dtUser), dtUser.openId, dtUser.unionId || ''],
+      [PROVIDER, buildExternalKey(dtUser), dtUser.openId, dtUser.unionId || '', config.corpId || ''],
     )
     return result.rows[0] ?? null
   } catch (error) {

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -1,0 +1,546 @@
+import crypto from 'node:crypto'
+import Redis from 'ioredis'
+import { Logger } from '../core/logger'
+import { query, transaction } from '../db/pg'
+import {
+  exchangeCodeForUserAccessToken,
+  fetchDingTalkCurrentUser,
+  isDingTalkConfigured as isClientConfigured,
+  readDingTalkOauthConfig,
+} from '../integrations/dingtalk/client'
+
+const logger = new Logger('DingTalkOAuth')
+
+const PROVIDER = 'dingtalk'
+const STATE_TTL_MS = 5 * 60 * 1000
+const MAX_PENDING_STATES = 10_000
+const STATE_REDIS_RETENTION_MS = 60 * 1000
+const STATE_REDIS_KEY_PREFIX = 'metasheet:auth:dingtalk:state:'
+const STATE_REDIS_INDEX_KEY = 'metasheet:auth:dingtalk:state:index'
+
+export interface DingTalkUserInfo {
+  openId: string
+  unionId: string
+  nick: string
+  email?: string
+  mobile?: string
+  avatarUrl?: string
+}
+
+export interface DingTalkExchangeResult {
+  dingtalkUser: DingTalkUserInfo
+  localUserId: string
+  localUserEmail: string
+  localUserName: string
+  localUserRole: string
+  isNewUser: boolean
+}
+
+interface LocalUserRow {
+  id: string
+  email: string
+  name: string
+  role: string
+}
+
+interface StateRecord {
+  expiresAt: number
+  redirectPath?: string
+}
+
+export interface StateValidationResult {
+  valid: boolean
+  error?: string
+  redirectPath?: string
+}
+
+const pendingStates = new Map<string, StateRecord>()
+let redisStateClient: Redis | null = null
+let redisStateClientPromise: Promise<Redis | null> | null = null
+let redisFallbackLogged = false
+
+function parseBooleanEnv(name: string, fallback: boolean): boolean {
+  const raw = String(process.env[name] ?? '').trim().toLowerCase()
+  if (!raw) return fallback
+  if (['1', 'true', 'yes', 'on', 'enabled'].includes(raw)) return true
+  if (['0', 'false', 'no', 'off', 'disabled'].includes(raw)) return false
+  return fallback
+}
+
+function shouldAutoLinkEmail(): boolean {
+  return parseBooleanEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', true)
+}
+
+function shouldAutoProvision(): boolean {
+  return parseBooleanEnv('DINGTALK_AUTH_AUTO_PROVISION', false)
+}
+
+function buildRedisUrl(): string | null {
+  const explicitUrl = process.env.REDIS_URL?.trim()
+  if (explicitUrl) return explicitUrl
+
+  const host = process.env.REDIS_HOST?.trim()
+  if (!host) return null
+
+  const port = process.env.REDIS_PORT?.trim() || '6379'
+  const password = process.env.REDIS_PASSWORD?.trim()
+  if (password) {
+    return `redis://:${encodeURIComponent(password)}@${host}:${port}`
+  }
+  return `redis://${host}:${port}`
+}
+
+function stateRedisKey(state: string): string {
+  return `${STATE_REDIS_KEY_PREFIX}${state}`
+}
+
+function buildExternalKey(dtUser: DingTalkUserInfo): string {
+  const config = readDingTalkOauthConfig()
+  if (config.corpId) {
+    return `${config.corpId}:${dtUser.openId}`
+  }
+  return dtUser.unionId || dtUser.openId
+}
+
+function pruneExpiredStates(): void {
+  const now = Date.now()
+  for (const [key, record] of pendingStates) {
+    if (record.expiresAt <= now) pendingStates.delete(key)
+  }
+}
+
+function logRedisFallback(reason: string, error?: unknown): void {
+  if (redisFallbackLogged) return
+  redisFallbackLogged = true
+  logger.warn(
+    `Falling back to in-memory DingTalk OAuth state store: ${reason}${error instanceof Error ? ` (${error.message})` : ''}`,
+  )
+}
+
+async function getRedisStateClient(): Promise<Redis | null> {
+  if (redisStateClient) return redisStateClient
+  if (redisStateClientPromise) return redisStateClientPromise
+
+  const redisUrl = buildRedisUrl()
+  if (!redisUrl) return null
+
+  redisStateClientPromise = (async () => {
+    try {
+      const client = new Redis(redisUrl, {
+        lazyConnect: true,
+        maxRetriesPerRequest: 1,
+      })
+
+      client.on('error', (error) => {
+        logRedisFallback('Redis state store connection error', error)
+        if (redisStateClient === client) {
+          redisStateClient = null
+        }
+      })
+      client.on('end', () => {
+        if (redisStateClient === client) {
+          redisStateClient = null
+        }
+      })
+
+      await client.connect()
+      redisFallbackLogged = false
+      redisStateClient = client
+      return client
+    } catch (error) {
+      logRedisFallback('Redis state store unavailable', error)
+      return null
+    } finally {
+      redisStateClientPromise = null
+    }
+  })()
+
+  return redisStateClientPromise
+}
+
+async function invalidateRedisStateClient(client: Redis | null): Promise<void> {
+  if (!client) return
+  if (redisStateClient === client) {
+    redisStateClient = null
+  }
+  try {
+    await client.quit()
+  } catch {
+    client.disconnect()
+  }
+}
+
+async function pruneRedisStateIndex(client: Redis, now: number): Promise<void> {
+  const expiredStateIds = await client.zrangebyscore(STATE_REDIS_INDEX_KEY, 0, now)
+  if (expiredStateIds.length === 0) return
+
+  const keys = expiredStateIds.map((state) => stateRedisKey(state))
+  const cleanup = client.multi()
+  cleanup.del(...keys)
+  cleanup.zrem(STATE_REDIS_INDEX_KEY, ...expiredStateIds)
+  await cleanup.exec()
+}
+
+async function trimRedisStateIndex(client: Redis): Promise<void> {
+  const count = await client.zcard(STATE_REDIS_INDEX_KEY)
+  if (count < MAX_PENDING_STATES) return
+
+  const overflow = count - MAX_PENDING_STATES + 1
+  const oldestStateIds = await client.zrange(STATE_REDIS_INDEX_KEY, 0, overflow - 1)
+  if (oldestStateIds.length === 0) return
+
+  const keys = oldestStateIds.map((state) => stateRedisKey(state))
+  const cleanup = client.multi()
+  cleanup.del(...keys)
+  cleanup.zrem(STATE_REDIS_INDEX_KEY, ...oldestStateIds)
+  await cleanup.exec()
+}
+
+async function writeStateToRedis(state: string, record: StateRecord): Promise<boolean> {
+  const client = await getRedisStateClient()
+  if (!client) return false
+
+  try {
+    await pruneRedisStateIndex(client, Date.now())
+    await trimRedisStateIndex(client)
+
+    const ttlMs = Math.max(record.expiresAt - Date.now() + STATE_REDIS_RETENTION_MS, STATE_REDIS_RETENTION_MS)
+    await client.multi()
+      .set(stateRedisKey(state), JSON.stringify(record), 'PX', ttlMs)
+      .zadd(STATE_REDIS_INDEX_KEY, record.expiresAt, state)
+      .exec()
+    return true
+  } catch (error) {
+    logRedisFallback('Redis state write failed', error)
+    await invalidateRedisStateClient(client)
+    return false
+  }
+}
+
+async function validateStateFromRedis(state: string): Promise<StateValidationResult | null> {
+  const client = await getRedisStateClient()
+  if (!client) return null
+
+  try {
+    const results = await client.multi()
+      .get(stateRedisKey(state))
+      .del(stateRedisKey(state))
+      .zrem(STATE_REDIS_INDEX_KEY, state)
+      .exec()
+
+    const statePayload = results?.[0]?.[1]
+    if (typeof statePayload !== 'string') {
+      return { valid: false, error: 'Invalid or unknown state parameter' }
+    }
+
+    let parsed: StateRecord | null = null
+    try {
+      parsed = JSON.parse(statePayload) as StateRecord
+    } catch {
+      parsed = null
+    }
+
+    if (!parsed || typeof parsed.expiresAt !== 'number') {
+      return { valid: false, error: 'Invalid or unknown state parameter' }
+    }
+
+    if (Date.now() > parsed.expiresAt) {
+      return { valid: false, error: 'State parameter has expired' }
+    }
+
+    return {
+      valid: true,
+      redirectPath: parsed.redirectPath,
+    }
+  } catch (error) {
+    logRedisFallback('Redis state validation failed', error)
+    await invalidateRedisStateClient(client)
+    return null
+  }
+}
+
+function writeStateToMemory(state: string, record: StateRecord): void {
+  pruneExpiredStates()
+  if (pendingStates.size >= MAX_PENDING_STATES) {
+    const oldest = pendingStates.keys().next().value
+    if (oldest) pendingStates.delete(oldest)
+  }
+  pendingStates.set(state, record)
+}
+
+function validateStateFromMemory(state: string): StateValidationResult {
+  const record = pendingStates.get(state)
+  if (!record) return { valid: false, error: 'Invalid or unknown state parameter' }
+  pendingStates.delete(state)
+
+  if (Date.now() > record.expiresAt) {
+    return { valid: false, error: 'State parameter has expired' }
+  }
+
+  return {
+    valid: true,
+    redirectPath: record.redirectPath,
+  }
+}
+
+async function readGrantEnabled(localUserId: string): Promise<boolean | null> {
+  try {
+    const result = await query<{ enabled: boolean }>(
+      `SELECT enabled
+       FROM user_external_auth_grants
+       WHERE provider = $1 AND local_user_id = $2
+       LIMIT 1`,
+      [PROVIDER, localUserId],
+    )
+    if (result.rows.length === 0) return null
+    return result.rows[0]?.enabled === true
+  } catch (error) {
+    logger.warn('Failed to read DingTalk auth grant; treating as optional', error instanceof Error ? error : undefined)
+    return null
+  }
+}
+
+async function ensureGrant(localUserId: string): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+       VALUES ($1, $2, TRUE, $3, NOW(), NOW())
+       ON CONFLICT (provider, local_user_id) DO NOTHING`,
+      [PROVIDER, localUserId, localUserId],
+    )
+  } catch (error) {
+    logger.warn('Failed to persist DingTalk auth grant', error instanceof Error ? error : undefined)
+  }
+}
+
+async function upsertExternalIdentity(localUserId: string, dtUser: DingTalkUserInfo): Promise<void> {
+  const config = readDingTalkOauthConfig()
+  const externalKey = buildExternalKey(dtUser)
+  const profile = JSON.stringify(dtUser)
+
+  await transaction(async (client) => {
+    const existingByUser = await client.query(
+      `SELECT id
+       FROM user_external_identities
+       WHERE provider = $1 AND local_user_id = $2
+       LIMIT 1`,
+      [PROVIDER, localUserId],
+    )
+
+    if (existingByUser.rows.length > 0) {
+      await client.query(
+        `UPDATE user_external_identities
+         SET external_key = $3,
+             provider_union_id = $4,
+             provider_open_id = $5,
+             corp_id = $6,
+             profile = $7::jsonb,
+             bound_by = COALESCE(bound_by, $2),
+             last_login_at = NOW(),
+             updated_at = NOW()
+         WHERE provider = $1 AND local_user_id = $2`,
+        [PROVIDER, localUserId, externalKey, dtUser.unionId || null, dtUser.openId, config.corpId, profile],
+      )
+      return
+    }
+
+    await client.query(
+      `INSERT INTO user_external_identities (
+         provider,
+         external_key,
+         provider_union_id,
+         provider_open_id,
+         corp_id,
+         local_user_id,
+         profile,
+         bound_by,
+         last_login_at,
+         created_at,
+         updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $6, NOW(), NOW(), NOW())
+       ON CONFLICT (provider, external_key)
+       DO UPDATE SET
+         provider_union_id = EXCLUDED.provider_union_id,
+         provider_open_id = EXCLUDED.provider_open_id,
+         corp_id = EXCLUDED.corp_id,
+         local_user_id = EXCLUDED.local_user_id,
+         profile = EXCLUDED.profile,
+         bound_by = COALESCE(user_external_identities.bound_by, EXCLUDED.bound_by),
+         last_login_at = NOW(),
+         updated_at = NOW()`,
+      [PROVIDER, externalKey, dtUser.unionId || null, dtUser.openId, config.corpId, localUserId, profile],
+    )
+  })
+}
+
+async function findUserByEmail(email: string): Promise<LocalUserRow | null> {
+  const result = await query<LocalUserRow>(
+    `SELECT id, email, COALESCE(name, '') AS name, COALESCE(role, 'user') AS role
+     FROM users
+     WHERE LOWER(email) = LOWER($1)
+     LIMIT 1`,
+    [email],
+  )
+  return result.rows[0] ?? null
+}
+
+async function findIdentityUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow | null> {
+  try {
+    const result = await query<LocalUserRow>(
+      `SELECT u.id, u.email, COALESCE(u.name, '') AS name, COALESCE(u.role, 'user') AS role
+       FROM user_external_identities identity
+       JOIN users u ON u.id = identity.local_user_id
+       WHERE identity.provider = $1
+         AND (
+           identity.external_key = $2
+           OR identity.provider_open_id = $3
+           OR ($4 <> '' AND identity.provider_union_id = $4)
+         )
+       ORDER BY identity.updated_at DESC
+       LIMIT 1`,
+      [PROVIDER, buildExternalKey(dtUser), dtUser.openId, dtUser.unionId || ''],
+    )
+    return result.rows[0] ?? null
+  } catch (error) {
+    logger.warn('Failed to resolve DingTalk external identity', error instanceof Error ? error : undefined)
+    return null
+  }
+}
+
+async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow> {
+  const userId = crypto.randomUUID()
+  const email = dtUser.email || `dingtalk_${dtUser.openId}@placeholder.local`
+  const name = dtUser.nick || 'DingTalk User'
+
+  const result = await query<LocalUserRow>(
+    `INSERT INTO users (id, email, name, role, created_at, updated_at)
+     VALUES ($1, $2, $3, 'user', NOW(), NOW())
+     ON CONFLICT (email)
+     DO UPDATE SET name = COALESCE(NULLIF(EXCLUDED.name, ''), users.name), updated_at = NOW()
+     RETURNING id, email, COALESCE(name, '') AS name, COALESCE(role, 'user') AS role`,
+    [userId, email, name],
+  )
+
+  const row = result.rows[0]
+  if (!row) {
+    throw new Error('Failed to create local user for DingTalk login')
+  }
+  return row
+}
+
+async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: LocalUserRow; isNewUser: boolean }> {
+  const identityUser = await findIdentityUser(dtUser)
+  if (identityUser) {
+    const grantEnabled = await readGrantEnabled(identityUser.id)
+    if (grantEnabled === false) {
+      throw new Error('DingTalk login is disabled for this user')
+    }
+    await upsertExternalIdentity(identityUser.id, dtUser)
+    return { localUser: identityUser, isNewUser: false }
+  }
+
+  if (dtUser.email && shouldAutoLinkEmail()) {
+    const emailUser = await findUserByEmail(dtUser.email)
+    if (emailUser) {
+      const grantEnabled = await readGrantEnabled(emailUser.id)
+      if (grantEnabled === false) {
+        throw new Error('DingTalk login is disabled for this user')
+      }
+      await ensureGrant(emailUser.id)
+      await upsertExternalIdentity(emailUser.id, dtUser)
+      return { localUser: emailUser, isNewUser: false }
+    }
+  }
+
+  if (!shouldAutoProvision()) {
+    throw new Error(
+      dtUser.email
+        ? `DingTalk account ${dtUser.email} is not linked to a local user`
+        : 'DingTalk account is not linked to a local user',
+    )
+  }
+
+  const provisionedUser = await createProvisionedUser(dtUser)
+  await ensureGrant(provisionedUser.id)
+  await upsertExternalIdentity(provisionedUser.id, dtUser)
+  return { localUser: provisionedUser, isNewUser: true }
+}
+
+export function isDingTalkConfigured(): boolean {
+  return isClientConfigured()
+}
+
+export async function generateState(options: { redirectPath?: string | null } = {}): Promise<string> {
+  const state = crypto.randomUUID()
+  const record: StateRecord = {
+    expiresAt: Date.now() + STATE_TTL_MS,
+    ...(typeof options.redirectPath === 'string' && options.redirectPath.trim().length > 0
+      ? { redirectPath: options.redirectPath.trim() }
+      : {}),
+  }
+
+  const storedInRedis = await writeStateToRedis(state, record)
+  if (!storedInRedis) {
+    writeStateToMemory(state, record)
+  }
+
+  return state
+}
+
+export async function validateState(state: string): Promise<StateValidationResult> {
+  if (!state) return { valid: false, error: 'Missing required parameter: state' }
+
+  const redisResult = await validateStateFromRedis(state)
+  if (redisResult?.valid) return redisResult
+  if (redisResult?.error === 'State parameter has expired') return redisResult
+
+  return validateStateFromMemory(state)
+}
+
+export async function __resetDingTalkOAuthStateStoreForTests(): Promise<void> {
+  pendingStates.clear()
+  redisFallbackLogged = false
+  const client = redisStateClient
+  redisStateClient = null
+  redisStateClientPromise = null
+  await invalidateRedisStateClient(client)
+}
+
+export function buildAuthUrl(state: string): string {
+  const config = readDingTalkOauthConfig()
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    response_type: 'code',
+    scope: 'openid',
+    state,
+    prompt: 'consent',
+  })
+  return `https://login.dingtalk.com/oauth2/auth?${params.toString()}`
+}
+
+export async function exchangeCodeForUser(code: string): Promise<DingTalkExchangeResult> {
+  const token = await exchangeCodeForUserAccessToken(code)
+  const profile = await fetchDingTalkCurrentUser(token.accessToken)
+
+  const dingtalkUser: DingTalkUserInfo = {
+    openId: profile.openId,
+    unionId: profile.unionId,
+    nick: profile.nick,
+    email: profile.email,
+    mobile: profile.mobile,
+    avatarUrl: profile.avatarUrl,
+  }
+
+  const { localUser, isNewUser } = await resolveLocalUser(dingtalkUser)
+
+  return {
+    dingtalkUser,
+    localUserId: localUser.id,
+    localUserEmail: localUser.email,
+    localUserName: localUser.name,
+    localUserRole: localUser.role,
+    isNewUser,
+  }
+}

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto'
+import * as bcrypt from 'bcryptjs'
 import Redis from 'ioredis'
 import { Logger } from '../core/logger'
 import { query, transaction } from '../db/pg'
@@ -8,6 +9,7 @@ import {
   isDingTalkConfigured as isClientConfigured,
   readDingTalkOauthConfig,
 } from '../integrations/dingtalk/client'
+import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 
 const logger = new Logger('DingTalkOAuth')
 
@@ -17,6 +19,7 @@ const MAX_PENDING_STATES = 10_000
 const STATE_REDIS_RETENTION_MS = 60 * 1000
 const STATE_REDIS_KEY_PREFIX = 'metasheet:auth:dingtalk:state:'
 const STATE_REDIS_INDEX_KEY = 'metasheet:auth:dingtalk:state:index'
+const DINGTALK_LOGIN_DISABLED_ERROR = 'DingTalk login is disabled for this user'
 
 export interface DingTalkUserInfo {
   openId: string
@@ -41,6 +44,7 @@ interface LocalUserRow {
   email: string
   name: string
   role: string
+  is_active: boolean
 }
 
 interface StateRecord {
@@ -388,7 +392,11 @@ async function upsertExternalIdentity(localUserId: string, dtUser: DingTalkUserI
 
 async function findUserByEmail(email: string): Promise<LocalUserRow | null> {
   const result = await query<LocalUserRow>(
-    `SELECT id, email, COALESCE(name, '') AS name, COALESCE(role, 'user') AS role
+    `SELECT id,
+            email,
+            COALESCE(name, '') AS name,
+            COALESCE(role, 'user') AS role,
+            COALESCE(is_active, TRUE) AS is_active
      FROM users
      WHERE LOWER(email) = LOWER($1)
      LIMIT 1`,
@@ -400,7 +408,11 @@ async function findUserByEmail(email: string): Promise<LocalUserRow | null> {
 async function findIdentityUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow | null> {
   try {
     const result = await query<LocalUserRow>(
-      `SELECT u.id, u.email, COALESCE(u.name, '') AS name, COALESCE(u.role, 'user') AS role
+      `SELECT u.id,
+              u.email,
+              COALESCE(u.name, '') AS name,
+              COALESCE(u.role, 'user') AS role,
+              COALESCE(u.is_active, TRUE) AS is_active
        FROM user_external_identities identity
        JOIN users u ON u.id = identity.local_user_id
        WHERE identity.provider = $1
@@ -420,10 +432,20 @@ async function findIdentityUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow 
   }
 }
 
+function assertLocalUserLoginAllowed(localUser: LocalUserRow): void {
+  if (localUser.role === 'disabled' || localUser.is_active === false) {
+    throw new Error(DINGTALK_LOGIN_DISABLED_ERROR)
+  }
+}
+
 async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow> {
   const userId = crypto.randomUUID()
   const email = dtUser.email || `dingtalk_${dtUser.openId}@placeholder.local`
   const name = dtUser.nick || 'DingTalk User'
+  const passwordHash = await bcrypt.hash(
+    crypto.randomBytes(32).toString('base64url'),
+    getBcryptSaltRounds(),
+  )
 
   if (dtUser.email) {
     const existingUser = await findUserByEmail(dtUser.email)
@@ -434,10 +456,14 @@ async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUse
 
   try {
     const result = await query<LocalUserRow>(
-      `INSERT INTO users (id, email, name, role, created_at, updated_at)
-       VALUES ($1, $2, $3, 'user', NOW(), NOW())
-       RETURNING id, email, COALESCE(name, '') AS name, COALESCE(role, 'user') AS role`,
-      [userId, email, name],
+      `INSERT INTO users (id, email, name, password_hash, role, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'user', NOW(), NOW())
+       RETURNING id,
+                 email,
+                 COALESCE(name, '') AS name,
+                 COALESCE(role, 'user') AS role,
+                 COALESCE(is_active, TRUE) AS is_active`,
+      [userId, email, name, passwordHash],
     )
 
     const row = result.rows[0]
@@ -462,9 +488,10 @@ async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUse
 async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: LocalUserRow; isNewUser: boolean }> {
   const identityUser = await findIdentityUser(dtUser)
   if (identityUser) {
+    assertLocalUserLoginAllowed(identityUser)
     const grantEnabled = await readGrantEnabled(identityUser.id)
     if (grantEnabled === false) {
-      throw new Error('DingTalk login is disabled for this user')
+      throw new Error(DINGTALK_LOGIN_DISABLED_ERROR)
     }
     await upsertExternalIdentity(identityUser.id, dtUser)
     return { localUser: identityUser, isNewUser: false }
@@ -473,9 +500,10 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
   if (dtUser.email && shouldAutoLinkEmail()) {
     const emailUser = await findUserByEmail(dtUser.email)
     if (emailUser) {
+      assertLocalUserLoginAllowed(emailUser)
       const grantEnabled = await readGrantEnabled(emailUser.id)
       if (grantEnabled === false) {
-        throw new Error('DingTalk login is disabled for this user')
+        throw new Error(DINGTALK_LOGIN_DISABLED_ERROR)
       }
       await ensureGrant(emailUser.id)
       await upsertExternalIdentity(emailUser.id, dtUser)

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -58,10 +58,29 @@ export interface StateValidationResult {
   redirectPath?: string
 }
 
+export class DingTalkLoginPolicyError extends Error {
+  readonly statusCode: number
+  readonly code: string
+
+  constructor(message: string, options: { statusCode?: number; code?: string } = {}) {
+    super(message)
+    this.name = 'DingTalkLoginPolicyError'
+    this.statusCode = options.statusCode ?? 403
+    this.code = options.code ?? 'policy_denied'
+  }
+}
+
 const pendingStates = new Map<string, StateRecord>()
 let redisStateClient: Redis | null = null
 let redisStateClientPromise: Promise<Redis | null> | null = null
 let redisFallbackLogged = false
+
+function createPolicyError(
+  message: string,
+  options: { statusCode?: number; code?: string } = {},
+): DingTalkLoginPolicyError {
+  return new DingTalkLoginPolicyError(message, options)
+}
 
 function parseBooleanEnv(name: string, fallback: boolean): boolean {
   const raw = String(process.env[name] ?? '').trim().toLowerCase()
@@ -448,7 +467,10 @@ async function findIdentityUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow 
 
 function assertLocalUserLoginAllowed(localUser: LocalUserRow): void {
   if (localUser.role === 'disabled' || localUser.is_active === false) {
-    throw new Error(DINGTALK_LOGIN_DISABLED_ERROR)
+    throw createPolicyError(DINGTALK_LOGIN_DISABLED_ERROR, {
+      statusCode: 403,
+      code: 'local_user_disabled',
+    })
   }
 }
 
@@ -464,7 +486,13 @@ async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUse
   if (dtUser.email) {
     const existingUser = await findUserByEmail(dtUser.email)
     if (existingUser) {
-      throw new Error('Refusing to auto-provision DingTalk user because a local account already exists with the same email')
+      throw createPolicyError(
+        'Refusing to auto-provision DingTalk user because a local account already exists with the same email',
+        {
+          statusCode: 409,
+          code: 'auto_provision_email_conflict',
+        },
+      )
     }
   }
 
@@ -493,7 +521,13 @@ async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUse
       'code' in error &&
       error.code === '23505'
     ) {
-      throw new Error('Refusing to auto-provision DingTalk user because a local account already exists with the same email')
+      throw createPolicyError(
+        'Refusing to auto-provision DingTalk user because a local account already exists with the same email',
+        {
+          statusCode: 409,
+          code: 'auto_provision_email_conflict',
+        },
+      )
     }
     throw error
   }
@@ -505,7 +539,10 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
     assertLocalUserLoginAllowed(identityUser)
     const grantEnabled = await readGrantEnabled(identityUser.id)
     if (grantEnabled === false) {
-      throw new Error(DINGTALK_LOGIN_DISABLED_ERROR)
+      throw createPolicyError(DINGTALK_LOGIN_DISABLED_ERROR, {
+        statusCode: 403,
+        code: 'grant_disabled',
+      })
     }
     await upsertExternalIdentity(identityUser.id, dtUser)
     return { localUser: identityUser, isNewUser: false }
@@ -517,7 +554,10 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
       assertLocalUserLoginAllowed(emailUser)
       const grantEnabled = await readGrantEnabled(emailUser.id)
       if (grantEnabled === false) {
-        throw new Error(DINGTALK_LOGIN_DISABLED_ERROR)
+        throw createPolicyError(DINGTALK_LOGIN_DISABLED_ERROR, {
+          statusCode: 403,
+          code: 'grant_disabled',
+        })
       }
       await ensureGrant(emailUser.id)
       await upsertExternalIdentity(emailUser.id, dtUser)
@@ -526,10 +566,14 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
   }
 
   if (!shouldAutoProvision()) {
-    throw new Error(
+    throw createPolicyError(
       dtUser.email
         ? `DingTalk account ${dtUser.email} is not linked to a local user`
         : 'DingTalk account is not linked to a local user',
+      {
+        statusCode: 403,
+        code: 'unlinked_local_user',
+      },
     )
   }
 

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -1,0 +1,211 @@
+import { Logger } from '../../core/logger'
+
+const logger = new Logger('DingTalkClient')
+
+export interface DingTalkOauthConfig {
+  clientId: string
+  clientSecret: string
+  redirectUri: string
+  corpId: string | null
+}
+
+export interface DingTalkUserAccessToken {
+  accessToken: string
+  expireIn?: number
+  refreshToken?: string
+}
+
+export interface DingTalkCurrentUserProfile {
+  openId: string
+  unionId: string
+  nick: string
+  email?: string
+  mobile?: string
+  avatarUrl?: string
+}
+
+class DingTalkRequestError extends Error {
+  statusCode: number
+  responseBody: Record<string, unknown> | null
+
+  constructor(message: string, statusCode: number, responseBody: Record<string, unknown> | null) {
+    super(message)
+    this.name = 'DingTalkRequestError'
+    this.statusCode = statusCode
+    this.responseBody = responseBody
+  }
+}
+
+function readStringEnv(...keys: string[]): string {
+  for (const key of keys) {
+    const value = process.env[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim()
+    }
+  }
+  return ''
+}
+
+function normalizeErrorMessage(payload: Record<string, unknown> | null, fallback: string): string {
+  if (!payload) return fallback
+  const candidates = [
+    payload.message,
+    payload.msg,
+    payload.error_description,
+    payload.errorDescription,
+    payload.error,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+  }
+  return fallback
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    const payload = await response.json()
+    return payload && typeof payload === 'object' ? payload as Record<string, unknown> : null
+  } catch {
+    return null
+  }
+}
+
+async function requestDingTalkJson(
+  input: string,
+  init: RequestInit,
+  fallbackError: string,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(input, init)
+  const payload = await readJson(response)
+
+  if (!response.ok) {
+    const message = normalizeErrorMessage(payload, fallbackError)
+    logger.warn(`DingTalk request failed (${response.status}): ${message}`)
+    throw new DingTalkRequestError(message, response.status, payload)
+  }
+
+  return payload ?? {}
+}
+
+export function readDingTalkOauthConfig(): DingTalkOauthConfig {
+  const clientId = readStringEnv('DINGTALK_CLIENT_ID', 'DINGTALK_APP_KEY')
+  const clientSecret = readStringEnv('DINGTALK_CLIENT_SECRET', 'DINGTALK_APP_SECRET')
+  const redirectUri = readStringEnv('DINGTALK_REDIRECT_URI')
+  const corpId = readStringEnv('DINGTALK_CORP_ID') || null
+
+  if (!clientId) throw new Error('DINGTALK_CLIENT_ID or DINGTALK_APP_KEY is not configured')
+  if (!clientSecret) throw new Error('DINGTALK_CLIENT_SECRET or DINGTALK_APP_SECRET is not configured')
+  if (!redirectUri) throw new Error('DINGTALK_REDIRECT_URI is not configured')
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUri,
+    corpId,
+  }
+}
+
+export function isDingTalkConfigured(): boolean {
+  return Boolean(
+    readStringEnv('DINGTALK_CLIENT_ID', 'DINGTALK_APP_KEY') &&
+    readStringEnv('DINGTALK_CLIENT_SECRET', 'DINGTALK_APP_SECRET') &&
+    readStringEnv('DINGTALK_REDIRECT_URI'),
+  )
+}
+
+export async function exchangeCodeForUserAccessToken(
+  code: string,
+  config: DingTalkOauthConfig = readDingTalkOauthConfig(),
+): Promise<DingTalkUserAccessToken> {
+  const payload = await requestDingTalkJson(
+    'https://api.dingtalk.com/v1.0/oauth2/userAccessToken',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clientId: config.clientId,
+        clientSecret: config.clientSecret,
+        code,
+        grantType: 'authorization_code',
+      }),
+    },
+    'Failed to obtain access token from DingTalk',
+  )
+
+  const accessToken = typeof payload.accessToken === 'string'
+    ? payload.accessToken
+    : typeof payload.access_token === 'string'
+      ? payload.access_token
+      : ''
+
+  if (!accessToken) {
+    throw new Error(normalizeErrorMessage(payload, 'Failed to obtain access token from DingTalk'))
+  }
+
+  return {
+    accessToken,
+    expireIn:
+      typeof payload.expireIn === 'number'
+        ? payload.expireIn
+        : typeof payload.expiresIn === 'number'
+          ? payload.expiresIn
+          : undefined,
+    refreshToken:
+      typeof payload.refreshToken === 'string'
+        ? payload.refreshToken
+        : typeof payload.refresh_token === 'string'
+          ? payload.refresh_token
+          : undefined,
+  }
+}
+
+export async function fetchDingTalkCurrentUser(accessToken: string): Promise<DingTalkCurrentUserProfile> {
+  const payload = await requestDingTalkJson(
+    'https://api.dingtalk.com/v1.0/contact/users/me',
+    {
+      method: 'GET',
+      headers: {
+        'x-acs-dingtalk-access-token': accessToken,
+      },
+    },
+    'Failed to get current user info from DingTalk',
+  )
+
+  const openId = typeof payload.openId === 'string'
+    ? payload.openId
+    : typeof payload.open_id === 'string'
+      ? payload.open_id
+      : ''
+  const unionId = typeof payload.unionId === 'string'
+    ? payload.unionId
+    : typeof payload.union_id === 'string'
+      ? payload.union_id
+      : ''
+  const nick = typeof payload.nick === 'string'
+    ? payload.nick
+    : typeof payload.name === 'string'
+      ? payload.name
+      : ''
+
+  if (!openId) {
+    throw new Error(normalizeErrorMessage(payload, 'Failed to resolve DingTalk openId'))
+  }
+
+  return {
+    openId,
+    unionId,
+    nick,
+    email: typeof payload.email === 'string' ? payload.email : undefined,
+    mobile: typeof payload.mobile === 'string' ? payload.mobile : undefined,
+    avatarUrl:
+      typeof payload.avatarUrl === 'string'
+        ? payload.avatarUrl
+        : typeof payload.avatar_url === 'string'
+          ? payload.avatar_url
+          : undefined,
+  }
+}
+
+export { DingTalkRequestError }

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -217,6 +217,12 @@ function normalizeDingTalkRedirectPath(value: unknown): string | null {
   return normalized
 }
 
+function isTruthyQueryFlag(value: unknown): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value !== 'string') return false
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
 async function loadAuthPermissions(userId: string): Promise<string[]> {
   try {
     return await listUserPermissions(userId)
@@ -850,6 +856,15 @@ authRouter.get('/dingtalk/launch', async (req: Request, res: Response) => {
   }
 
   try {
+    if (isTruthyQueryFlag(req.query.probe)) {
+      return res.json({
+        success: true,
+        data: {
+          available: true,
+        },
+      })
+    }
+
     const redirectPath = normalizeDingTalkRedirectPath(req.query.redirect)
     const state = await generateState({ redirectPath })
     const url = buildAuthUrl(state)

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -10,6 +10,13 @@ import * as bcrypt from 'bcryptjs'
 import jwt, { type SignOptions } from 'jsonwebtoken'
 import { authService, type User } from '../auth/AuthService'
 import { buildOnboardingPacket, getAccessPreset } from '../auth/access-presets'
+import {
+  buildAuthUrl,
+  exchangeCodeForUser,
+  generateState,
+  isDingTalkConfigured,
+  validateState,
+} from '../auth/dingtalk-oauth'
 import { markInviteAccepted } from '../auth/invite-ledger'
 import { verifyInviteToken } from '../auth/invite-tokens'
 import { validatePassword } from '../auth/password-policy'
@@ -18,6 +25,7 @@ import { revokeUserSessions } from '../auth/session-revocation'
 import { FEATURE_FLAGS } from '../config/flags'
 import { Logger } from '../core/logger'
 import { query } from '../db/pg'
+import { listUserPermissions } from '../rbac/service'
 import { secretManager } from '../security/SecretManager'
 import { isPlmEnabled, resolveEffectiveProductMode } from '../config/product-mode'
 import { getBcryptSaltRounds, resolveRuntimeJwtSecret } from '../security/auth-runtime-config'
@@ -199,6 +207,57 @@ function buildFeaturePayload(authUser: User) {
     plm,
     mode,
   }
+}
+
+function normalizeDingTalkRedirectPath(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  if (!normalized || !normalized.startsWith('/') || normalized.startsWith('//')) return null
+  if (normalized === '/' || normalized.startsWith('/login') || normalized.startsWith('/dingtalk')) return null
+  return normalized
+}
+
+async function loadAuthPermissions(userId: string): Promise<string[]> {
+  try {
+    return await listUserPermissions(userId)
+  } catch (error) {
+    logger.warn('Failed to load RBAC permissions for auth user', error instanceof Error ? error : undefined)
+  }
+
+  try {
+    const result = await query<{ permissions: string[] | null }>(
+      'SELECT permissions FROM users WHERE id = $1 LIMIT 1',
+      [userId],
+    )
+    const permissions = result.rows[0]?.permissions
+    return Array.isArray(permissions) ? permissions.map((permission) => String(permission)) : []
+  } catch (error) {
+    logger.warn('Failed to load legacy permissions for auth user', error instanceof Error ? error : undefined)
+    return []
+  }
+}
+
+async function issueAuthSessionToken(user: User, req: Request): Promise<string> {
+  const sessionId = randomUUID()
+  const token = authService.createToken(user, { sid: sessionId })
+  const payload = authService.readTokenPayload(token)
+
+  if (payload?.exp) {
+    await createUserSession(user.id, {
+      sessionId,
+      expiresAt: new Date(payload.exp * 1000).toISOString(),
+      ipAddress: getClientIP(req),
+      userAgent: typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : null,
+    })
+  }
+
+  try {
+    await query('UPDATE users SET last_login_at = NOW() WHERE id = $1', [user.id])
+  } catch (error) {
+    logger.warn('Failed to update last_login_at after external auth login', error instanceof Error ? error : undefined)
+  }
+
+  return token
 }
 
 async function getInviteTarget(userId: string, email: string) {
@@ -774,6 +833,105 @@ authRouter.post('/sessions/:sessionId/logout', async (req: Request, res: Respons
     return res.status(500).json({
       success: false,
       error: 'Internal server error'
+    })
+  }
+})
+
+// ============================================
+// DingTalk OAuth
+// ============================================
+
+authRouter.get('/dingtalk/launch', async (req: Request, res: Response) => {
+  if (!isDingTalkConfigured()) {
+    return res.status(503).json({
+      success: false,
+      error: 'DingTalk login is not configured on this server',
+    })
+  }
+
+  try {
+    const redirectPath = normalizeDingTalkRedirectPath(req.query.redirect)
+    const state = await generateState({ redirectPath })
+    const url = buildAuthUrl(state)
+
+    return res.json({
+      success: true,
+      data: {
+        url,
+        state,
+      },
+    })
+  } catch (error) {
+    logger.error('DingTalk launch error', error instanceof Error ? error : undefined)
+    return res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to build DingTalk auth URL',
+    })
+  }
+})
+
+authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
+  try {
+    const code = typeof req.body?.code === 'string' ? req.body.code.trim() : ''
+    const state = typeof req.body?.state === 'string' ? req.body.state.trim() : ''
+
+    if (!code) {
+      return res.status(400).json({
+        success: false,
+        error: 'Missing required parameter: code',
+      })
+    }
+
+    const stateCheck = await validateState(state)
+    if (!stateCheck.valid) {
+      return res.status(400).json({
+        success: false,
+        error: stateCheck.error,
+      })
+    }
+
+    if (!isDingTalkConfigured()) {
+      return res.status(503).json({
+        success: false,
+        error: 'DingTalk login is not configured on this server',
+      })
+    }
+
+    const result = await exchangeCodeForUser(code)
+    const permissions = await loadAuthPermissions(result.localUserId)
+    const user: User = {
+      id: result.localUserId,
+      email: result.localUserEmail,
+      name: result.localUserName,
+      role: result.localUserRole,
+      permissions,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const token = await issueAuthSessionToken(user, req)
+
+    logger.info(`DingTalk login for ${user.email} (openId: ${result.dingtalkUser.openId}, new: ${result.isNewUser})`)
+
+    return res.json({
+      success: true,
+      data: {
+        user: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+          permissions: user.permissions,
+        },
+        token,
+        redirectPath: stateCheck.redirectPath || null,
+        features: buildFeaturePayload(user),
+      },
+    })
+  } catch (error) {
+    logger.error('DingTalk callback error', error instanceof Error ? error : undefined)
+    return res.status(502).json({
+      success: false,
+      error: error instanceof Error ? error.message : 'DingTalk authentication failed',
     })
   }
 })

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -950,7 +950,7 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
       ? error.statusCode
       : error instanceof DingTalkRequestError
         ? 502
-        : 502
+        : 500
 
     return res.status(statusCode).json({
       success: false,

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -951,10 +951,15 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
       : error instanceof DingTalkRequestError
         ? 502
         : 500
+    const message = error instanceof DingTalkLoginPolicyError
+      ? error.message
+      : error instanceof DingTalkRequestError
+        ? error.message
+        : 'DingTalk authentication failed'
 
     return res.status(statusCode).json({
       success: false,
-      error: error instanceof Error ? error.message : 'DingTalk authentication failed',
+      error: message,
     })
   }
 })

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -12,6 +12,7 @@ import { authService, type User } from '../auth/AuthService'
 import { buildOnboardingPacket, getAccessPreset } from '../auth/access-presets'
 import {
   buildAuthUrl,
+  DingTalkLoginPolicyError,
   exchangeCodeForUser,
   generateState,
   isDingTalkConfigured,
@@ -29,6 +30,7 @@ import { listUserPermissions } from '../rbac/service'
 import { secretManager } from '../security/SecretManager'
 import { isPlmEnabled, resolveEffectiveProductMode } from '../config/product-mode'
 import { getBcryptSaltRounds, resolveRuntimeJwtSecret } from '../security/auth-runtime-config'
+import { DingTalkRequestError } from '../integrations/dingtalk/client'
 
 const logger = new Logger('AuthRouter')
 
@@ -944,7 +946,13 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
     })
   } catch (error) {
     logger.error('DingTalk callback error', error instanceof Error ? error : undefined)
-    return res.status(502).json({
+    const statusCode = error instanceof DingTalkLoginPolicyError
+      ? error.statusCode
+      : error instanceof DingTalkRequestError
+        ? 502
+        : 502
+
+    return res.status(statusCode).json({
       success: false,
       error: error instanceof Error ? error.message : 'DingTalk authentication failed',
     })

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -568,4 +568,26 @@ describe('auth login routes', () => {
     expect((response.body as Record<string, any>).error).toBe('State parameter has expired')
     expect(dingtalkOauthMocks.exchangeCodeForUser).not.toHaveBeenCalled()
   })
+
+  it('surfaces disabled-local-user errors from the DingTalk callback exchange', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/attendance',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.exchangeCodeForUser.mockRejectedValue(
+      new Error('DingTalk login is disabled for this user'),
+    )
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: {
+        code: 'auth-code',
+        state: 'state-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(502)
+    expect((response.body as Record<string, any>).error).toBe('DingTalk login is disabled for this user')
+    expect(rbacMocks.listUserPermissions).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -28,10 +28,23 @@ const sessionMocks = vi.hoisted(() => ({
 }))
 
 const sessionRegistryMocks = vi.hoisted(() => ({
+  createUserSession: vi.fn(),
   listUserSessions: vi.fn(),
   getUserSession: vi.fn(),
   revokeUserSession: vi.fn(),
   touchUserSession: vi.fn(),
+}))
+
+const dingtalkOauthMocks = vi.hoisted(() => ({
+  isDingTalkConfigured: vi.fn(),
+  generateState: vi.fn(),
+  buildAuthUrl: vi.fn(),
+  validateState: vi.fn(),
+  exchangeCodeForUser: vi.fn(),
+}))
+
+const rbacMocks = vi.hoisted(() => ({
+  listUserPermissions: vi.fn(),
 }))
 
 vi.mock('../../src/auth/AuthService', () => ({
@@ -53,10 +66,23 @@ vi.mock('../../src/auth/session-revocation', () => ({
 }))
 
 vi.mock('../../src/auth/session-registry', () => ({
+  createUserSession: sessionRegistryMocks.createUserSession,
   listUserSessions: sessionRegistryMocks.listUserSessions,
   getUserSession: sessionRegistryMocks.getUserSession,
   revokeUserSession: sessionRegistryMocks.revokeUserSession,
   touchUserSession: sessionRegistryMocks.touchUserSession,
+}))
+
+vi.mock('../../src/auth/dingtalk-oauth', () => ({
+  isDingTalkConfigured: dingtalkOauthMocks.isDingTalkConfigured,
+  generateState: dingtalkOauthMocks.generateState,
+  buildAuthUrl: dingtalkOauthMocks.buildAuthUrl,
+  validateState: dingtalkOauthMocks.validateState,
+  exchangeCodeForUser: dingtalkOauthMocks.exchangeCodeForUser,
+}))
+
+vi.mock('../../src/rbac/service', () => ({
+  listUserPermissions: rbacMocks.listUserPermissions,
 }))
 
 import { authRouter } from '../../src/routes/auth'
@@ -144,10 +170,17 @@ describe('auth login routes', () => {
     bcryptMocks.hash.mockReset()
     bcryptMocks.compare.mockReset()
     sessionMocks.revokeUserSessions.mockReset()
+    sessionRegistryMocks.createUserSession.mockReset()
     sessionRegistryMocks.listUserSessions.mockReset()
     sessionRegistryMocks.getUserSession.mockReset()
     sessionRegistryMocks.revokeUserSession.mockReset()
     sessionRegistryMocks.touchUserSession.mockReset()
+    dingtalkOauthMocks.isDingTalkConfigured.mockReset()
+    dingtalkOauthMocks.generateState.mockReset()
+    dingtalkOauthMocks.buildAuthUrl.mockReset()
+    dingtalkOauthMocks.validateState.mockReset()
+    dingtalkOauthMocks.exchangeCodeForUser.mockReset()
+    rbacMocks.listUserPermissions.mockReset()
   })
 
   it('returns feature payload on successful login', async () => {
@@ -410,5 +443,112 @@ describe('auth login routes', () => {
     })
     expect(sessionMocks.revokeUserSessions).not.toHaveBeenCalled()
     expect((response.body as Record<string, any>).data.scope).toBe('current-session')
+  })
+
+  it('builds a DingTalk auth URL and preserves a safe redirect path in state', async () => {
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.generateState.mockResolvedValue('state-1')
+    dingtalkOauthMocks.buildAuthUrl.mockReturnValue('https://login.dingtalk.test/oauth')
+
+    const response = await invokeRoute('get', '/dingtalk/launch', {
+      query: {
+        redirect: '/workflows?tab=mine',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(dingtalkOauthMocks.generateState).toHaveBeenCalledWith({
+      redirectPath: '/workflows?tab=mine',
+    })
+    expect(dingtalkOauthMocks.buildAuthUrl).toHaveBeenCalledWith('state-1')
+    expect((response.body as Record<string, any>).data.url).toBe('https://login.dingtalk.test/oauth')
+  })
+
+  it('exchanges a DingTalk callback into a local session token', async () => {
+    const expSeconds = Math.floor(new Date('2026-04-08T10:00:00.000Z').getTime() / 1000)
+
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/attendance',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.exchangeCodeForUser.mockResolvedValue({
+      dingtalkUser: {
+        openId: 'open-id-1',
+        unionId: 'union-id-1',
+        nick: 'Ding User',
+        email: 'manager@example.com',
+      },
+      localUserId: 'user-1',
+      localUserEmail: 'manager@example.com',
+      localUserName: 'Manager',
+      localUserRole: 'admin',
+      isNewUser: false,
+    })
+    rbacMocks.listUserPermissions.mockResolvedValue(['attendance:admin', 'workflow:read'])
+    authServiceMocks.createToken.mockReturnValue('jwt-dingtalk-token')
+    authServiceMocks.readTokenPayload.mockReturnValue({
+      exp: expSeconds,
+    })
+    sessionRegistryMocks.createUserSession.mockResolvedValue(undefined)
+    pgMocks.query.mockResolvedValue({ rows: [] })
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      headers: {
+        'user-agent': 'Vitest Browser',
+      },
+      body: {
+        code: 'auth-code',
+        state: 'state-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(dingtalkOauthMocks.validateState).toHaveBeenCalledWith('state-1')
+    expect(dingtalkOauthMocks.exchangeCodeForUser).toHaveBeenCalledWith('auth-code')
+    expect(rbacMocks.listUserPermissions).toHaveBeenCalledWith('user-1')
+    expect(authServiceMocks.createToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'user-1',
+        email: 'manager@example.com',
+        role: 'admin',
+        permissions: ['attendance:admin', 'workflow:read'],
+      }),
+      expect.objectContaining({ sid: expect.any(String) }),
+    )
+    expect(sessionRegistryMocks.createUserSession).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({
+        ipAddress: '127.0.0.1',
+        userAgent: 'Vitest Browser',
+      }),
+    )
+    expect((response.body as Record<string, any>).data).toMatchObject({
+      token: 'jwt-dingtalk-token',
+      redirectPath: '/attendance',
+      user: {
+        id: 'user-1',
+        email: 'manager@example.com',
+        role: 'admin',
+      },
+    })
+  })
+
+  it('rejects DingTalk callback when state validation fails', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: false,
+      error: 'State parameter has expired',
+    })
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: {
+        code: 'auth-code',
+        state: 'expired-state',
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect((response.body as Record<string, any>).error).toBe('State parameter has expired')
+    expect(dingtalkOauthMocks.exchangeCodeForUser).not.toHaveBeenCalled()
   })
 })

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -647,6 +647,25 @@ describe('auth login routes', () => {
     expect((response.body as Record<string, any>).error).toBe('Failed to obtain access token from DingTalk')
   })
 
+  it('maps unexpected local callback failures to 500', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/attendance',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.exchangeCodeForUser.mockRejectedValue(new Error('session registry unavailable'))
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: {
+        code: 'auth-code',
+        state: 'state-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect((response.body as Record<string, any>).error).toBe('session registry unavailable')
+  })
+
   it('returns 409 for local auto-provision email conflicts', async () => {
     dingtalkOauthMocks.validateState.mockResolvedValue({
       valid: true,

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -41,6 +41,31 @@ const dingtalkOauthMocks = vi.hoisted(() => ({
   buildAuthUrl: vi.fn(),
   validateState: vi.fn(),
   exchangeCodeForUser: vi.fn(),
+  DingTalkLoginPolicyError: class DingTalkLoginPolicyError extends Error {
+    statusCode: number
+    code: string
+
+    constructor(message: string, options: { statusCode?: number; code?: string } = {}) {
+      super(message)
+      this.name = 'DingTalkLoginPolicyError'
+      this.statusCode = options.statusCode ?? 403
+      this.code = options.code ?? 'policy_denied'
+    }
+  },
+}))
+
+const dingtalkClientMocks = vi.hoisted(() => ({
+  DingTalkRequestError: class DingTalkRequestError extends Error {
+    statusCode: number
+    responseBody: Record<string, unknown> | null
+
+    constructor(message: string, statusCode = 502, responseBody: Record<string, unknown> | null = null) {
+      super(message)
+      this.name = 'DingTalkRequestError'
+      this.statusCode = statusCode
+      this.responseBody = responseBody
+    }
+  },
 }))
 
 const rbacMocks = vi.hoisted(() => ({
@@ -79,10 +104,15 @@ vi.mock('../../src/auth/dingtalk-oauth', () => ({
   buildAuthUrl: dingtalkOauthMocks.buildAuthUrl,
   validateState: dingtalkOauthMocks.validateState,
   exchangeCodeForUser: dingtalkOauthMocks.exchangeCodeForUser,
+  DingTalkLoginPolicyError: dingtalkOauthMocks.DingTalkLoginPolicyError,
 }))
 
 vi.mock('../../src/rbac/service', () => ({
   listUserPermissions: rbacMocks.listUserPermissions,
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  DingTalkRequestError: dingtalkClientMocks.DingTalkRequestError,
 }))
 
 import { authRouter } from '../../src/routes/auth'
@@ -576,7 +606,34 @@ describe('auth login routes', () => {
     })
     dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
     dingtalkOauthMocks.exchangeCodeForUser.mockRejectedValue(
-      new Error('DingTalk login is disabled for this user'),
+      new dingtalkOauthMocks.DingTalkLoginPolicyError('DingTalk login is disabled for this user', {
+        statusCode: 403,
+        code: 'local_user_disabled',
+      }),
+    )
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: {
+        code: 'auth-code',
+        state: 'state-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect((response.body as Record<string, any>).error).toBe('DingTalk login is disabled for this user')
+    expect(rbacMocks.listUserPermissions).not.toHaveBeenCalled()
+  })
+
+  it('keeps upstream DingTalk request failures mapped to 502', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/attendance',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.exchangeCodeForUser.mockRejectedValue(
+      new dingtalkClientMocks.DingTalkRequestError('Failed to obtain access token from DingTalk', 401, {
+        error: 'invalid_client',
+      }),
     )
 
     const response = await invokeRoute('post', '/dingtalk/callback', {
@@ -587,7 +644,33 @@ describe('auth login routes', () => {
     })
 
     expect(response.statusCode).toBe(502)
-    expect((response.body as Record<string, any>).error).toBe('DingTalk login is disabled for this user')
-    expect(rbacMocks.listUserPermissions).not.toHaveBeenCalled()
+    expect((response.body as Record<string, any>).error).toBe('Failed to obtain access token from DingTalk')
+  })
+
+  it('returns 409 for local auto-provision email conflicts', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/attendance',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.exchangeCodeForUser.mockRejectedValue(
+      new dingtalkOauthMocks.DingTalkLoginPolicyError(
+        'Refusing to auto-provision DingTalk user because a local account already exists with the same email',
+        {
+          statusCode: 409,
+          code: 'auto_provision_email_conflict',
+        },
+      ),
+    )
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: {
+        code: 'auth-code',
+        state: 'state-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect((response.body as Record<string, any>).error).toContain('same email')
   })
 })

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -663,7 +663,7 @@ describe('auth login routes', () => {
     })
 
     expect(response.statusCode).toBe(500)
-    expect((response.body as Record<string, any>).error).toBe('session registry unavailable')
+    expect((response.body as Record<string, any>).error).toBe('DingTalk authentication failed')
   })
 
   it('returns 409 for local auto-provision email conflicts', async () => {

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -464,6 +464,23 @@ describe('auth login routes', () => {
     expect((response.body as Record<string, any>).data.url).toBe('https://login.dingtalk.test/oauth')
   })
 
+  it('supports probing DingTalk availability without generating OAuth state', async () => {
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+
+    const response = await invokeRoute('get', '/dingtalk/launch', {
+      query: {
+        probe: '1',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(dingtalkOauthMocks.generateState).not.toHaveBeenCalled()
+    expect(dingtalkOauthMocks.buildAuthUrl).not.toHaveBeenCalled()
+    expect((response.body as Record<string, any>).data).toEqual({
+      available: true,
+    })
+  })
+
   it('exchanges a DingTalk callback into a local session token', async () => {
     const expSeconds = Math.floor(new Date('2026-04-08T10:00:00.000Z').getTime() / 1000)
 

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -6,6 +6,7 @@ const redisMockState = vi.hoisted(() => {
   const behavior = {
     connectFail: false,
     opsFail: false,
+    execTupleError: false,
   }
 
   function readZset(key: string): Map<string, number> {
@@ -30,6 +31,7 @@ const redisMockState = vi.hoisted(() => {
       zsets.clear()
       behavior.connectFail = false
       behavior.opsFail = false
+      behavior.execTupleError = false
     },
     readZset,
     isExpired,
@@ -150,6 +152,9 @@ vi.mock('ioredis', () => {
           return chain
         },
         exec: async () => {
+          if (redisMockState.behavior.execTupleError) {
+            return ops.map(() => [new Error('redis exec tuple error'), null] as [Error, null])
+          }
           const results: Array<[Error | null, unknown]> = []
           for (const op of ops) {
             try {
@@ -173,17 +178,36 @@ vi.mock('../../src/db/pg', () => ({
   transaction: vi.fn(),
 }))
 
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  exchangeCodeForUserAccessToken: vi.fn(),
+  fetchDingTalkCurrentUser: vi.fn(),
+  isDingTalkConfigured: vi.fn(() => true),
+  readDingTalkOauthConfig: vi.fn(() => ({
+    clientId: 'client-id',
+    clientSecret: 'client-secret',
+    redirectUri: 'https://example.com/login/dingtalk/callback',
+    corpId: null,
+  })),
+}))
+
 import {
   __resetDingTalkOAuthStateStoreForTests,
+  exchangeCodeForUser,
   generateState,
   validateState,
 } from '../../src/auth/dingtalk-oauth'
+import { query, transaction } from '../../src/db/pg'
+import { exchangeCodeForUserAccessToken, fetchDingTalkCurrentUser } from '../../src/integrations/dingtalk/client'
 
 describe('DingTalk OAuth state store', () => {
   beforeEach(async () => {
     vi.useRealTimers()
     vi.unstubAllEnvs()
     redisMockState.reset()
+    vi.mocked(query).mockReset()
+    vi.mocked(transaction).mockReset()
+    vi.mocked(exchangeCodeForUserAccessToken).mockReset()
+    vi.mocked(fetchDingTalkCurrentUser).mockReset()
     await __resetDingTalkOAuthStateStoreForTests()
   })
 
@@ -239,5 +263,47 @@ describe('DingTalk OAuth state store', () => {
       valid: true,
       redirectPath: '/workflows',
     })
+  })
+
+  it('falls back to in-memory storage when Redis multi exec returns tuple errors', async () => {
+    vi.stubEnv('REDIS_URL', 'redis://localhost:6379')
+    redisMockState.behavior.execTupleError = true
+
+    const state = await generateState({ redirectPath: '/attendance' })
+    redisMockState.behavior.execTupleError = false
+
+    const validation = await validateState(state)
+    expect(validation).toEqual({
+      valid: true,
+      redirectPath: '/attendance',
+    })
+  })
+
+  it('refuses auto-provision when a local account already exists with the same email', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '0')
+    vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
+      accessToken: 'access-token',
+    })
+    vi.mocked(fetchDingTalkCurrentUser).mockResolvedValue({
+      openId: 'open-id-1',
+      unionId: 'union-id-1',
+      nick: 'Ding User',
+      email: 'manager@example.com',
+    })
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'manager@example.com',
+          name: 'Manager',
+          role: 'user',
+        }],
+      } as any)
+
+    await expect(exchangeCodeForUser('auth-code')).rejects.toThrow(
+      'Refusing to auto-provision DingTalk user because a local account already exists with the same email',
+    )
   })
 })

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const redisMockState = vi.hoisted(() => {
+  const kv = new Map<string, { value: string; expiresAt: number | null }>()
+  const zsets = new Map<string, Map<string, number>>()
+  const behavior = {
+    connectFail: false,
+    opsFail: false,
+  }
+
+  function readZset(key: string): Map<string, number> {
+    let zset = zsets.get(key)
+    if (!zset) {
+      zset = new Map<string, number>()
+      zsets.set(key, zset)
+    }
+    return zset
+  }
+
+  function isExpired(record: { expiresAt: number | null }): boolean {
+    return record.expiresAt !== null && Date.now() > record.expiresAt
+  }
+
+  return {
+    behavior,
+    kv,
+    zsets,
+    reset() {
+      kv.clear()
+      zsets.clear()
+      behavior.connectFail = false
+      behavior.opsFail = false
+    },
+    readZset,
+    isExpired,
+  }
+})
+
+vi.mock('ioredis', () => {
+  class MockRedis {
+    constructor(_url: string, _opts: Record<string, unknown>) {}
+
+    async connect() {
+      if (redisMockState.behavior.connectFail) {
+        throw new Error('connect fail')
+      }
+    }
+
+    on(_event: string, _cb: (...args: unknown[]) => void) {}
+
+    async quit() {}
+
+    disconnect() {}
+
+    private assertHealthy() {
+      if (redisMockState.behavior.opsFail) {
+        throw new Error('redis op fail')
+      }
+    }
+
+    async get(key: string) {
+      this.assertHealthy()
+      const record = redisMockState.kv.get(key)
+      if (!record) return null
+      if (redisMockState.isExpired(record)) {
+        redisMockState.kv.delete(key)
+        return null
+      }
+      return record.value
+    }
+
+    async set(key: string, value: string, mode?: string, ttlMs?: number) {
+      this.assertHealthy()
+      const expiresAt = mode === 'PX' && typeof ttlMs === 'number'
+        ? Date.now() + ttlMs
+        : null
+      redisMockState.kv.set(key, { value, expiresAt })
+      return 'OK'
+    }
+
+    async del(...keys: string[]) {
+      this.assertHealthy()
+      let deleted = 0
+      for (const key of keys) {
+        if (redisMockState.kv.delete(key)) deleted += 1
+      }
+      return deleted
+    }
+
+    async zadd(key: string, score: number, member: string) {
+      this.assertHealthy()
+      const zset = redisMockState.readZset(key)
+      zset.set(member, Number(score))
+      return 1
+    }
+
+    async zcard(key: string) {
+      this.assertHealthy()
+      return redisMockState.readZset(key).size
+    }
+
+    async zrange(key: string, start: number, stop: number) {
+      this.assertHealthy()
+      const values = Array.from(redisMockState.readZset(key).entries())
+        .sort((a, b) => a[1] - b[1])
+        .map(([member]) => member)
+      const normalizedStop = stop < 0 ? values.length - 1 : stop
+      return values.slice(start, normalizedStop + 1)
+    }
+
+    async zrangebyscore(key: string, min: number, max: number) {
+      this.assertHealthy()
+      return Array.from(redisMockState.readZset(key).entries())
+        .filter(([, score]) => score >= Number(min) && score <= Number(max))
+        .sort((a, b) => a[1] - b[1])
+        .map(([member]) => member)
+    }
+
+    async zrem(key: string, ...members: string[]) {
+      this.assertHealthy()
+      const zset = redisMockState.readZset(key)
+      let deleted = 0
+      for (const member of members) {
+        if (zset.delete(member)) deleted += 1
+      }
+      return deleted
+    }
+
+    multi() {
+      const ops: Array<() => Promise<unknown>> = []
+      const chain = {
+        get: (key: string) => {
+          ops.push(() => this.get(key))
+          return chain
+        },
+        del: (...keys: string[]) => {
+          ops.push(() => this.del(...keys))
+          return chain
+        },
+        zrem: (key: string, ...members: string[]) => {
+          ops.push(() => this.zrem(key, ...members))
+          return chain
+        },
+        set: (key: string, value: string, mode?: string, ttlMs?: number) => {
+          ops.push(() => this.set(key, value, mode, ttlMs))
+          return chain
+        },
+        zadd: (key: string, score: number, member: string) => {
+          ops.push(() => this.zadd(key, score, member))
+          return chain
+        },
+        exec: async () => {
+          const results: Array<[Error | null, unknown]> = []
+          for (const op of ops) {
+            try {
+              results.push([null, await op()])
+            } catch (error) {
+              results.push([error instanceof Error ? error : new Error(String(error)), null])
+            }
+          }
+          return results
+        },
+      }
+      return chain
+    }
+  }
+
+  return { default: MockRedis }
+})
+
+vi.mock('../../src/db/pg', () => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+import {
+  __resetDingTalkOAuthStateStoreForTests,
+  generateState,
+  validateState,
+} from '../../src/auth/dingtalk-oauth'
+
+describe('DingTalk OAuth state store', () => {
+  beforeEach(async () => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+    redisMockState.reset()
+    await __resetDingTalkOAuthStateStoreForTests()
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+    redisMockState.reset()
+    await __resetDingTalkOAuthStateStoreForTests()
+  })
+
+  it('stores and consumes state via Redis when configured', async () => {
+    vi.stubEnv('REDIS_URL', 'redis://localhost:6379')
+
+    const state = await generateState({ redirectPath: '/attendance' })
+    expect(typeof state).toBe('string')
+
+    const firstValidation = await validateState(state)
+    expect(firstValidation).toEqual({
+      valid: true,
+      redirectPath: '/attendance',
+    })
+
+    const secondValidation = await validateState(state)
+    expect(secondValidation).toEqual({
+      valid: false,
+      error: 'Invalid or unknown state parameter',
+    })
+  })
+
+  it('returns expired when a Redis-backed state exceeds its logical TTL', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-31T00:00:00.000Z'))
+    vi.stubEnv('REDIS_URL', 'redis://localhost:6379')
+
+    const state = await generateState()
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1_000)
+
+    const expiredValidation = await validateState(state)
+    expect(expiredValidation).toEqual({
+      valid: false,
+      error: 'State parameter has expired',
+    })
+  })
+
+  it('falls back to in-memory storage when Redis is unavailable', async () => {
+    vi.stubEnv('REDIS_URL', 'redis://localhost:6379')
+    redisMockState.behavior.connectFail = true
+
+    const state = await generateState({ redirectPath: '/workflows' })
+    const validation = await validateState(state)
+
+    expect(validation).toEqual({
+      valid: true,
+      redirectPath: '/workflows',
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -197,7 +197,11 @@ import {
   validateState,
 } from '../../src/auth/dingtalk-oauth'
 import { query, transaction } from '../../src/db/pg'
-import { exchangeCodeForUserAccessToken, fetchDingTalkCurrentUser } from '../../src/integrations/dingtalk/client'
+import {
+  exchangeCodeForUserAccessToken,
+  fetchDingTalkCurrentUser,
+  readDingTalkOauthConfig,
+} from '../../src/integrations/dingtalk/client'
 
 describe('DingTalk OAuth state store', () => {
   beforeEach(async () => {
@@ -330,6 +334,32 @@ describe('DingTalk OAuth state store', () => {
     await expect(exchangeCodeForUser('auth-code')).rejects.toThrow(
       'DingTalk login is disabled for this user',
     )
+  })
+
+  it('scopes identity fallback lookups to the configured corp id', async () => {
+    vi.mocked(readDingTalkOauthConfig).mockReturnValue({
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      redirectUri: 'https://example.com/login/dingtalk/callback',
+      corpId: 'ding-corp-1',
+    })
+    vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
+      accessToken: 'access-token',
+    })
+    vi.mocked(fetchDingTalkCurrentUser).mockResolvedValue({
+      openId: 'open-id-1',
+      unionId: 'union-id-1',
+      nick: 'Ding User',
+      email: 'manager@example.com',
+    })
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+
+    await expect(exchangeCodeForUser('auth-code')).rejects.toThrow('is not linked to a local user')
+
+    expect(vi.mocked(query).mock.calls[0]?.[0]).toContain('identity.corp_id = $5')
+    expect(vi.mocked(query).mock.calls[0]?.[1]?.[4]).toBe('ding-corp-1')
   })
 
   it('rejects email auto-link when the matched local user is disabled', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -306,4 +306,93 @@ describe('DingTalk OAuth state store', () => {
       'Refusing to auto-provision DingTalk user because a local account already exists with the same email',
     )
   })
+
+  it('rejects external identities linked to inactive local users', async () => {
+    vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
+      accessToken: 'access-token',
+    })
+    vi.mocked(fetchDingTalkCurrentUser).mockResolvedValue({
+      openId: 'open-id-1',
+      unionId: 'union-id-1',
+      nick: 'Ding User',
+      email: 'manager@example.com',
+    })
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [{
+        id: 'user-1',
+        email: 'manager@example.com',
+        name: 'Manager',
+        role: 'user',
+        is_active: false,
+      }],
+    } as any)
+
+    await expect(exchangeCodeForUser('auth-code')).rejects.toThrow(
+      'DingTalk login is disabled for this user',
+    )
+  })
+
+  it('rejects email auto-link when the matched local user is disabled', async () => {
+    vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
+      accessToken: 'access-token',
+    })
+    vi.mocked(fetchDingTalkCurrentUser).mockResolvedValue({
+      openId: 'open-id-1',
+      unionId: 'union-id-1',
+      nick: 'Ding User',
+      email: 'manager@example.com',
+    })
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'manager@example.com',
+          name: 'Manager',
+          role: 'disabled',
+          is_active: true,
+        }],
+      } as any)
+
+    await expect(exchangeCodeForUser('auth-code')).rejects.toThrow(
+      'DingTalk login is disabled for this user',
+    )
+  })
+
+  it('writes a password hash when auto-provisioning a new DingTalk user', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
+      accessToken: 'access-token',
+    })
+    vi.mocked(fetchDingTalkCurrentUser).mockResolvedValue({
+      openId: 'open-id-1',
+      unionId: 'union-id-1',
+      nick: 'Ding User',
+    })
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-new',
+          email: 'dingtalk_open-id-1@placeholder.local',
+          name: 'Ding User',
+          role: 'user',
+          is_active: true,
+        }],
+      } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+
+    vi.mocked(transaction).mockImplementation(async (callback: (client: { query: typeof query }) => Promise<unknown>) => {
+      const clientQuery = vi.fn()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+      return callback({ query: clientQuery as unknown as typeof query })
+    })
+
+    const result = await exchangeCodeForUser('auth-code')
+
+    expect(result.localUserId).toBe('user-new')
+    expect(vi.mocked(query).mock.calls[1]?.[0]).toContain('password_hash')
+    expect(vi.mocked(query).mock.calls[1]?.[1]?.[3]).toMatch(/^\$2[aby]\$/)
+  })
 })

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -362,7 +362,27 @@ describe('DingTalk OAuth state store', () => {
     expect(vi.mocked(query).mock.calls[0]?.[1]?.[4]).toBe('ding-corp-1')
   })
 
+  it('does not auto-link by email when the flag is unset', async () => {
+    vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
+      accessToken: 'access-token',
+    })
+    vi.mocked(fetchDingTalkCurrentUser).mockResolvedValue({
+      openId: 'open-id-1',
+      unionId: 'union-id-1',
+      nick: 'Ding User',
+      email: 'manager@example.com',
+    })
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as any)
+
+    await expect(exchangeCodeForUser('auth-code')).rejects.toThrow(
+      'DingTalk account manager@example.com is not linked to a local user',
+    )
+
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(1)
+  })
+
   it('rejects email auto-link when the matched local user is disabled', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1')
     vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
       accessToken: 'access-token',
     })

--- a/scripts/ops/backfill-dingtalk-corp-identities.sh
+++ b/scripts/ops/backfill-dingtalk-corp-identities.sh
@@ -17,26 +17,48 @@ function require_psql() {
 function usage() {
   cat <<'EOF'
 Usage:
-  backfill-dingtalk-corp-identities.sh --corp-id <corpId> [--apply]
+  backfill-dingtalk-corp-identities.sh --corp-id <corpId> [--export-file <path>]
+  backfill-dingtalk-corp-identities.sh --corp-id <corpId> --allowlist-file <path> --apply
 
 Environment:
   DATABASE_URL  PostgreSQL connection string (required)
 
 Behavior:
   - default mode is dry-run
-  - --apply performs the update after safety checks pass
+  - --export-file writes candidate rows to CSV for manual review
+  - --apply requires --allowlist-file and only updates allowlisted identity ids
 EOF
 }
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CORP_ID=""
 APPLY=0
+EXPORT_FILE=""
+ALLOWLIST_FILE=""
+ALLOWLIST_NORMALIZED=""
+
+function cleanup() {
+  if [[ -n "${ALLOWLIST_NORMALIZED}" && -f "${ALLOWLIST_NORMALIZED}" ]]; then
+    rm -f "${ALLOWLIST_NORMALIZED}"
+  fi
+}
+
+trap cleanup EXIT
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --corp-id)
       [[ $# -ge 2 ]] || die "--corp-id requires a value"
       CORP_ID="$2"
+      shift 2
+      ;;
+    --export-file)
+      [[ $# -ge 2 ]] || die "--export-file requires a value"
+      EXPORT_FILE="$2"
+      shift 2
+      ;;
+    --allowlist-file)
+      [[ $# -ge 2 ]] || die "--allowlist-file requires a value"
+      ALLOWLIST_FILE="$2"
       shift 2
       ;;
     --apply)
@@ -57,14 +79,43 @@ done
 [[ -n "${CORP_ID}" ]] || die "--corp-id is required"
 require_psql
 
-read_counts_sql() {
+if (( APPLY == 1 )) && [[ -z "${ALLOWLIST_FILE}" ]]; then
+  die "--apply requires --allowlist-file"
+fi
+
+if (( APPLY == 0 )) && [[ -n "${ALLOWLIST_FILE}" ]]; then
+  die "--allowlist-file is only valid together with --apply"
+fi
+
+function sanitize_allowlist_file() {
+  local source_file="$1"
+  [[ -f "${source_file}" ]] || die "allowlist file not found: ${source_file}"
+
+  local tmp_file
+  tmp_file="$(mktemp "${TMPDIR:-/tmp}/dingtalk-corp-allowlist.XXXXXX.csv")"
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line%%#*}"
+    line="$(printf '%s' "${line}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [[ -n "${line}" ]] || continue
+    printf '%s\n' "${line}" >> "${tmp_file}"
+  done < "${source_file}"
+
+  [[ -s "${tmp_file}" ]] || die "allowlist file contains no usable identity ids: ${source_file}"
+  ALLOWLIST_NORMALIZED="${tmp_file}"
+}
+
+function read_counts_sql() {
   cat <<'EOF'
 WITH candidate_rows AS (
   SELECT
     id,
+    local_user_id,
     provider_open_id,
+    provider_union_id,
     corp_id,
-    external_key
+    external_key,
+    created_at,
+    updated_at
   FROM user_external_identities
   WHERE provider = 'dingtalk'
     AND corp_id IS NULL
@@ -107,6 +158,27 @@ SELECT json_build_object(
 EOF
 }
 
+function candidate_export_sql() {
+  cat <<'EOF'
+COPY (
+  SELECT
+    id AS identity_id,
+    local_user_id,
+    provider_open_id,
+    provider_union_id,
+    external_key,
+    corp_id,
+    created_at,
+    updated_at
+  FROM user_external_identities
+  WHERE provider = 'dingtalk'
+    AND corp_id IS NULL
+    AND provider_open_id IS NOT NULL
+  ORDER BY updated_at DESC, created_at DESC, id DESC
+) TO STDOUT WITH CSV HEADER
+EOF
+}
+
 COUNTS_JSON="$(
   psql "${DATABASE_URL}" \
     --no-psqlrc \
@@ -128,26 +200,35 @@ for key in ("candidate_rows", "missing_open_id_rows", "conflict_rows", "apply_ro
     print(f"{key}={payload[key]}")
 PY
 
-CANDIDATE_ROWS="$(COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
-import json, os
-print(json.loads(os.environ["COUNTS_JSON"])["candidate_rows"])
-PY
-)"
-MISSING_OPEN_ID_ROWS="$(COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
+MISSING_OPEN_ID_ROWS="$(
+  COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
 import json, os
 print(json.loads(os.environ["COUNTS_JSON"])["missing_open_id_rows"])
 PY
 )"
-CONFLICT_ROWS="$(COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
+CONFLICT_ROWS="$(
+  COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
 import json, os
 print(json.loads(os.environ["COUNTS_JSON"])["conflict_rows"])
 PY
 )"
-APPLY_ROWS="$(COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
-import json, os
-print(json.loads(os.environ["COUNTS_JSON"])["apply_rows"])
-PY
-)"
+
+if [[ -n "${EXPORT_FILE}" ]]; then
+  mkdir -p "$(dirname "${EXPORT_FILE}")"
+  psql "${DATABASE_URL}" \
+    --no-psqlrc \
+    --set ON_ERROR_STOP=1 \
+    --quiet \
+    --command "$(candidate_export_sql)" > "${EXPORT_FILE}"
+  info "exported DingTalk corpId backfill candidates to ${EXPORT_FILE}"
+fi
+
+if (( APPLY == 0 )); then
+  info "dry-run complete for corpId=${CORP_ID}"
+  exit 0
+fi
+
+sanitize_allowlist_file "${ALLOWLIST_FILE}"
 
 if (( MISSING_OPEN_ID_ROWS > 0 )); then
   die "found ${MISSING_OPEN_ID_ROWS} legacy DingTalk identity rows with corp_id IS NULL and provider_open_id IS NULL; resolve them manually before corpId rollout"
@@ -157,9 +238,125 @@ if (( CONFLICT_ROWS > 0 )); then
   die "found ${CONFLICT_ROWS} corp-scoped external_key conflicts; resolve conflicts before corpId rollout"
 fi
 
-if (( APPLY == 0 )); then
-  info "dry-run complete for corpId=${CORP_ID} in ${ROOT_DIR}"
-  exit 0
+APPLY_JSON="$(
+  psql "${DATABASE_URL}" \
+    --no-psqlrc \
+    --set ON_ERROR_STOP=1 \
+    --set "corp_id=${CORP_ID}" \
+    --set "allowlist_file=${ALLOWLIST_NORMALIZED}" \
+    --tuples-only \
+    --quiet <<'SQL'
+CREATE TEMP TABLE dingtalk_allowlist (
+  identity_id text PRIMARY KEY
+) ON COMMIT DROP;
+
+\copy dingtalk_allowlist (identity_id) FROM :'allowlist_file' WITH (FORMAT csv)
+
+WITH allowlisted AS (
+  SELECT identity_id
+  FROM dingtalk_allowlist
+),
+missing_rows AS (
+  SELECT a.identity_id
+  FROM allowlisted a
+  LEFT JOIN user_external_identities identity ON identity.id::text = a.identity_id
+  WHERE identity.id IS NULL
+),
+invalid_candidate_rows AS (
+  SELECT a.identity_id
+  FROM allowlisted a
+  JOIN user_external_identities identity ON identity.id::text = a.identity_id
+  WHERE NOT (
+    identity.provider = 'dingtalk'
+    AND identity.corp_id IS NULL
+    AND identity.provider_open_id IS NOT NULL
+  )
+),
+conflict_rows AS (
+  SELECT a.identity_id
+  FROM allowlisted a
+  JOIN user_external_identities identity ON identity.id::text = a.identity_id
+  WHERE EXISTS (
+    SELECT 1
+    FROM user_external_identities existing
+    WHERE existing.provider = 'dingtalk'
+      AND existing.external_key = :'corp_id' || ':' || identity.provider_open_id
+      AND existing.id <> identity.id
+  )
+),
+updatable_rows AS (
+  SELECT identity.id
+  FROM allowlisted a
+  JOIN user_external_identities identity ON identity.id::text = a.identity_id
+  WHERE identity.provider = 'dingtalk'
+    AND identity.corp_id IS NULL
+    AND identity.provider_open_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM user_external_identities existing
+      WHERE existing.provider = 'dingtalk'
+        AND existing.external_key = :'corp_id' || ':' || identity.provider_open_id
+        AND existing.id <> identity.id
+    )
+)
+SELECT json_build_object(
+  'allowlisted_rows', (SELECT count(*)::bigint FROM allowlisted),
+  'missing_rows', (SELECT count(*)::bigint FROM missing_rows),
+  'invalid_candidate_rows', (SELECT count(*)::bigint FROM invalid_candidate_rows),
+  'conflict_rows', (SELECT count(*)::bigint FROM conflict_rows),
+  'updatable_rows', (SELECT count(*)::bigint FROM updatable_rows)
+)::text;
+SQL
+)"
+
+APPLY_JSON="$(printf '%s' "${APPLY_JSON}" | tr -d '\n' | sed 's/^ *//; s/ *$//')"
+[[ -n "${APPLY_JSON}" ]] || die "failed to validate allowlist"
+
+ALLOWLISTED_ROWS="$(
+  APPLY_JSON="${APPLY_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["APPLY_JSON"])["allowlisted_rows"])
+PY
+)"
+MISSING_ROWS="$(
+  APPLY_JSON="${APPLY_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["APPLY_JSON"])["missing_rows"])
+PY
+)"
+INVALID_CANDIDATE_ROWS="$(
+  APPLY_JSON="${APPLY_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["APPLY_JSON"])["invalid_candidate_rows"])
+PY
+)"
+ALLOWLIST_CONFLICT_ROWS="$(
+  APPLY_JSON="${APPLY_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["APPLY_JSON"])["conflict_rows"])
+PY
+)"
+UPDATABLE_ROWS="$(
+  APPLY_JSON="${APPLY_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["APPLY_JSON"])["updatable_rows"])
+PY
+)"
+
+if (( ALLOWLISTED_ROWS == 0 )); then
+  die "allowlist contains no identity ids"
+fi
+if (( MISSING_ROWS > 0 )); then
+  die "allowlist contains ${MISSING_ROWS} unknown identity ids"
+fi
+if (( INVALID_CANDIDATE_ROWS > 0 )); then
+  die "allowlist contains ${INVALID_CANDIDATE_ROWS} ids that are not eligible legacy DingTalk corp backfill candidates"
+fi
+if (( ALLOWLIST_CONFLICT_ROWS > 0 )); then
+  die "allowlist contains ${ALLOWLIST_CONFLICT_ROWS} ids that would collide with existing corp-scoped external keys"
+fi
+if (( UPDATABLE_ROWS == 0 )); then
+  die "allowlist did not select any updatable DingTalk identity rows"
 fi
 
 UPDATE_COUNT="$(
@@ -167,16 +364,23 @@ UPDATE_COUNT="$(
     --no-psqlrc \
     --set ON_ERROR_STOP=1 \
     --set "corp_id=${CORP_ID}" \
+    --set "allowlist_file=${ALLOWLIST_NORMALIZED}" \
     --tuples-only \
-    --quiet \
-    <<'SQL'
+    --quiet <<'SQL'
+CREATE TEMP TABLE dingtalk_allowlist (
+  identity_id text PRIMARY KEY
+) ON COMMIT DROP;
+
+\copy dingtalk_allowlist (identity_id) FROM :'allowlist_file' WITH (FORMAT csv)
+
 WITH updated AS (
   UPDATE user_external_identities identity
   SET
     corp_id = :'corp_id',
     external_key = :'corp_id' || ':' || identity.provider_open_id,
     updated_at = now()
-  WHERE identity.provider = 'dingtalk'
+  WHERE identity.id IN (SELECT identity_id::uuid FROM dingtalk_allowlist)
+    AND identity.provider = 'dingtalk'
     AND identity.corp_id IS NULL
     AND identity.provider_open_id IS NOT NULL
   RETURNING 1
@@ -186,4 +390,4 @@ SQL
 )"
 
 UPDATE_COUNT="$(printf '%s' "${UPDATE_COUNT}" | tr -d '\n' | sed 's/^ *//; s/ *$//')"
-info "applied corpId backfill for ${UPDATE_COUNT} legacy DingTalk identity rows"
+info "applied corpId backfill for ${UPDATE_COUNT} allowlisted DingTalk identity rows"

--- a/scripts/ops/backfill-dingtalk-corp-identities.sh
+++ b/scripts/ops/backfill-dingtalk-corp-identities.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function die() {
+  echo "[backfill-dingtalk-corp-identities] ERROR: $*" >&2
+  exit 1
+}
+
+function info() {
+  echo "[backfill-dingtalk-corp-identities] $*" >&2
+}
+
+function require_psql() {
+  command -v psql >/dev/null 2>&1 || die "psql is required"
+}
+
+function usage() {
+  cat <<'EOF'
+Usage:
+  backfill-dingtalk-corp-identities.sh --corp-id <corpId> [--apply]
+
+Environment:
+  DATABASE_URL  PostgreSQL connection string (required)
+
+Behavior:
+  - default mode is dry-run
+  - --apply performs the update after safety checks pass
+EOF
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CORP_ID=""
+APPLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --corp-id)
+      [[ $# -ge 2 ]] || die "--corp-id requires a value"
+      CORP_ID="$2"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "${DATABASE_URL:-}" ]] || die "DATABASE_URL is required"
+[[ -n "${CORP_ID}" ]] || die "--corp-id is required"
+require_psql
+
+read_counts_sql() {
+  cat <<'EOF'
+WITH candidate_rows AS (
+  SELECT
+    id,
+    provider_open_id,
+    corp_id,
+    external_key
+  FROM user_external_identities
+  WHERE provider = 'dingtalk'
+    AND corp_id IS NULL
+    AND provider_open_id IS NOT NULL
+),
+missing_open_id_rows AS (
+  SELECT count(*)::bigint AS count
+  FROM user_external_identities
+  WHERE provider = 'dingtalk'
+    AND corp_id IS NULL
+    AND provider_open_id IS NULL
+),
+conflict_rows AS (
+  SELECT count(*)::bigint AS count
+  FROM candidate_rows c
+  WHERE EXISTS (
+    SELECT 1
+    FROM user_external_identities existing
+    WHERE existing.provider = 'dingtalk'
+      AND existing.external_key = :'corp_id' || ':' || c.provider_open_id
+      AND existing.id <> c.id
+  )
+)
+SELECT json_build_object(
+  'candidate_rows', (SELECT count(*)::bigint FROM candidate_rows),
+  'missing_open_id_rows', (SELECT count FROM missing_open_id_rows),
+  'conflict_rows', (SELECT count FROM conflict_rows),
+  'apply_rows', (
+    SELECT count(*)::bigint
+    FROM candidate_rows c
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM user_external_identities existing
+      WHERE existing.provider = 'dingtalk'
+        AND existing.external_key = :'corp_id' || ':' || c.provider_open_id
+        AND existing.id <> c.id
+    )
+  )
+)::text;
+EOF
+}
+
+COUNTS_JSON="$(
+  psql "${DATABASE_URL}" \
+    --no-psqlrc \
+    --set ON_ERROR_STOP=1 \
+    --set "corp_id=${CORP_ID}" \
+    --tuples-only \
+    --quiet \
+    --command "$(read_counts_sql)"
+)"
+
+COUNTS_JSON="$(printf '%s' "${COUNTS_JSON}" | tr -d '\n' | sed 's/^ *//; s/ *$//')"
+[[ -n "${COUNTS_JSON}" ]] || die "failed to read candidate counts"
+
+COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
+import json
+import os
+payload = json.loads(os.environ["COUNTS_JSON"])
+for key in ("candidate_rows", "missing_open_id_rows", "conflict_rows", "apply_rows"):
+    print(f"{key}={payload[key]}")
+PY
+
+CANDIDATE_ROWS="$(COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["COUNTS_JSON"])["candidate_rows"])
+PY
+)"
+MISSING_OPEN_ID_ROWS="$(COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["COUNTS_JSON"])["missing_open_id_rows"])
+PY
+)"
+CONFLICT_ROWS="$(COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["COUNTS_JSON"])["conflict_rows"])
+PY
+)"
+APPLY_ROWS="$(COUNTS_JSON="${COUNTS_JSON}" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["COUNTS_JSON"])["apply_rows"])
+PY
+)"
+
+if (( MISSING_OPEN_ID_ROWS > 0 )); then
+  die "found ${MISSING_OPEN_ID_ROWS} legacy DingTalk identity rows with corp_id IS NULL and provider_open_id IS NULL; resolve them manually before corpId rollout"
+fi
+
+if (( CONFLICT_ROWS > 0 )); then
+  die "found ${CONFLICT_ROWS} corp-scoped external_key conflicts; resolve conflicts before corpId rollout"
+fi
+
+if (( APPLY == 0 )); then
+  info "dry-run complete for corpId=${CORP_ID} in ${ROOT_DIR}"
+  exit 0
+fi
+
+UPDATE_COUNT="$(
+  psql "${DATABASE_URL}" \
+    --no-psqlrc \
+    --set ON_ERROR_STOP=1 \
+    --set "corp_id=${CORP_ID}" \
+    --tuples-only \
+    --quiet \
+    <<'SQL'
+WITH updated AS (
+  UPDATE user_external_identities identity
+  SET
+    corp_id = :'corp_id',
+    external_key = :'corp_id' || ':' || identity.provider_open_id,
+    updated_at = now()
+  WHERE identity.provider = 'dingtalk'
+    AND identity.corp_id IS NULL
+    AND identity.provider_open_id IS NOT NULL
+  RETURNING 1
+)
+SELECT count(*)::bigint FROM updated;
+SQL
+)"
+
+UPDATE_COUNT="$(printf '%s' "${UPDATE_COUNT}" | tr -d '\n' | sed 's/^ *//; s/ *$//')"
+info "applied corpId backfill for ${UPDATE_COUNT} legacy DingTalk identity rows"


### PR DESCRIPTION
## Summary
- add the shared DingTalk OAuth/login foundation on top of current `main`
- expose `/api/auth/dingtalk/launch` and `/api/auth/dingtalk/callback`
- add the login-page DingTalk entry and callback route/view
- keep the slice narrow and compatible with current session/JWT flow

## Review Order
- review this PR first in the stack
- follow-up stacked PRs: `#723` and `#724`

## Scope
- backend shared DingTalk client and OAuth state store
- auth route integration with current MetaSheet session issuance
- login page DingTalk discovery and redirect flow
- callback page token/session handling
- `.env.example` additions for DingTalk auth config

## Review Fixes

Latest follow-up on top of `1f615a653`:

- `DINGTALK_AUTH_AUTO_LINK_EMAIL` is now safe-by-default and stays off unless explicitly enabled.
- `/api/auth/dingtalk/callback` now preserves `502` for upstream DingTalk failures and returns a generic `500` for unexpected local callback faults.
- Added corp-scoped rollout gate assets for `DINGTALK_CORP_ID`:
  - `scripts/ops/backfill-dingtalk-corp-identities.sh`
  - `docs/development/dingtalk-pr1-corpid-rollout-20260410.md`
  - rollout now uses candidate export + manual allowlist apply instead of whole-database apply
- Added backend regressions for:
  - default auto-link disabled behavior
  - unexpected local callback failures returning generic `500` responses

Latest local verification:

```bash
pnpm install --offline --frozen-lockfile
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/dingtalk-oauth-state-store.test.ts
pnpm --filter @metasheet/core-backend build
bash -n scripts/ops/backfill-dingtalk-corp-identities.sh
```

## Verification
- `pnpm install --offline --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/dingtalk-oauth-state-store.test.ts`
- `pnpm --filter @metasheet/core-backend build`
- earlier frontend review fixes remain covered by:
  - `pnpm --filter @metasheet/web exec vitest run tests/dingtalk-auth-callback.spec.ts tests/LoginView.spec.ts --watch=false`
  - `pnpm --filter @metasheet/web type-check`

## Docs
- `docs/development/dingtalk-pr1-foundation-login-design-20260408.md`
- `docs/development/dingtalk-pr1-foundation-login-verification-20260408.md`
- `docs/development/dingtalk-pr1-review-design-20260409.md`
- `docs/development/dingtalk-pr1-review-development-20260409.md`
- `docs/development/dingtalk-pr1-review-verification-20260409.md`
- `docs/development/dingtalk-pr1-corpid-rollout-20260410.md`

## Known Risks
- no live DingTalk tenant validation yet
- `DINGTALK_AUTH_AUTO_LINK_EMAIL` is now disabled by default and must be explicitly enabled for email auto-link rollout
- no admin-facing DingTalk grant management in this slice
- enabling `DINGTALK_CORP_ID` in production now requires candidate export, manual allowlist review, and a one-time backfill of approved legacy DingTalk identity rows before rollout

## Merge Readiness
- current status: ready to review
- refresh status: rebased onto latest `origin/main`, then updated with follow-up review fixes on `1f615a653` after the final minimal refresh onto the latest `origin/main`
- local verification status: backend review-fix tests and build passed on the latest head
- gate status: GitHub full checks are rerunning on the refreshed head; after green, the remaining gate is human review / approval
- next action: review and approve this PR first in the stack
- downstream impact: `#723` stays draft until this PR merges, then retargets to `main`
- production policy target for later rollout: `REQUIRE_GRANT=1`, `AUTO_LINK_EMAIL=1`, `AUTO_PROVISION=0`






