### PR TITLE
docs(platform): recut project builder and after-sales design packet

### DIFF
--- a/docs/development/after-sales-project-template-design-20260407.md
+++ b/docs/development/after-sales-project-template-design-20260407.md
@@ -1,0 +1,340 @@
+# 售后项目模板设计 (after-sales-project-template-design-20260407)
+
+> **文档类型**：业务模板设计 / Pre-Implementation Design
+> **日期**：2026-04-07
+> **范围**：v1 唯一售后子域实例的默认模板（`after-sales-default`）
+> **来源词典**：2026-04-07 接口词典 v1.0（locked）
+> **配套交付**：本文档为「2026-04-07 平台项目创建器 + 售后模板」5 份设计稿之 #1，后续 #2-#5 见同目录其他 `*-20260407.md` 文件
+
+## TL;DR
+
+售后默认模板把"客户 / 装机资产 / 工单 / 服务记录 / 配件 / 回访"6 个对象、5 个默认视图、3 个默认自动化、4 个默认通知主题与 6 个角色权限，打包成一份可一键启用的项目蓝图。v1 每租户启用一次即得唯一售后业务子域；退款/赔付审批走 `ApprovalBridgeService`；`fieldPolicies.hidden` 仅在 UI 层隐藏 `refundAmount`，API 仍返回；v2 才扩展为多个售后项目实例。
+
+---
+
+## 1. 业务目标
+
+售后默认模板的目标是让一个全新租户在不写任何代码、不调任何 API 的情况下，从启用按钮到可用的售后业务系统在分钟级完成。覆盖能力：
+
+- 客户与装机资产档案管理
+- 工单创建、分派、SLA 监控
+- 现场 / 远程 / 到店三种服务方式
+- 配件与耗材消耗记录
+- 退款 / 赔付审批桥接
+- 服务结束后的定时回访
+- 6 类角色的权限边界
+
+模板交付的不是"功能"，而是"可被实施者一比一落地的对象 + 视图 + 流程 + 通知 + 权限的完整声明"。
+
+## 2. 角色矩阵
+
+v1 使用 6 个固定角色 slug。类型与接口层使用英文 slug，UI 文案与文档叙述使用中文标签。
+
+| Slug | 中文标签 | 默认权限 |
+|---|---|---|
+| `customer_service` | 客服 | `after_sales:read`, `after_sales:write` |
+| `technician` | 技师 | `after_sales:read`, `after_sales:write` |
+| `supervisor` | 主管 | `after_sales:read`, `after_sales:write`, `after_sales:approve` |
+| `finance` | 财务 | `after_sales:read`, `after_sales:approve` |
+| `admin` | 管理员 | `after_sales:read`, `after_sales:write`, `after_sales:approve`, `after_sales:admin` |
+| `viewer` | 只读 | `after_sales:read` |
+
+### 字段级权限策略 (fieldPolicies)
+
+v1 唯一启用 `fieldPolicies` 的字段是 `serviceTicket.refundAmount`：
+
+| 角色 | visibility | editability |
+|---|---|---|
+| `finance` | `visible` | `editable` |
+| `admin` | `visible` | `editable` |
+| `supervisor` | `visible` | `readonly` |
+| `customer_service` | `hidden` | `readonly` |
+| `technician` | `hidden` | `readonly` |
+| `viewer` | `hidden` | `readonly` |
+
+**v1 强约束**：`visibility = 'hidden'` 仅在前端字段渲染层隐藏，与 multitable 现有 `hidden_field_ids` 实现对齐（参考 `apps/web` 与 `packages/core-backend/src/routes/univer-meta.ts:1086 / 3133`）。**API 仍返回该列**。v2 才考虑列级 API 裁剪。
+
+## 3. 默认对象字段表
+
+模板安装时生成 6 个 **multitable 对象** 的默认字段表。此外保留 `warrantyPolicy` 作为 service-backed 支撑能力，由 `AfterSalesTemplateConfig.enableWarranty` 配置开关控制，**不进入这 6 张字段表**（详见 §11 与 #2 安装器文档对 backing 选择的说明）。
+
+字段类型严格使用接口词典 v1.0 的 10 种规范类型（`string / number / boolean / date / formula / select / link / lookup / rollup / attachment`），识别类字段一律使用 `string`。
+
+### 3.1 Customer (客户)
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `id` | `string` | ✓ | 主键 |
+| `customerCode` | `string` | ✓ | 客户编码（识别类字段） |
+| `name` | `string` | ✓ | 客户名称 |
+| `type` | `select` | ✓ | options: `individual` / `enterprise` |
+| `contactPhone` | `string` |  | |
+| `contactEmail` | `string` |  | |
+| `address` | `string` |  | |
+| `accountManager` | `link` |  | reference: `{ objectId: 'user', refKind: 'user' }` |
+| `createdAt` | `date` | ✓ | |
+| `updatedAt` | `date` | ✓ | |
+
+### 3.2 InstalledAsset (装机资产)
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `id` | `string` | ✓ | 主键 |
+| `assetCode` | `string` | ✓ | 资产编码（识别类字段） |
+| `serialNo` | `string` | ✓ | 序列号（识别类字段） |
+| `customerId` | `link` | ✓ | reference: `{ objectId: 'customer' }` |
+| `model` | `string` |  | 型号 |
+| `installedAt` | `date` |  | 安装日期 |
+| `warrantyUntil` | `date` |  | 保修截止 |
+| `status` | `select` | ✓ | options: `active` / `expired` / `decommissioned` |
+| `location` | `string` |  | 安装地点 |
+| `createdAt` | `date` | ✓ | |
+| `updatedAt` | `date` | ✓ | |
+
+### 3.3 ServiceTicket (工单) — 词典锁定字段集
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `id` | `string` | ✓ | 主键 |
+| `ticketNo` | `string` | ✓ | 工单号（识别类字段） |
+| `title` | `string` | ✓ | |
+| `customerId` | `link` | ✓ | reference: `{ objectId: 'customer' }` |
+| `assetId` | `link` |  | reference: `{ objectId: 'installedAsset' }` |
+| `source` | `select` | ✓ | options: `phone` / `email` / `web` / `wechat` |
+| `priority` | `select` | ✓ | options: `low` / `normal` / `high` / `urgent`，默认 `normal` |
+| `status` | `select` | ✓ | options: `new` / `assigned` / `inProgress` / `done` / `closed`，默认 `new` |
+| `slaDueAt` | `date` | ✓ | SLA 截止时间，由 ticket-triage 自动写入 |
+| `assignedTo` | `link` |  | reference: `{ objectId: 'user', refKind: 'user' }` |
+| `refundAmount` | `number` |  | 受 fieldPolicies 控制 |
+| `createdAt` | `date` | ✓ | |
+| `updatedAt` | `date` | ✓ | |
+
+### 3.4 ServiceRecord (服务记录) — 词典锁定字段集
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `id` | `string` | ✓ | 主键 |
+| `ticketId` | `link` | ✓ | reference: `{ objectId: 'serviceTicket' }` |
+| `visitType` | `select` | ✓ | options: `onsite` / `remote` / `pickup` |
+| `scheduledAt` | `date` | ✓ | 计划上门时间 |
+| `startedAt` | `date` |  | 实际开始时间 |
+| `completedAt` | `date` |  | 完成时间 |
+| `technicianId` | `link` | ✓ | reference: `{ objectId: 'user', refKind: 'user' }` |
+| `workSummary` | `string` |  | 工作摘要 |
+| `result` | `select` | ✓ | options: `resolved` / `partial` / `escalated` |
+| `createdAt` | `date` | ✓ | |
+
+### 3.5 PartItem (配件 / 耗材)
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `id` | `string` | ✓ | 主键 |
+| `partNo` | `string` | ✓ | 物料编码（识别类字段） |
+| `name` | `string` | ✓ | 物料名称 |
+| `category` | `select` | ✓ | options: `spare_part` / `consumable` / `tool` |
+| `unit` | `string` | ✓ | 计量单位（pcs / kg / m 等） |
+| `unitCost` | `number` |  | 单价 |
+| `stockQuantity` | `number` | ✓ | 当前库存 |
+| `minStockQuantity` | `number` |  | 安全库存阈值 |
+| `createdAt` | `date` | ✓ | |
+| `updatedAt` | `date` | ✓ | |
+
+### 3.6 FollowUp (回访)
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `id` | `string` | ✓ | 主键 |
+| `ticketId` | `link` | ✓ | reference: `{ objectId: 'serviceTicket' }` |
+| `customerId` | `link` | ✓ | reference: `{ objectId: 'customer' }` |
+| `scheduledAt` | `date` | ✓ | 计划回访时间 |
+| `followUpType` | `select` | ✓ | options: `phone` / `sms` / `email` / `visit` |
+| `status` | `select` | ✓ | options: `pending` / `done` / `skipped`，默认 `pending` |
+| `satisfactionScore` | `number` |  | 1-5 评分 |
+| `feedback` | `string` |  | 客户反馈文本 |
+| `followedUpBy` | `link` |  | reference: `{ objectId: 'user', refKind: 'user' }` |
+| `createdAt` | `date` | ✓ | |
+
+## 4. 默认视图清单
+
+模板声明 5 个默认视图，全部落在 `grid` / `kanban` / `calendar` / `form` 四种类型上。**v1 不使用 `gantt` / `timeline`**（依据：`packages/core-backend/src/services/view-service.ts:12` 当前公开类型上界为 gantt，timeline 仅前端有，未在核心 view-service 暴露）。
+
+| 视图 ID | 名称 | 类型 | 对象 | 关键配置 |
+|---|---|---|---|---|
+| `ticket-board` | 工单看板 | `kanban` | `serviceTicket` | groupBy: `status` |
+| `today-visit-calendar` | 今日上门日历 | `calendar` | `serviceRecord` | dateField: `scheduledAt` |
+| `customer-360` | 客户 360 | `form` | `customer` | layout: 全字段单条详情 |
+| `sla-risk-list` | SLA 风险列表 | `grid` | `serviceTicket` | filter: `slaDueAt` < now + 24h, sort: `slaDueAt` asc |
+| `pending-followup` | 待回访列表 | `grid` | `followUp` | filter: `status = pending`, sort: `scheduledAt` asc |
+
+## 5. 默认自动化 (AutomationRuleDraft)
+
+模板声明 3 条默认自动化规则，使用接口词典 v1.0 的结构化 trigger。所有规则的 `conditions` 字段在 v1 留空数组，v2 才启用运行时条件。
+
+### 5.1 ticket-triage (工单分派)
+
+```json
+{
+  "id": "ticket-triage",
+  "trigger": { "event": "ticket.created" },
+  "conditions": [],
+  "actions": [
+    { "type": "assign", "assigneeRule": "by-area-or-round-robin" },
+    { "type": "updateField", "field": "slaDueAt", "value": "{{computeSlaDueAt(priority)}}" },
+    { "type": "sendNotification", "topic": "after-sales.ticket.assigned" }
+  ],
+  "enabled": true
+}
+```
+
+### 5.2 sla-watcher (SLA 超时升级)
+
+```json
+{
+  "id": "sla-watcher",
+  "trigger": {
+    "event": "ticket.overdue",
+    "filter": [
+      { "field": "status", "operator": "in", "value": ["new", "assigned", "inProgress"] }
+    ]
+  },
+  "conditions": [],
+  "actions": [
+    { "type": "updateField", "field": "priority", "value": "urgent" },
+    { "type": "sendNotification", "topic": "after-sales.ticket.overdue" }
+  ],
+  "enabled": true
+}
+```
+
+### 5.3 refund-approval (退款 / 赔付审批)
+
+```json
+{
+  "id": "refund-approval",
+  "trigger": { "event": "ticket.refundRequested" },
+  "conditions": [],
+  "actions": [
+    { "type": "submitApproval", "bridge": "after-sales-refund" },
+    { "type": "sendNotification", "topic": "after-sales.approval.pending" }
+  ],
+  "enabled": true
+}
+```
+
+**强约束**：退款 / 赔付审批 v1 必须通过 `ApprovalBridgeService` 完成，`submitApproval.bridge` 固定为 `after-sales-refund`。**禁止**在 workflow 引擎中实现人工审批节点。
+
+## 6. 默认通知主题 (NotificationTopicSpec)
+
+| topic | event | channels | defaultRecipients |
+|---|---|---|---|
+| `after-sales.ticket.assigned` | `ticket.assigned` | `email`, `feishu` | `{{ticket.assignedTo}}` |
+| `after-sales.ticket.overdue` | `ticket.overdue` | `email`, `feishu` | `{{ticket.assignedTo}}`, `{{ticket.assignedSupervisor}}` |
+| `after-sales.approval.pending` | `approval.pending` | `feishu` | `role:finance`, `role:supervisor` |
+| `after-sales.followup.due` | `followup.due` | `feishu` | `{{followUp.followedUpBy}}` |
+
+**v1 强约束**：channels 枚举固定为 `email` / `webhook` / `feishu`，与 `packages/core-backend/src/services/NotificationService.ts:263` 已注册的渠道对齐。**禁止出现 `inApp`**——`inApp` 是 v2 通知中枢的目标，v1 文档不得出现。
+
+## 7. 默认值小表 (AfterSalesTemplateConfig)
+
+| 配置 | 默认值 | 备注 |
+|---|---|---|
+| `enableWarranty` | `true` | |
+| `enableRefundApproval` | `true` | true 时挂载 ApprovalBridge: `after-sales-refund` |
+| `enableVisitScheduling` | `true` | |
+| `enableFollowUp` | `true` | |
+| `defaultSlaHours` | `24` | 普通工单 SLA |
+| `urgentSlaHours` | `4` | 紧急工单 SLA |
+| `followUpAfterDays` | `7` | 工单完成后第 7 天触发回访 |
+
+`computeSlaDueAt(priority)` 的语义：
+- `priority ∈ {low, normal, high}` → `now + defaultSlaHours`
+- `priority = urgent` → `now + urgentSlaHours`
+
+## 8. 业务闭环图 (Mermaid)
+
+```mermaid
+flowchart LR
+  A[客户报修] --> B[创建工单]
+  B -->|ticket-triage| C[自动分派 + SLA 计算]
+  C --> D[通知技师]
+  D --> E[现场 / 远程 / 到店]
+  E --> F[填写服务记录]
+  F --> G{解决?}
+  G -- 是 --> H[关闭工单]
+  G -- 否 --> I[升级]
+  H -->|followUpAfterDays 后| J[定时回访]
+  J --> K[满意度评分 + 反馈]
+
+  C -.sla-watcher.-> L[超时升级 priority=urgent]
+  L --> M[通知主管]
+
+  H -.涉及退款.-> N[refund-approval]
+  N --> O[ApprovalBridge: after-sales-refund]
+  O --> P[财务/主管审批]
+```
+
+## 9. 对象关系图 (Mermaid ER)
+
+```mermaid
+erDiagram
+  Customer ||--o{ InstalledAsset : owns
+  Customer ||--o{ ServiceTicket : submits
+  InstalledAsset ||--o{ ServiceTicket : referenced
+  ServiceTicket ||--o{ ServiceRecord : has
+  ServiceTicket ||--o{ FollowUp : triggers
+  ServiceRecord }o--o{ PartItem : consumes
+  ServiceTicket }o--|| User : assignedTo
+  ServiceRecord }o--|| User : technician
+  FollowUp }o--|| User : followedUpBy
+```
+
+## 10. v1 / v2 差异
+
+| 维度 | v1（本文档范围） | v2（未来） |
+|---|---|---|
+| 实例语义 | 每租户每应用 = 唯一业务子域 | 每租户每应用 = 多个项目实例 |
+| `projectId` | 伪值 `${tenantId}:after-sales` | 用户创建时分配真值 |
+| 启用动作 | "启用售后" | "创建项目"（可多次） |
+| 入口 UI | 主导航单一菜单项 | 项目切换器 + 多项目主页 |
+| 数据隔离 | 仅 `tenant_id` | `tenant_id` + `project_id` |
+| 卸载粒度 | 关停整个应用 | 删除单个项目 / 关停整个应用 |
+| RBAC 粒度 | `after_sales:write` | `after_sales:write@projectId=...` |
+| 字段 ACL | UI 层隐藏（本文档） | UI 隐藏 + API 列裁剪 |
+| 通知渠道 | `email` / `webhook` / `feishu` | + `inApp`（通知中枢） |
+| API 路由 | `/api/after-sales/...` | `/api/p/:projectId/after-sales/...` |
+
+**v1 → v2 升级承诺**：v1 安装器创建的所有 multitable 数据，在 v2 加入 `project_id` 列时统一回填为 `${tenantId}:after-sales`。v1 实施代码必须避免 hardcode `WHERE tenant_id = ?` 的查询模式，应通过 service helper 留出 projectId 过滤挂点；安装器账本表的 `project_id` 列已经预留真值位（详见 #2 对象模型与模板安装器文档）。
+
+## 11. 与 plugin-after-sales 起点文件的映射
+
+本模板**不重写**起点文件，只补完它们的语义。
+
+| 起点文件 | 当前内容 | 模板对应 |
+|---|---|---|
+| `plugins/plugin-after-sales/app.manifest.json` | `boundedContext`、`objects`、`workflows`、`permissions` 声明 | 本文档 §3 字段表是 `objects` 的细化；§5 自动化是 `workflows` 的细化；§2 角色矩阵覆盖 `permissions` |
+| `plugins/plugin-after-sales/index.cjs` | `/api/after-sales/health`、`/api/after-sales/app-manifest` 路由；`after-sales.plugin.activated` 事件 | v1 实施期新增 `/api/after-sales/projects/install` 入口（HTTP 契约见 #4 创建流程文档） |
+| `apps/web/src/views/AfterSalesView.vue` | manifest 卡片展示页 | v1 演进为售后首页：默认视图入口、partial 状态条与"重新安装"按钮（细节见 #4） |
+
+起点文件已声明的 3 对象与 2 工作流是本模板的**最小子集**。本模板的扩展方式：
+
+- **multitable 对象**：把起点文件中的 `serviceTicket` / `installedAsset` 两个 multitable 对象扩展为 6 个（新增 `customer` / `serviceRecord` / `partItem` / `followUp`），统一进入 §3 字段表
+- **service-backed 对象**：`warrantyPolicy` 在 v1 仍以 service backing 存在，由 `enableWarranty` 配置开关控制，**不进入 §3 字段表**，也不由模板安装器创建表结构；其内部 schema 由 plugin-after-sales 服务自管
+- **自动化**：把 `ticket-triage / refund-approval` 扩展为 3 条（新增 `sla-watcher`），全部以 `AutomationRuleDraft` 形式描述
+
+## 12. 词典补丁记录
+
+按"对象字段可增补，公共契约不可偷改"规则，本文档对接口词典 v1.0 只做对象字段层补充，**不改公共类型 / 枚举 / 默认值 / 接口字段名**。
+
+| 补丁类型 | 内容 | 触发位置 |
+|---|---|---|
+| 新增对象字段 | `Customer.{customerCode, name, type, contactPhone, contactEmail, address, accountManager}` | §3.1 |
+| 新增对象字段 | `InstalledAsset.{assetCode, serialNo, customerId, model, installedAt, warrantyUntil, status, location}` | §3.2 |
+| 新增对象字段 | `PartItem.{partNo, name, category, unit, unitCost, stockQuantity, minStockQuantity}` | §3.5 |
+| 新增对象字段 | `FollowUp.{ticketId, customerId, scheduledAt, followUpType, status, satisfactionScore, feedback, followedUpBy}` | §3.6 |
+| 命名约定 | 5 个默认视图 ID 使用 kebab-case slug | §4 |
+| 命名约定 | 3 条默认自动化 ID 使用 kebab-case slug | §5 |
+| 命名约定 | 通知 topic 使用 `after-sales.{domain}.{event}` 三段式 | §6 |
+| Helper 引用 | `computeSlaDueAt(priority)` 是模板使用的服务端 helper，**v1 由 #2 安装器文档以"有限 helper 白名单"形式明文化**，禁止理解为通用表达式引擎 | §5.1 / §7 |
+| 上下文字段约定 | 通知 recipient 中的 `{{ticket.assignedSupervisor}}` 是 plugin-after-sales 在事件发出前 enrich 的扁平上下文字段，**禁止链式取值如 `{{ticket.assignedTo.supervisor}}`**，由 #3 文档以"recipient 解析约定"明文化 | §6 |
+
+**未触发公共契约升级**：本文档未新增字段类型、未改 `AutomationRuleDraft` 结构、未改默认值、未改 API 字段名。词典版本仍为 **v1.0**。

--- a/docs/development/platform-automation-permission-notification-design-20260407.md
+++ b/docs/development/platform-automation-permission-notification-design-20260407.md
@@ -1,0 +1,568 @@
+# 自动化 / 权限 / 通知设计 (platform-automation-permission-notification-design-20260407)
+
+> **文档类型**：横切能力设计 / Pre-Implementation Design
+> **日期**：2026-04-07
+> **范围**：v1 `AutomationRuleDraft` / `RolePermissionMatrix` / `NotificationTopicSpec` 的运行时语义、注册幂等契约、recipient 解析约定、channel/type 对齐规则
+> **来源词典**：2026-04-07 接口词典 v1.0（locked）
+> **配套交付**：本文档为 5 份设计稿之 #3，前置 #1 / #2，后置 #4 `platform-project-creation-flow-design-20260407.md`、#5 `platform-project-builder-and-template-architecture-design-20260407.md`
+
+## TL;DR
+
+v1 自动化是**声明式描述**，运行时仍由 workflow 引擎执行；人工审批走 `ApprovalBridgeService`，禁止在 workflow 中实现审批节点；权限走现有 RBAC `resource:action`；通知走 `NotificationService`，channel 锁定为 `email / webhook / feishu`（无 `inApp`）。**三类注册（自动化规则、通知主题、角色绑定）必须按稳定 key 幂等 upsert**，这是 #2 "账本仅记终态 + 崩溃后可安全重试 enable" 承诺在运行时的必要条件。recipient 解析：`{{...}}` 只取**扁平**上下文字段（禁链式），`role:<slug>` 按角色展开，最终必须落为 `NotificationRecipient[]`；channel 与 recipient type 严格对齐（`feishu→user` / `email→email` / `webhook→webhook`），不匹配项跳过并写 warning。
+
+---
+
+## 1. 核心目标与非目标
+
+### 1.1 v1 目标
+
+- 把 `AutomationRuleDraft` / `RolePermissionMatrix` / `NotificationTopicSpec` 三类声明式类型的运行时语义写死
+- 定义三类注册的**幂等契约**，让 #2 的"账本仅终态 + 安全重试"承诺在运行时自洽
+- 定义 recipient 解析约定，消除 #1 §6 留下的字符串语义空白
+- 定义 channel/type 对齐规则，对齐 `NotificationService.ts:263` 实际能力
+- 锁死"退款 / 赔付审批走 `ApprovalBridgeService`"的强约束
+
+### 1.2 v1 非目标
+
+- ❌ 不重写 workflow 引擎；`AutomationRuleDraft` 只是声明式描述，运行时由现有 workflow 服务翻译执行
+- ❌ 不在 workflow 中实现人工审批节点；退款 / 赔付必须通过 `ApprovalBridgeService`
+- ❌ 不引入 scoped RBAC（`after_sales:write@projectId=...` 是 v2）
+- ❌ 不引入新 notification channel；`inApp` 是 v2 通知中枢目标
+- ❌ 不引入通用表达式引擎；helper 白名单见 #2 §7
+- ❌ 不做记录级 RBAC（行级权限是 v2 及以后）
+
+### 1.3 依赖的仓库现状与薄适配层契约
+
+本文档引用的几个服务调用（`NotificationService.publish(...)` / `ApprovalBridgeService.submit(...)` / topic 注册 / bridge 注册）**不是仓库现成 API**，而是 v1 需要由 plugin-after-sales 内部实现的**薄适配层契约**。对照关系：
+
+| 文档中引用的调用形态 | 现有仓库 API | 薄适配层职责 |
+|---|---|---|
+| `NotificationService.publish({ topic, payload })` | 仓库现有是 `NotificationService.send(...)` / `sendTemplate(...)`（参考 `packages/core-backend/src/types/plugin.ts:1067`） | plugin-after-sales 内部包一个 `publish(topic, payload)` helper：从内部 topic 注册表中取出 channels + defaultRecipients，按 §7 解析为 `NotificationRecipient[]`，再调现有 `send` |
+| `NotificationService` topic 注册 | 仓库当前**没有**通用 topic 注册机制 | plugin-after-sales 维护一张**内部** topic 注册表（内存 map 或 jsonb 列），在 install 时由安装器按 §4.1 稳定 key upsert |
+| `ApprovalBridgeService.submit({ bridge, payload })` | 现状见 `packages/core-backend/src/services/ApprovalBridgeService.ts:112`（形态与本文档描述略有差异） | plugin-after-sales 包一个 `submitRefundApproval(ticketId, amount)` helper，把参数翻译为现有 bridge API 的入参形态 |
+| `ApprovalBridgeService` bridge 注册 + resolver/callback | 仓库有 bridge 体系，但注册 API 形态不同 | plugin-after-sales 在 `activate` 阶段按现有 bridge API 注册，回调路由内部映射到本文档描述的 `onApproved` / `onRejected` 语义 |
+
+**薄适配层存在的意义**：让 `AutomationRuleDraft.actions` 中的 `submitApproval` / `sendNotification` 等声明式动作有稳定的运行时目标，同时**不要求**改动核心服务。v2 若统一到平台原语时，本层可被替换，但 `AutomationRuleDraft` / `NotificationTopicSpec` 的 blueprint 层契约不变。
+
+**强约束**：
+
+- 薄适配层必须物理位于 `plugins/plugin-after-sales/` 内
+- **不得**修改 `packages/core-backend/src/services/NotificationService.ts` 或 `ApprovalBridgeService.ts` 的对外接口
+- 薄适配层代码"够用即可"；如果出现大量业务逻辑或超过数百行，说明设计越界，应重新审视
+
+下文所有对 `NotificationService.publish` / topic 注册 / `ApprovalBridgeService.submit` / bridge 注册 的引用，一律指上表中的薄适配层契约形态。
+
+## 2. AutomationRuleDraft 运行时语义
+
+### 2.1 trigger 结构
+
+```ts
+trigger: {
+  event: string                      // 例 'ticket.created'
+  filter?: Array<{
+    field: string                    // 事件 payload 中的扁平字段名
+    operator: 'eq' | 'in'
+    value: unknown
+  }>
+}
+```
+
+**事件命名约定**：`<domain>.<object>.<verb>` 三段式，段与段之间用 `.` 分隔；**单段内部**若为多词使用 lowerCamelCase（如 `refundRequested` / `assignedSupervisor`），单词段直接小写（如 `ticket` / `assigned`）。售后 v1 使用的事件集合：
+
+| event | 触发时机 | 必备扁平 payload |
+|---|---|---|
+| `ticket.created` | 工单落库成功 | `ticket.id`, `ticket.priority`, `ticket.source`, `ticket.customerId` |
+| `ticket.assigned` | `assignedTo` 字段首次被写入 | `ticket.id`, `ticket.assignedTo`, `ticket.assignedSupervisor` |
+| `ticket.overdue` | 定时器扫描 `slaDueAt < now` | `ticket.id`, `ticket.status`, `ticket.priority`, `ticket.assignedTo`, `ticket.assignedSupervisor` |
+| `ticket.refundRequested` | 工单 `refundAmount` 非空且审批未发起 | `ticket.id`, `ticket.refundAmount`, `ticket.requestedBy` |
+| `approval.pending` | `ApprovalBridgeService` 发起新审批后 | `approval.id`, `approval.bridge`, `approval.ticketId` |
+| `followup.due` | 定时器扫描 `FollowUp.scheduledAt < now && status='pending'` | `followUp.id`, `followUp.ticketId`, `followUp.followedUpBy` |
+
+**事件 payload 必须扁平**：所有嵌套字段（如 `ticket.assignedSupervisor`）由 plugin-after-sales 在事件发出前 **enrich**，不允许在 `filter` / `recipient` 中做链式取值（见 §6）。
+
+### 2.2 filter 语义
+
+- `operator: 'eq'` → `payload[field] === value`
+- `operator: 'in'` → `Array.isArray(value) && value.includes(payload[field])`
+- 多个 filter 之间为 **AND** 关系；不支持 OR（v2 再议）
+- `field` 只能是扁平路径，**不允许** `ticket.customer.name` 等链式
+
+### 2.3 conditions（v1 留空）
+
+v1 不使用 `conditions` 字段。蓝图中应写 `"conditions": []`，安装器校验时如发现非空则写 warning 并忽略该字段。v2 才启用运行时条件（与 filter 的区别：filter 基于事件 payload，conditions 基于运行时数据库查询结果）。
+
+### 2.4 actions（4 种）
+
+```ts
+actions: Array<
+  | { type: 'updateField'; field: string; value: unknown }
+  | { type: 'assign'; assigneeRule: string }
+  | { type: 'submitApproval'; bridge: string }
+  | { type: 'sendNotification'; topic: string }
+>
+```
+
+各动作语义：
+
+#### 2.4.1 `updateField`
+- `field`：被触发事件所属对象的字段路径（扁平）
+- `value`：字面量或 helper 白名单调用（见 #2 §7）
+- 执行时：workflow 引擎直接写 multitable 对象字段
+- 失败：写执行日志，不回滚前序动作
+
+#### 2.4.2 `assign`
+- `assigneeRule`：由 plugin-after-sales 提供的分派策略字符串，v1 白名单仅含：
+  - `'by-area-or-round-robin'`（按客户地区分派，无地区则轮询）
+- 其他值 → 安装器校验时写 warning，运行时跳过该 action
+- 执行时：解析策略 → 查询候选技师 → 写入目标对象的 `assignedTo` 字段
+
+#### 2.4.3 `submitApproval`
+- `bridge`：`ApprovalBridgeService` 已注册的 bridge 标识
+- v1 模板使用的 bridge 白名单仅含：
+  - `'after-sales-refund'`
+- 执行时：workflow 引擎调用 `ApprovalBridgeService.submit({ bridge, payload, initiator, tenantId })`
+- **强约束**：此类 action 是 v1 **唯一**的人工节点入口；workflow 引擎不得实现任何其他形式的人工审批
+
+#### 2.4.4 `sendNotification`
+- `topic`：已在同 blueprint `notifications` 段注册的 `NotificationTopicSpec.topic`
+- 执行时：workflow 引擎调用 `NotificationService.publish({ tenantId, topic, payload })`
+- recipient 展开发生在 NotificationService 内部（见 §6）
+- **v1 无 `webhook` action**：对外回调走 `sendNotification` + `topic.channels = ['webhook']`，DSL 更干净；`callWebhook` / `invokeConnector` 是 v2
+
+### 2.5 enabled 开关
+
+- `enabled: false` 的规则**仍然注册**到 workflow 引擎，但触发时立即跳过
+- 安装器把 enabled 状态同步到 workflow 规则的 active 标志
+
+## 3. 退款审批：ApprovalBridgeService 强约束
+
+### 3.1 bridge 注册
+
+- plugin-after-sales 在 `activate` 阶段向 `ApprovalBridgeService` 注册 bridge `after-sales-refund`
+- 注册信息包括：
+  - `bridge: 'after-sales-refund'`
+  - `displayName: '售后退款 / 赔付审批'`
+  - `approverResolver`: 返回 `finance` + `supervisor` 两个角色的用户集合
+  - `onApproved`: 回调 → 更新工单 `refundStatus = 'approved'` → 触发 `refund.settled` 事件
+  - `onRejected`: 回调 → 更新工单 `refundStatus = 'rejected'` → 通知发起人
+- 注册必须**幂等**（见 §4）
+
+### 3.2 运行时路径
+
+```mermaid
+sequenceDiagram
+  participant WF as workflow engine
+  participant AB as ApprovalBridgeService
+  participant DB as multitable (serviceTicket)
+  participant NS as NotificationService
+
+  Note over WF: ticket.refundRequested 触发 refund-approval 规则
+  WF->>AB: submit({ bridge: 'after-sales-refund', payload: { ticketId, refundAmount } })
+  AB->>AB: resolve approvers (finance + supervisor)
+  AB->>NS: publish after-sales.approval.pending
+  Note over AB: 等待审批人决策（异步）
+  alt 通过
+    AB->>DB: update ticket.refundStatus = 'approved'
+    AB->>WF: emit refund.settled
+  else 驳回
+    AB->>DB: update ticket.refundStatus = 'rejected'
+    AB->>NS: publish after-sales.refund.rejected
+  end
+```
+
+### 3.3 禁止的替代实现
+
+以下做法在 v1 **严禁**：
+
+- ❌ 在 workflow 的 action 列表中手动编排 "wait-for-user-decision" 节点
+- ❌ 把审批状态存在 workflow 实例内存中
+- ❌ 在 `AutomationRuleDraft.actions` 中直接写 `assignApprover` / `waitForApproval` 类 action
+- ❌ 绕开 `ApprovalBridgeService` 直接写工单 `refundStatus` 字段（除 bridge 回调路径外）
+
+## 4. 注册幂等契约 ⭐
+
+**这是 v1 的核心横切约束**，由 #2 §4.5 "账本仅记终态" 与 §6.5 "安装器不持中间态" 的承诺倒逼：如果三类注册不是幂等 upsert，崩溃后重试 enable 会产生重复规则 / 重复 topic / 重复权限绑定，违背 #2 的可重试承诺。
+
+### 4.1 三类注册的稳定 key
+
+| 注册类型 | 稳定 key | upsert 语义 |
+|---|---|---|
+| AutomationRule | `(tenantId, appId, rule.id)` | 同 key 存在 → 覆盖 `trigger / filter / actions / enabled`；不存在 → 新建 |
+| NotificationTopic | `(tenantId, topic)` | 同 key 存在 → 覆盖 `event / channels / defaultRecipients`；不存在 → 新建 |
+| RolePermissionBinding | `(tenantId, role, permission)` | 同 key 存在 → noop；不存在 → 新建 |
+| FieldPolicyBinding | `(tenantId, role, objectId, field)` | 同 key 存在 → 覆盖 `visibility / editability`；不存在 → 新建 |
+| ApprovalBridge | `(tenantId, bridge)` | 同 key 存在 → 覆盖 resolver / 回调引用；不存在 → 新建 |
+
+### 4.2 实现要求
+
+- 若底层服务（workflow / NotificationService / RBAC / ApprovalBridgeService）原生支持 upsert → 直接调用
+- 若底层服务只提供 create / update / delete → 安装器的翻译层实现 "check-then-update-or-insert" 模式
+- 翻译层必须把"查找 + 写入"包在**同一事务**内，防止并发 enable 产生重复
+- 查找与写入的 key 必须与 §4.1 的稳定 key 完全一致，**不得**使用自增主键或随机 UUID 作为识别条件
+
+### 4.3 并发 enable 的防护
+
+理论上两个并发 enable 请求都可能穿过 #2 §5.1 的账本检查（因为账本此时无行）。防护层级：
+
+1. **账本层**：`plugin_after_sales_template_installs` 的 `UNIQUE (tenant_id, app_id)` 唯一约束是最后一道兜底——第二个并发请求的 UPSERT 会得到冲突错误，前端收到 `already-installed`
+2. **注册层**：§4.1 的稳定 key upsert 保证即使两个请求都注册了同一规则，也只落一条
+3. **建表层**：multitable 的建表接口如果不幂等，第二个请求会失败并进入 warnings；这不是灾难，因为第一个请求的建表已经成功了
+
+这三层共同保证：**并发 enable 不会产生脏数据**，只会让其中一个请求得到 `already-installed` 错误。
+
+### 4.4 与 #2 的互锁关系
+
+| #2 承诺 | #3 对应幂等 |
+|---|---|
+| 账本仅记终态 | 重试前必然无"进行中"行可参考；重试必须把注册全跑一遍，必须幂等 |
+| 安装器不持中间态 | 崩溃后内存状态丢失；重试只能依赖稳定 key 识别已注册项 |
+| reinstall = 增量补齐 | 增量补齐的底层机制就是 §4.1 的 upsert |
+| 并发 enable 安全 | 账本唯一约束 + 注册层幂等 = 双保险 |
+
+**如果任一类注册不支持 §4.1 的稳定 key upsert**，则必须在 #2 §4.5 的"仅终态"承诺上打补丁，或在 plugin-after-sales 中实现该类注册的"先删后建"清理逻辑。v1 选择强制实现 upsert，不打补丁。
+
+## 5. RolePermissionMatrix 运行时语义
+
+### 5.1 六角色详表
+
+| slug | 中文标签 | 默认 permissions |
+|---|---|---|
+| `customer_service` | 客服 | `after_sales:read`, `after_sales:write` |
+| `technician` | 技师 | `after_sales:read`, `after_sales:write` |
+| `supervisor` | 主管 | `after_sales:read`, `after_sales:write`, `after_sales:approve` |
+| `finance` | 财务 | `after_sales:read`, `after_sales:approve` |
+| `admin` | 管理员 | `after_sales:read`, `after_sales:write`, `after_sales:approve`, `after_sales:admin` |
+| `viewer` | 只读 | `after_sales:read` |
+
+### 5.2 permission 语法
+
+- v1 格式：`<resource>:<action>`
+- `resource` v1 固定为 `after_sales`
+- `action` v1 枚举：`read` / `write` / `approve` / `admin`
+- **严禁**在 v1 中出现 `after_sales:write@projectId=...` 这类 scoped 语法——那是 v2
+
+### 5.3 fieldPolicies 运行时语义
+
+`fieldPolicies` 仅作用于前端字段渲染层，**v1 不在 API 层裁剪列**（参考 `packages/core-backend/src/routes/univer-meta.ts:1086 / 3133`）。
+
+```ts
+fieldPolicies?: Array<{
+  objectId: string                   // 'serviceTicket'
+  field: string                      // 'refundAmount'
+  visibility: 'visible' | 'hidden'   // hidden → 前端隐藏渲染
+  editability: 'editable' | 'readonly'  // readonly → 前端禁用编辑控件
+}>
+```
+
+### 5.4 v1 唯一 fieldPolicy 示例：refundAmount
+
+| 角色 | visibility | editability |
+|---|---|---|
+| `finance` | `visible` | `editable` |
+| `admin` | `visible` | `editable` |
+| `supervisor` | `visible` | `readonly` |
+| `customer_service` | `hidden` | `readonly` |
+| `technician` | `hidden` | `readonly` |
+| `viewer` | `hidden` | `readonly` |
+
+**强约束**：
+
+- `hidden` 仅影响前端字段渲染；后端 API 仍返回该列
+- 数据导出（CSV / Excel）默认遵循 fieldPolicy，但可由 `admin` 角色显式勾选"包含隐藏字段"绕过
+- 日志、审计、搜索索引**不受** fieldPolicy 影响（v1 审计面向 admin / finance / supervisor，默认可见）
+- v2 才考虑列级 API 裁剪
+
+### 5.5 角色分配的源头
+
+- v1 不提供"把用户加入某角色"的 UI；角色分配走现有 RBAC 服务的管理端
+- 模板安装只定义"角色 → 权限"映射，**不**定义"用户 → 角色"映射
+- plugin-after-sales 假设租户管理员已通过现有 RBAC 管理端完成用户-角色分配
+
+## 6. NotificationTopicSpec 运行时语义
+
+### 6.1 topic 命名约定
+
+- 格式：`<appId>.<domain>.<event>`
+- 售后 v1 使用的 4 个 topic：
+  - `after-sales.ticket.assigned`
+  - `after-sales.ticket.overdue`
+  - `after-sales.approval.pending`
+  - `after-sales.followup.due`
+- topic 是稳定 key 的一部分（见 §4.1）；改名等价于删旧建新，v1 应避免
+
+### 6.2 channels 锁定枚举
+
+```ts
+channels: Array<'email' | 'webhook' | 'feishu'>
+```
+
+**强约束**：与 `packages/core-backend/src/services/NotificationService.ts:263` 已注册的渠道对齐。**禁止**在 v1 中出现：
+
+- ❌ `inApp`（v2 通知中枢目标）
+- ❌ `sms`（尚未在 NotificationService 注册）
+- ❌ `dingtalk` / `wework` / `slack` 等（v2 connector 扩展）
+
+如未来 `NotificationService` 新增 channel，必须先升级接口词典到 v1.1 再更新本文档。
+
+### 6.3 defaultRecipients 是模板层描述，不是运行时入参
+
+**这是 v1 最容易被误解的一条**。
+
+- `NotificationTopicSpec.defaultRecipients: string[]` 是**模板蓝图层**的字符串描述，由安装器透传到 `NotificationService` 的 topic 注册调用
+- 运行时 `NotificationService.publish()` **实际吃的是** `NotificationRecipient[]`，而不是字符串数组
+- 两者之间的转换（字符串 → `NotificationRecipient[]`）由 `NotificationService` 在发送时完成，具体规则见 §6.4
+- 参考：`packages/core-backend/src/services/NotificationService.ts` 与 `packages/core-backend/src/types/plugin.ts:1120`
+
+**安装器的职责**：只把 `defaultRecipients: string[]` 原样注册给 topic，**不**解析占位符、**不**展开 role slug、**不**做 channel/type 检查。所有解析与校验发生在发送时。
+
+## 7. recipient 解析约定 ⭐
+
+**这是 v1 必须写死的核心章节**，填补 #1 §6 留下的字符串语义空白。
+
+### 7.1 输入 / 输出类型
+
+- **输入**：`defaultRecipients: string[]`（模板层字符串数组）+ 事件 payload（已预填为一层命名空间结构，见 §7.4）
+- **输出**：`NotificationRecipient[]`，形如 `{ id: string; type: 'user' | 'email' | 'webhook'; metadata?: Record<string, unknown> }`（参考 `packages/core-backend/src/types/plugin.ts:1120`）
+- 其中 `id` 字段承载**投递地址**：`type='user'` 时是系统用户 id、`type='email'` 时是邮箱地址、`type='webhook'` 时是 URL；`metadata` 可选，用于携带渠道特定参数（飞书 card 模板 id、邮件模板变量等）
+
+### 7.2 字符串语法：三种形态
+
+| 形态 | 语法 | 示例 | 解析行为 |
+|---|---|---|---|
+| 模板变量 | `{{fieldName}}` | `{{ticket.assignedTo}}` | 从事件 payload 中读取**扁平**字段；找到 → 生成一个 recipient；找不到 → 跳过并写 warning |
+| 角色引用 | `role:<slug>` | `role:finance` | 通过 RBAC 服务查询该租户该角色的所有用户；为空 → 跳过并写 warning |
+| 字面量 | 其他所有字符串 | `admin@example.com` / `user_123` | 原样作为投递地址传入，不做解析 |
+
+### 7.3 模板变量的严格约束
+
+- **只支持一层命名空间取值**：`{{ticket.assignedTo}}` 允许（`payload.ticket` 是一层命名空间，`assignedTo` 是其中的标量字段），`{{ticket.customer.contactPhone}}` **禁止**（需要二次嵌套查找 `customer` 对象内的字段）
+- 识别正则：`/^\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}$/`（严格两段式：`<namespace>.<field>`）
+- **点号数量**必须恰好为 1（`ticket.assignedTo` 允许，`ticket.assignedTo.name` 禁止，`assignedTo` 也禁止——必须带命名空间前缀）
+- 违反链式约束 → 跳过该占位符 + 写 warning `"chained recipient template not supported: {{...}}"`
+
+### 7.4 上下文扁平化是 plugin 侧的职责
+
+- plugin-after-sales 在发出任何事件**之前**必须先 enrich payload，把所有通知可能用到的关联字段预填为**一层命名空间下的扁平标量**
+- 具体约定：事件对象按 `{ <namespace>: { <flatField>: scalar, ... } }` 组织，命名空间之下**只允许扁平标量或 id，不允许二次嵌套对象**
+
+  ```ts
+  // ✅ 允许：一层命名空间 + 其下全为标量
+  {
+    ticket: {
+      id: 'tk_001',
+      priority: 'urgent',
+      assignedTo: 'user_42',           // 用户 id（标量）
+      assignedSupervisor: 'user_88',   // plugin 预先 enrich 的标量
+      customerId: 'cust_003',          // 关联 id（标量）
+    }
+  }
+
+  // ❌ 禁止：命名空间之下出现嵌套对象
+  {
+    ticket: {
+      customer: { id: 'cust_003', name: '...' },           // 禁止
+      assignedTo: { id: 'user_42', supervisor: 'user_88' } // 禁止
+    }
+  }
+  ```
+
+- 这一约束与 #1 §6 把 `{{ticket.assignedTo.supervisor}}` 改写为 `{{ticket.assignedSupervisor}}` 的理由一致
+- 如果未来需要新字段，**先**扩展 plugin 的 enrichment 逻辑 **再**在模板中引用
+
+### 7.5 `role:<slug>` 展开规则
+
+- `slug` 必须是已知角色之一（见 §5.1 六角色表）
+- 展开 = 查询 RBAC 服务：`getUsersByRole(tenantId, slug)`，返回 user id 列表
+- 若列表为空 → 跳过 + 写 warning `"no users found for role: <slug>"`，不阻断通知发送
+- 展开后的每个 user id 进入下一步 channel/type 对齐检查
+
+### 7.6 channel / type 严格对齐 ⭐
+
+解析出的 user id / 字面量必须与 topic 的每个 channel 做**类型匹配**，生成对应的 `NotificationRecipient`：
+
+| channel | 合法 recipient.type | 含义 | 不匹配处理 |
+|---|---|---|---|
+| `feishu` | `'user'` 仅限 | 需要内部 user id（作为飞书身份解析的起点） | 跳过 + warning `"feishu channel requires type=user"` |
+| `email` | `'email'` 仅限 | 需要 email 地址（可由 user id 解析得到） | 跳过 + warning `"email channel requires resolvable email"` |
+| `webhook` | `'webhook'` 仅限 | 需要 webhook URL（字面量） | 跳过 + warning `"webhook channel requires webhook URL"` |
+
+### 7.7 解析链完整示例
+
+输入：
+```json
+{
+  "topic": "after-sales.ticket.overdue",
+  "channels": ["email", "feishu"],
+  "defaultRecipients": ["{{ticket.assignedTo}}", "{{ticket.assignedSupervisor}}"]
+}
+```
+
+事件 payload（已扁平）：
+```json
+{
+  "ticket": {
+    "id": "tk_001",
+    "assignedTo": "user_42",
+    "assignedSupervisor": "user_88"
+  }
+}
+```
+
+解析步骤：
+
+1. 扫描 `defaultRecipients` → 识别两个 `{{...}}` 占位符
+2. 从 payload 取值 → `user_42` / `user_88`（均为 user id）
+3. 对每个 channel 做类型对齐（生成 `NotificationRecipient` 时 `id` 字段承载投递地址，见 §7.1）：
+   - `feishu` 需要 `type = 'user'` → `user_42` / `user_88` 直接满足 → 生成两条 `{ id: 'user_42', type: 'user' }` 与 `{ id: 'user_88', type: 'user' }`
+   - `email` 需要 `type = 'email'` → 查 user 表取邮箱 → 生成两条 `{ id: '<user_42.email>', type: 'email' }` 与 `{ id: '<user_88.email>', type: 'email' }`
+4. 最终 `NotificationRecipient[]` = 4 条（2 user + 2 email）
+5. `NotificationService` 按 channel 分发投递
+
+### 7.8 warning 汇总
+
+所有解析期 warning 不阻断发送，也不进入模板安装账本，而是写到通知发送日志表（由 `NotificationService` 现有日志机制承担）。
+
+## 8. 安装时 vs 运行时 分工矩阵
+
+| 动作 | 安装时（InstallerOrchestrator） | 运行时（workflow / NotificationService / RBAC） |
+|---|---|---|
+| 解析 blueprint | ✓ | ✗ |
+| 注册自动化规则 | ✓ 调 workflow service upsert | ✗ |
+| 注册通知 topic | ✓ 调 NotificationService upsert | ✗ |
+| 注册 role → permission | ✓ 调 RBAC upsert | ✗ |
+| 注册 bridge 回调 | ✓ 调 ApprovalBridgeService upsert | ✗ |
+| 解析 helper 白名单 `{{computeSlaDueAt(priority)}}` | ✗（仅校验白名单命中） | ✓（workflow 执行 action 时） |
+| 展开 recipient 占位符 | ✗（仅字符串透传） | ✓（NotificationService 发送时） |
+| 执行 channel/type 对齐 | ✗ | ✓ |
+| enrich 事件 payload 扁平化 | ✗ | ✓（plugin 发事件前） |
+| 调 ApprovalBridgeService.submit | ✗ | ✓（workflow 执行 submitApproval action 时） |
+
+**设计原则**：安装时只做"声明注册"，运行时才做"解释执行"。这让安装成为纯幂等的写入操作，运行时行为完全由 payload + 当前数据库状态决定。
+
+## 9. 运行时联动 Mermaid
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant P as plugin-after-sales
+  participant WF as workflow engine
+  participant MT as multitable
+  participant AB as ApprovalBridgeService
+  participant NS as NotificationService
+  participant RBAC as RBAC
+  participant U as 用户终端
+
+  Note over P: 工单被创建, plugin enrich 事件 payload（扁平化）
+  P->>WF: emit ticket.created
+  WF->>WF: match ticket-triage rule (trigger.event)
+  loop ticket-triage.actions
+    WF->>WF: 解析 updateField.value<br/>(helper 白名单: computeSlaDueAt(priority))
+    WF->>MT: update ticket.slaDueAt
+    WF->>WF: assign by-area-or-round-robin
+    WF->>MT: update ticket.assignedTo
+    WF->>NS: publish after-sales.ticket.assigned
+    NS->>NS: 解析 defaultRecipients (扁平 {{ticket.assignedTo}})
+    NS->>NS: channel=feishu → type=user 对齐
+    NS->>NS: channel=email → 查 user → type=email
+    NS->>U: 投递
+  end
+
+  Note over P,U: ——— 稍后：工单标记退款 ———
+
+  P->>WF: emit ticket.refundRequested
+  WF->>WF: match refund-approval rule
+  WF->>AB: submit({ bridge: 'after-sales-refund', payload })
+  AB->>RBAC: getUsersByRole('finance') + getUsersByRole('supervisor')
+  AB->>NS: publish after-sales.approval.pending
+  NS->>U: 投递审批待办
+  U->>AB: 审批通过
+  AB->>MT: update ticket.refundStatus='approved'
+  AB->>WF: emit refund.settled
+```
+
+## 10. v1 → v2 升级承诺
+
+### 10.1 稳定 key 的向前兼容
+
+- 自动化稳定 key 从 `(tenantId, appId, rule.id)` 扩展为 `(tenantId, appId, projectId, rule.id)`；v1 数据的 `projectId` 填伪值 `${tenantId}:after-sales`
+- topic 稳定 key 从 `(tenantId, topic)` 扩展为 `(tenantId, projectId, topic)`
+- 角色绑定稳定 key 从 `(tenantId, role, permission)` 扩展为 `(tenantId, projectId, role, permission)`
+- bridge 稳定 key 从 `(tenantId, bridge)` 扩展为 `(tenantId, projectId, bridge)`
+
+v2 扩展都是"追加列"而非"改列"，v1 数据可原地升级。
+
+### 10.2 API 列裁剪承诺
+
+- v2 引入列级 API 裁剪时，`fieldPolicies.visibility = 'hidden'` 将从"仅 UI 层"升级为"同时裁剪 API 返回列"
+- v1 调用方的代码**不需要**为此做兼容性判断；升级后原本能读到 `refundAmount` 的前端组件会开始收不到该字段（对 hidden 角色而言），这是预期行为
+- v2 同时提供一个 admin-only 的 `?includeHidden=true` 查询参数用于审计
+
+### 10.3 helper 白名单扩展
+
+- v2 可新增 helper 函数（如 `computeFollowUpDate(completedAt)` / `getSupervisor(userId)`）
+- v2 必须保持 v1 已有 helper 的签名与返回值不变
+- v2 不得引入通用表达式引擎
+
+### 10.4 channel 扩展
+
+- v2 新增 `inApp` channel；v1 模板的 topic 不自动获得 `inApp`，需显式升级蓝图
+- v2 通知中枢为 `inApp` 提供统一收件箱；v1 的 `email / webhook / feishu` 通路不变
+
+## 11. 实施者开工自检表
+
+### 11.1 四大禁区
+
+- ❌ **不重写 workflow 引擎**：`AutomationRuleDraft` 只是声明式描述，运行时由现有 workflow 服务翻译执行；严禁在本次实施中引入新的规则引擎 / 状态机框架
+- ❌ **不在 workflow 中实现人工审批节点**：退款 / 赔付必须走 `ApprovalBridgeService`；workflow action 列表中严禁出现 `waitForApproval` / `assignApprover` 等同义词
+- ❌ **不做非幂等注册**：三类注册（自动化 / 通知 topic / 角色绑定）必须按 §4.1 的稳定 key upsert；严禁使用自增主键 / 随机 UUID 作为识别条件
+- ❌ **不解析 recipient 占位符于安装时**：安装器只把 `defaultRecipients: string[]` 原样透传给 `NotificationService`；所有展开发生在发送时
+
+### 11.2 细项 checklist
+
+- [ ] `AutomationRuleDraft.trigger.event` 使用三段式 `<domain>.<object>.<verb>` 命名
+- [ ] `trigger.filter` 的 `field` 是扁平字段名，无链式（无 `.` 或仅 1 个 `.`）
+- [ ] `conditions` 留空数组（v1 不使用）
+- [ ] `actions` 只使用四种 type 之一：`updateField / assign / submitApproval / sendNotification`
+- [ ] `assign.assigneeRule` 在 v1 白名单内（`by-area-or-round-robin`）
+- [ ] `submitApproval.bridge` 在 v1 白名单内（`after-sales-refund`）
+- [ ] `sendNotification.topic` 对应同 blueprint 已声明的 topic
+- [ ] 自动化注册按 `(tenantId, appId, rule.id)` upsert
+- [ ] 通知 topic 注册按 `(tenantId, topic)` upsert
+- [ ] 角色绑定按 `(tenantId, role, permission)` upsert
+- [ ] FieldPolicy 按 `(tenantId, role, objectId, field)` upsert
+- [ ] ApprovalBridge 按 `(tenantId, bridge)` upsert
+- [ ] 注册翻译层使用同事务的 "check-then-update-or-insert"
+- [ ] 事件 payload 在 plugin 发出前已 enrich 为扁平结构
+- [ ] 扁平字段命名（如 `ticket.assignedSupervisor`）与 #1 §6 通知表一致
+- [ ] recipient 解析器只识别 `{{...}}` / `role:<slug>` / 字面量三种形态
+- [ ] recipient 解析器对链式 `{{a.b.c.d}}` 返回 warning 并跳过
+- [ ] channel `feishu` 只接受 `type='user'` 的 recipient
+- [ ] channel `email` 只接受 `type='email'` 的 recipient
+- [ ] channel `webhook` 只接受 `type='webhook'` 的 recipient
+- [ ] channel / type 不匹配 → 跳过 + warning，不阻断整条通知
+- [ ] `fieldPolicies.visibility = 'hidden'` 只在前端生效，后端 API 不裁剪
+- [ ] 六角色 slug 使用英文：`customer_service / technician / supervisor / finance / admin / viewer`
+- [ ] `after_sales:write@projectId=...` 类 scoped 语法不出现
+- [ ] 所有新增 channel / topic / role / bridge 名称先进接口词典 v1.1 再写代码
+
+---
+
+## 附：本文档触发的词典补丁记录
+
+本文档对接口词典 v1.0 做以下**非破坏性**补充，不改字段名 / 类型 / 可选性，仅明文化现有字段的运行时语义。词典版本**不升级**，仍为 v1.0。
+
+| 补丁类型 | 内容 | 位置 |
+|---|---|---|
+| `AutomationRuleDraft.trigger.event` 命名约定 | 三段式 `<domain>.<object>.<verb>`，扁平 payload | §2.1 |
+| `AutomationRuleDraft.conditions` v1 语义 | 必须为空数组，非空则 warning 后忽略 | §2.3 |
+| `assign.assigneeRule` v1 白名单 | 仅 `by-area-or-round-robin` | §2.4.2 |
+| `submitApproval.bridge` v1 白名单 | 仅 `after-sales-refund` | §2.4.3 |
+| 三类注册稳定 key 列表 | 自动化 / topic / role / fieldPolicy / bridge 各一行 | §4.1 |
+| `fieldPolicies` 运行时语义 | UI-only，API 不裁剪；数据导出可绕过（admin）；日志/审计不受影响 | §5.3 |
+| `NotificationTopicSpec.channels` 锁定枚举 | `email / webhook / feishu`，禁 `inApp / sms / dingtalk` 等 | §6.2 |
+| `NotificationTopicSpec.defaultRecipients` 透传语义 | 模板层字符串，运行时解析 | §6.3 |
+| recipient 三形态语法 | `{{...}}` / `role:<slug>` / 字面量 | §7.2 |
+| recipient 模板变量深度约束 | 点号数量 ≤ 1，禁链式 | §7.3 |
+| recipient channel/type 对齐矩阵 | feishu→user / email→email / webhook→webhook | §7.6 |
+
+**未触发词典版本升级**：本文档未新增字段类型、未改 `AutomationRuleDraft` / `RolePermissionMatrix` / `NotificationTopicSpec` 的字段名或类型或可选性。词典版本仍为 **v1.0**。

--- a/docs/development/platform-object-model-and-template-installer-design-20260407.md
+++ b/docs/development/platform-object-model-and-template-installer-design-20260407.md
@@ -1,0 +1,489 @@
+# 对象模型与模板安装器设计 (platform-object-model-and-template-installer-design-20260407)
+
+> **文档类型**：平台抽象与执行器设计 / Pre-Implementation Design
+> **日期**：2026-04-07
+> **范围**：v1 项目模板蓝图类型、模板安装器编排、账本表、reinstall / partial / 幂等语义、helper 白名单、v1→v2 升级承诺
+> **来源词典**：2026-04-07 接口词典 v1.0（locked）
+> **配套交付**：本文档为 5 份设计稿之 #2，前置 #1 `after-sales-project-template-design-20260407.md`，后置 #3 `platform-automation-permission-notification-design-20260407.md`
+
+## TL;DR
+
+本文档锁定 `ProjectTemplateBlueprint` / `TemplateInstallRequest` / `TemplateInstallResult` 的字段与语义；定义 v1 账本表 `plugin_after_sales_template_installs`（由核心 migration 创建，插件运行时通过 `context.api.database` 访问）；把安装器定位为**薄壳编排器**（逐表调现有 multitable API），非统一 BlueprintInstaller 平台服务；锁死 v1 **幂等键** `(tenant_id, app_id)`、**reinstall = 增量补齐不删数据**、**partial = 进首页 + 顶部状态条 + 重新安装按钮**、**helper 白名单仅含 `computeSlaDueAt(priority)`**；明确 v1→v2 的无损演进路径。
+
+---
+
+## 1. 核心目标与非目标
+
+### 1.1 v1 目标
+
+- 为"项目模板"定义一份**可序列化、可审计、可 diff** 的蓝图类型
+- 把蓝图**安全、幂等、增量**地落成 multitable 对象 / 视图 / 自动化 / 通知 / 角色绑定
+- 把 reinstall / partial / 幂等键 / 报告引用等边界情况写死，让实施者无需二次决策
+- 为未来 v2 多实例留出无损演进路径（所有 v1 代码都能原地升级）
+
+### 1.2 v1 非目标（非常重要）
+
+以下能力**不在 v1 范围**，文档中不得出现与其矛盾的表述，实施者也不得私自实现：
+
+- ❌ 不做统一 `BlueprintInstaller` 平台服务；安装器是 plugin-after-sales 内部的薄壳编排器
+- ❌ 不引入新的 multitable 批量创建 API；逐表调用现有接口即可，接受 N 秒级耗时
+- ❌ 不要求跨对象强事务；步骤级失败通过 warnings 与 partial 状态表达
+- ❌ 不做 marketplace / sandbox / scoped CoreAPI / workspaceId / organizationId
+- ❌ **不做通用表达式引擎**；helper 必须走白名单（详见 §8）
+- ❌ 不引入 `project_id` 列；v2 才加（详见 §12）
+- ❌ 不改 `packages/core-backend/src/db/types.ts`（多线冲突热区）
+- ❌ 不引入"插件自管 migration runner"这一当前不存在的能力
+
+## 2. ProjectTemplateBlueprint 字段清单与约束
+
+本节是接口词典 v1.0 的**详细扩写**，不新增字段，仅补充约束与示例。
+
+### 2.1 顶层结构
+
+```ts
+interface ProjectTemplateBlueprint {
+  id: string                          // kebab-case slug, 必须匹配 /^[a-z][a-z0-9-]*$/
+  version: string                     // semver, 必须匹配 /^\d+\.\d+\.\d+$/
+  displayName: string                 // 人类可读名
+  appId: string                       // 必须等于某个已声明 app.manifest.json 的 boundedContext.code
+  objects: ObjectDescriptor[]         // 至少 1 个
+  views: ViewDescriptor[]             // 可为空数组
+  automations: AutomationRuleDraft[]  // 可为空数组
+  roles: RolePermissionMatrix[]       // 可为空数组
+  notifications: NotificationTopicSpec[]  // 可为空数组
+  configDefaults: Record<string, unknown>  // 蓝图默认值的快照（对售后模板即 AfterSalesTemplateConfig）
+}
+```
+
+### 2.2 ObjectDescriptor 约束
+
+- `id`：kebab-case 或 camelCase 均可，必须在同一 blueprint 内唯一
+- `backing`：`'multitable' | 'service' | 'hybrid'`，v1 模板安装器只创建 `multitable` backing 的对象；`service` / `hybrid` 对象由插件自身服务层管理，模板不代创建
+- `fields`：至少包含 `id` + 1 个业务字段；每个 `FieldDescriptor.type` 必须是词典锁定的 10 种规范类型之一
+- `primaryViewId`：如指定，必须在同 blueprint 的 `views` 数组中存在
+
+### 2.3 FieldDescriptor.reference 约束
+
+- `link` / `lookup` / `rollup` 字段必须声明 `reference`
+- `reference.objectId` 必须满足以下之一：
+  - 等于同 blueprint 中某个 `ObjectDescriptor.id`
+  - 等于特殊值 `'user'`（表示系统用户表），此时必须同时指定 `refKind: 'user'`
+- **严禁**跨 blueprint 引用（v1 不支持）
+
+### 2.4 ViewDescriptor 约束
+
+- `type` v1 默认模板只使用 `grid / kanban / calendar / gallery / form` 五种；`gantt` 允许但不推荐；`timeline` 在 core view-service 未暴露（`packages/core-backend/src/services/view-service.ts:12`），v1 禁用
+- `config` 为 `Record<string, unknown>`，v1 不强约束 schema；推荐字段：
+  - `groupBy`（kanban 必填）
+  - `dateField`（calendar 必填）
+  - `filter`（grid 可选）
+  - `sort`（grid / kanban 可选）
+
+### 2.5 蓝图 JSON 片段示例（售后默认模板的 objects 段节选）
+
+```json
+{
+  "id": "after-sales-default",
+  "version": "0.1.0",
+  "displayName": "售后默认模板",
+  "appId": "after-sales",
+  "objects": [
+    {
+      "id": "serviceTicket",
+      "name": "工单",
+      "backing": "multitable",
+      "fields": [
+        { "id": "id", "name": "ID", "type": "string", "required": true },
+        { "id": "ticketNo", "name": "工单号", "type": "string", "required": true },
+        { "id": "priority", "name": "优先级", "type": "select", "required": true,
+          "options": ["low", "normal", "high", "urgent"], "default": "normal" },
+        { "id": "assignedTo", "name": "处理人", "type": "link", "required": false,
+          "reference": { "objectId": "user", "refKind": "user" } }
+      ],
+      "primaryViewId": "ticket-board"
+    }
+  ]
+}
+```
+
+## 3. TemplateInstallRequest / TemplateInstallResult
+
+本节扩写词典 v1.0 的 A 节第 2/3 类型。
+
+### 3.1 TemplateInstallRequest 字段语义
+
+| 字段 | 类型 | v1 语义 |
+|---|---|---|
+| `tenantId` | `string` | 当前请求的租户 id，由路由中间件从 `TenantContextData.tenantId` 注入 |
+| `appId` | `string` | v1 固定 `'after-sales'` |
+| `projectId` | `string?` | **v1 忽略客户端传值**，安装器内部重置为 `${tenantId}:${appId}` |
+| `blueprint` | `ProjectTemplateBlueprint` | 完整蓝图对象，由插件打包发货（v1 不支持用户上传自定义蓝图） |
+| `mode` | `'enable' \| 'reinstall'` | 见 §8 与 §9 |
+
+### 3.2 TemplateInstallResult 字段语义
+
+| 字段 | 类型 | v1 语义 |
+|---|---|---|
+| `projectId` | `string` | v1 = `${tenantId}:${appId}` |
+| `status` | `'installed' \| 'partial' \| 'failed'` | 见下方状态表 |
+| `createdObjects` | `string[]` | 本次调用**新建**的 multitable 对象 id 列表；reinstall 时仅列新增项，不列已存在项 |
+| `createdViews` | `string[]` | 同上语义 |
+| `warnings` | `string[]` | 人类可读的告警字符串；用于首页状态条展示 |
+| `reportRef` | `string?` | 指向账本表的行 id（UUID），前端可用于拉取详细报告 |
+
+### 3.3 status 三态语义表
+
+| 状态 | 触发条件 | 用户可进入首页 | 状态条 |
+|---|---|---|---|
+| `installed` | 核心对象 + 视图 + 自动化 + 通知 + 角色**全部**创建/更新成功 | ✓ | 无 |
+| `partial` | 核心对象（见本节定义）就绪；**但**部分视图 / 自动化 / 通知 / 角色失败，warnings 非空 | ✓ | 橙色状态条 + "重新安装" 按钮 |
+| `failed` | 核心对象创建失败（账本仍写入 status='failed'，留下行供 current 查询）；或账本写入操作本身失败（chicken-and-egg，不留行） | ✗ | 红色错误页 + 重试按钮；重试 mode 由前端按 current.status 决定：账本有行（status='failed'）→ `mode='reinstall'`；账本无行（ledger-write-failed）→ `mode='enable'`。详见 #5 §6.2 / §6.3 |
+
+**核心对象定义（售后模板）**：`customer` / `installedAsset` / `serviceTicket` / `serviceRecord` 四者均创建成功。`partItem` / `followUp` 失败不阻断，仅 warnings。
+
+### 3.4 `already-installed` 是错误码，不是状态
+
+**重要**：`mode = 'enable'` 且账本已存在 `(tenant_id, app_id)` 行时，安装器**立即返回 `already-installed` 错误码**，**不进入** §3.3 的三态流程。该错误不是 `partial`，也不是 `failed`，而是"调用方调用时机不对"的语义，不写新的账本行、不触发任何 DDL / DML。前端应提示用户"已启用"并引导进入首页；**不**应再次触发 enable，**不**应自动降级为 reinstall——那需要用户显式点击"重新安装"按钮。
+
+## 4. 账本表 `plugin_after_sales_template_installs`
+
+### 4.1 归属与创建方式
+
+- **逻辑归属**：插件拥有（`plugin-after-sales`），命名空间 `plugin_after_sales_*`，与 multitable 元数据 `meta_*` 命名隔离
+- **物理创建**：由核心 migration 创建，路径 `packages/core-backend/src/db/migrations/zzzz20260408xxxxxx_create_plugin_after_sales_template_installs.ts`，遵循仓库既有 `zzzz<timestamp>_<verb>_<subject>.ts` 命名约定
+- **不进入** `packages/core-backend/src/db/types.ts`（该文件是多线冲突热区），类型定义留在 plugin-after-sales 自身的 TS 源码中
+- **运行时访问**：插件通过 `context.api.database.query` / `transaction` 直接执行 SQL，不依赖 Kysely schema codegen
+
+### 4.2 表结构
+
+| 列 | 类型 | 约束 | 说明 |
+|---|---|---|---|
+| `id` | `uuid` | PK, default gen_random_uuid() | 行主键，即 `reportRef` |
+| `tenant_id` | `text` | NOT NULL | 与 `TenantContextData.tenantId` 对齐 |
+| `app_id` | `text` | NOT NULL | v1 固定 `'after-sales'` |
+| `project_id` | `text` | NOT NULL | v1 = `${tenant_id}:after-sales`（伪值）；v2 = 真值 |
+| `template_id` | `text` | NOT NULL | `'after-sales-default'` |
+| `template_version` | `text` | NOT NULL | 蓝图 semver |
+| `mode` | `text` | NOT NULL, CHECK IN ('enable','reinstall') | 本次安装模式 |
+| `status` | `text` | NOT NULL, CHECK IN ('installed','partial','failed') | |
+| `created_objects_json` | `jsonb` | NOT NULL DEFAULT '[]' | `string[]` |
+| `created_views_json` | `jsonb` | NOT NULL DEFAULT '[]' | `string[]` |
+| `warnings_json` | `jsonb` | NOT NULL DEFAULT '[]' | `string[]` |
+| `last_install_at` | `timestamptz` | NOT NULL DEFAULT now() | reinstall 时更新 |
+| `created_at` | `timestamptz` | NOT NULL DEFAULT now() | |
+| `display_name` | `text` | NOT NULL DEFAULT '' | 项目展示名（来自 `ProjectCreateRequest.displayName`），供 `ProjectCurrentResponse` 返回；详见 #5 §5.2.1 / §11.5 |
+| `config_json` | `jsonb` | NOT NULL DEFAULT '{}' | `AfterSalesTemplateConfig` 序列化快照，供 reinstall 与首页状态恢复使用；详见 #5 §5.2.1 / §11.5 |
+
+### 4.3 索引
+
+- **v1 唯一索引**：`UNIQUE (tenant_id, app_id)`，即每租户每应用至多一行
+- **v2 演进**：唯一索引扩展为 `(tenant_id, project_id)`；v1 既有行的 `project_id` 列已经填了真形态伪值，v2 migration 仅 `DROP INDEX ... ; CREATE UNIQUE INDEX ... ON (tenant_id, project_id)` 即可，**无数据回填**
+
+### 4.4 访问模式（插件运行时）
+
+```ts
+// 伪代码：插件内部 helper，不进 core db/types.ts
+async function loadInstallLedger(tenantId: string, appId: string) {
+  const sql = `
+    SELECT id, project_id, template_version, status, warnings_json, last_install_at
+    FROM plugin_after_sales_template_installs
+    WHERE tenant_id = $1 AND app_id = $2
+    LIMIT 1
+  `
+  return context.api.database.query(sql, [tenantId, appId])
+}
+```
+
+### 4.5 账本生命周期：仅记录终态
+
+**账本表的 `status` 列合法值严格限定为 `installed | partial | failed` 三态**。v1 **不引入** `pending` / `installing` / `rolling-back` 等中间态；安装器在步骤 1-10 执行过程中**不预写**账本行，只在步骤 11 的汇总完成后一次性 UPSERT。
+
+这一设计的结果：
+
+- 任何中途崩溃（进程退出 / DB 连接断开 / OOM）→ 账本维持旧值（或无行）→ 调用方按 §5.1 幂等规则安全重试 `enable`
+- v1 **无须**实现"恢复半成品安装"的特殊路径
+- v1 **无须**引入"插件自管 migration runner"这一当前仓库不存在的能力
+- 安装报告的可审计性完全由账本行的终态快照承载，不需要额外的事件流或状态机存储
+
+## 5. v1 幂等键与 v2 演进
+
+### 5.1 v1 幂等键
+
+- **键**：`(tenant_id, app_id)`
+- **查询点**：每次 `TemplateInstallRequest` 入口必须先查账本
+- **分支**：
+  - 账本无行 + `mode = 'enable'` → 走首次安装
+  - 账本无行 + `mode = 'reinstall'` → 错误 `no-install-to-rebuild`
+  - 账本有行 + `mode = 'enable'` → 错误 `already-installed`（返回既有 `reportRef`，前端引导用户进首页）
+  - 账本有行 + `mode = 'reinstall'` → 走增量补齐
+
+### 5.2 v2 演进点
+
+| v1 | v2 |
+|---|---|
+| `(tenant_id, app_id)` 唯一 | `(tenant_id, project_id)` 唯一 |
+| 1 租户 × 1 应用 = 1 行 | 1 租户 × 1 应用 × N 项目 = N 行 |
+| `project_id` 列为伪值 | `project_id` 列为真值 |
+| 查询代码 `WHERE tenant_id = ? AND app_id = ?` | 查询代码 `WHERE tenant_id = ? AND app_id = ? AND project_id = ?` |
+
+**v1 实施期的 SQL 编写规则**：所有涉及本账本或 after-sales 业务表的查询，必须通过一个 `getProjectId(tenantId, appId)` helper 获取 projectId 字符串，**不得** 把"只用 tenant_id 过滤"写进 SQL 的硬编码习惯。当前 helper 恒返回伪值；v2 升级时只需改 helper 一个点。
+
+## 6. v1 安装器定义
+
+### 6.1 定位
+
+安装器 = **plugin-after-sales 内部的薄壳编排器**，不是平台级服务。它：
+
+- 物理位置：`plugins/plugin-after-sales/` 内部 TS 源码（或 CJS，与当前 `index.cjs` 同级）
+- 依赖：`context.api.database` / `context.api.http` / 调用已有 multitable / workflow / NotificationService / RBAC 的公开 API
+- **不依赖**：任何尚不存在的平台运行时能力
+
+### 6.2 职责顺序（11 步）
+
+| 步骤 | 动作 | 失败行为 |
+|---|---|---|
+| 1 | `validateBlueprint` | 语法错误 → 立即 failed，不写账本 |
+| 2 | `loadInstallLedger` | DB 连接失败 → failed |
+| 3 | 根据 mode 与账本行决定分支（见 §5.1） | 违约 → 对应错误码 |
+| 4 | `generateProjectId = ${tenantId}:${appId}` | - |
+| 5 | `createMultitableObjects`：逐对象调 multitable 现有创建 API | 核心对象失败 → 仍走步骤 11 写入账本 (status='failed'，createdObjects 记录已成功的部分)，再返回 failed；非核心对象失败 → warnings 继续 |
+| 6 | `createViews`：逐视图调 multitable 视图创建 API | 全部失败 → warnings，不阻断 |
+| 7 | `registerAutomations`：把 `AutomationRuleDraft[]` 翻译为 workflow service 可接受的注册调用 | 单条失败 → warnings |
+| 8 | `registerNotificationTopics`：调用 `NotificationService` 注册 topic | 单条失败 → warnings |
+| 9 | `applyRoleMatrix`：把 `RolePermissionMatrix[]` 通过 RBAC 服务落为角色-权限绑定 | 单条失败 → warnings |
+| 10 | 汇总 `status`：核心对象就绪 && warnings 为空 → installed；否则 partial | - |
+| 11 | `writeLedger`：UPSERT 一行到账本表 | 写入失败 → failed 并退回，给用户可见错误 |
+
+### 6.3 步骤 5 的"核心对象"定义
+
+见 §3.3。`customer / installedAsset / serviceTicket / serviceRecord` 四者任一失败即 failed，不走 partial。
+
+### 6.4 为什么是薄壳，不是统一服务
+
+- 当前仓库没有统一的 blueprint 运行时；强造一个会触动 `index.ts:719` 的 CoreAPI 注入链路（多线冲突热区）
+- 售后是第一份模板，还没到"抽象统一"的时机；抽象的条件是至少出现 2-3 份相似模板
+- v2 若证明需要统一，可以把 plugin-after-sales 内部的编排器下沉到 `packages/core-backend/src/services/template-installer.ts`，接口不变（即 `TemplateInstallRequest` → `TemplateInstallResult`），对 plugin 无破坏性
+
+### 6.5 安装器不持有中间态
+
+安装器在**进程内内存**维护各步骤结果（`createdObjects` / `createdViews` / `warnings` 等）；**不**在账本表预写"进行中"状态。执行过程中的任何崩溃都不污染账本，调用方可按 §5.1 幂等规则安全重试。这与 §4.5 "仅记录终态"互为佐证——二者共同保证 v1 不需要引入插件 migration runner 或跨步骤事务管理器。
+
+## 7. 模板表达式约定（v1 Helper 白名单）⭐
+
+**本节是 v1 的关键约束**，由 #1 的 §5.1 ticket-triage 的 `"{{computeSlaDueAt(priority)}}"` 使用场景逼出。
+
+### 7.1 v1 表达式规则
+
+`AutomationRuleDraft.actions` 中 `updateField.value` 的合法取值：
+
+1. **字面量**：`string` / `number` / `boolean` / `null` / ISO8601 日期字符串
+2. **Helper 调用**：`"{{helperName(arg1,arg2,...)}}"` 形式，且 `helperName` 必须在 v1 白名单中
+
+**严禁**：
+- 通用模板引擎（Jinja / Liquid / Handlebars / Mustache / lodash.template）
+- 链式取值（`{{a.b.c}}`）
+- 运行时函数组合（`{{f(g(x))}}`）
+- 用户可注入的 helper 名
+
+### 7.2 v1 Helper 白名单
+
+**v1 白名单只有 1 项**：
+
+| Helper | 签名 | 返回 | 依赖 | 时机 |
+|---|---|---|---|---|
+| `computeSlaDueAt(priority)` | `priority: 'low' \| 'normal' \| 'high' \| 'urgent'` | ISO8601 日期字符串 | 当前租户的 `AfterSalesTemplateConfig.defaultSlaHours` / `urgentSlaHours` | **自动化执行时**（不是安装时） |
+
+计算规则：
+- `priority ∈ {low, normal, high}` → `now + defaultSlaHours` 小时
+- `priority = 'urgent'` → `now + urgentSlaHours` 小时
+
+### 7.3 实现位置
+
+`computeSlaDueAt` 是 **plugin-after-sales 服务端**的纯函数，由自动化执行引擎（workflow service）在解释 `updateField.value` 字符串时：
+
+1. 正则识别 `/^\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\((.*?)\)\s*\}\}$/`
+2. 查白名单 → 命中 `computeSlaDueAt` → 调用其实现
+3. 未命中 → 把字符串当字面量处理，并写一条 warning 到执行日志
+
+### 7.4 安装器的校验职责
+
+`validateBlueprint` 步骤必须扫描所有 `AutomationRuleDraft.actions[].value`，对形如 `"{{...}}"` 的字符串执行白名单检查；未命中的记入 warnings，但**不阻断** enable（v1 容忍蓝图包含未知占位符，以便后续手工修复）。
+
+### 7.5 v2 演进提示
+
+v2 可以扩展 helper 白名单（如 `computeFollowUpDate(completedAt)` / `getSupervisor(userId)`），但**白名单机制本身不变**——永远没有通用表达式引擎。
+
+### 7.6 recipient 解析不在本文档展开
+
+`NotificationTopicSpec.defaultRecipients` 中的 `{{...}}` / `role:<slug>` 占位符**不是**本节模板表达式系统的一部分——它们在通知服务层解释，与自动化 `updateField.value` 走完全不同的代码路径。**通知收件人模板解析约定见 #3 `platform-automation-permission-notification-design-20260407.md`**，本文档不作展开。
+
+**强约束**：安装器**不**解析 `defaultRecipients` 中的占位符，只做字符串透传到 `NotificationService` 的 topic 注册调用；占位符到 `NotificationRecipient[]` 的展开发生在通知发送时，由通知服务层负责。
+
+## 8. reinstall 语义
+
+**reinstall = 增量补齐，不删数据。**
+
+### 8.1 允许的动作
+
+- 创建账本中未记录 `createdObjects` 的 ObjectDescriptor：按首次安装流程建表与字段
+- 已存在对象中**补充缺失字段**：通过 multitable 的字段追加 API 添加；不修改已有字段的 type / required / options
+- 创建账本中未记录 `createdViews` 的 ViewDescriptor：按首次安装流程建视图
+- 注册账本中未记录的 `AutomationRuleDraft` / `NotificationTopicSpec` / `RolePermissionMatrix` 条目
+- 更新账本行的 `last_install_at` / `warnings_json` / `created_objects_json` / `created_views_json`
+
+### 8.2 禁止的动作
+
+- ❌ DROP TABLE / DELETE FROM / TRUNCATE
+- ❌ ALTER COLUMN 改字段类型
+- ❌ 删除视图 / 自动化 / 通知主题 / 角色绑定
+- ❌ 覆盖用户自定义的视图 config（如果视图 id 已存在，跳过并写 warning）
+- ❌ 重置 `project_id` 列（该列 v1 伪值不变，v2 才涉及真值，且 v2 由独立 migration 处理）
+
+### 8.3 冲突处理
+
+- 字段名冲突且类型不同 → warnings，不改数据
+- 视图 id 已存在 → warnings，不动视图
+- 自动化 id 已存在 → warnings，不覆盖规则
+
+### 8.4 reinstall 后的 status
+
+- 所有本次 diff 的新增项均创建成功且 warnings 为空 → `installed`
+- 存在 warnings 或部分非核心新增项失败 → `partial`
+- 账本写入失败 → `failed`
+
+## 9. partial 语义
+
+### 9.1 用户体验
+
+- 安装器返回 `status = 'partial'` + 非空 `warnings` + `reportRef`
+- 前端 `AfterSalesView.vue` 根据 `installResult.status` 渲染首页顶部状态条：
+  - 背景色：橙色（`#f59e0b` 系）
+  - 文案：`"部分组件安装未完成 (N 条告警)"`
+  - 右侧两个按钮：`"查看详情"`（打开 reportRef 指向的报告弹窗） / `"重新安装"`（触发 `mode: 'reinstall'`）
+
+### 9.2 重新安装行为
+
+- 调用方再次 POST `TemplateInstallRequest`，`mode = 'reinstall'`
+- 安装器走 §8 的增量补齐路径
+- 成功后：
+  - 账本 `status` 更新为 `installed`
+  - `last_install_at` 刷新
+  - `warnings_json` 重写为空数组（如确实全部修复）
+  - 前端状态条消失
+
+### 9.3 partial 是非阻塞状态
+
+**强约束**：partial 下用户**可以**使用已就绪的核心对象（创建工单、服务记录等）。状态条只是提示，不是模态阻断。这一点必须在 `AfterSalesView.vue` 的实现中明确。
+
+## 10. 安装器时序图 (Mermaid)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant UI as AfterSalesView.vue
+  participant API as POST /api/after-sales/projects/install
+  participant ORCH as InstallerOrchestrator<br/>(plugin-after-sales)
+  participant LEDGER as plugin_after_sales_template_installs
+  participant MT as multitable service
+  participant WF as workflow service
+  participant NS as NotificationService
+  participant RBAC as RBAC service
+
+  UI->>API: ProjectCreateRequest
+  API->>ORCH: install(request)
+  ORCH->>ORCH: validateBlueprint
+  ORCH->>LEDGER: SELECT WHERE tenant_id, app_id
+  alt 已存在 && mode=enable
+    LEDGER-->>ORCH: row
+    ORCH-->>API: error already-installed
+  else 不存在 && mode=reinstall
+    ORCH-->>API: error no-install-to-rebuild
+  else 允许执行
+    ORCH->>ORCH: generateProjectId
+    loop 每个 multitable ObjectDescriptor
+      ORCH->>MT: createTable + fields
+      MT-->>ORCH: ok / error→warnings
+    end
+    loop 每个 ViewDescriptor
+      ORCH->>MT: createView
+      MT-->>ORCH: ok / error→warnings
+    end
+    ORCH->>WF: registerAutomations (翻译 AutomationRuleDraft)
+    WF-->>ORCH: ok / error→warnings
+    ORCH->>NS: registerTopics
+    NS-->>ORCH: ok / error→warnings
+    ORCH->>RBAC: applyRoleMatrix
+    RBAC-->>ORCH: ok / error→warnings
+    ORCH->>ORCH: 汇总 status
+    ORCH->>LEDGER: UPSERT row
+    LEDGER-->>ORCH: ok
+    ORCH-->>API: TemplateInstallResult
+  end
+  API-->>UI: ProjectCreateResponse
+```
+
+## 11. v1 → v2 升级承诺
+
+### 11.1 数据层承诺
+
+- v1 安装器创建的所有 multitable 表，**未来 v2 给它们加 `project_id` 列**时，回填值统一为 `${tenantId}:after-sales`
+- v1 账本表 `plugin_after_sales_template_installs` 的 `project_id` 列已经是真形态，v2 无需回填
+- v2 对账本表的唯一索引变更是纯 DDL（DROP + CREATE INDEX），无数据迁移
+
+### 11.2 代码层承诺
+
+v1 实施期的**查询与写入代码**必须遵守：
+
+- **禁止**：`SELECT ... FROM after_sales_xxx WHERE tenant_id = ?`（硬编码只按租户过滤，没有任何 projectId 过滤挂点）
+- **强制**：所有涉及 after-sales 业务表的查询全部走 plugin 内部的 service helper（如 `TicketRepository.findByProject(...)` / `CustomerRepository.findByProject(...)`）。在 v1，service helper 接收 `projectId` 参数**但内部直接吞掉它**——因为 v1 没有 `project_id` 列，SQL 只按 `tenant_id` 过滤；在 v2，同一个 helper 的实现升级为在 SQL 中追加 `AND project_id = ?`。调用方代码 v1/v2 完全一致：
+
+  ```ts
+  // 调用方 v1 与 v2 零改动:
+  const projectId = getProjectId(tenantId, 'after-sales')
+  const rows = await ticketRepository.findByProject(tenantId, projectId, filter)
+  ```
+
+**关键约束**：v1 SQL 中**不得直接出现**硬编码的 `WHERE tenant_id = ?`；所有 tenant / project 过滤逻辑集中在 service helper 这一层，由它"吞掉" projectId 参数。v2 升级时只改 service helper 内部的 SQL 拼接（1 个文件），调用方零改动。这是 v1 为 v2 留出的唯一可控扩展点。
+
+### 11.3 Helper 层承诺
+
+`computeSlaDueAt` 的签名在 v1/v2 保持不变；v2 可新增其他 helper，但不能修改既有 helper 的参数顺序或返回类型。
+
+## 12. 实施者开工自检表
+
+### 12.1 四大禁区（硬性红线）
+
+以下 4 条是 v1 的**硬性禁区**，代码 review 发现任一条即打回，不得以"先这样再优化"为由突破：
+
+- ❌ **不改 `packages/core-backend/src/db/types.ts`**：该文件是多线冲突热区；本期所有类型声明留在 plugin-after-sales 自身的 TS 源码中
+- ❌ **不发明 plugin migration runner**：当前仓库没有插件自管 migration 的运行时能力；账本表必须走核心 migration 目录 `packages/core-backend/src/db/migrations/` 创建，不得在 plugin activate 阶段动态建表
+- ❌ **不把 reinstall 写成删表重建**：reinstall 严格只做增量补齐（见 §8）；代码中不得出现 `DROP TABLE` / `DELETE FROM` / `TRUNCATE` 关键字，也不得用 `CREATE TABLE IF NOT EXISTS` 配合先查后删的变通写法
+- ❌ **不把 helper 白名单扩成通用表达式系统**：v1 白名单只含 `computeSlaDueAt(priority)` 一个；严禁引入 Jinja / Liquid / Handlebars / Mustache / lodash.template / eval / Function(...) 类运行时
+
+### 12.2 细项 checklist
+
+实施者在动手写代码前，逐项打勾：
+
+- [ ] Blueprint 中所有 `FieldDescriptor.type` 使用 10 种规范类型之一（`string / number / boolean / date / formula / select / link / lookup / rollup / attachment`）
+- [ ] 识别类字段（`customerCode` / `assetCode` / `serialNo` / `partNo` / `ticketNo`）全部使用 `string`
+- [ ] `select` 字段仅用于有限枚举，并在 `options` 中列齐
+- [ ] 所有 `link` 字段的 `reference.objectId` 要么是同 blueprint 的对象 id，要么是 `'user'` 且 `refKind: 'user'`
+- [ ] `AutomationRuleDraft.actions` 中 `updateField.value` 只包含字面量或白名单 helper 调用
+- [ ] `NotificationTopicSpec.channels` 无 `inApp`
+- [ ] `NotificationTopicSpec.defaultRecipients` 中的 `{{...}}` 仅取扁平上下文字段
+- [ ] 账本表创建 migration 放在 `packages/core-backend/src/db/migrations/`，命名 `zzzz20260408xxxxxx_create_plugin_after_sales_template_installs.ts`
+- [ ] **不**往 `packages/core-backend/src/db/types.ts` 追加类型
+- [ ] 插件运行时访问账本表走 `context.api.database.query`，不引入新 ORM 依赖
+- [ ] 查询代码使用 `getProjectId(tenantId, appId)` helper 而不是硬编码 `WHERE tenant_id = ?`
+- [ ] 安装器失败时的错误码在客户端可见，至少区分 `already-installed` / `no-install-to-rebuild` / `validation-failed` / `core-object-failed` / `ledger-write-failed` 五类
+- [ ] partial 状态下首页顶部状态条的"重新安装"按钮已实现，且点击后 POST `mode: 'reinstall'`
+- [ ] reinstall 路径的代码中**不存在** `DROP TABLE` / `DELETE FROM` / `TRUNCATE` 关键字
+- [ ] reinstall 遇到字段类型冲突时只写 warning，不改数据
+- [ ] 核心对象定义（`customer / installedAsset / serviceTicket / serviceRecord`）与 #1 §3 对齐
+- [ ] `computeSlaDueAt(priority)` 实现放在 plugin-after-sales 服务层，作为纯函数
+
+---
+
+## 附：本文档未触发词典升级
+
+本文档未新增字段类型、未改公共契约字段名、未改默认值、未改 HTTP 契约。仅对已有类型做约束扩写与实现语义固化。词典版本仍为 **v1.0**。

--- a/docs/development/platform-project-builder-and-template-architecture-design-20260407.md
+++ b/docs/development/platform-project-builder-and-template-architecture-design-20260407.md
@@ -1,0 +1,539 @@
+# 平台项目构建器与模板架构设计 (platform-project-builder-and-template-architecture-design-20260407)
+
+> **文档类型**：架构总览 / 总收口
+> **日期**：2026-04-07
+> **范围**：Plugin / App / Project 三层模型；v1/v2 正式定义；全局术语规范；全局接口索引；全局状态机（含 failed 重试规则）；非目标；v1→v2 升级承诺；5 份文档之间的依赖关系
+> **来源词典**：2026-04-07 接口词典 v1.0（locked）
+> **配套交付**：本文档为 5 份设计稿之 #5（总收口），前置 #1 / #2 / #3 / #4
+
+## TL;DR
+
+锁定 **Plugin / App / Project 三层模型**：Plugin 是代码交付物，App 是 manifest 中的业务声明，Project 是部署层实例。**v1 = 业务子域**（每租户每应用恰好一个 Project），**v2 = 多实例项目**（每租户每应用 N 个 Project）。v1 接口已经预留 `projectId` 字段（取伪值 `${tenantId}:${appId}`），v2 升级是纯 additive。本文档汇总 5 份设计稿的全局接口索引、全局状态机（首次给出"failed 重试走 reinstall"的规范规则）、非目标列表（首次明文"v1 不承诺步骤级进度"）与 v1→v2 升级承诺，并指明对前 4 份文档需要回补的小修订点。
+
+---
+
+## 1. 引言：为什么需要这套架构
+
+### 1.1 现状与缺口
+
+仓库内已经存在 4 个售后插件起点文件：
+
+- `plugins/plugin-after-sales/plugin.json`
+- `plugins/plugin-after-sales/app.manifest.json`
+- `plugins/plugin-after-sales/index.cjs`
+- `apps/web/src/views/AfterSalesView.vue`
+
+这 4 个文件证明 MetaSheet2 的微内核可以承载新的业务插件，但**没有**回答以下问题：
+
+1. 如果要让"售后"作为一个**模板**被一键启用、被增量重装、被多次实例化，需要哪些抽象？
+2. 售后的"对象 / 视图 / 自动化 / 通知 / 角色"声明应该走什么形态进入安装器？
+3. "项目"在 v1 和 v2 中分别是什么？
+4. 如何在不改核心服务（multitable / workflow / approvals / NotificationService / RBAC / db/types.ts）的前提下完成上述能力？
+5. 5 份设计文档之间的术语、接口、状态语义如何保持一致？
+
+### 1.2 本套设计的边界
+
+- **写文档，不写代码**：5 份 Markdown 是本轮的全部交付物
+- **不动核心服务对外接口**：所有新能力以 plugin-after-sales 内部薄壳 + 核心 migration 的形式实现
+- **v1 子域 / v2 多实例**：v1 接口预留 projectId 字段，v2 升级是纯 additive
+- **5 份文档形成闭环**：本文档作为总收口，任何后续不一致以本文档为准
+
+## 2. 三层模型
+
+### 2.1 概念定义
+
+| 层 | 名称 | 物理形态 | 职责 | 类比 |
+|---|---|---|---|---|
+| 1 | **Plugin（插件）** | 代码包，在仓库内的 `plugins/<name>/` 目录 | 提供代码、HTTP 路由、前端组件、生命周期钩子 | npm package |
+| 2 | **App / BoundedContext（应用）** | manifest 文件中的声明（`app.manifest.json` 的 `boundedContext` 段） | 业务能力声明：bounded context 边界、对象列表、工作流、权限、集成 | npm package 的 `package.json` |
+| 3 | **Project（项目）** | 模板安装器在某租户下创建的一组 multitable 对象 + 自动化 + 通知 + 角色绑定 | 真正承载业务数据的部署实例 | npm 包安装到某项目后产生的 node_modules 实例 |
+
+### 2.2 三层关系
+
+```mermaid
+graph TB
+  subgraph 代码层
+    P[Plugin: plugin-after-sales]
+    P --> P1[index.cjs]
+    P --> P2[plugin.json]
+    P --> P3[app.manifest.json]
+    P --> P4[AfterSalesView.vue]
+  end
+
+  subgraph 业务声明层
+    A[App: after-sales BoundedContext]
+    A --> A1[objects: serviceTicket / installedAsset / warrantyPolicy]
+    A --> A2[workflows: ticket-triage / refund-approval]
+    A --> A3[permissions: after_sales:read/write/approve/admin]
+  end
+
+  subgraph 部署层
+    PR[Project Instance]
+    PR --> PR1[multitable 表实体]
+    PR --> PR2[自动化注册]
+    PR --> PR3[通知 topic 注册]
+    PR --> PR4[角色绑定]
+    PR --> PR5[安装账本行]
+  end
+
+  P -- 提供 --> A
+  A -- 实例化为 --> PR
+
+  style P fill:#e0f2fe
+  style A fill:#fef3c7
+  style PR fill:#dcfce7
+```
+
+### 2.3 v1 与 v2 在三层模型中的位置
+
+| 层 | v1 状态 | v2 演进 |
+|---|---|---|
+| Plugin | 1 个代码包 | 同 v1 |
+| App | 1 个 manifest 声明 | 同 v1 |
+| **Project** | 每租户每 App 恰好 **1 个**实例 | 每租户每 App 可有 **N 个**实例 |
+
+**只有 Project 层在 v1/v2 之间发生形态变化。** Plugin 与 App 层的代码与声明都不需要 v2 改动。
+
+## 3. v1 / v2 正式定义
+
+### 3.1 v1 = 业务子域
+
+> **v1 Project = 某租户内某 BoundedContext 的唯一业务子域实例。**
+> 每租户 × 每 BoundedContext = 恰好 1 个 Project；
+> projectId 取**伪值** `${tenantId}:${appId}`，由安装器在服务端生成；
+> 用户感知：启用了一个业务模块。
+
+### 3.2 v2 = 多实例项目
+
+> **v2 Project = 同一 BoundedContext 在同一租户内可创建的多个独立实例。**
+> 每租户 × 每 BoundedContext = N 个 Project；
+> projectId 由用户在创建时分配的真值；
+> 用户感知：创建了多个项目（如"华东售后" / "华南售后"）。
+
+### 3.3 v1 接口预留 projectId
+
+v1 所有契约层（`ProjectCreateRequest` / `TemplateInstallRequest` / `ProjectCurrentResponse` / `TemplateInstallResult`）都已经**预留** projectId 字段。v1 服务端固定生成伪值，v2 由用户输入分配真值。**这是 v1 为 v2 留出的零成本扩展点**——v2 升级不需要改任何对外契约的字段名或字段顺序。
+
+## 4. 全局术语规范
+
+| 术语 | v1 中含义 | v2 中含义 | 红线 |
+|---|---|---|---|
+| Plugin / 插件 | 代码交付物 | 同 v1 | 不要把 Plugin 写成"项目" |
+| App / BoundedContext / 应用 | manifest 中的业务声明 | 同 v1 | 不要把 App 写成 plugin id 或 project id |
+| Project / 项目 | 唯一业务子域实例 | 多实例之一 | v1 不要写成"完全独立运行时" |
+| Template / 模板 | 项目蓝图（如 `after-sales-default`） | 同 v1 | 不要和 App 混 |
+| projectId | 伪值 `${tenantId}:${appId}` | 真值 `proj_xxxx` | v1 章节中不能写成用户可见 |
+| Workspace / 工作空间 | **不允许出现** | v2 才引入 | 出现在 v1 章节就是 bug |
+| organizationId | **不允许出现** | v2 才引入 | 同上 |
+| workspaceId | **不允许出现** | v2 才引入 | 同上 |
+| projectId-scoped RBAC | **不允许出现** | v2 才引入 | v1 写成 `after_sales:write@projectId=...` 是 bug |
+
+### 4.1 v1 章节红线（grep 验收用）
+
+5 份文档写作和 review 时，下列字符串**不应出现在 v1 范畴的描述里**：
+
+- `workspaceId` / `workspace_id` / `Workspace` （除非明确标注 v2）
+- `organizationId` / `organization_id` / `Organization`
+- `inApp` 渠道（除非明确标注 v2）
+- `BlueprintInstaller` 平台服务（除非作为 v2 演进目标）
+- `通用表达式引擎` / `表达式引擎`
+- `plugin migration runner` / `插件迁移运行时`
+- `scoped CoreAPI` / `capability scope`
+- `marketplace` / `应用市场`（除非作为 v2 目标）
+- `sandbox 隔离` / `Sandbox`（除非作为 v2 目标）
+- `/api/p/:projectId/`（v1 路由前缀）
+- `after_sales:write@projectId=` （v2 scoped 权限语法）
+
+## 5. 全局接口索引
+
+本节是 5 份文档共享的**真理源**。所有公共类型在此罗列并指向其详细定义文档。如发现任何文档中的字段定义与本节冲突，**以本节为准**。
+
+### 5.1 蓝图与安装契约（详见 #2）
+
+```ts
+interface ProjectTemplateBlueprint { /* §2 of #2 */ }
+interface ObjectDescriptor       { /* §2.2 of #2 */ }
+interface FieldDescriptor        { /* §2.3 of #2 */ }
+interface ViewDescriptor         { /* §2.4 of #2 */ }
+interface TemplateInstallRequest { /* §3.1 of #2 */ }
+interface TemplateInstallResult  { /* §3.2 of #2 */ }
+```
+
+### 5.2 项目创建契约（详见 #4，本文档对 ProjectCurrentResponse 做修订）
+
+```ts
+interface ProjectCreateRequest   { /* §4.1 of #4 */ }
+interface ProjectCreateResponse  { /* §4.2 of #4 */ }
+```
+
+#### 5.2.1 ProjectCurrentResponse —— 修订并锁定
+
+**v1 ProjectCurrentResponse 锁定形态**（取代 #4 §2.3 的旧版）：
+
+```ts
+interface ProjectCurrentResponse {
+  status: 'not-installed' | 'installed' | 'partial' | 'failed'
+  projectId?: string                          // status ∈ {installed, partial, failed} 时返回
+  displayName?: string                        // 修订新增：同上条件
+  config?: AfterSalesTemplateConfig           // 修订新增：同上条件
+  installResult?: TemplateInstallResult       // status ∈ {installed, partial, failed} 时返回
+  reportRef?: string                          // 同上
+}
+```
+
+**修订原因**：让 `current` 接口成为售后首页的**完整状态数据源**。原先的版本缺少 `displayName` 与 `config`，但 #4 §6.2 的 reinstall 流程描述"从 current 响应中取" `displayName` 与 `config` 作为重装请求体——两处不一致。修订后两边一致：current 接口在已安装态下返回完整 displayName 与 config，前端在 partial 恢复时直接使用而无需依赖本地缓存。
+
+**status 与字段返回的对照**：
+
+| status | projectId | displayName | config | installResult | reportRef |
+|---|---|---|---|---|---|
+| `not-installed` | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `installed` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `partial` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `failed` | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+**字段来源**：`displayName` / `config` 来自首次成功安装时存入账本的字段。这要求**账本表新增 2 列**：`display_name` (text) 与 `config_json` (jsonb)。这两列在 v1 必须由 #2 §4.2 的账本 schema 补齐（见 §11 回补清单）。
+
+### 5.3 横切能力契约（详见 #3）
+
+```ts
+interface AutomationRuleDraft    { /* §2 of #3 */ }
+interface RolePermissionMatrix   { /* §5 of #3 */ }
+interface NotificationTopicSpec  { /* §6 of #3 */ }
+interface NotificationRecipient  { /* §7.1 of #3 */ }
+interface AfterSalesTemplateConfig { /* §3 of #1 / §7 of #1 默认值表 */ }
+```
+
+### 5.4 一致性验收规则
+
+任何后续 PR 修改任一文档中的上述类型，必须**同步**：
+
+1. 更新本文档 §5 的索引描述
+2. 跨 5 份文档 grep 比对字段名 / 类型 / 可选性，全文一致
+3. 如修改了字段语义，必须同时更新所有引用文档的相应章节
+
+## 6. 全局状态机
+
+### 6.1 项目级 status 枚举
+
+v1 项目状态来源于账本表的 `status` 列：
+
+- `not-installed`：账本无行
+- `installed`：账本有行且 status='installed'
+- `partial`：账本有行且 status='partial'
+- `failed`：账本有行且 status='failed'
+
+**注意**：`installing` 不是持久化状态。前端在 `POST install` 等待响应期间临时显示"安装中"UI，但账本表中**永不出现** `installing` 行（这是 #2 §4.5 "仅记录终态" 的要求）。
+
+### 6.2 安装请求 mode 与 current.status 的合法组合 ⭐
+
+**这是 v1 的规范来源**，跨 #2 / #4 都引用本表。如其他文档与本表不一致，**以本表为准**。
+
+| 当前 current.status | 允许的 mode | 安装器分支 | 不允许的 mode → 错误 |
+|---|---|---|---|
+| `not-installed` | `enable` | 首次安装（步骤 5-11） | `reinstall` → 404 `no-install-to-rebuild` |
+| `installed` | `reinstall` | 增量补齐（v1 通常是 noop） | `enable` → 409 `already-installed` |
+| `partial` | `reinstall` | 增量补齐失败项 | `enable` → 409 `already-installed` |
+| `failed` | `reinstall` | 重试核心对象创建（账本行已存在，所以走 reinstall 路径） | `enable` → 409 `already-installed` |
+
+**核心规则**：
+- `enable` **仅**用于首次安装（current = not-installed）
+- `reinstall` 用于所有"账本已有行"的场景，包括 `installed` / `partial` / `failed`
+- 用户的"重试"按钮（failed 错误页）和"重新安装"按钮（partial 状态条）**都触发 `mode: 'reinstall'`**
+- 不存在"自动从 enable 降级到 reinstall"的逻辑；mode 必须由前端明确传入
+
+### 6.3 failed 必须留下账本行 ⭐
+
+为了让 §6.2 的 `failed` 行可被 `current` 接口查询到，**安装器在所有失败路径上都必须先尝试写入账本行 (status='failed')，再返回错误**。
+
+**唯一例外**：账本写入操作本身失败（chicken-and-egg：`ledger-write-failed` 错误），此时 current 返回 `not-installed`，重试走 `enable` 路径。
+
+具体行为：
+
+| 失败位置 | 是否写账本 | current 后续返回 | 重试 mode |
+|---|---|---|---|
+| 步骤 1 校验 (`validation-failed`) | ❌ 不写（因为这是 plugin bug 不是用户问题） | `not-installed` | `enable` |
+| 步骤 5 核心对象创建失败 (`core-object-failed`) | ✅ 写 `status=failed`，`createdObjects` 记录已成功的部分 | `failed` | `reinstall` |
+| 步骤 6-10 任一非核心步骤失败（partial 形态） | ✅ 写 `status=partial`，warnings 非空 | `partial` | `reinstall` |
+| 步骤 11 账本 UPSERT 自身失败 (`ledger-write-failed`) | ❌ 写不进去 | `not-installed` | `enable` |
+| 全部步骤成功 | ✅ 写 `status=installed` | `installed` | `reinstall`（用户主动） |
+
+**这一节是 #2 §3.3 / §6.2 / §4.5 的隐含规则的正式写出**。#2 §3.3 与 §6.2 需要按本节回补一致表述（见 §11 回补清单）。
+
+### 6.4 状态转换图
+
+```mermaid
+stateDiagram-v2
+  [*] --> not_installed
+  not_installed --> installing_enable: POST install (enable)
+  installing_enable --> installed: 全部成功
+  installing_enable --> partial: 非核心失败
+  installing_enable --> failed: 核心失败 + 账本写入成功
+  installing_enable --> not_installed: 账本写入失败 (ledger-write-failed)
+
+  installed --> installing_reinstall: 用户主动 (重新安装)
+  partial --> installing_reinstall: 状态条按钮 (重新安装)
+  failed --> installing_reinstall: 错误页按钮 (重试)
+
+  installing_reinstall --> installed: 修复完成
+  installing_reinstall --> partial: 仍有 warnings
+  installing_reinstall --> failed: 核心仍失败
+
+  note right of installing_enable
+    前端临时态
+    账本中无行
+  end note
+
+  note right of installing_reinstall
+    前端临时态
+    账本仍是上一终态
+  end note
+```
+
+### 6.5 retry 流程统一规范
+
+| 触发位置 | 当前 current.status | 触发的 install mode | 用户文案 |
+|---|---|---|---|
+| 启用引导页"启用"按钮 | `not-installed` | `enable` | "启用售后" |
+| 错误页"重试"按钮 | `failed` | **`reinstall`** | "重试安装" |
+| 状态条"重新安装"按钮 | `partial` | `reinstall` | "重新安装" |
+| 已安装首页（无 UI 入口） | `installed` | （无） | （无） |
+
+**关键修订**：原 #4 §2.2 步骤 7c 的"重试"按钮触发 `enable` 是错的——会被 §6.2 拦截为 `already-installed`。**正确做法是触发 `reinstall`**。这一规则需要回补到 #4 §2.2 / §4.3 / §11（见 §11 回补清单）。
+
+## 7. 非目标（Non-Goals）
+
+以下能力**不在 v1 范围**。任何文档若提及这些能力为 v1 可用，均为错误。
+
+### 7.1 平台基础设施类
+
+- ❌ **marketplace（应用市场）**：v1 没有应用列表与第三方上架；plugin-after-sales 是静态预装的
+- ❌ **sandbox（插件沙箱隔离）**：当前 `packages/core-backend/src/core/plugin-sandbox.ts:8` 是 NoopSandbox，无真隔离能力
+- ❌ **scoped CoreAPI**：当前 `packages/core-backend/src/index.ts:719` 直接注入完整 CoreAPI，没有按 plugin 切片的能力
+- ❌ **plugin migration runner**：当前没有插件自管 migration 的运行时；账本表必须走核心 migration 目录创建
+- ❌ **workspaceId / organizationId**：当前 `packages/core-backend/src/db/sharding/tenant-context.ts:19-28` 只承载 `tenantId`，没有 workspace 槽位
+
+### 7.2 抽象与通用能力类
+
+- ❌ **统一 BlueprintInstaller 平台服务**：v1 安装器是 plugin-after-sales 内部的薄壳，不是平台级服务
+- ❌ **通用表达式引擎**：v1 helper 走白名单机制（v1 唯一白名单项是 `computeSlaDueAt(priority)`）
+- ❌ **通用规则引擎 / 工作流重写**：v1 自动化是声明式描述，运行时仍由现有 workflow 服务执行
+- ❌ **通用通知中枢 + inApp 渠道**：v1 通知 channel 锁定为 `email / webhook / feishu`
+- ❌ **multitable 批量创建 API**：v1 安装器逐表调现有创建接口，接受 N 秒级耗时
+
+### 7.3 用户体验类
+
+- ❌ **步骤级安装进度可视化** ⭐：同步 HTTP 在响应返回前无法报告分步进度。v1 安装期 UI 仅显示单一文案"正在初始化售后模板..."；**不承诺**进度条或步骤列表。步骤级可视化留给 v2 异步任务模型。
+- ❌ **多项目切换器**：v1 主导航只显示"售后"一个菜单项
+- ❌ **单项目卸载按钮**：v1 卸载 = 关停整个 plugin-after-sales；不提供"删除单项目"按钮
+- ❌ **应用配置回滚 / 历史版本**：v1 reinstall 不保存历史快照
+- ❌ **模板用户自定义**：v1 用户不能上传自定义蓝图；`templateId` 白名单只有 `'after-sales-default'`
+
+### 7.4 RBAC 与数据治理类
+
+- ❌ **project-scoped RBAC**：v1 权限只有 `after_sales:write` 形态，不支持 `after_sales:write@projectId=xxx`
+- ❌ **API 列裁剪**：v1 fieldPolicies.hidden 只在前端隐藏，API 仍返回该列
+- ❌ **行级权限**：v1 没有"客服只能看到自己负责的工单"这类记录级 RBAC
+- ❌ **数据导出权限细分**：v1 导出权限走 admin 角色统一控制
+- ❌ **审计日志按项目隔离**：v1 审计日志全租户合一
+
+### 7.5 数据迁移类
+
+- ❌ **multitable 表加 project_id 列**：v1 multitable schema 不变；project_id 是 v2 演进
+- ❌ **跨对象事务**：v1 安装器不要求跨对象强事务，失败通过 warnings + partial 表达
+- ❌ **自动 reinstall 于版本升级**：v1 plugin 升级后不会自动 reinstall；需用户手动点"重新安装"
+
+## 8. v1 → v2 升级承诺
+
+### 8.1 接口字段层
+
+| 字段 | v1 形态 | v2 演进 | 兼容性 |
+|---|---|---|---|
+| `ProjectCreateRequest.projectId` | 服务端忽略 | 服务端尊重客户端传值 | 字段名不变，向前兼容 |
+| `ProjectCurrentResponse.projectId` | 伪值 | 真值 | 字段名不变 |
+| `TemplateInstallRequest.projectId` | 服务端覆盖 | 服务端使用客户端传值 | 字段名不变 |
+| `TemplateInstallResult.projectId` | 伪值 | 真值 | 字段名不变 |
+| `ProjectCurrentResponse.displayName` / `.config` | 已存在（本文档 §5.2.1 锁定） | 同 v1 | 无变更 |
+
+**v1 调用方代码 0 行修改即可使用 v2 接口。**
+
+### 8.2 路由层
+
+| 场景 | v1 路由 | v2 路由 |
+|---|---|---|
+| 前端主页 | `/p/plugin-after-sales/after-sales` | `/p/after-sales/:projectId/home` |
+| 后端安装 | `POST /api/after-sales/projects/install` | `POST /api/after-sales/projects` |
+| 后端查状态 | `GET /api/after-sales/projects/current` | `GET /api/after-sales/projects/:projectId` |
+| 后端业务数据 | `GET /api/after-sales/tickets` | `GET /api/after-sales/tickets?projectId=...` 或 `/api/p/:projectId/after-sales/tickets` |
+
+v2 路由是**纯 additive**：v1 路由不会被废弃，但新功能只在 v2 路由上提供。
+
+### 8.3 数据库层
+
+| 维度 | v1 形态 | v2 演进 |
+|---|---|---|
+| 多维表对象 | 仅 `tenant_id` 过滤 | 追加 `project_id` 列，回填 `${tenantId}:after-sales` |
+| 账本表唯一索引 | `(tenant_id, app_id)` | 升级为 `(tenant_id, project_id)` |
+| RBAC 角色绑定 | `(tenantId, role, permission)` | 追加 projectId 形成 `(tenantId, projectId, role, permission)` |
+| 通知 topic 注册 | `(tenantId, topic)` | 追加 projectId |
+| 自动化规则注册 | `(tenantId, appId, rule.id)` | 追加 projectId |
+
+**v2 升级是 schema 追加列 + 回填值**，不删数据、不改既有列。`getProjectId(tenantId, appId)` helper（#2 §11.2 强制约束）是 v1 → v2 升级的唯一可控扩展点。
+
+### 8.4 能力扩展层
+
+| 能力 | v1 形态 | v2 演进 |
+|---|---|---|
+| Helper 白名单 | 只有 `computeSlaDueAt` | 可新增 helper，但 v1 已有的不改签名 |
+| 通知 channel | `email / webhook / feishu` | 新增 `inApp`（通知中枢） |
+| API 列裁剪 | 不裁剪，前端 UI 隐藏 | fieldPolicies.hidden 升级为 API 层裁剪 |
+| 模板白名单 | 只有 `after-sales-default` | 允许多个模板共存，可加用户自定义 |
+
+### 8.5 跨版本不变量
+
+以下不变量在 v1 / v2 都成立，**绝不打破**：
+
+- AutomationRuleDraft / RolePermissionMatrix / NotificationTopicSpec 的字段名和类型
+- ObjectDescriptor / FieldDescriptor / ViewDescriptor 的字段名和类型
+- 10 种规范字段类型（`string / number / boolean / date / formula / select / link / lookup / rollup / attachment`）
+- 6 个角色 slug（`customer_service / technician / supervisor / finance / admin / viewer`）
+- helper 白名单只能加不能改
+- 通知 channel 枚举只能加不能改
+- 安装器的 `mode='enable'` 与 `mode='reinstall'` 的语义边界
+
+## 9. 5 份文档之间的依赖关系
+
+### 9.1 写作顺序与依赖方向
+
+```mermaid
+graph TB
+  D1["#1 售后模板设计<br/>(具体业务对象)"] --> D2
+  D2["#2 对象模型与<br/>模板安装器"] --> D3
+  D2 --> D4
+  D3["#3 自动化 / 权限 / 通知"] --> D4
+  D4["#4 项目创建流程"] --> D5
+  D5["#5 总览架构 (本文)"]
+
+  D1 -. 反向回补 .-> D5
+  D2 -. 反向回补 .-> D5
+  D3 -. 反向回补 .-> D5
+  D4 -. 反向回补 .-> D5
+
+  style D5 fill:#fef3c7
+```
+
+**说明**：文档按 #1 → #5 顺序写作，先具体后抽象；但写作过程中后续文档对前面文档的修订**反向回补**到前面文档。本文档（#5）作为总收口，整理所有跨文档的不一致并指明回补方向。
+
+### 9.2 文档职责矩阵
+
+| 文档 | 主要职责 | 输出锁定的关键类型 / 规则 |
+|---|---|---|
+| #1 | 售后业务模板的具体声明 | 6 个对象的字段表、5 个默认视图、3 条自动化、4 个通知主题、6 个角色、7 个默认值 |
+| #2 | 对象模型抽象与安装执行 | `ProjectTemplateBlueprint` / `TemplateInstallRequest` / `TemplateInstallResult` / 账本表 schema / 安装器步骤 / reinstall 语义 / partial 语义 / helper 白名单机制 |
+| #3 | 横切能力的运行时语义 | `AutomationRuleDraft` 详细 / `RolePermissionMatrix` 详细 / `NotificationTopicSpec` 详细 / recipient 解析约定 / channel/type 对齐 / 注册幂等契约 |
+| #4 | 用户路径与 HTTP 契约 | `ProjectCreateRequest/Response` / `ProjectCurrentResponse` / 状态条 UX / partial 恢复路径 / v1 路由清单 |
+| #5 | 架构总览与全局收口 | 三层模型 / v1/v2 定义 / 全局术语 / 全局接口索引 / 全局状态机 / 非目标 / v1→v2 升级承诺 |
+
+### 9.3 跨文档引用规则
+
+- 任何接口字段定义以 §5 全局接口索引为准
+- 任何状态机语义以 §6 全局状态机为准
+- 任何"v1 不做什么"以 §7 非目标为准
+- 任何 v1→v2 升级路径以 §8 升级承诺为准
+- 如其他文档与本文档冲突，**以本文档为准**，并按 §11 提交回补 PR
+
+## 10. 实施者总览 checklist
+
+### 10.1 跨文档共同的四大禁区
+
+- ❌ **不改 `packages/core-backend/src/db/types.ts`**
+- ❌ **不发明 plugin migration runner**
+- ❌ **不引入通用表达式引擎**
+- ❌ **不引入 `/api/p/:projectId/...` 路由前缀**
+
+### 10.2 高层架构 checklist
+
+- [ ] Plugin / App / Project 三层在代码组织和文档表述中都清晰区分
+- [ ] v1 项目语义是"业务子域"，每租户每应用唯一
+- [ ] projectId 在所有契约层都有字段位置，但 v1 服务端固定生成伪值
+- [ ] 不在 v1 章节出现 workspaceId / organizationId / inApp / scoped CoreAPI 等 v2 概念
+- [ ] 所有失败路径都尽量留下账本行（status='failed'），让 current 接口可查询
+- [ ] failed 状态的"重试"按钮触发 `mode='reinstall'`，不是 `enable`
+- [ ] partial 状态条的"重新安装"按钮触发 `mode='reinstall'`
+- [ ] enable 仅用于 current=not-installed
+- [ ] 安装期 UI 只显示单一文案，不承诺步骤级进度
+- [ ] `ProjectCurrentResponse` 在 installed/partial/failed 状态下返回完整 `displayName` + `config`
+- [ ] 账本表 schema 包含 `display_name` 与 `config_json` 列
+- [ ] v1 → v2 升级是 additive：列追加、字段追加、helper 追加、channel 追加，**绝不**修改既有
+- [ ] `getProjectId(tenantId, appId)` helper 是 v1 SQL 查询的唯一 projectId 接入点
+- [ ] 所有 service helper 接收 projectId 参数，v1 内部"吞掉"它，v2 升级时单文件改造
+
+## 11. 对前 4 份文档的回补清单 ⭐
+
+本节列出本文档（#5）的全局规则与前 4 份文档的不一致点，及对应的回补动作。**这些回补是 5 份文档形成闭环的必要条件**，应在本文档定稿后立即执行。
+
+### 11.1 回补到 #4
+
+| 章节 | 原文问题 | 回补动作 |
+|---|---|---|
+| `#4 §2.3` ProjectCurrentResponse 定义 | 缺 `displayName` / `config` 字段 | 按 §5.2.1 更新类型定义 |
+| `#4 §2.2` 步骤 7c 的"重试"按钮 | 写"再次触发步骤 5"（即 enable），与 §6.2 冲突 | 改为"触发 `mode: 'reinstall'`"，与状态机一致 |
+| `#4 §2.2` 步骤 6 安装期文案 | 暗示可以"列出当前步骤" | 改为"显示单一文案 '正在初始化售后模板...'"；删除"从 response 消息体可选拉取"表述 |
+| `#4 §11` AfterSalesView 状态机草图 | retry-install 分支语义不明 | 注明 retry → reinstall（不是 enable） |
+| `#4 §4.3` 错误码表 | `failed` 后的重试默认走 enable | 注明 failed 后重试 mode 必须由前端按 current.status 决定 |
+| `#4 §6.2` reinstall request body | "从 current 响应中取" `displayName` / `config` | 与 §5.2.1 修订后的 ProjectCurrentResponse 一致即可，无需额外文案 |
+
+### 11.2 回补到 #2
+
+| 章节 | 原文问题 | 回补动作 |
+|---|---|---|
+| `#2 §3.3` partial / failed 三态表 | failed 行写"必须重试 enable" | 改为"必须重试 reinstall（除 ledger-write-failed 例外）"，并指向 #5 §6.2 |
+| `#2 §6.2` 步骤 5 失败处理 | 写"核心对象失败 → failed"但未说明账本仍要写入 | 补一句"核心对象失败 → 仍需走步骤 11 写入账本，status='failed'，createdObjects 记录已成功的部分"；ledger-write-failed 是唯一例外 |
+| `#2 §4.2` 账本表 schema | 缺 `display_name` / `config_json` 列 | 补上两列；migration 文件命名按 §11.4 给出的 zzzz 时间戳约定 |
+
+### 11.3 回补到 #3
+
+无强制回补项。#3 已经通过本轮 4 次微调与本文档一致。
+
+### 11.4 回补到 #1
+
+无强制回补项。#1 是最具体的业务文档，与本文档抽象层级正交。
+
+### 11.5 账本表 schema 升级（重要）
+
+由于 §5.2.1 给 `ProjectCurrentResponse` 加了 `displayName` 与 `config` 字段，账本表必须能持久化这两个值。修订后的账本表 schema：
+
+| 列 | 类型 | 约束 | 说明 |
+|---|---|---|---|
+| ...（原 13 列保持不变） | | | 见 #2 §4.2 |
+| `display_name` | `text` | NOT NULL DEFAULT '' | 用户输入的项目展示名（v1 由 ProjectCreateRequest.displayName 提供） |
+| `config_json` | `jsonb` | NOT NULL DEFAULT '{}' | `AfterSalesTemplateConfig` 序列化值 |
+
+migration 文件路径建议：`packages/core-backend/src/db/migrations/zzzz20260408xxxxxx_create_plugin_after_sales_template_installs.ts`，将这两列直接写入初始 schema（不是后续 alter migration），因为 v1 还没有任何已部署的 v0 版本。
+
+### 11.6 5 份文档定稿后的最终一致性验收
+
+按本文档 §5.4 一致性验收规则，最后一次跨文档 grep 比对：
+
+- [ ] `ProjectCreateRequest` 字段在 #4 / #5 一致
+- [ ] `ProjectCurrentResponse` 字段在 #4 (回补后) / #5 一致
+- [ ] `TemplateInstallRequest` / `TemplateInstallResult` 在 #2 / #5 一致
+- [ ] `AutomationRuleDraft` / `RolePermissionMatrix` / `NotificationTopicSpec` 在 #3 / #5 一致
+- [ ] `AfterSalesTemplateConfig` 在 #1 / #3 / #4 / #5 一致
+- [ ] failed → reinstall 规则在 #2 (回补后) / #4 (回补后) / #5 一致
+- [ ] 账本表 schema 在 #2 (回补后) / #5 一致
+- [ ] 非目标列表中 v1 不做的能力在所有文档中无矛盾表述
+
+---
+
+## 附：词典版本与本文档定位
+
+本文档对接口词典 v1.0 做以下**补充**：
+
+- `ProjectCurrentResponse` 增加 `displayName?` / `config?` 字段（从 #4 的本地契约提升为词典级类型）
+- 账本表新增 `display_name` / `config_json` 两列（属于实现层 schema，不进词典正文）
+- failed → reinstall 的状态机规则正式化（属于行为契约，不改字段定义）
+
+这些**不改任何已有字段名 / 类型 / 可选性**。词典版本仍为 **v1.0**。
+
+本文档作为 5 份设计稿的总收口，**任何后续文档级修订必须先更新本文档**，再更新被影响的 #1-#4 文档。本文档是 v1 设计阶段的"宪法"。

--- a/docs/development/platform-project-creation-flow-design-20260407.md
+++ b/docs/development/platform-project-creation-flow-design-20260407.md
@@ -1,0 +1,441 @@
+# 项目创建流程设计 (platform-project-creation-flow-design-20260407)
+
+> **文档类型**：用户流程与 HTTP 契约设计 / Pre-Implementation Design
+> **日期**：2026-04-07
+> **范围**：v1 用户从应用市场到售后首页的完整路径、`ProjectCreateRequest` / `ProjectCreateResponse` 契约、partial 恢复路径、二次启用行为、卸载行为、v1/v2 对照
+> **来源词典**：2026-04-07 接口词典 v1.0（locked）
+> **配套交付**：本文档为 5 份设计稿之 #4，前置 #1 / #2 / #3，后置 #5 `platform-project-builder-and-template-architecture-design-20260407.md`
+
+## TL;DR
+
+v1 用户路径"选择售后应用 → 点击启用 → 模板初始化 → 进入售后首页"走同步安装链路，全程在秒级完成。`ProjectCreateRequest` 的 `projectId` 字段被客户端原样透传但**服务端忽略**，安装器固定生成 `${tenantId}:after-sales`。二次启用命中 `already-installed` 错误并引导进入首页；partial 状态下首页顶部显示橙色状态条，用户点击"重新安装"触发 `mode: 'reinstall'`。v1 卸载 = 关停整个应用；v2 才有"删除单个项目"。所有路由保持 `/api/after-sales/...` 风格，**v1 不引入** `/api/p/:projectId/...` 前缀。
+
+---
+
+## 1. 核心目标与非目标
+
+### 1.1 v1 目标
+
+- 定义用户从零到拥有可用售后系统的完整路径
+- 锁定 `ProjectCreateRequest` / `ProjectCreateResponse` HTTP 契约
+- 定义二次启用、partial 恢复、卸载三类边界行为的用户可见结果
+- 与 #2 的安装器语义、#3 的运行时语义形成闭环
+
+### 1.2 v1 非目标
+
+- ❌ 不做异步安装队列；v1 安装是同步 HTTP 请求，秒级返回
+- ❌ 不做多租户应用市场；v1 入口是 plugin-after-sales 静态注册的主导航项
+- ❌ 不做"创建多个项目"流程；v1 每租户每应用只有一个实例
+- ❌ 不引入 `/api/p/:projectId/...` 路由前缀；v1 路由风格与现有 `/api/after-sales/...` 保持一致
+- ❌ 不做 v1 项目级卸载；v1 卸载等价于"关停整个 plugin-after-sales 应用"
+
+## 2. v1 用户路径（详细步骤）
+
+### 2.1 前提
+
+- 租户管理员（`admin` 角色）已登录
+- plugin-after-sales 已在后端 activate（`/api/after-sales/app-manifest` 可访问）
+- 目标租户的 `plugin_after_sales_template_installs` 账本**无行**（首次安装）
+
+### 2.2 步骤序列
+
+| 步骤 | 用户动作 | 前端行为 | 后端行为 |
+|---|---|---|---|
+| 1 | 点击主导航"售后" | 加载 `/p/plugin-after-sales/after-sales` 路由，渲染 `AfterSalesView.vue` | - |
+| 2 | 组件挂载 | `onMounted` 调 `GET /api/after-sales/projects/current` 判断安装状态 | 查账本，返回 `{ status: 'not-installed' }` |
+| 3 | 首次进入，显示"启用"引导页 | 渲染"售后应用尚未启用"卡片 + 模板概览（来自 `/api/after-sales/app-manifest`）+ "启用"按钮 | - |
+| 4 | 点击"启用" | 弹出确认对话框，展示 `AfterSalesTemplateConfig` 默认值 + 允许开关调整 | - |
+| 5 | 确认启用 | POST `/api/after-sales/projects/install` with `mode: 'enable'` + config | 安装器执行 11 步流程（#2 §6），同步返回 `TemplateInstallResult` |
+| 6 | 安装期间 | 显示满屏 `InstallingOverlay`，固定文案"正在初始化售后模板..."；**不承诺**步骤级进度（同步 HTTP 在响应返回前拿不到分步进度，见 #5 §7.3） | - |
+| 7a | 安装成功 (status='installed') | 跳转到售后首页，默认视图为 ticket-board；无状态条 | - |
+| 7b | 安装 partial (status='partial') | 跳转到售后首页，首页顶部显示橙色状态条（见 §5） | - |
+| 7c | 安装 failed (status='failed') | 停留在错误页，展示错误码 + "重试"按钮（按 #5 §6.2 / §6.5 状态机：当账本已有 failed 行时，重试触发 `mode='reinstall'`，**不是** `enable`） | - |
+
+### 2.3 步骤 3 的 current 状态判断
+
+`GET /api/after-sales/projects/current` 返回体（v1 契约，**以 #5 §5.2.1 为准**）：
+
+```ts
+interface ProjectCurrentResponse {
+  status: 'not-installed' | 'installed' | 'partial' | 'failed'
+  projectId?: string                          // status ∈ {installed, partial, failed} 时返回
+  displayName?: string                        // 同上条件
+  config?: AfterSalesTemplateConfig           // 同上条件
+  installResult?: TemplateInstallResult       // 同上条件
+  reportRef?: string                          // 同上条件
+}
+```
+
+`displayName` 与 `config` 在已安装态下返回，让 current 接口成为首页状态的**完整**数据源——前端在 partial 恢复时直接使用，无需依赖本地缓存。
+
+- `not-installed`：账本无行 → 展示启用引导页
+- `installed`：账本有行且 status='installed' → 直接进首页
+- `partial`：账本有行且 status='partial' → 进首页 + 顶部状态条
+- `failed`：账本有行且 status='failed' → 展示错误页 + "重试"按钮（按 #5 §6.2 状态机，重试触发 `mode='reinstall'`）
+
+### 2.4 为什么步骤 5 是同步调用
+
+- v1 安装器走逐表 multitable 创建，6 对象 + 5 视图 + 3 自动化 + 4 通知 + 6 角色 + 4 字段策略 ≈ 28 个写入操作
+- 单次耗时预期 2-10 秒，在同步 HTTP 承受范围内
+- 同步调用让前端状态机极简：loading → result 两态
+- v2 若对象数量激增，可迁移到异步任务 + 进度推送；v1 不值得提前优化
+
+## 3. v2 用户路径（简述，供对照）
+
+| 步骤 | v2 行为 |
+|---|---|
+| 1 | 点击主导航"售后 ▸ +" 或进入应用市场 |
+| 2 | 展示"创建售后项目"表单：项目名、负责区域、初始配置 |
+| 3 | 提交 → POST `/api/after-sales/projects` with 真实 `projectId` |
+| 4 | 后端生成真 `projectId`，走多实例安装 |
+| 5 | 返回后跳转到 `/p/after-sales/:projectId/home` |
+| 6 | 主导航"售后 ▸ 华东售后 / 华南售后"两级展示 |
+
+**v1/v2 的用户感知差异**：v1 是"启用一个业务模块"，v2 是"创建一个项目实例"。这一差异在本文档的 §10 Mermaid 对照图中可视化。
+
+## 4. HTTP 契约
+
+### 4.1 ProjectCreateRequest
+
+```ts
+interface ProjectCreateRequest {
+  templateId: string              // v1 固定 'after-sales-default'
+  projectId?: string              // v1 服务端忽略；v2 真值
+  displayName: string             // v1 仅用于状态条/日志展示，不进入路由或权限作用域
+  config: AfterSalesTemplateConfig
+}
+```
+
+**v1 字段语义**：
+
+| 字段 | v1 处理 | v2 处理 |
+|---|---|---|
+| `templateId` | 校验必须等于 `'after-sales-default'`，否则 400 | 允许多个模板 |
+| `projectId` | **服务端忽略客户端传值**，内部重置为 `${tenantId}:after-sales`；即使客户端不传也不报错 | 服务端生成真值并返回 |
+| `displayName` | 只用于日志与状态条；不影响路由、权限、数据隔离 | 同时用作项目切换器的显示名 |
+| `config` | 传入 `TemplateInstallRequest.blueprint.configDefaults` 的运行时覆盖值 | 同 v1 |
+
+### 4.2 ProjectCreateResponse
+
+```ts
+interface ProjectCreateResponse {
+  projectId: string                     // v1 = `${tenantId}:after-sales`
+  appId: string                         // v1 固定 'after-sales'
+  routes: {
+    home: string                        // v1 = '/p/plugin-after-sales/after-sales'
+    apiBase: string                     // v1 = '/api/after-sales'
+  }
+  installResult: TemplateInstallResult  // 详见 #2 §3
+}
+```
+
+### 4.3 错误响应
+
+v1 安装 API 的错误响应遵循统一格式：
+
+```ts
+interface ProjectCreateError {
+  error: {
+    code: string                  // 见下表
+    message: string               // 人类可读
+    details?: Record<string, unknown>
+  }
+}
+```
+
+| error.code | HTTP 状态 | 触发条件 | 前端处理 |
+|---|---|---|---|
+| `already-installed` | 409 | `mode='enable'` 且账本已有行 | 提示"售后已启用"，自动跳转到首页 |
+| `no-install-to-rebuild` | 404 | `mode='reinstall'` 但账本无行 | 展示错误提示，引导用户先点"启用" |
+| `validation-failed` | 400 | blueprint 语法错误 | 展示错误详情，这是实施者 bug，用户不应遇到 |
+| `core-object-failed` | 500 | 核心 multitable 对象创建失败 | 展示错误详情 + "重试"按钮（按 #5 §6.2，前端按 current.status 决定 mode：failed → reinstall） |
+| `ledger-write-failed` | 500 | 账本 UPSERT 失败 | 展示错误详情 + "重试"按钮（账本无行 → mode='enable'） |
+| `invalid-template-id` | 400 | `templateId` 不在白名单 | 视为前端 bug，展示通用错误 |
+
+**重试 mode 选择规则**（详见 #5 §6.5）：
+
+| 当前 current.status | 重试 mode |
+|---|---|
+| `not-installed`（账本无行） | `enable` |
+| `failed`（账本有行） | `reinstall` |
+| `partial`（账本有行） | `reinstall` |
+
+前端**不能**为 failed 状态硬编码 enable，否则会被后端 §6.2 拦截为 `already-installed`。
+
+### 4.4 HTTP 路由一览（v1）
+
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| `GET` | `/api/after-sales/health` | 已有（`plugins/plugin-after-sales/index.cjs`），返回 plugin 健康 |
+| `GET` | `/api/after-sales/app-manifest` | 已有，返回 app.manifest.json 内容 |
+| `GET` | `/api/after-sales/projects/current` | **新增**，返回当前租户的安装状态（§2.3） |
+| `POST` | `/api/after-sales/projects/install` | **新增**，触发安装器（§2.2 步骤 5） |
+
+**v1 只新增 2 个路由**，均在 plugin-after-sales 内部，不触动核心路由层。所有新路由都走现有的 `context.api.http.addRoute` 注册机制。
+
+### 4.5 路由风格演进承诺
+
+- **v1**：`/api/after-sales/projects/install`（与现有 `/api/after-sales/*` 风格一致）
+- **v2**：`/api/after-sales/projects` + 项目级操作通过查询参数或 POST body 中的 `projectId` 识别；或最终演进为 `/api/p/:projectId/after-sales/...`
+- **不在 v1 引入 `/p/:projectId` 前缀**：引入它需要改动核心路由中间件注入 projectId 到上下文，这是 v2 的 Phase 1B 工作
+
+## 5. 页面与状态清单
+
+### 5.1 页面列表（v1）
+
+| 页面 ID | 路由 | 承担状态 | 主要组件 |
+|---|---|---|---|
+| `after-sales-enable-guide` | `/p/plugin-after-sales/after-sales` (when not-installed) | 展示模板概览 + 启用按钮 | 现有 `AfterSalesView.vue` 扩展 |
+| `after-sales-enable-confirm` | 弹窗（不独立路由） | 展示 `AfterSalesTemplateConfig` + 确认按钮 | 新建 `EnableConfirmDialog.vue` |
+| `after-sales-installing` | 全屏覆盖层（不独立路由） | 安装期进度显示 | 新建 `InstallingOverlay.vue` |
+| `after-sales-home` | `/p/plugin-after-sales/after-sales` (when installed/partial) | 售后主页 + 5 默认视图入口 | 现有 `AfterSalesView.vue` 重构 |
+| `after-sales-failed` | `/p/plugin-after-sales/after-sales` (when failed) | 错误页 + 重试按钮 | `AfterSalesView.vue` 的错误分支 |
+| `after-sales-warnings-modal` | 弹窗（不独立路由） | 展示 warnings 详情 | 新建 `WarningsDetailModal.vue` |
+
+所有页面 / 弹窗都在 `apps/web/src/views/` 或其子目录，不改全局路由注册。
+
+### 5.2 partial 状态条（§2.2 步骤 7b 产物）
+
+**位置**：售后主页（`after-sales-home`）最顶部
+
+**外观**：
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ ⚠ 部分组件安装未完成（N 条告警）        [查看详情]  [重新安装]     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- 背景色：橙色（推荐 Element Plus `--el-color-warning` 或 `#f59e0b`）
+- 图标：警告三角（`Warning` icon）
+- 文案：`"部分组件安装未完成（${warnings.length} 条告警）"`
+- 右侧两个按钮：
+  - `"查看详情"`：打开 `after-sales-warnings-modal` 弹窗，展示 warnings 数组内容
+  - `"重新安装"`：触发 §6 的恢复路径
+
+**关键约束**：
+
+- 状态条**不阻断**首页交互；用户可以正常创建工单、查看视图、使用已就绪的功能
+- 状态条**不是模态**；只是在视图顶部占一条横幅
+- partial → installed 成功后状态条自动消失；reinstall 失败则更新告警数
+
+## 6. partial 恢复路径
+
+### 6.1 用户交互
+
+1. 用户点击状态条的"重新安装"按钮
+2. 前端弹出确认对话框："确定重新安装？不会删除已有数据"（确认文案明示安全性）
+3. 用户确认 → POST `/api/after-sales/projects/install` with `mode: 'reinstall'`
+4. 前端展示 `InstallingOverlay`（与首次安装共用组件）
+5. 后端走 #2 §8 的增量补齐流程
+6. 返回 `TemplateInstallResult`：
+   - `status: 'installed'` → 状态条消失，首页刷新
+   - `status: 'partial'` → 状态条保留，`warnings` 刷新为本次结果
+   - `status: 'failed'` → 不应发生（reinstall 不触碰核心对象），若发生则展示错误弹窗并保留原状态条
+
+### 6.2 reinstall 调用的 request body
+
+```ts
+{
+  templateId: 'after-sales-default',
+  displayName: '<原 displayName>',  // 从 current 响应中取
+  config: <原 config>               // 从 current 响应中取，或允许用户调整
+}
+```
+
+注意：v1 reinstall 请求**不传 projectId**（因为服务端会忽略），也**不允许**修改 `templateId`（后端校验）。`displayName` 与 `config` 可选，未传时保持账本中的原值。
+
+### 6.3 "重新安装"的防误触保护
+
+- 按钮必须二次确认
+- 每次 reinstall 都刷新账本 `last_install_at`，便于审计
+- 连续点击"重新安装"之间有 3 秒冷却（前端节流），防止并发请求
+- 后端账本 `UNIQUE(tenant_id, app_id)` 约束作为最终防护
+
+## 7. 二次启用行为（已启用应用的重复点击）
+
+### 7.1 场景
+
+用户 A 已启用售后；用户 B（同租户）首次进入售后菜单。此时用户 B 不应被引导到"启用"页，而应直接看到已启用的售后主页。
+
+### 7.2 流程
+
+1. 用户 B 点击主导航"售后"
+2. 前端调 `GET /api/after-sales/projects/current`
+3. 返回 `status: 'installed'` → 前端直接跳转到售后主页
+4. **不显示**启用引导页
+
+### 7.3 异常场景：用户强行调 install API
+
+（理论上不会发生，但作为安全网）
+
+- 用户通过开发者工具或 curl 发起 `POST /api/after-sales/projects/install` with `mode: 'enable'`
+- 后端查账本发现已有行
+- 返回 409 + `error.code = 'already-installed'`
+- **不执行**任何 DDL / DML（见 #2 §3.4）
+
+### 7.4 同一用户重复点击"启用"按钮
+
+- 前端按钮在第一次点击后立即 disable 并展示 loading
+- 即使双击也只发送一个请求
+- 响应返回前不允许重复点击
+
+## 8. 卸载行为
+
+### 8.1 v1 卸载
+
+**v1 卸载 = 关停整个 plugin-after-sales 应用**。
+
+- 触发方式：租户管理员在"应用管理"页（由平台侧提供，不是本 plugin 提供）关停 plugin-after-sales
+- 关停动作：调用现有 plugin 生命周期的 `deactivate` 接口
+- 对数据的影响：**不删数据**。所有 multitable 表、账本行、角色绑定都保留
+- 用户感知：主导航"售后"菜单项消失；直接访问 `/p/plugin-after-sales/after-sales` 返回 404
+
+**v1 不提供"卸载按钮"**，因为项目与应用是 1:1 关系，"卸载"语义等价于"关停插件"。
+
+### 8.2 v1 卸载后重新启用
+
+- 重新 activate plugin-after-sales → 主导航"售后"菜单恢复
+- 用户点击"售后" → `GET /api/after-sales/projects/current` 返回 `installed`（账本还在）→ 直接进入首页
+- **不需要**重新执行安装流程
+- 历史数据完整保留
+
+### 8.3 v2 卸载
+
+| 粒度 | 动作 | 对数据影响 |
+|---|---|---|
+| 单项目 | 删除单个项目实例 | 删除该项目的 multitable 记录（带 `project_id` 过滤），保留其他项目 |
+| 整个应用 | 关停 plugin-after-sales | 同 v1：不删数据 |
+
+v2 单项目卸载在 v1 不实现，不留退化 API。
+
+## 9. v1 / v2 创建流程对照 (Mermaid 泳道图)
+
+```mermaid
+flowchart TB
+  subgraph v1["v1：业务子域模型"]
+    v1_1[点击主导航 售后] --> v1_2{查询 current}
+    v1_2 -- not-installed --> v1_3[展示启用引导页]
+    v1_3 --> v1_4[点击启用]
+    v1_4 --> v1_5[确认弹窗 展示 config]
+    v1_5 --> v1_6[POST install mode=enable]
+    v1_6 --> v1_7{安装结果}
+    v1_7 -- installed --> v1_8[进入售后首页]
+    v1_7 -- partial --> v1_9[首页 + 橙色状态条]
+    v1_7 -- failed --> v1_10[错误页 + 重试]
+    v1_2 -- installed/partial --> v1_8
+    v1_2 -- failed --> v1_10
+  end
+
+  subgraph v2["v2：多实例项目模型"]
+    v2_1[点击主导航 售后 ▸ +] --> v2_2[展示创建项目表单]
+    v2_2 --> v2_3[输入项目名 + config]
+    v2_3 --> v2_4[POST projects 带真实 projectId]
+    v2_4 --> v2_5{安装结果}
+    v2_5 -- installed --> v2_6[跳转到 / p / after-sales / projId / home]
+    v2_5 -- partial --> v2_7[项目首页 + 状态条]
+    v2_1 -.已有项目.-> v2_8[展开项目列表]
+    v2_8 --> v2_9[选择项目]
+    v2_9 --> v2_6
+  end
+```
+
+## 10. 路由表达规则（v1/v2 对照）
+
+| 场景 | v1 路由 | v2 路由 |
+|---|---|---|
+| 前端主页 | `/p/plugin-after-sales/after-sales` | `/p/after-sales/:projectId/home` |
+| 后端安装 | `POST /api/after-sales/projects/install` | `POST /api/after-sales/projects` |
+| 后端查当前状态 | `GET /api/after-sales/projects/current` | `GET /api/after-sales/projects/:projectId` |
+| 后端业务数据 | `GET /api/after-sales/tickets?...` | `GET /api/p/:projectId/after-sales/tickets?...` 或 `GET /api/after-sales/tickets?projectId=...` |
+
+**v1 实施时的强约束**：
+
+- 路由字符串中**不出现** `:projectId` 占位符
+- 路由 handler 中**不调用**任何"从请求中解析 projectId 注入 tenant context"的中间件
+- projectId 派生只发生在 service helper 层（见 #2 §11.2 修订版）
+
+这些约束保证 v1 代码可以在 v2 引入 projectId 中间件时做**纯 additive** 扩展。
+
+## 11. 与 plugin-after-sales 起点文件的映射
+
+| 起点文件 | v1 扩展动作 |
+|---|---|
+| `plugins/plugin-after-sales/index.cjs` | 新增 2 个 HTTP 路由：`POST /api/after-sales/projects/install` / `GET /api/after-sales/projects/current`。原有 `/health` / `/app-manifest` 保持不变 |
+| `plugins/plugin-after-sales/app.manifest.json` | 不动 |
+| `apps/web/src/views/AfterSalesView.vue` | 从"manifest 卡片展示页"重构为"多态首页"：根据 current 响应的 status 分支渲染启用引导页 / 安装进度 / 首页 + 状态条 / 错误页 |
+
+重构后 `AfterSalesView.vue` 的状态机：
+
+```
+                 ┌────────────────┐
+  onMounted ───> │  fetch current │
+                 └──────┬─────────┘
+                        │
+       ┌────────────────┼──────────────────┬───────────────┐
+       ▼                ▼                  ▼               ▼
+   not-installed   installed           partial          failed
+       │                │                  │               │
+       ▼                ▼                  ▼               ▼
+   enable-guide     home (clean)      home + bar       error-page
+       │                                   │               │
+       ▼                                   ▼               ▼
+   enable-confirm                    reinstall btn    retry btn
+       │                                   │               │
+       ▼                                   ▼               ▼
+   POST install        POST install        POST install
+   mode=enable         mode=reinstall      mode=reinstall   ◀── 注意：failed 重试也走 reinstall
+       │                   │                   │
+       └───────────┬───────┴───────────────────┘
+                   ▼
+              installing overlay (单一文案)
+                   │
+                   ▼
+       按响应 status 重新分支
+```
+
+**关键修订**：failed 错误页的"重试"按钮触发 `mode='reinstall'`，不是 `enable`——因为 #5 §6.3 要求 failed 状态下账本已有行（status='failed'），enable 会被拦截为 `already-installed`。
+
+## 12. 实施者开工自检表
+
+### 12.1 四大禁区
+
+- ❌ **不引入 `/api/p/:projectId/...` 前缀**：v1 路由完全走 `/api/after-sales/...` 风格；引入前缀需要改核心路由中间件，是 v2 Phase 1B
+- ❌ **不在路由 handler 中解析 projectId 到上下文**：projectId 仅在 service helper 内部派生，见 #2 §11.2
+- ❌ **不在 v1 实现"卸载单项目"**：v1 卸载 = 关停整个应用；"删除单项目"是 v2
+- ❌ **不允许 `mode='enable'` 走 reinstall 分支做"智能升级"**：必须严格命中 `already-installed` 错误；用户的"重新安装"是显式的 reinstall 点击，不是自动降级
+
+### 12.2 细项 checklist
+
+- [ ] `AfterSalesView.vue` 首次渲染调 `/api/after-sales/projects/current`，根据 status 分支
+- [ ] `not-installed` 状态渲染"启用"引导页 + 模板概览
+- [ ] `installed` 状态直接渲染首页，不再显示启用按钮
+- [ ] `partial` 状态渲染首页 + 顶部橙色状态条
+- [ ] `failed` 状态渲染错误页 + "重试"按钮
+- [ ] "启用"按钮点击后弹出确认对话框，展示 `AfterSalesTemplateConfig` 默认值
+- [ ] 确认对话框中的 config 可编辑（`enableWarranty` 等开关 + `defaultSlaHours` 等数值）
+- [ ] 确认后 POST `/api/after-sales/projects/install` with `mode: 'enable'`
+- [ ] 安装期显示 `InstallingOverlay`（可复用）
+- [ ] 同步响应后按 `installResult.status` 分支
+- [ ] 状态条"查看详情"打开 `WarningsDetailModal`
+- [ ] 状态条"重新安装"触发二次确认 + POST `install` with `mode: 'reinstall'`
+- [ ] 重新安装请求不传 `projectId` 字段（或传空字符串）
+- [ ] "重新安装"按钮有 3 秒前端冷却节流
+- [ ] 后端对 `mode='enable'` 且账本已有行 → 返回 409 `already-installed`
+- [ ] 后端对 `mode='reinstall'` 且账本无行 → 返回 404 `no-install-to-rebuild`
+- [ ] 前端收到 `already-installed` → 提示 + 自动跳转首页
+- [ ] 前端收到 `no-install-to-rebuild` → 引导用户先点"启用"
+- [ ] 前端收到 `core-object-failed` / `ledger-write-failed` → 错误详情 + 重试
+- [ ] `ProjectCreateRequest.projectId` 字段即使被前端传入也不影响服务端行为
+- [ ] `ProjectCreateRequest.displayName` 只用于日志与状态条展示，不进入路由或权限
+- [ ] v1 前端代码中**不出现** `/p/:projectId` / `/projects/:projectId` 等 v2 路由字面量
+- [ ] 卸载 v1 = 关停整个 plugin-after-sales；**不**在首页提供"卸载项目"按钮
+- [ ] 重新 activate plugin 后主导航"售后"菜单自动恢复，历史数据完整保留
+
+---
+
+## 附：本文档未触发词典升级
+
+本文档未新增字段类型、未改公共契约字段名、未改默认值、未改 HTTP 契约字段。仅对 `ProjectCreateRequest` / `ProjectCreateResponse` 做字段语义扩写，并新增 `ProjectCurrentResponse` 作为 v1 状态查询契约。词典版本仍为 **v1.0**。
+
+`ProjectCurrentResponse` 已被 #5 §5.2.1 提升为**全局接口索引项**（含 `displayName?` / `config?` 修订），但**未升级词典版本**——补充字段不构成 breaking change。本文档 §2.3 的类型定义以 #5 §5.2.1 为准。


### PR DESCRIPTION
## Summary
- recut the remaining docs-only slice from stale #717
- preserve the 2026-04-07 after-sales/project-template design packet as a standalone docs PR
- keep executable PLM slices separate from design history

## Scope
- docs/development/after-sales-project-template-design-20260407.md
- docs/development/platform-automation-permission-notification-design-20260407.md
- docs/development/platform-object-model-and-template-installer-design-20260407.md
- docs/development/platform-project-builder-and-template-architecture-design-20260407.md
- docs/development/platform-project-creation-flow-design-20260407.md

## Verification
- git diff --check
