### PR TITLE
ci(after-sales): enforce integration test gate

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Use empty npmrc for pnpm
         run: |
           echo "" > /tmp/empty-npmrc
-          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> $GITHUB_ENV
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -159,6 +159,87 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.node-version }}
+          path: |
+            packages/core-backend/coverage/
+            packages/core-backend/test-results/
+
+  after-sales-integration:
+    name: after-sales integration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+      - name: Show pnpm version
+        run: pnpm -v
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> $GITHUB_ENV
+
+      - name: Get pnpm store directory
+        id: pnpm-cache-after-sales
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache-after-sales.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies (with log)
+        run: |
+          set -o pipefail
+          pnpm install --frozen-lockfile 2>&1 | tee install.log
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-log-after-sales-integration
+          path: install.log
+
+      - name: Start Postgres
+        uses: ankane/setup-postgres@v1
+        with:
+          postgres-version: 14
+          user: postgres
+
+      - name: Create test database
+        run: |
+          createdb -U postgres metasheet_test || true
+
+      - name: Run DB migrations
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+        run: |
+          pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run after-sales integration test
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+        run: |
+          pnpm --filter @metasheet/core-backend test:integration:after-sales
+
+      - name: Upload after-sales integration artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: after-sales-integration-artifacts
           path: |
             packages/core-backend/coverage/
             packages/core-backend/test-results/

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -21,6 +21,7 @@
     "test:phase5": "vitest --config vitest.phase5.config.ts run",
     "test:unit": "vitest run tests/unit --reporter=dot",
     "test:integration": "vitest --config vitest.integration.config.ts run tests/integration --reporter=dot",
+    "test:integration:after-sales": "vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot",
     "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --reporter=dot",
     "test:contract": "vitest run tests/contract --reporter=dot",
     "test:e2e:handoff": "npx playwright test --config tests/e2e/playwright.config.ts",


### PR DESCRIPTION
## Summary
- add a dedicated `test:integration:after-sales` script for the real-DB after-sales integration file
- add a strict `after-sales integration` job to `plugin-tests.yml`
- keep the broader integration sweep non-blocking, but make this one critical after-sales path fail PR CI when it regresses

## Why
`after-sales-plugin.install.test.ts` is now carrying important real-DB regression coverage for installer, runtime-admin, approval bridge, and reinstall semantics. Before this PR, the generic integration step in `plugin-tests.yml` was still `|| true`, so failures in that file could be silently ignored by CI.

This PR gives us one explicit job with `DATABASE_URL` + migrations + real Postgres that must pass.

## Verification
- `DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 pnpm --filter @metasheet/core-backend test:integration:after-sales`
  - passed locally: `24 tests` in `after-sales-plugin.install.test.ts`
- `git diff --check -- .github/workflows/plugin-tests.yml packages/core-backend/package.json`
  - passed

Related: #715