### PR TITLE
test(contract): add Wave 3 BOM and approval pact coverage

### DIFF
--- a/docs/development/plm-yuantus-bom-approvals-pact-wave3-20260411.md
+++ b/docs/development/plm-yuantus-bom-approvals-pact-wave3-20260411.md
@@ -1,0 +1,80 @@
+# PLM Yuantus BOM And Approval Pact Wave 3
+
+## Scope
+
+This slice extends the hand-authored Metasheet2 -> Yuantus pact from 9 to 14
+interactions by covering the next five **real** `PLMAdapter.ts` call sites on
+`main`:
+
+- `GET /api/v1/bom/{id}/where-used`
+- `GET /api/v1/bom/compare/schema`
+- `GET /api/v1/eco/{id}/approvals`
+- `POST /api/v1/eco/{id}/approve`
+- `POST /api/v1/eco/{id}/reject`
+
+Source call sites on `main`:
+
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts:1636`
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts:1662`
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts:1683`
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts:1715`
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts:1813`
+
+## Design Decisions
+
+1. Keep contract-first discipline strict.
+Only endpoints with live consumer call sites were added. `aml/metadata` stays
+out because `PLMAdapter.ts` still does not call it.
+
+2. Append, do not reorder, prior interactions.
+The 9 previously verified interactions remain byte-stable and the 5 new ones
+append at the tail of the pact. This minimizes diff noise and keeps provider
+history legible.
+
+3. Lock payload shape where the adapter has real semantics.
+The Wave 3 pact now freezes:
+
+- `recursive` / `max_levels` on where-used
+- compare schema array/object envelopes
+- approval history list shape
+- optimistic-lock action payload shape for `approve` / `reject`
+
+4. Back the pact with adapter unit coverage.
+`plm-adapter-yuantus.test.ts` now asserts the adapter calls the exact Wave 3
+paths and payloads, so a future source change can fail before pact drift reaches
+CI.
+
+## Files Changed
+
+- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json`
+- `packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts`
+- `packages/core-backend/tests/contract/README.md`
+- `packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts`
+
+## Verification
+
+Run from `packages/core-backend`:
+
+```bash
+npx vitest run tests/contract/plm-adapter-yuantus.pact.test.ts
+npx vitest run tests/unit/plm-adapter-yuantus.test.ts
+npx vitest run tests/unit/federation.contract.test.ts
+npx vitest run tests/unit/approvals-bridge-routes.test.ts
+```
+
+Observed results on 2026-04-11:
+
+- `tests/contract/plm-adapter-yuantus.pact.test.ts`: 10 passed
+- `tests/unit/plm-adapter-yuantus.test.ts`: 14 passed
+- `tests/unit/federation.contract.test.ts`: 10 passed
+- `tests/unit/approvals-bridge-routes.test.ts`: 20 passed
+
+## Notes
+
+The clean worktree needs both dependency trees linked:
+
+- repo root `node_modules`
+- `packages/core-backend/node_modules`
+
+Without the package-local symlink, Vitest fails before collection on unresolved
+pnpm-linked dependencies such as `uuid`.

--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -20,8 +20,9 @@ when running in `apiMode='yuantus'`. Without a contract test, any field
 rename on the Yuantus side would silently break Metasheet at runtime.
 
 This Pact set freezes the **shape** (not the values) of the 6 Wave 1 P0
-endpoints plus the 3 document-semantics endpoints that `PLMAdapter.ts`
-currently calls in `getProductDocuments()` for `apiMode='yuantus'`.
+endpoints plus the 3 document-semantics endpoints and the 5 BOM-analysis /
+ECO-approval endpoints that `PLMAdapter.ts` currently calls for
+`apiMode='yuantus'`.
 (Codex's PACT_FIRST plan lists 7 endpoints in Wave 1 — see "Discrepancy
 with codex plan" below.)
 
@@ -34,13 +35,15 @@ The pact JSON in `pacts/metasheet2-yuantus-plm.json` is **hand-authored** in
 Pact v3 format. It is **not** yet generated from `@pact-foundation/pact`,
 because adding that npm dependency requires explicit approval.
 
-The `plm-adapter-yuantus.pact.test.ts` vitest test guards three things:
+The `plm-adapter-yuantus.pact.test.ts` vitest test guards four things:
 
 1. The pact JSON exists and parses as Pact v3.
-2. It contains the 9 currently used interactions in the documented order.
+2. It contains the 14 currently used interactions in the documented order.
 3. Every endpoint named in the pact is also referenced by the live
    `packages/core-backend/src/data-adapters/PLMAdapter.ts` source — so the
    pact cannot drift away from what the adapter actually calls.
+4. The Wave 3 additions lock the exact envelope for `where-used`,
+   `bom compare schema`, `approval history`, `approve`, and `reject`.
 
 ## Discrepancy with codex's PACT_FIRST plan
 
@@ -93,29 +96,24 @@ cd /Users/huazhou/Downloads/Github/Yuantus
    src/yuantus/api/tests/test_pact_provider_yuantus_plm.py
 ```
 
-### Current verifier state (2026-04-08)
+### Current verifier state (2026-04-11)
 
-Wired end-to-end with `pact-python 3.2.1`. Verifier no longer skips —
-it actually starts the FastAPI app, replays each interaction, and reports
-real verification results.
+Wired end-to-end with `pact-python 3.2.1`. The provider verifier now starts
+the FastAPI app, seeds an isolated test DB, and replays all 14 interactions.
 
-**Wave 1 baseline result: 1 passing, 5 failing.**
+**Current result: 14 passing, 0 failing.**
 
-| Interaction | State | Why |
-|---|---|---|
-| `GET /api/v1/health` | ✅ PASS | no auth / no provider state needed |
-| `POST /api/v1/auth/login` | ❌ FAIL | needs seeded test user (Wave 1.5) |
-| `GET /api/v1/search/` | ❌ FAIL | needs seeded item + auth token (Wave 1.5) |
-| `POST /api/v1/aml/apply` | ❌ FAIL | needs seeded test Part with id 01H...P1 (Wave 1.5) |
-| `GET /api/v1/bom/{id}/tree` | ❌ FAIL | needs seeded BOM relationship (Wave 1.5) |
-| `GET /api/v1/bom/compare` | ❌ FAIL | needs two seeded comparable items (Wave 1.5) |
+Wave 3 adds coverage for:
 
-The 5 failing interactions are NOT shape drift — they fail because the
-provider state handler is currently a no-op and the requests hit a clean
-test database. Implementing real state seeding is tracked as Wave 1.5
-work; the deliberate break experiment in
-`Yuantus/docs/PACT_DELIBERATE_BREAK_EXPERIMENT_20260408.md` confirmed the
-gate correctly distinguishes "missing state" from "real shape drift".
+- `GET /api/v1/bom/{id}/where-used`
+- `GET /api/v1/bom/compare/schema`
+- `GET /api/v1/eco/{id}/approvals`
+- `POST /api/v1/eco/{id}/approve`
+- `POST /api/v1/eco/{id}/reject`
+
+The provider keeps its state handler as a no-op by using distinct seeded ECO
+fixtures for `history`, `approve`, and `reject`, so mutating approval actions
+cannot contaminate later interactions in the same verifier run.
 
 To install `pact-python` and run locally:
 
@@ -143,27 +141,22 @@ The artifact path stays the same, so the Yuantus provider verifier does not
 need to be reconfigured. The current sanity test serves as an executable
 specification of what the generated pact must contain.
 
-## Wave 2 endpoints
+## Still intentionally outside the pact
 
-The following endpoints were intentionally out of scope for the first pact.
-Document semantics is now covered, so these still remain outside the pact:
+The following surfaces remain outside the pact because `PLMAdapter.ts` does
+not currently call them on `main`:
 
-- `GET /api/v1/bom/{id}/where-used`
-- `GET /api/v1/bom/compare/schema`
-- `GET /api/v1/eco/{id}/approvals`
-- `POST /api/v1/eco/{id}/approve`
-- `POST /api/v1/eco/{id}/reject`
-
-They will be added in a Wave 2 pact once Wave 1 is verified green in CI on
-both repos. See `docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md` §"Two-Week
-Execution Sequence" -> Week 2 in the Yuantus repo.
+- `GET /api/v1/aml/metadata/{item_type_name}`
+- `GET /api/v1/bom/{line_id}/substitutes`
+- `POST /api/v1/bom/{line_id}/substitutes`
+- `DELETE /api/v1/bom/substitutes/{substitute_id}`
 
 ## Forward compatibility note
 
 The `metasheet2-plm-workbench` long-running spike branch has version-aware
 `approveApproval(id, **version**, comment)` and `rejectApproval(id, **version**,
 comment)` for optimistic locking. When that improvement merges back into this
-mainline branch, the Wave 2 pact for `/api/v1/eco/{id}/approve` should
+mainline branch, the Wave 3 pact for `/api/v1/eco/{id}/approve` should
 declare the `version` field as **optional** so the contract does not
 retroactively break this branch's existing approve/reject signature.
 

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -631,6 +631,378 @@
           }
         }
       }
+    },
+    {
+      "description": "find where a child Part is used across parent BOMs",
+      "providerStates": [
+        {
+          "name": "item 01H000000000000000000000P2 is used by parent 01H000000000000000000000P1 in a BOM"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/bom/01H000000000000000000000P2/where-used",
+        "query": {
+          "recursive": [
+            "true"
+          ],
+          "max_levels": [
+            "4"
+          ]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "item_id": "01H000000000000000000000P2",
+          "count": 1,
+          "parents": [
+            {
+              "relationship": {
+                "id": "01H000000000000000000000R1"
+              },
+              "parent": {
+                "id": "01H000000000000000000000P1"
+              },
+              "level": 1
+            }
+          ],
+          "recursive": true,
+          "max_levels": 4
+        },
+        "matchingRules": {
+          "body": {
+            "$.item_id": { "matchers": [{ "match": "type" }] },
+            "$.count": { "matchers": [{ "match": "integer", "min": 0 }] },
+            "$.parents": { "matchers": [{ "match": "type", "min": 1 }] },
+            "$.parents[*].relationship": { "matchers": [{ "match": "type" }] },
+            "$.parents[*].parent": { "matchers": [{ "match": "type" }] },
+            "$.parents[*].level": { "matchers": [{ "match": "integer", "min": 1 }] },
+            "$.recursive": { "matchers": [{ "match": "type" }] },
+            "$.max_levels": { "matchers": [{ "match": "integer", "min": 1 }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch BOM compare schema metadata for compare-mode aware clients",
+      "providerStates": [
+        {
+          "name": "the BOM compare schema is available"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/bom/compare/schema",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "line_fields": [
+            {
+              "field": "quantity",
+              "severity": "major",
+              "normalized": "float",
+              "description": "BOM quantity on the relationship line."
+            }
+          ],
+          "compare_modes": [
+            {
+              "mode": "summarized",
+              "line_key": "child_config",
+              "include_relationship_props": [
+                "quantity",
+                "uom"
+              ],
+              "aggregate_quantities": true,
+              "aliases": [
+                "summary"
+              ],
+              "description": "Aggregate quantities for identical children."
+            }
+          ],
+          "line_key_options": [
+            "child_config",
+            "child_id"
+          ],
+          "defaults": {
+            "max_levels": 10,
+            "line_key": "child_config",
+            "include_substitutes": false,
+            "include_effectivity": false
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.line_fields": { "matchers": [{ "match": "type", "min": 1 }] },
+            "$.line_fields[*].field": { "matchers": [{ "match": "type" }] },
+            "$.line_fields[*].severity": { "matchers": [{ "match": "type" }] },
+            "$.line_fields[*].normalized": { "matchers": [{ "match": "type" }] },
+            "$.line_fields[*].description": { "matchers": [{ "match": "type" }] },
+            "$.compare_modes": { "matchers": [{ "match": "type", "min": 1 }] },
+            "$.compare_modes[*].mode": { "matchers": [{ "match": "type" }] },
+            "$.compare_modes[*].line_key": { "matchers": [{ "match": "type" }] },
+            "$.compare_modes[*].include_relationship_props": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.compare_modes[*].aggregate_quantities": { "matchers": [{ "match": "type" }] },
+            "$.compare_modes[*].aliases": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.compare_modes[*].description": { "matchers": [{ "match": "type" }] },
+            "$.line_key_options": { "matchers": [{ "match": "type", "min": 1 }] },
+            "$.defaults": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "list ECO approval history records for a change request",
+      "providerStates": [
+        {
+          "name": "ECO 01H000000000000000000000E1 has one approval history record"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/eco/01H000000000000000000000E1/approvals",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": [
+          {
+            "id": "01H000000000000000000000H1",
+            "eco_id": "01H000000000000000000000E1",
+            "stage_id": "01H000000000000000000000S1",
+            "approval_type": "mandatory",
+            "required_role": "engineer",
+            "user_id": 1,
+            "status": "pending",
+            "comment": "Waiting for engineering review",
+            "created_at": "2026-04-11T00:00:00.000Z"
+          }
+        ],
+        "matchingRules": {
+          "body": {
+            "$": { "matchers": [{ "match": "type", "min": 1 }] },
+            "$[*].id": { "matchers": [{ "match": "type" }] },
+            "$[*].eco_id": { "matchers": [{ "match": "type" }] },
+            "$[*].stage_id": { "matchers": [{ "match": "type" }] },
+            "$[*].approval_type": { "matchers": [{ "match": "type" }] },
+            "$[*].required_role": { "matchers": [{ "match": "type" }] },
+            "$[*].user_id": { "matchers": [{ "match": "integer" }] },
+            "$[*].status": { "matchers": [{ "match": "type" }] },
+            "$[*].comment": { "matchers": [{ "match": "type" }] },
+            "$[*].created_at": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "approve an ECO at its current stage using optimistic-lock payload shape",
+      "providerStates": [
+        {
+          "name": "ECO 01H000000000000000000000E2 is approvable by the current user"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/eco/01H000000000000000000000E2/approve",
+        "headers": {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "body": {
+          "version": 7,
+          "comment": "Ship it"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.version": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.comment": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": "approval-approve-example",
+          "eco_id": "01H000000000000000000000E2",
+          "stage_id": "01H000000000000000000000S2",
+          "approval_type": "mandatory",
+          "user_id": 1,
+          "status": "approved",
+          "comment": "Ship it",
+          "approved_at": "2026-04-11T00:00:00.000Z",
+          "created_at": "2026-04-11T00:00:00.000Z"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": { "matchers": [{ "match": "type" }] },
+            "$.eco_id": { "matchers": [{ "match": "type" }] },
+            "$.stage_id": { "matchers": [{ "match": "type" }] },
+            "$.approval_type": { "matchers": [{ "match": "type" }] },
+            "$.user_id": { "matchers": [{ "match": "integer" }] },
+            "$.status": { "matchers": [{ "match": "type" }] },
+            "$.comment": { "matchers": [{ "match": "type" }] },
+            "$.approved_at": { "matchers": [{ "match": "type" }] },
+            "$.created_at": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "reject an ECO at its current stage using optimistic-lock payload shape",
+      "providerStates": [
+        {
+          "name": "ECO 01H000000000000000000000E3 is rejectable by the current user"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/eco/01H000000000000000000000E3/reject",
+        "headers": {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "body": {
+          "version": 8,
+          "comment": "Missing test evidence"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.version": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.comment": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": "approval-reject-example",
+          "eco_id": "01H000000000000000000000E3",
+          "stage_id": "01H000000000000000000000S3",
+          "approval_type": "mandatory",
+          "user_id": 1,
+          "status": "rejected",
+          "comment": "Missing test evidence",
+          "approved_at": "2026-04-11T00:00:00.000Z",
+          "created_at": "2026-04-11T00:00:00.000Z"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": { "matchers": [{ "match": "type" }] },
+            "$.eco_id": { "matchers": [{ "match": "type" }] },
+            "$.stage_id": { "matchers": [{ "match": "type" }] },
+            "$.approval_type": { "matchers": [{ "match": "type" }] },
+            "$.user_id": { "matchers": [{ "match": "integer" }] },
+            "$.status": { "matchers": [{ "match": "type" }] },
+            "$.comment": { "matchers": [{ "match": "type" }] },
+            "$.approved_at": { "matchers": [{ "match": "type" }] },
+            "$.created_at": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -11,8 +11,8 @@
  *
  *   1. The pact JSON exists and parses as Pact v3.
  *   2. The 6 Wave 1 P0 interactions plus the document-semantics Wave 2
- *      interactions that PLMAdapter currently calls are present, in the
- *      documented order.
+ *      interactions plus the BOM-analysis / ECO-approval Wave 3 interactions
+ *      that PLMAdapter currently calls are present, in the documented order.
  *      (codex's plan also lists `aml/metadata`, but PLMAdapter does not yet
  *      call it; deferred until there is a real consumer call site.)
  *   3. The PLMAdapter actually calls every endpoint declared in the pact, so
@@ -90,6 +90,11 @@ const PACT_PATHS = [
   { method: 'GET', path: '/api/v1/file/item/01H000000000000000000000P1' },
   { method: 'GET', path: '/api/v1/file/01H000000000000000000000F1' },
   { method: 'POST', path: '/api/v1/aml/query' },
+  { method: 'GET', path: '/api/v1/bom/01H000000000000000000000P2/where-used' },
+  { method: 'GET', path: '/api/v1/bom/compare/schema' },
+  { method: 'GET', path: '/api/v1/eco/01H000000000000000000000E1/approvals' },
+  { method: 'POST', path: '/api/v1/eco/01H000000000000000000000E2/approve' },
+  { method: 'POST', path: '/api/v1/eco/01H000000000000000000000E3/reject' },
 ] as const
 
 function loadPact(): PactDocument {
@@ -101,7 +106,7 @@ function loadAdapter(): string {
   return readFileSync(ADAPTER_PATH, 'utf8')
 }
 
-describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + document semantics Wave 2)', () => {
+describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 document semantics + Wave 3 BOM/approval)', () => {
   it('pact JSON exists, parses as Pact v3, and names the right consumer/provider', () => {
     const pact = loadPact()
     expect(pact.consumer.name).toBe('Metasheet2')
@@ -138,10 +143,15 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + document se
       '/api/v1/health',
       '/api/v1/search/',
       '/api/v1/aml/apply',
-      '/api/v1/bom/',
+      '/api/v1/bom/${productId}/tree',
       '/api/v1/bom/compare',
+      '/api/v1/bom/${itemId}/where-used',
+      '/api/v1/bom/compare/schema',
       '/api/v1/file/item/',
       '/api/v1/aml/query',
+      '/api/v1/eco/${approvalId}/approvals',
+      '/api/v1/eco/${approvalId}/approve',
+      '/api/v1/eco/${approvalId}/reject',
       'fetchYuantusFileMetadata',
     ]
     for (const ep of endpointsToFind) {
@@ -205,5 +215,58 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + document se
     expect(body.where).toEqual({ id: '01H000000000000000000000P1' })
     expect(body.expand).toEqual(['Document Part'])
     expect(body.page_size).toBe(1)
+  })
+
+  it('where-used and compare-schema interactions lock the BOM analysis surfaces consumed on mainline', () => {
+    const pact = loadPact()
+    const whereUsed = pact.interactions.find(
+      i => i.request.path === '/api/v1/bom/01H000000000000000000000P2/where-used',
+    )
+    const compareSchema = pact.interactions.find(
+      i => i.request.path === '/api/v1/bom/compare/schema',
+    )
+
+    expect(whereUsed).toBeDefined()
+    expect(compareSchema).toBeDefined()
+    expect(whereUsed!.request.query).toEqual({
+      recursive: ['true'],
+      max_levels: ['4'],
+    })
+    expect(compareSchema!.response.body).toMatchObject({
+      line_fields: expect.any(Array),
+      compare_modes: expect.any(Array),
+      line_key_options: expect.any(Array),
+    })
+  })
+
+  it('approval-history and approval-action interactions lock the ECO approval envelope used by federation', () => {
+    const pact = loadPact()
+    const history = pact.interactions.find(
+      i => i.request.path === '/api/v1/eco/01H000000000000000000000E1/approvals',
+    )
+    const approve = pact.interactions.find(
+      i => i.request.path === '/api/v1/eco/01H000000000000000000000E2/approve',
+    )
+    const reject = pact.interactions.find(
+      i => i.request.path === '/api/v1/eco/01H000000000000000000000E3/reject',
+    )
+
+    expect(history).toBeDefined()
+    expect(approve).toBeDefined()
+    expect(reject).toBeDefined()
+    expect(history!.response.body).toEqual([
+      expect.objectContaining({
+        eco_id: '01H000000000000000000000E1',
+        status: expect.any(String),
+      }),
+    ])
+    expect(approve!.request.body).toEqual({
+      version: 7,
+      comment: 'Ship it',
+    })
+    expect(reject!.request.body).toEqual({
+      version: 8,
+      comment: 'Missing test evidence',
+    })
   })
 })

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -276,6 +276,149 @@ describe('PLMAdapter Yuantus approvals mapping', () => {
   })
 })
 
+describe('PLMAdapter Yuantus BOM analysis and approval actions', () => {
+  it('maps approval history from ECO approvals endpoint', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'approval-1',
+          eco_id: 'eco-1',
+          stage_id: 'stage-1',
+          approval_type: 'mandatory',
+          required_role: 'engineer',
+          user_id: 7,
+          status: 'pending',
+          comment: null,
+          approved_at: null,
+          created_at: '2026-01-04T00:00:00.000Z',
+        },
+      ],
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getApprovalHistory('eco-1')
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/eco/eco-1/approvals')
+    expect(result.data).toEqual([
+      {
+        id: 'approval-1',
+        eco_id: 'eco-1',
+        stage_id: 'stage-1',
+        approval_type: 'mandatory',
+        required_role: 'engineer',
+        user_id: 7,
+        status: 'pending',
+        comment: null,
+        approved_at: null,
+        created_at: '2026-01-04T00:00:00.000Z',
+      },
+    ])
+  })
+
+  it('posts approve and reject actions to ECO endpoints with optimistic-lock version payloads', async () => {
+    const adapter = createAdapter()
+    const selectMock = vi.fn()
+      .mockResolvedValueOnce({
+        data: [{ id: 'eco-approve-1', status: 'approved', comment: 'Ship it' }],
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'eco-reject-1', status: 'rejected', comment: 'Missing test evidence' }],
+      })
+
+    ;(adapter as any).select = selectMock
+
+    const approved = await adapter.approveApproval('eco-approve-1', 7, 'Ship it')
+    const rejected = await adapter.rejectApproval('eco-reject-1', 8, 'Missing test evidence')
+
+    expect(selectMock).toHaveBeenNthCalledWith(1, '/api/v1/eco/eco-approve-1/approve', {
+      method: 'POST',
+      data: { version: 7, comment: 'Ship it' },
+    })
+    expect(selectMock).toHaveBeenNthCalledWith(2, '/api/v1/eco/eco-reject-1/reject', {
+      method: 'POST',
+      data: { version: 8, comment: 'Missing test evidence' },
+    })
+    expect(approved.data[0]).toMatchObject({ id: 'eco-approve-1', status: 'approved' })
+    expect(rejected.data[0]).toMatchObject({ id: 'eco-reject-1', status: 'rejected' })
+  })
+
+  it('queries where-used with recursive and max-level parameters', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [{
+        item_id: 'item-child-1',
+        count: 1,
+        parents: [{
+          relationship: { id: 'rel-1', quantity: 4 },
+          parent: { id: 'item-parent-1', properties: { item_number: 'ASM-001' } },
+          level: 1,
+        }],
+      }],
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getWhereUsed('item-child-1', {
+      recursive: true,
+      maxLevels: 4,
+    })
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/bom/item-child-1/where-used', [
+      { recursive: true, max_levels: 4 },
+    ])
+    expect(result.data[0]).toMatchObject({
+      item_id: 'item-child-1',
+      count: 1,
+      parents: [expect.objectContaining({ level: 1 })],
+    })
+  })
+
+  it('loads BOM compare schema from the dedicated schema endpoint', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [{
+        line_fields: [
+          {
+            field: 'quantity',
+            severity: 'major',
+            normalized: 'float',
+            description: 'BOM quantity on the relationship line.',
+          },
+        ],
+        compare_modes: [
+          {
+            mode: 'summarized',
+            line_key: 'child_config',
+            include_relationship_props: ['quantity', 'uom'],
+            aggregate_quantities: true,
+            aliases: ['summary'],
+            description: 'Aggregate quantities for identical children.',
+          },
+        ],
+        line_key_options: ['child_config', 'child_id'],
+        defaults: {
+          max_levels: 10,
+          line_key: 'child_config',
+        },
+      }],
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getBomCompareSchema()
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/bom/compare/schema')
+    expect(result.data[0]).toMatchObject({
+      line_fields: [expect.objectContaining({ field: 'quantity', severity: 'major' })],
+      compare_modes: [expect.objectContaining({ mode: 'summarized' })],
+      line_key_options: ['child_config', 'child_id'],
+      defaults: expect.objectContaining({ max_levels: 10 }),
+    })
+  })
+})
+
 describe('PLMAdapter Yuantus documents single-side failure + sources metadata', () => {
   it('returns AML related documents when file/item endpoint errors, with sources showing degradation', async () => {
     const adapter = createAdapter()


### PR DESCRIPTION
## Summary
- extend the canonical Yuantus pact from 9 to 14 interactions
- add Wave 3 coverage for where-used, BOM compare schema, ECO approval history, approve, and reject
- add adapter unit coverage for the new BOM-analysis and approval call sites
- document the Wave 3 design and verification flow

## Verification
- `cd packages/core-backend && npx vitest run tests/contract/plm-adapter-yuantus.pact.test.ts`
- `cd packages/core-backend && npx vitest run tests/unit/plm-adapter-yuantus.test.ts`
- `cd packages/core-backend && npx vitest run tests/unit/federation.contract.test.ts`
- `cd packages/core-backend && npx vitest run tests/unit/approvals-bridge-routes.test.ts`

## Notes
- design doc: `docs/development/plm-yuantus-bom-approvals-pact-wave3-20260411.md`
- pact remains hand-authored until `@pact-foundation/pact` is approved as a dev dependency
