### PR TITLE
feat(plm): recut document handoff slice

### DIFF
--- a/apps/web/src/components/plm/PlmDocumentsPanel.vue
+++ b/apps/web/src/components/plm/PlmDocumentsPanel.vue
@@ -118,6 +118,11 @@
       :delete-team-view-selection="panel.deleteDocumentTeamViewSelection"
     />
     <p v-if="panel.documentsError.value" class="status error">{{ panel.documentsError.value }}</p>
+    <p v-if="panel.documentsWarning.value && !panel.documentsError.value" class="status warning">⚠ {{ panel.documentsWarning.value }}</p>
+    <p v-if="panel.documentSourceProductId.value" class="status return-source">
+      <button class="btn ghost mini" @click="panel.returnToDocumentSource">← 返回源产品</button>
+      <span class="return-hint">当前正在查看关联文档对象</span>
+    </p>
     <div v-if="!panel.documents.value.length" class="empty">
       暂无文档
       <span class="empty-hint">（可先在 PLM 关联文件或设置文档角色过滤）</span>
@@ -190,6 +195,13 @@
           </td>
           <td v-if="panel.documentColumns.value.actions">
             <div class="inline-actions">
+              <button
+                v-if="panel.isAmlRelatedDocument(doc)"
+                class="btn ghost mini"
+                @click="panel.applyProductFromDocument(doc)"
+              >
+                打开
+              </button>
               <button class="btn ghost mini" @click="panel.copyDocumentId(doc)">复制 ID</button>
               <button
                 class="btn ghost mini"

--- a/apps/web/src/services/PlmService.ts
+++ b/apps/web/src/services/PlmService.ts
@@ -1,10 +1,17 @@
 import { localizedPlmFederationClient as plmClient } from './plm/plmFederationClient'
 
 export type PlmListResponse<T = Record<string, unknown>> = {
+  productId?: string
   items: T[]
   total?: number
   limit?: number
   offset?: number
+  sources?: Array<{
+    name: string
+    ok: boolean
+    count: number
+    error?: string
+  }>
 }
 
 export type PlmApprovalHistoryResponse<T = Record<string, unknown>> = {

--- a/apps/web/src/views/PlmProductView.vue
+++ b/apps/web/src/views/PlmProductView.vue
@@ -174,6 +174,10 @@ import {
   buildWorkbenchAuditQuery,
 } from './plm/plmWorkbenchSceneAudit'
 import {
+  buildPlmDocumentDegradationMessage,
+  type PlmDocumentSourceStatus,
+} from './plm/plmDocumentDegradation'
+import {
   readWorkbenchSceneFocus,
 } from './plm/plmWorkbenchSceneFocus'
 import {
@@ -394,6 +398,9 @@ const documentColumnOptions = [
 const documents = ref<DocumentEntry[]>([])
 const documentsLoading = ref(false)
 const documentsError = ref('')
+const documentsWarning = ref('')
+const documentSourceProductId = ref('')
+const documentSourceItemType = ref('')
 
 const cadFileId = ref('')
 const cadOtherFileId = ref('')
@@ -1415,6 +1422,9 @@ function resetAll() {
   documentSortDir.value = 'desc'
   documents.value = []
   documentsError.value = ''
+  documentsWarning.value = ''
+  documentSourceProductId.value = ''
+  documentSourceItemType.value = ''
   documentFilter.value = ''
   documentColumns.value = { ...defaultDocumentColumns }
   documentTeamViewQuery.value = ''
@@ -1924,12 +1934,21 @@ async function loadDocuments() {
   if (!productId.value) return
   documentsLoading.value = true
   documentsError.value = ''
+  documentsWarning.value = ''
   try {
     const result = await plmService.listDocuments<DocumentEntry>({
       productId: productId.value,
       role: documentRole.value || undefined,
     })
     documents.value = result.items || []
+    const degradation = buildPlmDocumentDegradationMessage(
+      (result.sources ?? []) as PlmDocumentSourceStatus[],
+    )
+    if (degradation.error) {
+      documentsError.value = degradation.error
+    } else if (degradation.warning) {
+      documentsWarning.value = degradation.warning
+    }
   } catch (error: any) {
     handleAuthError(error)
     documentsError.value = error?.message || '加载文档失败'
@@ -2509,6 +2528,43 @@ async function copyDocumentUrl(doc: DocumentEntry, kind: 'preview' | 'download')
     return
   }
   setDeepLinkMessage(`已复制${kind === 'preview' ? '预览' : '下载'}链接。`)
+}
+
+function isAmlRelatedDocument(doc: DocumentEntry): boolean {
+  const documentType = String(doc.document_type || doc.metadata?.document_type || '').toLowerCase()
+  return !getDocumentDownloadUrl(doc) && (documentType === 'document' || documentType === 'related_document')
+}
+
+function resolveDocumentItemId(doc: DocumentEntry): string {
+  return String(doc.id || doc.config_id || doc.metadata?.config_id || '')
+}
+
+function applyProductFromDocument(doc: DocumentEntry) {
+  const documentId = resolveDocumentItemId(doc)
+  if (!documentId) {
+    setDeepLinkMessage('文档缺少对象 ID', true)
+    return
+  }
+  documentSourceProductId.value = productId.value
+  documentSourceItemType.value = itemType.value
+  productId.value = documentId
+  productItemNumber.value = ''
+  itemType.value = 'Document'
+  productError.value = ''
+  setDeepLinkMessage(`已切换到关联文档：${getDocumentName(doc) || documentId}`)
+  void loadProduct()
+}
+
+function returnToDocumentSource() {
+  if (!documentSourceProductId.value) return
+  productId.value = documentSourceProductId.value
+  productItemNumber.value = ''
+  itemType.value = documentSourceItemType.value || DEFAULT_ITEM_TYPE
+  productError.value = ''
+  setDeepLinkMessage(`已返回源产品：${documentSourceProductId.value}`)
+  documentSourceProductId.value = ''
+  documentSourceItemType.value = ''
+  void loadProduct()
 }
 
 function getApprovalTitle(entry: ApprovalEntry): string {
@@ -5746,6 +5802,7 @@ function applyHydratedPanelDataReset(options: {
     documents.value = []
     documentsLoading.value = false
     documentsError.value = ''
+    documentsWarning.value = ''
   }
   if (reset.clearCad) {
     cadProperties.value = null
@@ -7085,6 +7142,9 @@ const documentsPanel = {
   setDocumentTeamViewDefault,
   clearDocumentTeamViewDefault,
   selectCadFile,
+  applyProductFromDocument,
+  returnToDocumentSource,
+  isAmlRelatedDocument,
   copyDocumentId,
   copyDocumentUrl,
   getDocumentName,
@@ -7145,6 +7205,8 @@ const documentsPanel = {
   documents,
   documentsLoading,
   documentsError,
+  documentsWarning,
+  documentSourceProductId,
   documentsFiltered,
   documentsSorted,
   documentFieldCatalog,

--- a/apps/web/src/views/plm/plmDocumentDegradation.ts
+++ b/apps/web/src/views/plm/plmDocumentDegradation.ts
@@ -1,0 +1,40 @@
+export interface PlmDocumentSourceStatus {
+  name: string
+  ok: boolean
+  count: number
+  error?: string
+}
+
+const DOCUMENT_SOURCE_LABELS: Record<string, string> = {
+  attachments: 'attachments（文件附件）',
+  related_documents: 'AML related docs（关联文档）',
+}
+
+function formatSourceLabel(name: string): string {
+  return DOCUMENT_SOURCE_LABELS[name] ?? name
+}
+
+function formatFailureDetail(source: PlmDocumentSourceStatus): string {
+  const label = formatSourceLabel(source.name)
+  return source.error ? `${label}（${source.error}）` : label
+}
+
+export function buildPlmDocumentDegradationMessage(
+  sources: PlmDocumentSourceStatus[],
+): { warning?: string; error?: string } {
+  if (!Array.isArray(sources) || sources.length === 0) return {}
+
+  const failed = sources.filter(source => !source.ok)
+  if (failed.length === 0) return {}
+
+  const failedLabels = failed.map(formatFailureDetail)
+  if (failed.length >= sources.length) {
+    return {
+      error: `文档数据源均不可用：${failedLabels.join('、')}`,
+    }
+  }
+
+  return {
+    warning: `${failedLabels.join('、')}不可用，当前显示可能不完整`,
+  }
+}

--- a/apps/web/src/views/plm/plmPanelModels.ts
+++ b/apps/web/src/views/plm/plmPanelModels.ts
@@ -328,6 +328,9 @@ export type DocumentMetadata = UnknownRecord & {
   file_id?: string | number
   filename?: string
   file_name?: string
+  item_number?: string | number
+  config_id?: string | number
+  current_version_id?: string | number
   document_type?: string
   file_type?: string
   document_version?: string
@@ -350,6 +353,9 @@ export type DocumentEntry = UnknownRecord & {
   name?: string
   filename?: string
   file_name?: string
+  item_number?: string | number
+  config_id?: string | number
+  current_version_id?: string | number
   document_type?: string
   engineering_revision?: string
   revision?: string
@@ -832,6 +838,9 @@ export type PlmDocumentsPanelModel = {
   exportDocumentsCsv: PanelAction
   loadDocuments: PanelAction
   selectCadFile: (doc: DocumentEntry, target?: 'primary' | 'other') => void
+  applyProductFromDocument: (doc: DocumentEntry) => void
+  returnToDocumentSource: PanelAction
+  isAmlRelatedDocument: (doc: DocumentEntry) => boolean
   copyDocumentId: (doc: DocumentEntry) => Promise<void>
   copyDocumentUrl: (doc: DocumentEntry, kind: 'preview' | 'download') => Promise<void>
   getDocumentName: (doc: DocumentEntry) => string
@@ -904,6 +913,8 @@ export type PlmDocumentsPanelModel = {
   documents: Ref<DocumentEntry[]>
   documentsLoading: Ref<boolean>
   documentsError: Ref<string>
+  documentsWarning: Ref<string>
+  documentSourceProductId: Ref<string>
   documentsFiltered: ComputedRef<DocumentEntry[]>
   documentsSorted: ComputedRef<DocumentEntry[]>
   documentFieldCatalog: Array<{ key: string; label: string; source: string; fallback: string }>

--- a/apps/web/tests/plmDocumentDegradation.spec.ts
+++ b/apps/web/tests/plmDocumentDegradation.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlmDocumentDegradationMessage } from '../src/views/plm/plmDocumentDegradation'
+
+describe('plmDocumentDegradation', () => {
+  it('names the failed side explicitly when attachments are down', () => {
+    expect(buildPlmDocumentDegradationMessage([
+      { name: 'attachments', ok: false, count: 0, error: 'file endpoint down' },
+      { name: 'related_documents', ok: true, count: 1 },
+    ])).toEqual({
+      warning: 'attachments（文件附件）（file endpoint down）不可用，当前显示可能不完整',
+    })
+  })
+
+  it('names the failed side explicitly when AML related docs are down', () => {
+    expect(buildPlmDocumentDegradationMessage([
+      { name: 'attachments', ok: true, count: 1 },
+      { name: 'related_documents', ok: false, count: 0, error: 'aml query down' },
+    ])).toEqual({
+      warning: 'AML related docs（关联文档）（aml query down）不可用，当前显示可能不完整',
+    })
+  })
+
+  it('returns an error when both sides fail', () => {
+    expect(buildPlmDocumentDegradationMessage([
+      { name: 'attachments', ok: false, count: 0, error: 'file side down' },
+      { name: 'related_documents', ok: false, count: 0, error: 'aml side down' },
+    ])).toEqual({
+      error: '文档数据源均不可用：attachments（文件附件）（file side down）、AML related docs（关联文档）（aml side down）',
+    })
+  })
+
+  it('returns an empty message when both sides are healthy', () => {
+    expect(buildPlmDocumentDegradationMessage([
+      { name: 'attachments', ok: true, count: 1 },
+      { name: 'related_documents', ok: true, count: 1 },
+    ])).toEqual({})
+  })
+})

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -23,6 +23,7 @@
     "test:integration": "vitest --config vitest.integration.config.ts run tests/integration --reporter=dot",
     "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --reporter=dot",
     "test:contract": "vitest run tests/contract --reporter=dot",
+    "test:e2e:handoff": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:cache": "npm run build:cache && TEST_USE_DIST=true vitest --config vitest.cache.config.ts run --reporter=dot",
     "clean": "rimraf dist"
   },

--- a/packages/core-backend/src/data-adapters/BaseAdapter.ts
+++ b/packages/core-backend/src/data-adapters/BaseAdapter.ts
@@ -73,6 +73,12 @@ export interface QueryResult<T = Record<string, DbValue>> {
     totalCount?: number
     pageCount?: number
     currentPage?: number
+    sources?: Array<{
+      name: string
+      ok: boolean
+      count: number
+      error?: string
+    }>
     columns?: Array<{
       name: string
       type: string

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -251,6 +251,9 @@ export interface PLMDocument {
   document_type: string
   description?: string
   engineering_state: string
+  item_number?: string
+  config_id?: string
+  current_version_id?: string
   file_size?: number
   mime_type?: string
   is_production_doc?: boolean
@@ -439,6 +442,20 @@ interface YuantusFileMetadata {
   author?: string
   source_system?: string
   source_version?: string
+}
+
+interface YuantusRelatedDocument extends Record<string, unknown> {
+  id?: string
+  name?: string
+  state?: string
+  current_version_id?: string
+  config_id?: string
+  item_number?: string
+  document_type?: string
+  engineering_state?: string
+  properties?: Record<string, unknown>
+  created_at?: string
+  updated_at?: string
 }
 
 interface YuantusEco {
@@ -1118,6 +1135,87 @@ export class PLMAdapter extends HTTPAdapter {
     }
   }
 
+  private mapYuantusRelatedDocumentFields(entry: YuantusRelatedDocument): PLMDocument {
+    const properties = entry.properties || {}
+    const docId = String(entry.id || properties.id || '')
+    const itemNumber = String(
+      entry.item_number ||
+      (properties.item_number as string | number | undefined) ||
+      (properties.doc_number as string | number | undefined) ||
+      (properties.number as string | number | undefined) ||
+      ''
+    )
+    const configId = String(entry.config_id || (properties.config_id as string | number | undefined) || '')
+    const currentVersionId = String(
+      entry.current_version_id ||
+      (properties.current_version_id as string | number | undefined) ||
+      ''
+    )
+    const name = String(
+      entry.name ||
+      (properties.name as string | number | undefined) ||
+      (properties.title as string | number | undefined) ||
+      itemNumber ||
+      configId ||
+      docId
+    )
+    const documentType = String(
+      entry.document_type ||
+      (properties.document_type as string | number | undefined) ||
+      (properties.type as string | number | undefined) ||
+      'document'
+    )
+    const engineeringState = String(
+      entry.engineering_state ||
+      entry.state ||
+      (properties.state as string | number | undefined) ||
+      (properties.status as string | number | undefined) ||
+      ''
+    ) || 'unknown'
+    const createdAt = this.toIsoString(entry.created_at || (properties.created_at as string | undefined)) || new Date().toISOString()
+    const updatedAt = this.toIsoString(entry.updated_at || (properties.updated_at as string | undefined) || entry.created_at) || createdAt
+    const previewUrl = this.resolveUrl(
+      String(entry.preview_url || (properties.preview_url as string | undefined) || '')
+    )
+    const downloadUrl = this.resolveUrl(
+      String(entry.download_url || (properties.download_url as string | undefined) || '')
+    )
+
+    return {
+      id: docId || itemNumber || configId,
+      name,
+      engineering_code: itemNumber || configId || docId || undefined,
+      engineering_revision: currentVersionId || undefined,
+      document_type: documentType,
+      description: String(
+        entry.description ||
+        (properties.description as string | number | undefined) ||
+        ''
+      ) || undefined,
+      engineering_state: engineeringState,
+      item_number: itemNumber || undefined,
+      config_id: configId || undefined,
+      current_version_id: currentVersionId || undefined,
+      file_size: this.toNumber(entry.file_size ?? properties.file_size, 0),
+      mime_type: String(entry.mime_type || (properties.mime_type as string | undefined) || '') || undefined,
+      is_production_doc: ['released', 'approved', 'done', 'production', 'primary'].includes(engineeringState.toLowerCase()),
+      preview_url: previewUrl,
+      download_url: downloadUrl,
+      metadata: {
+        id: docId || undefined,
+        item_number: itemNumber || undefined,
+        config_id: configId || undefined,
+        current_version_id: currentVersionId || undefined,
+        document_type: documentType || undefined,
+        engineering_state: engineeringState || undefined,
+        preview_url: previewUrl,
+        download_url: downloadUrl,
+      },
+      created_at: createdAt,
+      updated_at: updatedAt,
+    }
+  }
+
   private mapYuantusApprovalStatus(state?: string): ApprovalRequest['status'] {
     const normalized = (state || '').toLowerCase()
     if (['approved', 'done'].includes(normalized)) {
@@ -1181,6 +1279,49 @@ export class PLMAdapter extends HTTPAdapter {
     } catch (_err) {
       return null
     }
+  }
+
+  private extractYuantusRelatedDocuments(rows: Array<Record<string, unknown>>): YuantusRelatedDocument[] {
+    const documents: YuantusRelatedDocument[] = []
+    for (const row of rows) {
+      if (!row || typeof row !== 'object') continue
+      const related = row['Document Part']
+      if (Array.isArray(related)) {
+        documents.push(...related.filter((doc): doc is YuantusRelatedDocument => !!doc && typeof doc === 'object'))
+      }
+    }
+    return documents
+  }
+
+  private getYuantusDocumentKey(document: PLMDocument): string {
+    return String(
+      document.id ||
+      document.metadata?.file_id ||
+      document.item_number ||
+      document.config_id ||
+      document.engineering_code ||
+      ''
+    )
+  }
+
+  private mergeYuantusDocuments(...groups: PLMDocument[][]): PLMDocument[] {
+    const seen = new Set<string>()
+    const merged: PLMDocument[] = []
+
+    for (const group of groups) {
+      for (const document of group) {
+        const key = this.getYuantusDocumentKey(document)
+        if (key && seen.has(key)) {
+          continue
+        }
+        if (key) {
+          seen.add(key)
+        }
+        merged.push(document)
+      }
+    }
+
+    return merged
   }
 
   async getProductById(id: string, options?: { itemType?: string }): Promise<PLMProduct | null> {
@@ -1266,23 +1407,61 @@ export class PLMAdapter extends HTTPAdapter {
       const params: Record<string, unknown> = {}
       if (options?.role) params.role = options.role
 
-      const result = await this.query<YuantusItemFile>(`/api/v1/file/item/${productId}`, [params])
+      const [attachmentsResult, relatedResult] = await Promise.all([
+        this.query<YuantusItemFile>(`/api/v1/file/item/${productId}`, [params]),
+        this.select<Record<string, unknown>>('/api/v1/aml/query', {
+          method: 'POST',
+          data: {
+            type: this.yuantusItemType,
+            where: { id: productId },
+            select: ['id', 'name', 'state', 'properties', 'current_version_id', 'config_id'],
+            expand: ['Document Part'],
+            depth: 1,
+            page: 1,
+            page_size: 1,
+          },
+        }),
+      ])
       const includeMetadata = options?.includeMetadata !== false
-      const mapped = await Promise.all(
-        result.data.map(async (entry) => {
+      const mappedAttachments = await Promise.all(
+        attachmentsResult.data.map(async (entry) => {
           const fileId = String(entry.file_id || entry.id || '')
           const metadata = includeMetadata ? await this.fetchYuantusFileMetadata(fileId) : null
           return this.mapYuantusDocumentFields(entry, metadata)
         })
       )
+      const mappedRelated = this.extractYuantusRelatedDocuments(relatedResult.data)
+        .map(entry => this.mapYuantusRelatedDocumentFields(entry))
+      const merged = this.mergeYuantusDocuments(mappedAttachments, mappedRelated)
       const offset = options?.offset ?? 0
       const limit = options?.limit
-      const sliced = typeof limit === 'number' ? mapped.slice(offset, offset + limit) : mapped.slice(offset)
+      const sliced = typeof limit === 'number' ? merged.slice(offset, offset + limit) : merged.slice(offset)
+      const error = attachmentsResult.error && relatedResult.error
+        ? attachmentsResult.error
+        : undefined
+
+      // Partial-degradation visibility: let the caller know which sources
+      // contributed to the result and which failed, so the UI can show a
+      // warning instead of silently returning fewer documents.
+      const sources = [
+        {
+          name: 'attachments' as const,
+          ok: !attachmentsResult.error,
+          count: mappedAttachments.length,
+          ...(attachmentsResult.error ? { error: String(attachmentsResult.error) } : {}),
+        },
+        {
+          name: 'related_documents' as const,
+          ok: !relatedResult.error,
+          count: mappedRelated.length,
+          ...(relatedResult.error ? { error: String(relatedResult.error) } : {}),
+        },
+      ]
 
       return {
         data: sliced,
-        metadata: { totalCount: mapped.length },
-        error: result.error,
+        metadata: { totalCount: merged.length, sources },
+        error,
       }
     }
 

--- a/packages/core-backend/src/routes/federation.ts
+++ b/packages/core-backend/src/routes/federation.ts
@@ -1210,8 +1210,14 @@ export function federationRouter(injector?: Injector): Router {
               role,
               includeMetadata,
             })
-            if (sendAdapterError(res, result.error, 'Failed to query documents', metrics, 'POST', `/plm/${operation}`, startTime)) {
-              return
+            // When sources metadata is present, always return it so the UI
+            // can tell the user exactly which document sources failed — even
+            // when both sources are down. Without this, sendAdapterError
+            // would short-circuit and the sources detail would be lost.
+            if (result.error && !result.metadata?.sources) {
+              if (sendAdapterError(res, result.error, 'Failed to query documents', metrics, 'POST', `/plm/${operation}`, startTime)) {
+                return
+              }
             }
 
             metrics.recordRequest(
@@ -1227,6 +1233,7 @@ export function federationRouter(injector?: Injector): Router {
                 total: result.metadata?.totalCount ?? result.data.length,
                 limit: pagination?.limit ?? 100,
                 offset: pagination?.offset ?? 0,
+                ...(result.metadata?.sources ? { sources: result.metadata.sources } : {}),
               },
             })
           }

--- a/packages/core-backend/tests/PACKAGE_SCRIPTS.md
+++ b/packages/core-backend/tests/PACKAGE_SCRIPTS.md
@@ -31,6 +31,7 @@ Add these scripts to your `package.json` for convenient test execution:
 - `npm run test:db` - Run only database operation tests
 - `npm run test:integration` - Run only integration tests
 - `npm run test:unit` - Run all unit tests
+- `npm run test:e2e:handoff` - Run federated document handoff Playwright E2E (requires 3 external servers; auto-skips if not reachable)
 - `npm run test:perf` - Run only performance tests
 - `npm run test:ui` - Open Vitest UI for interactive testing
 - `npm run test:contract` - Run Pact consumer contract tests

--- a/packages/core-backend/tests/e2e/README.md
+++ b/packages/core-backend/tests/e2e/README.md
@@ -1,0 +1,49 @@
+# E2E Tests
+
+Browser-level regression tests for federated PLM user journeys.
+
+## Prerequisites
+
+These tests require **three servers running externally**:
+
+1. **Yuantus** on `http://127.0.0.1:7910`
+2. **Metasheet backend** on `http://localhost:7778`
+3. **Metasheet frontend** on `http://127.0.0.1:8899`
+
+Tests auto-skip if any server is unreachable.
+
+## Quick start
+
+```bash
+# Terminal 1: Yuantus
+cd /path/to/Yuantus
+./.venv/bin/uvicorn yuantus.api.app:create_app --factory --host 127.0.0.1 --port 7910
+
+# Terminal 2: Metasheet backend
+cd /path/to/metasheet2/packages/core-backend
+PLM_BASE_URL=http://127.0.0.1:7910 PLM_API_MODE=yuantus PLM_TENANT_ID=tenant-1 \
+  PLM_ORG_ID=org-1 PLM_USERNAME=phase0-test PLM_PASSWORD=phase0pass PLM_ITEM_TYPE=Part \
+  npx tsx src/index.ts
+
+# Terminal 3: Metasheet frontend
+cd /path/to/metasheet2/apps/web
+npx vite --host 127.0.0.1 --port 8899
+
+# Terminal 4: Run E2E
+cd /path/to/metasheet2/packages/core-backend
+npx playwright test --config tests/e2e/playwright.config.ts
+```
+
+## Test data
+
+Tests use the B demo object:
+
+- Part `b5ecee24-5ce8-4b59-9551-446e1c50b608` (Doc UI Product)
+- Has 1 file attachment + 1 AML related document (Doc UI Doc)
+- Has 1 ECO (DOCUI-ECO-1768357216, state=progress)
+
+Metasheet user: `phase0@test.local` / `Phase0Test!2026` (role=admin)
+
+## What's tested
+
+- `handoff-journey.spec.ts`: source product → documents → open AML doc → return → roundtrip

--- a/packages/core-backend/tests/e2e/handoff-journey.spec.ts
+++ b/packages/core-backend/tests/e2e/handoff-journey.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Federated handoff journey E2E regression.
+ *
+ * Validates the full source product → AML related document → return to source
+ * user journey introduced in Phase 0.13.
+ *
+ * Prerequisites: Yuantus (:7910), Metasheet backend (:7778), frontend (:8899)
+ * must be running externally. Tests skip if servers are unreachable.
+ *
+ * Run:
+ *   npx playwright test --config tests/e2e/playwright.config.ts
+ */
+import { test, expect } from '@playwright/test'
+
+const FE = 'http://127.0.0.1:8899'
+const API = 'http://localhost:7778'
+const B_ID = 'b5ecee24-5ce8-4b59-9551-446e1c50b608'
+
+// ── Setup: login + connect PLM, skip if servers down ──────────
+
+let token = ''
+
+test.beforeAll(async ({ request }) => {
+  // Skip entire suite if servers are not reachable
+  try {
+    const health = await request.get(`${API}/health`, { timeout: 3000 })
+    if (!health.ok()) test.skip(true, 'Metasheet backend not reachable')
+  } catch {
+    test.skip(true, 'Metasheet backend not reachable')
+  }
+
+  // Login
+  const loginRes = await request.post(`${API}/api/auth/login`, {
+    data: { email: 'phase0@test.local', password: 'Phase0Test!2026' },
+  })
+  const loginBody = await loginRes.json()
+  token = loginBody.data?.token
+  if (!token) test.skip(true, 'Login failed — phase0 user may not exist')
+
+  // Connect PLM
+  await request.post(`${API}/api/federation/systems/plm/connect`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+})
+
+// ── Helpers ───────────────────────────────────────────────────
+
+async function injectTokenAndGo(page: any, path: string) {
+  await page.goto(FE)
+  await page.evaluate((t: string) => {
+    localStorage.setItem('metasheet_token', t)
+    localStorage.setItem('token', t)
+  }, token)
+  await page.goto(`${FE}${path}`)
+  await page.waitForTimeout(2000)
+}
+
+async function clickLoad(page: any) {
+  const btn = page.locator('button:has-text("加载产品")').first()
+  if (await btn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await btn.click()
+    await page.waitForTimeout(4000)
+  }
+}
+
+async function clickRefreshDocs(page: any) {
+  const btn = page.locator('button:has-text("刷新文档")').first()
+  if (await btn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await btn.click()
+    await page.waitForTimeout(3000)
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+test.describe('Federated document handoff journey', () => {
+  test('"打开" button only appears on AML related document rows', async ({ page }) => {
+    await injectTokenAndGo(page, `/plm?productId=${B_ID}`)
+    await clickLoad(page)
+    await clickRefreshDocs(page)
+
+    // The doc table should have 2 rows: attachment + AML doc.
+    // "打开" should only be on the AML doc row.
+    const openButtons = page.locator('button:has-text("打开")')
+    await expect(openButtons).toHaveCount(1)
+
+    // The AML doc row should contain "Doc UI Doc" or "document"
+    const amlRow = page.locator('tr:has(button:has-text("打开"))')
+    await expect(amlRow).toContainText('document')
+  })
+
+  test('clicking "打开" switches to Document item without manual type change', async ({ page }) => {
+    await injectTokenAndGo(page, `/plm?productId=${B_ID}`)
+    await clickLoad(page)
+    await clickRefreshDocs(page)
+
+    // Click the "打开" button
+    await page.locator('button:has-text("打开")').first().click()
+    await page.waitForTimeout(4000)
+
+    // Verify Document detail loaded
+    const body = await page.locator('body').textContent()
+    expect(body).toMatch(/Doc UI Doc|DOCUI-D/)
+    expect(body).toContain('Document')
+  })
+
+  test('"← 返回源产品" banner appears after handoff and works', async ({ page }) => {
+    await injectTokenAndGo(page, `/plm?productId=${B_ID}`)
+    await clickLoad(page)
+    await clickRefreshDocs(page)
+
+    // Handoff to document
+    await page.locator('button:has-text("打开")').first().click()
+    await page.waitForTimeout(4000)
+
+    // Return banner should be visible
+    const returnBtn = page.locator('button:has-text("返回源产品")')
+    await expect(returnBtn).toBeVisible()
+
+    const hint = page.locator('.return-hint')
+    await expect(hint).toContainText('关联文档对象')
+
+    // Click return
+    await returnBtn.click()
+    await page.waitForTimeout(4000)
+
+    // Source product restored
+    const body = await page.locator('body').textContent()
+    expect(body).toMatch(/Doc UI Product|DOCUI-P/)
+
+    // Return button should be gone
+    await expect(returnBtn).not.toBeVisible()
+  })
+
+  test('documents survive full roundtrip without degradation', async ({ page }) => {
+    await injectTokenAndGo(page, `/plm?productId=${B_ID}`)
+    await clickLoad(page)
+    await clickRefreshDocs(page)
+
+    // Handoff → return
+    await page.locator('button:has-text("打开")').first().click()
+    await page.waitForTimeout(4000)
+    await page.locator('button:has-text("返回源产品")').first().click()
+    await page.waitForTimeout(4000)
+
+    // Refresh documents after roundtrip
+    await clickRefreshDocs(page)
+
+    // Both document types should still be present
+    const body = await page.locator('body').textContent()
+    expect(body).toMatch(/drawing|\.pdf/)    // attachment
+    expect(body).toContain('Doc UI Doc')      // AML related doc
+
+    // No degradation warning
+    const warning = page.locator('.status.warning')
+    await expect(warning).not.toBeVisible()
+  })
+})

--- a/packages/core-backend/tests/e2e/playwright.config.ts
+++ b/packages/core-backend/tests/e2e/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test'
+
+/**
+ * Minimal Playwright config for federated PLM E2E tests.
+ *
+ * Prerequisites (external — not auto-started by this config):
+ *   1. Yuantus on http://127.0.0.1:7910
+ *   2. Metasheet backend on http://localhost:7778
+ *   3. Metasheet frontend on http://127.0.0.1:8899
+ *
+ * Tests skip automatically if servers are not reachable.
+ *
+ * Run:
+ *   cd packages/core-backend
+ *   npx playwright test --config tests/e2e/playwright.config.ts
+ */
+export default defineConfig({
+  testDir: '.',
+  testMatch: '*.spec.ts',
+  timeout: 60_000,
+  retries: 0,
+  use: {
+    headless: true,
+    baseURL: 'http://127.0.0.1:8899',
+  },
+})

--- a/packages/core-backend/tests/unit/federation.contract.test.ts
+++ b/packages/core-backend/tests/unit/federation.contract.test.ts
@@ -466,3 +466,139 @@ describe('Federation contract routes', () => {
     })
   })
 })
+
+
+// ---------------------------------------------------------------------------
+// PLM documents partial-degradation (route-level regression)
+// ---------------------------------------------------------------------------
+
+describe('Federation PLM documents degradation visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    rbacMocks.userHasPermission.mockResolvedValue(true)
+    rbacMocks.listUserPermissions.mockResolvedValue(['federation:read', 'federation:write'])
+    auditMocks.auditLog.mockResolvedValue(undefined)
+  })
+
+  function createDocPlmAdapter(overrides: {
+    getProductDocuments: (...args: any[]) => Promise<any>
+  }) {
+    const base = createPlmAdapterMock()
+    return { ...base, getProductDocuments: vi.fn(overrides.getProductDocuments) }
+  }
+
+  it('returns sources metadata when attachments fail but AML succeeds', async () => {
+    const plmAdapter = createDocPlmAdapter({
+      getProductDocuments: async () => ({
+        data: [{ id: 'doc-aml-1', name: 'AML Doc', document_type: 'document' }],
+        metadata: {
+          totalCount: 1,
+          sources: [
+            { name: 'attachments', ok: false, count: 0, error: 'file endpoint down' },
+            { name: 'related_documents', ok: true, count: 1 },
+          ],
+        },
+      }),
+    })
+    const app = createFederationApp({ plmAdapter })
+
+    const res = await request(app)
+      .post('/api/federation/plm/query')
+      .send({ operation: 'documents', productId: 'prod-1' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.items).toHaveLength(1)
+    expect(res.body.data.sources).toBeDefined()
+    expect(res.body.data.sources[0]).toMatchObject({ name: 'attachments', ok: false })
+    expect(res.body.data.sources[0].error).toBe('file endpoint down')
+    expect(res.body.data.sources[1]).toMatchObject({ name: 'related_documents', ok: true, count: 1 })
+  })
+
+  it('returns sources metadata when AML fails but attachments succeed', async () => {
+    const plmAdapter = createDocPlmAdapter({
+      getProductDocuments: async () => ({
+        data: [{ id: 'file-1', name: 'drawing.pdf', document_type: 'drawing' }],
+        metadata: {
+          totalCount: 1,
+          sources: [
+            { name: 'attachments', ok: true, count: 1 },
+            { name: 'related_documents', ok: false, count: 0, error: 'aml query down' },
+          ],
+        },
+      }),
+    })
+    const app = createFederationApp({ plmAdapter })
+
+    const res = await request(app)
+      .post('/api/federation/plm/query')
+      .send({ operation: 'documents', productId: 'prod-1' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.items).toHaveLength(1)
+    expect(res.body.data.sources[0]).toMatchObject({ name: 'attachments', ok: true })
+    expect(res.body.data.sources[1]).toMatchObject({ name: 'related_documents', ok: false })
+  })
+
+  it('returns sources metadata even when both sides fail (no sendAdapterError short-circuit)', async () => {
+    const plmAdapter = createDocPlmAdapter({
+      getProductDocuments: async () => ({
+        data: [],
+        metadata: {
+          totalCount: 0,
+          sources: [
+            { name: 'attachments', ok: false, count: 0, error: 'file side down' },
+            { name: 'related_documents', ok: false, count: 0, error: 'aml side down' },
+          ],
+        },
+        error: new Error('file side down'),
+      }),
+    })
+    const app = createFederationApp({ plmAdapter })
+
+    const res = await request(app)
+      .post('/api/federation/plm/query')
+      .send({ operation: 'documents', productId: 'prod-1' })
+
+    // Key assertion: even with result.error set, the route should still
+    // return ok:true + sources because sources metadata is present. The
+    // sendAdapterError path is bypassed for documents when sources exist.
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.items).toHaveLength(0)
+    expect(res.body.data.sources).toBeDefined()
+    expect(res.body.data.sources[0]).toMatchObject({ name: 'attachments', ok: false })
+    expect(res.body.data.sources[1]).toMatchObject({ name: 'related_documents', ok: false })
+  })
+
+  it('returns no sources field when both sides succeed (clean response)', async () => {
+    const plmAdapter = createDocPlmAdapter({
+      getProductDocuments: async () => ({
+        data: [
+          { id: 'f1', name: 'spec.pdf', document_type: 'drawing' },
+          { id: 'd1', name: 'Related Doc', document_type: 'document' },
+        ],
+        metadata: {
+          totalCount: 2,
+          sources: [
+            { name: 'attachments', ok: true, count: 1 },
+            { name: 'related_documents', ok: true, count: 1 },
+          ],
+        },
+      }),
+    })
+    const app = createFederationApp({ plmAdapter })
+
+    const res = await request(app)
+      .post('/api/federation/plm/query')
+      .send({ operation: 'documents', productId: 'prod-1' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.items).toHaveLength(2)
+    expect(res.body.data.sources).toBeDefined()
+    expect(res.body.data.sources.every((s: any) => s.ok)).toBe(true)
+  })
+})

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -109,7 +109,7 @@ describe('PLMAdapter Yuantus product detail mapping', () => {
 })
 
 describe('PLMAdapter Yuantus documents mapping', () => {
-  it('maps document metadata and resolves URLs', async () => {
+  it('merges file attachments with AML related documents and resolves URLs', async () => {
     const adapter = createAdapter()
     ;(adapter as any).config.connection.url = 'http://plm.local'
 
@@ -142,16 +142,50 @@ describe('PLMAdapter Yuantus documents mapping', () => {
       }
       return { data: [] }
     })
+    const selectMock = vi.fn(async (path: string) => {
+      if (path === '/api/v1/aml/query') {
+        return {
+          data: [{
+            id: 'item-1',
+            name: 'Root Part',
+            state: 'Released',
+            config_id: 'cfg-root',
+            'Document Part': [{
+              id: 'doc-2',
+              name: 'Spec Document',
+              state: 'Draft',
+              item_number: 'DOC-002',
+              config_id: 'cfg-doc-2',
+              current_version_id: 'ver-2',
+              properties: {
+                document_type: 'specification',
+                engineering_state: 'draft',
+              },
+            }],
+          }],
+        }
+      }
+      return { data: [] }
+    })
 
     ;(adapter as any).query = queryMock
+    ;(adapter as any).select = selectMock
 
     const result = await adapter.getProductDocuments('item-1')
 
     expect(queryMock).toHaveBeenCalledWith('/api/v1/file/item/item-1', [expect.any(Object)])
+    expect(selectMock).toHaveBeenCalledWith('/api/v1/aml/query', expect.objectContaining({
+      method: 'POST',
+      data: expect.objectContaining({
+        type: 'Part',
+        where: { id: 'item-1' },
+        expand: ['Document Part'],
+      }),
+    }))
     expect(queryMock).toHaveBeenCalledWith('/api/v1/file/file-1')
-    expect(result.data).toHaveLength(1)
+    expect(result.data).toHaveLength(2)
 
-    const doc = result.data[0]
+    const [doc, relatedDoc] = result.data
     expect(doc.id).toBe('file-1')
     expect(doc.name).toBe('meta-name.dwg')
     expect(doc.document_type).toBe('drawing')
@@ -162,6 +196,57 @@ describe('PLMAdapter Yuantus documents mapping', () => {
     expect(doc.download_url).toBe('http://cdn.local/download/file-1')
     expect(doc.is_production_doc).toBe(true)
     expect(doc.metadata?.file_role).toBe('primary')
+
+    expect(relatedDoc.id).toBe('doc-2')
+    expect(relatedDoc.name).toBe('Spec Document')
+    expect(relatedDoc.document_type).toBe('specification')
+    expect(relatedDoc.engineering_state).toBe('Draft')
+    expect(relatedDoc.item_number).toBe('DOC-002')
+    expect(relatedDoc.config_id).toBe('cfg-doc-2')
+    expect(relatedDoc.current_version_id).toBe('ver-2')
+    expect(relatedDoc.metadata?.config_id).toBe('cfg-doc-2')
+  })
+
+  it('deduplicates merged documents by id and file id', async () => {
+    const adapter = createAdapter()
+
+    const queryMock = vi.fn(async (path: string) => {
+      if (path.startsWith('/api/v1/file/item/')) {
+        return {
+          data: [{
+            file_id: 'shared-1',
+            filename: 'shared.dwg',
+            file_role: 'primary',
+            document_type: 'drawing',
+          }],
+        }
+      }
+      return { data: [] }
+    })
+    const selectMock = vi.fn(async (path: string) => {
+      if (path === '/api/v1/aml/query') {
+        return {
+          data: [{
+            id: 'item-1',
+            'Document Part': [{
+              id: 'shared-1',
+              name: 'Shared Document',
+              state: 'Released',
+              item_number: 'DOC-SHARED',
+            }],
+          }],
+        }
+      }
+      return { data: [] }
+    })
+
+    ;(adapter as any).query = queryMock
+    ;(adapter as any).select = selectMock
+
+    const result = await adapter.getProductDocuments('item-1')
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0].id).toBe('shared-1')
   })
 })
 
@@ -188,5 +273,159 @@ describe('PLMAdapter Yuantus approvals mapping', () => {
     expect(all.data).toHaveLength(3)
     expect(all.data.map((entry) => entry.status)).toEqual(['approved', 'rejected', 'pending'])
     expect(all.data.map((entry) => entry.version)).toEqual([12, undefined, 3])
+  })
+})
+
+describe('PLMAdapter Yuantus documents single-side failure + sources metadata', () => {
+  it('returns AML related documents when file/item endpoint errors, with sources showing degradation', async () => {
+    const adapter = createAdapter()
+
+    const queryMock = vi.fn(async (path: string) => {
+      if (path.startsWith('/api/v1/file/item/')) {
+        return { data: [], error: new Error('file endpoint down') }
+      }
+      return { data: [] }
+    })
+    const selectMock = vi.fn(async (path: string) => {
+      if (path === '/api/v1/aml/query') {
+        return {
+          data: [{
+            id: 'item-1',
+            'Document Part': [{
+              id: 'doc-aml-1',
+              name: 'Surviving AML Doc',
+              state: 'Released',
+              item_number: 'DOC-AML-1',
+            }],
+          }],
+        }
+      }
+      return { data: [] }
+    })
+
+    ;(adapter as any).query = queryMock
+    ;(adapter as any).select = selectMock
+
+    const result = await adapter.getProductDocuments('item-1')
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0].name).toBe('Surviving AML Doc')
+    expect(result.error).toBeUndefined()
+
+    // sources metadata: attachments failed, related_documents succeeded
+    const sources = (result.metadata as any)?.sources
+    expect(sources).toBeDefined()
+    expect(sources).toHaveLength(2)
+    expect(sources[0]).toMatchObject({ name: 'attachments', ok: false })
+    expect(sources[0].error).toBeDefined()
+    expect(sources[1]).toMatchObject({ name: 'related_documents', ok: true, count: 1 })
+  })
+
+  it('returns file attachments when AML query endpoint errors, with sources showing degradation', async () => {
+    const adapter = createAdapter()
+
+    const queryMock = vi.fn(async (path: string) => {
+      if (path.startsWith('/api/v1/file/item/')) {
+        return {
+          data: [{
+            file_id: 'file-survive-1',
+            filename: 'surviving-file.pdf',
+            file_role: 'primary',
+            document_type: 'drawing',
+          }],
+        }
+      }
+      if (path.startsWith('/api/v1/file/')) {
+        return { data: [] }
+      }
+      return { data: [] }
+    })
+    const selectMock = vi.fn(async () => {
+      return { data: [], error: new Error('aml query down') }
+    })
+
+    ;(adapter as any).query = queryMock
+    ;(adapter as any).select = selectMock
+
+    const result = await adapter.getProductDocuments('item-1')
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0].name).toBe('surviving-file.pdf')
+    expect(result.error).toBeUndefined()
+
+    // sources metadata: attachments succeeded, related_documents failed
+    const sources = (result.metadata as any)?.sources
+    expect(sources).toBeDefined()
+    expect(sources[0]).toMatchObject({ name: 'attachments', ok: true, count: 1 })
+    expect(sources[1]).toMatchObject({ name: 'related_documents', ok: false })
+    expect(sources[1].error).toBeDefined()
+  })
+
+  it('propagates error and marks both sources failed when both sides fail', async () => {
+    const adapter = createAdapter()
+
+    const fileError = new Error('file side down')
+    const queryMock = vi.fn(async () => {
+      return { data: [], error: fileError }
+    })
+    const selectMock = vi.fn(async () => {
+      return { data: [], error: new Error('aml side down') }
+    })
+
+    ;(adapter as any).query = queryMock
+    ;(adapter as any).select = selectMock
+
+    const result = await adapter.getProductDocuments('item-1')
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+
+    // sources metadata: both failed
+    const sources = (result.metadata as any)?.sources
+    expect(sources).toBeDefined()
+    expect(sources[0]).toMatchObject({ name: 'attachments', ok: false })
+    expect(sources[1]).toMatchObject({ name: 'related_documents', ok: false })
+  })
+
+  it('reports both sources ok when neither fails', async () => {
+    const adapter = createAdapter()
+
+    const queryMock = vi.fn(async (path: string) => {
+      if (path.startsWith('/api/v1/file/item/')) {
+        return {
+          data: [{
+            file_id: 'f1',
+            filename: 'spec.pdf',
+            file_role: 'primary',
+            document_type: 'drawing',
+          }],
+        }
+      }
+      return { data: [] }
+    })
+    const selectMock = vi.fn(async (path: string) => {
+      if (path === '/api/v1/aml/query') {
+        return {
+          data: [{
+            id: 'item-1',
+            'Document Part': [{
+              id: 'doc-1',
+              name: 'Related Doc',
+              state: 'Draft',
+            }],
+          }],
+        }
+      }
+      return { data: [] }
+    })
+
+    ;(adapter as any).query = queryMock
+    ;(adapter as any).select = selectMock
+
+    const result = await adapter.getProductDocuments('item-1')
+    expect(result.data).toHaveLength(2)
+    expect(result.error).toBeUndefined()
+
+    const sources = (result.metadata as any)?.sources
+    expect(sources).toBeDefined()
+    expect(sources[0]).toMatchObject({ name: 'attachments', ok: true, count: 1 })
+    expect(sources[1]).toMatchObject({ name: 'related_documents', ok: true, count: 1 })
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
       // Integration tests require pluginDirs option in PluginLoader constructor (not implemented)
       // and require running database/external services
       'tests/integration/**',
+      // Playwright E2E suites run through their own harness, not Vitest.
+      'tests/e2e/**',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- recut the PLM documents degradation and handoff UX out of the stale #717 branch onto latest `main`
- merge AML related documents with attachments on the backend and surface partial degradation details to the UI
- add the standalone handoff E2E harness, docs, and focused frontend/unit coverage

## Verify
- pnpm --filter @metasheet/web exec vitest run tests/plmDocumentDegradation.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts tests/unit/federation.contract.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
