### PR TITLE
docs: archive root worktree design notes

### DIFF
--- a/docs/deployment/multitable-platform-rc-notes-20260404.md
+++ b/docs/deployment/multitable-platform-rc-notes-20260404.md
@@ -1,50 +1,80 @@
-# MetaSheet Platform RC Notes
+# Multitable Platform RC Notes
 
 Date: 2026-04-04
-Recommended deployment profile: `PRODUCT_MODE=platform` + `ENABLE_PLM=0`
+Scope: customer-facing release notes for the `multitable/platform` on-prem line
 
-## Current milestone
+## Current RC Candidate
 
-- Functional milestone candidate: `multitable-onprem-run10-20260404`
-- RC polish follow-up: server-side package apply helper + delivery summary hardening
+`multitable-onprem-run10-20260404` is the current RC milestone candidate.
 
-## What stabilized across run2 -> run10
+Recommended deployment mode:
 
-### Platform shell
+```env
+PRODUCT_MODE=platform
+ENABLE_PLM=0
+```
 
-- Platform mode now grants attendance self-service access to ordinary employees.
-- `ENABLE_PLM=0` hides PLM entry points and returns `FEATURE_DISABLED` for PLM APIs.
-- The shell shows a single `考勤` entry and routes legacy plugin attendance paths back to `/attendance`.
+This keeps the platform shell enabled while allowing PLM to remain disabled.
 
-### Attendance experience
+## What Changed From Run2 To Run10
 
-- Employee mode is now split cleanly into `总览` and `报表`.
-- Reports gained summary cards, local filters, time-range quick switches, trend cards, and management metrics.
-- The employee overview now acts like a workbench with status focus, request follow-up, quick actions, and human-readable status explanations.
+The `run2 -> run10` progression focused on making the platform package usable for both administrators and employees:
 
-### Attendance operations
+1. `run2`
+   - Fixed platform-mode employee attendance permissions.
+   - Enabled `attendance:read` and `attendance:write` for normal employees.
+   - Kept PLM disabled when `ENABLE_PLM=0`.
 
-- Import and preview flows now show an operator-facing `Current import plan`.
-- Preview mode shows a `Preview outcome` summary and clears stale rows or warnings before retry.
-- Empty preview failures now keep the page in a readable zero-state instead of reusing the previous preview data.
+2. `run3`
+   - Localized attendance entry titles for Chinese UI.
+   - Reduced approval-center session dropouts.
+   - Hid PLM audit links when PLM is disabled.
 
-### Approval and permissions
+3. `run4`
+   - Removed duplicate `Attendance` navigation entries.
+   - Kept the platform shell aligned with `ENABLE_PLM=0`.
 
-- Approval inbox no longer drops the whole session because of `APPROVAL_USER_REQUIRED`.
-- Request approval flows, settlement checks, and ordinary employee attendance visibility are stable on the current platform profile.
-- Ordinary employees are blocked from `/api/events`.
+4. `run5`
+   - Fixed approval-center access so normal users no longer get kicked back to login.
+   - Removed the duplicate plugin attendance navigation path.
 
-## Coverage confirmed during RC
+5. `run6`
+   - Split the employee experience into clearer `Overview` and `Reports` tabs.
+   - Kept the two surfaces separate instead of repeating the same content.
 
-- Authentication and permissions
-- Platform navigation and PLM isolation
-- Attendance request -> approve -> settlement record loop
-- Attendance reports, filters, and time slices
-- Attendance import template, preview, commit, export, and idempotency smoke
-- On-prem package build, verify, upgrade, and healthcheck gates
+6. `run7`
+   - Added reporting summary cards and local filters.
+   - Made the reports page more analytical without changing backend behavior.
 
-## Recommended post-RC follow-up
+7. `run8`
+   - Added report time-range switching: `This week`, `This month`, `Last month`, `This quarter`.
+   - Added trend and management metric cards that refresh with the selected range.
 
-1. Run one real CSV import end-to-end on the target environment.
-2. Confirm rejected requests can be resubmitted cleanly by employees.
-3. Keep new work in product slices, not hotfix rerolls, unless a real P0/P1 appears.
+8. `run9`
+   - Expanded the employee self-service dashboard.
+   - Added task focus, request-status guidance, and clearer next-step actions.
+
+9. `run10`
+   - Added import operation summaries in the admin import flow.
+   - Added preview outcome summaries and better stale-preview cleanup.
+
+## What The RC Is Good For
+
+- Employee attendance self-service
+- Platform shell with PLM disabled
+- Attendance reporting and range-based analysis
+- Admin import workflow visibility
+- Approval-center access without session loss
+
+## Known Follow-Ups
+
+These are not blockers for the RC candidate, but they remain worth tracking:
+
+- Deployment automation could be simplified further for field rollout.
+- Full CSV import end-to-end verification still deserves a dedicated pass.
+- Additional edge cases around import rejection and re-submission can be polished later.
+- Non-critical logout-time 403 noise is still low priority.
+
+## Verification Position
+
+The current recommendation is to use `multitable-onprem-run10-20260404` as the RC baseline and continue only with polish or real blocker fixes.

--- a/docs/development/approval-workflow-audit-and-next-phase-plan-20260403.md
+++ b/docs/development/approval-workflow-audit-and-next-phase-plan-20260403.md
@@ -1,0 +1,414 @@
+# 审批/工作流系统现状审计与下一阶段开发计划
+
+Date: 2026-04-03
+
+## 1. 结论先行
+
+当前主仓已经不适合继续把主要研发资源放在多维表细节打磨上。
+
+更合理的下一阶段主线是：
+
+1. 把审批/工作流系统从“有引擎、有设计器、有部分业务接入”推进到“有统一产品入口和完整业务闭环”
+2. 明确考勤审批、PLM 审批和通用 BPMN 工作流之间的产品边界
+3. 停止把 `references/` 当成“可能还在运行的代码来源”理解，当前它更像参考资料库，而不是运行时依赖
+
+一句话判断：
+
+- 多维表：已达到 pilot/实施阶段
+- 审批/工作流：已具备基础能力，但前台产品面未收平
+- `references/`：存在参考借鉴，不是直接执行源
+
+## 2. 为什么接下来该转向审批/工作流
+
+当前仓库的几条主线里：
+
+1. 多维表已经有完整工作台和多视图基础
+2. 部署、发布、on-prem 文档链也已经补齐
+3. 旧 PR 治理和最值的运维补丁也已收口
+
+因此，继续开发最值的方向，不再是清理旧线，也不是继续补多维表局部 polish，而是补齐审批/工作流这条仍处在“能力 > 产品面”的系统。
+
+## 3. 当前审批/工作流系统到底到了什么阶段
+
+### 3.1 后端能力不是空壳
+
+当前主仓里，审批/工作流相关后端已经真实存在：
+
+- 工作流 API：
+  [workflow.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/routes/workflow.ts)
+- 工作流设计器 API：
+  [workflow-designer.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/routes/workflow-designer.ts)
+- 通用审批 API：
+  [approvals.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/routes/approvals.ts)
+- 审批历史 API：
+  [approval-history.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/routes/approval-history.ts)
+- BPMN 引擎：
+  [BPMNWorkflowEngine.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/workflow/BPMNWorkflowEngine.ts)
+- 设计器模型：
+  [WorkflowDesigner.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/workflow/WorkflowDesigner.ts)
+
+并且它们已经挂进运行时：
+
+- [index.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/index.ts#L548)
+
+实际运行挂载包括：
+
+1. `/api/workflow`
+2. `/api/workflow-designer`
+3. `/api/approvals/:id/history`
+4. `/api/approvals/pending`
+5. `/api/approvals/:id/approve`
+6. `/api/approvals/:id/reject`
+
+这说明审批/工作流后端不是概念层，已经有真实运行入口。
+
+### 3.2 数据层也已经有基础表
+
+通用审批表已经有 migration：
+
+- [20250924105000_create_approval_tables.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/db/migrations/20250924105000_create_approval_tables.ts)
+
+它创建了至少两张核心表：
+
+1. `approval_instances`
+2. `approval_records`
+
+考勤领域又单独有一套审批流配置表：
+
+- [zzzz20260120113000_create_attendance_approval_flows.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/db/migrations/zzzz20260120113000_create_attendance_approval_flows.ts)
+
+这意味着当前系统实际上已经出现了两层审批概念：
+
+1. 平台级审批实例/审批记录
+2. 业务级审批流配置
+
+这正是下一阶段必须统一建模的原因。
+
+### 3.3 前端工作流产品面是存在的
+
+前端已有真实工作流页面：
+
+- [WorkflowHubView.vue](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/views/WorkflowHubView.vue)
+- [WorkflowDesigner.vue](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/views/WorkflowDesigner.vue)
+
+路由里也真正挂了工作流入口：
+
+- [appRoutes.ts](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/router/appRoutes.ts#L136)
+
+对应路径是：
+
+1. `/workflows`
+2. `/workflows/designer/:id?`
+
+从界面结构看，当前已经不是简单 demo，而是包含：
+
+1. Workflow Hub
+2. 草稿目录
+3. 模板目录
+4. Team Views
+5. 设计器
+6. 校验、保存、部署动作
+
+### 3.4 但审批产品面没有收平
+
+这是当前最大的现实问题。
+
+路由类型里已经预留了审批页：
+
+- [types.ts](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/router/types.ts#L62)
+
+包括：
+
+1. `approval-list`
+2. `approval-detail`
+3. `approval-create`
+4. `approval-pending`
+5. `approval-history`
+
+路径常量也已经定义了：
+
+- [types.ts](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/router/types.ts#L368)
+
+但实际前端并没有统一审批中心落地：
+
+1. 路由表没有真正挂 `/approvals`
+2. 当前代码里几乎没有前端页面消费 `/api/approvals`
+3. `apps/web/src/stores` 下只有 [types.ts](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/stores/types.ts)，没有真正落地的 workflow/approval store
+
+因此当前审批系统的状态不是“没有”，而是：
+
+**后端基础完整度明显高于前端统一产品面。**
+
+## 4. 业务侧的审批能力目前是怎样接进去的
+
+### 4.1 考勤审批：已有业务配置，但更偏业务内嵌
+
+考勤后台已经有审批流管理 UI：
+
+- [AttendanceLeavePoliciesSection.vue](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/views/attendance/AttendanceLeavePoliciesSection.vue)
+
+它当前支持：
+
+1. 请假类型是否需要审批
+2. 加班规则是否需要审批
+3. 审批流配置
+4. 审批步骤 JSON 配置
+
+这说明考勤审批不是空白，而是已经有业务内嵌式配置能力。
+
+但当前问题是：
+
+1. 它主要还是业务域内配置
+2. 它尚未自然映射成一个平台统一审批中心
+3. 审批流结构目前偏 JSON 配置，不是统一 designer-first 体验
+
+### 4.2 考勤也已经接了设计器入口
+
+考勤视角下也已经有工作流设计器包装页：
+
+- [AttendanceWorkflowDesigner.vue](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/views/attendance/AttendanceWorkflowDesigner.vue)
+
+这说明系统方向上已经明确：
+
+**考勤审批并不是完全独立做一套，而是希望复用平台工作流能力。**
+
+### 4.3 PLM 审批：已经有桥接模型
+
+PLM 侧也不是从零开始，已经有桥接结构：
+
+- [plm-approval-bridge.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/federation/plm-approval-bridge.ts)
+
+它会把 PLM 审批映射成平台记录，例如：
+
+1. `externalSystem: 'plm'`
+2. `businessKey`
+3. `workflowKey`
+4. `status`
+5. `requester`
+6. `policy`
+
+这很关键，因为它说明平台层已经不是单纯“做个审批页面”，而是在尝试把不同业务系统的审批收敛到一个统一语义层。
+
+## 5. 当前审批/工作流系统的真实问题
+
+### 5.1 产品入口不统一
+
+当前统一工作流入口有了，但统一审批入口没有真正完成。
+
+表现为：
+
+1. `workflow` 有真实页面和路由
+2. `approval` 有类型定义和后端 API
+3. 但前端缺少真实审批中心页面与导航
+
+### 5.2 业务模型还没真正统一
+
+目前至少同时存在三种视角：
+
+1. 通用审批实例/审批记录
+2. 考勤审批流配置
+3. PLM 审批桥接记录
+
+这说明产品模型还没最终收平：
+
+- 审批中心到底看“实例”还是“业务对象”
+- 工作流设计器和考勤审批流配置是什么关系
+- PLM 是只桥接展示，还是要真正纳入统一审批操作闭环
+
+### 5.3 前端状态管理没收住
+
+当前 `stores` 里只有类型：
+
+- [types.ts](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/stores/types.ts)
+
+但没有看到真正统一的 approval/workflow store 实现。
+
+这通常意味着：
+
+1. 设计方向在推进
+2. 页面功能零散可用
+3. 但还没形成完整的、可持续维护的审批产品状态层
+
+### 5.4 workflow 还是 feature-gated
+
+默认特性开关里：
+
+- [featureFlags.ts](/Users/huazhou/Downloads/Github/metasheet2/apps/web/src/stores/featureFlags.ts#L29)
+
+`workflow` 默认是 `false`。
+
+这说明它当前更像：
+
+1. 可启用能力
+2. 内部/租户灰度能力
+3. 还不是完全默认全量开放的成熟模块
+
+## 6. `references/` 里的代码有没有直接执行
+
+结论：
+
+**当前主系统没有直接执行 `references/` 里的代码。**
+
+`references/` 下主要有三套参考：
+
+- [references/univer](/Users/huazhou/Downloads/Github/metasheet2/references/univer)
+- [references/apitable](/Users/huazhou/Downloads/Github/metasheet2/references/apitable)
+- [references/nocobase](/Users/huazhou/Downloads/Github/metasheet2/references/nocobase)
+
+但在主代码中没有查到直接 import/require 这些路径的运行时代码。
+
+实际情况更接近：
+
+1. `references/` 是参考资料库
+2. 当前主系统是自主实现
+3. 部分能力明显借鉴了参考项目的设计思路
+
+其中借鉴最明显的是 `univer` 路径：
+
+- 当前多维表核心路由是 [univer-meta.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/routes/univer-meta.ts)
+- 主运行时里也直接挂了 `/api/multitable` 和 dev alias `/api/univer-meta`
+  见 [index.ts](/Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/src/index.ts#L571)
+
+因此更准确的说法是：
+
+**有参考和吸收，但不是把 `references/` 目录当运行时代码执行。**
+
+## 7. 对当前系统的判断
+
+### 7.1 多维表当前判断
+
+多维表当前更接近：
+
+1. pilot 可实施
+2. on-prem 可部署
+3. 与飞书风格接近，但未达到飞书成熟产品级 parity
+
+所以多维表当前应该进入：
+
+- pilot 实施
+- 反馈驱动修补
+- 而不是持续做大面积主线开发
+
+### 7.2 审批/工作流当前判断
+
+审批/工作流当前更接近：
+
+1. 后端基础能力已具备
+2. 前端 workflow 产品面已有雏形
+3. 审批产品面仍不完整
+4. 业务接入路径分散在考勤、PLM、通用平台能力中
+
+所以审批/工作流现在最适合做：
+
+**产品化收口，而不是继续散点补丁。**
+
+## 8. 下一阶段开发建议
+
+建议把下一阶段拆成 3 步。
+
+### Phase A：审批/工作流现状收模
+
+目标：
+
+把当前零散能力变成统一模型。
+
+要做的事：
+
+1. 画清领域模型
+   - Workflow Definition
+   - Workflow Instance
+   - Approval Instance
+   - Approval Record
+   - Attendance Approval Flow
+   - PLM Approval Bridge
+2. 明确“审批中心”的主对象是什么
+3. 明确通用审批与业务审批的边界
+4. 明确哪些业务继续桥接，哪些业务直接内嵌
+
+建议产物：
+
+1. 系统模型图
+2. 路由/表结构映射表
+3. 前后端契约表
+
+### Phase B：统一审批中心 MVP
+
+目标：
+
+补齐前台产品面。
+
+最低可交付范围建议是：
+
+1. `/approvals`
+2. `/approvals/pending`
+3. `/approvals/history`
+4. `/approvals/:id`
+
+MVP 能力建议：
+
+1. 待办审批列表
+2. 已处理审批历史
+3. 审批详情
+4. approve / reject 操作
+5. 审批轨迹展示
+6. 基础筛选：状态、来源系统、更新时间
+
+这一步不要同时追求：
+
+1. 全业务深度打通
+2. 全通知中心
+3. 全自动化
+
+先把“统一审批入口”做出来。
+
+### Phase C：业务接入统一化
+
+目标：
+
+把考勤和 PLM 接到统一审批体验。
+
+建议顺序：
+
+1. 先接考勤
+   - 因为考勤已经有审批流配置和实际业务场景
+2. 再接 PLM
+   - 因为 PLM 目前更像桥接和 preview 语义
+
+这一阶段重点：
+
+1. 考勤审批流是否继续保留 JSON steps
+2. 是否逐步迁到 designer-first
+3. PLM 是只桥接状态，还是允许统一审批动作反写
+
+## 9. 建议的开发优先级
+
+按价值排序，我建议：
+
+1. 审批/工作流系统建模与入口统一
+2. 审批中心 MVP 页面
+3. 考勤审批接统一审批中心
+4. PLM 审批桥接收口
+5. 多维表继续按 pilot 反馈补缺，不作为当前主线
+
+## 10. 不建议的做法
+
+当前不建议：
+
+1. 继续沿旧 PR 线做零散修补
+2. 继续把主要资源投到多维表细枝末节 polish
+3. 继续把审批分散在各业务页面里，不建设统一审批中心
+4. 误以为 `references/` 目录里的代码仍在主系统直接运行
+
+## 11. 最终建议
+
+当前最好的开发主线是：
+
+**从“多维表主线开发”切换到“审批/工作流系统产品化收口”。**
+
+具体来说：
+
+1. 先做审批/工作流系统审计定稿
+2. 再做统一审批中心 MVP
+3. 再把考勤和 PLM 接上来
+
+这是当前最值、最能形成下一阶段产品增长面的方向。

--- a/docs/development/attendance-open-source-gap-matrix-20260404.md
+++ b/docs/development/attendance-open-source-gap-matrix-20260404.md
@@ -1,0 +1,394 @@
+# MetaSheet 考勤 vs Frappe HR / OrangeHRM / Kimai 差距矩阵
+
+Date: 2026-04-04
+
+## 1. 结论
+
+当前 `main` 上的考勤能力，已经达到：
+
+- **可交付、可试点、可 on-prem 部署**
+
+但还没有达到：
+
+- **成熟 HR/考勤产品级完整度**
+
+更准确地说，当前状态属于：
+
+- **核心链路可用**
+- **管理员能力较完整**
+- **员工自助与报表体系还有明显深化空间**
+
+如果审批中心由另一条线程独立推进，那么本线程完全可以继续深化考勤，但应聚焦：
+
+1. 员工自助工作台
+2. 总览 / 报表真正分层
+3. 导入导出和设备接入能力
+4. 计薪与周期汇总产品化
+
+## 2. 判断基准
+
+本矩阵基于两类事实：
+
+1. **当前主仓实际代码状态**
+   - `apps/web/src/views/attendance/**`
+   - `apps/web/src/views/AttendanceView.vue`
+   - `packages/core-backend/**`
+   - 当前 `main` 上已经通过的 release / smoke / on-prem 交付链
+2. **当前仍活跃的开源产品能力表述**
+   - Frappe HR
+   - OrangeHRM
+   - Kimai（含审批扩展生态）
+
+不把另一个窗口正在开发中的“完整审批中心”算入本线程当前成果。
+
+## 3. 当前主仓考勤能力概览
+
+### 3.1 已落地的主要前端入口
+
+- `/attendance`
+- `AttendanceExperienceView.vue`
+- `AttendanceOverview.vue`
+- `AttendanceAdminCenter.vue`
+- `AttendanceWorkflowDesigner.vue`
+- `AttendanceView.vue`
+
+### 3.2 已落地的主要能力
+
+- 员工侧总览
+  - summary / records / requests / anomalies / holidays
+- 申请能力
+  - leave
+  - overtime
+  - missed_check_in
+  - missed_check_out
+- 状态机
+  - pending / approved / rejected / cancelled
+- 管理端
+  - 班次
+  - 排班
+  - 轮班规则 / 轮班排班
+  - 节假日
+  - 请假类型
+  - 规则集 / 规则模板 / 结构化规则构建器
+  - 导入批次 / 导入工作流
+  - 审计日志
+  - 计薪模板 / 计薪周期
+- on-prem 交付
+  - attendance 包
+  - platform/multitable 包
+  - smoke / preflight / package verify / release gate
+
+### 3.3 当前已经可交付的部分
+
+- 核心 attendance API
+- 核心审批状态机
+- request -> approve -> records settlement
+- 导入模板 / preview / commit / export smoke
+- 权限隔离
+- 平台包下普通员工 attendance 自助权限
+- `ENABLE_PLM=0` 的 platform 壳
+
+## 4. 最值得参考的开源软件
+
+### 4.1 Frappe HR
+
+官方仓库：
+
+- <https://github.com/frappe/hrms>
+
+官方资料：
+
+- <https://frappe.io/hr/shifts-and-attendance>
+- <https://frappe.io/hr/leave-management>
+- <https://github.com/frappe/biometric-attendance-sync-tool>
+
+最适合借鉴：
+
+- 班次 / 轮班 / 自动考勤
+- 请假与考勤规则的结合
+- 打卡设备与生物考勤同步
+- HR 配置面板的信息架构
+
+### 4.2 OrangeHRM
+
+官方仓库：
+
+- <https://github.com/orangehrm/orangehrm>
+
+官方资料：
+
+- <https://help.orangehrm.com/hc/en-us/articles/360036161154-How-to-use-Leave-Module>
+- <https://help.orangehrm.com/hc/en-us/articles/49813414590617-How-to-use-OrangeHRM-Attendance-Module-Admin>
+
+最适合借鉴：
+
+- 员工自助入口
+- 请假 / 审批 / 门户式 UX
+- HR 管理导航分层
+- 员工与管理员视角分离
+
+### 4.3 Kimai
+
+官方仓库：
+
+- <https://github.com/kimai/kimai>
+
+官方资料：
+
+- <https://www.kimai.org/documentation/>
+- <https://www.kimai.org/documentation/permissions.html>
+- <https://github.com/KatjaGlassConsulting/ApprovalBundle>
+
+最适合借鉴：
+
+- timesheet / export / report 结构
+- 权限模型和角色隔离
+- 审批列表与周期间统计体验
+
+### 4.4 OpenHRMS
+
+官方仓库：
+
+- <https://github.com/CybroOdoo/OpenHRMS>
+
+官方资料：
+
+- <https://www.openhrms.com/leave-and-attendance-manager/>
+
+定位判断：
+
+- OpenHRMS 更像 **Odoo 上的一组 HR 插件模块集合**
+- 它不是 MetaSheet 这种“平台壳 + feature flag + on-prem 包”的产品形态
+
+最适合借鉴：
+
+- attendance regularization（补卡/考勤修正）流程
+- shift / overtime / holiday / vacation 的模块拆分
+- leave policy / leave approval 规则拆分
+
+不适合作为主参考：
+
+- 平台壳信息架构
+- 前端导航设计
+- on-prem 发布与交付链
+- 非 Odoo 体系下的应用承载方式
+
+## 5. 差距矩阵
+
+| 能力域 | 当前 MetaSheet 状态 | 推荐参考 | 差距等级 | 优先级 |
+|---|---|---|---|---|
+| 员工自助首页 | 基础可用，但更像数据页，不像员工工作台 | OrangeHRM | 中 | 高 |
+| 总览 vs 报表分层 | 已分入口，但产品语义仍偏近 | Kimai / OrangeHRM | 中到高 | 高 |
+| 申请创建与状态机 | 已可用 | Frappe HR / OrangeHRM | 低 | 低 |
+| 审批中心统一产品 | 正在另一线程推进 | OrangeHRM / ApprovalBundle | 高 | 由另一线程处理 |
+| 班次 / 排班 / 轮班 | 已具备核心能力 | Frappe HR | 中 | 高 |
+| 自动考勤与设备接入 | 规则具备，但设备同步链仍薄 | Frappe HR | 高 | 高 |
+| 请假类型 / 政策建模 | 已有基础模型 | Frappe HR / OrangeHRM | 中 | 中 |
+| 导入模板 / CSV 全流程 | 已有基础，但实施体验仍可加强 | Frappe HR | 中 | 高 |
+| 导出 / 统计 / 周期报表 | 已有基础，但管理报表深度不足 | Kimai | 中到高 | 高 |
+| 计薪模板 / 计薪周期 | 已有基础 API 与管理面 | Kimai / Frappe HR | 中 | 中到高 |
+| 审计与操作追踪 | 已具备 | Kimai | 低到中 | 中 |
+| 员工移动端体验 | 可访问，但并非产品级移动 UX | OrangeHRM | 高 | 中 |
+| 通知 / inbox / 催办 | 仍较薄 | OrangeHRM / Frappe HR | 高 | 中 |
+| 实施与交付链 | 已较强 | 当前已领先多数开源方案 | 低 | 低 |
+
+## 6. 已经接近成熟产品的部分
+
+### 6.1 管理后台 breadth
+
+当前 MetaSheet 的管理端 breadth 已经很高：
+
+- 班次
+- 排班
+- 轮班
+- 规则集
+- 节假日
+- 请假类型
+- 导入
+- 审计
+- 计薪
+
+这意味着现在的主要问题不是“没有模块”，而是：
+
+- 模块之间的产品闭环不够强
+- 员工视角完成度不够高
+- 报表和实施体验还能更顺
+
+### 6.2 on-prem 交付链
+
+与很多开源 HR/考勤系统相比，当前仓库在：
+
+- package build
+- package verify
+- preflight
+- smoke
+- release gate
+- operator artifact
+
+这条链已经非常完整，属于当前优势项。
+
+## 7. 差距最大的部分
+
+### 7.1 员工自助体验
+
+当前 `/attendance` 虽然可用，但更像“功能集合页”，不是员工真正的工作台。
+
+仍缺：
+
+- 更强的个人首页叙事
+- 我的问题 / 我今天 / 我这周 / 待处理事项
+- 申请与结果回写的清晰反馈
+- 面向员工的低认知负担路径
+
+这块最值得参考 OrangeHRM。
+
+### 7.2 总览与报表产品语义
+
+目前“总览”和“报表”已经不是同一页面，但仍偏近：
+
+- 总览还承载了部分报表性信息
+- 报表还不够像管理分析台
+
+这块最值得参考 Kimai：
+
+- 周期统计
+- 人员/项目/类型维度切片
+- 导出即分析
+
+### 7.3 设备接入与自动考勤深度
+
+当前规则引擎和班次/轮班已在，但设备接入和自动考勤产品化深度不够。
+
+仍缺：
+
+- 更明确的打卡源接入策略
+- 生物设备同步工具链
+- 自动考勤异常闭环
+- 补卡后规则重算 / 追溯更新的可解释性
+
+这块最值得参考 Frappe HR。
+
+## 8. 本线程建议避免的写入范围
+
+因为另一个窗口正在做“完整审批中心”，本线程应避免直接改这些区域：
+
+- `apps/web/src/views/ApprovalInboxView.vue`
+- `packages/core-backend/src/routes/approvals.ts`
+- `packages/core-backend/src/routes/approval-history.ts`
+
+本线程更适合改：
+
+- `apps/web/src/views/attendance/**`
+- `apps/web/src/views/AttendanceView.vue`
+- attendance import/export/report/scheduling/payroll 相关 API 与 UI
+
+## 9. 建议的下一阶段路线
+
+### Phase A: 员工自助工作台
+
+目标：
+
+- 让 `/attendance` 更像员工首页，而不是功能集合页
+
+建议内容：
+
+- 我的今日状态
+- 我的异常
+- 最近打卡
+- 我的申请状态
+- 待处理事项提示
+
+主要参考：
+
+- OrangeHRM
+
+### Phase B: 总览 / 报表彻底分层
+
+目标：
+
+- 总览 = 即时状态
+- 报表 = 周期分析 / 导出 / 管理视角
+
+建议内容：
+
+- 总览保留 summary / anomalies / recent records
+- 报表集中 request report / payroll summary / manager filters / CSV export
+
+主要参考：
+
+- Kimai
+
+### Phase C: 导入导出 + 设备接入深化
+
+目标：
+
+- 让实施与真实考勤接入更顺
+
+建议内容：
+
+- 更清晰的 mapping profile
+- 模板下载与错误回显强化
+- 生物考勤/打卡源同步链
+- 导入后影响报告和追溯解释
+
+主要参考：
+
+- Frappe HR
+
+## 10. 综合判断
+
+### 如果目标是：
+
+**“继续把考勤做深，但不和审批中心撞车”**
+
+结论：
+
+- **完全可以继续**
+
+### 如果目标是：
+
+**“下一条最值钱的深化开发”**
+
+结论：
+
+- **先做员工自助工作台 + 总览/报表分层**
+
+### 如果目标是：
+
+**“下一条最值得参考的开源主样板”**
+
+结论：
+
+- **主参考选 Frappe HR**
+- **员工自助 UX 补看 OrangeHRM**
+- **报表/导出/统计体验补看 Kimai**
+
+## 11. 参考优先级建议
+
+建议的参考优先级：
+
+1. **Frappe HR**
+   - 主参考
+   - 重点看班次、自动考勤、设备接入
+2. **OrangeHRM**
+   - 补员工自助和 HR 门户 UX
+3. **Kimai**
+   - 补报表、导出、统计体验
+4. **OpenHRMS**
+   - 只作为流程与模块拆分补充参考
+
+一句话判断：
+
+- **OpenHRMS 值得看**
+- **但更适合抄“业务流程点子”**
+- **不适合当 MetaSheet 考勤的主产品蓝本**
+
+## 12. 推荐外部口径
+
+建议内部表述为：
+
+> MetaSheet 当前考勤已经具备可交付的核心链路和较完整的管理后台；下一阶段应从“功能可用”转向“员工自助、报表体系、设备接入和产品完成度”。
+
+不建议表述为：
+
+> 考勤已经做完，只剩审批中心。

--- a/docs/development/delivery-method-standardization-design-20260408.md
+++ b/docs/development/delivery-method-standardization-design-20260408.md
@@ -1,0 +1,130 @@
+# Delivery Method Standardization
+
+Date: 2026-04-08
+
+## Goal
+
+Turn the delivery pattern already exercised on the DingTalk rollout and the multitable pilot into a reusable standard method instead of repeating the process ad hoc per line.
+
+## Scope
+
+Standardize these four layers:
+
+1. verification stages
+2. handoff artifact layout
+3. on-prem rollout / evidence return contract
+4. publish targets
+
+This design does not change product runtime behavior. It defines the repeatable delivery process around runtime changes.
+
+## Standard Stages
+
+Every release-bound business slice should move through the same checkpoints:
+
+1. local readiness
+2. release-bound gate
+3. real staging verification
+4. on-prem rollout
+5. handoff bundle publication
+6. field preflight evidence return
+
+Required meanings:
+
+- `local readiness`
+  proves the code path, focused smoke, and local operator contract.
+- `release-bound gate`
+  proves build, test, package, and canonical gate artifacts.
+- `real staging verification`
+  proves the actual public staging URL and real environment behavior.
+- `on-prem rollout`
+  proves the target host is actually running the intended build.
+- `handoff publication`
+  makes the package available through GitHub Release and the remote delivery directory.
+- `field preflight evidence return`
+  is the final boundary before checkpoint / expansion / UAT closeout / customer closeout.
+
+## Standard Artifact Layout
+
+Each final delivery bundle should contain:
+
+- `README.md`
+- `HANDOFF-SUMMARY.md`
+- `pilot-ready/`
+- `release-bound/`
+- `onprem-gate/`
+- `handoff/`
+- `staging-verify/`
+
+Required meanings:
+
+- `README.md`
+  quick entry for test / implementation / UAT.
+- `HANDOFF-SUMMARY.md`
+  canonical top-level decision and remaining boundary.
+- `pilot-ready/`
+  local readiness evidence.
+- `release-bound/`
+  release-bound gate evidence.
+- `onprem-gate/`
+  deployable package validation evidence.
+- `handoff/`
+  operator-facing combined packet.
+- `staging-verify/`
+  real staging rerun evidence, including smoke and any policy gates such as profile thresholds.
+
+## Standard Publish Targets
+
+Every final handoff line should publish to both:
+
+1. GitHub Release
+2. on-prem delivery directory
+
+Required targets:
+
+- GitHub Release
+  for versioned download, traceability, and checksum distribution.
+- remote delivery directory
+  for field/operator access without requiring GitHub credentials on the target host.
+
+Recommended remote path:
+
+- `~/delivery/<package-name>`
+
+## Standard Evidence Contract
+
+No line should be called customer-complete until both field preflight artifacts are returned:
+
+- `/opt/metasheet/output/preflight/<line>-preflight.json`
+- `/opt/metasheet/output/preflight/<line>-preflight.md`
+
+This contract should be repeated in:
+
+- `HANDOFF-SUMMARY.md`
+- `handoff/handoff.md`
+- GitHub Release notes
+- field/operator runbook
+
+## Standard Status Vocabulary
+
+To avoid ambiguous handoff language, use these fixed labels:
+
+- `READY FOR HANDOFF`
+- `functional staging verified`
+- `staging release-bound verified`
+- `customer sign-off pending returned preflight evidence`
+- `customer sign-off complete`
+
+Do not use `done` or `released` without saying which boundary has actually been crossed.
+
+## Standard Follow-Up Handling
+
+If functionally correct staging passes but policy gates fail, split the result:
+
+- handoff can proceed when functional staging is green and the remaining blocker is explicitly scoped
+- final release-bound status stays open until the gate is resolved
+
+Once the remaining gate is closed, the same bundle should be updated in place instead of creating a second ambiguous handoff package.
+
+## Immediate Next Step
+
+Apply this standard method to future cross-system integrations, including DingTalk interoperability work, so each line is delivered with the same checkpoints, artifacts, rollout proof, and returned-evidence contract.

--- a/docs/development/multitable-service-extraction-roadmap-20260407.md
+++ b/docs/development/multitable-service-extraction-roadmap-20260407.md
@@ -1,0 +1,440 @@
+# Multitable Service Extraction Roadmap (2026-04-07)
+
+> 文档类型：重构路线图 / 实施规划
+> 日期：2026-04-07
+> 范围：从 `packages/core-backend/src/routes/univer-meta.ts` 抽最小 helper，到长期维护 multitable 的阶段化方案
+> 关联主题：after-sales C-min / C-full、multitable 长期维护、plugin 与 core-backend 边界
+
+## TL;DR
+
+`univer-meta.ts` 已经成为 multitable 的单体路由内核，继续把新能力直接堆进去会放大维护成本。当前最合适的路线不是先做完整 service 化，也不是让业务插件直接写 `meta_*` SQL，而是先在 backend 内部建立最小 seam：`provisioning.ts`、`loaders.ts`、`access.ts`。after-sales installer 的 C-min 应作为第一个消费者，只真实创建 `installedAsset` 对象的最小字段集；随后再按 `attachment -> record -> query -> permission` 的顺序继续拆分。
+
+---
+
+## 1. 背景与问题定义
+
+### 1.1 当前事实
+
+- `packages/core-backend/src/routes/univer-meta.ts` 已经承载 multitable 的主要读写逻辑。
+- 该文件内部同时包含：
+  - 元数据创建：`/bases`、`/sheets`、`/fields`、`/views`
+  - 记录读写：`/records`
+  - 附件上传/下载/删除：`/attachments`
+  - 权限判断、字段只读判断、视图解析、attachment summary、lookup/link/rollup 辅助逻辑
+- 现有 helper 虽然已经存在，但仍全部内联在 route 文件中，例如：
+  - `ensureLegacyBase`
+  - `loadSheetRow`
+  - `loadFieldsForSheet`
+  - `tryResolveView`
+  - `resolveRequestAccess`
+  - `deriveCapabilities`
+- 当前没有可供插件直接依赖的 `context.api.multitable`，也没有独立的 multitable backend service。
+
+### 1.2 当前风险
+
+如果不先建立 backend 内部边界，后续会同时出现两类技术债：
+
+1. 新 multitable 能力继续堆进 `univer-meta.ts`，路由文件继续膨胀。
+2. 业务插件为了自救，开始直接操作 `meta_bases` / `meta_sheets` / `meta_fields` / `meta_views`，把平台内部 schema 知识扩散到插件层。
+
+这两条路径都会让未来的 multitable 长期维护更贵。
+
+### 1.3 当前时机为什么合适
+
+- after-sales installer 刚好需要“建 base / 建 sheet / 建 field”能力。
+- `app.manifest.json` 已经声明 `installedAsset` 的 `backing: "multitable"`。
+- 当前尚未把 `meta_*` schema 知识写进 after-sales 插件，边界还来得及放对。
+- `univer-meta.ts` 内已经有天然可抽的 helper 形状，重构成本可控。
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+本路线图同时服务两个目标：
+
+1. 给 after-sales C-min 提供一条不污染插件边界的真实 multitable 落地路径。
+2. 为 multitable 的长期维护建立稳定目录、抽取顺序与验收标准。
+
+### 2.2 非目标
+
+本路线图明确不做以下事情：
+
+- 不在本阶段重写整个 `univer-meta.ts`
+- 不先做完整 `MultitablePermissionService`
+- 不把插件变成 `meta_*` 表的直接操作者
+- 不通过 backend 自调自身 HTTP 的方式复用 multitable route
+- 不把现有 `packages/core-backend/src/services/view-service.ts` 强行扩展为 `meta_views` service
+- 不把 after-sales C-min 扩大成“完整售后模板全部对象 + 全部视图 + 全部自动化”
+
+---
+
+## 3. 当前结构盘点
+
+### 3.1 现有 multitable 元数据模型
+
+当前 multitable 主要围绕以下表组织：
+
+- `meta_bases`
+- `meta_sheets`
+- `meta_fields`
+- `meta_views`
+- `meta_records`
+- `multitable_attachments`
+
+关系概念上可理解为：
+
+```mermaid
+graph TD
+  B[meta_bases]
+  S[meta_sheets]
+  F[meta_fields]
+  V[meta_views]
+  R[meta_records]
+  A[multitable_attachments]
+
+  B --> S
+  S --> F
+  S --> V
+  S --> R
+  S --> A
+```
+
+### 3.2 `univer-meta.ts` 中已经存在的可抽边界
+
+当前可以较低风险抽出的块包括：
+
+- provisioning 相关
+  - `ensureLegacyBase`
+  - 创建 sheet 的 SQL 片段
+  - 创建 field 的 SQL 片段
+- loaders 相关
+  - `loadSheetRow`
+  - `loadFieldsForSheet`
+  - `tryResolveView`
+- access 相关
+  - `resolveRequestAccess`
+  - `deriveCapabilities`
+
+### 3.3 暂时不宜优先抽出的块
+
+以下块复杂度更高，不适合在第一步就动：
+
+- 全量 query/read 路径
+- lookup / rollup / link 复合查询路径
+- records patch 的所有联动写逻辑
+- 全量附件生命周期
+
+这些能力后面要拆，但不应该先拆。
+
+---
+
+## 4. 推荐目录结构
+
+建议在 backend 内新增目录：
+
+```text
+packages/core-backend/src/multitable/
+  provisioning.ts
+  loaders.ts
+  access.ts
+  field-codecs.ts
+  attachment-service.ts         # 后续阶段
+  record-service.ts             # 后续阶段
+  query-service.ts              # 后续阶段
+  permission-service.ts         # 远期按需
+```
+
+### 4.1 目录职责
+
+- `provisioning.ts`
+  - 负责创建 base / sheet / field
+  - 是 after-sales installer 的第一消费者目标
+- `loaders.ts`
+  - 负责 sheet / field / view 等基础加载
+- `access.ts`
+  - 负责能力推导、只读判断、基础访问控制
+- `field-codecs.ts`
+  - 负责字段类型映射、property 规范化、select/link/lookup/rollup 配置清洗
+
+### 4.2 边界原则
+
+- route 文件只保留 `req/res` 协调和 HTTP 错误映射
+- `meta_*` schema 只允许 backend 内核层访问
+- plugin 只依赖 adapter 接口或 backend 内部 helper，不直接写 SQL
+
+---
+
+## 5. 阶段化路线
+
+### 5.1 M0：建立最小 seam
+
+### 目标
+
+在不做大重构的前提下，先把最稳定的通用能力从 `univer-meta.ts` 抽出。
+
+### 交付
+
+- 新增 `packages/core-backend/src/multitable/provisioning.ts`
+- 新增 `packages/core-backend/src/multitable/loaders.ts`
+- 新增 `packages/core-backend/src/multitable/access.ts`
+- `univer-meta.ts` 改为调这些 helper，而不是继续内联新 SQL
+
+### 最小 API 形状
+
+`provisioning.ts` 建议先只暴露：
+
+- `ensureLegacyBase(query)`
+- `ensureSheet({ query, baseId, sheetId, name, description })`
+- `ensureFields({ query, sheetId, fields })`
+
+`loaders.ts` 建议先暴露：
+
+- `loadSheetRow(query, sheetId)`
+- `loadFieldsForSheet(query, sheetId)`
+- `tryResolveView(pool, viewId)`
+
+`access.ts` 建议先暴露：
+
+- `resolveRequestAccess(req)`
+- `deriveCapabilities(permissions, isAdminRole)`
+
+### 验收标准
+
+- 新 multitable 能力不再直接新增内联 SQL 到 `univer-meta.ts`
+- `provisioning.ts` 已可被 route 或 installer 复用
+- 至少有 helper-level unit test 覆盖上述 3 个文件
+
+### 5.2 M1：after-sales C-min 接入 provisioning seam
+
+### 目标
+
+让 after-sales installer 成为 `provisioning.ts` 的第一个真实消费者。
+
+### 范围
+
+- 不做完整售后模板安装
+- 只让 after-sales installer 对 `installedAsset` 执行真实 multitable 创建
+- views / records / attachments / automations / notifications 全部继续留在 C-full 或后续阶段
+
+### 推荐实现
+
+- plugin 内保留 adapter 接口
+- production adapter 调用 backend 内部 `provisioning.ts`
+- unit test 继续注入 fake adapter
+
+### 字段策略
+
+C-min 不应引入临时性的伪业务字段。推荐的最小持久字段集：
+
+- `assetCode: string`
+- `serialNo: string`（可选）
+
+不建议把以下字段当作 C-min 的“占位字段”：
+
+- `id`
+- `created_at`
+- `updated_at`
+- 纯展示用途但不进入最终设计的泛化字段
+
+### 验收标准
+
+- after-sales installer 不直接访问 `meta_*`
+- `runInstall()` 真实建出 `installedAsset` 对应 sheet 和字段
+- 现有 installer unit tests 继续通过
+- 新增 1-2 个 integration tests 验证 provisioning helper 与真实 DB 契约
+
+### 5.3 M2：抽 attachment 与 record 写路径
+
+### 目标
+
+把最容易出错、最容易复制粘贴的写路径从 route 中移出。
+
+### 顺序
+
+1. `attachment-service.ts`
+2. `record-service.ts`
+
+### 为什么 attachment 先于 record
+
+- 边界更清晰
+- 与 storage、上传、删除、副作用更集中
+- record 写路径和 attachment 校验存在依赖关系
+
+### 验收标准
+
+- 附件上传/删除/序列化逻辑不再主要驻留在 route handler
+- record create / patch 的字段校验、只读判断、attachment id 校验开始走 service
+
+### 5.4 M3：抽 query/read 路径
+
+### 目标
+
+把 multitable 的查询复杂度从 route 文件搬到内核 service。
+
+### 产物
+
+- `query-service.ts`
+
+### 负责内容
+
+- 视图读取
+- filter / sort / search
+- link summary
+- lookup / rollup 计算
+- attachment summaries
+
+### 风险说明
+
+这是整体路线里最重的一步，必须晚于 M0 / M1 / M2。否则会把“建立正确边界”演变成“同时重写读路径和写路径”。
+
+### 验收标准
+
+- 列表读取和视图读取主逻辑不再主要留在 route 中
+- query service 有独立 integration tests 覆盖典型 view/filter/sort 场景
+
+### 5.5 M4：权限服务化
+
+### 目标
+
+只有当 multitable ACL 真正复杂化时，才把 `access.ts` 升格为完整 service。
+
+### 触发条件
+
+以下任一条件满足时，再考虑 `permission-service.ts`：
+
+- 字段级 ACL 大幅增加
+- 对象级 / 记录级 ACL 成为稳定需求
+- project-scoped ACL 正式进入 multitable
+- route / service 中重复出现多套能力计算逻辑
+
+### 当前建议
+
+当前不要优先做 `permission-service.ts`。先有 `access.ts` 即可。
+
+---
+
+## 6. 推荐优先级
+
+长期维护 multitable 的推荐顺序如下：
+
+1. `provisioning.ts`
+2. `loaders.ts`
+3. `access.ts`
+4. `attachment-service.ts`
+5. `record-service.ts`
+6. `query-service.ts`
+7. `permission-service.ts`
+
+这个顺序的核心原则是：
+
+- 先建立“新功能必须经过的 backend seam”
+- 再收敛高频写路径
+- 最后处理最复杂的读路径和 ACL
+
+---
+
+## 7. 与 after-sales 的对应关系
+
+### 7.1 after-sales C-min
+
+after-sales C-min 不应该成为插件直接写 multitable schema 的入口。它应该承担两件事：
+
+1. 验证 `provisioning.ts` 的边界是否够用
+2. 为后续 C-full 与更多业务模板建立正确的 backend seam
+
+### 7.2 after-sales C-full
+
+C-full 再继续往下走时，建议顺序是：
+
+1. 补充 blueprint 来源
+2. 扩展 `installedAsset` 完整字段
+3. 增加更多 multitable-backed 对象
+4. 补视图 provisioning
+5. 接自动化、通知、审批桥接
+
+### 7.3 after-sales 不该做的事
+
+- 不把 `meta_*` SQL 写进插件
+- 不绕过 backend helper 直接操作 multitable 内部表
+- 不通过 backend 自调 HTTP 的方式复用 `/api/multitable/*`
+
+---
+
+## 8. 测试策略
+
+### 8.1 总体原则
+
+保持测试金字塔，不把所有责任压到 integration test。
+
+### 8.2 推荐分层
+
+- unit tests
+  - 锁住 installer 的业务分支、错误码、账本语义
+  - 锁住 provisioning helper 的入参校验和幂等行为
+- integration tests
+  - 锁住 provisioning helper 与真实 `meta_*` schema 的契约
+  - 锁住 route 与 helper 的装配行为
+
+### 8.3 不推荐的策略
+
+- 不建议把 multitable 全量行为复制到 fake 中
+- 不建议完全放弃 unit tests 改成只跑 integration
+
+---
+
+## 9. PR 切分建议
+
+建议按 4 个 PR 切：
+
+1. `refactor(multitable): extract provisioning/loaders/access helpers`
+2. `feat(after-sales): wire installer to provisioning helper (C-min)`
+3. `refactor(multitable): extract attachment and record services`
+4. `refactor(multitable): extract query service`
+
+如果权限复杂度后续真的上来，再补：
+
+5. `refactor(multitable): introduce permission service`
+
+---
+
+## 10. 硬规则
+
+从本路线开始，建议团队固定以下规则：
+
+1. 不再让插件直接访问 `meta_*` 表。
+2. 不再往 `univer-meta.ts` 新增核心 SQL，除非只是转调新 helper。
+3. 不把 `packages/core-backend/src/services/view-service.ts` 作为 `meta_views` 的承载点。
+4. 每抽出一层 helper / service，就补对应的 unit test 和 integration test。
+5. 新的 multitable 写入能力优先进入 `packages/core-backend/src/multitable/`。
+
+---
+
+## 11. 阶段验收表
+
+| 阶段 | 核心交付 | 不该发生的事 | 通过标准 |
+|---|---|---|---|
+| M0 | `provisioning.ts` / `loaders.ts` / `access.ts` | 继续把新 helper 散写在 route 中 | 新功能通过 helper 接入 |
+| M1 | after-sales C-min 走 provisioning helper | plugin 直接写 `meta_*` | installer 能真实建 `installedAsset` |
+| M2 | attachment / record service | record 写路径继续复制粘贴 | 写路径逻辑从 route 中收敛 |
+| M3 | query service | 在 route 中继续扩 filter/sort/query 复杂度 | 读路径主要逻辑迁到 query service |
+| M4 | permission service（按需） | 过早做大 ACL 重构 | 仅在 ACL 复杂度上升时引入 |
+
+---
+
+## 12. 结论
+
+当前最稳的路线不是：
+
+- 让 after-sales 插件直接写 multitable SQL
+- 先做完整的 multitable 大重构
+- 一开始就优先做 permission service
+
+当前最稳的路线是：
+
+1. 先从 `univer-meta.ts` 抽出最小 backend seam：`provisioning.ts`、`loaders.ts`、`access.ts`
+2. 让 after-sales C-min 成为 `provisioning.ts` 的第一个消费者
+3. 再按 `attachment -> record -> query -> permission` 的顺序推进长期维护
+
+这样既能解决眼前的 after-sales 安装器问题，也不会把 multitable 的长期技术债继续扩散到插件层。

--- a/docs/development/platform-application-blueprint-20260406.md
+++ b/docs/development/platform-application-blueprint-20260406.md
@@ -1,0 +1,163 @@
+# Platform Application Blueprint
+
+## Why this exists
+
+The current repository already has the main building blocks for a multi-business platform:
+
+- microkernel-style plugin loading
+- multitable as a generic data surface
+- approval and workflow engines
+- RBAC and admin controls
+
+What is still missing is a clean separation between:
+
+- platform primitives
+- business applications
+- plugin extensions
+
+This document defines a low-conflict execution path while `attendance`, `multitable`, and `approvals` are actively being developed in parallel.
+
+## Current platform mapping
+
+### Platform primitives that already exist
+
+- Data primitive: multitable
+- Process primitive: workflow + approvals
+- Access primitive: auth + RBAC
+- Extension primitive: plugin loader + plugin admin
+- Integration primitive: federation / external adapters
+
+### Business modules already visible in the repo
+
+- Attendance: plugin-first business module
+- Multitable: platform-owned core primitive
+- Approvals / workflow: platform-owned core primitive
+- PLM views / bridges: mixed platform and business integration layer
+
+## Target layering
+
+```text
+tenant / org / user / role
+  -> platform shell
+  -> platform primitives
+     -> multitable
+     -> workflow
+     -> approvals
+     -> comments
+     -> files
+     -> notifications
+     -> events
+  -> business applications
+     -> attendance
+     -> after-sales
+     -> purchasing
+     -> equipment
+  -> plugin extensions
+     -> connectors
+     -> custom pages
+     -> custom automation
+```
+
+## Execution policy during concurrent development
+
+Because the local worktree already contains unrelated changes in `attendance`, `multitable`, and `approvals`, phase 1 must avoid direct edits in those domains.
+
+Phase 1 safe change scope:
+
+- new documentation
+- new platform manifest definitions
+- new business app skeletons
+- minimal frontend plugin host generalization
+
+Do not change in phase 1:
+
+- existing attendance business logic
+- multitable record / field / view behavior
+- approval bridge implementation
+- platform startup / plugin runtime internals unless absolutely required
+
+## Platform primitive contract
+
+Business applications should prefer composition over bespoke infrastructure.
+
+### Data
+
+- Use multitable for configurable object storage first
+- Add service-owned tables only when the domain needs strict transactional or performance boundaries
+- Treat multitable as the default UI-facing schema layer
+
+### Process
+
+- Reuse workflow for long-running orchestration
+- Reuse approvals for human decision points
+- Avoid embedding approval state machines independently inside each business app
+
+### Access
+
+- Add app-scoped RBAC permissions such as `after_sales:read`
+- Keep platform-level admin separate from app-level admin
+
+### Extension
+
+- Use plugins for business-specific routes, sync jobs, connectors, or specialized pages
+- Do not use plugins as a substitute for platform primitives
+
+## App manifest model
+
+Every business application should eventually declare:
+
+- identity
+- bounded context ownership
+- platform dependencies
+- navigation entries
+- app permissions
+- domain objects
+- workflows
+- external integrations
+
+This repo now includes a first `PlatformAppManifest` schema plus an `after-sales` example skeleton.
+
+## After-sales application shape
+
+The recommended `after-sales` bounded context is:
+
+- tickets
+- service orders
+- customers
+- installed assets
+- warranty policies
+- service visits
+- closure / satisfaction feedback
+
+Recommended implementation split:
+
+- multitable for customer-facing objects and configurable data views
+- workflow / approvals for dispatch, escalation, refund, replacement, or exception handling
+- plugin code for SLA calculation, connector sync, specialized APIs, and dedicated UI pages
+
+## Phase 1 deliverables
+
+1. Add a platform app manifest schema
+2. Generalize the frontend plugin host to resolve more than one plugin page
+3. Scaffold `plugin-after-sales`
+4. Keep all changes isolated from active attendance / multitable / approvals work
+
+## Next phases
+
+### Phase 2
+
+- add backend loader support for `app.manifest.json`
+- expose platform apps through an `/api/apps` endpoint
+- bind app manifests to feature flags and RBAC
+
+### Phase 3
+
+- route app objects to multitable metadata
+- route app workflows to workflow designer templates
+- route app approvals to unified approval flows
+
+### Phase 4
+
+- strengthen runtime isolation for plugins
+- make frontend app pages dynamically discoverable
+- add app marketplace / version governance

--- a/docs/development/platform-evolution-plan-20260406.md
+++ b/docs/development/platform-evolution-plan-20260406.md
@@ -1,0 +1,1694 @@
+# MetaSheet2 Platform Evolution Plan
+
+Date: 2026-04-06  
+Scope: evolve MetaSheet2 from a multitable-centric tool into a Feishu/Lark-like business platform without rewriting the existing microkernel/plugin foundation, while preserving safe execution boundaries for the current attendance, multitable, and approvals delivery tracks.
+
+## Executive Summary
+
+MetaSheet2 already has the hard parts that many platform products add late: plugin loading, a real message bus, an event bus, granular permissions, multi-tenant context plumbing, real-time collaboration, and a growing domain surface around attendance, multitable, approvals, and PLM federation. The practical path forward is not a rewrite. It is a staged expansion of the current core so that:
+
+1. the platform gets an explicit organization/workspace/app shell,
+2. plugins become discoverable platform apps and extension providers,
+3. automation becomes a first-class trigger-condition-action layer across apps,
+4. notifications become shared platform primitives instead of app-local features,
+5. templates and internal app distribution become governed platform capabilities,
+6. dashboards and reporting become the synthesis layer across apps.
+
+The approved execution order below is dependency-driven and optimized to avoid collision with active business delivery:
+
+1. Phase 1A: Workspace shell, app registry, launcher, legacy redirects
+2. Phase 1B: request context extension with `organizationId` and `workspaceId`
+3. Phase 2A: UI extension registry for views, fields, triggers, and actions
+4. Phase 2B: automation runtime, run logs, and constrained rule builder
+5. Phase 3: Notification hub
+6. Phase 4: internal app catalog and template library
+7. Phase 5: Dashboard and reporting engine
+
+Cross-cutting implementation rule: reuse the current microkernel, `EventBusService`, `message-bus`, existing plugin manifests, `AsyncLocalStorage` tenant context, `Socket.IO` collaboration, and current multitable/workflow/approval services. Do not fork platform logic into parallel subsystems.
+
+## Execution Amendment
+
+This document remains the platform blueprint, but the implementation sequence is amended from the original draft. The goal is to preserve the target architecture while reducing risk against the current codebase and current parallel business streams.
+
+Approved implementation constraints:
+
+- `Phase 1A` must not change JWT/Auth semantics, the canonical meaning of `tenantId`, or the existing `workflow` `tenant_id` query path.
+- `Phase 1A` and `Phase 2A` must avoid refactoring attendance, multitable, and approvals internals. They are shell and registry phases, not domain rewrite phases.
+- `Phase 2A` and `Phase 2B` are intentionally split. Metadata registration and runtime automation must not ship as one large branch.
+- The original marketplace chapter is downgraded in the approved rollout to an internal app catalog plus first-party templates. Open or third-party marketplace behavior is explicitly deferred until plugin sandboxing and capability scoping become real runtime guarantees.
+- Calendar estimates in this document assume a mostly dedicated platform team. If the same engineers are concurrently shipping attendance, multitable, and approvals, apply a `1.5x` schedule-risk factor to calendar forecasts.
+
+Approved execution sequence:
+
+1. `Phase 1A`: `PlatformShell`, `app-registry`, launcher, legacy redirects
+2. `Phase 1B`: request context adds `organizationId` and `workspaceId`, while `tenantId` stays the shard routing key
+3. `Phase 2A`: extension registry for `views`, `fieldTypes`, `triggers`, and `actions`
+4. `Phase 2B`: automation runtime, execution logs, idempotency, and a constrained builder
+5. `Phase 3`: notification hub
+6. `Phase 4`: internal app catalog and template library
+7. `Phase 5`: dashboard and reporting engine
+
+## 1. Phase Capability Plan
+
+The sections below describe the target capability buckets. The approved rollout order is the amended sequence above.
+
+### Phase 1: Workspace and Platform Shell
+
+**Implementation note**
+
+Execution is split into `Phase 1A` and `Phase 1B`.
+
+- `Phase 1A` delivers shell, launcher, app registry, and legacy redirect compatibility.
+- `Phase 1B` adds request context enrichment and membership convergence.
+- Do not require JWT payload changes, `tenant-context` semantic changes, or workflow query rewrites in `Phase 1A`.
+
+**Goal**
+
+Introduce a real `organization -> workspace -> app` model and replace hardcoded shell navigation with a dynamic launcher, while preserving all existing routes and existing plugins unchanged.
+
+**Why this phase comes first**
+
+Feishu/Lark-like evolution is impossible without a stable shell. Every later capability in this plan needs a workspace context, app catalog, and launcher contract.
+
+**Standalone value delivered**
+
+- Workspace switcher for the same tenant/org.
+- Dynamic app launcher and sidebar.
+- First-class app catalog for attendance, multitable, approvals, PLM, and plugin apps.
+- Per-workspace app enablement without code changes.
+
+**Files to create**
+
+- `packages/core-backend/src/db/migrations/zzzz20260406100000_create_platform_workspace_org_tables.ts`
+- `packages/core-backend/src/routes/workspaces.ts`
+- `packages/core-backend/src/routes/platform-apps.ts`
+- `packages/core-backend/src/services/WorkspaceService.ts`
+- `packages/core-backend/src/services/PlatformAppService.ts`
+- `packages/core-backend/src/platform/app-registry.ts`
+- `apps/web/src/components/PlatformShell.vue`
+- `apps/web/src/components/AppLauncher.vue`
+- `apps/web/src/components/WorkspaceSwitcher.vue`
+- `apps/web/src/views/PlatformHomeView.vue`
+- `apps/web/src/views/WorkspaceSettingsView.vue`
+- `apps/web/src/composables/useWorkspace.ts`
+- `apps/web/src/composables/usePlatformApps.ts`
+
+**Files to modify**
+
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/platform/app-manifest.ts`
+- `packages/core-backend/src/db/types.ts`
+- `packages/core-backend/src/db/sharding/tenant-context.ts`
+- `packages/core-backend/src/auth/AuthService.ts`
+- `packages/core-backend/src/auth/jwt-middleware.ts`
+- `apps/web/src/App.vue`
+- `apps/web/src/main.ts`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/router/types.ts`
+- `apps/web/src/composables/usePlugins.ts`
+- `apps/web/src/view-registry.ts`
+- `apps/web/src/stores/featureFlags.ts`
+- `apps/web/src/types/plugins.ts`
+
+**Database migration**
+
+- Create `platform_organizations`, `platform_organization_members`, `platform_workspaces`, `platform_workspace_members`, `platform_workspace_apps`, `platform_user_contexts`.
+- Add `workspace_id` to `spreadsheets` if missing and backfill with a deterministic legacy workspace.
+- Backfill organizations from existing `user_orgs`.
+- Seed default core app enablement rows in the migration, then let `PlatformAppService.ts` bootstrap plugin-backed app entries from the runtime app registry on first startup.
+
+**API endpoints**
+
+- `GET /api/me/context`
+- `GET /api/orgs`
+- `POST /api/orgs`
+- `GET /api/orgs/:orgId/workspaces`
+- `POST /api/orgs/:orgId/workspaces`
+- `POST /api/workspaces/:workspaceId/context/switch`
+- `GET /api/workspaces/:workspaceId/apps`
+- `PUT /api/workspaces/:workspaceId/apps/:appId`
+- `GET /api/platform/apps`
+
+**Frontend changes**
+
+- `App.vue` becomes a thin root that renders `PlatformShell.vue`.
+- `PlatformShell.vue` owns sidebar, workspace switcher, app launcher, top bar, and `router-view`.
+- `appRoutes.ts` gains workspace-scoped routes such as `/w/:workspaceId` and keeps legacy routes as redirects.
+- `usePlatformApps()` becomes the source for launcher/navigation; `usePlugins()` remains a lower-level runtime status API.
+
+**Effort estimate**
+
+- Backend: 4 person-weeks
+- Frontend: 3 person-weeks
+- Infra/devops: 1 person-week
+- Total: 8 person-weeks
+
+**Top risks**
+
+- Workspace context leaks into the wrong tenant scope.
+- Hardcoded route assumptions in the frontend shell regress existing paths.
+- Auth token payloads drift from route guard expectations.
+
+**Mitigations**
+
+- Keep legacy URLs operational and redirect them into the new shell only after context resolution.
+- Introduce a deterministic `legacy` org/workspace backfill and dual-read old/new membership tables for one full phase.
+- Extend `tenant-context.ts` with `organizationId` and `workspaceId`, but keep `tenantId` as the canonical shard routing input until later rollout stages prove the new context path.
+
+### Phase 2: Automation and UI Extension Registry
+
+**Implementation note**
+
+Execution is split into `Phase 2A` and `Phase 2B`.
+
+- `Phase 2A` is registry work: plugin contribution validation, catalog APIs, and frontend registration/lookup.
+- `Phase 2B` is runtime work: rule execution, logs, idempotency, loop prevention, and the first constrained builder.
+- Do not deliver both tracks as one branch or one milestone.
+
+**Goal**
+
+Turn the existing eventing and plugin contribution model into a workspace-scoped automation engine and a registry for plugin-provided views, fields, triggers, actions, and widget types.
+
+**Why this phase comes second**
+
+Automation and dynamic UI extension both need workspace scoping and app identity from phase 1. Once the shell exists, rules and extension points become the core multiplier.
+
+**Standalone value delivered**
+
+- Cross-app automation for multitable, attendance, approvals, and plugin events.
+- Dynamic registration of view types and field types from plugins without hardcoded frontend maps.
+- Rule execution history with replay/debug support built on top of existing event/message infrastructure.
+
+**Files to create**
+
+- `packages/core-backend/src/db/migrations/zzzz20260406110000_create_automation_rule_tables.ts`
+- `packages/core-backend/src/routes/automation.ts`
+- `packages/core-backend/src/services/AutomationRuleService.ts`
+- `packages/core-backend/src/services/AutomationRunner.ts`
+- `packages/core-backend/src/services/ExtensionRegistryService.ts`
+- `apps/web/src/views/AutomationRulesView.vue`
+- `apps/web/src/components/AutomationRuleBuilder.vue`
+- `apps/web/src/components/AutomationCatalogDrawer.vue`
+- `apps/web/src/composables/useAutomationRules.ts`
+- `apps/web/src/composables/useExtensionRegistry.ts`
+
+**Files to modify**
+
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/core/plugin-loader.ts`
+- `packages/core-backend/src/types/plugin.ts`
+- `packages/core-backend/src/routes/events.ts`
+- `packages/core-backend/src/routes/views.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/src/services/DeadLetterQueueService.ts`
+- `apps/web/src/view-registry.ts`
+- `apps/web/src/plugins/viewRegistry.ts`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/multitable/components/MetaFieldManager.vue`
+- `apps/web/src/multitable/components/MetaViewManager.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/src/multitable/types.ts`
+
+**Database migration**
+
+- Create `automation_rules`, `automation_rule_versions`, `automation_rule_bindings`, `automation_runs`, `automation_run_steps`.
+- Reuse the existing dead-letter queue for failed actions instead of creating a second failure store.
+
+**API endpoints**
+
+- `GET /api/workspaces/:workspaceId/automations`
+- `POST /api/workspaces/:workspaceId/automations`
+- `GET /api/automations/:ruleId`
+- `PUT /api/automations/:ruleId`
+- `POST /api/automations/:ruleId/publish`
+- `POST /api/automations/:ruleId/toggle`
+- `GET /api/automations/:ruleId/runs`
+- `POST /api/automations/test-run`
+- `GET /api/platform/extensions`
+- `GET /api/platform/extensions/catalog`
+
+**Frontend changes**
+
+- Introduce an automation builder page using Element Plus drawers, trees, forms, and step editors.
+- Replace hardcoded `view-registry.ts` and multitable field/view menus with API-driven registries.
+- Add a rule catalog that includes core triggers/actions and plugin-provided triggers/actions.
+
+**Effort estimate**
+
+- Backend: 6 person-weeks
+- Frontend: 4 person-weeks
+- Infra/devops: 1 person-week
+- Total: 11 person-weeks
+
+**Top risks**
+
+- Event storms and duplicate automation runs.
+- Plugins registering unsafe actions or malformed extension metadata.
+- UI complexity of the first automation builder release.
+
+**Mitigations**
+
+- Require idempotency keys per run and persist trigger fingerprints in `automation_runs`.
+- Validate plugin contributions at load time and refuse unsafe action types before publishing them to the catalog.
+- Ship a constrained v1 builder: trigger -> conditions -> sequential actions only; parallel branches wait for phase 5.
+
+### Phase 3: Marketplace and Template Library
+
+**Implementation note**
+
+In the approved rollout, this capability bucket moves after the notification hub and is intentionally narrowed for the first release.
+
+- Treat this as an internal app catalog plus first-party template library first.
+- Keep package trust boundaries internal-only until sandboxing and capability scoping are enforceable at runtime.
+- Do not position this phase as an open marketplace in planning or staffing until plugin isolation is real.
+
+**Goal**
+
+Add a governed package catalog and template library so workspaces can enable apps, install first-party plugin packages, and provision business blueprints without code deployment.
+
+**Why this phase comes third**
+
+Marketplace packages are only useful after app identity, workspace scoping, and extension contracts are stable. Templates are materially more valuable after automation exists.
+
+**Standalone value delivered**
+
+- Internal app marketplace for attendance, after-sales, approval bridge, PLM, and future domain apps.
+- Template center for workspace starter kits, multitable bases, workflow/approval bundles, automation packs, and dashboards.
+- Versioned package rollout instead of repo-only enablement.
+
+**Files to create**
+
+- `packages/core-backend/src/db/migrations/zzzz20260406120000_create_marketplace_and_template_tables.ts`
+- `packages/core-backend/src/routes/marketplace.ts`
+- `packages/core-backend/src/routes/templates.ts`
+- `packages/core-backend/src/services/MarketplaceService.ts`
+- `packages/core-backend/src/services/TemplateLibraryService.ts`
+- `packages/core-backend/src/platform/package-registry.ts`
+- `apps/web/src/views/MarketplaceView.vue`
+- `apps/web/src/views/TemplateLibraryView.vue`
+- `apps/web/src/components/MarketplacePackageCard.vue`
+- `apps/web/src/components/TemplateInstallDrawer.vue`
+- `apps/web/src/composables/useMarketplace.ts`
+- `apps/web/src/composables/useTemplates.ts`
+
+**Files to modify**
+
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/platform/app-registry.ts`
+- `packages/core-backend/src/core/plugin-loader.ts`
+- `packages/core-backend/src/routes/platform-apps.ts`
+- `packages/core-backend/src/db/types.ts`
+- `apps/web/src/components/AppLauncher.vue`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/composables/usePlatformApps.ts`
+
+**Database migration**
+
+- Create `marketplace_packages`, `marketplace_package_versions`, `marketplace_installations`, `template_libraries`, `template_versions`, `template_installs`.
+- Treat all current first-party plugins as `system` packages on day one so nothing disappears from the current admin/plugin experience.
+
+**API endpoints**
+
+- `GET /api/marketplace/packages`
+- `GET /api/marketplace/packages/:packageId`
+- `POST /api/workspaces/:workspaceId/marketplace/install`
+- `POST /api/workspaces/:workspaceId/marketplace/upgrade`
+- `GET /api/workspaces/:workspaceId/marketplace/installations`
+- `GET /api/templates`
+- `GET /api/templates/:templateId`
+- `POST /api/workspaces/:workspaceId/templates/:templateVersionId/install`
+
+**Frontend changes**
+
+- Add a marketplace view with package cards, compatibility warnings, and install/upgrade actions.
+- Add a template library page with preview, scope, and dependency summaries.
+- Expose “Browse marketplace” and “Use template” in the launcher and workspace home.
+
+**Effort estimate**
+
+- Backend: 5 person-weeks
+- Frontend: 3 person-weeks
+- Infra/devops: 2 person-weeks
+- Total: 10 person-weeks
+
+**Top risks**
+
+- Package trust and supply-chain governance.
+- Template installs mutating live workspace data incorrectly.
+- Plugin lifecycle/hot reload conflicts during install or upgrade.
+
+**Mitigations**
+
+- Restrict the first release to signed internal packages and first-party templates.
+- Implement template install as a transaction plus post-commit validation job with rollback metadata in `template_installs`.
+- Perform package enable/disable through the current plugin loader and admin guardrails, not through ad hoc filesystem mutation.
+
+### Phase 4: Notification Hub
+
+**Implementation note**
+
+This capability bucket is promoted earlier in the approved rollout because the current codebase already has reusable notification, scheduling, and DLQ foundations.
+
+**Goal**
+
+Promote notifications from an in-memory send abstraction to a durable, multi-channel platform hub with inbox, subscriptions, preferences, and external delivery connectors.
+
+**Why this phase comes fourth**
+
+The notification hub depends on app identity, automation actions, and marketplace-installed apps/templates. It also becomes much more valuable once more than one app emits events.
+
+**Standalone value delivered**
+
+- Unified inbox for approvals, attendance alerts, automation failures, assignment changes, and marketplace updates.
+- Channel routing to in-app, email, webhook, DingTalk, Feishu, and WeCom.
+- User preferences, read state, subscriptions, and delivery observability.
+
+**Files to create**
+
+- `packages/core-backend/src/db/migrations/zzzz20260406130000_create_notification_hub_tables.ts`
+- `packages/core-backend/src/routes/notifications.ts`
+- `packages/core-backend/src/services/NotificationHubService.ts`
+- `packages/core-backend/src/services/NotificationPreferenceService.ts`
+- `packages/core-backend/src/services/NotificationDeliveryWorker.ts`
+- `apps/web/src/components/NotificationBell.vue`
+- `apps/web/src/components/NotificationDrawer.vue`
+- `apps/web/src/views/NotificationCenterView.vue`
+- `apps/web/src/views/NotificationPreferencesView.vue`
+- `apps/web/src/composables/useNotifications.ts`
+- `apps/web/src/composables/useNotificationPreferences.ts`
+
+**Files to modify**
+
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/services/NotificationService.ts`
+- `packages/core-backend/src/services/SchedulerService.ts`
+- `packages/core-backend/src/services/ChangeManagementService.ts`
+- `packages/core-backend/src/services/SLOService.ts`
+- `packages/core-backend/src/services/ApprovalBridgeService.ts`
+- `apps/web/src/components/PlatformShell.vue`
+- `apps/web/src/router/appRoutes.ts`
+
+**Database migration**
+
+- Create `notification_channels`, `notification_topics`, `notification_subscriptions`, `notification_messages`, `notification_deliveries`, `notification_user_preferences`.
+- Use `notification_deliveries.read_at` as inbox read state; no separate read table required in v1.
+
+**API endpoints**
+
+- `GET /api/workspaces/:workspaceId/notifications`
+- `POST /api/workspaces/:workspaceId/notifications/mark-read`
+- `GET /api/workspaces/:workspaceId/notification-topics`
+- `GET /api/workspaces/:workspaceId/notification-subscriptions`
+- `PUT /api/workspaces/:workspaceId/notification-subscriptions/:subscriptionId`
+- `GET /api/workspaces/:workspaceId/notification-preferences`
+- `PUT /api/workspaces/:workspaceId/notification-preferences`
+- `POST /api/workspaces/:workspaceId/notification-channels/test`
+
+**Frontend changes**
+
+- Add a top-bar notification bell with unread badge.
+- Add inbox drawer and full notification center page.
+- Add channel and digest preferences in workspace/user settings.
+
+**Effort estimate**
+
+- Backend: 4 person-weeks
+- Frontend: 3 person-weeks
+- Infra/devops: 2 person-weeks
+- Total: 9 person-weeks
+
+**Top risks**
+
+- Alert fatigue and duplicate delivery.
+- Secret management for external connectors.
+- Provider-specific rate limits and reliability differences.
+
+**Mitigations**
+
+- Deduplicate on `(message source, recipient, channel)` and support digest policies.
+- Store only `secret_ref` in DB and resolve credentials through the existing secret/config path.
+- Use the current scheduler and DLQ paths for retries, backoff, and visibility.
+
+### Phase 5: Dashboard and Reporting Engine
+
+**Goal**
+
+Turn the existing latent dashboard schema into a real workspace/app reporting layer with reusable widgets, saved queries, report schedules, and cross-app home dashboards.
+
+**Why this phase comes fifth**
+
+Dashboards are most useful after app identity, automation, package templates, and notifications all exist. They should become the synthesis layer, not the first layer.
+
+**Standalone value delivered**
+
+- Workspace home dashboards.
+- App-level operational dashboards for attendance, approvals, PLM, and marketplace usage.
+- Report schedules with notification delivery.
+- Reusable widgets backed by multitable, workflow, approval, or plugin resources.
+
+**Files to create**
+
+- `packages/core-backend/src/db/migrations/zzzz20260406140000_expand_dashboard_and_report_tables.ts`
+- `packages/core-backend/src/routes/dashboards.ts`
+- `packages/core-backend/src/routes/reports.ts`
+- `packages/core-backend/src/routes/analytics.ts`
+- `packages/core-backend/src/services/DashboardService.ts`
+- `packages/core-backend/src/services/ReportService.ts`
+- `packages/core-backend/src/services/MetricsQueryService.ts`
+- `apps/web/src/views/DashboardCenterView.vue`
+- `apps/web/src/views/ReportCenterView.vue`
+- `apps/web/src/components/DashboardCanvas.vue`
+- `apps/web/src/components/WidgetRenderer.vue`
+- `apps/web/src/components/ReportScheduleDrawer.vue`
+- `apps/web/src/composables/useDashboards.ts`
+- `apps/web/src/composables/useReports.ts`
+
+**Files to modify**
+
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/db/types.ts`
+- `packages/core-backend/src/services/DataMaterializationService.ts`
+- `packages/core-backend/src/services/CollabService.ts`
+- `apps/web/src/views/PlatformHomeView.vue`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/components/AppLauncher.vue`
+
+**Database migration**
+
+- Extend `meta_dashboards` and `meta_widgets`.
+- Create `dashboard_data_sources`, `report_definitions`, `report_runs`, `report_shares`.
+- Reuse notification hub for scheduled report delivery rather than creating a parallel mailer path.
+
+**API endpoints**
+
+- `GET /api/workspaces/:workspaceId/dashboards`
+- `POST /api/workspaces/:workspaceId/dashboards`
+- `GET /api/dashboards/:dashboardId`
+- `PUT /api/dashboards/:dashboardId`
+- `POST /api/dashboards/:dashboardId/widgets/query`
+- `GET /api/workspaces/:workspaceId/reports`
+- `POST /api/workspaces/:workspaceId/reports`
+- `POST /api/reports/:reportId/run`
+- `PUT /api/reports/:reportId/schedule`
+
+**Frontend changes**
+
+- Add a widget canvas, filter rail, saved dashboard views, and share/export flows.
+- Use extension registry entries so plugins can contribute widget types or datasource resolvers later.
+- Make `PlatformHomeView.vue` render a workspace default dashboard.
+
+**Effort estimate**
+
+- Backend: 6 person-weeks
+- Frontend: 5 person-weeks
+- Infra/devops: 1.5 person-weeks
+- Total: 12.5 person-weeks
+
+**Top risks**
+
+- Slow cross-app queries and dashboard N+1 patterns.
+- Data leakage across workspaces or roles.
+- Endless bespoke widget requests that undermine maintainability.
+
+**Mitigations**
+
+- Start with a constrained widget catalog and cached/snapshot query path.
+- Enforce workspace and RBAC filters inside datasource adapters, not only in the UI.
+- Add report materialization for expensive queries before opening arbitrary SQL or arbitrary cross-plugin joins.
+
+## 2. Database Schema Designs
+
+Implementation note: follow the existing Kysely style in `packages/core-backend/src/db/migrations/` by using `up/down`, `sql`, idempotent `CREATE ... IF NOT EXISTS`, and helper patterns from `_patterns.ts` where useful.
+
+### Phase 1 Migration
+
+File: `packages/core-backend/src/db/migrations/zzzz20260406100000_create_platform_workspace_org_tables.ts`
+
+```ts
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+const LEGACY_ORG_ID = 'org_legacy'
+const LEGACY_WORKSPACE_ID = 'ws_legacy'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS platform_organizations (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      slug text NOT NULL UNIQUE,
+      name text NOT NULL,
+      status text NOT NULL DEFAULT 'active',
+      settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_by text REFERENCES users(id) ON DELETE SET NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS platform_organization_members (
+      organization_id text NOT NULL REFERENCES platform_organizations(id) ON DELETE CASCADE,
+      user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      role text NOT NULL DEFAULT 'member',
+      status text NOT NULL DEFAULT 'active',
+      is_default boolean NOT NULL DEFAULT false,
+      permissions jsonb NOT NULL DEFAULT '[]'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (organization_id, user_id)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_platform_org_members_user
+    ON platform_organization_members(user_id)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS platform_workspaces (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      organization_id text NOT NULL REFERENCES platform_organizations(id) ON DELETE CASCADE,
+      slug text NOT NULL,
+      name text NOT NULL,
+      type text NOT NULL DEFAULT 'general',
+      status text NOT NULL DEFAULT 'active',
+      settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+      home_app_id text,
+      created_by text REFERENCES users(id) ON DELETE SET NULL,
+      archived_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (organization_id, slug)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_platform_workspaces_org
+    ON platform_workspaces(organization_id)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS platform_workspace_members (
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      role text NOT NULL DEFAULT 'member',
+      status text NOT NULL DEFAULT 'active',
+      is_default boolean NOT NULL DEFAULT false,
+      permissions jsonb NOT NULL DEFAULT '[]'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (workspace_id, user_id)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_platform_workspace_members_user
+    ON platform_workspace_members(user_id)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS platform_workspace_apps (
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      app_id text NOT NULL,
+      source_type text NOT NULL DEFAULT 'core',
+      source_ref text,
+      enabled boolean NOT NULL DEFAULT true,
+      pinned boolean NOT NULL DEFAULT false,
+      nav_order integer NOT NULL DEFAULT 0,
+      settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (workspace_id, app_id)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_platform_workspace_apps_enabled
+    ON platform_workspace_apps(workspace_id, enabled, nav_order)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS platform_user_contexts (
+      user_id text PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      organization_id text REFERENCES platform_organizations(id) ON DELETE SET NULL,
+      workspace_id text REFERENCES platform_workspaces(id) ON DELETE SET NULL,
+      recent_app_id text,
+      preferences jsonb NOT NULL DEFAULT '{}'::jsonb,
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE spreadsheets
+    ADD COLUMN IF NOT EXISTS workspace_id text
+  `.execute(db)
+
+  await sql`
+    INSERT INTO platform_organizations (id, slug, name, status, settings)
+    VALUES (${LEGACY_ORG_ID}, 'legacy', 'Legacy Organization', 'active', '{}'::jsonb)
+    ON CONFLICT (id) DO NOTHING
+  `.execute(db)
+
+  await sql`
+    INSERT INTO platform_workspaces (id, organization_id, slug, name, type, status, settings)
+    VALUES (${LEGACY_WORKSPACE_ID}, ${LEGACY_ORG_ID}, 'main', 'Main Workspace', 'general', 'active', '{}'::jsonb)
+    ON CONFLICT (id) DO NOTHING
+  `.execute(db)
+
+  await sql`
+    INSERT INTO platform_organizations (id, slug, name, status, settings)
+    SELECT DISTINCT
+      user_orgs.org_id,
+      concat('org-', user_orgs.org_id),
+      concat('Organization ', user_orgs.org_id),
+      'active',
+      '{}'::jsonb
+    FROM user_orgs
+    ON CONFLICT (id) DO NOTHING
+  `.execute(db)
+
+  await sql`
+    INSERT INTO platform_organization_members (organization_id, user_id, role, status, is_default)
+    SELECT
+      user_orgs.org_id,
+      user_orgs.user_id,
+      CASE WHEN users.is_admin THEN 'owner' ELSE 'member' END,
+      CASE WHEN user_orgs.is_active THEN 'active' ELSE 'disabled' END,
+      true
+    FROM user_orgs
+    JOIN users ON users.id = user_orgs.user_id
+    ON CONFLICT (organization_id, user_id) DO NOTHING
+  `.execute(db)
+
+  await sql`
+    INSERT INTO platform_workspaces (id, organization_id, slug, name, type, status, settings)
+    SELECT
+      concat('ws_', platform_organizations.id),
+      platform_organizations.id,
+      'main',
+      concat(platform_organizations.name, ' Workspace'),
+      'general',
+      'active',
+      '{}'::jsonb
+    FROM platform_organizations
+    ON CONFLICT (id) DO NOTHING
+  `.execute(db)
+
+  await sql`
+    INSERT INTO platform_workspace_members (workspace_id, user_id, role, status, is_default)
+    SELECT
+      concat('ws_', platform_organization_members.organization_id),
+      platform_organization_members.user_id,
+      platform_organization_members.role,
+      platform_organization_members.status,
+      platform_organization_members.is_default
+    FROM platform_organization_members
+    ON CONFLICT (workspace_id, user_id) DO NOTHING
+  `.execute(db)
+
+  await sql`
+    UPDATE spreadsheets
+    SET workspace_id = ${LEGACY_WORKSPACE_ID}
+    WHERE workspace_id IS NULL
+  `.execute(db)
+
+  await sql`
+    INSERT INTO platform_workspace_apps (workspace_id, app_id, source_type, enabled, pinned, nav_order)
+    SELECT workspace_id, app_id, source_type, enabled, pinned, nav_order
+    FROM (
+      SELECT id AS workspace_id, 'multitable' AS app_id, 'core' AS source_type, true AS enabled, true AS pinned, 10 AS nav_order FROM platform_workspaces
+      UNION ALL
+      SELECT id, 'approvals', 'core', true, true, 20 FROM platform_workspaces
+      UNION ALL
+      SELECT id, 'workflow', 'core', true, false, 30 FROM platform_workspaces
+    ) seed
+    ON CONFLICT (workspace_id, app_id) DO NOTHING
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('platform_user_contexts').ifExists().cascade().execute()
+  await db.schema.dropTable('platform_workspace_apps').ifExists().cascade().execute()
+  await db.schema.dropTable('platform_workspace_members').ifExists().cascade().execute()
+  await db.schema.dropTable('platform_workspaces').ifExists().cascade().execute()
+  await db.schema.dropTable('platform_organization_members').ifExists().cascade().execute()
+  await db.schema.dropTable('platform_organizations').ifExists().cascade().execute()
+}
+```
+
+### Phase 2 Migration
+
+File: `packages/core-backend/src/db/migrations/zzzz20260406110000_create_automation_rule_tables.ts`
+
+```ts
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS automation_rules (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      app_id text NOT NULL,
+      name text NOT NULL,
+      description text,
+      status text NOT NULL DEFAULT 'draft',
+      trigger_type text NOT NULL,
+      trigger_config jsonb NOT NULL DEFAULT '{}'::jsonb,
+      condition_tree jsonb NOT NULL DEFAULT '{}'::jsonb,
+      action_graph jsonb NOT NULL DEFAULT '[]'::jsonb,
+      concurrency_policy text NOT NULL DEFAULT 'allow',
+      created_by text REFERENCES users(id) ON DELETE SET NULL,
+      last_published_version_id text,
+      archived_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_rules_workspace_status
+    ON automation_rules(workspace_id, status, updated_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS automation_rule_versions (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      rule_id text NOT NULL REFERENCES automation_rules(id) ON DELETE CASCADE,
+      version_number integer NOT NULL,
+      snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+      change_note text,
+      published_by text REFERENCES users(id) ON DELETE SET NULL,
+      published_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (rule_id, version_number)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS automation_rule_bindings (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      rule_id text NOT NULL REFERENCES automation_rules(id) ON DELETE CASCADE,
+      resource_type text NOT NULL,
+      resource_id text NOT NULL,
+      event_pattern text NOT NULL,
+      enabled boolean NOT NULL DEFAULT true,
+      config jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_rule_bindings_resource
+    ON automation_rule_bindings(resource_type, resource_id, enabled)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_rule_bindings_event
+    ON automation_rule_bindings(event_pattern)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS automation_runs (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      rule_id text REFERENCES automation_rules(id) ON DELETE SET NULL,
+      rule_version_id text REFERENCES automation_rule_versions(id) ON DELETE SET NULL,
+      status text NOT NULL DEFAULT 'queued',
+      trigger_fingerprint text,
+      correlation_id text,
+      trigger_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+      execution_context jsonb NOT NULL DEFAULT '{}'::jsonb,
+      retry_count integer NOT NULL DEFAULT 0,
+      error_message text,
+      started_at timestamptz,
+      finished_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_automation_runs_idempotent
+    ON automation_runs(rule_id, trigger_fingerprint)
+    WHERE trigger_fingerprint IS NOT NULL
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_runs_workspace_status
+    ON automation_runs(workspace_id, status, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS automation_run_steps (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      run_id text NOT NULL REFERENCES automation_runs(id) ON DELETE CASCADE,
+      step_key text NOT NULL,
+      step_type text NOT NULL,
+      status text NOT NULL DEFAULT 'pending',
+      input jsonb NOT NULL DEFAULT '{}'::jsonb,
+      output jsonb NOT NULL DEFAULT '{}'::jsonb,
+      error_message text,
+      started_at timestamptz,
+      finished_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_run_steps_run
+    ON automation_run_steps(run_id, created_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('automation_run_steps').ifExists().cascade().execute()
+  await db.schema.dropTable('automation_runs').ifExists().cascade().execute()
+  await db.schema.dropTable('automation_rule_bindings').ifExists().cascade().execute()
+  await db.schema.dropTable('automation_rule_versions').ifExists().cascade().execute()
+  await db.schema.dropTable('automation_rules').ifExists().cascade().execute()
+}
+```
+
+### Phase 3 Migration
+
+File: `packages/core-backend/src/db/migrations/zzzz20260406120000_create_marketplace_and_template_tables.ts`
+
+```ts
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS marketplace_packages (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      slug text NOT NULL UNIQUE,
+      type text NOT NULL DEFAULT 'app',
+      display_name text NOT NULL,
+      summary text,
+      category text,
+      owner_team text,
+      source_plugin_name text,
+      visibility text NOT NULL DEFAULT 'internal',
+      status text NOT NULL DEFAULT 'draft',
+      icon text,
+      manifest jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS marketplace_package_versions (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      package_id text NOT NULL REFERENCES marketplace_packages(id) ON DELETE CASCADE,
+      version text NOT NULL,
+      channel text NOT NULL DEFAULT 'stable',
+      compatibility jsonb NOT NULL DEFAULT '{}'::jsonb,
+      artifact_ref text,
+      checksum text,
+      release_notes text,
+      published_by text REFERENCES users(id) ON DELETE SET NULL,
+      published_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (package_id, version)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_marketplace_package_versions_channel
+    ON marketplace_package_versions(package_id, channel, published_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS marketplace_installations (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      package_id text NOT NULL REFERENCES marketplace_packages(id) ON DELETE CASCADE,
+      version_id text REFERENCES marketplace_package_versions(id) ON DELETE SET NULL,
+      status text NOT NULL DEFAULT 'installed',
+      source text NOT NULL DEFAULT 'marketplace',
+      config jsonb NOT NULL DEFAULT '{}'::jsonb,
+      installed_by text REFERENCES users(id) ON DELETE SET NULL,
+      installed_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (workspace_id, package_id)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_marketplace_installations_workspace
+    ON marketplace_installations(workspace_id, status, installed_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS template_libraries (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      package_id text REFERENCES marketplace_packages(id) ON DELETE SET NULL,
+      slug text NOT NULL UNIQUE,
+      name text NOT NULL,
+      category text,
+      scope text NOT NULL DEFAULT 'workspace',
+      summary text,
+      preview jsonb NOT NULL DEFAULT '{}'::jsonb,
+      manifest jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS template_versions (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      template_id text NOT NULL REFERENCES template_libraries(id) ON DELETE CASCADE,
+      version text NOT NULL,
+      install_mode text NOT NULL DEFAULT 'clone',
+      content jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (template_id, version)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS template_installs (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      template_id text REFERENCES template_libraries(id) ON DELETE SET NULL,
+      template_version_id text REFERENCES template_versions(id) ON DELETE SET NULL,
+      status text NOT NULL DEFAULT 'completed',
+      installed_by text REFERENCES users(id) ON DELETE SET NULL,
+      target_refs jsonb NOT NULL DEFAULT '{}'::jsonb,
+      validation_summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_template_installs_workspace
+    ON template_installs(workspace_id, created_at DESC)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('template_installs').ifExists().cascade().execute()
+  await db.schema.dropTable('template_versions').ifExists().cascade().execute()
+  await db.schema.dropTable('template_libraries').ifExists().cascade().execute()
+  await db.schema.dropTable('marketplace_installations').ifExists().cascade().execute()
+  await db.schema.dropTable('marketplace_package_versions').ifExists().cascade().execute()
+  await db.schema.dropTable('marketplace_packages').ifExists().cascade().execute()
+}
+```
+
+### Phase 4 Migration
+
+File: `packages/core-backend/src/db/migrations/zzzz20260406130000_create_notification_hub_tables.ts`
+
+```ts
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS notification_channels (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      type text NOT NULL,
+      name text NOT NULL,
+      provider text,
+      status text NOT NULL DEFAULT 'active',
+      config jsonb NOT NULL DEFAULT '{}'::jsonb,
+      secret_ref text,
+      created_by text REFERENCES users(id) ON DELETE SET NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_notification_channels_workspace
+    ON notification_channels(workspace_id, type, status)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS notification_topics (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      key text NOT NULL,
+      display_name text NOT NULL,
+      source_app_id text,
+      default_channel_types jsonb NOT NULL DEFAULT '[]'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (workspace_id, key)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS notification_subscriptions (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      topic_id text REFERENCES notification_topics(id) ON DELETE CASCADE,
+      channel_id text REFERENCES notification_channels(id) ON DELETE SET NULL,
+      user_id text REFERENCES users(id) ON DELETE SET NULL,
+      target_type text NOT NULL,
+      target_ref text NOT NULL,
+      enabled boolean NOT NULL DEFAULT true,
+      filters jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_notification_subscriptions_topic
+    ON notification_subscriptions(workspace_id, topic_id, enabled)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS notification_messages (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      topic_id text REFERENCES notification_topics(id) ON DELETE SET NULL,
+      source_app_id text,
+      source_type text,
+      source_id text,
+      severity text NOT NULL DEFAULT 'info',
+      title text NOT NULL,
+      body text NOT NULL,
+      payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+      actor_id text REFERENCES users(id) ON DELETE SET NULL,
+      status text NOT NULL DEFAULT 'queued',
+      scheduled_at timestamptz,
+      expires_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_notification_messages_workspace
+    ON notification_messages(workspace_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS notification_deliveries (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      message_id text NOT NULL REFERENCES notification_messages(id) ON DELETE CASCADE,
+      channel_id text REFERENCES notification_channels(id) ON DELETE SET NULL,
+      recipient_type text NOT NULL,
+      recipient_ref text NOT NULL,
+      delivery_status text NOT NULL DEFAULT 'pending',
+      provider_message_id text,
+      attempts integer NOT NULL DEFAULT 0,
+      last_error text,
+      delivered_at timestamptz,
+      read_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_notification_deliveries_recipient
+    ON notification_deliveries(recipient_type, recipient_ref, delivery_status, read_at)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS notification_user_preferences (
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      quiet_hours jsonb NOT NULL DEFAULT '{}'::jsonb,
+      digest_frequency text NOT NULL DEFAULT 'off',
+      channel_overrides jsonb NOT NULL DEFAULT '{}'::jsonb,
+      locale text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (workspace_id, user_id)
+    )
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('notification_user_preferences').ifExists().cascade().execute()
+  await db.schema.dropTable('notification_deliveries').ifExists().cascade().execute()
+  await db.schema.dropTable('notification_messages').ifExists().cascade().execute()
+  await db.schema.dropTable('notification_subscriptions').ifExists().cascade().execute()
+  await db.schema.dropTable('notification_topics').ifExists().cascade().execute()
+  await db.schema.dropTable('notification_channels').ifExists().cascade().execute()
+}
+```
+
+### Phase 5 Migration
+
+File: `packages/core-backend/src/db/migrations/zzzz20260406140000_expand_dashboard_and_report_tables.ts`
+
+```ts
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    ALTER TABLE meta_dashboards
+    ADD COLUMN IF NOT EXISTS workspace_id text REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+    ADD COLUMN IF NOT EXISTS app_id text,
+    ADD COLUMN IF NOT EXISTS visibility text NOT NULL DEFAULT 'private',
+    ADD COLUMN IF NOT EXISTS is_home boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS layout jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS filters jsonb NOT NULL DEFAULT '{}'::jsonb
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_dashboards_workspace
+    ON meta_dashboards(workspace_id, app_id, updated_at DESC)
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE meta_widgets
+    ADD COLUMN IF NOT EXISTS widget_key text,
+    ADD COLUMN IF NOT EXISTS position jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS data_source_kind text NOT NULL DEFAULT 'query',
+    ADD COLUMN IF NOT EXISTS data_source_ref text,
+    ADD COLUMN IF NOT EXISTS bindings jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS refresh_interval_seconds integer
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS dashboard_data_sources (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      name text NOT NULL,
+      source_type text NOT NULL,
+      config jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_by text REFERENCES users(id) ON DELETE SET NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (workspace_id, name)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS report_definitions (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      workspace_id text NOT NULL REFERENCES platform_workspaces(id) ON DELETE CASCADE,
+      app_id text,
+      name text NOT NULL,
+      description text,
+      status text NOT NULL DEFAULT 'draft',
+      query_spec jsonb NOT NULL DEFAULT '{}'::jsonb,
+      visualization_spec jsonb NOT NULL DEFAULT '{}'::jsonb,
+      parameter_spec jsonb NOT NULL DEFAULT '{}'::jsonb,
+      schedule_spec jsonb NOT NULL DEFAULT '{}'::jsonb,
+      owner_id text REFERENCES users(id) ON DELETE SET NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_report_definitions_workspace
+    ON report_definitions(workspace_id, app_id, updated_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS report_runs (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      report_id text NOT NULL REFERENCES report_definitions(id) ON DELETE CASCADE,
+      status text NOT NULL DEFAULT 'queued',
+      parameters jsonb NOT NULL DEFAULT '{}'::jsonb,
+      result_meta jsonb NOT NULL DEFAULT '{}'::jsonb,
+      output_uri text,
+      error_message text,
+      started_at timestamptz,
+      finished_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_report_runs_report
+    ON report_runs(report_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS report_shares (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      report_id text NOT NULL REFERENCES report_definitions(id) ON DELETE CASCADE,
+      target_type text NOT NULL,
+      target_ref text NOT NULL,
+      permission text NOT NULL DEFAULT 'view',
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('report_shares').ifExists().cascade().execute()
+  await db.schema.dropTable('report_runs').ifExists().cascade().execute()
+  await db.schema.dropTable('report_definitions').ifExists().cascade().execute()
+  await db.schema.dropTable('dashboard_data_sources').ifExists().cascade().execute()
+}
+```
+
+## 3. API Designs
+
+Conventions:
+
+- Keep the current Express style: explicit routers in `packages/core-backend/src/routes/`, authenticated `GET/POST/PUT/DELETE`, JSON responses shaped as `{ ok, data }` or existing route-local `{ success, data }` where backwards compatibility requires it.
+- Require JWT authentication for all new endpoints except future public template previews.
+- Enforce workspace membership and RBAC at the router boundary.
+
+### Phase 1 APIs
+
+| Method | Path | Auth | Request shape | Response shape |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/me/context` | `JWT` | none | `{ ok: true, data: { user, organizations, workspaces, currentOrganizationId, currentWorkspaceId } }` |
+| `GET` | `/api/orgs` | `JWT` | none | `{ ok: true, data: { items: [{ id, slug, name, role, isDefault }] } }` |
+| `POST` | `/api/orgs` | `JWT + platform_admin` | `{ slug, name, settings? }` | `{ ok: true, data: { id, slug, name, status } }` |
+| `GET` | `/api/orgs/:orgId/workspaces` | `JWT + org member` | none | `{ ok: true, data: { items: [{ id, slug, name, type, role, appCount }] } }` |
+| `POST` | `/api/orgs/:orgId/workspaces` | `JWT + org owner/admin` | `{ slug, name, type?, settings?, seedApps?: string[] }` | `{ ok: true, data: { id, organizationId, slug, name, type } }` |
+| `POST` | `/api/workspaces/:workspaceId/context/switch` | `JWT + workspace member` | `{ recentAppId? }` | `{ ok: true, data: { currentWorkspaceId, currentOrganizationId, recentAppId } }` |
+| `GET` | `/api/platform/apps` | `JWT` | query: `?workspaceId=` | `{ ok: true, data: { items: [{ id, displayName, sourceType, navigation, permissions, enabledInWorkspace }] } }` |
+| `GET` | `/api/workspaces/:workspaceId/apps` | `JWT + workspace member` | none | `{ ok: true, data: { items: [{ appId, enabled, pinned, navOrder, manifest }] } }` |
+| `PUT` | `/api/workspaces/:workspaceId/apps/:appId` | `JWT + workspace admin` | `{ enabled?, pinned?, navOrder?, settings? }` | `{ ok: true, data: { workspaceId, appId, enabled, pinned, navOrder, settings } }` |
+
+### Phase 2 APIs
+
+| Method | Path | Auth | Request shape | Response shape |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/workspaces/:workspaceId/automations` | `JWT + automation:read` | query: `?status=&appId=` | `{ ok: true, data: { items: [{ id, name, appId, status, updatedAt, lastRunAt }] } }` |
+| `POST` | `/api/workspaces/:workspaceId/automations` | `JWT + automation:write` | `{ appId, name, description?, triggerType, triggerConfig, conditionTree?, actionGraph }` | `{ ok: true, data: { id, status: "draft", ...rule } }` |
+| `GET` | `/api/automations/:ruleId` | `JWT + automation:read` | none | `{ ok: true, data: { rule, latestVersion, bindings } }` |
+| `PUT` | `/api/automations/:ruleId` | `JWT + automation:write` | `{ name?, description?, triggerConfig?, conditionTree?, actionGraph?, bindings? }` | `{ ok: true, data: { id, updatedAt } }` |
+| `POST` | `/api/automations/:ruleId/publish` | `JWT + automation:write` | `{ changeNote? }` | `{ ok: true, data: { ruleId, versionId, status: "active" } }` |
+| `POST` | `/api/automations/:ruleId/toggle` | `JWT + automation:write` | `{ enabled: boolean }` | `{ ok: true, data: { ruleId, status } }` |
+| `GET` | `/api/automations/:ruleId/runs` | `JWT + automation:read` | query: `?status=&limit=` | `{ ok: true, data: { items: [{ id, status, startedAt, finishedAt, errorMessage }] } }` |
+| `POST` | `/api/automations/test-run` | `JWT + automation:write` | `{ workspaceId, draftRule, samplePayload }` | `{ ok: true, data: { runId, simulatedSteps, warnings } }` |
+| `GET` | `/api/platform/extensions` | `JWT` | query: `?workspaceId=` | `{ ok: true, data: { views, fields, triggers, actions, widgets } }` |
+| `GET` | `/api/platform/extensions/catalog` | `JWT` | query: `?kind=view|field|trigger|action|widget` | `{ ok: true, data: { items: [{ key, plugin, appId, schema, status }] } }` |
+
+### Phase 3 APIs
+
+| Method | Path | Auth | Request shape | Response shape |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/marketplace/packages` | `JWT` | query: `?type=&category=&channel=` | `{ ok: true, data: { items: [{ id, slug, type, displayName, summary, latestVersion, installed }] } }` |
+| `GET` | `/api/marketplace/packages/:packageId` | `JWT` | none | `{ ok: true, data: { package, versions, templates, compatibility } }` |
+| `POST` | `/api/workspaces/:workspaceId/marketplace/install` | `JWT + workspace admin` | `{ packageId, versionId?, config? }` | `{ ok: true, data: { installationId, status, packageId, versionId } }` |
+| `POST` | `/api/workspaces/:workspaceId/marketplace/upgrade` | `JWT + workspace admin` | `{ packageId, targetVersionId }` | `{ ok: true, data: { installationId, fromVersionId, targetVersionId, status } }` |
+| `GET` | `/api/workspaces/:workspaceId/marketplace/installations` | `JWT + workspace member` | none | `{ ok: true, data: { items: [{ id, packageId, versionId, status, installedAt }] } }` |
+| `GET` | `/api/templates` | `JWT` | query: `?category=&packageId=&scope=` | `{ ok: true, data: { items: [{ id, name, category, packageId, latestVersion, preview }] } }` |
+| `GET` | `/api/templates/:templateId` | `JWT` | none | `{ ok: true, data: { template, versions, preview, dependencies } }` |
+| `POST` | `/api/workspaces/:workspaceId/templates/:templateVersionId/install` | `JWT + workspace admin` | `{ variables?, targetAppId?, installMode? }` | `{ ok: true, data: { installId, status, targetRefs, warnings } }` |
+
+### Phase 4 APIs
+
+| Method | Path | Auth | Request shape | Response shape |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/workspaces/:workspaceId/notifications` | `JWT + workspace member` | query: `?status=unread&topic=&cursor=` | `{ ok: true, data: { items: [{ deliveryId, messageId, title, body, severity, readAt, createdAt }], nextCursor } }` |
+| `POST` | `/api/workspaces/:workspaceId/notifications/mark-read` | `JWT + workspace member` | `{ deliveryIds: string[] }` | `{ ok: true, data: { updated: number } }` |
+| `GET` | `/api/workspaces/:workspaceId/notification-topics` | `JWT + workspace member` | none | `{ ok: true, data: { items: [{ id, key, displayName, sourceAppId }] } }` |
+| `GET` | `/api/workspaces/:workspaceId/notification-subscriptions` | `JWT + workspace member` | none | `{ ok: true, data: { items: [{ id, topicId, channelId, targetType, targetRef, enabled }] } }` |
+| `PUT` | `/api/workspaces/:workspaceId/notification-subscriptions/:subscriptionId` | `JWT + workspace member or admin` | `{ enabled?, filters?, channelId? }` | `{ ok: true, data: { id, enabled, filters, channelId } }` |
+| `GET` | `/api/workspaces/:workspaceId/notification-preferences` | `JWT + workspace member` | none | `{ ok: true, data: { quietHours, digestFrequency, channelOverrides, locale } }` |
+| `PUT` | `/api/workspaces/:workspaceId/notification-preferences` | `JWT + workspace member` | `{ quietHours?, digestFrequency?, channelOverrides?, locale? }` | `{ ok: true, data: { workspaceId, userId, ...preferences } }` |
+| `POST` | `/api/workspaces/:workspaceId/notification-channels/test` | `JWT + workspace admin` | `{ channelId, sampleMessage }` | `{ ok: true, data: { channelId, result: "sent" | "failed", errorMessage? } }` |
+
+### Phase 5 APIs
+
+| Method | Path | Auth | Request shape | Response shape |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/workspaces/:workspaceId/dashboards` | `JWT + dashboard:read` | query: `?appId=&visibility=` | `{ ok: true, data: { items: [{ id, name, appId, visibility, isHome, updatedAt }] } }` |
+| `POST` | `/api/workspaces/:workspaceId/dashboards` | `JWT + dashboard:write` | `{ name, appId?, description?, layout?, filters?, visibility? }` | `{ ok: true, data: { id, name, appId, visibility } }` |
+| `GET` | `/api/dashboards/:dashboardId` | `JWT + dashboard:read` | none | `{ ok: true, data: { dashboard, widgets, filterState, permissions } }` |
+| `PUT` | `/api/dashboards/:dashboardId` | `JWT + dashboard:write` | `{ name?, layout?, filters?, widgets? }` | `{ ok: true, data: { id, updatedAt } }` |
+| `POST` | `/api/dashboards/:dashboardId/widgets/query` | `JWT + dashboard:read` | `{ widgetId, runtimeFilters?, viewport? }` | `{ ok: true, data: { widgetId, rows, series, totals, cacheHit } }` |
+| `GET` | `/api/workspaces/:workspaceId/reports` | `JWT + report:read` | query: `?appId=&status=` | `{ ok: true, data: { items: [{ id, name, status, nextRunAt, lastRunAt }] } }` |
+| `POST` | `/api/workspaces/:workspaceId/reports` | `JWT + report:write` | `{ name, appId?, querySpec, visualizationSpec, parameterSpec?, scheduleSpec? }` | `{ ok: true, data: { id, name, status } }` |
+| `POST` | `/api/reports/:reportId/run` | `JWT + report:write` | `{ parameters?, notifyRecipients? }` | `{ ok: true, data: { runId, status } }` |
+| `PUT` | `/api/reports/:reportId/schedule` | `JWT + report:write` | `{ scheduleSpec, deliveryChannels? }` | `{ ok: true, data: { reportId, scheduleSpec } }` |
+
+## 4. Frontend Architecture Changes
+
+### Target Shell Tree
+
+```text
+App.vue
+└─ PlatformShell.vue
+   ├─ WorkspaceSwitcher.vue
+   ├─ AppLauncher.vue
+   ├─ NotificationBell.vue
+   ├─ Platform navigation rail
+   └─ router-view
+      ├─ PlatformHomeView.vue
+      ├─ WorkspaceSettingsView.vue
+      ├─ PluginViewHost.vue
+      ├─ AutomationRulesView.vue
+      ├─ MarketplaceView.vue
+      ├─ TemplateLibraryView.vue
+      ├─ NotificationCenterView.vue
+      ├─ DashboardCenterView.vue
+      ├─ ReportCenterView.vue
+      └─ existing app views
+         ├─ AttendanceExperienceView.vue
+         ├─ MultitableWorkbench.vue
+         ├─ WorkflowHubView.vue
+         ├─ SpreadsheetDetailView.vue
+         └─ PlmProductView.vue
+```
+
+### Route Evolution
+
+Current state:
+
+- hardcoded routes such as `/grid`, `/attendance`, `/kanban`, `/gallery`, `/workflows`
+- plugin pages under `/p/:plugin/:viewId`
+
+Target state:
+
+- `/w/:workspaceId` -> workspace home dashboard/launcher
+- `/w/:workspaceId/apps/:appId` -> app root
+- `/w/:workspaceId/apps/:appId/*` -> app child routes
+- `/w/:workspaceId/multitable/:baseId/:sheetId/:viewId?` -> multitable host
+- legacy routes remain and redirect after workspace resolution
+
+### New Composables
+
+- `useWorkspace.ts`
+  - current organization/workspace
+  - workspace switch action
+  - workspace membership/role state
+- `usePlatformApps.ts`
+  - launcher catalog
+  - workspace-enabled apps
+  - app navigation groups
+- `useExtensionRegistry.ts`
+  - runtime catalog of views, field types, actions, triggers, widgets
+- `useAutomationRules.ts`
+  - rule CRUD, publish, run history
+- `useMarketplace.ts`
+  - package search/install/upgrade
+- `useTemplates.ts`
+  - template browse/preview/install
+- `useNotifications.ts`
+  - inbox feed, unread count, mark-read
+- `useNotificationPreferences.ts`
+  - digest and channel settings
+- `useDashboards.ts`
+  - dashboard CRUD and widget data execution
+- `useReports.ts`
+  - report CRUD, run, schedule
+
+### Dynamic Plugin UI Registration
+
+Current state:
+
+- `apps/web/src/view-registry.ts` is a static name-to-loader map.
+- `apps/web/src/plugins/viewRegistry.ts` is effectively a hardcoded compatibility layer.
+- multitable view and field menus are still mostly hardcoded.
+
+Target state:
+
+1. `packages/core-backend/src/platform/app-registry.ts` loads core manifests plus synthesized app manifests from active plugins.
+2. `packages/core-backend/src/services/ExtensionRegistryService.ts` normalizes plugin contributions from `contributes.views`, `contributes.fieldTypes`, `contributes.triggers`, `contributes.actions`, and future `contributes.widgets`.
+3. `GET /api/platform/extensions` returns a workspace-filtered catalog.
+4. `apps/web/src/view-registry.ts` becomes a runtime registry with functions such as `registerViewLoader()` and `resolveViewLoader()`.
+5. `MetaViewManager.vue` renders available view types from the registry instead of a fixed list.
+6. `MetaFieldManager.vue` renders field creation options from the registry and only falls back to the built-in types when the registry is unavailable.
+
+### App Launcher Shell
+
+`PlatformShell.vue` should own:
+
+- workspace identity strip
+- app launcher drawer
+- per-workspace app favorites/pins
+- top search entry point
+- notification bell
+- profile and session controls
+
+Element Plus patterns that fit the current codebase:
+
+- `el-container` / `el-aside` / `el-header`
+- `el-menu` for launcher/sidebar
+- `el-drawer` for app launcher and notification inbox
+- `el-dropdown` for workspace and account actions
+- `el-badge` for unread notifications
+- `el-tabs` for app home and dashboard/report tabs
+- `el-form` and `el-tree` for automation builder editing
+
+### Multitable and Existing App Integration
+
+The multitable workbench remains a platform primitive, but phase 2 changes how it gets optional capabilities:
+
+- view type definitions come from the extension registry
+- field type definitions come from the extension registry
+- automation actions for record events are surfaced inline in multitable
+- dashboard widgets can later query multitable through registered datasource resolvers
+
+Attendance, approvals, and PLM remain existing views during phase 1. They become first-class app surfaces through launcher metadata, not through a rewrite.
+
+## 5. Backward Compatibility Strategy
+
+### Compatibility Principles
+
+- Existing plugins keep loading through the current plugin loader.
+- Existing routes keep working until the new shell is fully stable.
+- Existing runtime services remain the execution backbone even when new APIs are added.
+- New platform primitives must wrap or reuse existing services before replacing them.
+
+### Phase-by-Phase Compatibility
+
+| Surface | Strategy |
+| --- | --- |
+| `user_orgs` | Keep the table and backfill from it into new platform tables in phase 1. Read both during the transition. |
+| Existing JWT/session flow | Add organization/workspace context claims opportunistically, but do not require them for legacy routes on day one. |
+| Existing plugin manifests | If `app.manifest.json` is missing, synthesize app identity from `plugin.json` and `contributes.views`. |
+| `/api/plugins` | Keep it unchanged; add `/api/platform/apps` as the new shell-facing API. |
+| Existing plugin views under `/p/:plugin/:viewId` | Keep them operational. New launcher routes point to the same component host until plugin apps add richer manifests. |
+| Hardcoded frontend routes | Preserve them and redirect into workspace routes only after context resolution. |
+| `NotificationService.ts` | Keep it as the send engine; the notification hub capability adds persistence and inbox semantics around it. Existing callers do not need to change immediately. |
+| `meta_dashboards` / `meta_widgets` | Extend them in phase 5 instead of replacing them with new tables. |
+| Event and message buses | Automation uses them directly; no second bus is introduced. |
+
+### How Existing 15+ Plugins Continue Working Unchanged
+
+1. Loader shim
+   - `packages/core-backend/src/core/plugin-loader.ts` continues to load current `plugin.json` files unchanged.
+   - `packages/core-backend/src/platform/app-registry.ts` synthesizes app metadata from current plugin manifests.
+
+2. View compatibility
+   - Current `contributes.views` entries continue to appear in `/api/plugins`.
+   - They are also mapped into the platform app catalog and launcher.
+
+3. No forced `app.manifest.json`
+   - Existing plugins can opt into richer platform metadata later.
+   - First-party plugins should get optional manifests after phase 1 is stable, but the critical path does not depend on them.
+
+4. Extension fallback
+   - If a plugin does not register field types, triggers, actions, or widgets, the platform simply treats it as a view-only app.
+
+5. Package bootstrap
+   - The internal app catalog/template capability should seed current built-in plugins as `system` packages so the plugin manager and catalog do not disagree about what is installed.
+
+6. Notification bridge
+   - Existing plugin code that calls the current notification service continues to work; the new hub receives mirrored message records from the wrapper.
+
+7. Dashboard bridge
+   - Existing plugins are not required to expose dashboards. Phase 5 dashboards can consume existing REST endpoints and multitable/workflow data sources without plugin changes.
+
+### Legacy Redirect and Decommission Plan
+
+- `Phase 1A` through `Phase 2B`: legacy routes stay first-class
+- After `Phase 1A` stabilization: launcher can become the default entry after login
+- When the notification hub ships: replace ad hoc unread indicators
+- When dashboard/reporting ships: workspace home can default to a dashboard instead of a hardcoded redirect
+- After phase 5 stabilization: convert old top-level app URLs to permanent redirects and deprecate only after one release train
+
+## 6. Effort Estimates
+
+Assumptions:
+
+- 1 senior backend/platform lead
+- 1 additional backend engineer
+- 1 frontend engineer
+- shared infra/devops support
+- QA and product/design overhead add roughly 20-25% beyond the engineering numbers below
+- If the same engineers continue shipping attendance, multitable, and approvals in parallel, apply a `1.5x` schedule-risk factor to calendar forecasts.
+
+| Phase | Backend | Frontend | Infra | Total person-weeks | Notes |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Phase 1: Workspace and shell | 4.0 | 3.0 | 1.0 | 8.0 | heavy coordination across auth, routing, and shell |
+| Phase 2: Automation and extension registry | 6.0 | 4.0 | 1.0 | 11.0 | hardest platform-logic phase |
+| Phase 3: Marketplace and templates | 5.0 | 3.0 | 2.0 | 10.0 | governance and install safety matter as much as coding |
+| Phase 4: Notification hub | 4.0 | 3.0 | 2.0 | 9.0 | connector reliability and secret handling drive infra work |
+| Phase 5: Dashboards and reports | 6.0 | 5.0 | 1.5 | 12.5 | query execution, widget system, and scheduling are broad |
+| **Total** | **25.0** | **18.0** | **7.5** | **50.5** | about 3-4 calendar months with a mostly dedicated 4-person core team; longer if shared with active business streams |
+
+Suggested staffing by phase:
+
+- Phase 1: 1 backend lead, 1 frontend, 0.5 backend shared
+- Phase 2: 2 backend, 1 frontend
+- Phase 3: 1.5 backend, 1 frontend, 0.5 infra
+- Phase 4: 1 backend, 1 frontend, 0.5 infra
+- Phase 5: 2 backend, 1 frontend, analytics-heavy support
+
+## 7. Risk Analysis
+
+| Phase | Risk | Why it matters | Concrete mitigation |
+| --- | --- | --- | --- |
+| 1 | Context leakage between tenant/org/workspace | Incorrect data scope is a platform-breaking failure | keep shard routing on existing tenant id first, add workspace context in parallel, add request-scope assertions in middleware and integration tests |
+| 1 | Shell regression from hardcoded routes | Attendance and multitable are active tracks right now | keep legacy routes live, introduce redirects only after bootstrap context is loaded, test route parity before switching default home |
+| 1 | Dual membership model drift | `user_orgs` and new platform tables can diverge | make one migration backfill, then designate new tables as source of truth while keeping a compatibility sync job |
+| 2 | Automation duplicates and loops | Existing event volume plus new rules can explode quickly | idempotency fingerprint, loop guard on source event metadata, per-rule concurrency policy, DLQ integration |
+| 2 | Unsafe plugin contributions | Dynamic field/action registration widens attack surface | validate contributions at load time, require explicit capabilities, reject untrusted JS actions in v1 |
+| 2 | Builder UX complexity | A bad rule builder will stall adoption | narrow v1 scope, provide tested templates, keep JSON inspector for advanced users |
+| 3 | Marketplace trust and version drift | Installing a bad package affects whole workspaces | first release is internal-only, signed package metadata, compatibility checks against core version and required permissions |
+| 3 | Template side effects | Templates can create bad workflows or mutate live data | dry-run preview, transaction + validation summary, rollback handles in `template_installs` |
+| 3 | Plugin install/hot reload instability | runtime enable/disable is already sensitive | route installs through current plugin loader admin flows and pause package upgrades during active reloads |
+| 4 | Notification fatigue | Too many alerts will reduce trust in the hub | per-topic subscription defaults, digest modes, quiet hours, dedupe key across deliveries |
+| 4 | Credential handling for external channels | DingTalk/Feishu/WeCom/webhook secrets are sensitive | secret references only in DB, use existing secret/config infrastructure, audit admin changes |
+| 4 | Delivery cost and retries | provider outages or rate limits can saturate the system | async worker + retry backoff + DLQ + workspace/channel quotas |
+| 5 | Slow queries and report load | dashboards become unusable if every widget runs expensive live queries | add datasource adapters, cache, scheduled materialization, and hard limits on live widget queries |
+| 5 | Cross-workspace data exposure | analytics often bypass app-level permission assumptions | enforce workspace and RBAC inside datasource resolvers, add query guardrails and audit trails |
+| 5 | Widget proliferation | too many one-off widgets create long-term maintenance debt | ship a constrained core widget catalog first and require plugins to register widgets through the extension registry contract |
+
+## 8. Platform Comparison
+
+### Feishu/Lark
+
+**Documented approach**
+
+- Lark positions itself as a unified work platform or “superapp” with multiple built-in business surfaces, not a single spreadsheet product.
+- Lark Base is documented as a no-code way to build custom tools and workflows with multiple views, dashboards, workflow automation, and notifications into chat.
+- Lark Approval is documented as a centralized approval center with templates and no-code customization.
+- Lark’s pricing and product pages show Base automation workflows, granular permissions, dashboard permissions, webhook triggers, mini apps, templates, and approvals as connected platform capabilities.
+
+**What MetaSheet2 should learn**
+
+- The shell matters as much as the data layer.
+- Approvals should stay a platform primitive rather than becoming app-specific logic.
+- Templates and automations are distribution mechanisms, not “nice to have” extras.
+- Notifications feel more valuable when they are embedded in the main shell rather than buried inside each app.
+
+**Where MetaSheet2 should diverge**
+
+- Do not try to become chat-first in the near term. MetaSheet2 does not currently have IM, meetings, docs, or calendar as native products.
+- Use the current strength: structured data, workflow, approval bridge, and plugin extensibility. The Feishu/Lark analog here is the operational platform layer, not the communication stack.
+- Build an app shell and notification center, but avoid spending early roadmap on chat-native metaphors that the repo does not support today.
+
+**Hypothesis**
+
+The public product packaging strongly suggests Lark evolved by layering Base, approvals, templates, and app surfaces into a unified shell. Public marketing/docs do not fully expose the internal sequencing, so the exact order should be treated as inference rather than confirmed architecture history.
+
+### Notion
+
+**Documented approach**
+
+- Notion documents blocks as its universal content primitive.
+- Notion databases are collections of pages, with multiple views and properties layered on top of the same underlying object model.
+- Notion later added database automations and a large template marketplace on top of that same content/database substrate.
+- The Notion workspace model centers navigation, sidebar, and content inside one consistent shell.
+
+**What MetaSheet2 should learn**
+
+- Strong primitives beat many bespoke features. In Notion, the block/page/database model made templates, views, and automations composable.
+- The shell, the data model, and the template ecosystem reinforce each other.
+- Automations become much easier to explain when they are anchored to a small set of core objects.
+
+**Where MetaSheet2 should diverge**
+
+- Do not force every future business surface into a pure block/page model. MetaSheet2 already has richer service-oriented primitives such as approvals, attendance rules, plugin RPC, and federation.
+- Keep multitable as the default operational data primitive, but allow service-owned tables where stronger domain guarantees are required.
+- MetaSheet2 should be more explicit about app boundaries than Notion, because its plugin system and enterprise workflows need clearer operational contracts.
+
+### Airtable
+
+**Documented approach**
+
+- Airtable organizes work around workspaces and bases.
+- Automations are explicitly modeled as triggers plus one or more actions.
+- Interfaces sit on top of the underlying base and are intended to tailor experiences to specific audiences without exposing the full base.
+- Extensions are modular components attached to a base; Airtable publicly notes they were previously called Blocks and then Apps.
+
+**What MetaSheet2 should learn**
+
+- Separate the data layer from the user experience layer.
+- Builder/admin users and end users often need different shells.
+- Granular interface permissions let the same data model serve more audiences.
+- A marketplace/distribution surface is more useful after the installable unit and permissions model are clear.
+
+**Where MetaSheet2 should diverge**
+
+- Airtable’s installable surface is base-centric. MetaSheet2 should become workspace-centric much earlier because it already has multiple business domains, approval flows, and plugin apps.
+- MetaSheet2 should connect automation, notifications, and approvals across apps sooner than Airtable’s base-local model typically encourages.
+- Because MetaSheet2 already has a microkernel, it can let plugins extend views, fields, triggers, and widgets through one registry instead of separate product silos.
+
+### NocoBase
+
+**Documented approach**
+
+- NocoBase explicitly documents a microkernel architecture where business functions are provided as plugins.
+- Its plugins are full-stack and can register client/server behavior.
+- Workflow, notification management, and data visualization are documented as built-in plugins rather than separate products.
+- NocoBase documentation also exposes plugin lifecycle, plugin manager, workflow extension, and extensible blocks/fields/actions.
+
+**What MetaSheet2 should learn**
+
+- The current MetaSheet2 architecture is already closer to NocoBase than to the other three products.
+- New platform primitives should be framed as microkernel services plus registries, not as giant framework rewrites.
+- Full-stack plugin contributions are the right place to extend views, fields, actions, and widgets.
+
+**Where MetaSheet2 should diverge**
+
+- NocoBase skews toward admin-builder systems. MetaSheet2 should keep investing in collaborative, real-time, spreadsheet-like UX because that is a differentiator it already has.
+- MetaSheet2 should also lean harder into approvals, attendance, and Feishu-like operational flows than a generic internal-tools builder would.
+
+## Recommended Strategic Positioning
+
+MetaSheet2 should converge toward:
+
+- Feishu/Lark’s shell, template, workflow, and operational-platform posture
+- Notion’s discipline around core primitives and composability
+- Airtable’s separation between data layer and tailored interfaces
+- NocoBase’s microkernel/plugin operating model
+
+It should not try to converge toward:
+
+- a full chat superapp in the short term
+- a universal block editor as the root primitive
+- a base-local extension model that ignores workspace/app context
+- a generic admin-builder product that neglects real-time structured collaboration
+
+## References
+
+Public references used to ground the comparison section:
+
+- Lark Base product page: https://www.larksuite.com/ja_jp/product/base
+- Lark Approval product page: https://www.larksuite.com/zh_cn/product/approval
+- Lark Base plans and platform capability packaging: https://www.larksuite.com/lp/en/base-plans
+- Lark templates example: https://www.larksuite.com/en_us/templates/lark-retail-customer-service-management-tracking-base
+- Notion block model: https://www.notion.com/help/what-is-a-block
+- Notion API block reference: https://developers.notion.com/reference/block
+- Notion workspace model: https://www.notion.com/help/intro-to-workspaces
+- Notion database model: https://www.notion.com/help/intro-to-databases
+- Notion database automations: https://www.notion.com/help/database-automations
+- Notion marketplace/templates: https://www.notion.com/templates
+- Airtable workspace settings overview: https://support.airtable.com/docs/account-page-overview
+- Airtable automations overview: https://support.airtable.com/docs/getting-started-with-airtable-automations
+- Airtable extensions overview: https://support.airtable.com/docs/airtable-extensions-overview
+- Airtable interface designer overview: https://support.airtable.com/v1/docs/getting-started-with-airtable-interface-designer
+- Airtable interface layouts: https://support.airtable.com/v1/docs/adding-layouts-to-interfaces
+- NocoBase plugin development overview: https://v2.docs.nocobase.com/plugin-development/
+- NocoBase workflow overview: https://v2.docs.nocobase.com/workflow/
+- NocoBase notification manager: https://v2.docs.nocobase.com/plugins/%40nocobase/plugin-notification-manager
+- NocoBase data visualization overview: https://v2.docs.nocobase.com/data-visualization/
+- NocoBase development architecture overview: https://v2.docs.nocobase.com/development/

--- a/docs/development/root-worktree-archive-notes-20260411.md
+++ b/docs/development/root-worktree-archive-notes-20260411.md
@@ -1,0 +1,19 @@
+# Root Worktree Archive Notes (2026-04-11)
+
+This docs-only slice preserves design and audit notes that were still present in the frozen root worktree `codex/approval-bridge-plm-phase1-20260404` after the executable recuts had already landed on `main`.
+
+These documents are archived for reference only.
+
+- They should not be read as proof that the described behavior is already implemented.
+- They were intentionally split away from the stale root worktree so future development can continue from clean branches on top of `main`.
+- The root worktree remains a read-only archive and is no longer a valid base for code salvage.
+
+Included documents:
+
+- `docs/deployment/multitable-platform-rc-notes-20260404.md`
+- `docs/development/approval-workflow-audit-and-next-phase-plan-20260403.md`
+- `docs/development/attendance-open-source-gap-matrix-20260404.md`
+- `docs/development/delivery-method-standardization-design-20260408.md`
+- `docs/development/multitable-service-extraction-roadmap-20260407.md`
+- `docs/development/platform-application-blueprint-20260406.md`
+- `docs/development/platform-evolution-plan-20260406.md`


### PR DESCRIPTION
## Summary
- preserve the small set of design and audit notes worth keeping from the frozen root worktree
- keep the old root branch read-only instead of continuing code salvage from it
- add an archive note explaining the provenance and intended use of these docs

## Scope
- docs/deployment/multitable-platform-rc-notes-20260404.md
- docs/development/approval-workflow-audit-and-next-phase-plan-20260403.md
- docs/development/attendance-open-source-gap-matrix-20260404.md
- docs/development/delivery-method-standardization-design-20260408.md
- docs/development/multitable-service-extraction-roadmap-20260407.md
- docs/development/platform-application-blueprint-20260406.md
- docs/development/platform-evolution-plan-20260406.md
- docs/development/root-worktree-archive-notes-20260411.md

## Verification
- git diff --check
