### PR TITLE
feat(after-sales): add part item inventory surface

### DIFF
--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -1201,7 +1201,7 @@
         </article>
       </section>
 
-      <section v-if="isInstalled && hasPartItemProjection" class="after-sales-view__part-items-shell">
+      <section v-if="showPartItemPanel" class="after-sales-view__part-items-shell">
         <article class="after-sales-view__card after-sales-view__card--wide">
           <div class="after-sales-view__section-header">
             <div>
@@ -2585,6 +2585,7 @@ const current = ref<CurrentResponse>({ status: 'not-installed' })
 const tickets = ref<TicketViewModel[]>([])
 const installedAssets = ref<InstalledAssetViewModel[]>([])
 const partItems = ref<PartItemViewModel[]>([])
+const partItemProjectionAvailable = ref<boolean | null>(null)
 const customers = ref<CustomerViewModel[]>([])
 const followUps = ref<FollowUpViewModel[]>([])
 const serviceRecords = ref<ServiceRecordViewModel[]>([])
@@ -2679,6 +2680,9 @@ const hasCustomerProjection = computed(() =>
 const hasPartItemProjection = computed(() =>
   Array.isArray(manifest.value?.objects) &&
   manifest.value.objects.some((object) => object && object.id === 'partItem'),
+)
+const showPartItemPanel = computed(
+  () => isInstalled.value && hasPartItemProjection.value && partItemProjectionAvailable.value !== false,
 )
 const hasFollowUpProjection = computed(() =>
   Array.isArray(manifest.value?.objects) &&
@@ -2791,6 +2795,14 @@ function extractMessage(payload: unknown, fallback: string): string {
       ? (payload as { error?: { message?: string } }).error?.message
       : ''
   return typeof errorMessage === 'string' && errorMessage.trim().length > 0 ? errorMessage : fallback
+}
+
+function extractErrorCode(payload: unknown): string {
+  const errorCode =
+    payload && typeof payload === 'object' && 'error' in payload
+      ? (payload as { error?: { code?: string } }).error?.code
+      : ''
+  return typeof errorCode === 'string' ? errorCode : ''
 }
 
 async function readEnvelope<T>(path: string, options?: RequestInit): Promise<T> {
@@ -3978,20 +3990,37 @@ async function loadPartItemsForCurrentState(state: CurrentResponse): Promise<voi
   partItemsError.value = ''
   try {
     if (!hasPartItemProjection.value) {
+      partItemProjectionAvailable.value = null
       partItems.value = []
       return
     }
     if (state.status === 'not-installed' || state.status === 'failed') {
+      partItemProjectionAvailable.value = null
       partItems.value = []
       return
     }
 
-    const payload = await readEnvelope<PartItemsResponse>(buildPartItemListPath())
-    const rows = Array.isArray(payload?.partItems) ? payload.partItems : []
+    const { response, payload } = await readEnvelopeResponse<PartItemsResponse>(buildPartItemListPath())
+    if (!response.ok) {
+      const errorCode = extractErrorCode(payload)
+      if (errorCode === 'AFTER_SALES_OBJECT_UNAVAILABLE') {
+        partItemProjectionAvailable.value = false
+        partItems.value = []
+        return
+      }
+      throw new Error(extractMessage(payload, `${response.status} ${response.statusText}`))
+    }
+
+    const nextPayload = ((payload as ApiEnvelope<PartItemsResponse> | null)?.data ?? null) as PartItemsResponse | null
+    const rows = Array.isArray(nextPayload?.partItems) ? nextPayload.partItems : []
+    partItemProjectionAvailable.value = true
     partItems.value = rows.map((row) => normalizePartItemRow(row))
   } catch (err: unknown) {
     partItems.value = []
-    if (state.status === 'installed' || state.status === 'partial') {
+    if (
+      partItemProjectionAvailable.value !== false &&
+      (state.status === 'installed' || state.status === 'partial')
+    ) {
       partItemsError.value = err instanceof Error ? err.message : 'Failed to load parts'
     }
   } finally {

--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -1201,6 +1201,279 @@
         </article>
       </section>
 
+      <section v-if="isInstalled && hasPartItemProjection" class="after-sales-view__part-items-shell">
+        <article class="after-sales-view__card after-sales-view__card--wide">
+          <div class="after-sales-view__section-header">
+            <div>
+              <p class="after-sales-view__pill">Parts</p>
+              <h2>Part inventory</h2>
+              <p>
+                这里展示售后项目里的配件主数据，便于在工单和装机资产之间核对库存与可用状态。
+              </p>
+            </div>
+          </div>
+
+          <form class="after-sales-view__part-item-form" @submit.prevent="submitPartItem">
+            <label class="after-sales-view__field">
+              <span>Part no</span>
+              <input
+                id="after-sales-part-item-part-no"
+                v-model="partItemDraft.partNo"
+                class="after-sales-view__field-input"
+                placeholder="PRT-1001"
+                type="text"
+              />
+            </label>
+            <label class="after-sales-view__field">
+              <span>Category</span>
+              <select
+                id="after-sales-part-item-category"
+                v-model="partItemDraft.category"
+                class="after-sales-view__field-input"
+              >
+                <option value="spare">Spare</option>
+                <option value="consumable">Consumable</option>
+              </select>
+            </label>
+            <label class="after-sales-view__field">
+              <span>Status</span>
+              <select
+                id="after-sales-part-item-status"
+                v-model="partItemDraft.status"
+                class="after-sales-view__field-input"
+              >
+                <option value="available">Available</option>
+                <option value="reserved">Reserved</option>
+                <option value="consumed">Consumed</option>
+              </select>
+            </label>
+            <label class="after-sales-view__field">
+              <span>Name</span>
+              <input
+                id="after-sales-part-item-name"
+                v-model="partItemDraft.name"
+                class="after-sales-view__field-input"
+                placeholder="Compressor filter"
+                type="text"
+              />
+            </label>
+            <label class="after-sales-view__field">
+              <span>Stock qty</span>
+              <input
+                id="after-sales-part-item-stock-qty"
+                v-model="partItemDraft.stockQty"
+                class="after-sales-view__field-input"
+                min="0"
+                step="1"
+                type="number"
+              />
+            </label>
+          </form>
+
+          <div class="after-sales-view__action-row after-sales-view__action-row--compact">
+            <button
+              class="after-sales-view__primary-btn"
+              :disabled="partItemCreating || partItemsLoading || Boolean(partItemDeletingId) || Boolean(partItemUpdatingId) || Boolean(partItemEditingId) || !canSubmitPartItem"
+              @click="submitPartItem"
+            >
+              {{ partItemCreating ? 'Creating...' : 'Create part' }}
+            </button>
+            <button
+              class="after-sales-view__ghost-btn"
+              :disabled="partItemCreating || partItemsLoading || Boolean(partItemDeletingId) || Boolean(partItemUpdatingId) || Boolean(partItemEditingId)"
+              @click="resetPartItemDraft"
+            >
+              Reset part draft
+            </button>
+          </div>
+
+          <p v-if="partItemDraftError" class="after-sales-view__inline-error">{{ partItemDraftError }}</p>
+
+          <p v-if="partItemSubmitError" class="after-sales-view__inline-error">{{ partItemSubmitError }}</p>
+          <p v-else-if="partItemSubmitSuccess" class="after-sales-view__inline-success">{{ partItemSubmitSuccess }}</p>
+
+          <form class="after-sales-view__part-item-filters" @submit.prevent="applyPartItemFilters">
+            <label class="after-sales-view__field">
+              <span>Filter status</span>
+              <select
+                id="after-sales-part-item-filter-status"
+                v-model="partItemFilters.status"
+                class="after-sales-view__field-input"
+              >
+                <option value="">All statuses</option>
+                <option value="available">Available</option>
+                <option value="reserved">Reserved</option>
+                <option value="consumed">Consumed</option>
+              </select>
+            </label>
+            <label class="after-sales-view__field after-sales-view__field--wide">
+              <span>Search part</span>
+              <input
+                id="after-sales-part-item-filter-search"
+                v-model="partItemFilters.search"
+                class="after-sales-view__field-input"
+                placeholder="part no, name, category..."
+                type="text"
+              />
+            </label>
+          </form>
+
+          <div class="after-sales-view__action-row after-sales-view__action-row--compact">
+            <button
+              class="after-sales-view__ghost-btn"
+              :disabled="partItemsLoading || partItemCreating || Boolean(partItemDeletingId) || Boolean(partItemUpdatingId) || Boolean(partItemEditingId)"
+              @click="refreshPartItems"
+            >
+              {{ partItemsLoading ? 'Refreshing...' : 'Refresh list' }}
+            </button>
+            <button
+              class="after-sales-view__ghost-btn"
+              :disabled="partItemsLoading || partItemCreating || Boolean(partItemDeletingId) || Boolean(partItemUpdatingId) || Boolean(partItemEditingId)"
+              @click="applyPartItemFilters"
+            >
+              {{ partItemsLoading ? 'Applying...' : 'Apply filters' }}
+            </button>
+            <button
+              class="after-sales-view__ghost-btn"
+              :disabled="partItemsLoading || partItemCreating || Boolean(partItemDeletingId) || Boolean(partItemUpdatingId) || Boolean(partItemEditingId)"
+              @click="resetPartItemFilters"
+            >
+              Clear filters
+            </button>
+          </div>
+
+          <p v-if="partItemsLoading" class="after-sales-view__muted-state">Loading parts...</p>
+          <p v-else-if="partItemsError" class="after-sales-view__inline-error">{{ partItemsError }}</p>
+          <div v-else-if="partItems.length" class="after-sales-view__part-item-list">
+            <article v-for="partItem in partItems" :key="partItem.id" class="after-sales-view__part-item-row">
+              <div class="after-sales-view__part-item-main">
+                <template v-if="partItemEditingId === partItem.id">
+                  <div class="after-sales-view__part-item-headline">
+                    <strong>{{ partItemEditDraft.partNo || partItem.data.partNo }}</strong>
+                    <span class="after-sales-view__tag">{{ partItemEditDraft.status }}</span>
+                    <span class="after-sales-view__tag after-sales-view__tag--subtle">{{ partItemEditDraft.category }}</span>
+                  </div>
+                  <form class="after-sales-view__part-item-form after-sales-view__ticket-form--inline" @submit.prevent="submitPartItemEdit(partItem)">
+                    <label class="after-sales-view__field">
+                      <span>Part no</span>
+                      <input
+                        :id="`after-sales-part-item-edit-part-no-${partItem.id}`"
+                        v-model="partItemEditDraft.partNo"
+                        class="after-sales-view__field-input"
+                        type="text"
+                      />
+                    </label>
+                    <label class="after-sales-view__field">
+                      <span>Category</span>
+                      <select
+                        :id="`after-sales-part-item-edit-category-${partItem.id}`"
+                        v-model="partItemEditDraft.category"
+                        class="after-sales-view__field-input"
+                      >
+                        <option value="spare">Spare</option>
+                        <option value="consumable">Consumable</option>
+                      </select>
+                    </label>
+                    <label class="after-sales-view__field">
+                      <span>Status</span>
+                      <select
+                        :id="`after-sales-part-item-edit-status-${partItem.id}`"
+                        v-model="partItemEditDraft.status"
+                        class="after-sales-view__field-input"
+                      >
+                        <option value="available">Available</option>
+                        <option value="reserved">Reserved</option>
+                        <option value="consumed">Consumed</option>
+                      </select>
+                    </label>
+                    <label class="after-sales-view__field">
+                      <span>Name</span>
+                      <input
+                        :id="`after-sales-part-item-edit-name-${partItem.id}`"
+                        v-model="partItemEditDraft.name"
+                        class="after-sales-view__field-input"
+                        type="text"
+                      />
+                    </label>
+                    <label class="after-sales-view__field">
+                      <span>Stock qty</span>
+                      <input
+                        :id="`after-sales-part-item-edit-stock-qty-${partItem.id}`"
+                        v-model="partItemEditDraft.stockQty"
+                        class="after-sales-view__field-input"
+                        min="0"
+                        step="1"
+                        type="number"
+                      />
+                    </label>
+                  </form>
+                  <p v-if="partItemEditDraftError" class="after-sales-view__inline-error">{{ partItemEditDraftError }}</p>
+                </template>
+                <template v-else>
+                  <div class="after-sales-view__part-item-headline">
+                    <strong>{{ partItem.data.partNo }}</strong>
+                    <span class="after-sales-view__tag">{{ partItem.data.status }}</span>
+                    <span class="after-sales-view__tag after-sales-view__tag--subtle">{{ partItem.data.category }}</span>
+                  </div>
+                  <p>{{ partItem.data.name || 'No part name yet.' }}</p>
+                </template>
+              </div>
+
+              <div class="after-sales-view__part-item-side">
+                <dl class="after-sales-view__part-item-meta">
+                  <div>
+                    <dt>Stock qty</dt>
+                    <dd>{{ formatOptionalNumber(partItem.data.stockQty) }}</dd>
+                  </div>
+                  <div>
+                    <dt>Category</dt>
+                    <dd>{{ partItem.data.category }}</dd>
+                  </div>
+                  <div>
+                    <dt>Name</dt>
+                    <dd>{{ partItem.data.name || 'Unnamed part' }}</dd>
+                  </div>
+                </dl>
+                <div v-if="partItemEditingId === partItem.id" class="after-sales-view__ticket-actions">
+                  <button
+                    class="after-sales-view__primary-btn after-sales-view__ticket-action-btn"
+                    :disabled="partItemUpdatingId === partItem.id || partItemsLoading || !canSubmitPartItemEdit"
+                    @click="submitPartItemEdit(partItem)"
+                  >
+                    {{ partItemUpdatingId === partItem.id ? 'Saving...' : 'Save changes' }}
+                  </button>
+                  <button
+                    class="after-sales-view__ghost-btn after-sales-view__ticket-action-btn"
+                    :disabled="partItemUpdatingId === partItem.id"
+                    @click="cancelPartItemEdit"
+                  >
+                    Cancel edit
+                  </button>
+                </div>
+                <button
+                  v-if="partItemEditingId !== partItem.id"
+                  class="after-sales-view__ghost-btn after-sales-view__part-item-delete"
+                  :aria-label="`Edit part ${partItem.data.partNo}`"
+                  :disabled="Boolean(partItemDeletingId) || Boolean(partItemUpdatingId) || Boolean(partItemEditingId)"
+                  @click="startPartItemEdit(partItem)"
+                >
+                  Edit
+                </button>
+                <button
+                  class="after-sales-view__ghost-btn after-sales-view__part-item-delete"
+                  :aria-label="`Delete part ${partItem.data.partNo}`"
+                  :disabled="partItemDeletingId === partItem.id || partItemCreating || partItemsLoading || Boolean(partItemUpdatingId) || partItemEditingId === partItem.id"
+                  @click="deletePartItem(partItem)"
+                >
+                  {{ partItemDeletingId === partItem.id ? 'Deleting...' : 'Delete' }}
+                </button>
+              </div>
+            </article>
+          </div>
+          <p v-else class="after-sales-view__muted-state">No parts found yet.</p>
+        </article>
+      </section>
+
       <section v-if="isInstalled && hasCustomerProjection" class="after-sales-view__customers-shell">
         <article class="after-sales-view__card after-sales-view__card--wide">
           <div class="after-sales-view__section-header">
@@ -1929,6 +2202,12 @@ interface InstalledAssetRow {
   data: Record<string, unknown>
 }
 
+interface PartItemRow {
+  id: string
+  version: number
+  data: Record<string, unknown>
+}
+
 interface CustomerRow {
   id: string
   version: number
@@ -1938,6 +2217,12 @@ interface CustomerRow {
 interface InstalledAssetsResponse {
   projectId: string
   installedAssets: InstalledAssetRow[]
+  count: number
+}
+
+interface PartItemsResponse {
+  projectId: string
+  partItems: PartItemRow[]
   count: number
 }
 
@@ -1969,6 +2254,18 @@ interface InstalledAssetViewModel {
     location: string
     installedAt: string
     warrantyUntil: string
+    status: string
+  }
+}
+
+interface PartItemViewModel {
+  id: string
+  version: number
+  data: {
+    partNo: string
+    name: string
+    category: string
+    stockQty: number | null
     status: string
   }
 }
@@ -2043,6 +2340,22 @@ interface InstalledAssetDraft {
   status: 'active' | 'expired' | 'decommissioned'
 }
 
+interface PartItemDraft {
+  partNo: string
+  name: string
+  category: 'spare' | 'consumable'
+  stockQty: string
+  status: 'available' | 'reserved' | 'consumed'
+}
+
+interface PartItemEditDraft {
+  partNo: string
+  name: string
+  category: 'spare' | 'consumable'
+  stockQty: string
+  status: 'available' | 'reserved' | 'consumed'
+}
+
 interface InstalledAssetEditDraft {
   assetCode: string
   serialNo: string
@@ -2098,6 +2411,11 @@ interface InstalledAssetFilterDraft {
   search: string
 }
 
+interface PartItemFilterDraft {
+  status: '' | 'available' | 'reserved' | 'consumed'
+  search: string
+}
+
 interface CustomerFilterDraft {
   status: '' | 'active' | 'inactive'
   search: string
@@ -2122,6 +2440,11 @@ interface CreateServiceRecordResponse {
 interface CreateInstalledAssetResponse {
   projectId: string
   installedAsset: InstalledAssetRow
+}
+
+interface CreatePartItemResponse {
+  projectId: string
+  partItem: PartItemRow
 }
 
 interface CreateCustomerResponse {
@@ -2217,9 +2540,11 @@ const ticketRefundSubmittingId = ref('')
 const ticketUpdatingId = ref('')
 const ticketDeletingId = ref('')
 const installedAssetsLoading = ref(false)
+const partItemsLoading = ref(false)
 const customersLoading = ref(false)
 const followUpsLoading = ref(false)
 const installedAssetCreating = ref(false)
+const partItemCreating = ref(false)
 const customerCreating = ref(false)
 const followUpCreating = ref(false)
 const followUpDeletingId = ref('')
@@ -2228,6 +2553,8 @@ const customerDeletingId = ref('')
 const customerUpdatingId = ref('')
 const installedAssetUpdatingId = ref('')
 const installedAssetDeletingId = ref('')
+const partItemUpdatingId = ref('')
+const partItemDeletingId = ref('')
 const serviceRecordsLoading = ref(false)
 const serviceRecordCreating = ref(false)
 const serviceRecordUpdatingId = ref('')
@@ -2235,6 +2562,7 @@ const serviceRecordDeletingId = ref('')
 const error = ref('')
 const ticketsError = ref('')
 const installedAssetsError = ref('')
+const partItemsError = ref('')
 const customersError = ref('')
 const followUpsError = ref('')
 const customerSubmitError = ref('')
@@ -2243,6 +2571,8 @@ const followUpSubmitError = ref('')
 const followUpSubmitSuccess = ref('')
 const installedAssetSubmitError = ref('')
 const installedAssetSubmitSuccess = ref('')
+const partItemSubmitError = ref('')
+const partItemSubmitSuccess = ref('')
 const ticketSubmitError = ref('')
 const ticketSubmitSuccess = ref('')
 const ticketRefundErrorById = ref<Record<string, string>>({})
@@ -2254,6 +2584,7 @@ const manifest = ref<AfterSalesManifest | null>(null)
 const current = ref<CurrentResponse>({ status: 'not-installed' })
 const tickets = ref<TicketViewModel[]>([])
 const installedAssets = ref<InstalledAssetViewModel[]>([])
+const partItems = ref<PartItemViewModel[]>([])
 const customers = ref<CustomerViewModel[]>([])
 const followUps = ref<FollowUpViewModel[]>([])
 const serviceRecords = ref<ServiceRecordViewModel[]>([])
@@ -2284,7 +2615,12 @@ const installedAssetFilters = ref<InstalledAssetFilterDraft>({
   status: '',
   search: '',
 })
+const partItemFilters = ref<PartItemFilterDraft>({
+  status: '',
+  search: '',
+})
 const customerDraft = ref<CustomerDraft>(createCustomerDraft())
+const partItemDraft = ref<PartItemDraft>(createPartItemDraft())
 const followUpDraft = ref<FollowUpDraft>(createFollowUpDraft())
 const followUpEditingId = ref('')
 const followUpEditDraft = ref<FollowUpEditDraft>(createFollowUpEditDraft())
@@ -2302,6 +2638,8 @@ const followUpFilters = ref<FollowUpFilterDraft>({
 const installedAssetDraft = ref<InstalledAssetDraft>(createInstalledAssetDraft())
 const installedAssetEditingId = ref('')
 const installedAssetEditDraft = ref<InstalledAssetEditDraft>(createInstalledAssetEditDraft())
+const partItemEditingId = ref('')
+const partItemEditDraft = ref<PartItemEditDraft>(createPartItemEditDraft())
 const serviceRecordDraft = ref<ServiceRecordDraft>(createServiceRecordDraft())
 const serviceRecordEditingId = ref('')
 const serviceRecordEditDraft = ref<ServiceRecordEditDraft>(createServiceRecordEditDraft())
@@ -2337,6 +2675,10 @@ const runtimeAdminFieldPolicyRoles = computed(() => runtimeAdminFieldPolicyDraft
 const hasCustomerProjection = computed(() =>
   Array.isArray(manifest.value?.objects) &&
   manifest.value.objects.some((object) => object && object.id === 'customer'),
+)
+const hasPartItemProjection = computed(() =>
+  Array.isArray(manifest.value?.objects) &&
+  manifest.value.objects.some((object) => object && object.id === 'partItem'),
 )
 const hasFollowUpProjection = computed(() =>
   Array.isArray(manifest.value?.objects) &&
@@ -2374,6 +2716,27 @@ const canSubmitInstalledAssetEdit = computed(
   () =>
     Boolean(installedAssetEditingId.value) &&
     toText(installedAssetEditDraft.value.assetCode).length > 0,
+)
+const partItemDraftError = computed(() => {
+  const parsedStockQty = parseOptionalNumber(partItemDraft.value.stockQty)
+  return parsedStockQty.valid ? '' : 'Stock quantity must be a valid number'
+})
+const canSubmitPartItem = computed(
+  () =>
+    toText(partItemDraft.value.partNo).length > 0 &&
+    toText(partItemDraft.value.name).length > 0 &&
+    partItemDraftError.value.length === 0,
+)
+const partItemEditDraftError = computed(() => {
+  const parsedStockQty = parseOptionalNumber(partItemEditDraft.value.stockQty)
+  return parsedStockQty.valid ? '' : 'Stock quantity must be a valid number'
+})
+const canSubmitPartItemEdit = computed(
+  () =>
+    Boolean(partItemEditingId.value) &&
+    toText(partItemEditDraft.value.partNo).length > 0 &&
+    toText(partItemEditDraft.value.name).length > 0 &&
+    partItemEditDraftError.value.length === 0,
 )
 const canSubmitServiceRecordEdit = computed(
   () =>
@@ -2467,6 +2830,23 @@ function toRefundAmount(value: unknown): number | null {
   return Number.isFinite(next) ? next : null
 }
 
+function parseOptionalNumber(value: unknown): { valid: boolean; value?: number } {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? { valid: true, value } : { valid: false }
+  }
+  const text = toText(value)
+  if (!text) {
+    return { valid: true }
+  }
+
+  const next = Number(text)
+  if (!Number.isFinite(next)) {
+    return { valid: false }
+  }
+
+  return { valid: true, value: next }
+}
+
 function formatRefundAmount(value: unknown): string {
   const amount = toRefundAmount(value)
   if (amount == null) return '—'
@@ -2498,6 +2878,12 @@ function formatRecordDate(value: unknown): string {
     timeStyle: 'short',
     hour12: false,
   }).format(parsed)
+}
+
+function formatOptionalNumber(value: unknown): string {
+  const amount = toRefundAmount(value)
+  if (amount == null) return '—'
+  return Number.isInteger(amount) ? `${amount}` : `${amount}`
 }
 
 function cloneRuntimeAdminResponse(response: RuntimeAdminResponse): RuntimeAdminResponse {
@@ -2617,6 +3003,16 @@ function createInstalledAssetDraft(): InstalledAssetDraft {
   }
 }
 
+function createPartItemDraft(): PartItemDraft {
+  return {
+    partNo: '',
+    name: '',
+    category: 'spare',
+    stockQty: '',
+    status: 'available',
+  }
+}
+
 function createCustomerDraft(): CustomerDraft {
   return {
     customerCode: '',
@@ -2624,6 +3020,27 @@ function createCustomerDraft(): CustomerDraft {
     phone: '',
     email: '',
     status: 'active',
+  }
+}
+
+function normalizePartItemCategory(value: unknown): PartItemEditDraft['category'] {
+  return value === 'consumable' ? 'consumable' : 'spare'
+}
+
+function normalizePartItemStatus(value: unknown): PartItemEditDraft['status'] {
+  if (value === 'reserved' || value === 'consumed') {
+    return value
+  }
+  return 'available'
+}
+
+function createPartItemEditDraft(partItem?: Partial<PartItemViewModel['data']> | null): PartItemEditDraft {
+  return {
+    partNo: toText(partItem?.partNo),
+    name: toText(partItem?.name),
+    category: normalizePartItemCategory(partItem?.category),
+    stockQty: partItem?.stockQty == null ? '' : `${partItem.stockQty}`,
+    status: normalizePartItemStatus(partItem?.status),
   }
 }
 
@@ -2865,6 +3282,22 @@ function buildInstalledAssetPayload() {
   }
 }
 
+function buildPartItemPayload() {
+  const partNo = toText(partItemDraft.value.partNo)
+  const name = toText(partItemDraft.value.name)
+  const stockQty = parseOptionalNumber(partItemDraft.value.stockQty)
+
+  return {
+    partItem: {
+      partNo,
+      name,
+      category: partItemDraft.value.category,
+      status: partItemDraft.value.status,
+      ...(stockQty.valid && typeof stockQty.value === 'number' ? { stockQty: stockQty.value } : {}),
+    },
+  }
+}
+
 function buildCustomerPayload() {
   const customerCode = toText(customerDraft.value.customerCode)
   const name = toText(customerDraft.value.name)
@@ -2878,6 +3311,41 @@ function buildCustomerPayload() {
       status: customerDraft.value.status,
       ...(phone ? { phone } : {}),
       ...(email ? { email } : {}),
+    },
+  }
+}
+
+function buildPartItemUpdatePayload(partItem: PartItemViewModel) {
+  const partNo = toText(partItemEditDraft.value.partNo)
+  const name = toText(partItemEditDraft.value.name)
+  const category = partItemEditDraft.value.category
+  const status = partItemEditDraft.value.status
+  const stockQtyValue = partItemEditDraft.value.stockQty
+  const stockQtyInput = typeof stockQtyValue === 'number' ? `${stockQtyValue}` : toText(stockQtyValue)
+  const parsedStockQty = parseOptionalNumber(stockQtyValue)
+  const currentStockQty = toRefundAmount(partItem.data.stockQty)
+  const nextStockQty = stockQtyInput.length === 0 ? null : parsedStockQty.value ?? null
+
+  if (!parsedStockQty.valid) {
+    return null
+  }
+  if (
+    partNo === toText(partItem.data.partNo) &&
+    name === toText(partItem.data.name) &&
+    category === normalizePartItemCategory(partItem.data.category) &&
+    status === normalizePartItemStatus(partItem.data.status) &&
+    nextStockQty === currentStockQty
+  ) {
+    return null
+  }
+
+  return {
+    partItem: {
+      partNo,
+      name,
+      category,
+      status,
+      stockQty: nextStockQty,
     },
   }
 }
@@ -3054,6 +3522,19 @@ function matchesInstalledAssetFilters(asset: InstalledAssetViewModel) {
   return true
 }
 
+function matchesPartItemFilters(partItem: PartItemViewModel) {
+  const status = toText(partItemFilters.value.status)
+  const search = toText(partItemFilters.value.search).toLowerCase()
+
+  if (status && partItem.data.status !== status) return false
+  if (search) {
+    const haystack = JSON.stringify(partItem.data).toLowerCase()
+    if (!haystack.includes(search)) return false
+  }
+
+  return true
+}
+
 function buildTicketUpdatePayload() {
   return {
     ticket: {
@@ -3085,6 +3566,16 @@ function buildInstalledAssetListPath() {
   if (search) params.set('search', search)
   const query = params.toString()
   return query ? `/api/after-sales/installed-assets?${query}` : '/api/after-sales/installed-assets'
+}
+
+function buildPartItemListPath() {
+  const params = new URLSearchParams()
+  const status = toText(partItemFilters.value.status)
+  const search = toText(partItemFilters.value.search)
+  if (status) params.set('status', status)
+  if (search) params.set('search', search)
+  const query = params.toString()
+  return query ? `/api/after-sales/parts?${query}` : '/api/after-sales/parts'
 }
 
 function buildCustomerListPath() {
@@ -3240,6 +3731,21 @@ function normalizeInstalledAssetRow(record: InstalledAssetRow): InstalledAssetVi
   }
 }
 
+function normalizePartItemRow(record: PartItemRow): PartItemViewModel {
+  const rawData = record.data && typeof record.data === 'object' ? record.data : {}
+  return {
+    id: record.id,
+    version: record.version,
+    data: {
+      partNo: toText(rawData.partNo, record.id),
+      name: toText(rawData.name, 'Unnamed part'),
+      category: toText(rawData.category, 'spare'),
+      stockQty: toRefundAmount(rawData.stockQty),
+      status: toText(rawData.status, 'available'),
+    },
+  }
+}
+
 function normalizeCustomerRow(record: CustomerRow): CustomerViewModel {
   const rawData = record.data && typeof record.data === 'object' ? record.data : {}
   return {
@@ -3334,6 +3840,22 @@ function startInstalledAssetEdit(asset: InstalledAssetViewModel) {
   installedAssetEditDraft.value = createInstalledAssetEditDraft(asset.data)
   installedAssetSubmitError.value = ''
   installedAssetSubmitSuccess.value = ''
+}
+
+function startPartItemEdit(partItem: PartItemViewModel) {
+  if (
+    !partItem.id ||
+    partItemUpdatingId.value ||
+    partItemDeletingId.value ||
+    partItemCreating.value ||
+    partItemsLoading.value
+  ) {
+    return
+  }
+  partItemEditingId.value = partItem.id
+  partItemEditDraft.value = createPartItemEditDraft(partItem.data)
+  partItemSubmitError.value = ''
+  partItemSubmitSuccess.value = ''
 }
 
 function startServiceRecordEdit(record: ServiceRecordViewModel) {
@@ -3438,6 +3960,32 @@ async function loadInstalledAssetsForCurrentState(state: CurrentResponse): Promi
   }
 }
 
+async function loadPartItemsForCurrentState(state: CurrentResponse): Promise<void> {
+  partItemsLoading.value = true
+  partItemsError.value = ''
+  try {
+    if (!hasPartItemProjection.value) {
+      partItems.value = []
+      return
+    }
+    if (state.status === 'not-installed' || state.status === 'failed') {
+      partItems.value = []
+      return
+    }
+
+    const payload = await readEnvelope<PartItemsResponse>(buildPartItemListPath())
+    const rows = Array.isArray(payload?.partItems) ? payload.partItems : []
+    partItems.value = rows.map((row) => normalizePartItemRow(row))
+  } catch (err: unknown) {
+    partItems.value = []
+    if (state.status === 'installed' || state.status === 'partial') {
+      partItemsError.value = err instanceof Error ? err.message : 'Failed to load parts'
+    }
+  } finally {
+    partItemsLoading.value = false
+  }
+}
+
 async function loadCustomersForCurrentState(state: CurrentResponse): Promise<void> {
   customersLoading.value = true
   customersError.value = ''
@@ -3462,6 +4010,49 @@ async function loadCustomersForCurrentState(state: CurrentResponse): Promise<voi
   } finally {
     customersLoading.value = false
   }
+}
+
+async function applyPartItemFilters() {
+  if (
+    partItemsLoading.value ||
+    partItemCreating.value ||
+    partItemDeletingId.value ||
+    partItemUpdatingId.value ||
+    partItemEditingId.value
+  ) {
+    return
+  }
+  await loadPartItemsForCurrentState(current.value)
+}
+
+async function resetPartItemFilters() {
+  if (
+    partItemsLoading.value ||
+    partItemCreating.value ||
+    partItemDeletingId.value ||
+    partItemUpdatingId.value ||
+    partItemEditingId.value
+  ) {
+    return
+  }
+  partItemFilters.value = {
+    status: '',
+    search: '',
+  }
+  await loadPartItemsForCurrentState(current.value)
+}
+
+async function refreshPartItems() {
+  if (
+    partItemsLoading.value ||
+    partItemCreating.value ||
+    partItemDeletingId.value ||
+    partItemUpdatingId.value ||
+    partItemEditingId.value
+  ) {
+    return
+  }
+  await loadPartItemsForCurrentState(current.value)
 }
 
 async function applyCustomerFilters() {
@@ -3676,6 +4267,18 @@ async function deleteFollowUp(followUp: FollowUpViewModel) {
   }
 }
 
+function resetPartItemDraft() {
+  partItemDraft.value = createPartItemDraft()
+  partItemSubmitError.value = ''
+  partItemSubmitSuccess.value = ''
+}
+
+function cancelPartItemEdit() {
+  partItemEditingId.value = ''
+  partItemEditDraft.value = createPartItemEditDraft()
+  partItemSubmitError.value = ''
+}
+
 async function submitCustomer() {
   if (!canSubmitCustomer.value || customersLoading.value || customerCreating.value || customerDeletingId.value || customerUpdatingId.value || customerEditingId.value) {
     return
@@ -3776,6 +4379,123 @@ async function deleteCustomer(customer: CustomerViewModel) {
     customerSubmitError.value = err instanceof Error ? err.message : 'Failed to delete customer'
   } finally {
     customerDeletingId.value = ''
+  }
+}
+
+async function submitPartItem() {
+  if (
+    !canSubmitPartItem.value ||
+    partItemCreating.value ||
+    partItemsLoading.value ||
+    Boolean(partItemDeletingId.value) ||
+    Boolean(partItemUpdatingId.value) ||
+    Boolean(partItemEditingId.value)
+  ) {
+    return
+  }
+
+  partItemCreating.value = true
+  partItemSubmitError.value = ''
+  partItemSubmitSuccess.value = ''
+
+  try {
+    const payload = await readEnvelope<CreatePartItemResponse>('/api/after-sales/parts', {
+      method: 'POST',
+      body: JSON.stringify(buildPartItemPayload()),
+    })
+    const nextPartItem = payload?.partItem ? normalizePartItemRow(payload.partItem) : null
+
+    if (nextPartItem && matchesPartItemFilters(nextPartItem)) {
+      partItems.value = [nextPartItem, ...partItems.value.filter((item) => item.id !== nextPartItem.id)]
+      partItemsError.value = ''
+    }
+
+    resetPartItemDraft()
+    partItemSubmitSuccess.value = nextPartItem
+      ? `Created part ${nextPartItem.data.partNo}`
+      : 'Created part'
+  } catch (err: unknown) {
+    partItemSubmitError.value = err instanceof Error ? err.message : 'Failed to create part'
+  } finally {
+    partItemCreating.value = false
+  }
+}
+
+async function submitPartItemEdit(partItem: PartItemViewModel) {
+  if (
+    !partItem.id ||
+    partItemEditingId.value !== partItem.id ||
+    partItemUpdatingId.value ||
+    !canSubmitPartItemEdit.value
+  ) {
+    return
+  }
+
+  partItemUpdatingId.value = partItem.id
+  partItemSubmitError.value = ''
+  partItemSubmitSuccess.value = ''
+
+  try {
+    const updatePayload = buildPartItemUpdatePayload(partItem)
+    if (!updatePayload) {
+      partItemEditingId.value = ''
+      partItemEditDraft.value = createPartItemEditDraft()
+      return
+    }
+
+    const payload = await readEnvelope<CreatePartItemResponse>(
+      `/api/after-sales/parts/${encodeURIComponent(partItem.id)}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(updatePayload),
+      },
+    )
+    const nextPartItem = payload?.partItem ? normalizePartItemRow(payload.partItem) : null
+
+    if (nextPartItem) {
+      partItems.value = matchesPartItemFilters(nextPartItem)
+        ? partItems.value.map((item) => (item.id === nextPartItem.id ? nextPartItem : item))
+        : partItems.value.filter((item) => item.id !== nextPartItem.id)
+      partItemsError.value = ''
+      partItemSubmitSuccess.value = `Updated part ${nextPartItem.data.partNo}`
+    }
+
+    partItemEditingId.value = ''
+    partItemEditDraft.value = createPartItemEditDraft()
+  } catch (err: unknown) {
+    partItemSubmitError.value = err instanceof Error ? err.message : 'Failed to update part'
+  } finally {
+    partItemUpdatingId.value = ''
+  }
+}
+
+async function deletePartItem(partItem: PartItemViewModel) {
+  if (
+    !partItem.id ||
+    partItemDeletingId.value ||
+    partItemCreating.value ||
+    partItemsLoading.value ||
+    partItemUpdatingId.value ||
+    partItemEditingId.value
+  ) {
+    return
+  }
+
+  partItemDeletingId.value = partItem.id
+  partItemSubmitError.value = ''
+  partItemSubmitSuccess.value = ''
+
+  try {
+    await readEnvelope(`/api/after-sales/parts/${encodeURIComponent(partItem.id)}`, {
+      method: 'DELETE',
+    })
+    partItems.value = partItems.value.filter((item) => item.id !== partItem.id)
+    partItemsError.value = ''
+    partItemSubmitSuccess.value = `Deleted part ${partItem.data.partNo}`
+  } catch (err: unknown) {
+    partItemSubmitError.value = err instanceof Error ? err.message : 'Failed to delete part'
+  } finally {
+    partItemDeletingId.value = ''
   }
 }
 
@@ -4394,6 +5114,7 @@ async function refreshCurrentState() {
       loadFieldPoliciesForCurrentState(current.value),
       loadTicketsForCurrentState(current.value),
       loadInstalledAssetsForCurrentState(current.value),
+      loadPartItemsForCurrentState(current.value),
       loadCustomersForCurrentState(current.value),
       loadFollowUpsForCurrentState(current.value),
       loadServiceRecordsForCurrentState(current.value),
@@ -4408,6 +5129,7 @@ async function loadView() {
   error.value = ''
   ticketsError.value = ''
   installedAssetsError.value = ''
+  partItemsError.value = ''
   customersError.value = ''
   followUpsError.value = ''
   customerSubmitError.value = ''
@@ -4416,6 +5138,8 @@ async function loadView() {
   followUpSubmitSuccess.value = ''
   installedAssetSubmitError.value = ''
   installedAssetSubmitSuccess.value = ''
+  partItemSubmitError.value = ''
+  partItemSubmitSuccess.value = ''
   ticketSubmitError.value = ''
   ticketSubmitSuccess.value = ''
   serviceRecordsError.value = ''
@@ -4440,6 +5164,7 @@ async function loadView() {
       loadFieldPoliciesForCurrentState(nextCurrent),
       loadTicketsForCurrentState(nextCurrent),
       loadInstalledAssetsForCurrentState(nextCurrent),
+      loadPartItemsForCurrentState(nextCurrent),
       loadCustomersForCurrentState(nextCurrent),
       loadFollowUpsForCurrentState(nextCurrent),
       loadServiceRecordsForCurrentState(nextCurrent),
@@ -4596,6 +5321,7 @@ onMounted(() => {
 .after-sales-view__onboarding,
 .after-sales-view__tickets-shell,
 .after-sales-view__installed-assets-shell,
+.after-sales-view__part-items-shell,
 .after-sales-view__customers-shell,
 .after-sales-view__follow-ups-shell,
 .after-sales-view__service-records-shell {
@@ -4739,6 +5465,7 @@ onMounted(() => {
 .after-sales-view__grid,
 .after-sales-view__ticket-list,
 .after-sales-view__installed-asset-list,
+.after-sales-view__part-item-list,
 .after-sales-view__customer-list,
 .after-sales-view__follow-up-list,
 .after-sales-view__service-record-list {
@@ -4779,6 +5506,7 @@ onMounted(() => {
 .after-sales-view__meta,
 .after-sales-view__ticket-meta,
 .after-sales-view__installed-asset-meta,
+.after-sales-view__part-item-meta,
 .after-sales-view__customer-meta,
 .after-sales-view__follow-up-meta,
 .after-sales-view__service-record-meta {
@@ -4790,6 +5518,7 @@ onMounted(() => {
 .after-sales-view__meta div,
 .after-sales-view__ticket-meta div,
 .after-sales-view__installed-asset-meta div,
+.after-sales-view__part-item-meta div,
 .after-sales-view__customer-meta div,
 .after-sales-view__follow-up-meta div,
 .after-sales-view__service-record-meta div {
@@ -4800,6 +5529,7 @@ onMounted(() => {
 .after-sales-view__meta dt,
 .after-sales-view__ticket-meta dt,
 .after-sales-view__installed-asset-meta dt,
+.after-sales-view__part-item-meta dt,
 .after-sales-view__customer-meta dt,
 .after-sales-view__follow-up-meta dt,
 .after-sales-view__service-record-meta dt {
@@ -4812,6 +5542,7 @@ onMounted(() => {
 .after-sales-view__meta dd,
 .after-sales-view__ticket-meta dd,
 .after-sales-view__installed-asset-meta dd,
+.after-sales-view__part-item-meta dd,
 .after-sales-view__customer-meta dd,
 .after-sales-view__follow-up-meta dd,
 .after-sales-view__service-record-meta dd {
@@ -4868,6 +5599,7 @@ onMounted(() => {
 }
 
 .after-sales-view__installed-asset-row,
+.after-sales-view__part-item-row,
 .after-sales-view__customer-row,
 .after-sales-view__follow-up-row,
 .after-sales-view__service-record-row {
@@ -4881,6 +5613,7 @@ onMounted(() => {
 }
 
 .after-sales-view__installed-asset-main,
+.after-sales-view__part-item-main,
 .after-sales-view__customer-main,
 .after-sales-view__follow-up-main,
 .after-sales-view__service-record-main {
@@ -4890,6 +5623,7 @@ onMounted(() => {
 }
 
 .after-sales-view__installed-asset-main p,
+.after-sales-view__part-item-main p,
 .after-sales-view__customer-main p,
 .after-sales-view__follow-up-main p,
 .after-sales-view__service-record-main p {
@@ -4898,6 +5632,7 @@ onMounted(() => {
 }
 
 .after-sales-view__installed-asset-headline,
+.after-sales-view__part-item-headline,
 .after-sales-view__customer-headline,
 .after-sales-view__follow-up-headline,
 .after-sales-view__service-record-headline {
@@ -4908,6 +5643,7 @@ onMounted(() => {
 }
 
 .after-sales-view__installed-asset-headline strong,
+.after-sales-view__part-item-headline strong,
 .after-sales-view__customer-headline strong,
 .after-sales-view__follow-up-headline strong,
 .after-sales-view__service-record-headline strong {
@@ -4915,6 +5651,7 @@ onMounted(() => {
 }
 
 .after-sales-view__installed-asset-side,
+.after-sales-view__part-item-side,
 .after-sales-view__customer-side,
 .after-sales-view__follow-up-side,
 .after-sales-view__service-record-side {
@@ -4949,7 +5686,8 @@ onMounted(() => {
 }
 
 .after-sales-view__ticket-delete,
-.after-sales-view__service-record-delete {
+.after-sales-view__service-record-delete,
+.after-sales-view__part-item-delete {
   min-width: 120px;
 }
 
@@ -4975,10 +5713,12 @@ onMounted(() => {
 }
 
 .after-sales-view__installed-asset-form,
+.after-sales-view__part-item-form,
 .after-sales-view__customer-form,
 .after-sales-view__follow-up-form,
 .after-sales-view__ticket-form,
 .after-sales-view__installed-asset-filters,
+.after-sales-view__part-item-filters,
 .after-sales-view__customer-filters,
 .after-sales-view__follow-up-filters,
 .after-sales-view__service-record-form,
@@ -5132,6 +5872,7 @@ code {
   .after-sales-view__warning-banner,
   .after-sales-view__ticket-row,
   .after-sales-view__installed-asset-row,
+  .after-sales-view__part-item-row,
   .after-sales-view__customer-row,
   .after-sales-view__follow-up-row,
   .after-sales-view__service-record-row {
@@ -5146,10 +5887,12 @@ code {
   .after-sales-view__section-header,
   .after-sales-view__config-form,
   .after-sales-view__installed-asset-form,
+  .after-sales-view__part-item-form,
   .after-sales-view__customer-form,
   .after-sales-view__follow-up-form,
   .after-sales-view__ticket-form,
   .after-sales-view__installed-asset-filters,
+  .after-sales-view__part-item-filters,
   .after-sales-view__customer-filters,
   .after-sales-view__follow-up-filters,
   .after-sales-view__service-record-form,
@@ -5168,6 +5911,10 @@ code {
 
   .after-sales-view__ticket-side,
   .after-sales-view__ticket-actions {
+    justify-items: stretch;
+  }
+
+  .after-sales-view__part-item-side {
     justify-items: stretch;
   }
 }

--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -3522,13 +3522,26 @@ function matchesInstalledAssetFilters(asset: InstalledAssetViewModel) {
   return true
 }
 
+function buildPartItemSearchHaystack(data: PartItemViewModel['data']): string {
+  return [
+    toText(data.partNo),
+    toText(data.name),
+    toText(data.category),
+    toText(data.status),
+    data.stockQty == null ? '' : String(data.stockQty),
+  ]
+    .filter((value) => value.trim().length > 0)
+    .join(' ')
+    .toLowerCase()
+}
+
 function matchesPartItemFilters(partItem: PartItemViewModel) {
   const status = toText(partItemFilters.value.status)
   const search = toText(partItemFilters.value.search).toLowerCase()
 
   if (status && partItem.data.status !== status) return false
   if (search) {
-    const haystack = JSON.stringify(partItem.data).toLowerCase()
+    const haystack = buildPartItemSearchHaystack(partItem.data)
     if (!haystack.includes(search)) return false
   }
 

--- a/apps/web/tests/AfterSalesView.part-items.spec.ts
+++ b/apps/web/tests/AfterSalesView.part-items.spec.ts
@@ -1,0 +1,436 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp } from 'vue'
+import AfterSalesView from '../src/views/AfterSalesView.vue'
+
+const apiFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: apiFetchMock,
+}))
+
+interface MockResponseOptions {
+  ok?: boolean
+  status?: number
+  statusText?: string
+}
+
+function createResponse(payload: unknown, options: MockResponseOptions = {}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    statusText: options.statusText ?? 'OK',
+    json: async () => ({
+      ok: options.ok ?? true,
+      data: payload,
+    }),
+  } as Response
+}
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function waitForText(container: HTMLElement, text: string, cycles = 24): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    if (container.textContent?.includes(text)) {
+      return
+    }
+    await flushUi(1)
+  }
+
+  throw new Error(`Timed out waiting for text: ${text}`)
+}
+
+function mountAfterSalesView() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const app = createApp(AfterSalesView)
+  app.mount(container)
+
+  return { app, container }
+}
+
+function findSection(container: HTMLElement, headingText: string): HTMLElement {
+  const heading = Array.from(container.querySelectorAll('h2')).find((item) => item.textContent?.includes(headingText))
+  const section = heading?.closest('section')
+  if (!section) {
+    throw new Error(`Section with heading ${headingText} not found`)
+  }
+  return section as HTMLElement
+}
+
+function findButtonWithin(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find((item) => item.textContent?.includes(label))
+  if (!button) {
+    throw new Error(`Button with label ${label} not found`)
+  }
+  return button as HTMLButtonElement
+}
+
+async function setInputValue(input: HTMLInputElement, value: string): Promise<void> {
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  await flushUi()
+}
+
+async function setSelectValue(select: HTMLSelectElement, value: string): Promise<void> {
+  select.value = value
+  select.dispatchEvent(new Event('change', { bubbles: true }))
+  await flushUi()
+}
+
+describe('AfterSalesView part items panel', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  it('hides the parts panel when the manifest does not provision partItem', async () => {
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-parts-001',
+          },
+          reportRef: 'install-parts-001',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, tickets: [] })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          fields: {
+            serviceTicket: {
+              refundAmount: { visibility: 'visible', editability: 'editable' },
+            },
+          },
+        })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'Install state')
+
+    expect(container.textContent).not.toContain('Part inventory')
+    expect(container.textContent).not.toContain('No parts found yet.')
+  })
+
+  it('loads, filters, creates, edits, and deletes parts through the live parts panel', async () => {
+    const partItems = [
+      {
+        id: 'part-001',
+        version: 1,
+        data: {
+          partNo: 'PRT-1001',
+          name: 'Compressor filter',
+          category: 'spare',
+          stockQty: 12,
+          status: 'available',
+        },
+      },
+    ]
+
+    apiFetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [{ id: 'partItem', name: 'Parts', backing: 'multitable' }],
+          workflows: [],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: ['partItem'],
+            createdViews: ['partItem-grid'],
+            warnings: [],
+            reportRef: 'install-parts-002',
+          },
+          reportRef: 'install-parts-002',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, tickets: [] })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          fields: {
+            serviceTicket: {
+              refundAmount: { visibility: 'visible', editability: 'editable' },
+            },
+          },
+        })
+      }
+
+      if (path.startsWith('/api/after-sales/parts')) {
+        const url = new URL(path, 'http://localhost')
+        const method = init?.method ?? 'GET'
+
+        if (method === 'POST') {
+          const body = JSON.parse(String(init?.body ?? '{}')) as {
+            partItem?: {
+              partNo?: string
+              name?: string
+              category?: string
+              stockQty?: number
+              status?: string
+            }
+          }
+          const nextPartItem = {
+            id: `part-${partItems.length + 1}`,
+            version: 1,
+            data: {
+              partNo: body.partItem?.partNo ?? '',
+              name: body.partItem?.name ?? '',
+              category: body.partItem?.category ?? 'spare',
+              stockQty: typeof body.partItem?.stockQty === 'number' ? body.partItem.stockQty : null,
+              status: body.partItem?.status ?? 'available',
+            },
+          }
+          partItems.unshift(nextPartItem)
+          return createResponse({
+            projectId: 'tenant:after-sales',
+            partItem: nextPartItem,
+          })
+        }
+
+        if (method === 'PATCH') {
+          const partId = url.pathname.split('/').pop() ?? ''
+          const body = JSON.parse(String(init?.body ?? '{}')) as {
+            partItem?: Record<string, unknown>
+          }
+          const part = partItems.find((item) => item.id === partId)
+          if (!part) {
+            return createResponse({ error: { message: 'missing part' } }, { ok: false, status: 404, statusText: 'Not Found' })
+          }
+
+          part.data = {
+            ...part.data,
+            ...body.partItem,
+          }
+          part.version += 1
+          return createResponse({
+            projectId: 'tenant:after-sales',
+            partItem: part,
+          })
+        }
+
+        if (method === 'DELETE') {
+          const partId = url.pathname.split('/').pop() ?? ''
+          const index = partItems.findIndex((item) => item.id === partId)
+          if (index === -1) {
+            return createResponse({ error: { message: 'missing part' } }, { ok: false, status: 404, statusText: 'Not Found' })
+          }
+          const [deleted] = partItems.splice(index, 1)
+          return createResponse({
+            projectId: 'tenant:after-sales',
+            partItem: deleted,
+          })
+        }
+
+        const status = url.searchParams.get('status')
+        const search = url.searchParams.get('search')?.toLowerCase() ?? ''
+        const filtered = partItems.filter((item) => {
+          if (status && item.data.status !== status) return false
+          if (search) {
+            return JSON.stringify(item.data).toLowerCase().includes(search)
+          }
+          return true
+        })
+
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: filtered.length,
+          partItems: filtered,
+        })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'PRT-1001')
+
+    const section = findSection(container, 'Part inventory')
+    expect(section.textContent).toContain('Compressor filter')
+
+    const statusFilter = section.querySelector<HTMLSelectElement>('#after-sales-part-item-filter-status')
+    const searchFilter = section.querySelector<HTMLInputElement>('#after-sales-part-item-filter-search')
+    expect(statusFilter).toBeTruthy()
+    expect(searchFilter).toBeTruthy()
+    await setSelectValue(statusFilter as HTMLSelectElement, 'available')
+    await setInputValue(searchFilter as HTMLInputElement, 'compressor')
+    findButtonWithin(section, 'Apply filters').click()
+    await flushUi(2)
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/after-sales/parts?status=available&search=compressor', undefined)
+
+    const partNoInput = section.querySelector<HTMLInputElement>('#after-sales-part-item-part-no')
+    const nameInput = section.querySelector<HTMLInputElement>('#after-sales-part-item-name')
+    const categorySelect = section.querySelector<HTMLSelectElement>('#after-sales-part-item-category')
+    const statusSelect = section.querySelector<HTMLSelectElement>('#after-sales-part-item-status')
+    const stockQtyInput = section.querySelector<HTMLInputElement>('#after-sales-part-item-stock-qty')
+    expect(partNoInput).toBeTruthy()
+    expect(nameInput).toBeTruthy()
+    expect(categorySelect).toBeTruthy()
+    expect(statusSelect).toBeTruthy()
+    expect(stockQtyInput).toBeTruthy()
+
+    await setInputValue(partNoInput as HTMLInputElement, 'PRT-2002')
+    await setInputValue(nameInput as HTMLInputElement, 'Compressor pack')
+    await setSelectValue(categorySelect as HTMLSelectElement, 'consumable')
+    await setSelectValue(statusSelect as HTMLSelectElement, 'available')
+    await setInputValue(stockQtyInput as HTMLInputElement, '4')
+    findButtonWithin(section, 'Create part').click()
+    await flushUi(2)
+
+    const postCall = apiFetchMock.mock.calls.find(
+      ([path, init]) => path === '/api/after-sales/parts' && (init as RequestInit | undefined)?.method === 'POST',
+    )
+    expect(postCall).toBeTruthy()
+    expect(JSON.parse(String((postCall?.[1] as RequestInit | undefined)?.body))).toEqual({
+      partItem: {
+        partNo: 'PRT-2002',
+        name: 'Compressor pack',
+        category: 'consumable',
+        status: 'available',
+        stockQty: 4,
+      },
+    })
+    await waitForText(section, 'PRT-2002')
+
+    const editButton = section.querySelector<HTMLButtonElement>('button[aria-label="Edit part PRT-2002"]')
+    expect(editButton).toBeTruthy()
+    editButton.click()
+    await flushUi(1)
+
+    const editNameInput = section.querySelector<HTMLInputElement>('#after-sales-part-item-edit-name-part-2')
+    const editStockQtyInput = section.querySelector<HTMLInputElement>('#after-sales-part-item-edit-stock-qty-part-2')
+    expect(editNameInput).toBeTruthy()
+    expect(editStockQtyInput).toBeTruthy()
+    await setInputValue(editNameInput as HTMLInputElement, 'Compressor filter v2')
+    await setInputValue(editStockQtyInput as HTMLInputElement, '18')
+    findButtonWithin(section, 'Save changes').click()
+    await flushUi(2)
+
+    const patchCall = apiFetchMock.mock.calls.find(
+      ([path, init]) =>
+        path === '/api/after-sales/parts/part-2' && (init as RequestInit | undefined)?.method === 'PATCH',
+    )
+    expect(patchCall).toBeTruthy()
+    expect(JSON.parse(String((patchCall?.[1] as RequestInit | undefined)?.body))).toEqual({
+      partItem: {
+        partNo: 'PRT-2002',
+        name: 'Compressor filter v2',
+        category: 'consumable',
+        status: 'available',
+        stockQty: 18,
+      },
+    })
+    await waitForText(section, 'Updated part PRT-2002')
+    expect(section.textContent).toContain('Compressor filter v2')
+
+    const deleteCreatedButton = section.querySelector<HTMLButtonElement>('button[aria-label="Delete part PRT-2002"]')
+    expect(deleteCreatedButton).toBeTruthy()
+    deleteCreatedButton.click()
+    await flushUi(2)
+
+    const deleteCall = apiFetchMock.mock.calls.find(
+      ([path, init]) =>
+        path === '/api/after-sales/parts/part-2' && (init as RequestInit | undefined)?.method === 'DELETE',
+    )
+    expect(deleteCall).toBeTruthy()
+    await waitForText(section, 'Deleted part PRT-2002')
+    await waitForText(section, 'PRT-1001')
+
+    const deleteInitialButton = section.querySelector<HTMLButtonElement>('button[aria-label="Delete part PRT-1001"]')
+    expect(deleteInitialButton).toBeTruthy()
+    deleteInitialButton.click()
+    await flushUi(2)
+
+    const deleteInitialCall = apiFetchMock.mock.calls.find(
+      ([path, init]) =>
+        path === '/api/after-sales/parts/part-001' && (init as RequestInit | undefined)?.method === 'DELETE',
+    )
+    expect(deleteInitialCall).toBeTruthy()
+    await waitForText(section, 'No parts found yet.')
+  })
+})

--- a/apps/web/tests/AfterSalesView.part-items.spec.ts
+++ b/apps/web/tests/AfterSalesView.part-items.spec.ts
@@ -26,6 +26,25 @@ function createResponse(payload: unknown, options: MockResponseOptions = {}) {
   } as Response
 }
 
+function createErrorResponse(
+  code: string,
+  message: string,
+  options: MockResponseOptions = {},
+) {
+  return {
+    ok: false,
+    status: options.status ?? 409,
+    statusText: options.statusText ?? 'Conflict',
+    json: async () => ({
+      ok: false,
+      error: {
+        code,
+        message,
+      },
+    }),
+  } as Response
+}
+
 async function flushUi(cycles = 4): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
@@ -42,6 +61,17 @@ async function waitForText(container: HTMLElement, text: string, cycles = 24): P
   }
 
   throw new Error(`Timed out waiting for text: ${text}`)
+}
+
+async function waitForElementMissing(container: HTMLElement, selector: string, cycles = 24): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    if (!container.querySelector(selector)) {
+      return
+    }
+    await flushUi(1)
+  }
+
+  throw new Error(`Timed out waiting for element to disappear: ${selector}`)
 }
 
 function mountAfterSalesView() {
@@ -432,5 +462,82 @@ describe('AfterSalesView part items panel', () => {
     )
     expect(deleteInitialCall).toBeTruthy()
     await waitForText(section, 'No parts found yet.')
+  })
+
+  it('hides the parts panel when partial install leaves the part projection unavailable', async () => {
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [{ id: 'partItem', name: 'Parts', backing: 'multitable' }],
+          workflows: [],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'partial',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'partial',
+            createdObjects: ['serviceTicket', 'installedAsset', 'customer', 'serviceRecord'],
+            createdViews: ['ticket-board'],
+            warnings: ['partItem provisioning failed'],
+            reportRef: 'install-parts-003',
+          },
+          reportRef: 'install-parts-003',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, tickets: [] })
+      }
+
+      if (path === '/api/after-sales/installed-assets') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, installedAssets: [] })
+      }
+
+      if (path === '/api/after-sales/service-records') {
+        return createResponse({ projectId: 'tenant:after-sales', count: 0, serviceRecords: [] })
+      }
+
+      if (path === '/api/after-sales/field-policies') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          fields: {
+            serviceTicket: {
+              refundAmount: { visibility: 'visible', editability: 'editable' },
+            },
+          },
+        })
+      }
+
+      if (path === '/api/after-sales/parts') {
+        return createErrorResponse(
+          'AFTER_SALES_OBJECT_UNAVAILABLE',
+          'After-sales part inventory is unavailable for the current install state',
+        )
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'Install state')
+    await waitForElementMissing(container, '.after-sales-view__part-items-shell')
+
+    expect(container.textContent).not.toContain('Part inventory')
+    expect(container.textContent).not.toContain('Failed to load parts')
   })
 })

--- a/docs/development/after-sales-part-items-slice-20260411.md
+++ b/docs/development/after-sales-part-items-slice-20260411.md
@@ -73,7 +73,7 @@ Capabilities:
 Command:
 
 ```bash
-/Users/huazhou/Downloads/Github/metasheet2/node_modules/.bin/vitest run packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+./node_modules/.bin/vitest run packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
 ```
 
 Result:

--- a/docs/development/after-sales-part-items-slice-20260411.md
+++ b/docs/development/after-sales-part-items-slice-20260411.md
@@ -1,0 +1,132 @@
+# After-sales Part Items Slice
+
+## Goal
+
+Complete the missing `partItem` vertical slice that was already provisioned by the after-sales blueprint but not yet exposed through the plugin runtime or the main frontend view.
+
+## Scope
+
+- Add plugin HTTP CRUD routes for `partItem`
+- Add request validation/builders for create and update payloads
+- Add a frontend parts panel in `AfterSalesView.vue`
+- Add route-level unit coverage, live integration coverage, and frontend view coverage
+
+## Backend design
+
+### API shape
+
+- `POST /api/after-sales/parts`
+- `GET /api/after-sales/parts`
+- `PATCH /api/after-sales/parts/:partItemId`
+- `DELETE /api/after-sales/parts/:partItemId`
+
+### Data model
+
+Logical fields:
+
+- `partNo`
+- `name`
+- `category`
+- `stockQty`
+- `status`
+
+Enum policy:
+
+- `category`: `spare | consumable`
+- `status`: `available | reserved | consumed`
+
+### Implementation notes
+
+- Plugin routes follow the same guard rails as customers / installed-assets / follow-ups:
+  - require authenticated caller
+  - require `after_sales:read` or `after_sales:write`
+  - require operational install state
+  - use multitable provisioning + records seam only
+- `stockQty` is normalized back to `number | null` on read
+- update payloads patch only explicitly provided fields instead of rewriting the whole row
+
+## Frontend design
+
+### New panel
+
+`AfterSalesView.vue` now renders a `Part inventory` section when the manifest exposes the `partItem` projection.
+
+Capabilities:
+
+- create part
+- filter by `status`
+- free-text search
+- inline edit
+- delete
+- success/error banners consistent with existing after-sales panels
+
+### UX choices
+
+- panel layout mirrors existing customer / follow-up / installed-asset shells
+- edit mode is inline per row, not modal
+- create/edit forms keep the same compact field rhythm already used elsewhere in the view
+
+## Verification
+
+### Backend unit
+
+Command:
+
+```bash
+/Users/huazhou/Downloads/Github/metasheet2/node_modules/.bin/vitest run packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+```
+
+Result:
+
+- `108/108` tests passed
+
+### Backend integration
+
+Command:
+
+```bash
+./node_modules/.bin/vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts
+```
+
+Run directory:
+
+```text
+packages/core-backend
+```
+
+Result:
+
+- `25/25` tests passed
+- includes the new live `parts` CRUD flow
+
+### Frontend regression
+
+Command:
+
+```bash
+./node_modules/.bin/vitest run tests/AfterSalesView.spec.ts tests/AfterSalesView.installed-assets.spec.ts tests/AfterSalesView.service-records.spec.ts tests/AfterSalesView.customers.spec.ts tests/AfterSalesView.follow-ups.spec.ts tests/AfterSalesView.part-items.spec.ts --config vite.config.ts
+```
+
+Run directory:
+
+```text
+apps/web
+```
+
+Result:
+
+- `6/6` files passed
+- `78/78` tests passed
+
+## Files changed
+
+- `plugins/plugin-after-sales/index.cjs`
+- `plugins/plugin-after-sales/lib/event-entry.cjs`
+- `packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts`
+- `packages/core-backend/tests/integration/after-sales-plugin.install.test.ts`
+- `apps/web/src/views/AfterSalesView.vue`
+- `apps/web/tests/AfterSalesView.part-items.spec.ts`
+
+## Follow-up
+
+- If this slice is split into a PR, exclude unrelated `node_modules` noise already present in the worktree.

--- a/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
+++ b/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
@@ -1036,6 +1036,157 @@ describe('after-sales plugin install integration', () => {
     ])
   })
 
+  it('creates, lists, updates, and deletes part items through the real after-sales routes', async () => {
+    if (!baseUrl || !pool) return
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-part-item-it&roles=admin&perms=*:*`,
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+
+    const installRes = await requestJson(`${baseUrl}/api/after-sales/projects/install`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        templateId: 'after-sales-default',
+        displayName: 'After Sales Parts Flow',
+      }),
+    })
+    expect(installRes.status).toBe(200)
+
+    const createRes = await requestJson(`${baseUrl}/api/after-sales/parts`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        partItem: {
+          partNo: 'PRT-3001',
+          name: 'Outdoor Fan Motor',
+          category: 'spare',
+          stockQty: 6,
+          status: 'available',
+        },
+      }),
+    })
+    expect(createRes.status).toBe(201)
+    const createBody = createRes.body as {
+      ok?: boolean
+      data?: {
+        partItem?: {
+          id?: string
+          version?: number
+          data?: Record<string, unknown>
+        }
+      }
+    }
+    expect(createBody.ok).toBe(true)
+    expect(createBody.data?.partItem?.data).toMatchObject({
+      partNo: 'PRT-3001',
+      name: 'Outdoor Fan Motor',
+      category: 'spare',
+      stockQty: 6,
+      status: 'available',
+    })
+    const partItemId = createBody.data?.partItem?.id
+    expect(typeof partItemId).toBe('string')
+
+    const listRes = await requestJson(`${baseUrl}/api/after-sales/parts`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(listRes.status).toBe(200)
+    const listBody = listRes.body as {
+      ok?: boolean
+      data?: {
+        count?: number
+        partItems?: Array<{
+          id?: string
+          data?: Record<string, unknown>
+        }>
+      }
+    }
+    expect(listBody.ok).toBe(true)
+    expect(listBody.data?.count).toBe(1)
+    expect(listBody.data?.partItems).toEqual([
+      expect.objectContaining({
+        id: partItemId,
+        data: expect.objectContaining({
+          partNo: 'PRT-3001',
+          name: 'Outdoor Fan Motor',
+          category: 'spare',
+          stockQty: 6,
+          status: 'available',
+        }),
+      }),
+    ])
+
+    const updateRes = await requestJson(
+      `${baseUrl}/api/after-sales/parts/${encodeURIComponent(String(partItemId))}`,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          partItem: {
+            stockQty: 4,
+            status: 'reserved',
+          },
+        }),
+      },
+    )
+    expect(updateRes.status).toBe(200)
+    expect((updateRes.body as {
+      data?: {
+        partItem?: {
+          data?: Record<string, unknown>
+        }
+      }
+    }).data?.partItem?.data).toMatchObject({
+      partNo: 'PRT-3001',
+      name: 'Outdoor Fan Motor',
+      category: 'spare',
+      stockQty: 4,
+      status: 'reserved',
+    })
+
+    const deleteRes = await requestJson(
+      `${baseUrl}/api/after-sales/parts/${encodeURIComponent(String(partItemId))}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    )
+    expect(deleteRes.status).toBe(200)
+    expect((deleteRes.body as { data?: { deleted?: boolean } }).data?.deleted).toBe(true)
+
+    const listAfterDeleteRes = await requestJson(`${baseUrl}/api/after-sales/parts`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(listAfterDeleteRes.status).toBe(200)
+    expect((listAfterDeleteRes.body as {
+      data?: {
+        count?: number
+        partItems?: Array<unknown>
+      }
+    }).data).toMatchObject({
+      count: 0,
+      partItems: [],
+    })
+  })
+
   it('creates a ticket and requests refund through the real after-sales routes', async () => {
     if (!baseUrl || !pool) return
 

--- a/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
@@ -299,6 +299,7 @@ function createContext(): {
   const pk = (field: string) => `${MOCK_PROJECT_ID}:serviceTicket:${field}`
   const iaPk = (field: string) => `${MOCK_PROJECT_ID}:installedAsset:${field}`
   const cuPk = (field: string) => `${MOCK_PROJECT_ID}:customer:${field}`
+  const paPk = (field: string) => `${MOCK_PROJECT_ID}:partItem:${field}`
   const fuPk = (field: string) => `${MOCK_PROJECT_ID}:followUp:${field}`
   const getObjectSheetId = vi.fn((projectId: string, objectId: string) => `${projectId}:${objectId}:sheet`)
   const getFieldId = vi.fn((projectId: string, objectId: string, fieldId: string) => `${projectId}:${objectId}:${fieldId}`)
@@ -320,6 +321,8 @@ function createContext(): {
       ? 'rec_asset_001'
       : input.sheetId.includes('customer')
       ? 'rec_customer_001'
+      : input.sheetId.includes('partItem')
+      ? 'rec_part_001'
       : input.sheetId.includes('followUp')
       ? 'rec_follow_up_001'
       : input.sheetId.includes('serviceRecord')
@@ -356,6 +359,19 @@ function createContext(): {
             [cuPk('phone')]: '13800138000',
             [cuPk('email')]: 'alice@example.com',
             [cuPk('status')]: 'active',
+          },
+        }
+      : input.sheetId.includes('partItem')
+      ? {
+          id: 'rec_part_001',
+          sheetId: input.sheetId,
+          version: 2,
+          data: {
+            [paPk('partNo')]: 'PRT-1001',
+            [paPk('name')]: 'Starter Capacitor',
+            [paPk('category')]: 'spare',
+            [paPk('stockQty')]: 8,
+            [paPk('status')]: 'available',
           },
         }
       : input.sheetId.includes('followUp')
@@ -433,6 +449,21 @@ function createContext(): {
           filters: input.filters,
           search: input.search,
         }
+      : input.sheetId.includes('partItem')
+      ? {
+          id: 'rec_part_001',
+          sheetId: input.sheetId,
+          version: 2,
+          data: {
+            [paPk('partNo')]: 'PRT-1001',
+            [paPk('name')]: 'Starter Capacitor',
+            [paPk('category')]: 'spare',
+            [paPk('stockQty')]: 8,
+            [paPk('status')]: 'available',
+          },
+          filters: input.filters,
+          search: input.search,
+        }
       : input.sheetId.includes('followUp')
       ? {
           id: 'rec_follow_up_001',
@@ -504,6 +535,14 @@ function createContext(): {
           [srPk('workSummary')]: 'Replaced motor',
           [srPk('result')]: 'resolved',
         }
+      : input.sheetId.includes('partItem')
+      ? {
+          [paPk('partNo')]: 'PRT-1001',
+          [paPk('name')]: 'Starter Capacitor',
+          [paPk('category')]: 'spare',
+          [paPk('stockQty')]: 8,
+          [paPk('status')]: 'available',
+        }
       : input.sheetId.includes('followUp')
       ? {
           [fuPk('ticketNo')]: 'TK-2001',
@@ -554,6 +593,15 @@ function createContext(): {
           [cuPk('phone')]: '13800138000',
           [cuPk('email')]: 'alice@example.com',
           [cuPk('status')]: 'active',
+          ...input.changes,
+        }
+      : input.sheetId.includes('partItem')
+      ? {
+          [paPk('partNo')]: 'PRT-1001',
+          [paPk('name')]: 'Starter Capacitor',
+          [paPk('category')]: 'spare',
+          [paPk('stockQty')]: 8,
+          [paPk('status')]: 'available',
           ...input.changes,
         }
       : input.sheetId.includes('followUp')
@@ -710,6 +758,7 @@ const stPk = (field: string) => `${MOCK_PROJECT_ID}:serviceTicket:${field}`
 const srPk = (field: string) => `${MOCK_PROJECT_ID}:serviceRecord:${field}`
 const iaPk = (field: string) => `${MOCK_PROJECT_ID}:installedAsset:${field}`
 const cuPk = (field: string) => `${MOCK_PROJECT_ID}:customer:${field}`
+const paPk = (field: string) => `${MOCK_PROJECT_ID}:partItem:${field}`
 const fuPk = (field: string) => `${MOCK_PROJECT_ID}:followUp:${field}`
 
 function seedAfterSalesInstallRow(
@@ -3274,6 +3323,453 @@ describe('plugin-after-sales routes', () => {
       error: {
         code: 'AFTER_SALES_NOT_INSTALLED',
         message: 'After-sales must be installed before deleting customers',
+      },
+    })
+    expect(deleteRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 for parts create when caller lacks after-sales write access', async () => {
+    const handler = routes.get('POST /api/after-sales/parts')
+    const res = new FakeResponse()
+
+    await handler?.(buildReq({
+      user: {
+        id: 'user_42',
+        tenantId: 'tenant_42',
+        role: 'user',
+        roles: ['user'],
+        perms: ['after_sales:read'],
+      },
+      body: {
+        partItem: {
+          partNo: 'PRT-1001',
+          name: 'Starter Capacitor',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'After-sales write access required',
+      },
+    })
+    expect(createRecord).not.toHaveBeenCalled()
+  })
+
+  it('creates part items through the multitable write seam', async () => {
+    const handler = routes.get('POST /api/after-sales/parts')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+    })
+
+    await handler?.(buildReq({
+      body: {
+        partItem: {
+          partNo: 'PRT-1001',
+          name: 'Starter Capacitor',
+          category: 'spare',
+          stockQty: 12,
+          status: 'available',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(201)
+    expect(createRecord).toHaveBeenCalledWith({
+      sheetId: 'tenant_42:after-sales:partItem:sheet',
+      data: {
+        [paPk('partNo')]: 'PRT-1001',
+        [paPk('name')]: 'Starter Capacitor',
+        [paPk('category')]: 'spare',
+        [paPk('stockQty')]: 12,
+        [paPk('status')]: 'available',
+      },
+    })
+    expect(res.body.data).toEqual({
+      projectId: 'tenant_42:after-sales',
+      partItem: {
+        id: 'rec_part_001',
+        version: 1,
+        data: {
+          partNo: 'PRT-1001',
+          name: 'Starter Capacitor',
+          category: 'spare',
+          stockQty: 12,
+          status: 'available',
+        },
+      },
+    })
+  })
+
+  it('returns 400 when part create payload is invalid', async () => {
+    const handler = routes.get('POST /api/after-sales/parts')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+    })
+
+    await handler?.(buildReq({
+      body: {
+        partItem: {
+          partNo: 'PRT-1001',
+          name: '',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_EVENT_VALIDATION_FAILED',
+        message: 'partItem.name is required',
+        details: {
+          field: 'partItem.name',
+        },
+      },
+    })
+    expect(createRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 when parts are created from a failed install state', async () => {
+    const handler = routes.get('POST /api/after-sales/parts')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      mode: 'reinstall',
+      status: 'failed',
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+      warnings_json: JSON.stringify(['part projection failed']),
+    })
+
+    await handler?.(buildReq({
+      body: {
+        partItem: {
+          partNo: 'PRT-1001',
+          name: 'Starter Capacitor',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_NOT_INSTALLED',
+        message: 'After-sales must be installed before creating parts',
+      },
+    })
+    expect(createRecord).not.toHaveBeenCalled()
+  })
+
+  it('lists parts through the multitable query seam', async () => {
+    const handler = routes.get('GET /api/after-sales/parts')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+    })
+
+    await handler?.(buildReq({
+      query: {
+        status: 'available',
+        search: 'capacitor',
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(queryRecords).toHaveBeenCalledWith({
+      sheetId: 'tenant_42:after-sales:partItem:sheet',
+      filters: {
+        [paPk('status')]: 'available',
+      },
+      search: 'capacitor',
+      limit: undefined,
+      offset: undefined,
+    })
+    expect(res.body.data).toEqual({
+      projectId: 'tenant_42:after-sales',
+      partItems: [
+        {
+          id: 'rec_part_001',
+          version: 2,
+          data: {
+            partNo: 'PRT-1001',
+            name: 'Starter Capacitor',
+            category: 'spare',
+            stockQty: 8,
+            status: 'available',
+          },
+        },
+      ],
+      count: 1,
+    })
+  })
+
+  it('returns 403 for parts update when caller lacks after-sales write access', async () => {
+    const handler = routes.get('PATCH /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+
+    await handler?.(buildReq({
+      user: {
+        id: 'user_42',
+        tenantId: 'tenant_42',
+        role: 'user',
+        roles: ['user'],
+        perms: ['after_sales:read'],
+      },
+      params: {
+        partItemId: 'rec_part_001',
+      },
+      body: {
+        partItem: {
+          name: 'Starter Capacitor Updated',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'After-sales write access required',
+      },
+    })
+    expect(patchRecord).not.toHaveBeenCalled()
+  })
+
+  it('updates a part item through the multitable patch seam', async () => {
+    const handler = routes.get('PATCH /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+    })
+
+    await handler?.(buildReq({
+      user: {
+        id: 'writer_42',
+        tenantId: 'tenant_42',
+        role: 'user',
+        roles: ['user'],
+        perms: ['after_sales:write'],
+      },
+      params: {
+        partItemId: 'rec_part_001',
+      },
+      body: {
+        partItem: {
+          name: 'Starter Capacitor Updated',
+          stockQty: '',
+          status: 'reserved',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(getRecord).toHaveBeenCalledWith({
+      sheetId: 'tenant_42:after-sales:partItem:sheet',
+      recordId: 'rec_part_001',
+    })
+    expect(patchRecord).toHaveBeenCalledWith({
+      sheetId: 'tenant_42:after-sales:partItem:sheet',
+      recordId: 'rec_part_001',
+      changes: {
+        [paPk('name')]: 'Starter Capacitor Updated',
+        [paPk('stockQty')]: null,
+        [paPk('status')]: 'reserved',
+      },
+    })
+    expect(res.body.data).toEqual({
+      projectId: 'tenant_42:after-sales',
+      partItem: {
+        id: 'rec_part_001',
+        version: 4,
+        data: {
+          partNo: 'PRT-1001',
+          name: 'Starter Capacitor Updated',
+          category: 'spare',
+          stockQty: null,
+          status: 'reserved',
+        },
+      },
+    })
+  })
+
+  it('returns 404 when updating a missing part item', async () => {
+    const handler = routes.get('PATCH /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+    getRecord.mockRejectedValueOnce(Object.assign(new Error('Record not found: rec_part_missing'), {
+      code: 'NOT_FOUND',
+    }))
+
+    seedAfterSalesInstallRow(db, {
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+    })
+
+    await handler?.(buildReq({
+      user: {
+        id: 'writer_42',
+        tenantId: 'tenant_42',
+        role: 'user',
+        roles: ['user'],
+        perms: ['after_sales:write'],
+      },
+      params: {
+        partItemId: 'rec_part_missing',
+      },
+      body: {
+        partItem: {
+          name: 'Missing Part',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(404)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'NOT_FOUND',
+        message: 'Record not found: rec_part_missing',
+      },
+    })
+    expect(patchRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 when parts are updated from a failed install state', async () => {
+    const handler = routes.get('PATCH /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      mode: 'reinstall',
+      status: 'failed',
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+      warnings_json: JSON.stringify(['part projection failed']),
+    })
+
+    await handler?.(buildReq({
+      params: {
+        partItemId: 'rec_part_001',
+      },
+      body: {
+        partItem: {
+          name: 'Starter Capacitor Updated',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_NOT_INSTALLED',
+        message: 'After-sales must be installed before updating parts',
+      },
+    })
+    expect(patchRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 for parts delete when caller lacks after-sales write access', async () => {
+    const handler = routes.get('DELETE /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+
+    await handler?.(buildReq({
+      user: {
+        id: 'user_42',
+        tenantId: 'tenant_42',
+        role: 'user',
+        roles: ['user'],
+        perms: ['after_sales:read'],
+      },
+      params: {
+        partItemId: 'rec_part_001',
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'After-sales write access required',
+      },
+    })
+    expect(deleteRecord).not.toHaveBeenCalled()
+  })
+
+  it('deletes a part item through the multitable delete seam', async () => {
+    const handler = routes.get('DELETE /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+    })
+
+    await handler?.(buildReq({
+      user: {
+        id: 'writer_42',
+        tenantId: 'tenant_42',
+        role: 'user',
+        roles: ['user'],
+        perms: ['after_sales:write'],
+      },
+      params: {
+        partItemId: 'rec_part_001',
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(deleteRecord).toHaveBeenCalledWith({
+      sheetId: 'tenant_42:after-sales:partItem:sheet',
+      recordId: 'rec_part_001',
+    })
+    expect(res.body.data).toEqual({
+      projectId: 'tenant_42:after-sales',
+      partItemId: 'rec_part_001',
+      version: 4,
+      deleted: true,
+    })
+  })
+
+  it('returns 409 when parts are deleted from a failed install state', async () => {
+    const handler = routes.get('DELETE /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      mode: 'reinstall',
+      status: 'failed',
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+      warnings_json: JSON.stringify(['part projection failed']),
+    })
+
+    await handler?.(buildReq({
+      params: {
+        partItemId: 'rec_part_001',
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_NOT_INSTALLED',
+        message: 'After-sales must be installed before deleting parts',
       },
     })
     expect(deleteRecord).not.toHaveBeenCalled()

--- a/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
@@ -3516,6 +3516,32 @@ describe('plugin-after-sales routes', () => {
     })
   })
 
+  it('returns 400 when parts list pagination params are invalid', async () => {
+    const handler = routes.get('GET /api/after-sales/parts')
+    const res = new FakeResponse()
+
+    seedAfterSalesInstallRow(db, {
+      created_objects_json: JSON.stringify(['serviceTicket', 'partItem']),
+      created_views_json: JSON.stringify(['ticket-board', 'partItem-grid']),
+    })
+
+    await handler?.(buildReq({
+      query: {
+        limit: 'abc',
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'limit must be a non-negative integer',
+      },
+    })
+    expect(queryRecords).not.toHaveBeenCalled()
+  })
+
   it('returns 403 for parts update when caller lacks after-sales write access', async () => {
     const handler = routes.get('PATCH /api/after-sales/parts/:partItemId')
     const res = new FakeResponse()

--- a/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
@@ -3471,6 +3471,42 @@ describe('plugin-after-sales routes', () => {
     expect(createRecord).not.toHaveBeenCalled()
   })
 
+  it('returns 409 when parts create is requested but the part projection is unavailable', async () => {
+    const handler = routes.get('POST /api/after-sales/parts')
+    const res = new FakeResponse()
+    findObjectSheet.mockResolvedValueOnce(null)
+
+    seedAfterSalesInstallRow(db, {
+      mode: 'reinstall',
+      status: 'partial',
+      created_objects_json: JSON.stringify(['serviceTicket', 'installedAsset', 'customer', 'serviceRecord']),
+      created_views_json: JSON.stringify(['ticket-board']),
+      warnings_json: JSON.stringify(['partItem provisioning failed']),
+    })
+
+    await handler?.(buildReq({
+      body: {
+        partItem: {
+          partNo: 'PRT-1001',
+          name: 'Starter Capacitor',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_OBJECT_UNAVAILABLE',
+        message: 'After-sales part inventory is unavailable for the current install state',
+        details: {
+          objectId: 'partItem',
+        },
+      },
+    })
+    expect(createRecord).not.toHaveBeenCalled()
+  })
+
   it('lists parts through the multitable query seam', async () => {
     const handler = routes.get('GET /api/after-sales/parts')
     const res = new FakeResponse()
@@ -3540,6 +3576,36 @@ describe('plugin-after-sales routes', () => {
       },
     })
     expect(queryRecords).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 when parts list is requested but the part projection is unavailable', async () => {
+    const handler = routes.get('GET /api/after-sales/parts')
+    const res = new FakeResponse()
+    findObjectSheet.mockResolvedValueOnce(null)
+
+    seedAfterSalesInstallRow(db, {
+      mode: 'reinstall',
+      status: 'partial',
+      created_objects_json: JSON.stringify(['serviceTicket', 'installedAsset', 'customer', 'serviceRecord']),
+      created_views_json: JSON.stringify(['ticket-board']),
+      warnings_json: JSON.stringify(['partItem provisioning failed']),
+    })
+
+    await handler?.(buildReq(), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_OBJECT_UNAVAILABLE',
+        message: 'After-sales part inventory is unavailable for the current install state',
+        details: {
+          objectId: 'partItem',
+        },
+      },
+    })
+    expect(queryRecords).not.toHaveBeenCalled()
+    expect(listRecords).not.toHaveBeenCalled()
   })
 
   it('returns 403 for parts update when caller lacks after-sales write access', async () => {
@@ -3709,6 +3775,45 @@ describe('plugin-after-sales routes', () => {
     expect(patchRecord).not.toHaveBeenCalled()
   })
 
+  it('returns 409 when part update is requested but the part projection is unavailable', async () => {
+    const handler = routes.get('PATCH /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+    findObjectSheet.mockResolvedValueOnce(null)
+
+    seedAfterSalesInstallRow(db, {
+      mode: 'reinstall',
+      status: 'partial',
+      created_objects_json: JSON.stringify(['serviceTicket', 'installedAsset', 'customer', 'serviceRecord']),
+      created_views_json: JSON.stringify(['ticket-board']),
+      warnings_json: JSON.stringify(['partItem provisioning failed']),
+    })
+
+    await handler?.(buildReq({
+      params: {
+        partItemId: 'rec_part_001',
+      },
+      body: {
+        partItem: {
+          name: 'Starter Capacitor Updated',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_OBJECT_UNAVAILABLE',
+        message: 'After-sales part inventory is unavailable for the current install state',
+        details: {
+          objectId: 'partItem',
+        },
+      },
+    })
+    expect(getRecord).not.toHaveBeenCalled()
+    expect(patchRecord).not.toHaveBeenCalled()
+  })
+
   it('returns 403 for parts delete when caller lacks after-sales write access', async () => {
     const handler = routes.get('DELETE /api/after-sales/parts/:partItemId')
     const res = new FakeResponse()
@@ -3796,6 +3901,39 @@ describe('plugin-after-sales routes', () => {
       error: {
         code: 'AFTER_SALES_NOT_INSTALLED',
         message: 'After-sales must be installed before deleting parts',
+      },
+    })
+    expect(deleteRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 when part delete is requested but the part projection is unavailable', async () => {
+    const handler = routes.get('DELETE /api/after-sales/parts/:partItemId')
+    const res = new FakeResponse()
+    findObjectSheet.mockResolvedValueOnce(null)
+
+    seedAfterSalesInstallRow(db, {
+      mode: 'reinstall',
+      status: 'partial',
+      created_objects_json: JSON.stringify(['serviceTicket', 'installedAsset', 'customer', 'serviceRecord']),
+      created_views_json: JSON.stringify(['ticket-board']),
+      warnings_json: JSON.stringify(['partItem provisioning failed']),
+    })
+
+    await handler?.(buildReq({
+      params: {
+        partItemId: 'rec_part_001',
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'AFTER_SALES_OBJECT_UNAVAILABLE',
+        message: 'After-sales part inventory is unavailable for the current install state',
+        details: {
+          objectId: 'partItem',
+        },
       },
     })
     expect(deleteRecord).not.toHaveBeenCalled()

--- a/plugins/plugin-after-sales/index.cjs
+++ b/plugins/plugin-after-sales/index.cjs
@@ -165,6 +165,21 @@ function getUserId(req) {
   return u.id || u.sub || u.userId || null
 }
 
+function parseOptionalNonNegativeInteger(value, fieldName) {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const parsed = Number(trimmed)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    const error = new Error(`${fieldName} must be a non-negative integer`)
+    error.code = 'VALIDATION_ERROR'
+    throw error
+  }
+
+  return parsed
+}
+
 function normalizeClaimValues(input) {
   if (Array.isArray(input)) {
     return input
@@ -493,6 +508,36 @@ async function getPartItemById(multitableApi, projectId, partItemId) {
     record,
     logicalData: await fromPhysicalPartItemData(multitableApi.provisioning, projectId, record.data),
   }
+}
+
+function buildPartItemSearchHaystack(data) {
+  if (!data || typeof data !== 'object') return ''
+  return [
+    data.partNo,
+    data.name,
+    data.category,
+    data.status,
+    data.stockQty == null ? null : String(data.stockQty),
+  ]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .join(' ')
+    .toLowerCase()
+}
+
+function buildInstalledAssetSearchHaystack(data) {
+  if (!data || typeof data !== 'object') return ''
+  return [
+    data.assetCode,
+    data.serialNo,
+    data.model,
+    data.location,
+    data.installedAt,
+    data.warrantyUntil,
+    data.status,
+  ]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .join(' ')
+    .toLowerCase()
 }
 
 async function getFollowUpById(multitableApi, projectId, followUpId) {
@@ -1076,12 +1121,8 @@ module.exports = {
           const search = typeof req?.query?.search === 'string' && req.query.search.trim()
             ? req.query.search.trim()
             : null
-          const limit = typeof req?.query?.limit === 'string' && req.query.limit.trim()
-            ? Number(req.query.limit)
-            : undefined
-          const offset = typeof req?.query?.offset === 'string' && req.query.offset.trim()
-            ? Number(req.query.offset)
-            : undefined
+          const limit = parseOptionalNonNegativeInteger(req?.query?.limit, 'limit')
+          const offset = parseOptionalNonNegativeInteger(req?.query?.offset, 'offset')
 
           const recordsApi = multitableApi.records
           let tickets
@@ -1808,12 +1849,8 @@ module.exports = {
           const search = typeof req?.query?.search === 'string' && req.query.search.trim()
             ? req.query.search.trim()
             : null
-          const limit = typeof req?.query?.limit === 'string' && req.query.limit.trim()
-            ? Number(req.query.limit)
-            : undefined
-          const offset = typeof req?.query?.offset === 'string' && req.query.offset.trim()
-            ? Number(req.query.offset)
-            : undefined
+          const limit = parseOptionalNonNegativeInteger(req?.query?.limit, 'limit')
+          const offset = parseOptionalNonNegativeInteger(req?.query?.offset, 'offset')
 
           const recordsApi = multitableApi.records
           let installedAssets
@@ -1862,7 +1899,7 @@ module.exports = {
               ).filter((record) => {
                 if (status && record.data.status !== status) return false
                 if (!search) return true
-                const haystack = JSON.stringify(record.data).toLowerCase()
+                const haystack = buildInstalledAssetSearchHaystack(record.data)
                 return haystack.includes(search.toLowerCase())
               })
             : []
@@ -2422,12 +2459,8 @@ module.exports = {
           const search = typeof req?.query?.search === 'string' && req.query.search.trim()
             ? req.query.search.trim()
             : null
-          const limit = typeof req?.query?.limit === 'string' && req.query.limit.trim()
-            ? Number(req.query.limit)
-            : undefined
-          const offset = typeof req?.query?.offset === 'string' && req.query.offset.trim()
-            ? Number(req.query.offset)
-            : undefined
+          const limit = parseOptionalNonNegativeInteger(req?.query?.limit, 'limit')
+          const offset = parseOptionalNonNegativeInteger(req?.query?.offset, 'offset')
 
           const recordsApi = multitableApi.records
           let partItems

--- a/plugins/plugin-after-sales/index.cjs
+++ b/plugins/plugin-after-sales/index.cjs
@@ -30,9 +30,11 @@ const {
   buildCustomerCommand,
   buildFollowUpCommand,
   buildInstalledAssetCommand,
+  buildPartItemCommand,
   buildUpdateFollowUpCommand,
   buildUpdateCustomerCommand,
   buildUpdateInstalledAssetCommand,
+  buildUpdatePartItemCommand,
   buildUpdateTicketCommand,
   buildRefundDecisionEventPayload,
   buildServiceRecordCommand,
@@ -56,6 +58,7 @@ const SERVICE_TICKET_FIELDS = ['ticketNo', 'title', 'source', 'priority', 'statu
 const SERVICE_RECORD_FIELDS = ['ticketNo', 'visitType', 'scheduledAt', 'completedAt', 'technicianName', 'workSummary', 'result']
 const INSTALLED_ASSET_FIELDS = ['assetCode', 'serialNo', 'model', 'location', 'installedAt', 'warrantyUntil', 'status']
 const CUSTOMER_FIELDS = ['customerCode', 'name', 'phone', 'email', 'status']
+const PART_ITEM_FIELDS = ['partNo', 'name', 'category', 'stockQty', 'status']
 const FOLLOW_UP_FIELDS = ['ticketNo', 'customerName', 'dueAt', 'followUpType', 'ownerName', 'status', 'summary']
 
 async function toPhysicalTicketData(provisioning, projectId, logicalData) {
@@ -84,6 +87,24 @@ async function fromPhysicalInstalledAssetData(provisioning, projectId, physicalD
 
 async function fromPhysicalCustomerData(provisioning, projectId, physicalData) {
   return fromPhysicalRecord(provisioning, projectId, 'customer', CUSTOMER_FIELDS, physicalData)
+}
+
+async function toPhysicalPartItemData(provisioning, projectId, logicalData) {
+  return toPhysicalRecord(provisioning, projectId, 'partItem', logicalData)
+}
+
+async function fromPhysicalPartItemData(provisioning, projectId, physicalData) {
+  const logicalData = await fromPhysicalRecord(provisioning, projectId, 'partItem', PART_ITEM_FIELDS, physicalData)
+  return {
+    ...logicalData,
+    stockQty: typeof logicalData.stockQty === 'number'
+      ? logicalData.stockQty
+      : logicalData.stockQty == null || logicalData.stockQty === ''
+        ? null
+        : Number.isFinite(Number(logicalData.stockQty))
+          ? Number(logicalData.stockQty)
+          : null,
+  }
 }
 
 async function fromPhysicalFollowUpData(provisioning, projectId, physicalData) {
@@ -458,6 +479,19 @@ async function getCustomerById(multitableApi, projectId, customerId) {
     sheetId,
     record,
     logicalData: await fromPhysicalCustomerData(multitableApi.provisioning, projectId, record.data),
+  }
+}
+
+async function getPartItemById(multitableApi, projectId, partItemId) {
+  const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
+  const record = await multitableApi.records.getRecord({
+    sheetId,
+    recordId: partItemId,
+  })
+  return {
+    sheetId,
+    record,
+    logicalData: await fromPhysicalPartItemData(multitableApi.provisioning, projectId, record.data),
   }
 }
 
@@ -2240,6 +2274,436 @@ module.exports = {
           res.status(500).json({
             ok: false,
             error: { code: 'INTERNAL_ERROR', message: 'Failed to list after-sales customers' },
+          })
+        }
+      },
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/after-sales/parts',
+      async (req, res) => {
+        try {
+          const userId = getUserId(req)
+          if (!userId) {
+            sendUnauthorized(res)
+            return
+          }
+          if (!hasAfterSalesWriteAccess(req)) {
+            sendWriteForbidden(res)
+            return
+          }
+
+          const multitableApi = getMultitableWriteApi(context)
+          if (!multitableApi) {
+            res.status(503).json({
+              ok: false,
+              error: {
+                code: 'MULTITABLE_UNAVAILABLE',
+                message: 'Multitable record writer is not available on plugin context',
+              },
+            })
+            return
+          }
+
+          const tenantId = getTenantId(req, context.logger)
+          const current = await installer.loadCurrent(context, tenantId, appManifest.id)
+          if (!current || !isOperationalAfterSalesStatus(current.status)) {
+            res.status(409).json({
+              ok: false,
+              error: {
+                code: 'AFTER_SALES_NOT_INSTALLED',
+                message: 'After-sales must be installed before creating parts',
+              },
+            })
+            return
+          }
+
+          const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
+          const command = buildPartItemCommand((req && req.body) || {})
+          const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
+          const record = await multitableApi.records.createRecord({
+            sheetId,
+            data: await toPhysicalPartItemData(multitableApi.provisioning, projectId, command.recordData),
+          })
+          const logicalRecordData = await fromPhysicalPartItemData(
+            multitableApi.provisioning,
+            projectId,
+            record.data,
+          )
+
+          res.status(201).json({
+            ok: true,
+            data: {
+              projectId,
+              partItem: {
+                id: record.id,
+                version: record.version,
+                data: logicalRecordData,
+              },
+            },
+          })
+        } catch (err) {
+          if (err && err.code === 'AFTER_SALES_EVENT_VALIDATION_FAILED') {
+            sendBadRequest(res, err)
+            return
+          }
+          if (err && err.code === 'VALIDATION_ERROR') {
+            res.status(400).json({
+              ok: false,
+              error: { code: err.code, message: err.message },
+            })
+            return
+          }
+          if (err && err.code === 'NOT_FOUND') {
+            res.status(404).json({
+              ok: false,
+              error: { code: err.code, message: err.message },
+            })
+            return
+          }
+          logger.error && logger.error('after-sales create part item failed', err)
+          res.status(500).json({
+            ok: false,
+            error: { code: 'INTERNAL_ERROR', message: 'Failed to create after-sales part item' },
+          })
+        }
+      },
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/after-sales/parts',
+      async (req, res) => {
+        try {
+          const userId = getUserId(req)
+          if (!userId) {
+            sendUnauthorized(res)
+            return
+          }
+          if (!hasAfterSalesReadAccess(req)) {
+            res.status(403).json({
+              ok: false,
+              error: { code: 'FORBIDDEN', message: 'After-sales read access required' },
+            })
+            return
+          }
+
+          const multitableApi = getMultitableReadApi(context)
+          if (!multitableApi || (typeof multitableApi.records.listRecords !== 'function' && typeof multitableApi.records.queryRecords !== 'function')) {
+            res.status(503).json({
+              ok: false,
+              error: {
+                code: 'MULTITABLE_UNAVAILABLE',
+                message: 'Multitable record reader is not available on plugin context',
+              },
+            })
+            return
+          }
+
+          const tenantId = getTenantId(req, context.logger)
+          const current = await installer.loadCurrent(context, tenantId, appManifest.id)
+          if (!current || !isOperationalAfterSalesStatus(current.status)) {
+            res.status(409).json({
+              ok: false,
+              error: {
+                code: 'AFTER_SALES_NOT_INSTALLED',
+                message: 'After-sales must be installed before listing parts',
+              },
+            })
+            return
+          }
+
+          const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
+          const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
+          const status = typeof req?.query?.status === 'string' && req.query.status.trim()
+            ? req.query.status.trim()
+            : null
+          const search = typeof req?.query?.search === 'string' && req.query.search.trim()
+            ? req.query.search.trim()
+            : null
+          const limit = typeof req?.query?.limit === 'string' && req.query.limit.trim()
+            ? Number(req.query.limit)
+            : undefined
+          const offset = typeof req?.query?.offset === 'string' && req.query.offset.trim()
+            ? Number(req.query.offset)
+            : undefined
+
+          const recordsApi = multitableApi.records
+          let partItems
+          if (typeof recordsApi.queryRecords === 'function') {
+            const physicalFieldIds = status
+              ? await resolvePhysicalFieldIds(
+                  multitableApi.provisioning,
+                  projectId,
+                  'partItem',
+                  ['status'],
+                )
+              : {}
+            const filters = status
+              ? {
+                  [physicalFieldIds.status || 'status']: status,
+                }
+              : undefined
+            partItems = await recordsApi.queryRecords({
+              sheetId,
+              filters,
+              search,
+              limit,
+              offset,
+            })
+          } else {
+            partItems = await recordsApi.listRecords({
+              sheetId,
+              limit,
+              offset,
+            })
+          }
+
+          const logicalPartItems = Array.isArray(partItems)
+            ? (
+                await Promise.all(
+                  partItems.map(async (partItem) => ({
+                    id: partItem.id,
+                    version: partItem.version,
+                    data: await fromPhysicalPartItemData(
+                      multitableApi.provisioning,
+                      projectId,
+                      partItem.data,
+                    ),
+                  })),
+                )
+              ).filter((record) => {
+                if (status && record.data.status !== status) return false
+                if (!search) return true
+                const haystack = JSON.stringify(record.data).toLowerCase()
+                return haystack.includes(search.toLowerCase())
+              })
+            : []
+
+          res.json({
+            ok: true,
+            data: {
+              projectId,
+              partItems: logicalPartItems,
+              count: logicalPartItems.length,
+            },
+          })
+        } catch (err) {
+          if (err && err.code === 'VALIDATION_ERROR') {
+            res.status(400).json({
+              ok: false,
+              error: { code: err.code, message: err.message },
+            })
+            return
+          }
+          if (err && err.code === 'NOT_FOUND') {
+            res.status(404).json({
+              ok: false,
+              error: { code: err.code, message: err.message },
+            })
+            return
+          }
+          logger.error && logger.error('after-sales list parts failed', err)
+          res.status(500).json({
+            ok: false,
+            error: { code: 'INTERNAL_ERROR', message: 'Failed to list after-sales parts' },
+          })
+        }
+      },
+    )
+
+    context.api.http.addRoute(
+      'PATCH',
+      '/api/after-sales/parts/:partItemId',
+      async (req, res) => {
+        try {
+          const userId = getUserId(req)
+          if (!userId) {
+            sendUnauthorized(res)
+            return
+          }
+          if (!hasAfterSalesWriteAccess(req)) {
+            sendWriteForbidden(res)
+            return
+          }
+
+          const partItemId =
+            typeof req?.params?.partItemId === 'string' ? req.params.partItemId.trim() : ''
+          if (!partItemId) {
+            res.status(400).json({
+              ok: false,
+              error: { code: 'VALIDATION_ERROR', message: 'partItemId is required' },
+            })
+            return
+          }
+
+          const multitableApi = getMultitableWriteApi(context)
+          if (!multitableApi) {
+            res.status(503).json({
+              ok: false,
+              error: {
+                code: 'MULTITABLE_UNAVAILABLE',
+                message: 'Multitable record writer is not available on plugin context',
+              },
+            })
+            return
+          }
+
+          const tenantId = getTenantId(req, context.logger)
+          const current = await installer.loadCurrent(context, tenantId, appManifest.id)
+          if (!current || !isOperationalAfterSalesStatus(current.status)) {
+            res.status(409).json({
+              ok: false,
+              error: {
+                code: 'AFTER_SALES_NOT_INSTALLED',
+                message: 'After-sales must be installed before updating parts',
+              },
+            })
+            return
+          }
+
+          const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
+          const { sheetId, record, logicalData } = await getPartItemById(multitableApi, projectId, partItemId)
+          const command = buildUpdatePartItemCommand((req && req.body) || {}, {
+            id: record.id,
+            ...logicalData,
+          })
+          const updatedRecord = await multitableApi.records.patchRecord({
+            sheetId,
+            recordId: partItemId,
+            changes: await toPhysicalPartItemData(multitableApi.provisioning, projectId, command.changes),
+          })
+          const logicalRecordData = await fromPhysicalPartItemData(
+            multitableApi.provisioning,
+            projectId,
+            updatedRecord.data,
+          )
+
+          res.json({
+            ok: true,
+            data: {
+              projectId,
+              partItem: {
+                id: updatedRecord.id,
+                version: updatedRecord.version,
+                data: logicalRecordData,
+              },
+            },
+          })
+        } catch (err) {
+          if (err && err.code === 'AFTER_SALES_EVENT_VALIDATION_FAILED') {
+            sendBadRequest(res, err)
+            return
+          }
+          if (err && err.code === 'VALIDATION_ERROR') {
+            res.status(400).json({
+              ok: false,
+              error: { code: err.code, message: err.message },
+            })
+            return
+          }
+          if (err && err.code === 'NOT_FOUND') {
+            res.status(404).json({
+              ok: false,
+              error: { code: err.code, message: err.message },
+            })
+            return
+          }
+          logger.error && logger.error('after-sales update part item failed', err)
+          res.status(500).json({
+            ok: false,
+            error: { code: 'INTERNAL_ERROR', message: 'Failed to update after-sales part item' },
+          })
+        }
+      },
+    )
+
+    context.api.http.addRoute(
+      'DELETE',
+      '/api/after-sales/parts/:partItemId',
+      async (req, res) => {
+        try {
+          const userId = getUserId(req)
+          if (!userId) {
+            sendUnauthorized(res)
+            return
+          }
+          if (!hasAfterSalesWriteAccess(req)) {
+            sendWriteForbidden(res)
+            return
+          }
+
+          const partItemId =
+            typeof req?.params?.partItemId === 'string' ? req.params.partItemId.trim() : ''
+          if (!partItemId) {
+            res.status(400).json({
+              ok: false,
+              error: { code: 'VALIDATION_ERROR', message: 'partItemId is required' },
+            })
+            return
+          }
+
+          const multitableApi = getMultitableWriteApi(context)
+          if (!multitableApi || typeof multitableApi.records.deleteRecord !== 'function') {
+            res.status(503).json({
+              ok: false,
+              error: {
+                code: 'MULTITABLE_UNAVAILABLE',
+                message: 'Multitable record delete seam is not available on plugin context',
+              },
+            })
+            return
+          }
+
+          const tenantId = getTenantId(req, context.logger)
+          const current = await installer.loadCurrent(context, tenantId, appManifest.id)
+          if (!current || !isOperationalAfterSalesStatus(current.status)) {
+            res.status(409).json({
+              ok: false,
+              error: {
+                code: 'AFTER_SALES_NOT_INSTALLED',
+                message: 'After-sales must be installed before deleting parts',
+              },
+            })
+            return
+          }
+
+          const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
+          const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
+          const deleted = await multitableApi.records.deleteRecord({
+            sheetId,
+            recordId: partItemId,
+          })
+
+          res.json({
+            ok: true,
+            data: {
+              projectId,
+              partItemId: deleted.id,
+              version: deleted.version,
+              deleted: true,
+            },
+          })
+        } catch (err) {
+          if (err && err.code === 'VALIDATION_ERROR') {
+            res.status(400).json({
+              ok: false,
+              error: { code: err.code, message: err.message },
+            })
+            return
+          }
+          if (err && err.code === 'NOT_FOUND') {
+            res.status(404).json({
+              ok: false,
+              error: { code: err.code, message: err.message },
+            })
+            return
+          }
+          logger.error && logger.error('after-sales delete part item failed', err)
+          res.status(500).json({
+            ok: false,
+            error: { code: 'INTERNAL_ERROR', message: 'Failed to delete after-sales part item' },
           })
         }
       },

--- a/plugins/plugin-after-sales/index.cjs
+++ b/plugins/plugin-after-sales/index.cjs
@@ -369,6 +369,40 @@ function isOperationalAfterSalesStatus(status) {
   return status === 'installed' || status === 'partial'
 }
 
+function buildObjectUnavailableError(objectId) {
+  const label = objectId === 'partItem' ? 'part inventory' : `object ${objectId}`
+  const error = new Error(`After-sales ${label} is unavailable for the current install state`)
+  error.code = 'AFTER_SALES_OBJECT_UNAVAILABLE'
+  error.meta = { objectId }
+  return error
+}
+
+function sendObjectUnavailable(res, err) {
+  res.status(409).json({
+    ok: false,
+    error: {
+      code: err && err.code ? err.code : 'AFTER_SALES_OBJECT_UNAVAILABLE',
+      message:
+        err && err.message
+          ? err.message
+          : 'After-sales object is unavailable for the current install state',
+      ...(err && err.meta && typeof err.meta === 'object' ? { details: err.meta } : {}),
+    },
+  })
+}
+
+async function requireProvisionedObjectSheetId(provisioning, projectId, objectId) {
+  if (provisioning && typeof provisioning.findObjectSheet === 'function') {
+    const sheet = await provisioning.findObjectSheet({ projectId, objectId })
+    if (sheet && typeof sheet.id === 'string' && sheet.id) {
+      return sheet.id
+    }
+    throw buildObjectUnavailableError(objectId)
+  }
+
+  return findObjectSheetId(provisioning, projectId, objectId)
+}
+
 function getMultitableWriteApi(context) {
   const multitable = context && context.api && context.api.multitable
   const provisioning = multitable && multitable.provisioning
@@ -498,7 +532,7 @@ async function getCustomerById(multitableApi, projectId, customerId) {
 }
 
 async function getPartItemById(multitableApi, projectId, partItemId) {
-  const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
+  const sheetId = await requireProvisionedObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
   const record = await multitableApi.records.getRecord({
     sheetId,
     recordId: partItemId,
@@ -1297,6 +1331,10 @@ module.exports = {
             sendBadRequest(res, err)
             return
           }
+          if (err && err.code === 'AFTER_SALES_OBJECT_UNAVAILABLE') {
+            sendObjectUnavailable(res, err)
+            return
+          }
           if (err && err.code === 'VALIDATION_ERROR') {
             res.status(400).json({
               ok: false,
@@ -1396,6 +1434,10 @@ module.exports = {
         } catch (err) {
           if (err && err.code === 'AFTER_SALES_EVENT_VALIDATION_FAILED') {
             sendBadRequest(res, err)
+            return
+          }
+          if (err && err.code === 'AFTER_SALES_OBJECT_UNAVAILABLE') {
+            sendObjectUnavailable(res, err)
             return
           }
           if (err && err.code === 'VALIDATION_ERROR') {
@@ -1577,6 +1619,10 @@ module.exports = {
         } catch (err) {
           if (err && err.code === 'AFTER_SALES_EVENT_VALIDATION_FAILED') {
             sendBadRequest(res, err)
+            return
+          }
+          if (err && err.code === 'AFTER_SALES_OBJECT_UNAVAILABLE') {
+            sendObjectUnavailable(res, err)
             return
           }
           if (err && err.code === 'VALIDATION_ERROR') {
@@ -2358,7 +2404,11 @@ module.exports = {
 
           const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
           const command = buildPartItemCommand((req && req.body) || {})
-          const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
+          const sheetId = await requireProvisionedObjectSheetId(
+            multitableApi.provisioning,
+            projectId,
+            'partItem',
+          )
           const record = await multitableApi.records.createRecord({
             sheetId,
             data: await toPhysicalPartItemData(multitableApi.provisioning, projectId, command.recordData),
@@ -2383,6 +2433,10 @@ module.exports = {
         } catch (err) {
           if (err && err.code === 'AFTER_SALES_EVENT_VALIDATION_FAILED') {
             sendBadRequest(res, err)
+            return
+          }
+          if (err && err.code === 'AFTER_SALES_OBJECT_UNAVAILABLE') {
+            sendObjectUnavailable(res, err)
             return
           }
           if (err && err.code === 'VALIDATION_ERROR') {
@@ -2452,7 +2506,11 @@ module.exports = {
           }
 
           const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
-          const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
+          const sheetId = await requireProvisionedObjectSheetId(
+            multitableApi.provisioning,
+            projectId,
+            'partItem',
+          )
           const status = typeof req?.query?.status === 'string' && req.query.status.trim()
             ? req.query.status.trim()
             : null
@@ -2509,7 +2567,7 @@ module.exports = {
               ).filter((record) => {
                 if (status && record.data.status !== status) return false
                 if (!search) return true
-                const haystack = JSON.stringify(record.data).toLowerCase()
+                const haystack = buildPartItemSearchHaystack(record.data)
                 return haystack.includes(search.toLowerCase())
               })
             : []
@@ -2523,6 +2581,10 @@ module.exports = {
             },
           })
         } catch (err) {
+          if (err && err.code === 'AFTER_SALES_OBJECT_UNAVAILABLE') {
+            sendObjectUnavailable(res, err)
+            return
+          }
           if (err && err.code === 'VALIDATION_ERROR') {
             res.status(400).json({
               ok: false,
@@ -2629,6 +2691,10 @@ module.exports = {
             sendBadRequest(res, err)
             return
           }
+          if (err && err.code === 'AFTER_SALES_OBJECT_UNAVAILABLE') {
+            sendObjectUnavailable(res, err)
+            return
+          }
           if (err && err.code === 'VALIDATION_ERROR') {
             res.status(400).json({
               ok: false,
@@ -2703,7 +2769,11 @@ module.exports = {
           }
 
           const projectId = current.projectId || installer.getProjectId(tenantId, appManifest.id)
-          const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'partItem')
+          const sheetId = await requireProvisionedObjectSheetId(
+            multitableApi.provisioning,
+            projectId,
+            'partItem',
+          )
           const deleted = await multitableApi.records.deleteRecord({
             sheetId,
             recordId: partItemId,
@@ -2719,6 +2789,10 @@ module.exports = {
             },
           })
         } catch (err) {
+          if (err && err.code === 'AFTER_SALES_OBJECT_UNAVAILABLE') {
+            sendObjectUnavailable(res, err)
+            return
+          }
           if (err && err.code === 'VALIDATION_ERROR') {
             res.status(400).json({
               ok: false,

--- a/plugins/plugin-after-sales/lib/event-entry.cjs
+++ b/plugins/plugin-after-sales/lib/event-entry.cjs
@@ -262,6 +262,41 @@ function buildFollowUpCommand(input) {
   }
 }
 
+function buildPartItemCommand(input) {
+  const partItem =
+    input && typeof input.partItem === 'object' && !Array.isArray(input.partItem)
+      ? input.partItem
+      : input || {}
+
+  const partNo = requiredString(partItem.partNo ?? input.partNo, 'partItem.partNo')
+  const name = requiredString(partItem.name ?? input.name, 'partItem.name')
+  const category = normalizeEnumValue(
+    partItem.category,
+    'partItem.category',
+    ['spare', 'consumable'],
+    'spare',
+  )
+  const status = normalizeEnumValue(
+    partItem.status,
+    'partItem.status',
+    ['available', 'reserved', 'consumed'],
+    'available',
+  )
+  const stockQty = isMissingInputValue(partItem.stockQty ?? input.stockQty)
+    ? undefined
+    : requiredNumber(partItem.stockQty ?? input.stockQty, 'partItem.stockQty')
+
+  return {
+    recordData: {
+      partNo,
+      name,
+      category,
+      status,
+      ...(typeof stockQty === 'number' ? { stockQty } : {}),
+    },
+  }
+}
+
 function buildUpdateCustomerCommand(input, existingCustomer) {
   const command = input && typeof input === 'object' && !Array.isArray(input) ? input : {}
   const customerInput =
@@ -303,6 +338,61 @@ function buildUpdateCustomerCommand(input, existingCustomer) {
   }
   if (hasEmail) {
     changes.email = optionalString(customerInput.email ?? command.email) || null
+  }
+
+  return {
+    changes,
+  }
+}
+
+function buildUpdatePartItemCommand(input, existingPartItem) {
+  const command = input && typeof input === 'object' && !Array.isArray(input) ? input : {}
+  const partItemInput =
+    command.partItem && typeof command.partItem === 'object' && !Array.isArray(command.partItem)
+      ? command.partItem
+      : command
+  const currentPartItem =
+    existingPartItem && typeof existingPartItem === 'object' ? existingPartItem : {}
+
+  const changes = {}
+  const hasPartNo = hasOwnField(partItemInput, 'partNo') || hasOwnField(command, 'partNo')
+  const hasName = hasOwnField(partItemInput, 'name') || hasOwnField(command, 'name')
+  const hasCategory = hasOwnField(partItemInput, 'category') || hasOwnField(command, 'category')
+  const hasStatus = hasOwnField(partItemInput, 'status') || hasOwnField(command, 'status')
+  const hasStockQty = hasOwnField(partItemInput, 'stockQty') || hasOwnField(command, 'stockQty')
+
+  if (hasPartNo) {
+    changes.partNo = requiredString(
+      partItemInput.partNo ?? command.partNo,
+      'partItem.partNo',
+    )
+  }
+  if (hasName) {
+    changes.name = requiredString(
+      partItemInput.name ?? command.name,
+      'partItem.name',
+    )
+  }
+  if (hasCategory) {
+    changes.category = normalizeEnumValue(
+      partItemInput.category ?? command.category,
+      'partItem.category',
+      ['spare', 'consumable'],
+      optionalString(currentPartItem.category) || 'spare',
+    )
+  }
+  if (hasStatus) {
+    changes.status = normalizeEnumValue(
+      partItemInput.status ?? command.status,
+      'partItem.status',
+      ['available', 'reserved', 'consumed'],
+      optionalString(currentPartItem.status) || 'available',
+    )
+  }
+  if (hasStockQty) {
+    changes.stockQty = isMissingInputValue(partItemInput.stockQty ?? command.stockQty)
+      ? null
+      : requiredNumber(partItemInput.stockQty ?? command.stockQty, 'partItem.stockQty')
   }
 
   return {
@@ -718,8 +808,10 @@ module.exports = {
   buildCreateTicketCommand,
   buildCustomerCommand,
   buildFollowUpCommand,
+  buildPartItemCommand,
   buildUpdateFollowUpCommand,
   buildUpdateCustomerCommand,
+  buildUpdatePartItemCommand,
   buildInstalledAssetCommand,
   buildUpdateInstalledAssetCommand,
   buildUpdateTicketCommand,


### PR DESCRIPTION
## Summary

This PR completes the missing `partItem` vertical slice for plugin-after-sales.

What changed:
- add after-sales parts CRUD routes on the plugin runtime
- add part-item command builders and patch semantics
- add a `Part inventory` panel to `AfterSalesView`
- add backend unit coverage, live integration coverage, and frontend view coverage
- add a design and verification note under `docs/development/`
- tighten the new parts list route with `limit` / `offset` validation

## Why

The after-sales blueprint already provisions the `partItem` object and default grid view, but `origin/main` still had no plugin CRUD surface and no frontend consumer for that projection. This PR closes that gap and makes the sixth default object actually usable.

## Verification

Backend:
- `./node_modules/.bin/vitest run packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts`
- `./node_modules/.bin/vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts` (run from `packages/core-backend`)

Frontend:
- `./node_modules/.bin/vitest run tests/AfterSalesView.spec.ts tests/AfterSalesView.installed-assets.spec.ts tests/AfterSalesView.service-records.spec.ts tests/AfterSalesView.customers.spec.ts tests/AfterSalesView.follow-ups.spec.ts tests/AfterSalesView.part-items.spec.ts --config vite.config.ts` (run from `apps/web`)
- `./node_modules/.bin/vue-tsc -b` (run from `apps/web`)

## Notes

- The worktree contains unrelated local `node_modules` noise outside this commit; those files are not part of the PR.
- Detailed implementation/verification notes: `docs/development/after-sales-part-items-slice-20260411.md`
