### PR TITLE
test(contract): add document semantics pact coverage

### DIFF
--- a/docs/development/plm-yuantus-document-semantics-pact-wave2-20260411.md
+++ b/docs/development/plm-yuantus-document-semantics-pact-wave2-20260411.md
@@ -1,0 +1,96 @@
+# PLM Yuantus Document Semantics Pact Wave 2
+
+## Goal
+
+Extend the existing Metasheet2 -> Yuantus PLM pact artifact so it locks the
+document semantics calls already used by `PLMAdapter.getProductDocuments()` in
+`apiMode='yuantus'`.
+
+Before this slice, the implementation already merged:
+
+- physical file attachments via `GET /api/v1/file/item/{item_id}`
+- file metadata enrichment via `GET /api/v1/file/{file_id}`
+- AML related documents via `POST /api/v1/aml/query` + `expand: ['Document Part']`
+
+But the pact artifact still covered only the original 6 Wave 1 interactions.
+
+## Design
+
+### Canonical contract surface
+
+The pact artifact now includes 9 interactions total:
+
+1. `POST /api/v1/auth/login`
+2. `GET /api/v1/health`
+3. `GET /api/v1/search/`
+4. `POST /api/v1/aml/apply`
+5. `GET /api/v1/bom/{id}/tree`
+6. `GET /api/v1/bom/compare`
+7. `GET /api/v1/file/item/{item_id}`
+8. `GET /api/v1/file/{file_id}`
+9. `POST /api/v1/aml/query`
+
+### Contract-first rule
+
+The artifact still follows the same rule as Wave 1:
+
+- freeze only endpoints the live consumer actually calls
+- do not add aspirational endpoints
+- keep drift detection against `PLMAdapter.ts`
+
+That is why document semantics is now in scope, but unrelated Wave 2 candidates
+such as `where-used`, `compare/schema`, and ECO approval mutations remain out.
+
+### New assertions
+
+The static vitest sanity test now also verifies that:
+
+- `PLMAdapter.ts` still references `file/item`, `aml/query`, and the file
+  metadata enrichment helper
+- the AML query interaction still locks `expand: ['Document Part']`
+
+## Files Changed
+
+- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json`
+- `packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts`
+- `packages/core-backend/tests/contract/README.md`
+
+## Verification
+
+### Clean worktree contract test
+
+Command:
+
+```bash
+cd /tmp/metasheet2-docs-wave2-V3Ytr1
+npx vitest run packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+```
+
+Result:
+
+```text
+1 file passed, 8 tests passed
+```
+
+### Unit coverage against installed workspace deps
+
+Command:
+
+```bash
+cd /Users/huazhou/Downloads/Github/metasheet2/packages/core-backend
+npx vitest run \
+  tests/unit/plm-adapter-yuantus.test.ts \
+  tests/unit/federation.contract.test.ts
+```
+
+Result:
+
+```text
+2 files passed, 20 tests passed
+```
+
+Note:
+the clean worktree inherited pnpm symlink-resolution issues for package-local
+dependencies such as `uuid`, so the unchanged unit suites were verified against
+the primary repo's installed dependency graph instead. The code under test for
+those suites was unchanged by this slice.

--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -20,8 +20,10 @@ when running in `apiMode='yuantus'`. Without a contract test, any field
 rename on the Yuantus side would silently break Metasheet at runtime.
 
 This Pact set freezes the **shape** (not the values) of the 6 Wave 1 P0
-endpoints that `PLMAdapter.ts` currently calls. (Codex's PACT_FIRST plan
-lists 7 endpoints in Wave 1 — see "Discrepancy with codex plan" below.)
+endpoints plus the 3 document-semantics endpoints that `PLMAdapter.ts`
+currently calls in `getProductDocuments()` for `apiMode='yuantus'`.
+(Codex's PACT_FIRST plan lists 7 endpoints in Wave 1 — see "Discrepancy
+with codex plan" below.)
 
 The companion provider verifier lives in the Yuantus repo at
 `src/yuantus/api/tests/test_pact_provider_yuantus_plm.py`.
@@ -35,7 +37,7 @@ because adding that npm dependency requires explicit approval.
 The `plm-adapter-yuantus.pact.test.ts` vitest test guards three things:
 
 1. The pact JSON exists and parses as Pact v3.
-2. It contains the 6 Wave 1 P0 interactions in the documented order.
+2. It contains the 9 currently used interactions in the documented order.
 3. Every endpoint named in the pact is also referenced by the live
    `packages/core-backend/src/data-adapters/PLMAdapter.ts` source — so the
    pact cannot drift away from what the adapter actually calls.
@@ -143,11 +145,11 @@ specification of what the generated pact must contain.
 
 ## Wave 2 endpoints
 
-These are intentionally NOT in the Wave 1 pact:
+The following endpoints were intentionally out of scope for the first pact.
+Document semantics is now covered, so these still remain outside the pact:
 
 - `GET /api/v1/bom/{id}/where-used`
 - `GET /api/v1/bom/compare/schema`
-- `GET /api/v1/file/item/{item_id}`
 - `GET /api/v1/eco/{id}/approvals`
 - `POST /api/v1/eco/{id}/approve`
 - `POST /api/v1/eco/{id}/reject`

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -9,7 +9,7 @@
     "pactSpecification": {
       "version": "3.0.0"
     },
-    "claudeNote": "Hand-authored Wave 1 P0 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called, so metadata is deferred to Wave 2 (or earlier once PLMAdapter starts using it)."
+    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called. Wave 2 now adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']."
   },
   "interactions": [
     {
@@ -368,6 +368,266 @@
             "$.added": { "matchers": [{ "match": "type", "min": 0 }] },
             "$.removed": { "matchers": [{ "match": "type", "min": 0 }] },
             "$.changed": { "matchers": [{ "match": "type", "min": 0 }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "list file attachments for a Part through the item files endpoint",
+      "providerStates": [
+        {
+          "name": "a Part with id 01H000000000000000000000P1 has an attached file 01H000000000000000000000F1"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/file/item/01H000000000000000000000P1",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": [
+          {
+            "id": "01H000000000000000000000A1",
+            "file_id": "01H000000000000000000000F1",
+            "filename": "mounting-bracket-drawing.pdf",
+            "file_role": "primary",
+            "description": "Primary manufacturing drawing",
+            "file_type": "pdf",
+            "file_size": 2048,
+            "document_type": "drawing",
+            "author": "metasheet-svc",
+            "source_system": "yuantus",
+            "source_version": "v1",
+            "document_version": "A",
+            "preview_url": "/api/v1/file/01H000000000000000000000F1/preview",
+            "download_url": "/api/v1/file/01H000000000000000000000F1/download"
+          }
+        ],
+        "matchingRules": {
+          "body": {
+            "$": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$[*].id": { "matchers": [{ "match": "type" }] },
+            "$[*].file_id": { "matchers": [{ "match": "type" }] },
+            "$[*].filename": { "matchers": [{ "match": "type" }] },
+            "$[*].file_role": { "matchers": [{ "match": "type" }] },
+            "$[*].description": { "matchers": [{ "match": "type" }] },
+            "$[*].file_type": { "matchers": [{ "match": "type" }] },
+            "$[*].file_size": { "matchers": [{ "match": "integer" }] },
+            "$[*].document_type": { "matchers": [{ "match": "type" }] },
+            "$[*].author": { "matchers": [{ "match": "type" }] },
+            "$[*].source_system": { "matchers": [{ "match": "type" }] },
+            "$[*].source_version": { "matchers": [{ "match": "type" }] },
+            "$[*].document_version": { "matchers": [{ "match": "type" }] },
+            "$[*].preview_url": { "matchers": [{ "match": "type" }] },
+            "$[*].download_url": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch file metadata for an attached CAD or document file",
+      "providerStates": [
+        {
+          "name": "a Part with id 01H000000000000000000000P1 has an attached file 01H000000000000000000000F1"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/file/01H000000000000000000000F1",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": "01H000000000000000000000F1",
+          "filename": "mounting-bracket-drawing.pdf",
+          "file_type": "pdf",
+          "mime_type": "application/pdf",
+          "file_size": 2048,
+          "checksum": "sha256-demo-file-1",
+          "document_type": "drawing",
+          "is_native_cad": false,
+          "author": "metasheet-svc",
+          "source_system": "yuantus",
+          "source_version": "v1",
+          "document_version": "A",
+          "preview_url": "/api/v1/file/01H000000000000000000000F1/preview",
+          "geometry_url": null,
+          "cad_manifest_url": null,
+          "cad_document_url": null,
+          "cad_metadata_url": null,
+          "cad_bom_url": null,
+          "cad_dedup_url": null,
+          "cad_viewer_url": null,
+          "cad_document_schema_version": null,
+          "cad_review_state": null,
+          "cad_review_note": null,
+          "cad_review_by_id": null,
+          "cad_reviewed_at": null,
+          "conversion_status": "pending",
+          "viewer_readiness": {},
+          "created_at": "2026-01-01T00:00:00Z"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": { "matchers": [{ "match": "type" }] },
+            "$.filename": { "matchers": [{ "match": "type" }] },
+            "$.file_type": { "matchers": [{ "match": "type" }] },
+            "$.mime_type": { "matchers": [{ "match": "type" }] },
+            "$.file_size": { "matchers": [{ "match": "integer" }] },
+            "$.checksum": { "matchers": [{ "match": "type" }] },
+            "$.document_type": { "matchers": [{ "match": "type" }] },
+            "$.is_native_cad": { "matchers": [{ "match": "type" }] },
+            "$.author": { "matchers": [{ "match": "type" }] },
+            "$.source_system": { "matchers": [{ "match": "type" }] },
+            "$.source_version": { "matchers": [{ "match": "type" }] },
+            "$.document_version": { "matchers": [{ "match": "type" }] },
+            "$.preview_url": { "matchers": [{ "match": "type" }] },
+            "$.conversion_status": { "matchers": [{ "match": "type" }] },
+            "$.viewer_readiness": { "matchers": [{ "match": "type" }] },
+            "$.created_at": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "expand related Documents for a Part through AML query",
+      "providerStates": [
+        {
+          "name": "a Part with id 01H000000000000000000000P1 has a related Document through Document Part"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/aml/query",
+        "headers": {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "body": {
+          "type": "Part",
+          "where": {
+            "id": "01H000000000000000000000P1"
+          },
+          "select": ["id", "name", "state", "properties", "current_version_id", "config_id"],
+          "expand": ["Document Part"],
+          "depth": 1,
+          "page": 1,
+          "page_size": 1
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+            }
+          },
+          "body": {
+            "$.type": { "matchers": [{ "match": "type" }] },
+            "$.where.id": { "matchers": [{ "match": "type" }] },
+            "$.select": { "matchers": [{ "match": "type", "min": 1 }] },
+            "$.expand": { "matchers": [{ "match": "type", "min": 1 }] },
+            "$.depth": { "matchers": [{ "match": "integer" }] },
+            "$.page": { "matchers": [{ "match": "integer" }] },
+            "$.page_size": { "matchers": [{ "match": "integer" }] }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "items": [
+            {
+              "id": "01H000000000000000000000P1",
+              "type": "Part",
+              "name": "Mounting Bracket",
+              "state": "Released",
+              "config_id": "01H000000000000000000000C1",
+              "properties": {
+                "item_number": "P-0001",
+                "name": "Mounting Bracket"
+              },
+              "Document Part": [
+                {
+                  "id": "01H000000000000000000000D1",
+                  "type": "Document",
+                  "number": "DOC-0001",
+                  "name": "Mounting Bracket Drawing",
+                  "generation": 1,
+                  "state": "Draft",
+                  "config_id": "01H000000000000000000000CD1",
+                  "is_current": true,
+                  "properties": {
+                    "item_number": "DOC-0001",
+                    "doc_number": "DOC-0001",
+                    "number": "DOC-0001",
+                    "name": "Mounting Bracket Drawing",
+                    "current_version_id": "VER-0001",
+                    "document_type": "drawing"
+                  },
+                  "_rel_properties": {
+                    "role": "related_document"
+                  }
+                }
+              ]
+            }
+          ],
+          "total": 1,
+          "page": 1,
+          "page_size": 1,
+          "has_more": false
+        },
+        "matchingRules": {
+          "body": {
+            "$.items": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.items[*].id": { "matchers": [{ "match": "type" }] },
+            "$.items[*].type": { "matchers": [{ "match": "type" }] },
+            "$.items[*].name": { "matchers": [{ "match": "type" }] },
+            "$.items[*].state": { "matchers": [{ "match": "type" }] },
+            "$.items[*].config_id": { "matchers": [{ "match": "type" }] },
+            "$.items[*].properties": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part']": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.items[*]['Document Part'][*].id": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part'][*].type": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part'][*].number": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part'][*].name": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part'][*].generation": { "matchers": [{ "match": "integer" }] },
+            "$.items[*]['Document Part'][*].state": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part'][*].config_id": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part'][*].is_current": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part'][*].properties": { "matchers": [{ "match": "type" }] },
+            "$.items[*]['Document Part'][*]._rel_properties": { "matchers": [{ "match": "type" }] },
+            "$.total": { "matchers": [{ "match": "integer", "min": 0 }] },
+            "$.page": { "matchers": [{ "match": "integer", "min": 1 }] },
+            "$.page_size": { "matchers": [{ "match": "integer", "min": 1 }] },
+            "$.has_more": { "matchers": [{ "match": "type" }] }
           }
         }
       }

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -10,11 +10,11 @@
  * What this test guarantees today:
  *
  *   1. The pact JSON exists and parses as Pact v3.
- *   2. The 6 Wave 1 P0 interactions that PLMAdapter currently calls are
- *      present, in the order documented in
- *      `docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md`.
+ *   2. The 6 Wave 1 P0 interactions plus the document-semantics Wave 2
+ *      interactions that PLMAdapter currently calls are present, in the
+ *      documented order.
  *      (codex's plan also lists `aml/metadata`, but PLMAdapter does not yet
- *      call it; deferred to Wave 1.5.)
+ *      call it; deferred until there is a real consumer call site.)
  *   3. The PLMAdapter actually calls every endpoint declared in the pact, so
  *      the contract cannot drift away from the live consumer code without
  *      this test failing.
@@ -80,13 +80,16 @@ interface PactDocument {
 // is listed as Wave 1 P0 in docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md, but
 // PLMAdapter.ts does not currently invoke it. It is parked for Wave 1.5 / Wave
 // 2 and will be added to this list as soon as the adapter starts calling it.
-const WAVE_1_P0_PATHS = [
+const PACT_PATHS = [
   { method: 'POST', path: '/api/v1/auth/login' },
   { method: 'GET', path: '/api/v1/health' },
   { method: 'GET', path: '/api/v1/search/' },
   { method: 'POST', path: '/api/v1/aml/apply' },
   { method: 'GET', path: '/api/v1/bom/01H000000000000000000000P1/tree' },
   { method: 'GET', path: '/api/v1/bom/compare' },
+  { method: 'GET', path: '/api/v1/file/item/01H000000000000000000000P1' },
+  { method: 'GET', path: '/api/v1/file/01H000000000000000000000F1' },
+  { method: 'POST', path: '/api/v1/aml/query' },
 ] as const
 
 function loadPact(): PactDocument {
@@ -98,7 +101,7 @@ function loadAdapter(): string {
   return readFileSync(ADAPTER_PATH, 'utf8')
 }
 
-describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1)', () => {
+describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + document semantics Wave 2)', () => {
   it('pact JSON exists, parses as Pact v3, and names the right consumer/provider', () => {
     const pact = loadPact()
     expect(pact.consumer.name).toBe('Metasheet2')
@@ -106,11 +109,11 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1)', () => {
     expect(pact.metadata.pactSpecification.version).toBe('3.0.0')
   })
 
-  it('contains exactly the 6 Wave 1 P0 interactions PLMAdapter currently calls, in documented order', () => {
+  it('contains exactly the currently used interactions PLMAdapter calls, in documented order', () => {
     const pact = loadPact()
-    expect(pact.interactions).toHaveLength(WAVE_1_P0_PATHS.length)
+    expect(pact.interactions).toHaveLength(PACT_PATHS.length)
     pact.interactions.forEach((interaction, index) => {
-      const expected = WAVE_1_P0_PATHS[index]
+      const expected = PACT_PATHS[index]
       expect(interaction.request.method).toBe(expected.method)
       expect(interaction.request.path).toBe(expected.path)
     })
@@ -127,9 +130,9 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1)', () => {
 
   it('every protected endpoint is also called by the live PLMAdapter source', () => {
     const adapterSrc = loadAdapter()
-    // The 6 endpoints declared in the pact should appear verbatim in PLMAdapter.ts
-    // (as path segments). The auth/login endpoint is invoked via raw fetch and
-    // also appears as a string literal.
+    // Every endpoint declared in the pact should appear verbatim in
+    // PLMAdapter.ts (as path segments or helper callsites), so the pact
+    // cannot silently drift away from the live consumer implementation.
     const endpointsToFind = [
       '/api/v1/auth/login',
       '/api/v1/health',
@@ -137,6 +140,9 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1)', () => {
       '/api/v1/aml/apply',
       '/api/v1/bom/',
       '/api/v1/bom/compare',
+      '/api/v1/file/item/',
+      '/api/v1/aml/query',
+      'fetchYuantusFileMetadata',
     ]
     for (const ep of endpointsToFind) {
       expect(
@@ -169,5 +175,35 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1)', () => {
     expect(body).toHaveProperty('count')
     expect(body).toHaveProperty('items')
     expect(Array.isArray(body.items)).toBe(true)
+  })
+
+  it('document semantics interactions lock attachment listing, file metadata enrichment, and AML related-doc expansion', () => {
+    const pact = loadPact()
+    const attachmentList = pact.interactions.find(
+      i => i.request.path === '/api/v1/file/item/01H000000000000000000000P1',
+    )
+    const fileMetadata = pact.interactions.find(
+      i => i.request.path === '/api/v1/file/01H000000000000000000000F1',
+    )
+    const amlQuery = pact.interactions.find(
+      i => i.request.path === '/api/v1/aml/query',
+    )
+
+    expect(attachmentList).toBeDefined()
+    expect(fileMetadata).toBeDefined()
+    expect(amlQuery).toBeDefined()
+  })
+
+  it('aml/query request body documents the expand Document Part envelope used by getProductDocuments', () => {
+    const pact = loadPact()
+    const amlQuery = pact.interactions.find(
+      i => i.request.path === '/api/v1/aml/query',
+    )
+    expect(amlQuery).toBeDefined()
+    const body = amlQuery!.request.body as Record<string, unknown>
+    expect(body.type).toBe('Part')
+    expect(body.where).toEqual({ id: '01H000000000000000000000P1' })
+    expect(body.expand).toEqual(['Document Part'])
+    expect(body.page_size).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- extend the Metasheet2 -> Yuantus pact artifact from 6 to 9 live interactions
- lock document semantics coverage for file attachments, file metadata enrichment, and AML related-document expansion
- update the static contract test and contract README to reflect the new scope

## Verification
- npx vitest run packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
- cd /Users/huazhou/Downloads/Github/metasheet2/packages/core-backend && npx vitest run tests/unit/plm-adapter-yuantus.test.ts tests/unit/federation.contract.test.ts

## Design
- docs/development/plm-yuantus-document-semantics-pact-wave2-20260411.md