### PR TITLE
feat(after-sales): add runtime admin surface

### DIFF
--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -130,6 +130,171 @@
         </div>
       </section>
 
+      <section v-if="showRuntimeAdminSection" class="after-sales-view__runtime-admin-shell" id="after-sales-runtime-admin">
+        <article class="after-sales-view__card after-sales-view__card--wide">
+          <div class="after-sales-view__section-header">
+            <div>
+              <p class="after-sales-view__pill">Runtime admin</p>
+              <h2>Automation and field policy controls</h2>
+              <p>
+                这里仅提供售后插件本地运行时管理：自动化开关和 refundAmount 字段策略。
+              </p>
+            </div>
+            <button
+              class="after-sales-view__ghost-btn"
+              :disabled="runtimeAdminLoading"
+              @click="refreshRuntimeAdmin"
+            >
+              {{ runtimeAdminLoading ? 'Refreshing...' : 'Refresh runtime admin' }}
+            </button>
+          </div>
+
+          <p v-if="runtimeAdminLoading" class="after-sales-view__muted-state">Loading runtime admin controls...</p>
+          <p v-else-if="runtimeAdminError" class="after-sales-view__inline-error">
+            {{ runtimeAdminError }}
+          </p>
+          <template v-else-if="runtimeAdminDraft">
+            <section class="after-sales-view__runtime-admin-grid">
+              <article class="after-sales-view__runtime-admin-card">
+                <div class="after-sales-view__runtime-admin-card-header">
+                  <div>
+                    <p class="after-sales-view__pill">Automations</p>
+                    <h3>Default automation rules</h3>
+                    <p>
+                      Toggle the built-in after-sales workflows without changing their trigger or action shape.
+                    </p>
+                  </div>
+                </div>
+
+                <p class="after-sales-view__runtime-admin-meta">
+                  Project <code>{{ runtimeAdminDraft.projectId }}</code>
+                </p>
+
+                <div class="after-sales-view__runtime-admin-list">
+                  <label
+                    v-for="automation in runtimeAdminAutomationDraft"
+                    :key="automation.id"
+                    class="after-sales-view__runtime-admin-row"
+                    :for="`after-sales-runtime-admin-automation-${automation.id}`"
+                  >
+                    <div class="after-sales-view__runtime-admin-row-copy">
+                      <strong>{{ automation.name }}</strong>
+                      <span>{{ automation.triggerEvent }}</span>
+                    </div>
+                    <input
+                      :id="`after-sales-runtime-admin-automation-${automation.id}`"
+                      v-model="automation.enabled"
+                      class="after-sales-view__runtime-admin-switch"
+                      type="checkbox"
+                    />
+                  </label>
+                </div>
+
+                <div class="after-sales-view__action-row after-sales-view__action-row--compact">
+                  <button
+                    id="after-sales-runtime-admin-save-automations"
+                    class="after-sales-view__primary-btn"
+                    :disabled="runtimeAdminLoading || runtimeAdminAutomationsSaving || runtimeAdminAutomationDraft.length === 0"
+                    @click="saveRuntimeAdminAutomations"
+                  >
+                    {{ runtimeAdminAutomationsSaving ? 'Saving...' : 'Save automations' }}
+                  </button>
+                  <button
+                    id="after-sales-runtime-admin-reset-automations"
+                    class="after-sales-view__ghost-btn"
+                    :disabled="runtimeAdminLoading || runtimeAdminAutomationsSaving || runtimeAdminAutomationDraft.length === 0"
+                    @click="resetRuntimeAdminAutomations"
+                  >
+                    Reset automations
+                  </button>
+                </div>
+
+                <p v-if="runtimeAdminAutomationsError" class="after-sales-view__inline-error">
+                  {{ runtimeAdminAutomationsError }}
+                </p>
+                <p v-else-if="runtimeAdminAutomationsSuccess" class="after-sales-view__inline-success">
+                  {{ runtimeAdminAutomationsSuccess }}
+                </p>
+              </article>
+
+              <article class="after-sales-view__runtime-admin-card">
+                <div class="after-sales-view__runtime-admin-card-header">
+                  <div>
+                    <p class="after-sales-view__pill">Field policies</p>
+                    <h3>refundAmount role matrix</h3>
+                    <p>
+                      Edit the role-specific visibility and editability rows for <code>serviceTicket.refundAmount</code>.
+                    </p>
+                  </div>
+                </div>
+
+                <p class="after-sales-view__runtime-admin-meta" v-if="runtimeAdminFieldPolicyDraft">
+                  <code>{{ runtimeAdminFieldPolicyDraft.objectId }}.{{ runtimeAdminFieldPolicyDraft.field }}</code>
+                </p>
+
+                <div class="after-sales-view__runtime-admin-list">
+                  <label
+                    v-for="role in runtimeAdminFieldPolicyRoles"
+                    :key="role.roleSlug"
+                    class="after-sales-view__runtime-admin-row after-sales-view__runtime-admin-row--policy"
+                  >
+                    <div class="after-sales-view__runtime-admin-row-copy">
+                      <strong>{{ role.roleLabel }}</strong>
+                      <span>{{ role.roleSlug }}</span>
+                    </div>
+                    <select
+                      :id="`after-sales-runtime-admin-field-policy-${role.roleSlug}-visibility`"
+                      v-model="role.visibility"
+                      class="after-sales-view__field-input after-sales-view__runtime-admin-select"
+                      @change="syncRuntimeAdminRolePolicy(role)"
+                    >
+                      <option value="visible">Visible</option>
+                      <option value="hidden">Hidden</option>
+                    </select>
+                    <select
+                      :id="`after-sales-runtime-admin-field-policy-${role.roleSlug}-editability`"
+                      v-model="role.editability"
+                      class="after-sales-view__field-input after-sales-view__runtime-admin-select"
+                      :disabled="role.visibility === 'hidden'"
+                    >
+                      <option value="editable">Editable</option>
+                      <option value="readonly">Readonly</option>
+                    </select>
+                  </label>
+                </div>
+
+                <div class="after-sales-view__action-row after-sales-view__action-row--compact">
+                  <button
+                    id="after-sales-runtime-admin-save-field-policies"
+                    class="after-sales-view__primary-btn"
+                    :disabled="runtimeAdminLoading || runtimeAdminFieldPoliciesSaving || runtimeAdminFieldPolicyRoles.length === 0"
+                    @click="saveRuntimeAdminFieldPolicies"
+                  >
+                    {{ runtimeAdminFieldPoliciesSaving ? 'Saving...' : 'Save field policies' }}
+                  </button>
+                  <button
+                    id="after-sales-runtime-admin-reset-field-policies"
+                    class="after-sales-view__ghost-btn"
+                    :disabled="runtimeAdminLoading || runtimeAdminFieldPoliciesSaving || runtimeAdminFieldPolicyRoles.length === 0"
+                    @click="resetRuntimeAdminFieldPolicies"
+                  >
+                    Reset field policies
+                  </button>
+                </div>
+
+                <p v-if="runtimeAdminFieldPoliciesError" class="after-sales-view__inline-error">
+                  {{ runtimeAdminFieldPoliciesError }}
+                </p>
+                <p v-else-if="runtimeAdminFieldPoliciesSuccess" class="after-sales-view__inline-success">
+                  {{ runtimeAdminFieldPoliciesSuccess }}
+                </p>
+              </article>
+            </section>
+          </template>
+          <p v-else class="after-sales-view__muted-state">Runtime admin controls are not available yet.</p>
+        </article>
+      </section>
+
       <section v-if="isInstalled" class="after-sales-view__tickets-shell">
         <article class="after-sales-view__card after-sales-view__card--wide">
           <div class="after-sales-view__section-header">
@@ -2000,6 +2165,32 @@ interface TicketFieldPolicyResponse {
   }
 }
 
+interface RuntimeAdminAutomationRow {
+  id: string
+  name: string
+  triggerEvent: string
+  enabled: boolean
+}
+
+interface RuntimeAdminFieldPolicyRoleRow {
+  roleSlug: string
+  roleLabel: string
+  visibility: FieldVisibility
+  editability: FieldEditability
+}
+
+interface RuntimeAdminFieldPolicyDraft {
+  objectId: 'serviceTicket'
+  field: 'refundAmount'
+  roles: RuntimeAdminFieldPolicyRoleRow[]
+}
+
+interface RuntimeAdminResponse {
+  projectId: string
+  automations: RuntimeAdminAutomationRow[]
+  fieldPolicies: RuntimeAdminFieldPolicyDraft
+}
+
 const TEMPLATE_ID = 'after-sales-default'
 const DEFAULT_CONFIG = {
   enableWarranty: true,
@@ -2069,6 +2260,18 @@ const serviceRecords = ref<ServiceRecordViewModel[]>([])
 const configDraft = ref({ ...DEFAULT_CONFIG })
 const baselineConfigDraft = ref({ ...DEFAULT_CONFIG })
 const ticketFieldPolicies = ref<TicketFieldPolicyResponse | null>(null)
+const runtimeAdminLoading = ref(false)
+const runtimeAdminAccessDenied = ref(false)
+const runtimeAdminError = ref('')
+const runtimeAdminAutomationsError = ref('')
+const runtimeAdminAutomationsSuccess = ref('')
+const runtimeAdminFieldPoliciesError = ref('')
+const runtimeAdminFieldPoliciesSuccess = ref('')
+const runtimeAdminAutomationsSaving = ref(false)
+const runtimeAdminFieldPoliciesSaving = ref(false)
+const runtimeAdminLoaded = ref<RuntimeAdminResponse | null>(null)
+const runtimeAdminAutomationDraft = ref<RuntimeAdminAutomationRow[]>([])
+const runtimeAdminFieldPolicyDraft = ref<RuntimeAdminFieldPolicyDraft | null>(null)
 const ticketDraft = ref<TicketDraft>(createTicketDraft())
 const ticketEditingId = ref('')
 const ticketEditDraft = ref<TicketEditDraft>(createTicketEditDraft())
@@ -2114,6 +2317,12 @@ const createdObjectLabels = computed(() => current.value.installResult?.createdO
 const createdViewLabels = computed(() => current.value.installResult?.createdViews ?? [])
 const isInstalled = computed(() => current.value.status === 'installed' || current.value.status === 'partial')
 const isDegraded = computed(() => current.value.status === 'partial' || current.value.status === 'failed')
+const hasRuntimeAdminSupport = computed(
+  () => Array.isArray(manifest.value?.workflows) && manifest.value.workflows.some((workflow) => workflow && workflow.id === 'sla-watcher'),
+)
+const showRuntimeAdminSection = computed(
+  () => isInstalled.value && hasRuntimeAdminSupport.value && !runtimeAdminAccessDenied.value,
+)
 const refundAmountPolicy = computed<TicketFieldPolicy>(
   () => ticketFieldPolicies.value?.fields?.serviceTicket?.refundAmount ?? DEFAULT_TICKET_FIELD_POLICY,
 )
@@ -2121,6 +2330,10 @@ const isRefundAmountHidden = computed(() => refundAmountPolicy.value.visibility 
 const isRefundAmountEditable = computed(
   () => refundAmountPolicy.value.visibility === 'visible' && refundAmountPolicy.value.editability === 'editable',
 )
+const runtimeAdminDraft = computed(() =>
+  runtimeAdminLoaded.value ? { projectId: runtimeAdminLoaded.value.projectId } : null,
+)
+const runtimeAdminFieldPolicyRoles = computed(() => runtimeAdminFieldPolicyDraft.value?.roles ?? [])
 const hasCustomerProjection = computed(() =>
   Array.isArray(manifest.value?.objects) &&
   manifest.value.objects.some((object) => object && object.id === 'customer'),
@@ -2218,12 +2431,23 @@ function extractMessage(payload: unknown, fallback: string): string {
 }
 
 async function readEnvelope<T>(path: string, options?: RequestInit): Promise<T> {
-  const response = await apiFetch(path, options)
-  const payload = await response.json().catch(() => null)
+  const { response, payload } = await readEnvelopeResponse<T>(path, options)
   if (!response.ok) {
     throw new Error(extractMessage(payload, `${response.status} ${response.statusText}`))
   }
   return ((payload as ApiEnvelope<T> | null)?.data ?? null) as T
+}
+
+async function readEnvelopeResponse<T>(
+  path: string,
+  options?: RequestInit,
+): Promise<{ response: Response; payload: ApiEnvelope<T> | null }> {
+  const response = await apiFetch(path, options)
+  const payload = await response.json().catch(() => null)
+  return {
+    response,
+    payload: payload as ApiEnvelope<T> | null,
+  }
 }
 
 function toPositiveNumber(value: unknown, fallback: number): number {
@@ -2274,6 +2498,85 @@ function formatRecordDate(value: unknown): string {
     timeStyle: 'short',
     hour12: false,
   }).format(parsed)
+}
+
+function cloneRuntimeAdminResponse(response: RuntimeAdminResponse): RuntimeAdminResponse {
+  return {
+    projectId: response.projectId,
+    automations: Array.isArray(response.automations)
+      ? response.automations.map((automation) => ({ ...automation }))
+      : [],
+    fieldPolicies: {
+      objectId: response.fieldPolicies.objectId,
+      field: response.fieldPolicies.field,
+      roles: Array.isArray(response.fieldPolicies.roles)
+        ? response.fieldPolicies.roles.map((role) => ({ ...role }))
+        : [],
+    },
+  }
+}
+
+function resetRuntimeAdminDrafts() {
+  runtimeAdminLoaded.value = null
+  runtimeAdminAutomationDraft.value = []
+  runtimeAdminFieldPolicyDraft.value = null
+}
+
+function syncRuntimeAdminDraftsFromLoaded() {
+  if (!runtimeAdminLoaded.value) {
+    resetRuntimeAdminDrafts()
+    return
+  }
+
+  const cloned = cloneRuntimeAdminResponse(runtimeAdminLoaded.value)
+  runtimeAdminLoaded.value = cloned
+  runtimeAdminAutomationDraft.value = cloned.automations.map((automation) => ({ ...automation }))
+  runtimeAdminFieldPolicyDraft.value = {
+    objectId: cloned.fieldPolicies.objectId,
+    field: cloned.fieldPolicies.field,
+    roles: cloned.fieldPolicies.roles.map((role) => ({ ...role })),
+  }
+}
+
+function normalizeRuntimeAdminRolePolicy(role: RuntimeAdminFieldPolicyRoleRow): RuntimeAdminFieldPolicyRoleRow {
+  return {
+    roleSlug: toText(role.roleSlug),
+    roleLabel: toText(role.roleLabel, role.roleSlug),
+    visibility: role.visibility === 'hidden' ? 'hidden' : 'visible',
+    editability:
+      role.visibility === 'hidden'
+        ? 'readonly'
+        : role.editability === 'editable'
+          ? 'editable'
+          : 'readonly',
+  }
+}
+
+function normalizeRuntimeAdminResponse(response: RuntimeAdminResponse): RuntimeAdminResponse {
+  return {
+    projectId: toText(response.projectId),
+    automations: Array.isArray(response.automations)
+      ? response.automations.map((automation) => ({
+          id: toText(automation.id),
+          name: toText(automation.name, automation.id),
+          triggerEvent: toText(automation.triggerEvent),
+          enabled: automation.enabled !== false,
+        }))
+      : [],
+    fieldPolicies: {
+      objectId: 'serviceTicket',
+      field: 'refundAmount',
+      roles: Array.isArray(response.fieldPolicies?.roles)
+        ? response.fieldPolicies.roles.map((role) => normalizeRuntimeAdminRolePolicy(role))
+        : [],
+    },
+  }
+}
+
+function syncRuntimeAdminRolePolicy(role: RuntimeAdminFieldPolicyRoleRow) {
+  if (role.visibility === 'hidden') {
+    role.editability = 'readonly'
+  }
 }
 
 function normalizeConfigDraft(config?: Record<string, unknown> | null) {
@@ -3842,6 +4145,157 @@ async function loadFieldPoliciesForCurrentState(state: CurrentResponse): Promise
   }
 }
 
+async function loadRuntimeAdminForCurrentState(state: CurrentResponse): Promise<void> {
+  runtimeAdminError.value = ''
+  runtimeAdminAutomationsError.value = ''
+  runtimeAdminFieldPoliciesError.value = ''
+
+  if (state.status !== 'installed' && state.status !== 'partial') {
+    runtimeAdminAccessDenied.value = false
+    resetRuntimeAdminDrafts()
+    return
+  }
+
+  if (!hasRuntimeAdminSupport.value) {
+    runtimeAdminAccessDenied.value = false
+    resetRuntimeAdminDrafts()
+    return
+  }
+
+  runtimeAdminLoading.value = true
+
+  try {
+    const { response, payload } = await readEnvelopeResponse<RuntimeAdminResponse>('/api/after-sales/runtime-admin')
+
+    if (response.status === 403) {
+      runtimeAdminAccessDenied.value = true
+      resetRuntimeAdminDrafts()
+      return
+    }
+
+    runtimeAdminAccessDenied.value = false
+
+    if (!response.ok) {
+      throw new Error(extractMessage(payload, `${response.status} ${response.statusText}`))
+    }
+
+    const runtimeAdminPayload = (payload as ApiEnvelope<RuntimeAdminResponse> | null)?.data
+    if (!runtimeAdminPayload) {
+      throw new Error('Missing runtime admin payload')
+    }
+
+    runtimeAdminLoaded.value = normalizeRuntimeAdminResponse(runtimeAdminPayload)
+    syncRuntimeAdminDraftsFromLoaded()
+  } catch (err: unknown) {
+    runtimeAdminAccessDenied.value = false
+    runtimeAdminError.value = err instanceof Error ? err.message : 'Failed to load runtime admin controls'
+    resetRuntimeAdminDrafts()
+  } finally {
+    runtimeAdminLoading.value = false
+  }
+}
+
+function resetRuntimeAdminAutomations() {
+  if (!runtimeAdminLoaded.value || runtimeAdminAutomationsSaving.value || runtimeAdminLoading.value) {
+    return
+  }
+
+  runtimeAdminAutomationDraft.value = runtimeAdminLoaded.value.automations.map((automation) => ({ ...automation }))
+  runtimeAdminAutomationsError.value = ''
+  runtimeAdminAutomationsSuccess.value = ''
+}
+
+function resetRuntimeAdminFieldPolicies() {
+  if (!runtimeAdminLoaded.value || runtimeAdminFieldPoliciesSaving.value || runtimeAdminLoading.value) {
+    return
+  }
+
+  runtimeAdminFieldPolicyDraft.value = {
+    objectId: runtimeAdminLoaded.value.fieldPolicies.objectId,
+    field: runtimeAdminLoaded.value.fieldPolicies.field,
+    roles: runtimeAdminLoaded.value.fieldPolicies.roles.map((role) => ({ ...role })),
+  }
+  runtimeAdminFieldPoliciesError.value = ''
+  runtimeAdminFieldPoliciesSuccess.value = ''
+}
+
+async function refreshRuntimeAdmin() {
+  if (runtimeAdminLoading.value) {
+    return
+  }
+  await loadRuntimeAdminForCurrentState(current.value)
+}
+
+async function saveRuntimeAdminAutomations() {
+  if (
+    runtimeAdminLoading.value ||
+    runtimeAdminAutomationsSaving.value ||
+    !runtimeAdminLoaded.value ||
+    runtimeAdminAutomationDraft.value.length === 0
+  ) {
+    return
+  }
+
+  runtimeAdminAutomationsSaving.value = true
+  runtimeAdminAutomationsError.value = ''
+  runtimeAdminAutomationsSuccess.value = ''
+
+  try {
+    await readEnvelope<RuntimeAdminResponse>('/api/after-sales/runtime-admin/automations', {
+      method: 'PUT',
+      body: JSON.stringify({
+        automations: runtimeAdminAutomationDraft.value.map((automation) => ({
+          id: automation.id,
+          enabled: automation.enabled,
+        })),
+      }),
+    })
+    await loadRuntimeAdminForCurrentState(current.value)
+    runtimeAdminAutomationsSuccess.value = 'Saved automation controls'
+  } catch (err: unknown) {
+    runtimeAdminAutomationsError.value = err instanceof Error ? err.message : 'Failed to save automations'
+  } finally {
+    runtimeAdminAutomationsSaving.value = false
+  }
+}
+
+async function saveRuntimeAdminFieldPolicies() {
+  if (
+    runtimeAdminLoading.value ||
+    runtimeAdminFieldPoliciesSaving.value ||
+    !runtimeAdminFieldPolicyDraft.value ||
+    runtimeAdminFieldPolicyRoles.value.length === 0
+  ) {
+    return
+  }
+
+  runtimeAdminFieldPoliciesSaving.value = true
+  runtimeAdminFieldPoliciesError.value = ''
+  runtimeAdminFieldPoliciesSuccess.value = ''
+
+  try {
+    await readEnvelope<RuntimeAdminResponse>('/api/after-sales/runtime-admin/field-policies', {
+      method: 'PUT',
+      body: JSON.stringify({
+        roles: runtimeAdminFieldPolicyDraft.value.roles.map((role) => ({
+          roleSlug: role.roleSlug,
+          visibility: role.visibility,
+          editability: role.editability,
+        })),
+      }),
+    })
+    await Promise.all([
+      loadRuntimeAdminForCurrentState(current.value),
+      loadFieldPoliciesForCurrentState(current.value),
+    ])
+    runtimeAdminFieldPoliciesSuccess.value = 'Saved field policies'
+  } catch (err: unknown) {
+    runtimeAdminFieldPoliciesError.value = err instanceof Error ? err.message : 'Failed to save field policies'
+  } finally {
+    runtimeAdminFieldPoliciesSaving.value = false
+  }
+}
+
 async function deleteTicket(ticket: TicketViewModel) {
   if (!ticket.id || ticketDeletingId.value) {
     return
@@ -3920,6 +4374,7 @@ async function refreshCurrentState() {
     current.value = await readEnvelope<CurrentResponse>('/api/after-sales/projects/current')
     baselineConfigDraft.value = normalizeConfigDraft(current.value.config)
     await Promise.all([
+      loadRuntimeAdminForCurrentState(current.value),
       loadFieldPoliciesForCurrentState(current.value),
       loadTicketsForCurrentState(current.value),
       loadInstalledAssetsForCurrentState(current.value),
@@ -3950,6 +4405,11 @@ async function loadView() {
   serviceRecordsError.value = ''
   serviceRecordSubmitError.value = ''
   serviceRecordSubmitSuccess.value = ''
+  runtimeAdminError.value = ''
+  runtimeAdminAutomationsError.value = ''
+  runtimeAdminAutomationsSuccess.value = ''
+  runtimeAdminFieldPoliciesError.value = ''
+  runtimeAdminFieldPoliciesSuccess.value = ''
   try {
     const [nextManifest, nextCurrent] = await Promise.all([
       readEnvelope<AfterSalesManifest>('/api/after-sales/app-manifest'),
@@ -3960,6 +4420,7 @@ async function loadView() {
     baselineConfigDraft.value = normalizeConfigDraft(nextCurrent.config)
     configDraft.value = { ...baselineConfigDraft.value }
     await Promise.all([
+      loadRuntimeAdminForCurrentState(nextCurrent),
       loadFieldPoliciesForCurrentState(nextCurrent),
       loadTicketsForCurrentState(nextCurrent),
       loadInstalledAssetsForCurrentState(nextCurrent),
@@ -4115,6 +4576,7 @@ onMounted(() => {
 .after-sales-view__error-banner,
 .after-sales-view__warning-banner,
 .after-sales-view__config-shell,
+.after-sales-view__runtime-admin-shell,
 .after-sales-view__onboarding,
 .after-sales-view__tickets-shell,
 .after-sales-view__installed-assets-shell,
@@ -4176,6 +4638,79 @@ onMounted(() => {
 
 .after-sales-view__card--wide {
   grid-column: 1 / -1;
+}
+
+.after-sales-view__runtime-admin-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.after-sales-view__runtime-admin-card {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid #dbeafe;
+  background: linear-gradient(180deg, rgba(239, 246, 255, 0.85), rgba(255, 255, 255, 0.98));
+}
+
+.after-sales-view__runtime-admin-card-header h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: #0f172a;
+}
+
+.after-sales-view__runtime-admin-card-header p,
+.after-sales-view__runtime-admin-meta {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.after-sales-view__runtime-admin-list {
+  display: grid;
+  gap: 10px;
+}
+
+.after-sales-view__runtime-admin-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.after-sales-view__runtime-admin-row--policy {
+  grid-template-columns: minmax(0, 1fr) minmax(140px, 160px) minmax(140px, 160px);
+}
+
+.after-sales-view__runtime-admin-row-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.after-sales-view__runtime-admin-row-copy strong {
+  color: #0f172a;
+}
+
+.after-sales-view__runtime-admin-row-copy span {
+  color: #64748b;
+  font-size: 13px;
+}
+
+.after-sales-view__runtime-admin-switch {
+  width: 18px;
+  height: 18px;
+  justify-self: end;
+}
+
+.after-sales-view__runtime-admin-select {
+  min-width: 0;
 }
 
 .after-sales-view__onboarding-card {

--- a/apps/web/tests/AfterSalesView.spec.ts
+++ b/apps/web/tests/AfterSalesView.spec.ts
@@ -39,6 +39,39 @@ function createFieldPoliciesResponse(
   })
 }
 
+function createRuntimeAdminResponse(options: {
+  projectId?: string
+  automations?: Array<{ id: string; name: string; triggerEvent: string; enabled: boolean }>
+  fieldPolicies?: Array<{
+    roleSlug: string
+    roleLabel: string
+    visibility: 'hidden' | 'visible'
+    editability: 'readonly' | 'editable'
+  }>
+} = {}) {
+  return createResponse({
+    projectId: options.projectId ?? 'tenant:after-sales',
+    automations:
+      options.automations ?? [
+        { id: 'ticket-triage', name: 'Ticket triage', triggerEvent: 'ticket.created', enabled: true },
+        { id: 'sla-watcher', name: 'SLA watcher', triggerEvent: 'ticket.overdue', enabled: true },
+        { id: 'refund-approval', name: 'Refund approval', triggerEvent: 'ticket.refundRequested', enabled: true },
+        { id: 'service-record-notify', name: 'Service record notify', triggerEvent: 'service.recorded', enabled: true },
+      ],
+    fieldPolicies: {
+      objectId: 'serviceTicket',
+      field: 'refundAmount',
+      roles:
+        options.fieldPolicies ?? [
+          { roleSlug: 'finance', roleLabel: 'Finance', visibility: 'visible', editability: 'editable' },
+          { roleSlug: 'supervisor', roleLabel: 'Supervisor', visibility: 'visible', editability: 'readonly' },
+          { roleSlug: 'customer_service', roleLabel: 'Customer Service', visibility: 'hidden', editability: 'readonly' },
+          { roleSlug: 'technician', roleLabel: 'Technician', visibility: 'hidden', editability: 'readonly' },
+        ],
+    },
+  })
+}
+
 async function flushUi(cycles = 4): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
@@ -55,6 +88,17 @@ async function waitForText(container: HTMLElement, text: string, cycles = 24): P
   }
 
   throw new Error(`Timed out waiting for text: ${text}`)
+}
+
+async function waitForElementMissing(container: HTMLElement, selector: string, cycles = 24): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    if (!container.querySelector(selector)) {
+      return
+    }
+    await flushUi(1)
+  }
+
+  throw new Error(`Timed out waiting for element to disappear: ${selector}`)
 }
 
 function mountAfterSalesView() {
@@ -84,6 +128,12 @@ async function setInputValue(input: HTMLInputElement, value: string): Promise<vo
 async function setSelectValue(select: HTMLSelectElement, value: string): Promise<void> {
   select.value = value
   select.dispatchEvent(new Event('change', { bubbles: true }))
+  await flushUi()
+}
+
+async function setCheckboxValue(input: HTMLInputElement, value: boolean): Promise<void> {
+  input.checked = value
+  input.dispatchEvent(new Event('change', { bubbles: true }))
   await flushUi()
 }
 
@@ -1292,6 +1342,657 @@ describe('AfterSalesView', () => {
     await setInputValue(inlineRefundInput!, '120.5')
     refundButton.click()
     await waitForText(container!, 'Requested refund for AF-001')
+  })
+
+  it('renders runtime admin controls when the manifest exposes the runtime-admin workflow', async () => {
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [
+            { id: 'ticket-triage', name: 'Ticket Triage' },
+            { id: 'sla-watcher', name: 'SLA Watcher' },
+            { id: 'refund-approval', name: 'Refund Approval' },
+            { id: 'service-record-notify', name: 'Service Record Notification' },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-runtime-admin',
+          },
+          reportRef: 'install-runtime-admin',
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin') {
+        return createRuntimeAdminResponse()
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: 'visible',
+          editability: 'editable',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: 0,
+          tickets: [],
+        })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/customers') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, customers: [] })
+      }
+
+      if (path === '/api/after-sales/follow-ups') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, followUps: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'Default automation rules')
+
+    expect(container?.querySelector('#after-sales-runtime-admin')).not.toBeNull()
+    expect(container?.textContent).toContain('Default automation rules')
+    expect(container?.textContent).toContain('SLA Watcher')
+    expect(container?.textContent).toContain('refundAmount role matrix')
+  })
+
+  it('hides runtime admin controls when the backend denies access', async () => {
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [
+            { id: 'ticket-triage', name: 'Ticket Triage' },
+            { id: 'sla-watcher', name: 'SLA Watcher' },
+            { id: 'refund-approval', name: 'Refund Approval' },
+            { id: 'service-record-notify', name: 'Service Record Notification' },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-runtime-admin-403',
+          },
+          reportRef: 'install-runtime-admin-403',
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin') {
+        return createResponse({ message: 'Forbidden' }, { ok: false, status: 403, statusText: 'Forbidden' })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: 'visible',
+          editability: 'editable',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, tickets: [] })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/customers') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, customers: [] })
+      }
+
+      if (path === '/api/after-sales/follow-ups') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, followUps: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForElementMissing(container!, '#after-sales-runtime-admin')
+    expect(container?.textContent).not.toContain('Runtime admin')
+  })
+
+  it('saves runtime admin automation toggles with the selected payload', async () => {
+    let runtimeAdminLoads = 0
+    let savedPayload: unknown = null
+
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [
+            { id: 'ticket-triage', name: 'Ticket Triage' },
+            { id: 'sla-watcher', name: 'SLA Watcher' },
+            { id: 'refund-approval', name: 'Refund Approval' },
+            { id: 'service-record-notify', name: 'Service Record Notification' },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-runtime-admin-save',
+          },
+          reportRef: 'install-runtime-admin-save',
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin' && !options?.method) {
+        runtimeAdminLoads += 1
+        return createRuntimeAdminResponse({
+          automations:
+            runtimeAdminLoads === 1
+              ? [
+                  { id: 'ticket-triage', name: 'Ticket triage', triggerEvent: 'ticket.created', enabled: true },
+                  { id: 'sla-watcher', name: 'SLA watcher', triggerEvent: 'ticket.overdue', enabled: true },
+                  { id: 'refund-approval', name: 'Refund approval', triggerEvent: 'ticket.refundRequested', enabled: true },
+                  { id: 'service-record-notify', name: 'Service record notify', triggerEvent: 'service.recorded', enabled: true },
+                ]
+              : [
+                  { id: 'ticket-triage', name: 'Ticket triage', triggerEvent: 'ticket.created', enabled: true },
+                  { id: 'sla-watcher', name: 'SLA watcher', triggerEvent: 'ticket.overdue', enabled: false },
+                  { id: 'refund-approval', name: 'Refund approval', triggerEvent: 'ticket.refundRequested', enabled: true },
+                  { id: 'service-record-notify', name: 'Service record notify', triggerEvent: 'service.recorded', enabled: true },
+                ],
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin/automations' && options?.method === 'PUT') {
+        savedPayload = JSON.parse(String(options.body || '{}'))
+        return createRuntimeAdminResponse({
+          automations: [
+            { id: 'ticket-triage', name: 'Ticket triage', triggerEvent: 'ticket.created', enabled: true },
+            { id: 'sla-watcher', name: 'SLA watcher', triggerEvent: 'ticket.overdue', enabled: false },
+            { id: 'refund-approval', name: 'Refund approval', triggerEvent: 'ticket.refundRequested', enabled: true },
+            { id: 'service-record-notify', name: 'Service record notify', triggerEvent: 'service.recorded', enabled: true },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: 'visible',
+          editability: 'editable',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, tickets: [] })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/customers') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, customers: [] })
+      }
+
+      if (path === '/api/after-sales/follow-ups') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, followUps: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'Default automation rules')
+
+    const toggle = container?.querySelector<HTMLInputElement>('#after-sales-runtime-admin-automation-sla-watcher')
+    expect(toggle).toBeTruthy()
+    if (!toggle) return
+
+    await setCheckboxValue(toggle, false)
+    findButton(container, 'Save automations').click()
+    await waitForText(container, 'Saved automation controls')
+
+    expect(savedPayload).toEqual({
+      automations: [
+        { id: 'ticket-triage', enabled: true },
+        { id: 'sla-watcher', enabled: false },
+        { id: 'refund-approval', enabled: true },
+        { id: 'service-record-notify', enabled: true },
+      ],
+    })
+    expect(toggle.checked).toBe(false)
+  })
+
+  it('saves runtime admin field policies and refreshes refund controls', async () => {
+    let fieldPolicyMode: 'hidden' | 'visible' = 'hidden'
+    let fieldPolicyEditability: 'readonly' | 'editable' = 'readonly'
+    let savePayload: unknown = null
+
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [
+            { id: 'ticket-triage', name: 'Ticket Triage' },
+            { id: 'sla-watcher', name: 'SLA Watcher' },
+            { id: 'refund-approval', name: 'Refund Approval' },
+            { id: 'service-record-notify', name: 'Service Record Notification' },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-runtime-admin-field-policies',
+          },
+          reportRef: 'install-runtime-admin-field-policies',
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin') {
+        return createRuntimeAdminResponse({
+          fieldPolicies: [
+            {
+              roleSlug: 'finance',
+              roleLabel: 'Finance',
+              visibility: fieldPolicyMode,
+              editability: fieldPolicyEditability,
+            },
+            {
+              roleSlug: 'supervisor',
+              roleLabel: 'Supervisor',
+              visibility: 'visible',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'customer_service',
+              roleLabel: 'Customer Service',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'technician',
+              roleLabel: 'Technician',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin/field-policies' && options?.method === 'PUT') {
+        savePayload = JSON.parse(String(options.body || '{}'))
+        fieldPolicyMode = 'visible'
+        fieldPolicyEditability = 'editable'
+        return createRuntimeAdminResponse({
+          fieldPolicies: [
+            {
+              roleSlug: 'finance',
+              roleLabel: 'Finance',
+              visibility: fieldPolicyMode,
+              editability: fieldPolicyEditability,
+            },
+            {
+              roleSlug: 'supervisor',
+              roleLabel: 'Supervisor',
+              visibility: 'visible',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'customer_service',
+              roleLabel: 'Customer Service',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'technician',
+              roleLabel: 'Technician',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: fieldPolicyMode,
+          editability: fieldPolicyEditability,
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: 1,
+          tickets: [
+            {
+              id: 'ticket-1',
+              version: 1,
+              data: {
+                ticketNo: 'AF-001',
+                title: 'Install compressor',
+                status: 'open',
+                refundStatus: '',
+                refundAmount: 88.5,
+              },
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/customers') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, customers: [] })
+      }
+
+      if (path === '/api/after-sales/follow-ups') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, followUps: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'refundAmount role matrix')
+    expect(container?.querySelector('#after-sales-ticket-refund-amount')).toBeNull()
+
+    const visibilitySelect = container?.querySelector<HTMLSelectElement>('#after-sales-runtime-admin-field-policy-finance-visibility')
+    const editabilitySelect = container?.querySelector<HTMLSelectElement>('#after-sales-runtime-admin-field-policy-finance-editability')
+    expect(visibilitySelect).toBeTruthy()
+    expect(editabilitySelect).toBeTruthy()
+    if (!visibilitySelect || !editabilitySelect) return
+
+    await setSelectValue(visibilitySelect, 'visible')
+    await setSelectValue(editabilitySelect, 'editable')
+    findButton(container, 'Save field policies').click()
+    await waitForText(container, 'Saved field policies')
+    await waitForText(container, '¥88.50')
+
+    expect(savePayload).toEqual({
+      roles: [
+        { roleSlug: 'finance', visibility: 'visible', editability: 'editable' },
+        { roleSlug: 'supervisor', visibility: 'visible', editability: 'readonly' },
+        { roleSlug: 'customer_service', visibility: 'hidden', editability: 'readonly' },
+        { roleSlug: 'technician', visibility: 'hidden', editability: 'readonly' },
+      ],
+    })
+    expect(container?.querySelector('#after-sales-ticket-refund-amount')).not.toBeNull()
+    expect(container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-amount')?.disabled).toBe(false)
+    expect(container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-request-ticket-1')?.disabled).toBe(false)
+  })
+
+  it('reloads the refund controls after a field-policy save', async () => {
+    let fieldPolicyVisible = false
+
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [
+            { id: 'ticket-triage', name: 'Ticket Triage' },
+            { id: 'sla-watcher', name: 'SLA Watcher' },
+            { id: 'refund-approval', name: 'Refund Approval' },
+            { id: 'service-record-notify', name: 'Service Record Notification' },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-runtime-admin-refresh',
+          },
+          reportRef: 'install-runtime-admin-refresh',
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin') {
+        return createRuntimeAdminResponse({
+          fieldPolicies: [
+            {
+              roleSlug: 'finance',
+              roleLabel: 'Finance',
+              visibility: fieldPolicyVisible ? 'visible' : 'hidden',
+              editability: fieldPolicyVisible ? 'editable' : 'readonly',
+            },
+            {
+              roleSlug: 'supervisor',
+              roleLabel: 'Supervisor',
+              visibility: 'visible',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'customer_service',
+              roleLabel: 'Customer Service',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'technician',
+              roleLabel: 'Technician',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin/field-policies' && options?.method === 'PUT') {
+        fieldPolicyVisible = true
+        return createRuntimeAdminResponse({
+          fieldPolicies: [
+            {
+              roleSlug: 'finance',
+              roleLabel: 'Finance',
+              visibility: 'visible',
+              editability: 'editable',
+            },
+            {
+              roleSlug: 'supervisor',
+              roleLabel: 'Supervisor',
+              visibility: 'visible',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'customer_service',
+              roleLabel: 'Customer Service',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'technician',
+              roleLabel: 'Technician',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: fieldPolicyVisible ? 'visible' : 'hidden',
+          editability: fieldPolicyVisible ? 'editable' : 'readonly',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: 1,
+          tickets: [
+            {
+              id: 'ticket-1',
+              version: 1,
+              data: {
+                ticketNo: 'AF-001',
+                title: 'Install compressor',
+                status: 'open',
+                refundStatus: '',
+                refundAmount: 88.5,
+              },
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/customers') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, customers: [] })
+      }
+
+      if (path === '/api/after-sales/follow-ups') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, followUps: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'refundAmount role matrix')
+    expect(container?.querySelector('#after-sales-ticket-refund-amount')).toBeNull()
+
+    const visibilitySelect = container?.querySelector<HTMLSelectElement>('#after-sales-runtime-admin-field-policy-finance-visibility')
+    expect(visibilitySelect).toBeTruthy()
+    if (!visibilitySelect) return
+
+    await setSelectValue(visibilitySelect, 'visible')
+    findButton(container, 'Save field policies').click()
+    await waitForText(container, 'Saved field policies')
+    await waitForText(container, '¥88.50')
+
+    expect(container?.querySelector('#after-sales-ticket-refund-amount')).not.toBeNull()
+    expect(container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-amount')?.disabled).toBe(false)
+    expect(container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-request-ticket-1')?.disabled).toBe(false)
   })
 
   it('blocks refund requests when the inline refund amount is invalid', async () => {

--- a/docs/after-sales-runtime-admin-v1-design-20260411.md
+++ b/docs/after-sales-runtime-admin-v1-design-20260411.md
@@ -1,0 +1,166 @@
+# After-Sales Runtime Admin V1 Design
+
+Date: 2026-04-11
+
+## Summary
+
+This slice adds a plugin-local runtime admin surface for `plugin-after-sales`.
+
+It deliberately does not introduce a generic platform-wide plugin admin layer. The implementation stays inside the after-sales plugin and uses the existing runtime seams that already landed on `main`:
+
+- `services.automationRegistry`
+- `services.rbacProvisioning`
+- `plugin_automation_rule_registry`
+- `plugin_field_policy_registry`
+
+The goal is to let admins change two runtime concerns without reinstalling the plugin:
+
+1. Toggle the 4 default after-sales automation rules on or off.
+2. Edit the role-based `serviceTicket.refundAmount` field policy matrix.
+
+## Scope And Non-Goals
+
+In scope:
+
+- `GET /api/after-sales/runtime-admin`
+- `PUT /api/after-sales/runtime-admin/automations`
+- `PUT /api/after-sales/runtime-admin/field-policies`
+- `AfterSalesView` admin UI for the two controls above
+- manifest/runtime sync for the missing `sla-watcher` workflow declaration
+
+Out of scope:
+
+- generic plugin runtime admin APIs
+- editing automation trigger/action DSL
+- editing arbitrary field policies outside `serviceTicket.refundAmount`
+- changing install-time provisioning semantics
+
+## Backend Design
+
+### Route contract
+
+All three runtime-admin routes are admin-only and reuse the existing after-sales install admin gate:
+
+- missing user: `401 UNAUTHORIZED`
+- non-admin: `403 FORBIDDEN`
+- after-sales not in `installed|partial`: `409 AFTER_SALES_NOT_INSTALLED`
+
+Routes added:
+
+- `GET /api/after-sales/runtime-admin`
+- `PUT /api/after-sales/runtime-admin/automations`
+- `PUT /api/after-sales/runtime-admin/field-policies`
+
+### State model
+
+Runtime admin state is reconstructed from blueprint defaults plus registry overlay.
+
+Automation state:
+
+- source of truth for shape: `buildDefaultBlueprint(appManifest).automations`
+- source of truth for enabled state: `automationRegistry.listRules(...)`
+- persisted updates: `automationRegistry.upsertRules(...)`
+
+Field-policy state:
+
+- source of truth for role list and labels: `buildDefaultBlueprint(appManifest).roles`
+- source of truth for default policy rows: `buildDefaultBlueprint(appManifest).fieldPolicies`
+- source of truth for persisted overrides: `plugin_field_policy_registry`
+- persisted updates: `rbacProvisioning.applyRoleMatrix(...)`
+
+### Response shape
+
+`GET /api/after-sales/runtime-admin` returns:
+
+```json
+{
+  "projectId": "tenant:after-sales",
+  "automations": [
+    {
+      "id": "ticket-triage",
+      "name": "Ticket Triage",
+      "triggerEvent": "ticket.created",
+      "enabled": true
+    }
+  ],
+  "fieldPolicies": {
+    "objectId": "serviceTicket",
+    "field": "refundAmount",
+    "roles": [
+      {
+        "roleSlug": "finance",
+        "roleLabel": "财务",
+        "visibility": "visible",
+        "editability": "editable"
+      }
+    ]
+  }
+}
+```
+
+### Update semantics
+
+`PUT /api/after-sales/runtime-admin/automations`
+
+- accepts `{ automations: Array<{ id, enabled }> }`
+- requires the exact default rule id set
+- rebuilds full rule drafts from blueprint defaults
+- only `enabled` is mutable
+
+`PUT /api/after-sales/runtime-admin/field-policies`
+
+- accepts `{ roles: Array<{ roleSlug, visibility, editability }> }`
+- requires the exact default role set
+- rewrites a full replacement matrix for `serviceTicket.refundAmount`
+- coerces `hidden -> readonly` before persistence
+
+### Helper split
+
+Two plugin helpers now carry the logic that should not live inline in `index.cjs`:
+
+- `lib/runtime-admin.cjs`
+  - runtime-admin state assembly
+  - automation update validation
+  - field-policy update payload construction
+- `lib/field-policies.cjs`
+  - registry/default merge
+  - role-matrix assembly
+  - full replacement field-policy validation
+
+## Frontend Design
+
+`AfterSalesView.vue` now loads runtime-admin state only when all of these are true:
+
+- current install state is `installed` or `partial`
+- manifest includes `sla-watcher`, which acts as the runtime-admin capability marker
+
+Behavior:
+
+- `403` from `/api/after-sales/runtime-admin`: hide the admin section silently
+- other load failures: keep the rest of the page usable and show a panel-local error
+- separate save/reset flows for:
+  - automation toggles
+  - field policy matrix
+- after field-policy save:
+  - reload `/api/after-sales/runtime-admin`
+  - reload `/api/after-sales/field-policies`
+  - this immediately refreshes refund field visibility/editability in the ticket UI
+
+## Testing Strategy
+
+Backend:
+
+- unit coverage for helper normalization and validation
+- route tests for admin access, 409 guard, update payloads, and coercion
+- real Postgres integration for runtime-admin GET/PUT behavior
+
+Frontend:
+
+- `AfterSalesView.spec.ts` coverage for:
+  - runtime-admin render
+  - `403` hide behavior
+  - automation save payload
+  - field-policy save payload
+  - post-save refund control refresh
+
+The design intentionally keeps the surface narrow enough that route tests plus one real integration file provide strong regression coverage without introducing a new generic admin subsystem.

--- a/docs/after-sales-runtime-admin-v1-verification-20260411.md
+++ b/docs/after-sales-runtime-admin-v1-verification-20260411.md
@@ -1,0 +1,95 @@
+# After-Sales Runtime Admin V1 Verification
+
+Date: 2026-04-11
+Branch: `feature/after-sales-runtime-admin-v1`
+
+## Summary
+
+Runtime admin v1 was verified across backend unit tests, backend real-DB integration, frontend view tests, and production builds for both packages.
+
+Docs-only wrap-up branch was also landed first:
+
+- PR `#785`
+- merged at `2026-04-11T00:46:04Z`
+- merge commit `2fd9b4ff6d5f324135875bf5b06586ce24496d70`
+
+## Commands Run
+
+### Backend
+
+```bash
+pnpm install
+pnpm --filter @metasheet/core-backend test:unit
+DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend build
+```
+
+### Frontend
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/AfterSalesView.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run \
+  tests/AfterSalesView.spec.ts \
+  tests/AfterSalesView.follow-ups.spec.ts \
+  tests/AfterSalesView.customers.spec.ts \
+  tests/AfterSalesView.installed-assets.spec.ts \
+  tests/AfterSalesView.service-records.spec.ts \
+  --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+Backend unit suite:
+
+- `69` test files passed
+- `731` tests passed
+
+Backend integration:
+
+- `tests/integration/after-sales-plugin.install.test.ts`
+- `24` tests passed
+- includes new runtime-admin coverage for:
+  - admin GET
+  - automation toggle persistence
+  - field-policy update persistence
+  - finance-user effective policy refresh
+  - non-admin `403`
+
+Frontend view suite:
+
+- `tests/AfterSalesView.spec.ts`: `27` tests passed
+- all `AfterSalesView*` specs together: `74` tests passed
+
+Builds:
+
+- `@metasheet/core-backend` build passed
+- `@metasheet/web` build passed
+
+## Manual Verification Notes
+
+Observed backend/runtime behavior from automated coverage:
+
+- `/api/after-sales/runtime-admin` returns 4 default automations with manifest-aligned names
+- disabling `sla-watcher` persists to `plugin_automation_rule_registry`
+- saving a hidden finance policy is persisted as `hidden + readonly`
+- finance user effective field policy updates immediately after admin save
+- non-admin callers receive `403 FORBIDDEN`
+
+Observed UI behavior from frontend tests:
+
+- runtime-admin panel renders only when supported and accessible
+- `403` hides the panel without breaking the rest of `AfterSalesView`
+- automation save sends the minimal `{ id, enabled }` payload
+- field-policy save sends role matrix payload and refreshes refund controls
+- existing installed-assets / customers / follow-ups / service-records panels still pass their test suites
+
+## Non-Blocking Warnings
+
+Frontend build emitted pre-existing Vite warnings:
+
+- dynamic/static mixed import warning for `WorkflowDesigner.vue`
+- large chunk size warnings in the web build
+
+These warnings did not block the build and were not introduced by the runtime-admin slice.

--- a/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
+++ b/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
@@ -71,6 +71,13 @@ function requestJson(
   })
 }
 
+async function issueDevToken(baseUrl: string, query: string): Promise<string> {
+  const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?${query}`)
+  const token = (tokenRes.body as { token?: string } | undefined)?.token
+  expect(token).toBeTruthy()
+  return String(token)
+}
+
 function stableMetaId(prefix: string, ...parts: string[]): string {
   const digest = createHash('sha1')
     .update(parts.join(':'))
@@ -628,6 +635,219 @@ describe('after-sales plugin install integration', () => {
       await assertSheetFields(pool, objectDef.objectId, objectDef.sheetName, [...objectDef.fields])
       await assertView(pool, objectDef.objectId, objectDef.view.id, objectDef.view.name, objectDef.view.type)
     }
+  })
+
+  it('reads and updates runtime admin state against the live automation and field-policy registries', async () => {
+    if (!baseUrl || !pool) return
+
+    const adminToken = await issueDevToken(
+      baseUrl,
+      'userId=after-sales-runtime-admin-it&roles=admin&perms=*:*',
+    )
+    const financeToken = await issueDevToken(
+      baseUrl,
+      'userId=after-sales-runtime-admin-finance&roles=finance&perms=after_sales:read',
+    )
+
+    const installRes = await requestJson(`${baseUrl}/api/after-sales/projects/install`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        templateId: 'after-sales-default',
+        displayName: 'After Sales Runtime Admin',
+      }),
+    })
+    expect(installRes.status).toBe(200)
+
+    const runtimeAdminRes = await requestJson(`${baseUrl}/api/after-sales/runtime-admin`, {
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+      },
+    })
+    expect(runtimeAdminRes.status).toBe(200)
+    expect(runtimeAdminRes.body).toEqual({
+      ok: true,
+      data: {
+        projectId: PROJECT_ID,
+        automations: [
+          { id: 'ticket-triage', name: 'Ticket Triage', triggerEvent: 'ticket.created', enabled: true },
+          { id: 'sla-watcher', name: 'SLA Watcher', triggerEvent: 'ticket.overdue', enabled: true },
+          { id: 'refund-approval', name: 'Refund Approval', triggerEvent: 'ticket.refundRequested', enabled: true },
+          { id: 'service-record-notify', name: 'Service Record Notification', triggerEvent: 'service.recorded', enabled: true },
+        ],
+        fieldPolicies: {
+          objectId: 'serviceTicket',
+          field: 'refundAmount',
+          roles: [
+            { roleSlug: 'customer_service', roleLabel: '客服', visibility: 'hidden', editability: 'readonly' },
+            { roleSlug: 'technician', roleLabel: '技师', visibility: 'hidden', editability: 'readonly' },
+            { roleSlug: 'supervisor', roleLabel: '主管', visibility: 'visible', editability: 'readonly' },
+            { roleSlug: 'finance', roleLabel: '财务', visibility: 'visible', editability: 'editable' },
+            { roleSlug: 'admin', roleLabel: '管理员', visibility: 'visible', editability: 'editable' },
+            { roleSlug: 'viewer', roleLabel: '只读', visibility: 'hidden', editability: 'readonly' },
+          ],
+        },
+      },
+    })
+
+    const automationUpdateRes = await requestJson(`${baseUrl}/api/after-sales/runtime-admin/automations`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        automations: [
+          { id: 'ticket-triage', enabled: true },
+          { id: 'sla-watcher', enabled: false },
+          { id: 'refund-approval', enabled: true },
+          { id: 'service-record-notify', enabled: true },
+        ],
+      }),
+    })
+    expect(automationUpdateRes.status).toBe(200)
+    expect((automationUpdateRes.body as {
+      data?: { automations?: Array<{ id: string; enabled: boolean }> }
+    }).data?.automations).toMatchObject([
+      { id: 'ticket-triage', enabled: true },
+      { id: 'sla-watcher', enabled: false },
+      { id: 'refund-approval', enabled: true },
+      { id: 'service-record-notify', enabled: true },
+    ])
+
+    const automationRegistryRes = await pool.query<{ rule_id: string; enabled: boolean }>(
+      `SELECT rule_id, enabled
+       FROM plugin_automation_rule_registry
+       WHERE tenant_id = $1
+         AND plugin_id = $2
+         AND app_id = $3
+         AND project_id = $4
+       ORDER BY rule_id ASC`,
+      [TENANT_ID, PLUGIN_ID, APP_ID, PROJECT_ID],
+    )
+    expect(automationRegistryRes.rows).toEqual([
+      { rule_id: 'refund-approval', enabled: true },
+      { rule_id: 'service-record-notify', enabled: true },
+      { rule_id: 'sla-watcher', enabled: false },
+      { rule_id: 'ticket-triage', enabled: true },
+    ])
+
+    const fieldPolicyUpdateRes = await requestJson(`${baseUrl}/api/after-sales/runtime-admin/field-policies`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        roles: [
+          { roleSlug: 'customer_service', visibility: 'hidden', editability: 'readonly' },
+          { roleSlug: 'technician', visibility: 'hidden', editability: 'readonly' },
+          { roleSlug: 'supervisor', visibility: 'visible', editability: 'readonly' },
+          { roleSlug: 'finance', visibility: 'hidden', editability: 'editable' },
+          { roleSlug: 'admin', visibility: 'visible', editability: 'editable' },
+          { roleSlug: 'viewer', visibility: 'hidden', editability: 'readonly' },
+        ],
+      }),
+    })
+    expect(fieldPolicyUpdateRes.status).toBe(200)
+    expect((fieldPolicyUpdateRes.body as {
+      data?: {
+        fieldPolicies?: {
+          roles?: Array<{ roleSlug: string; visibility: string; editability: string }>
+        }
+      }
+    }).data?.fieldPolicies?.roles).toContainEqual({
+      roleSlug: 'finance',
+      roleLabel: '财务',
+      visibility: 'hidden',
+      editability: 'readonly',
+    })
+
+    const financeFieldPoliciesRes = await requestJson(`${baseUrl}/api/after-sales/field-policies`, {
+      headers: {
+        Authorization: `Bearer ${financeToken}`,
+      },
+    })
+    expect(financeFieldPoliciesRes.status).toBe(200)
+    expect(financeFieldPoliciesRes.body).toEqual({
+      ok: true,
+      data: {
+        projectId: PROJECT_ID,
+        fields: {
+          serviceTicket: {
+            refundAmount: {
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+          },
+        },
+      },
+    })
+
+    const fieldPolicyRegistryRes = await pool.query<{
+      role_slug: string
+      visibility: string
+      editability: string
+    }>(
+      `SELECT role_slug, visibility, editability
+       FROM plugin_field_policy_registry
+       WHERE tenant_id = $1
+         AND plugin_id = $2
+         AND app_id = $3
+         AND project_id = $4
+         AND object_id = 'serviceTicket'
+         AND field_name = 'refundAmount'
+       ORDER BY role_slug ASC`,
+      [TENANT_ID, PLUGIN_ID, APP_ID, PROJECT_ID],
+    )
+    expect(fieldPolicyRegistryRes.rows).toContainEqual({
+      role_slug: 'finance',
+      visibility: 'hidden',
+      editability: 'readonly',
+    })
+  })
+
+  it('rejects runtime admin for non-admin callers', async () => {
+    if (!baseUrl || !pool) return
+
+    const adminToken = await issueDevToken(
+      baseUrl,
+      'userId=after-sales-runtime-admin-owner&roles=admin&perms=*:*',
+    )
+    const nonAdminToken = await issueDevToken(
+      baseUrl,
+      'userId=after-sales-runtime-admin-reader&roles=supervisor&perms=after_sales:read',
+    )
+
+    const installRes = await requestJson(`${baseUrl}/api/after-sales/projects/install`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        templateId: 'after-sales-default',
+        displayName: 'After Sales Runtime Admin Permissions',
+      }),
+    })
+    expect(installRes.status).toBe(200)
+
+    const runtimeAdminRes = await requestJson(`${baseUrl}/api/after-sales/runtime-admin`, {
+      headers: {
+        Authorization: `Bearer ${nonAdminToken}`,
+      },
+    })
+    expect(runtimeAdminRes.status).toBe(403)
+    expect(runtimeAdminRes.body).toEqual({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Admin access required',
+      },
+    })
   })
 
   it('rejects install for non-admin callers', async () => {

--- a/packages/core-backend/tests/unit/after-sales-blueprint-sync.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-blueprint-sync.test.ts
@@ -62,6 +62,20 @@ describe('after-sales blueprint runtime sync', () => {
     }
   })
 
+  it('keeps manifest workflows aligned with the default automation ids', () => {
+    const result = blueprint.buildDefaultBlueprint(manifest)
+    const automationIds = (Array.isArray(result.automations) ? result.automations : [])
+      .map((rule) => String((rule as Record<string, unknown>).id || ''))
+      .filter(Boolean)
+      .sort()
+    const workflowIds = (Array.isArray(manifest.workflows) ? manifest.workflows : [])
+      .map((workflow) => String((workflow as Record<string, unknown>).id || ''))
+      .filter(Boolean)
+      .sort()
+
+    expect(workflowIds).toEqual(automationIds)
+  })
+
   it('registers workflow listeners for every automation trigger and notification event', () => {
     const result = blueprint.buildDefaultBlueprint(manifest)
     const automations = Array.isArray(result.automations)

--- a/packages/core-backend/tests/unit/after-sales-field-policies.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-field-policies.test.ts
@@ -6,6 +6,42 @@ const fieldPolicies = require('../../../../plugins/plugin-after-sales/lib/field-
     visibility: string
     editability: string
   }
+  buildFieldPolicyRoleMatrix: (
+    defaultRoles: Array<{ slug: string; label: string; permissions: string[] }>,
+    defaultPolicies: Array<{
+      objectId: string
+      field: string
+      roleSlug: string
+      visibility: string
+      editability: string
+    }>,
+    registryRows: Array<{ roleSlug: string; visibility: string; editability: string }>,
+  ) => Array<{
+    roleSlug: string
+    roleLabel: string
+    visibility: string
+    editability: string
+  }>
+  buildFieldPolicyUpdateMatrix: (
+    defaultRoles: Array<{ slug: string; label: string; permissions: string[] }>,
+    defaultPolicies: Array<{
+      objectId: string
+      field: string
+      roleSlug: string
+      visibility: string
+      editability: string
+    }>,
+    submittedRoles: Array<{ roleSlug: string; visibility: string; editability: string }>,
+  ) => {
+    roles: Array<{ slug: string; label: string; permissions: string[] }>
+    fieldPolicies: Array<{
+      objectId: string
+      field: string
+      roleSlug: string
+      visibility: string
+      editability: string
+    }>
+  }
   resolveFieldPolicyRoleSlugs: (user: Record<string, unknown> | null | undefined) => string[]
   resolveFieldPoliciesForUser: (
     database: { query: (sql: string, params?: unknown[]) => Promise<unknown[] | { rows: unknown[] }> },
@@ -33,6 +69,18 @@ function createDatabase(rows: Array<Record<string, unknown>>) {
   const query = vi.fn(async () => rows)
   return { query }
 }
+
+const DEFAULT_ROLES = [
+  { slug: 'admin', label: '管理员', permissions: ['after_sales:admin'] },
+  { slug: 'finance', label: '财务', permissions: ['after_sales:approve'] },
+  { slug: 'viewer', label: '只读', permissions: ['after_sales:read'] },
+]
+
+const DEFAULT_FIELD_POLICIES = [
+  { objectId: 'serviceTicket', field: 'refundAmount', roleSlug: 'admin', visibility: 'visible', editability: 'editable' },
+  { objectId: 'serviceTicket', field: 'refundAmount', roleSlug: 'finance', visibility: 'visible', editability: 'editable' },
+  { objectId: 'serviceTicket', field: 'refundAmount', roleSlug: 'viewer', visibility: 'hidden', editability: 'readonly' },
+]
 
 describe('after-sales field policy helper', () => {
   it('resolves role slugs from claims and infers admin from permission claims', () => {
@@ -124,5 +172,70 @@ describe('after-sales field policy helper', () => {
     })
 
     expect(result.fields.serviceTicket.refundAmount).toEqual(fieldPolicies.DEFAULT_EFFECTIVE_POLICY)
+  })
+
+  it('builds a role matrix by overlaying registry rows onto blueprint defaults', () => {
+    expect(
+      fieldPolicies.buildFieldPolicyRoleMatrix(
+        DEFAULT_ROLES,
+        DEFAULT_FIELD_POLICIES,
+        [{ roleSlug: 'finance', visibility: 'hidden', editability: 'editable' }],
+      ),
+    ).toEqual([
+      { roleSlug: 'admin', roleLabel: '管理员', visibility: 'visible', editability: 'editable' },
+      { roleSlug: 'finance', roleLabel: '财务', visibility: 'hidden', editability: 'readonly' },
+      { roleSlug: 'viewer', roleLabel: '只读', visibility: 'hidden', editability: 'readonly' },
+    ])
+  })
+
+  it('builds a full replacement update matrix and coerces hidden rows to readonly', () => {
+    expect(
+      fieldPolicies.buildFieldPolicyUpdateMatrix(
+        DEFAULT_ROLES,
+        DEFAULT_FIELD_POLICIES,
+        [
+          { roleSlug: 'admin', visibility: 'visible', editability: 'editable' },
+          { roleSlug: 'finance', visibility: 'hidden', editability: 'editable' },
+          { roleSlug: 'viewer', visibility: 'hidden', editability: 'readonly' },
+        ],
+      ),
+    ).toEqual({
+      roles: DEFAULT_ROLES,
+      fieldPolicies: [
+        {
+          objectId: 'serviceTicket',
+          field: 'refundAmount',
+          roleSlug: 'admin',
+          visibility: 'visible',
+          editability: 'editable',
+        },
+        {
+          objectId: 'serviceTicket',
+          field: 'refundAmount',
+          roleSlug: 'finance',
+          visibility: 'hidden',
+          editability: 'readonly',
+        },
+        {
+          objectId: 'serviceTicket',
+          field: 'refundAmount',
+          roleSlug: 'viewer',
+          visibility: 'hidden',
+          editability: 'readonly',
+        },
+      ],
+    })
+  })
+
+  it('rejects field policy updates that omit a default role', () => {
+    expect(() =>
+      fieldPolicies.buildFieldPolicyUpdateMatrix(
+        DEFAULT_ROLES,
+        DEFAULT_FIELD_POLICIES,
+        [
+          { roleSlug: 'admin', visibility: 'visible', editability: 'editable' },
+          { roleSlug: 'finance', visibility: 'visible', editability: 'editable' },
+        ],
+      )).toThrow('field policies must include every default role exactly once')
   })
 })

--- a/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
@@ -712,6 +712,30 @@ const iaPk = (field: string) => `${MOCK_PROJECT_ID}:installedAsset:${field}`
 const cuPk = (field: string) => `${MOCK_PROJECT_ID}:customer:${field}`
 const fuPk = (field: string) => `${MOCK_PROJECT_ID}:followUp:${field}`
 
+function seedAfterSalesInstallRow(
+  db: FakeDatabase,
+  overrides: Partial<FakeRowRaw> = {},
+) {
+  db.rows.push({
+    id: 'fake-uuid-1',
+    tenant_id: 'tenant_42',
+    app_id: 'after-sales',
+    project_id: 'tenant_42:after-sales',
+    template_id: 'after-sales-default',
+    template_version: '0.1.0',
+    mode: 'enable',
+    status: 'installed',
+    created_objects_json: JSON.stringify(['serviceTicket']),
+    created_views_json: JSON.stringify(['ticket-board']),
+    warnings_json: JSON.stringify([]),
+    display_name: 'After-sales',
+    config_json: JSON.stringify({}),
+    last_install_at: new Date(),
+    created_at: new Date(),
+    ...overrides,
+  })
+}
+
 describe('plugin-after-sales routes', () => {
   let routes: Map<string, RegisteredHandler>
   let ensureObject: ReturnType<typeof vi.fn>
@@ -1001,6 +1025,383 @@ describe('plugin-after-sales routes', () => {
       error: {
         code: 'AFTER_SALES_NOT_INSTALLED',
         message: 'After-sales must be installed before reading field policies',
+      },
+    })
+  })
+
+  it('returns runtime admin state for after-sales admins', async () => {
+    const handler = routes.get('GET /api/after-sales/runtime-admin')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db)
+    automationListRules.mockResolvedValueOnce([
+      { id: 'ticket-triage', enabled: true },
+      { id: 'sla-watcher', enabled: false },
+      { id: 'refund-approval', enabled: true },
+      { id: 'service-record-notify', enabled: true },
+    ])
+    db.fieldPolicyRows.push({
+      tenant_id: 'tenant_42',
+      plugin_id: 'plugin-after-sales',
+      app_id: 'after-sales',
+      project_id: 'tenant_42:after-sales',
+      object_id: 'serviceTicket',
+      field_name: 'refundAmount',
+      role_slug: 'finance',
+      visibility: 'hidden',
+      editability: 'editable',
+    })
+
+    await handler?.(buildReq(), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(automationListRules).toHaveBeenCalledWith({
+      tenantId: 'tenant_42',
+      pluginId: 'plugin-after-sales',
+      appId: 'after-sales',
+      projectId: 'tenant_42:after-sales',
+    })
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        projectId: 'tenant_42:after-sales',
+        automations: [
+          {
+            id: 'ticket-triage',
+            name: 'Ticket Triage',
+            triggerEvent: 'ticket.created',
+            enabled: true,
+          },
+          {
+            id: 'sla-watcher',
+            name: 'SLA Watcher',
+            triggerEvent: 'ticket.overdue',
+            enabled: false,
+          },
+          {
+            id: 'refund-approval',
+            name: 'Refund Approval',
+            triggerEvent: 'ticket.refundRequested',
+            enabled: true,
+          },
+          {
+            id: 'service-record-notify',
+            name: 'Service Record Notification',
+            triggerEvent: 'service.recorded',
+            enabled: true,
+          },
+        ],
+        fieldPolicies: {
+          objectId: 'serviceTicket',
+          field: 'refundAmount',
+          roles: [
+            {
+              roleSlug: 'customer_service',
+              roleLabel: '客服',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'technician',
+              roleLabel: '技师',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'supervisor',
+              roleLabel: '主管',
+              visibility: 'visible',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'finance',
+              roleLabel: '财务',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'admin',
+              roleLabel: '管理员',
+              visibility: 'visible',
+              editability: 'editable',
+            },
+            {
+              roleSlug: 'viewer',
+              roleLabel: '只读',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it('returns 403 for runtime admin when caller lacks admin access', async () => {
+    const handler = routes.get('GET /api/after-sales/runtime-admin')
+    const res = new FakeResponse()
+
+    await handler?.(buildReq({
+      user: {
+        id: 'reader_42',
+        tenantId: 'tenant_42',
+        role: 'supervisor',
+        roles: ['supervisor'],
+        perms: ['after_sales:read'],
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Admin access required',
+      },
+    })
+  })
+
+  it('returns 409 for runtime admin when after-sales is not operational', async () => {
+    const handler = routes.get('GET /api/after-sales/runtime-admin')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      mode: 'reinstall',
+      status: 'failed',
+      warnings_json: JSON.stringify(['adapter failed']),
+    })
+
+    await handler?.(buildReq(), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_NOT_INSTALLED',
+        message: 'After-sales must be installed before managing runtime admin state',
+      },
+    })
+  })
+
+  it('updates runtime automation toggles using the default rule payloads', async () => {
+    const handler = routes.get('PUT /api/after-sales/runtime-admin/automations')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db)
+    automationListRules.mockResolvedValueOnce([
+      { id: 'ticket-triage', enabled: true },
+      { id: 'sla-watcher', enabled: false },
+      { id: 'refund-approval', enabled: true },
+      { id: 'service-record-notify', enabled: true },
+    ])
+
+    await handler?.(buildReq({
+      body: {
+        automations: [
+          { id: 'ticket-triage', enabled: true },
+          { id: 'sla-watcher', enabled: false },
+          { id: 'refund-approval', enabled: true },
+          { id: 'service-record-notify', enabled: true },
+        ],
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(automationUpsertRules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: 'plugin-after-sales',
+        appId: 'after-sales',
+        tenantId: 'tenant_42',
+        projectId: 'tenant_42:after-sales',
+        templateId: 'after-sales-default',
+        rules: [
+          expect.objectContaining({
+            id: 'ticket-triage',
+            enabled: true,
+          }),
+          expect.objectContaining({
+            id: 'sla-watcher',
+            enabled: false,
+            trigger: { event: 'ticket.overdue', filter: [{ field: 'status', operator: 'in', value: ['new', 'assigned', 'inProgress'] }] },
+          }),
+          expect.objectContaining({
+            id: 'refund-approval',
+            enabled: true,
+          }),
+          expect.objectContaining({
+            id: 'service-record-notify',
+            enabled: true,
+          }),
+        ],
+      }),
+    )
+    expect(res.body.data.automations[1]).toEqual({
+      id: 'sla-watcher',
+      name: 'SLA Watcher',
+      triggerEvent: 'ticket.overdue',
+      enabled: false,
+    })
+  })
+
+  it('rejects automation updates that omit a default rule', async () => {
+    const handler = routes.get('PUT /api/after-sales/runtime-admin/automations')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db)
+
+    await handler?.(buildReq({
+      body: {
+        automations: [
+          { id: 'ticket-triage', enabled: true },
+          { id: 'refund-approval', enabled: true },
+          { id: 'service-record-notify', enabled: true },
+        ],
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'automations must include every default rule exactly once',
+        details: {
+          expectedRuleIds: ['refund-approval', 'service-record-notify', 'sla-watcher', 'ticket-triage'],
+        },
+      },
+    })
+  })
+
+  it('updates field policy matrix and coerces hidden rows to readonly', async () => {
+    const handler = routes.get('PUT /api/after-sales/runtime-admin/field-policies')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db)
+    applyRoleMatrix.mockImplementationOnce(async (input: Record<string, unknown>) => {
+      const matrix = input.matrix as {
+        fieldPolicies: Array<{
+          objectId: string
+          field: string
+          roleSlug: string
+          visibility: string
+          editability: string
+        }>
+      }
+      db.fieldPolicyRows = matrix.fieldPolicies.map((policy) => ({
+        tenant_id: 'tenant_42',
+        plugin_id: 'plugin-after-sales',
+        app_id: 'after-sales',
+        project_id: 'tenant_42:after-sales',
+        object_id: policy.objectId,
+        field_name: policy.field,
+        role_slug: policy.roleSlug,
+        visibility: policy.visibility,
+        editability: policy.editability,
+      }))
+      return {
+        rolesApplied: ['customer_service', 'technician', 'supervisor', 'finance', 'admin', 'viewer'],
+        fieldPoliciesApplied: matrix.fieldPolicies.length,
+      }
+    })
+
+    await handler?.(buildReq({
+      body: {
+        roles: [
+          { roleSlug: 'customer_service', visibility: 'hidden', editability: 'readonly' },
+          { roleSlug: 'technician', visibility: 'hidden', editability: 'readonly' },
+          { roleSlug: 'supervisor', visibility: 'visible', editability: 'readonly' },
+          { roleSlug: 'finance', visibility: 'hidden', editability: 'editable' },
+          { roleSlug: 'admin', visibility: 'visible', editability: 'editable' },
+          { roleSlug: 'viewer', visibility: 'hidden', editability: 'readonly' },
+        ],
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(applyRoleMatrix).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: 'plugin-after-sales',
+        appId: 'after-sales',
+        tenantId: 'tenant_42',
+        projectId: 'tenant_42:after-sales',
+        matrix: expect.objectContaining({
+          fieldPolicies: expect.arrayContaining([
+            expect.objectContaining({
+              roleSlug: 'finance',
+              visibility: 'hidden',
+              editability: 'readonly',
+            }),
+          ]),
+        }),
+      }),
+    )
+    expect(res.body.data.fieldPolicies.roles).toEqual([
+      {
+        roleSlug: 'customer_service',
+        roleLabel: '客服',
+        visibility: 'hidden',
+        editability: 'readonly',
+      },
+      {
+        roleSlug: 'technician',
+        roleLabel: '技师',
+        visibility: 'hidden',
+        editability: 'readonly',
+      },
+      {
+        roleSlug: 'supervisor',
+        roleLabel: '主管',
+        visibility: 'visible',
+        editability: 'readonly',
+      },
+      {
+        roleSlug: 'finance',
+        roleLabel: '财务',
+        visibility: 'hidden',
+        editability: 'readonly',
+      },
+      {
+        roleSlug: 'admin',
+        roleLabel: '管理员',
+        visibility: 'visible',
+        editability: 'editable',
+      },
+      {
+        roleSlug: 'viewer',
+        roleLabel: '只读',
+        visibility: 'hidden',
+        editability: 'readonly',
+      },
+    ])
+  })
+
+  it('rejects field policy updates that omit a default role', async () => {
+    const handler = routes.get('PUT /api/after-sales/runtime-admin/field-policies')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db)
+
+    await handler?.(buildReq({
+      body: {
+        roles: [
+          { roleSlug: 'customer_service', visibility: 'hidden', editability: 'readonly' },
+          { roleSlug: 'technician', visibility: 'hidden', editability: 'readonly' },
+          { roleSlug: 'supervisor', visibility: 'visible', editability: 'readonly' },
+          { roleSlug: 'finance', visibility: 'visible', editability: 'editable' },
+          { roleSlug: 'admin', visibility: 'visible', editability: 'editable' },
+        ],
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'field policies must include every default role exactly once',
+        details: {
+          expectedRoleSlugs: ['admin', 'customer_service', 'finance', 'supervisor', 'technician', 'viewer'],
+        },
       },
     })
   })

--- a/plugins/plugin-after-sales/app.manifest.json
+++ b/plugins/plugin-after-sales/app.manifest.json
@@ -82,6 +82,11 @@
       "trigger": "ticket.created"
     },
     {
+      "id": "sla-watcher",
+      "name": "SLA Watcher",
+      "trigger": "ticket.overdue"
+    },
+    {
       "id": "refund-approval",
       "name": "Refund Approval",
       "trigger": "ticket.refundRequested"

--- a/plugins/plugin-after-sales/index.cjs
+++ b/plugins/plugin-after-sales/index.cjs
@@ -21,6 +21,11 @@ const {
   resolveFieldPolicyRoleSlugs,
 } = require('./lib/field-policies.cjs')
 const {
+  buildAutomationUpdateRules,
+  buildFieldPolicyUpdatePayload,
+  loadRuntimeAdminState,
+} = require('./lib/runtime-admin.cjs')
+const {
   buildCreateTicketCommand,
   buildCustomerCommand,
   buildFollowUpCommand,
@@ -221,6 +226,35 @@ function hasAfterSalesReadAccess(req) {
     permissions.has('after_sales:write') ||
     permissions.has('after_sales:admin')
   )
+}
+
+function resolvePluginId(context) {
+  return context && context.metadata && typeof context.metadata.name === 'string' && context.metadata.name.trim()
+    ? context.metadata.name.trim()
+    : AFTER_SALES_PLUGIN_ID
+}
+
+function getAutomationRegistryService(context) {
+  return context &&
+    context.services &&
+    context.services.automationRegistry &&
+    typeof context.services.automationRegistry.listRules === 'function' &&
+    typeof context.services.automationRegistry.upsertRules === 'function'
+    ? context.services.automationRegistry
+    : null
+}
+
+function getRbacProvisioningService(context) {
+  return context &&
+    context.services &&
+    context.services.rbacProvisioning &&
+    typeof context.services.rbacProvisioning.applyRoleMatrix === 'function'
+    ? context.services.rbacProvisioning
+    : null
+}
+
+function getDefaultBlueprint() {
+  return buildDefaultBlueprint(appManifest)
 }
 
 /**
@@ -652,7 +686,7 @@ module.exports = {
               : {}
 
           const tenantId = getTenantId(req, context.logger)
-          const blueprint = buildDefaultBlueprint(appManifest)
+          const blueprint = getDefaultBlueprint()
 
           const result = await installer.runInstall({
             context,
@@ -738,6 +772,220 @@ module.exports = {
           res.status(500).json({
             ok: false,
             error: { code: 'INTERNAL_ERROR', message: 'Failed to load after-sales field policies' },
+          })
+        }
+      },
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/after-sales/runtime-admin',
+      async (req, res) => {
+        try {
+          const userId = getUserId(req)
+          if (!userId) {
+            sendUnauthorized(res)
+            return
+          }
+          if (!hasInstallAdminAccess(req)) {
+            sendForbidden(res)
+            return
+          }
+
+          const automationRegistry = getAutomationRegistryService(context)
+          if (!automationRegistry) {
+            throw new Error('automationRegistry service unavailable on plugin context')
+          }
+
+          const tenantId = getTenantId(req, context.logger)
+          const current = await installer.loadCurrent(context, tenantId, appManifest.id)
+          if (!current || !isOperationalAfterSalesStatus(current.status)) {
+            res.status(409).json({
+              ok: false,
+              error: {
+                code: 'AFTER_SALES_NOT_INSTALLED',
+                message: 'After-sales must be installed before managing runtime admin state',
+              },
+            })
+            return
+          }
+
+          const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
+          const data = await loadRuntimeAdminState({
+            database: context.api.database,
+            automationRegistry,
+            blueprint: getDefaultBlueprint(),
+            manifest: appManifest,
+            tenantId,
+            pluginId: resolvePluginId(context),
+            appId: appManifest.id,
+            projectId,
+          })
+
+          res.json({
+            ok: true,
+            data,
+          })
+        } catch (err) {
+          logger.error && logger.error('after-sales runtime admin lookup failed', err)
+          res.status(500).json({
+            ok: false,
+            error: { code: 'INTERNAL_ERROR', message: 'Failed to load after-sales runtime admin state' },
+          })
+        }
+      },
+    )
+
+    context.api.http.addRoute(
+      'PUT',
+      '/api/after-sales/runtime-admin/automations',
+      async (req, res) => {
+        try {
+          const userId = getUserId(req)
+          if (!userId) {
+            sendUnauthorized(res)
+            return
+          }
+          if (!hasInstallAdminAccess(req)) {
+            sendForbidden(res)
+            return
+          }
+
+          const automationRegistry = getAutomationRegistryService(context)
+          if (!automationRegistry) {
+            throw new Error('automationRegistry service unavailable on plugin context')
+          }
+
+          const tenantId = getTenantId(req, context.logger)
+          const current = await installer.loadCurrent(context, tenantId, appManifest.id)
+          if (!current || !isOperationalAfterSalesStatus(current.status)) {
+            res.status(409).json({
+              ok: false,
+              error: {
+                code: 'AFTER_SALES_NOT_INSTALLED',
+                message: 'After-sales must be installed before updating runtime automations',
+              },
+            })
+            return
+          }
+
+          const blueprint = getDefaultBlueprint()
+          const body = req && req.body && typeof req.body === 'object' ? req.body : {}
+          const rules = buildAutomationUpdateRules(blueprint, appManifest, body.automations)
+          const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
+
+          await automationRegistry.upsertRules({
+            pluginId: resolvePluginId(context),
+            appId: appManifest.id,
+            tenantId,
+            projectId,
+            templateId: blueprint.id,
+            rules,
+          })
+
+          const data = await loadRuntimeAdminState({
+            database: context.api.database,
+            automationRegistry,
+            blueprint,
+            manifest: appManifest,
+            tenantId,
+            pluginId: resolvePluginId(context),
+            appId: appManifest.id,
+            projectId,
+          })
+
+          res.json({
+            ok: true,
+            data,
+          })
+        } catch (err) {
+          if (err && err.code === 'VALIDATION_FAILED') {
+            sendBadRequest(res, err)
+            return
+          }
+          logger.error && logger.error('after-sales runtime automation update failed', err)
+          res.status(500).json({
+            ok: false,
+            error: { code: 'INTERNAL_ERROR', message: 'Failed to update after-sales automations' },
+          })
+        }
+      },
+    )
+
+    context.api.http.addRoute(
+      'PUT',
+      '/api/after-sales/runtime-admin/field-policies',
+      async (req, res) => {
+        try {
+          const userId = getUserId(req)
+          if (!userId) {
+            sendUnauthorized(res)
+            return
+          }
+          if (!hasInstallAdminAccess(req)) {
+            sendForbidden(res)
+            return
+          }
+
+          const rbacProvisioning = getRbacProvisioningService(context)
+          const automationRegistry = getAutomationRegistryService(context)
+          if (!rbacProvisioning) {
+            throw new Error('rbacProvisioning service unavailable on plugin context')
+          }
+          if (!automationRegistry) {
+            throw new Error('automationRegistry service unavailable on plugin context')
+          }
+
+          const tenantId = getTenantId(req, context.logger)
+          const current = await installer.loadCurrent(context, tenantId, appManifest.id)
+          if (!current || !isOperationalAfterSalesStatus(current.status)) {
+            res.status(409).json({
+              ok: false,
+              error: {
+                code: 'AFTER_SALES_NOT_INSTALLED',
+                message: 'After-sales must be installed before updating field policies',
+              },
+            })
+            return
+          }
+
+          const blueprint = getDefaultBlueprint()
+          const body = req && req.body && typeof req.body === 'object' ? req.body : {}
+          const roleMatrix = buildFieldPolicyUpdatePayload(blueprint, body.roles)
+          const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
+
+          await rbacProvisioning.applyRoleMatrix({
+            pluginId: resolvePluginId(context),
+            appId: appManifest.id,
+            tenantId,
+            projectId,
+            matrix: roleMatrix,
+          })
+
+          const data = await loadRuntimeAdminState({
+            database: context.api.database,
+            automationRegistry,
+            blueprint,
+            manifest: appManifest,
+            tenantId,
+            pluginId: resolvePluginId(context),
+            appId: appManifest.id,
+            projectId,
+          })
+
+          res.json({
+            ok: true,
+            data,
+          })
+        } catch (err) {
+          if (err && err.code === 'VALIDATION_FAILED') {
+            sendBadRequest(res, err)
+            return
+          }
+          logger.error && logger.error('after-sales runtime field policy update failed', err)
+          res.status(500).json({
+            ok: false,
+            error: { code: 'INTERNAL_ERROR', message: 'Failed to update after-sales field policies' },
           })
         }
       },

--- a/plugins/plugin-after-sales/lib/field-policies.cjs
+++ b/plugins/plugin-after-sales/lib/field-policies.cjs
@@ -2,10 +2,17 @@
 
 const { DEFAULT_FIELD_POLICIES } = require('./blueprint.cjs')
 
+const FIELD_POLICY_OBJECT_ID = 'serviceTicket'
+const FIELD_POLICY_FIELD_NAME = 'refundAmount'
+
 const DEFAULT_EFFECTIVE_POLICY = Object.freeze({
   visibility: 'hidden',
   editability: 'readonly',
 })
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value))
+}
 
 function normalizeClaimValues(input) {
   if (Array.isArray(input)) {
@@ -59,11 +66,22 @@ function buildFieldPolicyResponse(projectId, effectivePolicy) {
   return {
     projectId,
     fields: {
-      serviceTicket: {
-        refundAmount: effectivePolicy,
+      [FIELD_POLICY_OBJECT_ID]: {
+        [FIELD_POLICY_FIELD_NAME]: effectivePolicy,
       },
     },
   }
+}
+
+function normalizeVisibility(value) {
+  return value === 'visible' ? 'visible' : 'hidden'
+}
+
+function normalizeEditability(visibility, value) {
+  if (visibility === 'hidden') {
+    return 'readonly'
+  }
+  return value === 'editable' ? 'editable' : 'readonly'
 }
 
 async function listRegistryFieldPolicies(database, input) {
@@ -91,8 +109,8 @@ async function listRegistryFieldPolicies(database, input) {
   return rows
     .map((row) => ({
       roleSlug: typeof row.role_slug === 'string' ? row.role_slug : '',
-      visibility: row.visibility === 'visible' ? 'visible' : 'hidden',
-      editability: row.editability === 'editable' ? 'editable' : 'readonly',
+      visibility: normalizeVisibility(row.visibility),
+      editability: normalizeEditability(normalizeVisibility(row.visibility), row.editability),
     }))
     .filter((row) => row.roleSlug)
 }
@@ -107,6 +125,135 @@ function listDefaultFieldPolicies(objectId, fieldName) {
     }))
 }
 
+function mergeFieldPolicyRows(defaultPolicies, registryRows) {
+  const mergedByRole = new Map(
+    (Array.isArray(defaultPolicies) ? defaultPolicies : []).map((policy) => [
+      policy.roleSlug,
+      {
+        roleSlug: policy.roleSlug,
+        visibility: normalizeVisibility(policy.visibility),
+        editability: normalizeEditability(
+          normalizeVisibility(policy.visibility),
+          policy.editability,
+        ),
+      },
+    ]),
+  )
+
+  for (const row of Array.isArray(registryRows) ? registryRows : []) {
+    if (!row || typeof row.roleSlug !== 'string' || !row.roleSlug.trim()) continue
+    const visibility = normalizeVisibility(row.visibility)
+    mergedByRole.set(row.roleSlug, {
+      roleSlug: row.roleSlug,
+      visibility,
+      editability: normalizeEditability(visibility, row.editability),
+    })
+  }
+
+  return Array.from(mergedByRole.values())
+}
+
+function buildFieldPolicyRoleMatrix(defaultRoles, defaultPolicies, registryRows) {
+  const mergedRows = mergeFieldPolicyRows(defaultPolicies, registryRows)
+  const mergedByRole = new Map(mergedRows.map((row) => [row.roleSlug, row]))
+
+  return (Array.isArray(defaultRoles) ? defaultRoles : []).map((role) => {
+    const fallback = mergedByRole.get(role.slug) || DEFAULT_EFFECTIVE_POLICY
+    return {
+      roleSlug: typeof role.slug === 'string' ? role.slug : '',
+      roleLabel: typeof role.label === 'string' && role.label.trim() ? role.label.trim() : String(role.slug || ''),
+      visibility: fallback.visibility,
+      editability: fallback.editability,
+    }
+  }).filter((role) => role.roleSlug)
+}
+
+function createValidationError(message, details) {
+  const error = new Error(message)
+  error.code = 'VALIDATION_FAILED'
+  if (details && typeof details === 'object') {
+    error.details = details
+  }
+  return error
+}
+
+function buildFieldPolicyUpdateMatrix(defaultRoles, defaultPolicies, submittedRoles) {
+  const expectedRoles = Array.isArray(defaultRoles) ? defaultRoles : []
+  const expectedRoleSlugs = expectedRoles
+    .map((role) => (typeof role.slug === 'string' ? role.slug.trim() : ''))
+    .filter(Boolean)
+  const submitted = Array.isArray(submittedRoles) ? submittedRoles : []
+  const submittedByRole = new Map()
+
+  for (const row of submitted) {
+    const roleSlug = typeof row.roleSlug === 'string' ? row.roleSlug.trim() : ''
+    if (!roleSlug) {
+      throw createValidationError('field policy updates must include a non-empty roleSlug')
+    }
+    if (submittedByRole.has(roleSlug)) {
+      throw createValidationError(`field policy role(${roleSlug}) is duplicated`)
+    }
+
+    const visibility = normalizeVisibility(row.visibility)
+    if (row.visibility !== 'visible' && row.visibility !== 'hidden') {
+      throw createValidationError(`field policy role(${roleSlug}).visibility is invalid`)
+    }
+    if (row.editability !== 'editable' && row.editability !== 'readonly') {
+      throw createValidationError(`field policy role(${roleSlug}).editability is invalid`)
+    }
+
+    submittedByRole.set(roleSlug, {
+      roleSlug,
+      visibility,
+      editability: normalizeEditability(visibility, row.editability),
+    })
+  }
+
+  const actualRoleSlugs = Array.from(submittedByRole.keys()).sort()
+  const sortedExpectedRoleSlugs = [...expectedRoleSlugs].sort()
+  if (
+    actualRoleSlugs.length !== sortedExpectedRoleSlugs.length
+    || actualRoleSlugs.some((roleSlug, index) => roleSlug !== sortedExpectedRoleSlugs[index])
+  ) {
+    throw createValidationError(
+      'field policies must include every default role exactly once',
+      { expectedRoleSlugs: sortedExpectedRoleSlugs },
+    )
+  }
+
+  const basePolicies = Array.isArray(defaultPolicies)
+    ? defaultPolicies
+        .filter((policy) => policy && policy.objectId === FIELD_POLICY_OBJECT_ID && policy.field === FIELD_POLICY_FIELD_NAME)
+        .map((policy) => ({
+          roleSlug: policy.roleSlug,
+          visibility: policy.visibility,
+          editability: policy.editability,
+        }))
+    : listDefaultFieldPolicies(FIELD_POLICY_OBJECT_ID, FIELD_POLICY_FIELD_NAME)
+  const mergedByRole = new Map(
+    mergeFieldPolicyRows(basePolicies, [])
+      .map((policy) => [policy.roleSlug, policy]),
+  )
+
+  return {
+    roles: expectedRoles.map((role) => clone(role)),
+    fieldPolicies: expectedRoles.map((role) => {
+      const submittedRow = submittedByRole.get(role.slug)
+      const fallbackRow = mergedByRole.get(role.slug) || DEFAULT_EFFECTIVE_POLICY
+      const visibility = submittedRow ? submittedRow.visibility : fallbackRow.visibility
+      const editability = submittedRow ? submittedRow.editability : fallbackRow.editability
+
+      return {
+        objectId: FIELD_POLICY_OBJECT_ID,
+        field: FIELD_POLICY_FIELD_NAME,
+        roleSlug: role.slug,
+        visibility,
+        editability,
+      }
+    }),
+  }
+}
+
 async function resolveFieldPoliciesForUser(database, input) {
   const roleSlugs = Array.isArray(input.roleSlugs)
     ? input.roleSlugs.filter((role) => typeof role === 'string' && role.trim()).map((role) => role.trim())
@@ -116,13 +263,13 @@ async function resolveFieldPoliciesForUser(database, input) {
     pluginId: input.pluginId,
     appId: input.appId,
     projectId: input.projectId,
-    objectId: 'serviceTicket',
-    fieldName: 'refundAmount',
+    objectId: FIELD_POLICY_OBJECT_ID,
+    fieldName: FIELD_POLICY_FIELD_NAME,
   })
-
-  const candidateRows = registryRows.length > 0
-    ? registryRows
-    : listDefaultFieldPolicies('serviceTicket', 'refundAmount')
+  const candidateRows = mergeFieldPolicyRows(
+    listDefaultFieldPolicies(FIELD_POLICY_OBJECT_ID, FIELD_POLICY_FIELD_NAME),
+    registryRows,
+  )
   const matchingRows = candidateRows.filter((row) => roleSlugs.includes(row.roleSlug))
 
   return buildFieldPolicyResponse(input.projectId, mergeEffectivePolicy(matchingRows))
@@ -130,7 +277,13 @@ async function resolveFieldPoliciesForUser(database, input) {
 
 module.exports = {
   DEFAULT_EFFECTIVE_POLICY,
+  FIELD_POLICY_FIELD_NAME,
+  FIELD_POLICY_OBJECT_ID,
+  buildFieldPolicyRoleMatrix,
   buildFieldPolicyResponse,
+  buildFieldPolicyUpdateMatrix,
+  listDefaultFieldPolicies,
+  listRegistryFieldPolicies,
   mergeEffectivePolicy,
   resolveFieldPolicyRoleSlugs,
   resolveFieldPoliciesForUser,

--- a/plugins/plugin-after-sales/lib/runtime-admin.cjs
+++ b/plugins/plugin-after-sales/lib/runtime-admin.cjs
@@ -1,0 +1,184 @@
+'use strict'
+
+const {
+  FIELD_POLICY_FIELD_NAME,
+  FIELD_POLICY_OBJECT_ID,
+  buildFieldPolicyRoleMatrix,
+  buildFieldPolicyUpdateMatrix,
+  listRegistryFieldPolicies,
+} = require('./field-policies.cjs')
+
+function titleizeIdentifier(value) {
+  return String(value || '')
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value))
+}
+
+function createValidationError(message, details) {
+  const error = new Error(message)
+  error.code = 'VALIDATION_FAILED'
+  if (details && typeof details === 'object') {
+    error.details = details
+  }
+  return error
+}
+
+function buildWorkflowNameMap(manifest) {
+  const workflows = Array.isArray(manifest && manifest.workflows) ? manifest.workflows : []
+  return new Map(
+    workflows
+      .filter((workflow) => workflow && typeof workflow.id === 'string' && workflow.id.trim())
+      .map((workflow) => [workflow.id.trim(), typeof workflow.name === 'string' && workflow.name.trim()
+        ? workflow.name.trim()
+        : titleizeIdentifier(workflow.id)]),
+  )
+}
+
+function buildDefaultAutomationEntries(blueprint, manifest) {
+  const workflowNames = buildWorkflowNameMap(manifest)
+  const automations = Array.isArray(blueprint && blueprint.automations) ? blueprint.automations : []
+
+  return automations.map((rule) => ({
+    id: typeof rule.id === 'string' ? rule.id : '',
+    name: workflowNames.get(rule.id) || titleizeIdentifier(rule.id),
+    triggerEvent:
+      rule &&
+      rule.trigger &&
+      typeof rule.trigger === 'object' &&
+      typeof rule.trigger.event === 'string'
+        ? rule.trigger.event
+        : '',
+    enabled: rule && rule.enabled !== false,
+  }))
+}
+
+function overlayAutomationEntries(defaultEntries, registryRules) {
+  const enabledById = new Map()
+  for (const rule of Array.isArray(registryRules) ? registryRules : []) {
+    if (!rule || typeof rule.id !== 'string' || !rule.id.trim()) continue
+    enabledById.set(rule.id.trim(), rule.enabled !== false)
+  }
+
+  return defaultEntries.map((entry) => ({
+    ...entry,
+    enabled: enabledById.has(entry.id) ? enabledById.get(entry.id) : entry.enabled,
+  }))
+}
+
+function normalizeAutomationUpdates(defaultEntries, submittedAutomations) {
+  const expectedRuleIds = defaultEntries.map((entry) => entry.id)
+  const updates = Array.isArray(submittedAutomations) ? submittedAutomations : []
+  const updatesById = new Map()
+
+  for (const update of updates) {
+    const id = update && typeof update.id === 'string' ? update.id.trim() : ''
+    if (!id) {
+      throw createValidationError('automation updates must include a non-empty id')
+    }
+    if (typeof update.enabled !== 'boolean') {
+      throw createValidationError(`automation(${id}).enabled must be boolean`)
+    }
+    if (updatesById.has(id)) {
+      throw createValidationError(`automation(${id}) is duplicated`)
+    }
+    updatesById.set(id, update.enabled)
+  }
+
+  const actualRuleIds = Array.from(updatesById.keys()).sort()
+  const sortedExpectedRuleIds = [...expectedRuleIds].sort()
+  if (
+    actualRuleIds.length !== sortedExpectedRuleIds.length
+    || actualRuleIds.some((ruleId, index) => ruleId !== sortedExpectedRuleIds[index])
+  ) {
+    throw createValidationError(
+      'automations must include every default rule exactly once',
+      { expectedRuleIds: sortedExpectedRuleIds },
+    )
+  }
+
+  return defaultEntries.map((entry) => ({
+    id: entry.id,
+    enabled: updatesById.get(entry.id),
+  }))
+}
+
+async function loadRuntimeAdminState(input) {
+  const {
+    database,
+    automationRegistry,
+    blueprint,
+    manifest,
+    tenantId,
+    pluginId,
+    appId,
+    projectId,
+  } = input || {}
+
+  if (!database || typeof database.query !== 'function') {
+    throw new Error('database.query is required for runtime admin')
+  }
+  if (!automationRegistry || typeof automationRegistry.listRules !== 'function') {
+    throw new Error('automationRegistry.listRules is required for runtime admin')
+  }
+
+  const defaultAutomationEntries = buildDefaultAutomationEntries(blueprint, manifest)
+  const registryRules = await automationRegistry.listRules({
+    tenantId,
+    pluginId,
+    appId,
+    projectId,
+  })
+  const registryFieldPolicies = await listRegistryFieldPolicies(database, {
+    tenantId,
+    pluginId,
+    appId,
+    projectId,
+    objectId: FIELD_POLICY_OBJECT_ID,
+    fieldName: FIELD_POLICY_FIELD_NAME,
+  })
+
+  return {
+    projectId,
+    automations: overlayAutomationEntries(defaultAutomationEntries, registryRules),
+    fieldPolicies: {
+      objectId: FIELD_POLICY_OBJECT_ID,
+      field: FIELD_POLICY_FIELD_NAME,
+      roles: buildFieldPolicyRoleMatrix(
+        Array.isArray(blueprint && blueprint.roles) ? blueprint.roles : [],
+        Array.isArray(blueprint && blueprint.fieldPolicies) ? blueprint.fieldPolicies : [],
+        registryFieldPolicies,
+      ),
+    },
+  }
+}
+
+function buildAutomationUpdateRules(blueprint, manifest, submittedAutomations) {
+  const defaultAutomationEntries = buildDefaultAutomationEntries(blueprint, manifest)
+  const normalizedUpdates = normalizeAutomationUpdates(defaultAutomationEntries, submittedAutomations)
+  const updatesById = new Map(normalizedUpdates.map((update) => [update.id, update.enabled]))
+
+  return (Array.isArray(blueprint && blueprint.automations) ? blueprint.automations : []).map((rule) => ({
+    ...clone(rule),
+    enabled: updatesById.get(rule.id),
+  }))
+}
+
+function buildFieldPolicyUpdatePayload(blueprint, submittedRoles) {
+  return buildFieldPolicyUpdateMatrix(
+    Array.isArray(blueprint && blueprint.roles) ? blueprint.roles : [],
+    Array.isArray(blueprint && blueprint.fieldPolicies) ? blueprint.fieldPolicies : [],
+    submittedRoles,
+  )
+}
+
+module.exports = {
+  buildAutomationUpdateRules,
+  buildFieldPolicyUpdatePayload,
+  loadRuntimeAdminState,
+}


### PR DESCRIPTION
## Summary
- add plugin-local runtime admin APIs for after-sales automations and refundAmount field policies
- add the corresponding AfterSalesView runtime admin UI and test coverage
- sync the after-sales manifest workflow list with the real default automation set
- add design and verification docs for the runtime-admin slice

## Verification
- `pnpm --filter @metasheet/core-backend test:unit`
- `DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web exec vitest run tests/AfterSalesView.spec.ts tests/AfterSalesView.follow-ups.spec.ts tests/AfterSalesView.customers.spec.ts tests/AfterSalesView.installed-assets.spec.ts tests/AfterSalesView.service-records.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`

## Docs
- `docs/after-sales-runtime-admin-v1-design-20260411.md`
- `docs/after-sales-runtime-admin-v1-verification-20260411.md`
