### PR TITLE
fix(attendance): require shift ids in rotation rules

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1829,7 +1829,7 @@ describe('Attendance Plugin Integration', () => {
     expect(lookupRes.status).toBe(200)
   })
 
-  it('normalizes name-based rotation rules to shift UUIDs and blocks deleting a shift with an active rotation assignment', async () => {
+  it('blocks deleting a shift that is referenced by a rotation rule created with shift IDs', async () => {
     if (!baseUrl) return
 
     const runSuffix = Date.now().toString(36)
@@ -1857,10 +1857,8 @@ describe('Attendance Plugin Integration', () => {
     })
     expect(shiftRes.status).toBe(201)
     const shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
-    const shiftName = (shiftRes.body as { data?: { name?: string } } | undefined)?.data?.name
     expect(shiftId).toBeTruthy()
-    expect(shiftName).toBeTruthy()
-    if (!shiftId || !shiftName) return
+    if (!shiftId) return
 
     const rotationRuleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
       method: 'POST',
@@ -1871,15 +1869,13 @@ describe('Attendance Plugin Integration', () => {
       body: JSON.stringify({
         name: `Delete Guard Rotation ${runSuffix}`,
         timezone: 'Asia/Shanghai',
-        shiftSequence: [shiftName],
+        shiftSequence: [shiftId],
         isActive: true,
       }),
     })
     expect(rotationRuleRes.status).toBe(201)
     const rotationRuleId = (rotationRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
-    const createdRotationRule = (rotationRuleRes.body as { data?: { shiftSequence?: string[] } } | undefined)?.data
     expect(rotationRuleId).toBeTruthy()
-    expect(createdRotationRule?.shiftSequence).toEqual([shiftId])
     if (!rotationRuleId) return
 
     const rotationAssignmentRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
@@ -1916,7 +1912,7 @@ describe('Attendance Plugin Integration', () => {
     expect(lookupRes.status).toBe(200)
   })
 
-  it('accepts UUID-like shift names for rotation rules and runtime rotation resolution', async () => {
+  it('rejects non-UUID shift references for rotation rules, including UUID-like shift names', async () => {
     if (!baseUrl) return
 
     const runSuffix = Date.now().toString(36)
@@ -1928,9 +1924,28 @@ describe('Attendance Plugin Integration', () => {
     expect(token).toBeTruthy()
     if (!token) return
 
+    const shiftName = `Rotation Name Shift ${runSuffix}`
     const shiftUuidLikeName = randomUuidV4()
-    const workDate = '2026-03-30'
     const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: shiftName,
+        timezone: 'Asia/Tokyo',
+        workStartTime: '09:00',
+        workEndTime: '18:00',
+        workingDays: [1, 2, 3, 4, 5],
+      }),
+    })
+    expect(shiftRes.status).toBe(201)
+    const shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+    expect(shiftId).toBeTruthy()
+    if (!shiftId) return
+
+    const uuidLikeShiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -1944,65 +1959,91 @@ describe('Attendance Plugin Integration', () => {
         workingDays: [1, 2, 3, 4, 5],
       }),
     })
-    expect(shiftRes.status).toBe(201)
-    const shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
-    expect(shiftId).toBeTruthy()
-    if (!shiftId) return
+    expect(uuidLikeShiftRes.status).toBe(201)
 
-    const rotationRuleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
+    const invalidCreateByNameRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        name: `UUID Like Rotation ${runSuffix}`,
+        name: `Invalid Name Rotation ${runSuffix}`,
         timezone: 'Asia/Tokyo',
-        shiftSequence: [shiftUuidLikeName],
+        shiftSequence: [shiftName],
         isActive: true,
       }),
     })
-    expect(rotationRuleRes.status).toBe(201)
-    const rotationRule = (rotationRuleRes.body as { data?: { id?: string; shiftSequence?: string[] } } | undefined)?.data
-    expect(rotationRule?.shiftSequence).toEqual([shiftId])
-    expect(rotationRule?.id).toBeTruthy()
-    if (!rotationRule?.id) return
+    expect(invalidCreateByNameRes.status).toBe(400)
+    const invalidCreateByNameBody = invalidCreateByNameRes.body as { error?: { code?: string; message?: string } } | undefined
+    expect(invalidCreateByNameBody?.error?.code).toBe('VALIDATION_ERROR')
+    expect(String(invalidCreateByNameBody?.error?.message ?? '')).toContain('shiftSequence must contain shift IDs')
 
-    const rotationAssignmentRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+    const invalidCreateByUuidLikeNameRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        userId: testUserId,
-        rotationRuleId: rotationRule.id,
-        startDate: workDate,
-        isActive: true,
+        name: `Invalid UUID Like Rotation ${runSuffix}`,
+        timezone: 'Asia/Tokyo',
+        shift_sequence: [shiftUuidLikeName],
+        is_active: true,
       }),
     })
-    expect(rotationAssignmentRes.status).toBe(201)
+    expect(invalidCreateByUuidLikeNameRes.status).toBe(400)
+    const invalidCreateByUuidLikeNameBody = invalidCreateByUuidLikeNameRes.body as { error?: { code?: string; message?: string } } | undefined
+    expect(invalidCreateByUuidLikeNameBody?.error?.code).toBe('VALIDATION_ERROR')
+    expect(String(invalidCreateByUuidLikeNameBody?.error?.message ?? '')).toContain('shiftSequence must contain shift IDs')
 
-    const punchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+    const validRotationRuleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        eventType: 'check_in',
-        occurredAt: `${workDate}T09:00:00+09:00`,
+        name: `Valid Rotation ${runSuffix}`,
+        timezone: 'Asia/Tokyo',
+        shiftSequence: [shiftId],
+        isActive: true,
       }),
     })
-    expect(punchRes.status).toBe(200)
-    const punchBody = punchRes.body as {
-      data?: {
-        event?: { timezone?: string; workDate?: string; work_date?: string }
-        record?: { timezone?: string; workDate?: string; work_date?: string }
-      }
-    } | undefined
-    expect(punchBody?.data?.event?.timezone).toBe('Asia/Tokyo')
-    expect(punchBody?.data?.record?.timezone).toBe('Asia/Tokyo')
+    expect(validRotationRuleRes.status).toBe(201)
+    const rotationRuleId = (validRotationRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+    expect(rotationRuleId).toBeTruthy()
+    if (!rotationRuleId) return
+
+    const invalidUpdateByNameRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules/${rotationRuleId}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        shiftSequence: [shiftName],
+      }),
+    })
+    expect(invalidUpdateByNameRes.status).toBe(400)
+    const invalidUpdateByNameBody = invalidUpdateByNameRes.body as { error?: { code?: string; message?: string } } | undefined
+    expect(invalidUpdateByNameBody?.error?.code).toBe('VALIDATION_ERROR')
+    expect(String(invalidUpdateByNameBody?.error?.message ?? '')).toContain('shiftSequence must contain shift IDs')
+
+    const invalidUpdateByUuidLikeNameRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules/${rotationRuleId}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        shift_sequence: [shiftUuidLikeName],
+      }),
+    })
+    expect(invalidUpdateByUuidLikeNameRes.status).toBe(400)
+    const invalidUpdateByUuidLikeNameBody = invalidUpdateByUuidLikeNameRes.body as { error?: { code?: string; message?: string } } | undefined
+    expect(invalidUpdateByUuidLikeNameBody?.error?.code).toBe('VALIDATION_ERROR')
+    expect(String(invalidUpdateByUuidLikeNameBody?.error?.message ?? '')).toContain('shiftSequence must contain shift IDs')
   })
 
   it('returns 409 when deleting a shift that is still referenced by a rotation rule without assignments', async () => {

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -674,6 +674,7 @@ components:
           type: array
           items:
             type: string
+            format: uuid
         isActive:
           type: boolean
     AttendanceRotationAssignment:
@@ -6284,12 +6285,15 @@ paths:
                   type: string
                 shiftSequence:
                   type: array
+                  description: Ordered shift IDs.
                   items:
                     type: string
+                    format: uuid
                 shiftIds:
                   type: array
                   items:
                     type: string
+                    format: uuid
                   description: Compatibility alias for shiftSequence.
                 isActive:
                   type: boolean
@@ -6299,11 +6303,13 @@ paths:
                   type: array
                   items:
                     type: string
+                    format: uuid
                   description: Legacy snake_case alias for shiftSequence.
                 shift_ids:
                   type: array
                   items:
                     type: string
+                    format: uuid
                   description: Compatibility alias for shiftSequence.
                 is_active:
                   type: boolean
@@ -6428,8 +6434,16 @@ paths:
                   type: string
                 shiftSequence:
                   type: array
+                  description: Ordered shift IDs.
                   items:
                     type: string
+                    format: uuid
+                shift_sequence:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  description: Legacy snake_case alias for shiftSequence.
                 isActive:
                   type: boolean
                 orgId:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -954,7 +954,8 @@
           "shiftSequence": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           "isActive": {
@@ -9680,14 +9681,17 @@
                   },
                   "shiftSequence": {
                     "type": "array",
+                    "description": "Ordered shift IDs.",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     }
                   },
                   "shiftIds": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     },
                     "description": "Compatibility alias for shiftSequence."
                   },
@@ -9700,14 +9704,16 @@
                   "shift_sequence": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     },
                     "description": "Legacy snake_case alias for shiftSequence."
                   },
                   "shift_ids": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     },
                     "description": "Compatibility alias for shiftSequence."
                   },
@@ -9899,9 +9905,19 @@
                   },
                   "shiftSequence": {
                     "type": "array",
+                    "description": "Ordered shift IDs.",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     }
+                  },
+                  "shift_sequence": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "description": "Legacy snake_case alias for shiftSequence."
                   },
                   "isActive": {
                     "type": "boolean"

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -674,6 +674,7 @@ components:
           type: array
           items:
             type: string
+            format: uuid
         isActive:
           type: boolean
     AttendanceRotationAssignment:
@@ -6284,12 +6285,15 @@ paths:
                   type: string
                 shiftSequence:
                   type: array
+                  description: Ordered shift IDs.
                   items:
                     type: string
+                    format: uuid
                 shiftIds:
                   type: array
                   items:
                     type: string
+                    format: uuid
                   description: Compatibility alias for shiftSequence.
                 isActive:
                   type: boolean
@@ -6299,11 +6303,13 @@ paths:
                   type: array
                   items:
                     type: string
+                    format: uuid
                   description: Legacy snake_case alias for shiftSequence.
                 shift_ids:
                   type: array
                   items:
                     type: string
+                    format: uuid
                   description: Compatibility alias for shiftSequence.
                 is_active:
                   type: boolean
@@ -6428,8 +6434,16 @@ paths:
                   type: string
                 shiftSequence:
                   type: array
+                  description: Ordered shift IDs.
                   items:
                     type: string
+                    format: uuid
+                shift_sequence:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  description: Legacy snake_case alias for shiftSequence.
                 isActive:
                   type: boolean
                 orgId:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -629,6 +629,7 @@ components:
           type: array
           items:
             type: string
+            format: uuid
         isActive:
           type: boolean
     AttendanceRotationAssignment:

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -2387,20 +2387,21 @@ paths:
                 timezone: { type: string }
                 shiftSequence:
                   type: array
-                  items: { type: string }
+                  description: Ordered shift IDs.
+                  items: { type: string, format: uuid }
                 shiftIds:
                   type: array
-                  items: { type: string }
+                  items: { type: string, format: uuid }
                   description: Compatibility alias for shiftSequence.
                 isActive: { type: boolean }
                 orgId: { type: string }
                 shift_sequence:
                   type: array
-                  items: { type: string }
+                  items: { type: string, format: uuid }
                   description: Legacy snake_case alias for shiftSequence.
                 shift_ids:
                   type: array
-                  items: { type: string }
+                  items: { type: string, format: uuid }
                   description: Compatibility alias for shiftSequence.
                 is_active:
                   type: boolean
@@ -2503,7 +2504,12 @@ paths:
                 timezone: { type: string }
                 shiftSequence:
                   type: array
-                  items: { type: string }
+                  description: Ordered shift IDs.
+                  items: { type: string, format: uuid }
+                shift_sequence:
+                  type: array
+                  items: { type: string, format: uuid }
+                  description: Legacy snake_case alias for shiftSequence.
                 isActive: { type: boolean }
                 orgId: { type: string }
       responses:

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -880,6 +880,39 @@ function normalizeUuidString(value) {
     : null
 }
 
+async function validateRotationShiftSequenceIds(db, orgId, shiftSequence) {
+  const targetOrg = orgId || DEFAULT_ORG_ID
+  const normalizedSequence = normalizeStringArray(shiftSequence)
+  if (normalizedSequence.length === 0) {
+    return { shiftSequence: [], invalidReferences: [] }
+  }
+
+  const normalizedIds = normalizedSequence.map((shiftRef) => normalizeUuidString(shiftRef))
+  const malformedReferences = normalizedSequence.filter((_, index) => !normalizedIds[index])
+  if (malformedReferences.length > 0) {
+    return { shiftSequence: normalizedSequence, invalidReferences: malformedReferences }
+  }
+
+  const rows = await db.query(
+    'SELECT id FROM attendance_shifts WHERE org_id = $1 AND id = ANY($2::uuid[])',
+    [targetOrg, normalizedIds]
+  )
+  const existingIds = new Set(
+    rows
+      .map((row) => normalizeUuidString(row?.id))
+      .filter(Boolean)
+  )
+  const missingReferences = normalizedSequence.filter((shiftId) => !existingIds.has(shiftId))
+  if (missingReferences.length > 0) {
+    return { shiftSequence: normalizedSequence, invalidReferences: missingReferences }
+  }
+
+  return {
+    shiftSequence: normalizedIds,
+    invalidReferences: [],
+  }
+}
+
 function respondInvalidUuid(res, fieldName = 'id') {
   res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `${fieldName} must be a UUID` } })
 }
@@ -5016,39 +5049,6 @@ async function loadShiftReferenceLookup(db, orgId, options = {}) {
     )
   }
   return buildShiftReferenceLookup(rows)
-}
-
-async function normalizeRotationShiftSequence(db, orgId, shiftSequence, options = {}) {
-  const lookup = options.lookup ?? await loadShiftReferenceLookup(db, orgId)
-  const preserveUnknown = options.preserveUnknown === true
-  const nextSequence = []
-  const missingReferences = []
-  const ambiguousReferences = []
-  let changed = false
-
-  for (const shiftRef of normalizeStringArray(shiftSequence)) {
-    const resolution = resolveShiftReference(shiftRef, lookup)
-    if (resolution.status === 'resolved' && resolution.shift?.id) {
-      nextSequence.push(resolution.shift.id)
-      if (resolution.shift.id !== resolution.normalizedRef) changed = true
-      continue
-    }
-    if (resolution.status === 'ambiguous') {
-      ambiguousReferences.push(resolution.normalizedRef)
-    } else {
-      missingReferences.push(resolution.normalizedRef)
-    }
-    if (preserveUnknown && resolution.normalizedRef) {
-      nextSequence.push(resolution.normalizedRef)
-    }
-  }
-
-  return {
-    shiftSequence: nextSequence,
-    missingReferences,
-    ambiguousReferences,
-    changed,
-  }
 }
 
 async function loadShiftByReference(db, orgId, shiftRef) {
@@ -11961,28 +11961,15 @@ module.exports = {
         const orgId = getOrgId(req)
 
         try {
-          const normalizedSequence = await normalizeRotationShiftSequence(db, orgId, parsed.data.shiftSequence)
+          const normalizedSequence = await validateRotationShiftSequenceIds(db, orgId, parsed.data.shiftSequence)
           if (normalizedSequence.shiftSequence.length === 0) {
             res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Shift sequence required' } })
             return
           }
-          if (normalizedSequence.ambiguousReferences.length > 0) {
+          if (normalizedSequence.invalidReferences.length > 0) {
             res.status(400).json({
               ok: false,
-              error: {
-                code: 'VALIDATION_ERROR',
-                message: `Shift sequence contains ambiguous shift names: ${normalizedSequence.ambiguousReferences.join(', ')}`,
-              },
-            })
-            return
-          }
-          if (normalizedSequence.missingReferences.length > 0) {
-            res.status(400).json({
-              ok: false,
-              error: {
-                code: 'VALIDATION_ERROR',
-                message: `Shift sequence contains unknown shift references: ${normalizedSequence.missingReferences.join(', ')}`,
-              },
+              error: { code: 'VALIDATION_ERROR', message: 'shiftSequence must contain shift IDs' },
             })
             return
           }
@@ -12050,7 +12037,7 @@ module.exports = {
           }
 
           const existing = existingRows[0]
-          const normalizedSequence = await normalizeRotationShiftSequence(
+          const normalizedSequence = await validateRotationShiftSequenceIds(
             db,
             orgId,
             parsed.data.shiftSequence ?? existing.shift_sequence
@@ -12059,23 +12046,10 @@ module.exports = {
             res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Shift sequence required' } })
             return
           }
-          if (normalizedSequence.ambiguousReferences.length > 0) {
+          if (normalizedSequence.invalidReferences.length > 0) {
             res.status(400).json({
               ok: false,
-              error: {
-                code: 'VALIDATION_ERROR',
-                message: `Shift sequence contains ambiguous shift names: ${normalizedSequence.ambiguousReferences.join(', ')}`,
-              },
-            })
-            return
-          }
-          if (normalizedSequence.missingReferences.length > 0) {
-            res.status(400).json({
-              ok: false,
-              error: {
-                code: 'VALIDATION_ERROR',
-                message: `Shift sequence contains unknown shift references: ${normalizedSequence.missingReferences.join(', ')}`,
-              },
+              error: { code: 'VALIDATION_ERROR', message: 'shiftSequence must contain shift IDs' },
             })
             return
           }


### PR DESCRIPTION
## Summary
- tighten attendance rotation rule create/update payloads to accept ordered shift IDs only
- reject name-based and UUID-like-name shiftSequence entries with a fixed validation error
- align OpenAPI and integration coverage with the ID-only contract

## Verification
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false