### PR TITLE
test(contract): polish Wave 3 pact follow-up notes

### DIFF
--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -155,10 +155,10 @@ not currently call them on `main`:
 
 The `metasheet2-plm-workbench` long-running spike branch has version-aware
 `approveApproval(id, **version**, comment)` and `rejectApproval(id, **version**,
-comment)` for optimistic locking. When that improvement merges back into this
-mainline branch, the Wave 3 pact for `/api/v1/eco/{id}/approve` should
-declare the `version` field as **optional** so the contract does not
-retroactively break this branch's existing approve/reject signature.
+comment)` for optimistic locking. Mainline already requires `version` on both
+approval action call sites, so the Wave 3 pact keeps `version` required. Only
+relax this field if a real mainline consumer change lands that removes or makes
+`version` optional at the adapter boundary.
 
 The full repo source-of-truth analysis lives at
 `/Users/huazhou/Downloads/Github/Yuantus/docs/METASHEET_REPO_SOURCE_OF_TRUTH_INVESTIGATION_20260407.md`.

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -321,10 +321,22 @@ describe('PLMAdapter Yuantus BOM analysis and approval actions', () => {
     const adapter = createAdapter()
     const selectMock = vi.fn()
       .mockResolvedValueOnce({
-        data: [{ id: 'eco-approve-1', status: 'approved', comment: 'Ship it' }],
+        data: [{
+          id: 'eco-approve-1',
+          status: 'approved',
+          comment: 'Ship it',
+          approved_at: '2026-04-11T00:00:00.000Z',
+          created_at: '2026-04-11T00:00:00.000Z',
+        }],
       })
       .mockResolvedValueOnce({
-        data: [{ id: 'eco-reject-1', status: 'rejected', comment: 'Missing test evidence' }],
+        data: [{
+          id: 'eco-reject-1',
+          status: 'rejected',
+          comment: 'Missing test evidence',
+          approved_at: '2026-04-11T00:00:00.000Z',
+          created_at: '2026-04-11T00:00:00.000Z',
+        }],
       })
 
     ;(adapter as any).select = selectMock
@@ -340,8 +352,18 @@ describe('PLMAdapter Yuantus BOM analysis and approval actions', () => {
       method: 'POST',
       data: { version: 8, comment: 'Missing test evidence' },
     })
-    expect(approved.data[0]).toMatchObject({ id: 'eco-approve-1', status: 'approved' })
-    expect(rejected.data[0]).toMatchObject({ id: 'eco-reject-1', status: 'rejected' })
+    expect(approved.data[0]).toMatchObject({
+      id: 'eco-approve-1',
+      status: 'approved',
+      approved_at: '2026-04-11T00:00:00.000Z',
+      created_at: '2026-04-11T00:00:00.000Z',
+    })
+    expect(rejected.data[0]).toMatchObject({
+      id: 'eco-reject-1',
+      status: 'rejected',
+      approved_at: '2026-04-11T00:00:00.000Z',
+      created_at: '2026-04-11T00:00:00.000Z',
+    })
   })
 
   it('queries where-used with recursive and max-level parameters', async () => {


### PR DESCRIPTION
## Summary
- tighten the Wave 3 README note so it matches the current mainline adapter API
- keep `version` explicitly required while the mainline approval action boundary still requires it
- align the approve/reject unit test mocks with the pact response shape by including timestamp fields

## Verification
- `cd packages/core-backend && npx vitest run tests/contract/plm-adapter-yuantus.pact.test.ts tests/unit/plm-adapter-yuantus.test.ts`
