### PR TITLE
fix(after-sales): surface runtime admin refresh failures

### DIFF
--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -4132,7 +4132,10 @@ async function requestTicketRefund(ticket: TicketViewModel) {
   }
 }
 
-async function loadFieldPoliciesForCurrentState(state: CurrentResponse): Promise<void> {
+async function loadFieldPoliciesForCurrentState(
+  state: CurrentResponse,
+  options: { strict?: boolean } = {},
+): Promise<void> {
   if (state.status !== 'installed' && state.status !== 'partial') {
     ticketFieldPolicies.value = null
     return
@@ -4140,12 +4143,18 @@ async function loadFieldPoliciesForCurrentState(state: CurrentResponse): Promise
 
   try {
     ticketFieldPolicies.value = await readEnvelope<TicketFieldPolicyResponse>('/api/after-sales/field-policies')
-  } catch {
+  } catch (err: unknown) {
     ticketFieldPolicies.value = null
+    if (options.strict) {
+      throw err instanceof Error ? err : new Error('Failed to load after-sales field policies')
+    }
   }
 }
 
-async function loadRuntimeAdminForCurrentState(state: CurrentResponse): Promise<void> {
+async function loadRuntimeAdminForCurrentState(
+  state: CurrentResponse,
+  options: { strict?: boolean } = {},
+): Promise<void> {
   runtimeAdminError.value = ''
   runtimeAdminAutomationsError.value = ''
   runtimeAdminFieldPoliciesError.value = ''
@@ -4166,17 +4175,21 @@ async function loadRuntimeAdminForCurrentState(state: CurrentResponse): Promise<
 
   try {
     const { response, payload } = await readEnvelopeResponse<RuntimeAdminResponse>('/api/after-sales/runtime-admin')
+    const responseMessage = extractMessage(payload, `${response.status} ${response.statusText}`)
 
     if (response.status === 403) {
       runtimeAdminAccessDenied.value = true
       resetRuntimeAdminDrafts()
+      if (options.strict) {
+        throw new Error(responseMessage)
+      }
       return
     }
 
     runtimeAdminAccessDenied.value = false
 
     if (!response.ok) {
-      throw new Error(extractMessage(payload, `${response.status} ${response.statusText}`))
+      throw new Error(responseMessage)
     }
 
     const runtimeAdminPayload = (payload as ApiEnvelope<RuntimeAdminResponse> | null)?.data
@@ -4190,6 +4203,9 @@ async function loadRuntimeAdminForCurrentState(state: CurrentResponse): Promise<
     runtimeAdminAccessDenied.value = false
     runtimeAdminError.value = err instanceof Error ? err.message : 'Failed to load runtime admin controls'
     resetRuntimeAdminDrafts()
+    if (options.strict) {
+      throw err instanceof Error ? err : new Error('Failed to load runtime admin controls')
+    }
   } finally {
     runtimeAdminLoading.value = false
   }
@@ -4250,7 +4266,7 @@ async function saveRuntimeAdminAutomations() {
         })),
       }),
     })
-    await loadRuntimeAdminForCurrentState(current.value)
+    await loadRuntimeAdminForCurrentState(current.value, { strict: true })
     runtimeAdminAutomationsSuccess.value = 'Saved automation controls'
   } catch (err: unknown) {
     runtimeAdminAutomationsError.value = err instanceof Error ? err.message : 'Failed to save automations'
@@ -4285,8 +4301,8 @@ async function saveRuntimeAdminFieldPolicies() {
       }),
     })
     await Promise.all([
-      loadRuntimeAdminForCurrentState(current.value),
-      loadFieldPoliciesForCurrentState(current.value),
+      loadRuntimeAdminForCurrentState(current.value, { strict: true }),
+      loadFieldPoliciesForCurrentState(current.value, { strict: true }),
     ])
     runtimeAdminFieldPoliciesSuccess.value = 'Saved field policies'
   } catch (err: unknown) {

--- a/apps/web/tests/AfterSalesView.spec.ts
+++ b/apps/web/tests/AfterSalesView.spec.ts
@@ -1640,6 +1640,105 @@ describe('AfterSalesView', () => {
     expect(toggle.checked).toBe(false)
   })
 
+  it('shows an automation save error when the post-save runtime-admin refresh fails', async () => {
+    let runtimeAdminLoads = 0
+
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [
+            { id: 'ticket-triage', name: 'Ticket Triage' },
+            { id: 'sla-watcher', name: 'SLA Watcher' },
+            { id: 'refund-approval', name: 'Refund Approval' },
+            { id: 'service-record-notify', name: 'Service Record Notification' },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-runtime-admin-save-error',
+          },
+          reportRef: 'install-runtime-admin-save-error',
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin' && !options?.method) {
+        runtimeAdminLoads += 1
+        if (runtimeAdminLoads === 1) {
+          return createRuntimeAdminResponse()
+        }
+        return createResponse({}, { ok: false, status: 500, statusText: 'Internal Server Error' })
+      }
+
+      if (path === '/api/after-sales/runtime-admin/automations' && options?.method === 'PUT') {
+        return createRuntimeAdminResponse()
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createFieldPoliciesResponse({
+          visibility: 'visible',
+          editability: 'editable',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, tickets: [] })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/customers') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, customers: [] })
+      }
+
+      if (path === '/api/after-sales/follow-ups') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, followUps: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'Default automation rules')
+
+    const toggle = container?.querySelector<HTMLInputElement>('#after-sales-runtime-admin-automation-sla-watcher')
+    expect(toggle).toBeTruthy()
+    if (!toggle) return
+
+    await setCheckboxValue(toggle, false)
+    findButton(container, 'Save automations').click()
+    await waitForText(container, '500 Internal Server Error')
+
+    expect(container?.textContent).not.toContain('Saved automation controls')
+  })
+
   it('saves runtime admin field policies and refreshes refund controls', async () => {
     let fieldPolicyMode: 'hidden' | 'visible' = 'hidden'
     let fieldPolicyEditability: 'readonly' | 'editable' = 'readonly'
@@ -1823,6 +1922,177 @@ describe('AfterSalesView', () => {
     expect(container?.querySelector('#after-sales-ticket-refund-amount')).not.toBeNull()
     expect(container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-amount')?.disabled).toBe(false)
     expect(container?.querySelector<HTMLInputElement>('#after-sales-ticket-refund-request-ticket-1')?.disabled).toBe(false)
+  })
+
+  it('shows a field policy save error when the post-save policy refresh fails', async () => {
+    let fieldPolicyVisible = false
+    let fieldPolicyReads = 0
+
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [
+            { id: 'ticket-triage', name: 'Ticket Triage' },
+            { id: 'sla-watcher', name: 'SLA Watcher' },
+            { id: 'refund-approval', name: 'Refund Approval' },
+            { id: 'service-record-notify', name: 'Service Record Notification' },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-runtime-admin-field-policy-error',
+          },
+          reportRef: 'install-runtime-admin-field-policy-error',
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin') {
+        return createRuntimeAdminResponse({
+          fieldPolicies: [
+            {
+              roleSlug: 'finance',
+              roleLabel: 'Finance',
+              visibility: fieldPolicyVisible ? 'visible' : 'hidden',
+              editability: fieldPolicyVisible ? 'editable' : 'readonly',
+            },
+            {
+              roleSlug: 'supervisor',
+              roleLabel: 'Supervisor',
+              visibility: 'visible',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'customer_service',
+              roleLabel: 'Customer Service',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'technician',
+              roleLabel: 'Technician',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/runtime-admin/field-policies' && options?.method === 'PUT') {
+        fieldPolicyVisible = true
+        return createRuntimeAdminResponse({
+          fieldPolicies: [
+            {
+              roleSlug: 'finance',
+              roleLabel: 'Finance',
+              visibility: 'visible',
+              editability: 'editable',
+            },
+            {
+              roleSlug: 'supervisor',
+              roleLabel: 'Supervisor',
+              visibility: 'visible',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'customer_service',
+              roleLabel: 'Customer Service',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+            {
+              roleSlug: 'technician',
+              roleLabel: 'Technician',
+              visibility: 'hidden',
+              editability: 'readonly',
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        fieldPolicyReads += 1
+        if (fieldPolicyReads === 1) {
+          return createFieldPoliciesResponse({
+            visibility: 'hidden',
+            editability: 'readonly',
+          })
+        }
+        return createResponse({}, { ok: false, status: 500, statusText: 'Internal Server Error' })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: 1,
+          tickets: [
+            {
+              id: 'ticket-1',
+              version: 1,
+              data: {
+                ticketNo: 'AF-001',
+                title: 'Install compressor',
+                status: 'open',
+                refundStatus: '',
+                refundAmount: 88.5,
+              },
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/customers') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, customers: [] })
+      }
+
+      if (path === '/api/after-sales/follow-ups') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, followUps: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'refundAmount role matrix')
+
+    const visibilitySelect = container?.querySelector<HTMLSelectElement>('#after-sales-runtime-admin-field-policy-finance-visibility')
+    expect(visibilitySelect).toBeTruthy()
+    if (!visibilitySelect) return
+
+    await setSelectValue(visibilitySelect, 'visible')
+    findButton(container, 'Save field policies').click()
+    await waitForText(container, '500 Internal Server Error')
+
+    expect(container?.textContent).not.toContain('Saved field policies')
   })
 
   it('reloads the refund controls after a field-policy save', async () => {


### PR DESCRIPTION
## Summary
- fix AfterSalesView runtime-admin save flows so post-save refresh failures surface as errors
- cover both failure paths with focused frontend tests

## Context
- follow-up to merged PR #786
- #786 landed the runtime-admin surface itself
- this PR only keeps the save UX honest when the follow-up refresh fails after a successful write

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/AfterSalesView.spec.ts --watch=false`

## Scope
- `apps/web/src/views/AfterSalesView.vue`
- `apps/web/tests/AfterSalesView.spec.ts`
