### PR TITLE
docs(after-sales): add runtime and follow-up wrap-up reports

### DIFF
--- a/docs/after-sales-runtime-and-followup-development-report-20260410.md
+++ b/docs/after-sales-runtime-and-followup-development-report-20260410.md
@@ -1,0 +1,65 @@
+# After-sales Runtime And Follow-up Development Report (2026-04-10)
+
+## Overview
+Delivered the next after-sales mainline batch across four PRs:
+
+- `#780` runtime installer adapters for automation registry and RBAC provisioning
+- `#782` field policy read path and `refundAmount` UI gating
+- `#777` inline follow-up edit flow
+- `#778` follow-up due notification proof and payload fallback hardening
+
+This batch intentionally stayed inside the existing after-sales vertical slice. It did not introduce a generic workflow engine, a generic field-policy read API, or a broader UI redesign.
+
+## Key Capabilities
+### 1) Installer Runtime Adapters (`#780`)
+- Added install-time persistence seams for plugin automation rules and after-sales role/field-policy matrices.
+- Persisted automation state in a plugin automation registry table and RBAC/field policies in plugin-scoped registry tables.
+- Wired installer warnings so adapter failures degrade to `partial` with warnings instead of collapsing the whole install path.
+- Hardened runtime semantics:
+  - removed automation rules are retired during sync instead of staying enabled forever
+  - RBAC provisioning writes plugin/app namespaced role ids instead of mutating global `admin` / `finance` / `supervisor` / `viewer`
+
+### 2) Field Policy Consumption (`#782`)
+- Added a plugin-local `GET /api/after-sales/field-policies` route.
+- Computed effective `refundAmount` visibility/editability from install-time field policy registry rows with blueprint fallback for legacy installs.
+- Updated `AfterSalesView.vue` to consume the policy result:
+  - `hidden` hides the refund control path
+  - `readonly` shows but disables the control path
+  - `editable` keeps the current behavior
+
+### 3) Follow-up Edit Flow (`#777`)
+- Added `PATCH /api/after-sales/follow-ups/:followUpId` for partial follow-up updates.
+- Added inline follow-up edit UI and diff-only payload submission in `AfterSalesView.vue`.
+- Locked the normalization contract for clearing optional follow-up fields:
+  - cleared values normalize to `null`
+  - they do not round-trip as empty strings
+
+### 4) Follow-up Due Proof (`#778`)
+- Extended `followup.due` payload building so logical follow-up records can provide ownership through `ownerName` fallback.
+- Added route-level coverage for the fallback behavior.
+- Added real integration proof for:
+  - create ticket
+  - create follow-up
+  - emit `followup.due`
+  - dispatch `notificationService.send`
+- Tightened the validation error copy so the accepted owner sources are explicit: `followUpOwner` and `ownerName`.
+
+## Contract Decisions
+- Installer runtime adapter persistence is authoritative enough to drive after-sales runtime gating, but still falls back to existing default-enabled runtime behavior when registry lookup fails.
+- Field policy reads remain plugin-local in this batch. No generic core field-policy read API was introduced.
+- Role ids provisioned for after-sales are plugin/app namespaced to avoid polluting platform-global RBAC rows.
+- Optional follow-up fields normalize to `null` when cleared.
+- `followup.due` accepts both explicit recipient input (`followUpOwner`) and logical record fallback (`ownerName`).
+
+## Merge Record
+- `#780` merged to `main` as `e4a10ba4c441985b542c1ccde3780d4d3d7293c8`
+- `#782` merged to `main` as `40abae49d2cc311f5368413078ae1826a35e6d0c`
+- `#777` merged to `main` as `3ec53961c44d6eab1bc5ac0c2fdffce9198aac6f`
+- `#778` merged to `main` as `59e0d415407e356a01e0a2d4f776762079519200`
+
+## Non-goals Preserved
+- No scheduler/cron for due follow-ups
+- No generic automation expression engine
+- No generic core field-policy read endpoint
+- No broader `AfterSalesView` component split or redesign
+- No change to the cleared-follow-up-field `null` contract

--- a/docs/after-sales-runtime-and-followup-verification-report-20260410.md
+++ b/docs/after-sales-runtime-and-followup-verification-report-20260410.md
@@ -1,0 +1,59 @@
+# After-sales Runtime And Follow-up Verification Report (2026-04-10)
+
+## Scope
+This verification report covers the four after-sales PRs delivered in the same batch:
+
+- `#780` installer runtime adapters
+- `#782` field policy route + UI gating
+- `#777` follow-up edit flow
+- `#778` follow-up due proof
+
+## Commands Run
+### `#780`
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-automation-registry.test.ts tests/unit/after-sales-workflow-adapter.test.ts tests/unit/after-sales-installer.test.ts tests/unit/plugin-rbac-provisioning.test.ts`
+- `pnpm --filter @metasheet/core-backend build`
+- `DATABASE_URL=postgresql://metasheet:metasheet123@127.0.0.1:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`
+
+### `#782`
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/after-sales-field-policies.test.ts tests/unit/after-sales-plugin-routes.test.ts`
+- `pnpm --filter @metasheet/web exec vitest run tests/AfterSalesView.spec.ts --watch=false`
+- `pnpm --filter @metasheet/core-backend build`
+- `pnpm --filter @metasheet/web build`
+- `DATABASE_URL=postgresql://metasheet:metasheet123@127.0.0.1:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`
+
+### `#777`
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/after-sales-plugin-routes.test.ts`
+- `pnpm --filter @metasheet/web exec vitest run tests/AfterSalesView.follow-ups.spec.ts --watch=false`
+- `pnpm --filter @metasheet/core-backend build`
+- `pnpm --filter @metasheet/web build`
+- `DATABASE_URL=postgresql://metasheet:metasheet123@127.0.0.1:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`
+
+### `#778`
+- `pnpm install --frozen-lockfile` in the clean mainsync worktree (dependency bootstrap only; no repo-tracked file changes)
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/after-sales-plugin-routes.test.ts`
+- `DATABASE_URL=postgresql://metasheet:metasheet123@127.0.0.1:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`
+- `pnpm --filter @metasheet/core-backend build`
+
+## Results
+- ✅ `#780` local focused unit/build/install integration verification passed before merge.
+- ✅ `#782` local route/unit/web/build/install verification passed before merge.
+- ✅ `#777` local route/web/build/install verification passed after refresh onto latest `main`.
+- ✅ `#778` local route/build/install verification passed after retargeting to `main` and refreshing onto latest `main`.
+- ✅ `#780`, `#782`, `#777`, and `#778` are merged to `main`.
+
+## PR Merge Record
+- `#780` merged at `2026-04-10T14:52:23Z` as `e4a10ba4c441985b542c1ccde3780d4d3d7293c8`
+- `#782` merged at `2026-04-10T14:59:34Z` as `40abae49d2cc311f5368413078ae1826a35e6d0c`
+- `#777` merged at `2026-04-10T15:03:15Z` as `3ec53961c44d6eab1bc5ac0c2fdffce9198aac6f`
+- `#778` merged at `2026-04-10T15:10:04Z` as `59e0d415407e356a01e0a2d4f776762079519200`
+
+## Known Caveats
+- The root repo worktree remains intentionally ignored for this batch because it is dirty and unrelated.
+- One earlier `#778` PR comment had malformed inline code due to shell quoting; a clean replacement comment was posted with `--body-file`.
+- A dirty older `after-sales-followup-due-proof` worktree existed locally and was not reused; final `#778` work used a new clean mainsync worktree to avoid pulling unknown local edits into the PR.
+
+## Post-merge Smoke
+- ✅ `pnpm --filter @metasheet/core-backend build`
+- ✅ `pnpm --filter @metasheet/web build`
+- ✅ `DATABASE_URL=postgresql://metasheet:metasheet123@127.0.0.1:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`
+- ✅ `pnpm --filter @metasheet/web exec vitest run tests/AfterSalesView.spec.ts tests/AfterSalesView.follow-ups.spec.ts --watch=false`


### PR DESCRIPTION
## Summary
- add the after-sales runtime and follow-up development wrap-up report
- add the corresponding verification report

## Verification
- docs only
