### PR TITLE
feat(after-sales): surface field policy ui state

### DIFF
--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -179,12 +179,13 @@
                 <option value="wechat">WeChat</option>
               </select>
             </label>
-            <label class="after-sales-view__field">
+            <label v-if="!isRefundAmountHidden" class="after-sales-view__field">
               <span>Refund amount</span>
               <input
                 id="after-sales-ticket-refund-amount"
                 v-model="ticketDraft.refundAmount"
                 class="after-sales-view__field-input"
+                :disabled="!isRefundAmountEditable"
                 inputmode="decimal"
                 placeholder="optional"
                 type="text"
@@ -338,7 +339,7 @@
 
               <div class="after-sales-view__ticket-side">
                 <dl class="after-sales-view__ticket-meta">
-                  <div>
+                  <div v-if="!isRefundAmountHidden">
                     <dt>Refund amount</dt>
                     <dd>{{ formatRefundAmount(ticket.data.refundAmount) }}</dd>
                   </div>
@@ -364,12 +365,13 @@
                   </button>
                 </div>
                 <div v-else class="after-sales-view__ticket-actions">
-                  <label class="after-sales-view__field after-sales-view__field--compact">
+                  <label v-if="!isRefundAmountHidden" class="after-sales-view__field after-sales-view__field--compact">
                     <span>Refund request</span>
                     <input
                       :id="`after-sales-ticket-refund-request-${ticket.id}`"
                       :value="ticketRefundDrafts[ticket.id] ?? formatRefundDraft(ticket.data.refundAmount)"
                       class="after-sales-view__field-input"
+                      :disabled="!isRefundAmountEditable"
                       inputmode="decimal"
                       placeholder="88.5"
                       type="text"
@@ -377,8 +379,9 @@
                     />
                   </label>
                   <button
+                    v-if="!isRefundAmountHidden"
                     class="after-sales-view__ghost-btn after-sales-view__ticket-action-btn"
-                    :disabled="ticketCreating || ticketsLoading || ticketDeletingId === ticket.id || ticketRefundSubmittingId === ticket.id || ticketUpdatingId === ticket.id"
+                    :disabled="ticketCreating || ticketsLoading || ticketDeletingId === ticket.id || ticketRefundSubmittingId === ticket.id || ticketUpdatingId === ticket.id || !isRefundAmountEditable"
                     @click="requestTicketRefund(ticket)"
                   >
                     {{ ticketRefundSubmittingId === ticket.id ? 'Requesting...' : 'Request refund' }}
@@ -1866,6 +1869,23 @@ interface ApiEnvelope<T> {
   }
 }
 
+type FieldVisibility = 'hidden' | 'visible'
+type FieldEditability = 'readonly' | 'editable'
+
+interface TicketFieldPolicy {
+  visibility: FieldVisibility
+  editability: FieldEditability
+}
+
+interface TicketFieldPolicyResponse {
+  projectId: string
+  fields: {
+    serviceTicket: {
+      refundAmount: TicketFieldPolicy
+    }
+  }
+}
+
 const TEMPLATE_ID = 'after-sales-default'
 const DEFAULT_CONFIG = {
   enableWarranty: true,
@@ -1876,6 +1896,11 @@ const DEFAULT_CONFIG = {
   urgentSlaHours: 4,
   followUpAfterDays: 7,
   overdueWebhook: '',
+}
+
+const DEFAULT_TICKET_FIELD_POLICY: TicketFieldPolicy = {
+  visibility: 'visible',
+  editability: 'editable',
 }
 
 const loading = ref(true)
@@ -1928,6 +1953,7 @@ const followUps = ref<FollowUpViewModel[]>([])
 const serviceRecords = ref<ServiceRecordViewModel[]>([])
 const configDraft = ref({ ...DEFAULT_CONFIG })
 const baselineConfigDraft = ref({ ...DEFAULT_CONFIG })
+const ticketFieldPolicies = ref<TicketFieldPolicyResponse | null>(null)
 const ticketDraft = ref<TicketDraft>(createTicketDraft())
 const ticketEditingId = ref('')
 const ticketEditDraft = ref<TicketEditDraft>(createTicketEditDraft())
@@ -1971,6 +1997,13 @@ const createdObjectLabels = computed(() => current.value.installResult?.createdO
 const createdViewLabels = computed(() => current.value.installResult?.createdViews ?? [])
 const isInstalled = computed(() => current.value.status === 'installed' || current.value.status === 'partial')
 const isDegraded = computed(() => current.value.status === 'partial' || current.value.status === 'failed')
+const refundAmountPolicy = computed<TicketFieldPolicy>(
+  () => ticketFieldPolicies.value?.fields?.serviceTicket?.refundAmount ?? DEFAULT_TICKET_FIELD_POLICY,
+)
+const isRefundAmountHidden = computed(() => refundAmountPolicy.value.visibility === 'hidden')
+const isRefundAmountEditable = computed(
+  () => refundAmountPolicy.value.visibility === 'visible' && refundAmountPolicy.value.editability === 'editable',
+)
 const hasCustomerProjection = computed(() =>
   Array.isArray(manifest.value?.objects) &&
   manifest.value.objects.some((object) => object && object.id === 'customer'),
@@ -2012,6 +2045,9 @@ const canSubmitServiceRecordEdit = computed(
     toText(serviceRecordEditDraft.value.scheduledAt).length > 0,
 )
 const ticketDraftError = computed(() => {
+  if (!isRefundAmountEditable.value) {
+    return ''
+  }
   const parsedRefundAmount = parseOptionalRefundAmount(ticketDraft.value.refundAmount)
   return parsedRefundAmount.valid ? '' : 'Refund amount must be a valid number'
 })
@@ -2506,7 +2542,11 @@ function buildTicketPayload() {
       title,
       priority: ticketDraft.value.priority,
       source: ticketDraft.value.source,
-      ...(refundAmount.valid && typeof refundAmount.value === 'number' ? { refundAmount: refundAmount.value } : {}),
+      ...(
+        isRefundAmountEditable.value && refundAmount.valid && typeof refundAmount.value === 'number'
+          ? { refundAmount: refundAmount.value }
+          : {}
+      ),
     },
   }
 }
@@ -3384,7 +3424,7 @@ async function submitTicket() {
   ticketSubmitSuccess.value = ''
 
   const parsedRefundAmount = parseOptionalRefundAmount(ticketDraft.value.refundAmount)
-  if (!parsedRefundAmount.valid) {
+  if (isRefundAmountEditable.value && !parsedRefundAmount.valid) {
     ticketSubmitError.value = 'Refund amount must be a valid number'
     ticketCreating.value = false
     return
@@ -3454,6 +3494,9 @@ async function requestTicketRefund(ticket: TicketViewModel) {
   if (!ticket.id || ticketRefundSubmittingId.value || ticketUpdatingId.value || ticketEditingId.value === ticket.id) {
     return
   }
+  if (!isRefundAmountEditable.value || isRefundAmountHidden.value) {
+    return
+  }
 
   const rawRefundAmount = ticketRefundDrafts.value[ticket.id] ?? formatRefundDraft(ticket.data.refundAmount)
   const parsedRefundAmount = parseOptionalRefundAmount(rawRefundAmount)
@@ -3500,6 +3543,19 @@ async function requestTicketRefund(ticket: TicketViewModel) {
     }
   } finally {
     ticketRefundSubmittingId.value = ''
+  }
+}
+
+async function loadFieldPoliciesForCurrentState(state: CurrentResponse): Promise<void> {
+  if (state.status !== 'installed' && state.status !== 'partial') {
+    ticketFieldPolicies.value = null
+    return
+  }
+
+  try {
+    ticketFieldPolicies.value = await readEnvelope<TicketFieldPolicyResponse>('/api/after-sales/field-policies')
+  } catch {
+    ticketFieldPolicies.value = null
   }
 }
 
@@ -3581,6 +3637,7 @@ async function refreshCurrentState() {
     current.value = await readEnvelope<CurrentResponse>('/api/after-sales/projects/current')
     baselineConfigDraft.value = normalizeConfigDraft(current.value.config)
     await Promise.all([
+      loadFieldPoliciesForCurrentState(current.value),
       loadTicketsForCurrentState(current.value),
       loadInstalledAssetsForCurrentState(current.value),
       loadCustomersForCurrentState(current.value),
@@ -3620,6 +3677,7 @@ async function loadView() {
     baselineConfigDraft.value = normalizeConfigDraft(nextCurrent.config)
     configDraft.value = { ...baselineConfigDraft.value }
     await Promise.all([
+      loadFieldPoliciesForCurrentState(nextCurrent),
       loadTicketsForCurrentState(nextCurrent),
       loadInstalledAssetsForCurrentState(nextCurrent),
       loadCustomersForCurrentState(nextCurrent),

--- a/apps/web/tests/AfterSalesView.spec.ts
+++ b/apps/web/tests/AfterSalesView.spec.ts
@@ -26,6 +26,19 @@ function createResponse(payload: unknown, options: MockResponseOptions = {}) {
   } as Response
 }
 
+function createFieldPoliciesResponse(
+  policy: { visibility: 'hidden' | 'visible'; editability: 'readonly' | 'editable' },
+) {
+  return createResponse({
+    projectId: 'tenant:after-sales',
+    fields: {
+      serviceTicket: {
+        refundAmount: policy,
+      },
+    },
+  })
+}
+
 async function flushUi(cycles = 4): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
@@ -1019,6 +1032,266 @@ describe('AfterSalesView', () => {
         }),
       }),
     )
+  })
+
+  it('hides refund controls when the field policy is hidden', async () => {
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-006-hidden',
+          },
+          reportRef: 'install-006-hidden',
+        })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: 'hidden',
+          editability: 'readonly',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets' && !options?.method) {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: 1,
+          tickets: [
+            {
+              id: 'ticket-1',
+              version: 1,
+              data: {
+                ticketNo: 'AF-001',
+                title: 'Install compressor',
+                status: 'open',
+                refundStatus: '',
+                refundAmount: 88.5,
+              },
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'AF-001')
+
+    expect(container?.querySelector('#after-sales-ticket-refund-amount')).toBeNull()
+    expect(container?.querySelector('#after-sales-ticket-refund-request-ticket-1')).toBeNull()
+    const refundButton = Array.from(container?.querySelectorAll('button') ?? []).find((item) =>
+      item.textContent?.includes('Request refund'),
+    )
+    expect(refundButton).toBeUndefined()
+    expect(container?.textContent).not.toContain('¥88.50')
+  })
+
+  it('renders refund controls as readonly when the field policy is readonly', async () => {
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-006-readonly',
+          },
+          reportRef: 'install-006-readonly',
+        })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: 'visible',
+          editability: 'readonly',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets' && !options?.method) {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: 1,
+          tickets: [
+            {
+              id: 'ticket-1',
+              version: 1,
+              data: {
+                ticketNo: 'AF-001',
+                title: 'Install compressor',
+                status: 'open',
+                refundStatus: '',
+                refundAmount: 88.5,
+              },
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'AF-001')
+
+    const createRefundInput = container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-amount')
+    const inlineRefundInput = container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-request-ticket-1')
+    const refundButton = findButton(container!, 'Request refund')
+
+    expect(createRefundInput).toBeTruthy()
+    expect(inlineRefundInput).toBeTruthy()
+    expect(createRefundInput?.disabled).toBe(true)
+    expect(inlineRefundInput?.disabled).toBe(true)
+    expect(refundButton.disabled).toBe(true)
+    expect(container?.textContent).toContain('¥88.50')
+  })
+
+  it('keeps refund controls editable when the field policy is editable', async () => {
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-006-editable',
+          },
+          reportRef: 'install-006-editable',
+        })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: 'visible',
+          editability: 'editable',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets' && !options?.method) {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: 1,
+          tickets: [
+            {
+              id: 'ticket-1',
+              version: 1,
+              data: {
+                ticketNo: 'AF-001',
+                title: 'Install compressor',
+                status: 'open',
+                refundStatus: '',
+                refundAmount: 0,
+              },
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/tickets/ticket-1/refund-request' && options?.method === 'POST') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          ticket: {
+            id: 'ticket-1',
+            version: 2,
+            data: {
+              ticketNo: 'AF-001',
+              title: 'Install compressor',
+              status: 'open',
+              refundStatus: 'pending',
+              refundAmount: 120.5,
+            },
+          },
+        })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'AF-001')
+
+    const createRefundInput = container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-amount')
+    const inlineRefundInput = container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-request-ticket-1')
+    const refundButton = findButton(container!, 'Request refund')
+
+    expect(createRefundInput).toBeTruthy()
+    expect(inlineRefundInput).toBeTruthy()
+    expect(createRefundInput?.disabled).toBe(false)
+    expect(inlineRefundInput?.disabled).toBe(false)
+    expect(refundButton.disabled).toBe(false)
+
+    await setInputValue(inlineRefundInput!, '120.5')
+    refundButton.click()
+    await waitForText(container!, 'Requested refund for AF-001')
   })
 
   it('blocks refund requests when the inline refund amount is invalid', async () => {

--- a/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
+++ b/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
@@ -422,6 +422,27 @@ describe('after-sales plugin install integration', () => {
       displayName: 'After Sales Integration',
     })
 
+    const fieldPoliciesRes = await requestJson(`${baseUrl}/api/after-sales/field-policies`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(fieldPoliciesRes.status).toBe(200)
+    expect(fieldPoliciesRes.body).toEqual({
+      ok: true,
+      data: {
+        projectId: PROJECT_ID,
+        fields: {
+          serviceTicket: {
+            refundAmount: {
+              visibility: 'visible',
+              editability: 'editable',
+            },
+          },
+        },
+      },
+    })
+
     const ledgerRes = await pool.query<{
       tenant_id: string
       app_id: string

--- a/packages/core-backend/tests/unit/after-sales-field-policies.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-field-policies.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fieldPolicies = require('../../../../plugins/plugin-after-sales/lib/field-policies.cjs') as {
+  DEFAULT_EFFECTIVE_POLICY: {
+    visibility: string
+    editability: string
+  }
+  resolveFieldPolicyRoleSlugs: (user: Record<string, unknown> | null | undefined) => string[]
+  resolveFieldPoliciesForUser: (
+    database: { query: (sql: string, params?: unknown[]) => Promise<unknown[] | { rows: unknown[] }> },
+    input: {
+      tenantId: string
+      pluginId: string
+      appId: string
+      projectId: string
+      roleSlugs: string[]
+    },
+  ) => Promise<{
+    projectId: string
+    fields: {
+      serviceTicket: {
+        refundAmount: {
+          visibility: string
+          editability: string
+        }
+      }
+    }
+  }>
+}
+
+function createDatabase(rows: Array<Record<string, unknown>>) {
+  const query = vi.fn(async () => rows)
+  return { query }
+}
+
+describe('after-sales field policy helper', () => {
+  it('resolves role slugs from claims and infers admin from permission claims', () => {
+    expect(
+      fieldPolicies.resolveFieldPolicyRoleSlugs({
+        role: 'finance',
+        roles: ['supervisor'],
+        perms: ['after_sales:admin'],
+      }),
+    ).toEqual(['finance', 'supervisor', 'admin'])
+  })
+
+  it('returns the single-role registry policy when one role matches', async () => {
+    const database = createDatabase([
+      { role_slug: 'finance', visibility: 'visible', editability: 'editable' },
+      { role_slug: 'viewer', visibility: 'hidden', editability: 'readonly' },
+    ])
+
+    const result = await fieldPolicies.resolveFieldPoliciesForUser(database, {
+      tenantId: 'tenant_42',
+      pluginId: 'plugin-after-sales',
+      appId: 'after-sales',
+      projectId: 'tenant_42:after-sales',
+      roleSlugs: ['finance'],
+    })
+
+    expect(result).toEqual({
+      projectId: 'tenant_42:after-sales',
+      fields: {
+        serviceTicket: {
+          refundAmount: {
+            visibility: 'visible',
+            editability: 'editable',
+          },
+        },
+      },
+    })
+  })
+
+  it('uses the most permissive merge when multiple roles match', async () => {
+    const database = createDatabase([
+      { role_slug: 'supervisor', visibility: 'visible', editability: 'readonly' },
+      { role_slug: 'finance', visibility: 'visible', editability: 'editable' },
+      { role_slug: 'viewer', visibility: 'hidden', editability: 'readonly' },
+    ])
+
+    const result = await fieldPolicies.resolveFieldPoliciesForUser(database, {
+      tenantId: 'tenant_42',
+      pluginId: 'plugin-after-sales',
+      appId: 'after-sales',
+      projectId: 'tenant_42:after-sales',
+      roleSlugs: ['viewer', 'supervisor', 'finance'],
+    })
+
+    expect(result.fields.serviceTicket.refundAmount).toEqual({
+      visibility: 'visible',
+      editability: 'editable',
+    })
+  })
+
+  it('falls back to blueprint defaults when no registry rows exist', async () => {
+    const database = createDatabase([])
+
+    const result = await fieldPolicies.resolveFieldPoliciesForUser(database, {
+      tenantId: 'tenant_42',
+      pluginId: 'plugin-after-sales',
+      appId: 'after-sales',
+      projectId: 'tenant_42:after-sales',
+      roleSlugs: ['supervisor'],
+    })
+
+    expect(result.fields.serviceTicket.refundAmount).toEqual({
+      visibility: 'visible',
+      editability: 'readonly',
+    })
+  })
+
+  it('returns the conservative default when no matching role policy exists', async () => {
+    const database = createDatabase([
+      { role_slug: 'finance', visibility: 'visible', editability: 'editable' },
+    ])
+
+    const result = await fieldPolicies.resolveFieldPoliciesForUser(database, {
+      tenantId: 'tenant_42',
+      pluginId: 'plugin-after-sales',
+      appId: 'after-sales',
+      projectId: 'tenant_42:after-sales',
+      roleSlugs: ['viewer'],
+    })
+
+    expect(result.fields.serviceTicket.refundAmount).toEqual(fieldPolicies.DEFAULT_EFFECTIVE_POLICY)
+  })
+})

--- a/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
@@ -28,6 +28,17 @@ interface FakeRowRaw {
 
 interface FakeDatabase {
   rows: FakeRowRaw[]
+  fieldPolicyRows: Array<{
+    tenant_id: string
+    plugin_id: string
+    app_id: string
+    project_id: string
+    object_id: string
+    field_name: string
+    role_slug: string
+    visibility: string
+    editability: string
+  }>
   failNextQuery?: string
   query: (sql: string, params?: unknown[]) => Promise<FakeRowRaw[]>
 }
@@ -148,6 +159,7 @@ class FakeResponse {
 function createFakeDatabase(): FakeDatabase {
   const db: FakeDatabase = {
     rows: [],
+    fieldPolicyRows: [],
     async query(sql: string, params: unknown[] = []) {
       if (db.failNextQuery) {
         const errorMessage = db.failNextQuery
@@ -167,6 +179,17 @@ function createFakeDatabase(): FakeDatabase {
               } as unknown as FakeRowRaw,
             ]
           : []
+      }
+      if (normalized.startsWith('SELECT role_slug, visibility, editability FROM plugin_field_policy_registry')) {
+        const [tenantId, pluginId, appId, projectId, objectId, fieldName] = params as [string, string, string, string, string, string]
+        return db.fieldPolicyRows.filter((row) =>
+          row.tenant_id === tenantId &&
+          row.plugin_id === pluginId &&
+          row.app_id === appId &&
+          row.project_id === projectId &&
+          row.object_id === objectId &&
+          row.field_name === fieldName,
+        ) as unknown as FakeRowRaw[]
       }
       if (normalized.startsWith('SELECT')) {
         const [tenantId, appId] = params as [string, string]
@@ -792,6 +815,171 @@ describe('plugin-after-sales routes', () => {
       error: {
         code: 'ledger-read-failed',
         message: 'failed to read install ledger: simulated ledger read failure',
+      },
+    })
+  })
+
+  it('returns effective field policies using the most permissive matching role', async () => {
+    const handler = routes.get('GET /api/after-sales/field-policies')
+    const res = new FakeResponse()
+
+    db.rows.push({
+      id: 'fake-uuid-1',
+      tenant_id: 'tenant_42',
+      app_id: 'after-sales',
+      project_id: 'tenant_42:after-sales',
+      template_id: 'after-sales-default',
+      template_version: '0.1.0',
+      mode: 'enable',
+      status: 'installed',
+      created_objects_json: JSON.stringify(['serviceTicket']),
+      created_views_json: JSON.stringify(['ticket-board']),
+      warnings_json: JSON.stringify([]),
+      display_name: 'After-sales',
+      config_json: JSON.stringify({}),
+      last_install_at: new Date(),
+      created_at: new Date(),
+    })
+    db.fieldPolicyRows.push(
+      {
+        tenant_id: 'tenant_42',
+        plugin_id: 'plugin-after-sales',
+        app_id: 'after-sales',
+        project_id: 'tenant_42:after-sales',
+        object_id: 'serviceTicket',
+        field_name: 'refundAmount',
+        role_slug: 'viewer',
+        visibility: 'hidden',
+        editability: 'readonly',
+      },
+      {
+        tenant_id: 'tenant_42',
+        plugin_id: 'plugin-after-sales',
+        app_id: 'after-sales',
+        project_id: 'tenant_42:after-sales',
+        object_id: 'serviceTicket',
+        field_name: 'refundAmount',
+        role_slug: 'supervisor',
+        visibility: 'visible',
+        editability: 'readonly',
+      },
+      {
+        tenant_id: 'tenant_42',
+        plugin_id: 'plugin-after-sales',
+        app_id: 'after-sales',
+        project_id: 'tenant_42:after-sales',
+        object_id: 'serviceTicket',
+        field_name: 'refundAmount',
+        role_slug: 'finance',
+        visibility: 'visible',
+        editability: 'editable',
+      },
+    )
+
+    await handler?.(buildReq({
+      user: {
+        id: 'reader_42',
+        tenantId: 'tenant_42',
+        role: 'viewer',
+        roles: ['viewer', 'finance'],
+        perms: ['after_sales:read'],
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        projectId: 'tenant_42:after-sales',
+        fields: {
+          serviceTicket: {
+            refundAmount: {
+              visibility: 'visible',
+              editability: 'editable',
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('falls back to blueprint defaults when no registry rows exist for the project', async () => {
+    const handler = routes.get('GET /api/after-sales/field-policies')
+    const res = new FakeResponse()
+
+    db.rows.push({
+      id: 'fake-uuid-1',
+      tenant_id: 'tenant_42',
+      app_id: 'after-sales',
+      project_id: 'tenant_42:after-sales',
+      template_id: 'after-sales-default',
+      template_version: '0.1.0',
+      mode: 'enable',
+      status: 'installed',
+      created_objects_json: JSON.stringify(['serviceTicket']),
+      created_views_json: JSON.stringify(['ticket-board']),
+      warnings_json: JSON.stringify([]),
+      display_name: 'After-sales',
+      config_json: JSON.stringify({}),
+      last_install_at: new Date(),
+      created_at: new Date(),
+    })
+
+    await handler?.(buildReq({
+      user: {
+        id: 'reader_42',
+        tenantId: 'tenant_42',
+        role: 'supervisor',
+        roles: ['supervisor'],
+        perms: ['after_sales:read'],
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body.data.fields.serviceTicket.refundAmount).toEqual({
+      visibility: 'visible',
+      editability: 'readonly',
+    })
+  })
+
+  it('returns 409 for field policies when after-sales is not operational', async () => {
+    const handler = routes.get('GET /api/after-sales/field-policies')
+    const res = new FakeResponse()
+
+    db.rows.push({
+      id: 'fake-uuid-1',
+      tenant_id: 'tenant_42',
+      app_id: 'after-sales',
+      project_id: 'tenant_42:after-sales',
+      template_id: 'after-sales-default',
+      template_version: '0.1.0',
+      mode: 'reinstall',
+      status: 'failed',
+      created_objects_json: JSON.stringify(['serviceTicket']),
+      created_views_json: JSON.stringify(['ticket-board']),
+      warnings_json: JSON.stringify(['adapter failed']),
+      display_name: 'After-sales',
+      config_json: JSON.stringify({}),
+      last_install_at: new Date(),
+      created_at: new Date(),
+    })
+
+    await handler?.(buildReq({
+      user: {
+        id: 'reader_42',
+        tenantId: 'tenant_42',
+        role: 'viewer',
+        roles: ['viewer'],
+        perms: ['after_sales:read'],
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_NOT_INSTALLED',
+        message: 'After-sales must be installed before reading field policies',
       },
     })
   })

--- a/plugins/plugin-after-sales/index.cjs
+++ b/plugins/plugin-after-sales/index.cjs
@@ -17,6 +17,10 @@ const {
   registerAfterSalesWorkflowHandlers,
 } = require('./lib/workflow-adapter.cjs')
 const {
+  resolveFieldPoliciesForUser,
+  resolveFieldPolicyRoleSlugs,
+} = require('./lib/field-policies.cjs')
+const {
   buildCreateTicketCommand,
   buildCustomerCommand,
   buildFollowUpCommand,
@@ -41,6 +45,7 @@ const {
   fromPhysicalRecord,
 } = require('./lib/multitable-helpers.cjs')
 
+const AFTER_SALES_PLUGIN_ID = 'plugin-after-sales'
 const SERVICE_TICKET_FIELDS = ['ticketNo', 'title', 'source', 'priority', 'status', 'slaDueAt', 'refundAmount', 'refundStatus']
 const SERVICE_RECORD_FIELDS = ['ticketNo', 'visitType', 'scheduledAt', 'completedAt', 'technicianName', 'workSummary', 'result']
 const INSTALLED_ASSET_FIELDS = ['assetCode', 'serialNo', 'model', 'location', 'installedAt', 'warrantyUntil', 'status']
@@ -660,6 +665,60 @@ module.exports = {
           res.status(500).json({
             ok: false,
             error: { code: 'INTERNAL_ERROR', message: 'Install failed' },
+          })
+        }
+      },
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/after-sales/field-policies',
+      async (req, res) => {
+        try {
+          const userId = getUserId(req)
+          if (!userId) {
+            sendUnauthorized(res)
+            return
+          }
+          if (!hasAfterSalesReadAccess(req)) {
+            res.status(403).json({
+              ok: false,
+              error: { code: 'FORBIDDEN', message: 'After-sales read access required' },
+            })
+            return
+          }
+
+          const tenantId = getTenantId(req, context.logger)
+          const current = await installer.loadCurrent(context, tenantId, appManifest.id)
+          if (!current || !isOperationalAfterSalesStatus(current.status)) {
+            res.status(409).json({
+              ok: false,
+              error: {
+                code: 'AFTER_SALES_NOT_INSTALLED',
+                message: 'After-sales must be installed before reading field policies',
+              },
+            })
+            return
+          }
+
+          const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
+          const policies = await resolveFieldPoliciesForUser(context.api.database, {
+            tenantId,
+            pluginId: context.metadata && context.metadata.name ? context.metadata.name : 'plugin-after-sales',
+            appId: appManifest.id,
+            projectId,
+            roleSlugs: resolveFieldPolicyRoleSlugs(req && req.user),
+          })
+
+          res.json({
+            ok: true,
+            data: policies,
+          })
+        } catch (err) {
+          logger.error && logger.error('after-sales field policy lookup failed', err)
+          res.status(500).json({
+            ok: false,
+            error: { code: 'INTERNAL_ERROR', message: 'Failed to load after-sales field policies' },
           })
         }
       },

--- a/plugins/plugin-after-sales/lib/field-policies.cjs
+++ b/plugins/plugin-after-sales/lib/field-policies.cjs
@@ -1,0 +1,137 @@
+'use strict'
+
+const { DEFAULT_FIELD_POLICIES } = require('./blueprint.cjs')
+
+const DEFAULT_EFFECTIVE_POLICY = Object.freeze({
+  visibility: 'hidden',
+  editability: 'readonly',
+})
+
+function normalizeClaimValues(input) {
+  if (Array.isArray(input)) {
+    return input
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter(Boolean)
+  }
+  if (typeof input === 'string') {
+    return input
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+function resolveFieldPolicyRoleSlugs(user) {
+  const roles = new Set([
+    ...normalizeClaimValues(user && user.role),
+    ...normalizeClaimValues(user && user.roles),
+  ])
+
+  const permissions = new Set([
+    ...normalizeClaimValues(user && user.permissions),
+    ...normalizeClaimValues(user && user.perms),
+  ])
+
+  if (
+    permissions.has('*:*') ||
+    permissions.has('admin') ||
+    permissions.has('admin:all') ||
+    permissions.has('after_sales:admin')
+  ) {
+    roles.add('admin')
+  }
+
+  return Array.from(roles)
+}
+
+function mergeEffectivePolicy(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return { ...DEFAULT_EFFECTIVE_POLICY }
+  }
+
+  const visibility = rows.some((row) => row && row.visibility === 'visible') ? 'visible' : 'hidden'
+  const editability = rows.some((row) => row && row.editability === 'editable') ? 'editable' : 'readonly'
+  return { visibility, editability }
+}
+
+function buildFieldPolicyResponse(projectId, effectivePolicy) {
+  return {
+    projectId,
+    fields: {
+      serviceTicket: {
+        refundAmount: effectivePolicy,
+      },
+    },
+  }
+}
+
+async function listRegistryFieldPolicies(database, input) {
+  const result = await database.query(
+    `SELECT role_slug, visibility, editability
+     FROM plugin_field_policy_registry
+     WHERE tenant_id = $1
+       AND plugin_id = $2
+       AND app_id = $3
+       AND project_id = $4
+       AND object_id = $5
+       AND field_name = $6
+     ORDER BY role_slug ASC`,
+    [
+      input.tenantId,
+      input.pluginId,
+      input.appId,
+      input.projectId,
+      input.objectId,
+      input.fieldName,
+    ],
+  )
+
+  const rows = Array.isArray(result) ? result : result && Array.isArray(result.rows) ? result.rows : []
+  return rows
+    .map((row) => ({
+      roleSlug: typeof row.role_slug === 'string' ? row.role_slug : '',
+      visibility: row.visibility === 'visible' ? 'visible' : 'hidden',
+      editability: row.editability === 'editable' ? 'editable' : 'readonly',
+    }))
+    .filter((row) => row.roleSlug)
+}
+
+function listDefaultFieldPolicies(objectId, fieldName) {
+  return DEFAULT_FIELD_POLICIES
+    .filter((policy) => policy.objectId === objectId && policy.field === fieldName)
+    .map((policy) => ({
+      roleSlug: policy.roleSlug,
+      visibility: policy.visibility,
+      editability: policy.editability,
+    }))
+}
+
+async function resolveFieldPoliciesForUser(database, input) {
+  const roleSlugs = Array.isArray(input.roleSlugs)
+    ? input.roleSlugs.filter((role) => typeof role === 'string' && role.trim()).map((role) => role.trim())
+    : []
+  const registryRows = await listRegistryFieldPolicies(database, {
+    tenantId: input.tenantId,
+    pluginId: input.pluginId,
+    appId: input.appId,
+    projectId: input.projectId,
+    objectId: 'serviceTicket',
+    fieldName: 'refundAmount',
+  })
+
+  const candidateRows = registryRows.length > 0
+    ? registryRows
+    : listDefaultFieldPolicies('serviceTicket', 'refundAmount')
+  const matchingRows = candidateRows.filter((row) => roleSlugs.includes(row.roleSlug))
+
+  return buildFieldPolicyResponse(input.projectId, mergeEffectivePolicy(matchingRows))
+}
+
+module.exports = {
+  DEFAULT_EFFECTIVE_POLICY,
+  buildFieldPolicyResponse,
+  mergeEffectivePolicy,
+  resolveFieldPolicyRoleSlugs,
+  resolveFieldPoliciesForUser,
+}


### PR DESCRIPTION
## Summary
- add plugin-local after-sales field policy read route with blueprint fallback
- surface refundAmount visibility/editability state in `AfterSalesView.vue`
- cover backend route resolution and UI hidden/readonly/editable behavior

## Scope
Stacked on top of `#780` (`feature/after-sales-installer-runtime-adapters`).

## Validation
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/after-sales-field-policies.test.ts tests/unit/after-sales-plugin-routes.test.ts`
- `pnpm --filter @metasheet/web exec vitest run tests/AfterSalesView.spec.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `DATABASE_URL=postgresql://metasheet:metasheet123@127.0.0.1:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`
- `pnpm --filter @metasheet/web build`
