### PR TITLE
test(contract): recut PLM consumer pact harness

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -22,6 +22,7 @@
     "test:unit": "vitest run tests/unit --reporter=dot",
     "test:integration": "vitest --config vitest.integration.config.ts run tests/integration --reporter=dot",
     "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --reporter=dot",
+    "test:contract": "vitest run tests/contract --reporter=dot",
     "test:cache": "npm run build:cache && TEST_USE_DIST=true vitest --config vitest.cache.config.ts run --reporter=dot",
     "clean": "rimraf dist"
   },

--- a/packages/core-backend/tests/PACKAGE_SCRIPTS.md
+++ b/packages/core-backend/tests/PACKAGE_SCRIPTS.md
@@ -33,3 +33,4 @@ Add these scripts to your `package.json` for convenient test execution:
 - `npm run test:unit` - Run all unit tests
 - `npm run test:perf` - Run only performance tests
 - `npm run test:ui` - Open Vitest UI for interactive testing
+- `npm run test:contract` - Run Pact consumer contract tests

--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -1,0 +1,169 @@
+# Contract Tests
+
+This directory holds the consumer-side Pact contract tests for the Metasheet2
+PLM adapter against Yuantus.
+
+## What lives here
+
+```
+contract/
+├── README.md                                  ← this file
+├── plm-adapter-yuantus.pact.test.ts          ← vitest sanity test
+└── pacts/
+    └── metasheet2-yuantus-plm.json           ← the canonical pact artifact
+```
+
+## Why this exists
+
+Metasheet2 already calls Yuantus PLM in production through `PLMAdapter.ts`
+when running in `apiMode='yuantus'`. Without a contract test, any field
+rename on the Yuantus side would silently break Metasheet at runtime.
+
+This Pact set freezes the **shape** (not the values) of the 6 Wave 1 P0
+endpoints that `PLMAdapter.ts` currently calls. (Codex's PACT_FIRST plan
+lists 7 endpoints in Wave 1 — see "Discrepancy with codex plan" below.)
+
+The companion provider verifier lives in the Yuantus repo at
+`src/yuantus/api/tests/test_pact_provider_yuantus_plm.py`.
+
+## Current implementation note (2026-04-07)
+
+The pact JSON in `pacts/metasheet2-yuantus-plm.json` is **hand-authored** in
+Pact v3 format. It is **not** yet generated from `@pact-foundation/pact`,
+because adding that npm dependency requires explicit approval.
+
+The `plm-adapter-yuantus.pact.test.ts` vitest test guards three things:
+
+1. The pact JSON exists and parses as Pact v3.
+2. It contains the 6 Wave 1 P0 interactions in the documented order.
+3. Every endpoint named in the pact is also referenced by the live
+   `packages/core-backend/src/data-adapters/PLMAdapter.ts` source — so the
+   pact cannot drift away from what the adapter actually calls.
+
+## Discrepancy with codex's PACT_FIRST plan
+
+`docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md` lists 7 endpoints in Wave 1
+P0, including `GET /api/v1/aml/metadata/{item_type_name}`. When the
+contract test was first authored that endpoint was included, and the test
+**immediately failed** with:
+
+> PLMAdapter.ts no longer references /api/v1/aml/metadata/; pact has drifted
+> from the consumer.
+
+A grep across `metasheet2/packages/core-backend/src` confirmed no caller.
+The endpoint exists in Yuantus (`router.py:52`) and is intended for
+front-end form rendering, but the metasheet2 adapter does not yet use it.
+
+Per the contract-first principle, the pact must freeze what the consumer
+**actually** calls, not what is planned. The metadata endpoint has been
+moved to Wave 1.5 and will be added to this pact as soon as PLMAdapter
+starts calling it. When that happens:
+
+1. Add the call site in `PLMAdapter.ts`
+2. Add a new interaction back into `pacts/metasheet2-yuantus-plm.json`
+3. Add the path back into `WAVE_1_P0_PATHS` in the test
+4. Re-copy JSON to `Yuantus/contracts/pacts/`
+
+This drift catch is the pact gate working correctly on day one. The cost
+of removing one anticipated endpoint is much smaller than the cost of
+discovering an aspirational pact never matches the consumer.
+
+## Running the test
+
+```bash
+# from packages/core-backend/
+npm run test:contract
+```
+
+This runs under the existing vitest harness with no new dependencies.
+
+## Provider verification (Yuantus side)
+
+To verify Yuantus against this pact, copy or symlink the JSON into the
+Yuantus contracts directory and run the provider verifier:
+
+```bash
+cp pacts/metasheet2-yuantus-plm.json \
+   /Users/huazhou/Downloads/Github/Yuantus/contracts/pacts/
+
+cd /Users/huazhou/Downloads/Github/Yuantus
+./.venv/bin/python -m pytest \
+   src/yuantus/api/tests/test_pact_provider_yuantus_plm.py
+```
+
+### Current verifier state (2026-04-08)
+
+Wired end-to-end with `pact-python 3.2.1`. Verifier no longer skips —
+it actually starts the FastAPI app, replays each interaction, and reports
+real verification results.
+
+**Wave 1 baseline result: 1 passing, 5 failing.**
+
+| Interaction | State | Why |
+|---|---|---|
+| `GET /api/v1/health` | ✅ PASS | no auth / no provider state needed |
+| `POST /api/v1/auth/login` | ❌ FAIL | needs seeded test user (Wave 1.5) |
+| `GET /api/v1/search/` | ❌ FAIL | needs seeded item + auth token (Wave 1.5) |
+| `POST /api/v1/aml/apply` | ❌ FAIL | needs seeded test Part with id 01H...P1 (Wave 1.5) |
+| `GET /api/v1/bom/{id}/tree` | ❌ FAIL | needs seeded BOM relationship (Wave 1.5) |
+| `GET /api/v1/bom/compare` | ❌ FAIL | needs two seeded comparable items (Wave 1.5) |
+
+The 5 failing interactions are NOT shape drift — they fail because the
+provider state handler is currently a no-op and the requests hit a clean
+test database. Implementing real state seeding is tracked as Wave 1.5
+work; the deliberate break experiment in
+`Yuantus/docs/PACT_DELIBERATE_BREAK_EXPERIMENT_20260408.md` confirmed the
+gate correctly distinguishes "missing state" from "real shape drift".
+
+To install `pact-python` and run locally:
+
+```bash
+./.venv/bin/pip install pact-python
+```
+
+## Upgrading to a real consumer pact later
+
+When `@pact-foundation/pact` is approved as a devDependency, replace the
+hand-authored JSON with a real generated artifact:
+
+```bash
+npm install --save-dev @pact-foundation/pact
+```
+
+Then rewrite `plm-adapter-yuantus.pact.test.ts` to:
+
+1. Construct a `Pact` instance via `new PactV3({ consumer: 'Metasheet2', provider: 'YuantusPLM' })`.
+2. For each Wave 1 endpoint, declare the interaction via `pact.addInteraction()`.
+3. Call the actual `PLMAdapter` method against the mock URL.
+4. `pact.executeTest(...)` writes the artifact to `pacts/metasheet2-yuantus-plm.json`.
+
+The artifact path stays the same, so the Yuantus provider verifier does not
+need to be reconfigured. The current sanity test serves as an executable
+specification of what the generated pact must contain.
+
+## Wave 2 endpoints
+
+These are intentionally NOT in the Wave 1 pact:
+
+- `GET /api/v1/bom/{id}/where-used`
+- `GET /api/v1/bom/compare/schema`
+- `GET /api/v1/file/item/{item_id}`
+- `GET /api/v1/eco/{id}/approvals`
+- `POST /api/v1/eco/{id}/approve`
+- `POST /api/v1/eco/{id}/reject`
+
+They will be added in a Wave 2 pact once Wave 1 is verified green in CI on
+both repos. See `docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md` §"Two-Week
+Execution Sequence" -> Week 2 in the Yuantus repo.
+
+## Forward compatibility note
+
+The `metasheet2-plm-workbench` long-running spike branch has version-aware
+`approveApproval(id, **version**, comment)` and `rejectApproval(id, **version**,
+comment)` for optimistic locking. When that improvement merges back into this
+mainline branch, the Wave 2 pact for `/api/v1/eco/{id}/approve` should
+declare the `version` field as **optional** so the contract does not
+retroactively break this branch's existing approve/reject signature.
+
+The full repo source-of-truth analysis lives at
+`/Users/huazhou/Downloads/Github/Yuantus/docs/METASHEET_REPO_SOURCE_OF_TRUTH_INVESTIGATION_20260407.md`.

--- a/packages/core-backend/tests/contract/harness-discoverability.test.ts
+++ b/packages/core-backend/tests/contract/harness-discoverability.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const PKG_ROOT = resolve(__dirname, '..', '..')
+const pkg = JSON.parse(readFileSync(resolve(PKG_ROOT, 'package.json'), 'utf8'))
+const scripts: Record<string, string> = pkg.scripts ?? {}
+const docsPath = resolve(PKG_ROOT, 'tests', 'PACKAGE_SCRIPTS.md')
+const docs = existsSync(docsPath) ? readFileSync(docsPath, 'utf8') : ''
+
+describe('PLM consumer pact harness discoverability', () => {
+  it('package.json exposes test:contract for the pact suite', () => {
+    expect(scripts['test:contract']).toBeDefined()
+    expect(scripts['test:contract']).toContain('tests/contract')
+  })
+
+  it('PACKAGE_SCRIPTS.md documents test:contract', () => {
+    expect(docs).toContain('test:contract')
+  })
+
+  it('contract README exists', () => {
+    expect(existsSync(resolve(PKG_ROOT, 'tests', 'contract', 'README.md'))).toBe(true)
+  })
+
+  it('consumer pact artifact exists', () => {
+    expect(existsSync(resolve(PKG_ROOT, 'tests', 'contract', 'pacts', 'metasheet2-yuantus-plm.json'))).toBe(true)
+  })
+})

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -1,0 +1,376 @@
+{
+  "consumer": {
+    "name": "Metasheet2"
+  },
+  "provider": {
+    "name": "YuantusPLM"
+  },
+  "metadata": {
+    "pactSpecification": {
+      "version": "3.0.0"
+    },
+    "claudeNote": "Hand-authored Wave 1 P0 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called, so metadata is deferred to Wave 2 (or earlier once PLMAdapter starts using it)."
+  },
+  "interactions": [
+    {
+      "description": "authenticate with tenant credentials and receive a JWT",
+      "providerStates": [
+        {
+          "name": "a tenant user with valid credentials exists"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/auth/login",
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "tenant_id": "tenant-1",
+          "username": "metasheet-svc",
+          "password": "secret"
+        },
+        "matchingRules": {
+          "body": {
+            "$.tenant_id": { "matchers": [{ "match": "type" }] },
+            "$.username": { "matchers": [{ "match": "type" }] },
+            "$.password": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "access_token": "eyJhbGciOiJIUzI1NiJ9.example",
+          "token_type": "bearer",
+          "expires_in": 3600,
+          "tenant_id": "tenant-1",
+          "user_id": 1
+        },
+        "matchingRules": {
+          "body": {
+            "$.access_token": { "matchers": [{ "match": "type" }] },
+            "$.token_type": { "matchers": [{ "match": "type" }] },
+            "$.expires_in": { "matchers": [{ "match": "integer" }] },
+            "$.tenant_id": { "matchers": [{ "match": "type" }] },
+            "$.user_id": { "matchers": [{ "match": "integer" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "probe service health",
+      "providerStates": [
+        {
+          "name": "the provider is up"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/health"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "ok": true,
+          "service": "yuantus-plm",
+          "version": "0.1.3",
+          "tenant_id": null,
+          "org_id": null,
+          "tenancy_mode": "db-per-tenant-org",
+          "schema_mode": "shared",
+          "audit_enabled": true
+        },
+        "matchingRules": {
+          "body": {
+            "$.ok": { "matchers": [{ "match": "type" }] },
+            "$.service": { "matchers": [{ "match": "type" }] },
+            "$.version": { "matchers": [{ "match": "type" }] },
+            "$.tenancy_mode": { "matchers": [{ "match": "type" }] },
+            "$.schema_mode": { "matchers": [{ "match": "type" }] },
+            "$.audit_enabled": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "search items by query string and item type",
+      "providerStates": [
+        {
+          "name": "at least one item of type Part exists"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/search/",
+        "query": {
+          "q": ["bracket"],
+          "item_type": ["Part"],
+          "limit": ["20"]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "total": 1,
+          "hits": [
+            {
+              "id": "01H000000000000000000000P1",
+              "item_type_id": "Part",
+              "config_id": "01H000000000000000000000C1",
+              "state": "Released",
+              "item_number": "P-0001",
+              "name": "Mounting Bracket",
+              "description": "Steel mounting bracket",
+              "search_text": "P-0001 Mounting Bracket Steel mounting bracket",
+              "created_at": "2026-01-01T00:00:00Z",
+              "updated_at": null,
+              "properties": {}
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.total": { "matchers": [{ "match": "integer" }] },
+            "$.hits": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.hits[*].id": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].item_type_id": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].config_id": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].state": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].item_number": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].name": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].description": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].search_text": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].created_at": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].updated_at": { "matchers": [{ "match": "type" }] },
+            "$.hits[*].properties": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch a single item by id through the AML apply RPC entry point",
+      "providerStates": [
+        {
+          "name": "an item with id 01H000000000000000000000P1 of type Part exists"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/aml/apply",
+        "headers": {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "body": {
+          "type": "Part",
+          "action": "get",
+          "id": "01H000000000000000000000P1"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+            }
+          },
+          "body": {
+            "$.type": { "matchers": [{ "match": "type" }] },
+            "$.action": { "matchers": [{ "match": "regex", "regex": "^(get|add|update|delete)$" }] },
+            "$.id": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "count": 1,
+          "items": [
+            {
+              "id": "01H000000000000000000000P1",
+              "type": "Part",
+              "state": "Released",
+              "properties": {
+                "item_number": "P-0001",
+                "name": "Mounting Bracket"
+              }
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.count": { "matchers": [{ "match": "integer", "min": 0 }] },
+            "$.items": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.items[*].id": { "matchers": [{ "match": "type" }] },
+            "$.items[*].type": { "matchers": [{ "match": "type" }] },
+            "$.items[*].state": { "matchers": [{ "match": "type" }] },
+            "$.items[*].properties": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch a multi-level BOM tree for a top-level Part",
+      "providerStates": [
+        {
+          "name": "a Part with id 01H000000000000000000000P1 has at least one child"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/bom/01H000000000000000000000P1/tree",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": "01H000000000000000000000P1",
+          "item_number": "P-0001",
+          "name": "Mounting Bracket",
+          "state": "Released",
+          "created_on": "2026-01-01T00:00:00Z",
+          "modified_on": null,
+          "children": [
+            {
+              "child": {
+                "id": "01H000000000000000000000P2",
+                "item_number": "P-0002",
+                "name": "Bolt M6",
+                "state": "Released",
+                "created_on": "2026-01-01T00:00:00Z",
+                "modified_on": null,
+                "children": []
+              },
+              "relationship": {
+                "id": "01H000000000000000000000R1",
+                "source_id": "01H000000000000000000000P1",
+                "related_id": "01H000000000000000000000P2",
+                "quantity": 4,
+                "uom": "ea",
+                "find_num": "10",
+                "refdes": "B1",
+                "created_on": "2026-01-01T00:00:00Z",
+                "modified_on": null,
+                "properties": {}
+              }
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": { "matchers": [{ "match": "type" }] },
+            "$.item_number": { "matchers": [{ "match": "type" }] },
+            "$.name": { "matchers": [{ "match": "type" }] },
+            "$.state": { "matchers": [{ "match": "type" }] },
+            "$.created_on": { "matchers": [{ "match": "type" }] },
+            "$.modified_on": { "matchers": [{ "match": "type" }] },
+            "$.children": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.children[*].child.id": { "matchers": [{ "match": "type" }] },
+            "$.children[*].child.item_number": { "matchers": [{ "match": "type" }] },
+            "$.children[*].child.name": { "matchers": [{ "match": "type" }] },
+            "$.children[*].child.state": { "matchers": [{ "match": "type" }] },
+            "$.children[*].child.created_on": { "matchers": [{ "match": "type" }] },
+            "$.children[*].child.modified_on": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.id": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.source_id": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.related_id": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.quantity": { "matchers": [{ "match": "number" }] },
+            "$.children[*].relationship.uom": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.find_num": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.refdes": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.created_on": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.modified_on": { "matchers": [{ "match": "type" }] },
+            "$.children[*].relationship.properties": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "compare two BOM versions and report added/removed/changed entries",
+      "providerStates": [
+        {
+          "name": "two comparable BOM-bearing items 01H000000000000000000000P1 and 01H000000000000000000000P2 exist"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/bom/compare",
+        "query": {
+          "left_type": ["item"],
+          "left_id": ["01H000000000000000000000P1"],
+          "right_type": ["item"],
+          "right_id": ["01H000000000000000000000P2"]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "summary": {
+            "added": 0,
+            "removed": 0,
+            "changed": 0
+          },
+          "added": [],
+          "removed": [],
+          "changed": []
+        },
+        "matchingRules": {
+          "body": {
+            "$.summary.added": { "matchers": [{ "match": "integer", "min": 0 }] },
+            "$.summary.removed": { "matchers": [{ "match": "integer", "min": 0 }] },
+            "$.summary.changed": { "matchers": [{ "match": "integer", "min": 0 }] },
+            "$.added": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.removed": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.changed": { "matchers": [{ "match": "type", "min": 0 }] }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Wave 1 Pact contract sanity test for the Metasheet -> Yuantus PLM federation.
+ *
+ * This test currently performs a STATIC sanity check against a hand-authored
+ * Pact v3 artifact at `pacts/metasheet2-yuantus-plm.json`. It does not yet
+ * regenerate the artifact from real consumer interactions because that would
+ * require adding `@pact-foundation/pact` as a dependency, which has not been
+ * approved as of 2026-04-07.
+ *
+ * What this test guarantees today:
+ *
+ *   1. The pact JSON exists and parses as Pact v3.
+ *   2. The 6 Wave 1 P0 interactions that PLMAdapter currently calls are
+ *      present, in the order documented in
+ *      `docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md`.
+ *      (codex's plan also lists `aml/metadata`, but PLMAdapter does not yet
+ *      call it; deferred to Wave 1.5.)
+ *   3. The PLMAdapter actually calls every endpoint declared in the pact, so
+ *      the contract cannot drift away from the live consumer code without
+ *      this test failing.
+ *
+ * What this test does NOT yet do:
+ *
+ *   - Spin up a Pact mock server and replay PLMAdapter against it. That is the
+ *     "real" consumer pact behaviour and will land once `@pact-foundation/pact`
+ *     is approved as a devDependency. When that happens, this file should be
+ *     replaced (or extended) so the JSON is generated from `Pact.write()`
+ *     rather than committed by hand.
+ *
+ * The provider verification side already exists at:
+ *   /Users/huazhou/Downloads/Github/Yuantus/src/yuantus/api/tests/test_pact_provider_yuantus_plm.py
+ *
+ * See also:
+ *   - docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md
+ *   - docs/PLM_STANDALONE_METASHEET_BOUNDARY_STRATEGY_20260407.md
+ *   - docs/METASHEET_REPO_SOURCE_OF_TRUTH_INVESTIGATION_20260407.md
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const PACT_PATH = resolve(__dirname, 'pacts', 'metasheet2-yuantus-plm.json')
+const ADAPTER_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  'src',
+  'data-adapters',
+  'PLMAdapter.ts',
+)
+
+interface PactInteraction {
+  description: string
+  providerStates?: Array<{ name: string }>
+  request: {
+    method: string
+    path: string
+    body?: unknown
+    headers?: Record<string, string>
+    query?: Record<string, string[]>
+  }
+  response: {
+    status: number
+    body?: unknown
+  }
+}
+
+interface PactDocument {
+  consumer: { name: string }
+  provider: { name: string }
+  interactions: PactInteraction[]
+  metadata: { pactSpecification: { version: string } }
+}
+
+// Wave 1 P0 = endpoints PLMAdapter.ts CURRENTLY calls. Anything that is only
+// "planned" or "anticipated" must NOT live in this list — the contract-first
+// principle requires that pact freezes what is actually used, never aspiration.
+//
+// Notable omission from codex's PACT_FIRST plan: GET /api/v1/aml/metadata/{type}
+// is listed as Wave 1 P0 in docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md, but
+// PLMAdapter.ts does not currently invoke it. It is parked for Wave 1.5 / Wave
+// 2 and will be added to this list as soon as the adapter starts calling it.
+const WAVE_1_P0_PATHS = [
+  { method: 'POST', path: '/api/v1/auth/login' },
+  { method: 'GET', path: '/api/v1/health' },
+  { method: 'GET', path: '/api/v1/search/' },
+  { method: 'POST', path: '/api/v1/aml/apply' },
+  { method: 'GET', path: '/api/v1/bom/01H000000000000000000000P1/tree' },
+  { method: 'GET', path: '/api/v1/bom/compare' },
+] as const
+
+function loadPact(): PactDocument {
+  const raw = readFileSync(PACT_PATH, 'utf8')
+  return JSON.parse(raw) as PactDocument
+}
+
+function loadAdapter(): string {
+  return readFileSync(ADAPTER_PATH, 'utf8')
+}
+
+describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1)', () => {
+  it('pact JSON exists, parses as Pact v3, and names the right consumer/provider', () => {
+    const pact = loadPact()
+    expect(pact.consumer.name).toBe('Metasheet2')
+    expect(pact.provider.name).toBe('YuantusPLM')
+    expect(pact.metadata.pactSpecification.version).toBe('3.0.0')
+  })
+
+  it('contains exactly the 6 Wave 1 P0 interactions PLMAdapter currently calls, in documented order', () => {
+    const pact = loadPact()
+    expect(pact.interactions).toHaveLength(WAVE_1_P0_PATHS.length)
+    pact.interactions.forEach((interaction, index) => {
+      const expected = WAVE_1_P0_PATHS[index]
+      expect(interaction.request.method).toBe(expected.method)
+      expect(interaction.request.path).toBe(expected.path)
+    })
+  })
+
+  it('every interaction declares at least one provider state', () => {
+    const pact = loadPact()
+    for (const interaction of pact.interactions) {
+      expect(interaction.providerStates).toBeDefined()
+      expect(interaction.providerStates!.length).toBeGreaterThan(0)
+      expect(interaction.providerStates![0].name).toBeTruthy()
+    }
+  })
+
+  it('every protected endpoint is also called by the live PLMAdapter source', () => {
+    const adapterSrc = loadAdapter()
+    // The 6 endpoints declared in the pact should appear verbatim in PLMAdapter.ts
+    // (as path segments). The auth/login endpoint is invoked via raw fetch and
+    // also appears as a string literal.
+    const endpointsToFind = [
+      '/api/v1/auth/login',
+      '/api/v1/health',
+      '/api/v1/search/',
+      '/api/v1/aml/apply',
+      '/api/v1/bom/',
+      '/api/v1/bom/compare',
+    ]
+    for (const ep of endpointsToFind) {
+      expect(
+        adapterSrc.includes(ep),
+        `PLMAdapter.ts no longer references ${ep}; pact has drifted from the consumer.`,
+      ).toBe(true)
+    }
+  })
+
+  it('aml/apply request body documents the RPC envelope shape used by PLMAdapter', () => {
+    const pact = loadPact()
+    const applyInteraction = pact.interactions.find(
+      i => i.request.path === '/api/v1/aml/apply',
+    )
+    expect(applyInteraction).toBeDefined()
+    const body = applyInteraction!.request.body as Record<string, string>
+    expect(body).toHaveProperty('type')
+    expect(body).toHaveProperty('action')
+    expect(body).toHaveProperty('id')
+    expect(body.action).toBe('get')
+  })
+
+  it('aml/apply response declares the count + items envelope returned by GetOperation', () => {
+    const pact = loadPact()
+    const applyInteraction = pact.interactions.find(
+      i => i.request.path === '/api/v1/aml/apply',
+    )
+    expect(applyInteraction).toBeDefined()
+    const body = applyInteraction!.response.body as Record<string, unknown>
+    expect(body).toHaveProperty('count')
+    expect(body).toHaveProperty('items')
+    expect(Array.isArray(body.items)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- recut the PR #717 consumer pact work into a clean contract-only slice
- add the committed Metasheet2 -> Yuantus consumer pact artifact and sanity tests
- expose a focused `test:contract` package script plus a small discoverability guard

## Verification
- pnpm --filter @metasheet/core-backend test:contract
- pnpm --filter @metasheet/core-backend exec vitest run tests/contract --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- git diff --check