### PR TITLE
feat(dingtalk): manage directory account bindings

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -148,7 +148,7 @@
           <div class="directory-admin__section-head">
             <div>
               <h3>成员账号</h3>
-              <p class="directory-admin__hint">展示同步后的钉钉成员、钉钉 ID 与本地绑定状态；支持按本地用户 ID 或邮箱手工绑定。</p>
+              <p class="directory-admin__hint">展示同步后的钉钉成员、钉钉 ID 与本地绑定状态；支持按本地用户 ID 或邮箱手工绑定，并按页管理大规模组织。</p>
             </div>
             <div class="directory-admin__actions">
               <input
@@ -156,10 +156,16 @@
                 class="directory-admin__input directory-admin__input--search"
                 type="text"
                 placeholder="搜索姓名 / 邮箱 / 手机 / 钉钉 ID / 本地用户"
-                @keyup.enter="void loadAccounts(selectedIntegration.id)"
+                @keyup.enter="void searchAccounts()"
               />
-              <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="loadingAccounts" @click="void loadAccounts(selectedIntegration.id)">
-                {{ loadingAccounts ? '刷新中...' : '刷新成员' }}
+              <label class="directory-admin__field directory-admin__field--inline">
+                <span>每页</span>
+                <select class="directory-admin__input directory-admin__input--compact" :value="String(accountPageSize)" @change="void updateAccountPageSize($event)">
+                  <option v-for="size in accountPageSizeOptions" :key="size" :value="String(size)">{{ size }}</option>
+                </select>
+              </label>
+              <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="loadingAccounts" @click="void searchAccounts()">
+                {{ loadingAccounts ? '刷新中...' : accountQuery.trim().length > 0 ? '应用筛选' : '刷新成员' }}
               </button>
             </div>
           </div>
@@ -263,6 +269,30 @@
               </button>
             </div>
           </article>
+
+          <footer v-if="accountTotal > 0" class="directory-admin__pagination">
+            <p class="directory-admin__hint">
+              第 {{ accountPage }} / {{ accountPageCount }} 页 · 显示 {{ accountRangeStart }}-{{ accountRangeEnd }} / {{ accountTotal }}
+            </p>
+            <div class="directory-admin__actions">
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="loadingAccounts || accountPage <= 1"
+                @click="void changeAccountPage(accountPage - 1)"
+              >
+                上一页
+              </button>
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="loadingAccounts || accountPage >= accountPageCount"
+                @click="void changeAccountPage(accountPage + 1)"
+              >
+                下一页
+              </button>
+            </div>
+          </footer>
         </section>
 
         <section v-if="testResult" class="directory-admin__section">
@@ -408,6 +438,10 @@ type DirectoryDraft = {
 const integrations = ref<DirectoryIntegration[]>([])
 const runs = ref<DirectoryRun[]>([])
 const accounts = ref<DirectoryAccount[]>([])
+const accountPageSizeOptions = [25, 50, 100]
+const accountPage = ref(1)
+const accountPageSize = ref(25)
+const accountTotal = ref(0)
 const selectedIntegrationId = ref('')
 const loading = ref(false)
 const loadingRuns = ref(false)
@@ -442,6 +476,17 @@ const draft = reactive<DirectoryDraft>({
 const selectedIntegration = computed(() =>
   integrations.value.find((integration) => integration.id === selectedIntegrationId.value) ?? null,
 )
+const accountPageCount = computed(() => Math.max(1, Math.ceil(accountTotal.value / accountPageSize.value)))
+const accountRangeStart = computed(() => (
+  accountTotal.value === 0
+    ? 0
+    : ((accountPage.value - 1) * accountPageSize.value) + 1
+))
+const accountRangeEnd = computed(() => (
+  accountTotal.value === 0
+    ? 0
+    : Math.min(accountPage.value * accountPageSize.value, accountTotal.value)
+))
 
 const canSave = computed(() =>
   draft.name.trim().length > 0 &&
@@ -460,10 +505,15 @@ function resetDraft() {
   testResult.value = null
   runs.value = []
   accounts.value = []
+  accountPage.value = 1
+  accountPageSize.value = accountPageSizeOptions[0]
+  accountTotal.value = 0
   accountQuery.value = ''
+  for (const key of Object.keys(bindingDrafts)) delete bindingDrafts[key]
   for (const key of Object.keys(userSearchResults)) delete userSearchResults[key]
   for (const key of Object.keys(userSearchLoading)) delete userSearchLoading[key]
   for (const key of Object.keys(userSearchError)) delete userSearchError[key]
+  for (const key of Object.keys(grantToggles)) delete grantToggles[key]
   draft.name = ''
   draft.corpId = ''
   draft.appKey = ''
@@ -494,6 +544,8 @@ function applyIntegrationToDraft(integration: DirectoryIntegration) {
 function selectIntegration(integrationId: string) {
   selectedIntegrationId.value = integrationId
   testResult.value = null
+  accountPage.value = 1
+  accountTotal.value = 0
   const integration = integrations.value.find((item) => item.id === integrationId)
   if (!integration) return
   applyIntegrationToDraft(integration)
@@ -709,12 +761,36 @@ async function syncIntegration() {
   }
 }
 
+async function searchAccounts() {
+  if (!selectedIntegration.value) return
+  accountPage.value = 1
+  await loadAccounts(selectedIntegration.value.id)
+}
+
+async function changeAccountPage(nextPage: number) {
+  if (!selectedIntegration.value) return
+  const normalizedPage = Math.max(1, Math.min(nextPage, accountPageCount.value))
+  if (normalizedPage === accountPage.value) return
+  accountPage.value = normalizedPage
+  await loadAccounts(selectedIntegration.value.id)
+}
+
+async function updateAccountPageSize(event: Event) {
+  if (!selectedIntegration.value) return
+  const target = event.target
+  const nextPageSize = Number(target instanceof HTMLSelectElement ? target.value : accountPageSize.value)
+  if (!Number.isFinite(nextPageSize) || nextPageSize <= 0 || nextPageSize === accountPageSize.value) return
+  accountPageSize.value = nextPageSize
+  accountPage.value = 1
+  await loadAccounts(selectedIntegration.value.id)
+}
+
 async function loadAccounts(integrationId: string) {
   loadingAccounts.value = true
   try {
     const params = new URLSearchParams({
-      page: '1',
-      pageSize: '100',
+      page: String(accountPage.value),
+      pageSize: String(accountPageSize.value),
     })
     if (accountQuery.value.trim().length > 0) {
       params.set('q', accountQuery.value.trim())
@@ -722,9 +798,22 @@ async function loadAccounts(integrationId: string) {
     const response = await apiFetch(`/api/admin/directory/integrations/${integrationId}/accounts?${params.toString()}`)
     const body = await readJson(response)
     if (!response.ok) throw new Error(readApiError(body, '加载目录成员失败'))
-    accounts.value = Array.isArray(body?.data?.items) ? body.data.items : []
+    const items = Array.isArray(body?.data?.items) ? body.data.items : []
+    const total = typeof body?.data?.total === 'number'
+      ? body.data.total
+      : Number(body?.data?.total ?? items.length)
+    const normalizedTotal = Number.isFinite(total) && total >= 0 ? total : items.length
+    const maxPage = Math.max(1, Math.ceil(normalizedTotal / accountPageSize.value))
+    if (normalizedTotal > 0 && accountPage.value > maxPage) {
+      accountPage.value = maxPage
+      await loadAccounts(integrationId)
+      return
+    }
+    accountTotal.value = normalizedTotal
+    accounts.value = items
   } catch (error) {
     accounts.value = []
+    accountTotal.value = 0
     setStatus(error instanceof Error ? error.message : '加载目录成员失败', 'error')
   } finally {
     loadingAccounts.value = false
@@ -786,16 +875,17 @@ async function unbindAccount(account: DirectoryAccount) {
     const body = await readJson(response)
     if (!response.ok) throw new Error(readApiError(body, '解除绑定失败'))
 
-    accounts.value = accounts.value.map((item) => (
-      item.id === account.id
-        ? {
-          ...item,
-          linkStatus: 'pending',
-          matchStrategy: 'manual_admin',
-          localUser: null,
-        }
-        : item
-    ))
+    const unboundAccount = body?.data?.account as DirectoryAccount | undefined
+    accounts.value = accounts.value.map((item) => {
+      if (item.id !== account.id) return item
+      if (unboundAccount) return unboundAccount
+      return {
+        ...item,
+        linkStatus: 'unmatched',
+        matchStrategy: 'manual_unbound',
+        localUser: null,
+      }
+    })
     delete bindingDrafts[account.id]
     clearBindingSearch(account.id)
     setStatus(`目录成员 ${account.name} 已解除绑定`)
@@ -915,6 +1005,11 @@ onMounted(() => {
   gap: 8px;
 }
 
+.directory-admin__field--inline {
+  flex-direction: row;
+  align-items: center;
+}
+
 .directory-admin__toggle {
   justify-content: flex-end;
 }
@@ -928,6 +1023,10 @@ onMounted(() => {
 
 .directory-admin__input--search {
   min-width: min(320px, 100%);
+}
+
+.directory-admin__input--compact {
+  min-width: 88px;
 }
 
 .directory-admin__button,
@@ -1052,6 +1151,14 @@ onMounted(() => {
 .directory-admin__search-result span,
 .directory-admin__search-result small {
   color: #475569;
+}
+
+.directory-admin__pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .directory-admin__toggle--compact {

--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -144,6 +144,127 @@
           </p>
         </section>
 
+        <section v-if="selectedIntegration" class="directory-admin__section">
+          <div class="directory-admin__section-head">
+            <div>
+              <h3>成员账号</h3>
+              <p class="directory-admin__hint">展示同步后的钉钉成员、钉钉 ID 与本地绑定状态；支持按本地用户 ID 或邮箱手工绑定。</p>
+            </div>
+            <div class="directory-admin__actions">
+              <input
+                v-model.trim="accountQuery"
+                class="directory-admin__input directory-admin__input--search"
+                type="text"
+                placeholder="搜索姓名 / 邮箱 / 手机 / 钉钉 ID / 本地用户"
+                @keyup.enter="void loadAccounts(selectedIntegration.id)"
+              />
+              <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="loadingAccounts" @click="void loadAccounts(selectedIntegration.id)">
+                {{ loadingAccounts ? '刷新中...' : '刷新成员' }}
+              </button>
+            </div>
+          </div>
+
+          <div v-if="loadingAccounts" class="directory-admin__empty">成员加载中...</div>
+          <div v-else-if="accounts.length === 0" class="directory-admin__empty">暂无同步成员</div>
+          <article v-for="account in accounts" :key="account.id" class="directory-admin__account">
+            <div class="directory-admin__account-head">
+              <div>
+                <strong>{{ account.name }}</strong>
+                <p class="directory-admin__hint">
+                  {{ account.localUser ? `本地用户：${account.localUser.email || account.localUser.id}` : '未绑定本地用户' }}
+                </p>
+              </div>
+              <div class="directory-admin__chips">
+                <span class="directory-admin__chip">{{ account.linkStatus }}</span>
+                <span v-if="account.matchStrategy" class="directory-admin__chip">策略 {{ account.matchStrategy }}</span>
+                <span class="directory-admin__chip" :class="{ 'directory-admin__badge--inactive': !account.isActive }">
+                  {{ account.isActive ? '目录启用' : '目录停用' }}
+                </span>
+              </div>
+            </div>
+
+            <div class="directory-admin__account-grid">
+              <p class="directory-admin__hint"><strong>用户 ID：</strong>{{ account.externalUserId }}</p>
+              <p class="directory-admin__hint"><strong>Union ID：</strong>{{ account.unionId || '未返回' }}</p>
+              <p class="directory-admin__hint"><strong>Open ID：</strong>{{ account.openId || '未返回' }}</p>
+              <p class="directory-admin__hint"><strong>邮箱：</strong>{{ account.email || '无' }}</p>
+              <p class="directory-admin__hint"><strong>手机：</strong>{{ account.mobile || '无' }}</p>
+              <p class="directory-admin__hint"><strong>Corp：</strong>{{ account.corpId || '未记录' }}</p>
+            </div>
+
+            <p class="directory-admin__hint">
+              部门：{{ account.departmentPaths.join('，') || '未分配部门' }}
+            </p>
+
+            <div class="directory-admin__form-grid directory-admin__form-grid--account">
+              <label class="directory-admin__field">
+                <span>绑定到本地用户 ID / 邮箱</span>
+                <input
+                  :value="readBindingDraft(account)"
+                  class="directory-admin__input"
+                  type="text"
+                  placeholder="例如 user-123 或 alpha@example.com"
+                  @input="onBindingDraftInput(account.id, $event)"
+                  @focus="clearBindingSearch(account.id)"
+                />
+              </label>
+              <label class="directory-admin__toggle directory-admin__toggle--compact">
+                <input
+                  :checked="readGrantToggle(account.id)"
+                  type="checkbox"
+                  @change="onGrantToggleChange(account.id, $event)"
+                />
+                <span>绑定后同时开通钉钉登录</span>
+              </label>
+            </div>
+
+            <div class="directory-admin__actions">
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="readBindingDraft(account).trim().length === 0 || readBindingSearchLoading(account.id)"
+                @click="void searchLocalUsers(account.id)"
+              >
+                {{ readBindingSearchLoading(account.id) ? '搜索中...' : '搜索本地用户' }}
+              </button>
+              <button
+                class="directory-admin__button"
+                type="button"
+                :disabled="bindingAccountId === account.id || readBindingDraft(account).trim().length === 0"
+                @click="void bindAccount(account)"
+              >
+                {{ bindingAccountId === account.id ? '绑定中...' : account.localUser ? '更新绑定' : '绑定用户' }}
+              </button>
+              <button
+                v-if="account.localUser"
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="unbindingAccountId === account.id"
+                @click="void unbindAccount(account)"
+              >
+                {{ unbindingAccountId === account.id ? '解绑中...' : '解除绑定' }}
+              </button>
+            </div>
+
+            <p v-if="readBindingSearchError(account.id)" class="directory-admin__status directory-admin__status--error">
+              {{ readBindingSearchError(account.id) }}
+            </p>
+            <div v-if="readBindingSearchResults(account.id).length > 0" class="directory-admin__search-results">
+              <button
+                v-for="user in readBindingSearchResults(account.id)"
+                :key="user.id"
+                class="directory-admin__search-result"
+                type="button"
+                @click="chooseLocalUser(account.id, user)"
+              >
+                <strong>{{ user.name || user.email }}</strong>
+                <span>{{ user.email }}</span>
+                <small>{{ user.id }} · {{ user.role }} · {{ user.is_active ? 'active' : 'inactive' }}</small>
+              </button>
+            </div>
+          </article>
+        </section>
+
         <section v-if="testResult" class="directory-admin__section">
           <h3>连通性测试</h3>
           <div class="directory-admin__chips">
@@ -227,6 +348,41 @@ type DirectoryRun = {
   errorMessage: string | null
 }
 
+type DirectoryAccount = {
+  id: string
+  integrationId: string
+  provider: string
+  corpId: string | null
+  externalUserId: string
+  unionId: string | null
+  openId: string | null
+  externalKey: string
+  name: string
+  email: string | null
+  mobile: string | null
+  isActive: boolean
+  updatedAt: string
+  linkStatus: string
+  matchStrategy: string | null
+  reviewedBy: string | null
+  reviewNote: string | null
+  linkUpdatedAt: string | null
+  localUser: {
+    id: string
+    email: string | null
+    name: string | null
+  } | null
+  departmentPaths: string[]
+}
+
+type LocalUserOption = {
+  id: string
+  email: string
+  name: string | null
+  role: string
+  is_active: boolean
+}
+
 type TestResult = {
   rootDepartmentId: string
   departmentSampleCount: number
@@ -251,13 +407,23 @@ type DirectoryDraft = {
 
 const integrations = ref<DirectoryIntegration[]>([])
 const runs = ref<DirectoryRun[]>([])
+const accounts = ref<DirectoryAccount[]>([])
 const selectedIntegrationId = ref('')
 const loading = ref(false)
 const loadingRuns = ref(false)
+const loadingAccounts = ref(false)
 const busy = ref(false)
+const bindingAccountId = ref('')
+const unbindingAccountId = ref('')
 const status = ref('')
 const statusTone = ref<'info' | 'error'>('info')
 const testResult = ref<TestResult | null>(null)
+const accountQuery = ref('')
+const bindingDrafts = reactive<Record<string, string>>({})
+const userSearchResults = reactive<Record<string, LocalUserOption[]>>({})
+const userSearchLoading = reactive<Record<string, boolean>>({})
+const userSearchError = reactive<Record<string, string>>({})
+const grantToggles = reactive<Record<string, boolean>>({})
 
 const draft = reactive<DirectoryDraft>({
   name: '',
@@ -293,6 +459,11 @@ function resetDraft() {
   selectedIntegrationId.value = ''
   testResult.value = null
   runs.value = []
+  accounts.value = []
+  accountQuery.value = ''
+  for (const key of Object.keys(userSearchResults)) delete userSearchResults[key]
+  for (const key of Object.keys(userSearchLoading)) delete userSearchLoading[key]
+  for (const key of Object.keys(userSearchError)) delete userSearchError[key]
   draft.name = ''
   draft.corpId = ''
   draft.appKey = ''
@@ -326,7 +497,10 @@ function selectIntegration(integrationId: string) {
   const integration = integrations.value.find((item) => item.id === integrationId)
   if (!integration) return
   applyIntegrationToDraft(integration)
-  void loadRuns(integrationId)
+  void Promise.all([
+    loadRuns(integrationId),
+    loadAccounts(integrationId),
+  ])
 }
 
 function readApiError(payload: unknown, fallback: string): string {
@@ -361,6 +535,95 @@ async function loadIntegrations() {
   } finally {
     loading.value = false
   }
+}
+
+function readBindingDraft(account: DirectoryAccount): string {
+  return bindingDrafts[account.id] ?? account.localUser?.email ?? account.localUser?.id ?? ''
+}
+
+function readBindingDraftByAccountId(accountId: string): string {
+  const account = accounts.value.find((item) => item.id === accountId)
+  if (!account) return bindingDrafts[accountId] ?? ''
+  return readBindingDraft(account)
+}
+
+function updateBindingDraft(accountId: string, value: string) {
+  bindingDrafts[accountId] = value
+}
+
+function onBindingDraftInput(accountId: string, event: Event) {
+  const target = event.target
+  updateBindingDraft(accountId, target instanceof HTMLInputElement ? target.value : '')
+  clearBindingSearch(accountId)
+}
+
+function readBindingSearchResults(accountId: string): LocalUserOption[] {
+  return userSearchResults[accountId] ?? []
+}
+
+function readBindingSearchLoading(accountId: string): boolean {
+  return userSearchLoading[accountId] ?? false
+}
+
+function readBindingSearchError(accountId: string): string {
+  return userSearchError[accountId] ?? ''
+}
+
+function setBindingSearchState(accountId: string, state: {
+  loading?: boolean
+  error?: string
+  results?: LocalUserOption[]
+}) {
+  if (typeof state.loading === 'boolean') userSearchLoading[accountId] = state.loading
+  if (typeof state.error === 'string') userSearchError[accountId] = state.error
+  else delete userSearchError[accountId]
+  if (Array.isArray(state.results)) userSearchResults[accountId] = state.results
+}
+
+async function searchLocalUsers(accountId: string) {
+  const term = readBindingDraftByAccountId(accountId).trim()
+  if (!term) {
+    setBindingSearchState(accountId, { results: [], error: '', loading: false })
+    return
+  }
+
+  setBindingSearchState(accountId, { loading: true, error: '' })
+  try {
+    const params = new URLSearchParams({ page: '1', pageSize: '8', q: term })
+    const response = await apiFetch(`/api/admin/users?${params.toString()}`)
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '搜索本地用户失败'))
+    const items = Array.isArray(body?.data?.items) ? body.data.items : []
+    setBindingSearchState(accountId, { results: items, loading: false })
+  } catch (error) {
+    setBindingSearchState(accountId, {
+      results: [],
+      loading: false,
+      error: error instanceof Error ? error.message : '搜索本地用户失败',
+    })
+  }
+}
+
+function chooseLocalUser(accountId: string, user: LocalUserOption) {
+  updateBindingDraft(accountId, user.email || user.id)
+  setBindingSearchState(accountId, { results: [] })
+}
+
+function readGrantToggle(accountId: string): boolean {
+  return grantToggles[accountId] ?? true
+}
+
+function updateGrantToggle(accountId: string, value: boolean) {
+  grantToggles[accountId] = value
+}
+
+function onGrantToggleChange(accountId: string, event: Event) {
+  const target = event.target
+  updateGrantToggle(accountId, target instanceof HTMLInputElement ? target.checked : true)
+}
+
+function clearBindingSearch(accountId: string) {
+  setBindingSearchState(accountId, { results: [], error: '' })
 }
 
 function buildPayload() {
@@ -437,11 +700,34 @@ async function syncIntegration() {
     await Promise.all([
       loadIntegrations(),
       loadRuns(selectedIntegration.value.id),
+      loadAccounts(selectedIntegration.value.id),
     ])
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '目录同步失败', 'error')
   } finally {
     busy.value = false
+  }
+}
+
+async function loadAccounts(integrationId: string) {
+  loadingAccounts.value = true
+  try {
+    const params = new URLSearchParams({
+      page: '1',
+      pageSize: '100',
+    })
+    if (accountQuery.value.trim().length > 0) {
+      params.set('q', accountQuery.value.trim())
+    }
+    const response = await apiFetch(`/api/admin/directory/integrations/${integrationId}/accounts?${params.toString()}`)
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '加载目录成员失败'))
+    accounts.value = Array.isArray(body?.data?.items) ? body.data.items : []
+  } catch (error) {
+    accounts.value = []
+    setStatus(error instanceof Error ? error.message : '加载目录成员失败', 'error')
+  } finally {
+    loadingAccounts.value = false
   }
 }
 
@@ -457,6 +743,70 @@ async function loadRuns(integrationId: string) {
     setStatus(error instanceof Error ? error.message : '加载同步记录失败', 'error')
   } finally {
     loadingRuns.value = false
+  }
+}
+
+async function bindAccount(account: DirectoryAccount) {
+  bindingAccountId.value = account.id
+  try {
+    const response = await apiFetch(`/api/admin/directory/accounts/${account.id}/bind`, {
+      method: 'POST',
+      body: JSON.stringify({
+        localUserRef: readBindingDraft(account).trim(),
+        enableDingTalkGrant: readGrantToggle(account.id),
+      }),
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '绑定目录成员失败'))
+
+    const boundAccount = body?.data?.account as DirectoryAccount | undefined
+    if (boundAccount) {
+      accounts.value = accounts.value.map((item) => (item.id === boundAccount.id ? boundAccount : item))
+      bindingDrafts[account.id] = boundAccount.localUser?.email || boundAccount.localUser?.id || readBindingDraft(account)
+    }
+
+    setStatus(`目录成员 ${account.name} 已绑定到本地用户`)
+    if (selectedIntegration.value) {
+      await loadIntegrations()
+      await loadAccounts(selectedIntegration.value.id)
+    }
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '绑定目录成员失败', 'error')
+  } finally {
+    bindingAccountId.value = ''
+  }
+}
+
+async function unbindAccount(account: DirectoryAccount) {
+  unbindingAccountId.value = account.id
+  try {
+    const response = await apiFetch(`/api/admin/directory/accounts/${account.id}/unbind`, {
+      method: 'POST',
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '解除绑定失败'))
+
+    accounts.value = accounts.value.map((item) => (
+      item.id === account.id
+        ? {
+          ...item,
+          linkStatus: 'pending',
+          matchStrategy: 'manual_admin',
+          localUser: null,
+        }
+        : item
+    ))
+    delete bindingDrafts[account.id]
+    clearBindingSearch(account.id)
+    setStatus(`目录成员 ${account.name} 已解除绑定`)
+    if (selectedIntegration.value) {
+      await loadIntegrations()
+      await loadAccounts(selectedIntegration.value.id)
+    }
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '解除绑定失败', 'error')
+  } finally {
+    unbindingAccountId.value = ''
   }
 }
 
@@ -554,6 +904,10 @@ onMounted(() => {
   gap: 14px;
 }
 
+.directory-admin__form-grid--account {
+  grid-template-columns: minmax(0, 1.8fr) minmax(220px, 1fr);
+}
+
 .directory-admin__field,
 .directory-admin__toggle {
   display: flex;
@@ -570,6 +924,10 @@ onMounted(() => {
   border-radius: 12px;
   padding: 10px 12px;
   font: inherit;
+}
+
+.directory-admin__input--search {
+  min-width: min(320px, 100%);
 }
 
 .directory-admin__button,
@@ -650,9 +1008,63 @@ onMounted(() => {
   background: #f8fafc;
 }
 
+.directory-admin__account {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 16px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.directory-admin__account-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.directory-admin__account-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 16px;
+}
+
+.directory-admin__search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.directory-admin__search-result {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  background: #fff;
+  text-align: left;
+  cursor: pointer;
+}
+
+.directory-admin__search-result span,
+.directory-admin__search-result small {
+  color: #475569;
+}
+
+.directory-admin__toggle--compact {
+  justify-content: center;
+}
+
 @media (max-width: 960px) {
   .directory-admin__layout,
   .directory-admin__form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .directory-admin__account-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -79,6 +79,19 @@ function createAccount(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function createAccountListPayload(items: Record<string, unknown>[], overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    data: {
+      items,
+      total: items.length,
+      page: 1,
+      pageSize: 25,
+      ...overrides,
+    },
+  }
+}
+
 describe('DirectoryManagementView', () => {
   let app: App<Element> | null = null
   let container: HTMLDivElement | null = null
@@ -124,12 +137,9 @@ describe('DirectoryManagementView', () => {
           ],
         },
       }))
-      .mockResolvedValueOnce(createJsonResponse({
-        ok: true,
-        data: {
-          items: [createAccount()],
-        },
-      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()], { total: 60 }),
+      ))
 
     app = createApp(DirectoryManagementView)
     app.component('RouterLink', {
@@ -141,12 +151,13 @@ describe('DirectoryManagementView', () => {
 
     expect(apiFetchMock).toHaveBeenNthCalledWith(1, '/api/admin/directory/integrations')
     expect(apiFetchMock).toHaveBeenNthCalledWith(2, '/api/admin/directory/integrations/dir-1/runs?page=1&pageSize=10')
-    expect(apiFetchMock).toHaveBeenNthCalledWith(3, '/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=100')
+    expect(apiFetchMock).toHaveBeenNthCalledWith(3, '/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=25')
     expect(container?.textContent).toContain('DingTalk CN')
     expect(container?.textContent).toContain('账号 98')
     expect(container?.textContent).toContain('completed')
     expect(container?.textContent).toContain('Union ID')
     expect(container?.textContent).toContain('0447654442691174')
+    expect(container?.textContent).toContain('第 1 / 3 页')
   })
 
   it('posts manual sync and refreshes the selected integration', async () => {
@@ -161,12 +172,9 @@ describe('DirectoryManagementView', () => {
         ok: true,
         data: { items: [] },
       }))
-      .mockResolvedValueOnce(createJsonResponse({
-        ok: true,
-        data: {
-          items: [createAccount()],
-        },
-      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()], { total: 98 }),
+      ))
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
         data: {
@@ -210,17 +218,14 @@ describe('DirectoryManagementView', () => {
           ],
         },
       }))
-      .mockResolvedValueOnce(createJsonResponse({
-        ok: true,
-        data: {
-          items: [
-            createAccount({
-              matchStrategy: 'external_identity',
-              linkStatus: 'linked',
-            }),
-          ],
-        },
-      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            matchStrategy: 'external_identity',
+            linkStatus: 'linked',
+          }),
+        ], { total: 99 }),
+      ))
 
     app = createApp(DirectoryManagementView)
     app.component('RouterLink', {
@@ -241,9 +246,53 @@ describe('DirectoryManagementView', () => {
       '/api/admin/directory/integrations/dir-1/sync',
       expect.objectContaining({ method: 'POST' }),
     )
-    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=100')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=25')
     expect(container?.textContent).toContain('目录同步已完成')
     expect(container?.textContent).toContain('账号 99')
+  })
+
+  it('paginates directory accounts', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()], { total: 60 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-2',
+            externalUserId: '0447654442691175',
+            unionId: 'union-2',
+            name: '次页成员',
+          }),
+        ], { total: 60, page: 2 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const nextPageButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('下一页'))
+    expect(nextPageButton).toBeTruthy()
+    nextPageButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(6)
+
+    expect(apiFetchMock).toHaveBeenLastCalledWith('/api/admin/directory/integrations/dir-1/accounts?page=2&pageSize=25')
+    expect(container?.textContent).toContain('第 2 / 3 页')
+    expect(container?.textContent).toContain('次页成员')
   })
 
   it('binds a directory account to a local user reference', async () => {
@@ -258,12 +307,9 @@ describe('DirectoryManagementView', () => {
         ok: true,
         data: { items: [] },
       }))
-      .mockResolvedValueOnce(createJsonResponse({
-        ok: true,
-        data: {
-          items: [createAccount()],
-        },
-      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()]),
+      ))
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
         data: {
@@ -306,22 +352,19 @@ describe('DirectoryManagementView', () => {
           })],
         },
       }))
-      .mockResolvedValueOnce(createJsonResponse({
-        ok: true,
-        data: {
-          items: [
-            createAccount({
-              linkStatus: 'linked',
-              matchStrategy: 'manual_admin',
-              localUser: {
-                id: 'user-1',
-                email: 'alpha@example.com',
-                name: 'Alpha',
-              },
-            }),
-          ],
-        },
-      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ]),
+      ))
 
     app = createApp(DirectoryManagementView)
     app.component('RouterLink', {
@@ -382,23 +425,26 @@ describe('DirectoryManagementView', () => {
         ok: true,
         data: { items: [] },
       }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          linkStatus: 'linked',
+          matchStrategy: 'manual_admin',
+          localUser: {
+            id: 'user-1',
+            email: 'alpha@example.com',
+            name: 'Alpha',
+          },
+        })]),
+      ))
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
         data: {
-          items: [createAccount({
-            linkStatus: 'linked',
-            matchStrategy: 'manual_admin',
-            localUser: {
-              id: 'user-1',
-              email: 'alpha@example.com',
-              name: 'Alpha',
-            },
-          })],
+          account: createAccount({
+            linkStatus: 'unmatched',
+            matchStrategy: 'manual_unbound',
+            localUser: null,
+          }),
         },
-      }))
-      .mockResolvedValueOnce(createJsonResponse({
-        ok: true,
-        data: { ok: true },
       }))
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
@@ -406,16 +452,13 @@ describe('DirectoryManagementView', () => {
           items: [createIntegration()],
         },
       }))
-      .mockResolvedValueOnce(createJsonResponse({
-        ok: true,
-        data: {
-          items: [createAccount({
-            linkStatus: 'pending',
-            matchStrategy: 'manual_admin',
-            localUser: null,
-          })],
-        },
-      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          linkStatus: 'unmatched',
+          matchStrategy: 'manual_unbound',
+          localUser: null,
+        })]),
+      ))
 
     app = createApp(DirectoryManagementView)
     app.component('RouterLink', {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -23,6 +23,62 @@ function createJsonResponse(payload: unknown, status = 200) {
   }
 }
 
+function createIntegration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'dir-1',
+    name: 'DingTalk CN',
+    corpId: 'dingcorp',
+    status: 'active',
+    syncEnabled: true,
+    scheduleCron: null,
+    defaultDeprovisionPolicy: 'mark_inactive',
+    lastSyncAt: '2026-04-08T01:00:00.000Z',
+    lastSuccessAt: '2026-04-08T01:00:00.000Z',
+    lastError: null,
+    config: {
+      appKey: 'ding-app-key',
+      appSecretConfigured: true,
+      rootDepartmentId: '1',
+      baseUrl: null,
+      pageSize: 50,
+    },
+    stats: {
+      departmentCount: 12,
+      accountCount: 98,
+      pendingLinkCount: 4,
+      linkedCount: 88,
+      lastRunStatus: 'completed',
+    },
+    ...overrides,
+  }
+}
+
+function createAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'account-1',
+    integrationId: 'dir-1',
+    provider: 'dingtalk',
+    corpId: 'dingcorp',
+    externalUserId: '0447654442691174',
+    unionId: 'union-1',
+    openId: null,
+    externalKey: 'union-1',
+    name: '周华',
+    email: null,
+    mobile: '13758875801',
+    isActive: true,
+    updatedAt: '2026-04-08T01:00:00.000Z',
+    linkStatus: 'unmatched',
+    matchStrategy: 'none',
+    reviewedBy: null,
+    reviewNote: null,
+    linkUpdatedAt: '2026-04-08T01:00:00.000Z',
+    localUser: null,
+    departmentPaths: ['DingTalk CN'],
+    ...overrides,
+  }
+}
+
 describe('DirectoryManagementView', () => {
   let app: App<Element> | null = null
   let container: HTMLDivElement | null = null
@@ -45,34 +101,7 @@ describe('DirectoryManagementView', () => {
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
         data: {
-          items: [
-            {
-              id: 'dir-1',
-              name: 'DingTalk CN',
-              corpId: 'dingcorp',
-              status: 'active',
-              syncEnabled: true,
-              scheduleCron: null,
-              defaultDeprovisionPolicy: 'mark_inactive',
-              lastSyncAt: '2026-04-08T01:00:00.000Z',
-              lastSuccessAt: '2026-04-08T01:00:00.000Z',
-              lastError: null,
-              config: {
-                appKey: 'ding-app-key',
-                appSecretConfigured: true,
-                rootDepartmentId: '1',
-                baseUrl: null,
-                pageSize: 50,
-              },
-              stats: {
-                departmentCount: 12,
-                accountCount: 98,
-                pendingLinkCount: 4,
-                linkedCount: 88,
-                lastRunStatus: 'completed',
-              },
-            },
-          ],
+          items: [createIntegration()],
         },
       }))
       .mockResolvedValueOnce(createJsonResponse({
@@ -95,6 +124,12 @@ describe('DirectoryManagementView', () => {
           ],
         },
       }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createAccount()],
+        },
+      }))
 
     app = createApp(DirectoryManagementView)
     app.component('RouterLink', {
@@ -106,9 +141,12 @@ describe('DirectoryManagementView', () => {
 
     expect(apiFetchMock).toHaveBeenNthCalledWith(1, '/api/admin/directory/integrations')
     expect(apiFetchMock).toHaveBeenNthCalledWith(2, '/api/admin/directory/integrations/dir-1/runs?page=1&pageSize=10')
+    expect(apiFetchMock).toHaveBeenNthCalledWith(3, '/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=100')
     expect(container?.textContent).toContain('DingTalk CN')
     expect(container?.textContent).toContain('账号 98')
     expect(container?.textContent).toContain('completed')
+    expect(container?.textContent).toContain('Union ID')
+    expect(container?.textContent).toContain('0447654442691174')
   })
 
   it('posts manual sync and refreshes the selected integration', async () => {
@@ -116,39 +154,18 @@ describe('DirectoryManagementView', () => {
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
         data: {
-          items: [
-            {
-              id: 'dir-1',
-              name: 'DingTalk CN',
-              corpId: 'dingcorp',
-              status: 'active',
-              syncEnabled: true,
-              scheduleCron: null,
-              defaultDeprovisionPolicy: 'mark_inactive',
-              lastSyncAt: '2026-04-08T01:00:00.000Z',
-              lastSuccessAt: '2026-04-08T01:00:00.000Z',
-              lastError: null,
-              config: {
-                appKey: 'ding-app-key',
-                appSecretConfigured: true,
-                rootDepartmentId: '1',
-                baseUrl: null,
-                pageSize: 50,
-              },
-              stats: {
-                departmentCount: 12,
-                accountCount: 98,
-                pendingLinkCount: 4,
-                linkedCount: 88,
-                lastRunStatus: 'completed',
-              },
-            },
-          ],
+          items: [createIntegration()],
         },
       }))
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
         data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createAccount()],
+        },
       }))
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
@@ -160,34 +177,17 @@ describe('DirectoryManagementView', () => {
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
         data: {
-          items: [
-            {
-              id: 'dir-1',
-              name: 'DingTalk CN',
-              corpId: 'dingcorp',
-              status: 'active',
-              syncEnabled: true,
-              scheduleCron: null,
-              defaultDeprovisionPolicy: 'mark_inactive',
-              lastSyncAt: '2026-04-08T02:00:00.000Z',
-              lastSuccessAt: '2026-04-08T02:00:00.000Z',
-              lastError: null,
-              config: {
-                appKey: 'ding-app-key',
-                appSecretConfigured: true,
-                rootDepartmentId: '1',
-                baseUrl: null,
-                pageSize: 50,
-              },
-              stats: {
-                departmentCount: 13,
-                accountCount: 99,
-                pendingLinkCount: 3,
-                linkedCount: 89,
-                lastRunStatus: 'completed',
-              },
+          items: [createIntegration({
+            lastSyncAt: '2026-04-08T02:00:00.000Z',
+            lastSuccessAt: '2026-04-08T02:00:00.000Z',
+            stats: {
+              departmentCount: 13,
+              accountCount: 99,
+              pendingLinkCount: 3,
+              linkedCount: 89,
+              lastRunStatus: 'completed',
             },
-          ],
+          })],
         },
       }))
       .mockResolvedValueOnce(createJsonResponse({
@@ -207,6 +207,17 @@ describe('DirectoryManagementView', () => {
               },
               errorMessage: null,
             },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            createAccount({
+              matchStrategy: 'external_identity',
+              linkStatus: 'linked',
+            }),
           ],
         },
       }))
@@ -230,7 +241,199 @@ describe('DirectoryManagementView', () => {
       '/api/admin/directory/integrations/dir-1/sync',
       expect.objectContaining({ method: 'POST' }),
     )
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=100')
     expect(container?.textContent).toContain('目录同步已完成')
     expect(container?.textContent).toContain('账号 99')
+  })
+
+  it('binds a directory account to a local user reference', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createAccount()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+              role: 'user',
+              is_active: true,
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({
+            stats: {
+              departmentCount: 12,
+              accountCount: 98,
+              pendingLinkCount: 3,
+              linkedCount: 89,
+              lastRunStatus: 'completed',
+            },
+          })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            createAccount({
+              linkStatus: 'linked',
+              matchStrategy: 'manual_admin',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+              },
+            }),
+          ],
+        },
+      }))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const bindInput = container!.querySelector('input[placeholder="例如 user-123 或 alpha@example.com"]') as HTMLInputElement | null
+    expect(bindInput).toBeTruthy()
+    bindInput!.value = 'alpha@example.com'
+    bindInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    const searchButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('搜索本地用户'))
+    expect(searchButton).toBeTruthy()
+    searchButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(4)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/users?page=1&pageSize=8&q=alpha%40example.com',
+    )
+
+    const searchResult = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('alpha@example.com'))
+    expect(searchResult).toBeTruthy()
+    searchResult?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    const bindButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('绑定用户'))
+    expect(bindButton).toBeTruthy()
+    bindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/account-1/bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          localUserRef: 'alpha@example.com',
+          enableDingTalkGrant: true,
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('已绑定到本地用户')
+    expect(container?.textContent).toContain('alpha@example.com')
+  })
+
+  it('unbinds a linked directory account', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createAccount({
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { ok: true },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createAccount({
+            linkStatus: 'pending',
+            matchStrategy: 'manual_admin',
+            localUser: null,
+          })],
+        },
+      }))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const unbindButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('解除绑定'))
+    expect(unbindButton).toBeTruthy()
+    unbindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/account-1/unbind',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(container?.textContent).toContain('已解除绑定')
   })
 })

--- a/docs/development/dingtalk-directory-binding-design-20260411.md
+++ b/docs/development/dingtalk-directory-binding-design-20260411.md
@@ -1,0 +1,159 @@
+# DingTalk Directory Binding Design
+
+Date: 2026-04-11
+
+## Goal
+
+补齐钉钉目录同步后的两个关键缺口：
+
+1. 平台管理员能在页面上直接看到同步下来的钉钉成员及其核心 ID。
+2. 没有企业邮箱的成员，也能被管理员预绑定到本地用户，并为后续扫码登录做好身份映射。
+3. 绑定动作要更易用，管理员不应反复手输本地用户 ID，也需要可见的解绑入口与审计。
+
+## Problems
+
+之前的实现里，`directory_accounts` 已经落了 `external_user_id`、`union_id`、`open_id`、`corp_id`，但有两个问题：
+
+1. 前端目录页不展示成员明细，管理员无法在页面上操作绑定。
+2. 目录同步自动匹配只按 `user_external_identities.external_key` 比对；而钉钉 OAuth 在企业场景下使用的主键是 `corpId:openId`，目录同步里常见的却是 `unionId || openId || userId`。这会导致“已经绑定过/已经登录过”的账号在再次同步时仍然落成 `unmatched`。
+
+## Design Decisions
+
+### 1. 新增目录成员列表接口
+
+新增接口：
+
+- `GET /api/admin/directory/integrations/:integrationId/accounts`
+
+返回内容包含：
+
+- `externalUserId`
+- `unionId`
+- `openId`
+- `externalKey`
+- `corpId`
+- 邮箱、手机号、部门路径
+- 当前 `linkStatus`
+- `matchStrategy`
+- 已绑定的本地用户
+
+### 2. 新增目录成员绑定接口
+
+新增接口：
+
+- `POST /api/admin/directory/accounts/:accountId/bind`
+
+请求体：
+
+```json
+{
+  "localUserRef": "alpha@example.com",
+  "enableDingTalkGrant": true
+}
+```
+
+`localUserRef` 支持本地用户 `id` 或邮箱，降低管理员操作成本。
+
+### 2.1 新增目录成员解绑接口
+
+新增接口：
+
+- `POST /api/admin/directory/accounts/:accountId/unbind`
+
+解绑时只做三件事：
+
+1. 清除该目录成员的 `directory_account_links`
+2. 删除与该目录成员对应的 `user_external_identities`
+3. 写入管理员审计日志
+
+不会自动修改该本地用户的其他角色或 grant 开关，避免把“目录解绑”误扩大成“权限回收”。
+
+### 3. 预绑定时同步写入两张表
+
+预绑定不能只写 `directory_account_links`，因为扫码登录只读取 `user_external_identities`。
+
+绑定时在一个事务里同时写入：
+
+1. `user_external_identities`
+2. `user_external_auth_grants`
+3. `directory_account_links`
+
+这样可以保证：
+
+- 目录侧看到的是 `linked`
+- 登录侧首次扫码也能命中身份
+- 严格白名单模式下也不会因为未开通 grant 被拒绝
+
+### 4. Identity key 采用 OAuth 规则
+
+管理员预绑定写入 `user_external_identities.external_key` 时，不直接复用 `directory_accounts.external_key`，而是按钉钉 OAuth 的规则生成：
+
+- 有 `corpId + openId` 时：`corpId:openId`
+- 否则：`unionId || openId`
+
+原因：
+
+- 这是扫码登录实际使用的主键规则。
+- 如果直接写目录表里的 `unionId`，后续登录/更新时会产生隐性不一致。
+
+### 5. 缺失 `openId/unionId` 时拒绝预绑定登录身份
+
+仅有 `external_user_id` 不足以支持扫码登录命中当前鉴权逻辑，因此：
+
+- 如果目录账号缺少 `openId` 和 `unionId`
+- 则允许继续显示该成员
+- 但拒绝将其预绑定为“可扫码登录身份”
+
+这样比“看起来绑定成功，但首登仍失败”更安全。
+
+### 6. 自动匹配补齐 corp-scoped open/union 逻辑
+
+同步时除了原有的 `external_key` 精确匹配外，新增：
+
+- `corp_id + provider_open_id`
+- `corp_id + provider_union_id`
+
+匹配命中后直接标记为 `linked`。
+
+这样已预绑定或已登录过的无邮箱成员，在后续目录同步中不会反复回退成 `unmatched`。
+
+### 7. 前端用户选择直接复用现有用户搜索接口
+
+没有新增一套独立的“绑定用户搜索 API”，而是直接复用已有：
+
+- `GET /api/admin/users?q=...&page=1&pageSize=8`
+
+理由：
+
+- 后端已有分页与模糊检索能力
+- 可以直接按姓名、邮箱、用户 ID 搜索
+- 复用已有管理员权限边界，减少一套重复接口
+
+## UI Changes
+
+页面：[DirectoryManagementView.vue](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/apps/web/src/views/DirectoryManagementView.vue)
+
+新增“成员账号”区块，支持：
+
+- 展示同步后的钉钉成员
+- 展示 `externalUserId / unionId / openId / corpId`
+- 展示本地绑定状态与匹配策略
+- 搜索本地用户候选并点选
+- 通过“本地用户 ID / 邮箱”手工绑定
+- 绑定时一并开通钉钉登录 grant
+- 解除绑定
+
+## Backend Files
+
+- [directory-sync.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/packages/core-backend/src/directory/directory-sync.ts)
+- [admin-directory.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/packages/core-backend/src/routes/admin-directory.ts)
+
+## Frontend Files
+
+- [DirectoryManagementView.vue](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/apps/web/src/views/DirectoryManagementView.vue)
+
+## Test Files
+
+- [admin-directory-routes.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/packages/core-backend/tests/unit/admin-directory-routes.test.ts)
+- [directory-sync-bind-account.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts)
+- [directoryManagementView.spec.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/apps/web/tests/directoryManagementView.spec.ts)

--- a/docs/development/dingtalk-directory-binding-design-20260411.md
+++ b/docs/development/dingtalk-directory-binding-design-20260411.md
@@ -129,15 +129,30 @@ Date: 2026-04-11
 - 可以直接按姓名、邮箱、用户 ID 搜索
 - 复用已有管理员权限边界，减少一套重复接口
 
+### 8. 成员账号列表按页管理
+
+目录成员接口已经返回 `page / pageSize / total`，前端页不能再固定只拉首批结果。
+
+这次调整采用：
+
+- 默认每页 25 条
+- 支持 `25 / 50 / 100` 切换
+- 支持上一页 / 下一页
+- 搜索时自动回到第 1 页
+
+这样可以让大组织目录继续在同一管理页内完成绑定和解绑，不会因为成员数超过 100 而失去可操作性。
+
 ## UI Changes
 
-页面：[DirectoryManagementView.vue](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/apps/web/src/views/DirectoryManagementView.vue)
+页面：[DirectoryManagementView.vue](../../apps/web/src/views/DirectoryManagementView.vue)
 
 新增“成员账号”区块，支持：
 
 - 展示同步后的钉钉成员
 - 展示 `externalUserId / unionId / openId / corpId`
 - 展示本地绑定状态与匹配策略
+- 基于后端 `total/page/pageSize` 做服务端分页
+- 切换每页条数，并支持上一页 / 下一页翻页
 - 搜索本地用户候选并点选
 - 通过“本地用户 ID / 邮箱”手工绑定
 - 绑定时一并开通钉钉登录 grant
@@ -145,15 +160,15 @@ Date: 2026-04-11
 
 ## Backend Files
 
-- [directory-sync.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/packages/core-backend/src/directory/directory-sync.ts)
-- [admin-directory.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/packages/core-backend/src/routes/admin-directory.ts)
+- [directory-sync.ts](../../packages/core-backend/src/directory/directory-sync.ts)
+- [admin-directory.ts](../../packages/core-backend/src/routes/admin-directory.ts)
 
 ## Frontend Files
 
-- [DirectoryManagementView.vue](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/apps/web/src/views/DirectoryManagementView.vue)
+- [DirectoryManagementView.vue](../../apps/web/src/views/DirectoryManagementView.vue)
 
 ## Test Files
 
-- [admin-directory-routes.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/packages/core-backend/tests/unit/admin-directory-routes.test.ts)
-- [directory-sync-bind-account.test.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts)
-- [directoryManagementView.spec.ts](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/staging-deploy-unblock-20260408/apps/web/tests/directoryManagementView.spec.ts)
+- [admin-directory-routes.test.ts](../../packages/core-backend/tests/unit/admin-directory-routes.test.ts)
+- [directory-sync-bind-account.test.ts](../../packages/core-backend/tests/unit/directory-sync-bind-account.test.ts)
+- [directoryManagementView.spec.ts](../../apps/web/tests/directoryManagementView.spec.ts)

--- a/docs/development/dingtalk-directory-binding-verification-20260411.md
+++ b/docs/development/dingtalk-directory-binding-verification-20260411.md
@@ -1,0 +1,90 @@
+# DingTalk Directory Binding Verification
+
+Date: 2026-04-11
+
+## Scope
+
+验证以下改动：
+
+1. 目录成员列表接口可返回钉钉 ID 与本地绑定信息。
+2. 管理员可将目录成员按本地用户 ID / 邮箱绑定到本地用户。
+3. 预绑定写入的 DingTalk identity key 符合扫码登录规则。
+4. 目录页前端可展示成员账号并发起绑定请求。
+5. 目录页前端可搜索本地用户候选并执行解绑。
+
+## Commands
+
+### Backend unit tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts
+```
+
+Result:
+
+- 2 test files passed
+- 8 tests passed
+
+### Frontend unit tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts
+```
+
+Result:
+
+- 1 test file passed
+- 3 tests passed
+
+### Type checks
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+- backend type check passed
+- frontend type check passed
+
+## Verified Behaviors
+
+### Backend
+
+- `GET /api/admin/directory/integrations/:integrationId/accounts` 路由可用。
+- `POST /api/admin/directory/accounts/:accountId/bind` 路由可用。
+- `POST /api/admin/directory/accounts/:accountId/unbind` 路由可用。
+- 绑定时会同时更新：
+  - `user_external_identities`
+  - `user_external_auth_grants`
+  - `directory_account_links`
+- 解绑时会删除对应 `user_external_identities`，并把 `directory_account_links` 重置为 `manual_unbound / unmatched`。
+- 绑定时 `external_key` 会按 `corpId:openId` 规则写入，而不是直接照抄目录表里的 key。
+- 当目录成员缺失 `openId/unionId` 时，后端会拒绝预绑定登录身份，避免假成功。
+- 同步自动匹配已补上 `corp_id + open_id/union_id` 维度。
+- 绑定与解绑都会写管理员审计日志。
+
+### Frontend
+
+- 目录页会在选中集成后自动加载“成员账号”。
+- 页面会展示：
+  - `externalUserId`
+  - `unionId`
+  - `openId`
+  - `corpId`
+  - 绑定状态
+  - 本地用户
+  - 部门路径
+- 管理员输入本地用户邮箱后，可直接发起绑定请求。
+- 管理员可先搜索本地用户候选，再一键填充绑定目标。
+- 已绑定成员卡片上可直接执行“解除绑定”。
+
+## Follow-up
+
+当前版本已满足“同步展示钉钉 ID + 平台管理员预绑定 + 登录 grant 一并开通 + 解绑回收”的闭环。
+
+后续可继续补两项增强：
+
+1. 批量绑定/批量开通。
+2. 更细的解绑策略，例如“仅解绑目录关系”与“同时停用 grant”的显式选项。

--- a/docs/development/dingtalk-directory-binding-verification-20260411.md
+++ b/docs/development/dingtalk-directory-binding-verification-20260411.md
@@ -9,7 +9,7 @@ Date: 2026-04-11
 1. 目录成员列表接口可返回钉钉 ID 与本地绑定信息。
 2. 管理员可将目录成员按本地用户 ID / 邮箱绑定到本地用户。
 3. 预绑定写入的 DingTalk identity key 符合扫码登录规则。
-4. 目录页前端可展示成员账号并发起绑定请求。
+4. 目录页前端可展示成员账号、分页浏览并发起绑定请求。
 5. 目录页前端可搜索本地用户候选并执行解绑。
 
 ## Commands
@@ -23,7 +23,7 @@ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory
 Result:
 
 - 2 test files passed
-- 8 tests passed
+- 10 tests passed
 
 ### Frontend unit tests
 
@@ -34,7 +34,7 @@ pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.
 Result:
 
 - 1 test file passed
-- 3 tests passed
+- 5 tests passed
 
 ### Type checks
 
@@ -76,6 +76,8 @@ Result:
   - 绑定状态
   - 本地用户
   - 部门路径
+- 页面会按后端分页结果展示成员总数，并支持切换每页 25 / 50 / 100 条。
+- 页面支持上一页 / 下一页翻页，不再固定只拉首批 100 条成员。
 - 管理员输入本地用户邮箱后，可直接发起绑定请求。
 - 管理员可先搜索本地用户候选，再一键填充绑定目标。
 - 已绑定成员卡片上可直接执行“解除绑定”。

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -69,7 +69,10 @@ type DirectoryDepartmentRow = {
 
 type DirectoryAccountRow = {
   id: string
+  corp_id: string | null
   external_user_id: string
+  union_id: string | null
+  open_id: string | null
   external_key: string
   email: string | null
   mobile: string | null
@@ -84,6 +87,9 @@ type DirectoryAccountLinkRow = {
 
 type ExternalIdentityRow = {
   external_key: string
+  provider_union_id: string | null
+  provider_open_id: string | null
+  corp_id: string | null
   local_user_id: string
 }
 
@@ -91,6 +97,59 @@ type LocalUserRow = {
   id: string
   email?: string | null
   mobile?: string | null
+}
+
+type DirectoryIntegrationAccountRow = {
+  integration_id: string
+  provider: string
+  corp_id: string | null
+  directory_account_id: string
+  external_user_id: string
+  union_id: string | null
+  open_id: string | null
+  external_key: string
+  account_name: string
+  account_email: string | null
+  account_mobile: string | null
+  account_is_active: boolean
+  account_updated_at: string
+  link_status: string | null
+  match_strategy: string | null
+  reviewed_by: string | null
+  review_note: string | null
+  link_updated_at: string | null
+  local_user_id: string | null
+  local_user_email: string | null
+  local_user_name: string | null
+  department_paths: string[] | null
+}
+
+type DirectoryBindingUserRow = {
+  id: string
+  email: string
+  name: string | null
+  role: string
+  is_active: boolean
+}
+
+type DirectoryBindingTargetAccountRow = {
+  id: string
+  integration_id: string
+  provider: string
+  corp_id: string | null
+  external_user_id: string
+  union_id: string | null
+  open_id: string | null
+  external_key: string
+  name: string
+  email: string | null
+  mobile: string | null
+}
+
+type DirectoryAccountLinkedUserRow = {
+  local_user_id: string | null
+  local_user_email: string | null
+  local_user_name: string | null
 }
 
 export type DirectoryIntegrationSummary = {
@@ -160,6 +219,52 @@ export type DirectorySyncRunSummary = {
   triggerSource: string
   createdAt: string
   updatedAt: string
+}
+
+export type DirectoryIntegrationAccountSummary = {
+  id: string
+  integrationId: string
+  provider: string
+  corpId: string | null
+  externalUserId: string
+  unionId: string | null
+  openId: string | null
+  externalKey: string
+  name: string
+  email: string | null
+  mobile: string | null
+  isActive: boolean
+  updatedAt: string
+  linkStatus: string
+  matchStrategy: string | null
+  reviewedBy: string | null
+  reviewNote: string | null
+  linkUpdatedAt: string | null
+  localUser: {
+    id: string
+    email: string | null
+    name: string | null
+  } | null
+  departmentPaths: string[]
+}
+
+export type DirectoryAccountBindInput = {
+  localUserRef: string
+  adminUserId: string
+  enableDingTalkGrant?: boolean
+}
+
+export type DirectoryAccountUnbindInput = {
+  adminUserId: string
+}
+
+export type DirectoryAccountMutationResult = {
+  account: DirectoryIntegrationAccountSummary
+  previousLocalUser: {
+    id: string
+    email: string | null
+    name: string | null
+  } | null
 }
 
 function parseJsonRecord(value: JsonRecord | string | null | undefined): JsonRecord {
@@ -250,9 +355,59 @@ function summarizeRun(row: DirectoryRunRow): DirectorySyncRunSummary {
   }
 }
 
+function summarizeDirectoryAccount(row: DirectoryIntegrationAccountRow): DirectoryIntegrationAccountSummary {
+  return {
+    id: row.directory_account_id,
+    integrationId: row.integration_id,
+    provider: row.provider,
+    corpId: row.corp_id,
+    externalUserId: row.external_user_id,
+    unionId: row.union_id,
+    openId: row.open_id,
+    externalKey: row.external_key,
+    name: row.account_name,
+    email: row.account_email,
+    mobile: row.account_mobile,
+    isActive: row.account_is_active,
+    updatedAt: row.account_updated_at,
+    linkStatus: row.link_status ?? 'unmatched',
+    matchStrategy: row.match_strategy,
+    reviewedBy: row.reviewed_by,
+    reviewNote: row.review_note,
+    linkUpdatedAt: row.link_updated_at,
+    localUser: row.local_user_id
+      ? {
+        id: row.local_user_id,
+        email: row.local_user_email,
+        name: row.local_user_name,
+      }
+      : null,
+    departmentPaths: Array.isArray(row.department_paths) ? row.department_paths.filter(Boolean) : [],
+  }
+}
+
 function readErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error && error.message.trim().length > 0) return error.message
   return fallback
+}
+
+function buildScopedIdentityKey(corpId: string | null | undefined, providerId: string | null | undefined): string | null {
+  const normalizedProviderId = normalizeText(providerId)
+  if (!normalizedProviderId) return null
+  const normalizedCorpId = normalizeText(corpId)
+  return normalizedCorpId ? `${normalizedCorpId}:${normalizedProviderId}` : `global:${normalizedProviderId}`
+}
+
+function buildDingTalkIdentityExternalKey(corpId: string | null | undefined, openId: string | null | undefined, unionId: string | null | undefined): string {
+  const normalizedCorpId = normalizeText(corpId)
+  const normalizedOpenId = normalizeText(openId)
+  const normalizedUnionId = normalizeText(unionId)
+
+  if (normalizedCorpId && normalizedOpenId) {
+    return `${normalizedCorpId}:${normalizedOpenId}`
+  }
+
+  return normalizedUnionId || normalizedOpenId
 }
 
 function normalizeIntegrationInput(
@@ -577,14 +732,41 @@ async function markSyncFailure(integrationId: string, runId: string, message: st
   }
 }
 
-async function loadMatchMaps(externalKeys: string[], emails: string[], mobiles: string[]) {
+async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
+  const externalKeys = Array.from(new Set(accounts.map((account) => account.external_key).filter(Boolean)))
+  const unionIds = Array.from(new Set(
+    accounts
+      .map((account) => normalizeText(account.union_id))
+      .filter(Boolean),
+  ))
+  const openIds = Array.from(new Set(
+    accounts
+      .map((account) => normalizeText(account.open_id))
+      .filter(Boolean),
+  ))
+  const emails = Array.from(new Set(
+    accounts
+      .map((account) => normalizeText(account.email).toLowerCase())
+      .filter(Boolean),
+  ))
+  const mobiles = Array.from(new Set(
+    accounts
+      .map((account) => normalizeText(account.mobile))
+      .filter(Boolean),
+  ))
+
   const [externalIdentities, emailUsers, mobileUsers] = await Promise.all([
-    externalKeys.length > 0
+    externalKeys.length > 0 || unionIds.length > 0 || openIds.length > 0
       ? query<ExternalIdentityRow>(
-        `SELECT external_key, local_user_id
+        `SELECT external_key, provider_union_id, provider_open_id, corp_id, local_user_id
          FROM user_external_identities
-         WHERE provider = $1 AND external_key = ANY($2::text[])`,
-        [DEFAULT_PROVIDER, externalKeys],
+         WHERE provider = $1
+           AND (
+             external_key = ANY($2::text[])
+             OR provider_union_id = ANY($3::text[])
+             OR provider_open_id = ANY($4::text[])
+           )`,
+        [DEFAULT_PROVIDER, externalKeys, unionIds, openIds],
       )
       : Promise.resolve({ rows: [] } as Awaited<ReturnType<typeof query<ExternalIdentityRow>>>),
     emails.length > 0
@@ -605,8 +787,19 @@ async function loadMatchMaps(externalKeys: string[], emails: string[], mobiles: 
       : Promise.resolve({ rows: [] } as Awaited<ReturnType<typeof query<LocalUserRow>>>),
   ])
 
+  const scopedUnionIdentityMap = new Map<string, string>()
+  const scopedOpenIdentityMap = new Map<string, string>()
+  for (const row of externalIdentities.rows) {
+    const unionKey = buildScopedIdentityKey(row.corp_id, row.provider_union_id)
+    if (unionKey) scopedUnionIdentityMap.set(unionKey, row.local_user_id)
+    const openKey = buildScopedIdentityKey(row.corp_id, row.provider_open_id)
+    if (openKey) scopedOpenIdentityMap.set(openKey, row.local_user_id)
+  }
+
   return {
     externalIdentityMap: new Map(externalIdentities.rows.map((row) => [row.external_key, row.local_user_id])),
+    scopedUnionIdentityMap,
+    scopedOpenIdentityMap,
     emailMap: new Map(
       emailUsers.rows
         .map((row) => [normalizeText(row.email).toLowerCase(), row.id] as const)
@@ -743,7 +936,7 @@ export async function syncDirectoryIntegration(
           [integrationId],
         ),
         client.query(
-          `SELECT id, external_user_id, external_key, email, mobile
+          `SELECT id, corp_id, external_user_id, union_id, open_id, external_key, email, mobile
            FROM directory_accounts
            WHERE integration_id = $1`,
           [integrationId],
@@ -786,18 +979,9 @@ export async function syncDirectoryIntegration(
         }
       }
 
-      const externalKeys = Array.from(new Set(Array.from(accountIdMap.values()).map((account) => account.external_key).filter(Boolean)))
-      const emails = Array.from(new Set(
-        Array.from(accountIdMap.values())
-          .map((account) => normalizeText(account.email).toLowerCase())
-          .filter(Boolean),
-      ))
-      const mobiles = Array.from(new Set(
-        Array.from(accountIdMap.values())
-          .map((account) => normalizeText(account.mobile))
-          .filter(Boolean),
-      ))
-      const { externalIdentityMap, emailMap, mobileMap } = await loadMatchMaps(externalKeys, emails, mobiles)
+      const { externalIdentityMap, scopedUnionIdentityMap, scopedOpenIdentityMap, emailMap, mobileMap } = await loadMatchMaps(
+        Array.from(accountIdMap.values()),
+      )
 
       const existingLinksResult = await client.query(
         `SELECT directory_account_id, local_user_id, link_status, match_strategy
@@ -819,7 +1003,11 @@ export async function syncDirectoryIntegration(
         let matchStrategy = existing?.match_strategy ?? null
 
         if (!(existing && existing.link_status === 'linked' && existing.local_user_id)) {
+          const scopedOpenIdentityKey = buildScopedIdentityKey(account.corp_id, account.open_id)
+          const scopedUnionIdentityKey = buildScopedIdentityKey(account.corp_id, account.union_id)
           const externalIdentityUserId = externalIdentityMap.get(account.external_key)
+            || (scopedOpenIdentityKey ? scopedOpenIdentityMap.get(scopedOpenIdentityKey) : undefined)
+            || (scopedUnionIdentityKey ? scopedUnionIdentityMap.get(scopedUnionIdentityKey) : undefined)
           if (externalIdentityUserId) {
             localUserId = externalIdentityUserId
             linkStatus = 'linked'
@@ -939,5 +1127,442 @@ export async function listDirectorySyncRuns(
   return {
     items: rowsResult.rows.map(summarizeRun),
     total: Number(totalResult.rows[0]?.total ?? 0),
+  }
+}
+
+async function getDirectoryAccountSummary(accountId: string): Promise<DirectoryIntegrationAccountSummary | null> {
+  const result = await query<DirectoryIntegrationAccountRow>(
+    `SELECT
+        a.integration_id,
+        a.provider,
+        a.corp_id,
+        a.id AS directory_account_id,
+        a.external_user_id,
+        a.union_id,
+        a.open_id,
+        a.external_key,
+        a.name AS account_name,
+        a.email AS account_email,
+        a.mobile AS account_mobile,
+        a.is_active AS account_is_active,
+        a.updated_at AS account_updated_at,
+        l.link_status,
+        l.match_strategy,
+        l.reviewed_by,
+        l.review_note,
+        l.updated_at AS link_updated_at,
+        u.id AS local_user_id,
+        u.email AS local_user_email,
+        u.name AS local_user_name,
+        COALESCE(array_remove(array_agg(DISTINCT d.full_path), NULL), ARRAY[]::text[]) AS department_paths
+     FROM directory_accounts a
+     LEFT JOIN directory_account_links l ON l.directory_account_id = a.id
+     LEFT JOIN users u ON u.id = l.local_user_id
+     LEFT JOIN directory_account_departments ad ON ad.directory_account_id = a.id
+     LEFT JOIN directory_departments d ON d.id = ad.directory_department_id
+     WHERE a.id = $1
+     GROUP BY
+       a.integration_id, a.provider, a.corp_id, a.id, a.external_user_id, a.union_id, a.open_id, a.external_key,
+       a.name, a.email, a.mobile, a.is_active, a.updated_at,
+       l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
+       u.id, u.email, u.name`,
+    [accountId],
+  )
+
+  const row = result.rows[0]
+  return row ? summarizeDirectoryAccount(row) : null
+}
+
+async function resolveDirectoryBindingUser(localUserRef: string): Promise<DirectoryBindingUserRow | null> {
+  const ref = normalizeText(localUserRef)
+  if (!ref) return null
+
+  const result = await query<DirectoryBindingUserRow>(
+    `SELECT id,
+            email,
+            name,
+            COALESCE(role, 'user') AS role,
+            COALESCE(is_active, TRUE) AS is_active
+     FROM users
+     WHERE id = $1 OR LOWER(email) = LOWER($1)
+     ORDER BY CASE WHEN id = $1 THEN 0 ELSE 1 END
+     LIMIT 1`,
+    [ref],
+  )
+
+  return result.rows[0] ?? null
+}
+
+async function loadDirectoryBindingTargetAccount(directoryAccountId: string): Promise<DirectoryBindingTargetAccountRow | null> {
+  const result = await query<DirectoryBindingTargetAccountRow>(
+    `SELECT id, integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, email, mobile
+     FROM directory_accounts
+     WHERE id = $1
+     LIMIT 1`,
+    [directoryAccountId],
+  )
+  return result.rows[0] ?? null
+}
+
+async function loadDirectoryLinkedUser(directoryAccountId: string): Promise<DirectoryAccountLinkedUserRow | null> {
+  const result = await query<DirectoryAccountLinkedUserRow>(
+    `SELECT l.local_user_id,
+            u.email AS local_user_email,
+            u.name AS local_user_name
+     FROM directory_account_links l
+     LEFT JOIN users u ON u.id = l.local_user_id
+     WHERE l.directory_account_id = $1
+     LIMIT 1`,
+    [directoryAccountId],
+  )
+  return result.rows[0] ?? null
+}
+
+export async function listDirectoryIntegrationAccounts(
+  integrationId: string,
+  pagination: { limit: number; offset: number },
+  search?: string,
+): Promise<{ items: DirectoryIntegrationAccountSummary[]; total: number }> {
+  const normalizedIntegrationId = normalizeText(integrationId)
+  if (!normalizedIntegrationId) throw new Error('integrationId is required')
+
+  const normalizedSearch = normalizeText(search)
+  const values: unknown[] = [normalizedIntegrationId]
+  const where: string[] = ['a.integration_id = $1']
+
+  if (normalizedSearch) {
+    values.push(`%${normalizedSearch}%`)
+    where.push(`(
+      a.name ILIKE $${values.length}
+      OR COALESCE(a.email, '') ILIKE $${values.length}
+      OR COALESCE(a.mobile, '') ILIKE $${values.length}
+      OR a.external_user_id ILIKE $${values.length}
+      OR COALESCE(a.union_id, '') ILIKE $${values.length}
+      OR COALESCE(a.open_id, '') ILIKE $${values.length}
+      OR COALESCE(u.email, '') ILIKE $${values.length}
+      OR COALESCE(u.name, '') ILIKE $${values.length}
+      OR COALESCE(u.id, '') ILIKE $${values.length}
+    )`)
+  }
+
+  const whereSql = where.join(' AND ')
+  const countValues = [...values]
+  const listValues = [...values, pagination.limit, pagination.offset]
+
+  const [countResult, rowsResult] = await Promise.all([
+    query<{ total: number }>(
+      `SELECT COUNT(*)::int AS total
+       FROM directory_accounts a
+       LEFT JOIN directory_account_links l ON l.directory_account_id = a.id
+       LEFT JOIN users u ON u.id = l.local_user_id
+       WHERE ${whereSql}`,
+      countValues,
+    ),
+    query<DirectoryIntegrationAccountRow>(
+      `SELECT
+          a.integration_id,
+          a.provider,
+          a.corp_id,
+          a.id AS directory_account_id,
+          a.external_user_id,
+          a.union_id,
+          a.open_id,
+          a.external_key,
+          a.name AS account_name,
+          a.email AS account_email,
+          a.mobile AS account_mobile,
+          a.is_active AS account_is_active,
+          a.updated_at AS account_updated_at,
+          l.link_status,
+          l.match_strategy,
+          l.reviewed_by,
+          l.review_note,
+          l.updated_at AS link_updated_at,
+          u.id AS local_user_id,
+          u.email AS local_user_email,
+          u.name AS local_user_name,
+          COALESCE(array_remove(array_agg(DISTINCT d.full_path), NULL), ARRAY[]::text[]) AS department_paths
+       FROM directory_accounts a
+       LEFT JOIN directory_account_links l ON l.directory_account_id = a.id
+       LEFT JOIN users u ON u.id = l.local_user_id
+       LEFT JOIN directory_account_departments ad ON ad.directory_account_id = a.id
+       LEFT JOIN directory_departments d ON d.id = ad.directory_department_id
+       WHERE ${whereSql}
+       GROUP BY
+         a.integration_id, a.provider, a.corp_id, a.id, a.external_user_id, a.union_id, a.open_id, a.external_key,
+         a.name, a.email, a.mobile, a.is_active, a.updated_at,
+         l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
+         u.id, u.email, u.name
+       ORDER BY a.is_active DESC, a.name ASC, a.external_user_id ASC
+       LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
+      listValues,
+    ),
+  ])
+
+  return {
+    items: rowsResult.rows.map(summarizeDirectoryAccount),
+    total: Number(countResult.rows[0]?.total ?? 0),
+  }
+}
+
+export async function bindDirectoryAccount(
+  directoryAccountId: string,
+  input: DirectoryAccountBindInput,
+): Promise<DirectoryAccountMutationResult> {
+  const normalizedAccountId = normalizeText(directoryAccountId)
+  const normalizedLocalUserRef = normalizeText(input.localUserRef)
+  const normalizedAdminUserId = normalizeText(input.adminUserId)
+  const enableDingTalkGrant = input.enableDingTalkGrant !== false
+
+  if (!normalizedAccountId) throw new Error('directoryAccountId is required')
+  if (!normalizedLocalUserRef) throw new Error('localUserRef is required')
+  if (!normalizedAdminUserId) throw new Error('adminUserId is required')
+
+  const [account, previousLinkedUser] = await Promise.all([
+    loadDirectoryBindingTargetAccount(normalizedAccountId),
+    loadDirectoryLinkedUser(normalizedAccountId),
+  ])
+  if (!account) throw new Error('Directory account not found')
+
+  const identityExternalKey = buildDingTalkIdentityExternalKey(account.corp_id, account.open_id, account.union_id)
+  if (!identityExternalKey) {
+    throw new Error('Directory account is missing DingTalk openId/unionId and cannot be pre-bound for DingTalk login')
+  }
+
+  const localUser = await resolveDirectoryBindingUser(normalizedLocalUserRef)
+  if (!localUser) throw new Error('Local user not found')
+
+  const profile = JSON.stringify({
+    source: 'directory_admin_bind',
+    integrationId: account.integration_id,
+    corpId: account.corp_id,
+    externalUserId: account.external_user_id,
+    unionId: account.union_id,
+    openId: account.open_id,
+    externalKey: account.external_key,
+    name: account.name,
+    email: account.email,
+    mobile: account.mobile,
+  })
+
+  await transaction(async (client) => {
+    const conflictingIdentityResult = await client.query(
+      `SELECT local_user_id
+       FROM user_external_identities
+       WHERE provider = $1
+         AND local_user_id <> $5
+         AND (
+           external_key = $2
+           OR ($3 IS NOT NULL AND provider_union_id = $3 AND corp_id IS NOT DISTINCT FROM $4)
+           OR ($6 IS NOT NULL AND provider_open_id = $6 AND corp_id IS NOT DISTINCT FROM $4)
+       )
+       LIMIT 1`,
+      [account.provider, identityExternalKey, account.union_id, account.corp_id, localUser.id, account.open_id],
+    )
+    if (conflictingIdentityResult.rows.length > 0) {
+      throw new Error('DingTalk account is already bound to another local user')
+    }
+
+    const conflictingLinkResult = await client.query(
+      `SELECT l.directory_account_id
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE a.provider = $1
+         AND l.local_user_id = $2
+         AND l.link_status = 'linked'
+         AND l.directory_account_id <> $3
+       LIMIT 1`,
+      [account.provider, localUser.id, normalizedAccountId],
+    )
+    if (conflictingLinkResult.rows.length > 0) {
+      throw new Error('Local user is already linked to another DingTalk directory account')
+    }
+
+    const existingIdentityResult = await client.query(
+      `SELECT id
+       FROM user_external_identities
+       WHERE provider = $1 AND local_user_id = $2
+       LIMIT 1`,
+      [account.provider, localUser.id],
+    )
+
+    if (existingIdentityResult.rows.length > 0) {
+      await client.query(
+        `UPDATE user_external_identities
+         SET external_key = $3,
+             provider_union_id = $4,
+             provider_open_id = $5,
+             corp_id = $6,
+             profile = $7::jsonb,
+             bound_by = COALESCE(bound_by, $8),
+             updated_at = NOW()
+         WHERE provider = $1 AND local_user_id = $2`,
+        [
+          account.provider,
+          localUser.id,
+          identityExternalKey,
+          account.union_id,
+          account.open_id,
+          account.corp_id,
+          profile,
+          normalizedAdminUserId,
+        ],
+      )
+    } else {
+      await client.query(
+        `INSERT INTO user_external_identities (
+           provider,
+           external_key,
+           provider_union_id,
+           provider_open_id,
+           corp_id,
+           local_user_id,
+           profile,
+           bound_by,
+           created_at,
+           updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, NOW(), NOW())`,
+        [
+          account.provider,
+          identityExternalKey,
+          account.union_id,
+          account.open_id,
+          account.corp_id,
+          localUser.id,
+          profile,
+          normalizedAdminUserId,
+        ],
+      )
+    }
+
+    if (enableDingTalkGrant) {
+      await client.query(
+        `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+         VALUES ($1, $2, TRUE, $3, NOW(), NOW())
+         ON CONFLICT (provider, local_user_id)
+         DO UPDATE SET enabled = TRUE, granted_by = EXCLUDED.granted_by, updated_at = NOW()`,
+        [account.provider, localUser.id, normalizedAdminUserId],
+      )
+    }
+
+    await client.query(
+      `INSERT INTO directory_account_links (
+         directory_account_id, local_user_id, link_status, match_strategy, reviewed_by, review_note, created_at, updated_at
+       )
+       VALUES ($1, $2, 'linked', 'manual_admin', $3, NULL, NOW(), NOW())
+       ON CONFLICT (directory_account_id)
+       DO UPDATE SET
+         local_user_id = EXCLUDED.local_user_id,
+         link_status = EXCLUDED.link_status,
+         match_strategy = EXCLUDED.match_strategy,
+         reviewed_by = EXCLUDED.reviewed_by,
+         review_note = EXCLUDED.review_note,
+         updated_at = NOW()`,
+      [normalizedAccountId, localUser.id, normalizedAdminUserId],
+    )
+  })
+
+  const summary = await getDirectoryAccountSummary(normalizedAccountId)
+  if (!summary) {
+    throw new Error('Directory account bound but summary reload failed')
+  }
+
+  return {
+    account: summary,
+    previousLocalUser: previousLinkedUser?.local_user_id
+      ? {
+        id: previousLinkedUser.local_user_id,
+        email: previousLinkedUser.local_user_email,
+        name: previousLinkedUser.local_user_name,
+      }
+      : null,
+  }
+}
+
+export async function unbindDirectoryAccount(
+  directoryAccountId: string,
+  input: DirectoryAccountUnbindInput,
+): Promise<DirectoryAccountMutationResult> {
+  const normalizedAccountId = normalizeText(directoryAccountId)
+  const normalizedAdminUserId = normalizeText(input.adminUserId)
+
+  if (!normalizedAccountId) throw new Error('directoryAccountId is required')
+  if (!normalizedAdminUserId) throw new Error('adminUserId is required')
+
+  const [account, previousLinkedUser] = await Promise.all([
+    loadDirectoryBindingTargetAccount(normalizedAccountId),
+    loadDirectoryLinkedUser(normalizedAccountId),
+  ])
+  if (!account) throw new Error('Directory account not found')
+
+  const identityExternalKey = buildDingTalkIdentityExternalKey(account.corp_id, account.open_id, account.union_id)
+
+  await transaction(async (client) => {
+    if (previousLinkedUser?.local_user_id) {
+      const deleteIdentityParams: unknown[] = [
+        account.provider,
+        previousLinkedUser.local_user_id,
+      ]
+      const deleteIdentityClauses = [
+        'provider = $1',
+        'local_user_id = $2',
+      ]
+
+      if (identityExternalKey) {
+        deleteIdentityParams.push(identityExternalKey)
+        deleteIdentityClauses.push(`external_key = $${deleteIdentityParams.length}`)
+      } else if (normalizeText(account.open_id)) {
+        deleteIdentityParams.push(account.open_id, account.corp_id)
+        deleteIdentityClauses.push(
+          `(provider_open_id = $${deleteIdentityParams.length - 1} AND corp_id IS NOT DISTINCT FROM $${deleteIdentityParams.length})`,
+        )
+      } else if (normalizeText(account.union_id)) {
+        deleteIdentityParams.push(account.union_id, account.corp_id)
+        deleteIdentityClauses.push(
+          `(provider_union_id = $${deleteIdentityParams.length - 1} AND corp_id IS NOT DISTINCT FROM $${deleteIdentityParams.length})`,
+        )
+      }
+
+      if (deleteIdentityClauses.length > 2) {
+        await client.query(
+          `DELETE FROM user_external_identities
+           WHERE ${deleteIdentityClauses.join(' AND ')}`,
+          deleteIdentityParams,
+        )
+      }
+    }
+
+    await client.query(
+      `INSERT INTO directory_account_links (
+         directory_account_id, local_user_id, link_status, match_strategy, reviewed_by, review_note, created_at, updated_at
+       )
+       VALUES ($1, NULL, 'unmatched', 'manual_unbind', $2, 'unbound by admin', NOW(), NOW())
+       ON CONFLICT (directory_account_id)
+       DO UPDATE SET
+         local_user_id = NULL,
+         link_status = EXCLUDED.link_status,
+         match_strategy = EXCLUDED.match_strategy,
+         reviewed_by = EXCLUDED.reviewed_by,
+         review_note = EXCLUDED.review_note,
+         updated_at = NOW()`,
+      [normalizedAccountId, normalizedAdminUserId],
+    )
+  })
+
+  const summary = await getDirectoryAccountSummary(normalizedAccountId)
+  if (!summary) {
+    throw new Error('Directory account unbound but summary reload failed')
+  }
+
+  return {
+    account: summary,
+    previousLocalUser: previousLinkedUser?.local_user_id
+      ? {
+        id: previousLinkedUser.local_user_id,
+        email: previousLinkedUser.local_user_email,
+        name: previousLinkedUser.local_user_name,
+      }
+      : null,
   }
 }

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1537,7 +1537,7 @@ export async function unbindDirectoryAccount(
       `INSERT INTO directory_account_links (
          directory_account_id, local_user_id, link_status, match_strategy, reviewed_by, review_note, created_at, updated_at
        )
-       VALUES ($1, NULL, 'unmatched', 'manual_unbind', $2, 'unbound by admin', NOW(), NOW())
+       VALUES ($1, NULL, 'unmatched', 'manual_unbound', $2, 'unbound by admin', NOW(), NOW())
        ON CONFLICT (directory_account_id)
        DO UPDATE SET
          local_user_id = NULL,

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -1,13 +1,17 @@
 import type { Request, Response } from 'express'
 import { Router } from 'express'
+import { auditLog } from '../audit/audit'
 import { isAdmin as isRbacAdmin } from '../rbac/service'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 import {
+  bindDirectoryAccount,
   createDirectoryIntegration,
+  listDirectoryIntegrationAccounts,
   listDirectoryIntegrations,
   listDirectorySyncRuns,
   syncDirectoryIntegration,
   testDirectoryIntegration,
+  unbindDirectoryAccount,
   updateDirectoryIntegration,
 } from '../directory/directory-sync'
 
@@ -134,6 +138,115 @@ export function adminDirectoryRouter(): Router {
       })
     } catch (error) {
       jsonError(res, 500, 'DIRECTORY_RUNS_FAILED', readErrorMessage(error, 'Failed to load sync runs'))
+    }
+  })
+
+  router.get('/integrations/:integrationId/accounts', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const { page, pageSize, offset } = parsePagination(req.query as Record<string, unknown>, {
+        defaultPage: 1,
+        defaultPageSize: 50,
+        maxPageSize: 100,
+      })
+      const search = typeof req.query.q === 'string' ? req.query.q : undefined
+      const result = await listDirectoryIntegrationAccounts(req.params.integrationId, { limit: pageSize, offset }, search)
+      jsonOk(res, {
+        items: result.items,
+        total: result.total,
+        page,
+        pageSize,
+        query: search?.trim() || '',
+      })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory accounts')
+      jsonError(res, /required|invalid/i.test(message) ? 400 : 500, 'DIRECTORY_ACCOUNTS_FAILED', message)
+    }
+  })
+
+  router.post('/accounts/:accountId/bind', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const localUserRef = typeof req.body?.localUserRef === 'string' ? req.body.localUserRef : ''
+      const enableDingTalkGrant = typeof req.body?.enableDingTalkGrant === 'boolean'
+        ? req.body.enableDingTalkGrant
+        : true
+
+      const result = await bindDirectoryAccount(req.params.accountId, {
+        localUserRef,
+        adminUserId,
+        enableDingTalkGrant,
+      })
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'bind',
+        resourceType: 'directory-account-link',
+        resourceId: result.account.id,
+        meta: {
+          adminUserId,
+          directoryAccountId: result.account.id,
+          integrationId: result.account.integrationId,
+          previousLocalUserId: result.previousLocalUser?.id ?? null,
+          previousLocalUserEmail: result.previousLocalUser?.email ?? null,
+          localUserId: result.account.localUser?.id ?? null,
+          localUserEmail: result.account.localUser?.email ?? null,
+          externalUserId: result.account.externalUserId,
+          corpId: result.account.corpId,
+          enableDingTalkGrant,
+        },
+      })
+      jsonOk(res, { account: result.account })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to bind directory account')
+      const statusCode = /not found/i.test(message)
+        ? 404
+        : /already bound|already linked/i.test(message)
+          ? 409
+          : /required|cannot be pre-bound/i.test(message)
+            ? 400
+            : 500
+      jsonError(res, statusCode, 'DIRECTORY_BIND_FAILED', message)
+    }
+  })
+
+  router.post('/accounts/:accountId/unbind', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const result = await unbindDirectoryAccount(req.params.accountId, {
+        adminUserId,
+      })
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'unbind',
+        resourceType: 'directory-account-link',
+        resourceId: result.account.id,
+        meta: {
+          adminUserId,
+          directoryAccountId: result.account.id,
+          integrationId: result.account.integrationId,
+          externalUserId: result.account.externalUserId,
+          corpId: result.account.corpId,
+          previousLocalUserId: result.previousLocalUser?.id ?? null,
+          previousLocalUserEmail: result.previousLocalUser?.email ?? null,
+        },
+      })
+      jsonOk(res, { account: result.account })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to unbind directory account')
+      const statusCode = /not found/i.test(message)
+        ? 404
+        : /required/i.test(message)
+          ? 400
+          : 500
+      jsonError(res, statusCode, 'DIRECTORY_UNBIND_FAILED', message)
     }
   })
 

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -5,6 +5,10 @@ const rbacMocks = vi.hoisted(() => ({
   isRbacAdmin: vi.fn(),
 }))
 
+const auditMocks = vi.hoisted(() => ({
+  auditLog: vi.fn(),
+}))
+
 const directoryMocks = vi.hoisted(() => ({
   listDirectoryIntegrations: vi.fn(),
   createDirectoryIntegration: vi.fn(),
@@ -12,10 +16,17 @@ const directoryMocks = vi.hoisted(() => ({
   testDirectoryIntegration: vi.fn(),
   syncDirectoryIntegration: vi.fn(),
   listDirectorySyncRuns: vi.fn(),
+  listDirectoryIntegrationAccounts: vi.fn(),
+  bindDirectoryAccount: vi.fn(),
+  unbindDirectoryAccount: vi.fn(),
 }))
 
 vi.mock('../../src/rbac/service', () => ({
   isAdmin: rbacMocks.isRbacAdmin,
+}))
+
+vi.mock('../../src/audit/audit', () => ({
+  auditLog: auditMocks.auditLog,
 }))
 
 vi.mock('../../src/directory/directory-sync', () => ({
@@ -25,6 +36,9 @@ vi.mock('../../src/directory/directory-sync', () => ({
   testDirectoryIntegration: directoryMocks.testDirectoryIntegration,
   syncDirectoryIntegration: directoryMocks.syncDirectoryIntegration,
   listDirectorySyncRuns: directoryMocks.listDirectorySyncRuns,
+  listDirectoryIntegrationAccounts: directoryMocks.listDirectoryIntegrationAccounts,
+  bindDirectoryAccount: directoryMocks.bindDirectoryAccount,
+  unbindDirectoryAccount: directoryMocks.unbindDirectoryAccount,
 }))
 
 import { adminDirectoryRouter } from '../../src/routes/admin-directory'
@@ -99,12 +113,16 @@ async function invokeRoute(
 describe('adminDirectoryRouter', () => {
   beforeEach(() => {
     rbacMocks.isRbacAdmin.mockReset()
+    auditMocks.auditLog.mockReset()
     directoryMocks.listDirectoryIntegrations.mockReset()
     directoryMocks.createDirectoryIntegration.mockReset()
     directoryMocks.updateDirectoryIntegration.mockReset()
     directoryMocks.testDirectoryIntegration.mockReset()
     directoryMocks.syncDirectoryIntegration.mockReset()
     directoryMocks.listDirectorySyncRuns.mockReset()
+    directoryMocks.listDirectoryIntegrationAccounts.mockReset()
+    directoryMocks.bindDirectoryAccount.mockReset()
+    directoryMocks.unbindDirectoryAccount.mockReset()
   })
 
   it('rejects unauthenticated requests', async () => {
@@ -184,5 +202,124 @@ describe('adminDirectoryRouter', () => {
     expect(response.statusCode).toBe(200)
     expect(rbacMocks.isRbacAdmin).toHaveBeenCalledWith('user-2')
     expect(directoryMocks.listDirectorySyncRuns).toHaveBeenCalledWith('dir-1', { limit: 10, offset: 0 })
+  })
+
+  it('lists directory accounts for an integration', async () => {
+    directoryMocks.listDirectoryIntegrationAccounts.mockResolvedValue({
+      items: [{ id: 'account-1', externalUserId: '0447654442691174' }],
+      total: 1,
+    })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/accounts', {
+      params: { integrationId: 'dir-1' },
+      query: { page: '1', pageSize: '50', q: '0447' },
+      user: {
+        id: 'admin-1',
+        role: 'admin',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.listDirectoryIntegrationAccounts).toHaveBeenCalledWith('dir-1', { limit: 50, offset: 0 }, '0447')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        total: 1,
+        query: '0447',
+      },
+    })
+  })
+
+  it('binds a directory account to a local user reference', async () => {
+    directoryMocks.bindDirectoryAccount.mockResolvedValue({
+      account: {
+        id: 'account-1',
+        integrationId: 'dir-1',
+        corpId: 'dingcorp',
+        externalUserId: '0447654442691174',
+        localUser: {
+          id: 'user-1',
+          email: 'alpha@example.com',
+        },
+      },
+      previousLocalUser: null,
+    })
+
+    const response = await invokeRoute('post', '/accounts/:accountId/bind', {
+      params: { accountId: 'account-1' },
+      body: {
+        localUserRef: 'alpha@example.com',
+        enableDingTalkGrant: true,
+      },
+      user: {
+        id: 'admin-1',
+        role: 'admin',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.bindDirectoryAccount).toHaveBeenCalledWith('account-1', {
+      localUserRef: 'alpha@example.com',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: true,
+    })
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        account: {
+          id: 'account-1',
+          externalUserId: '0447654442691174',
+        },
+      },
+    })
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'bind',
+      resourceType: 'directory-account-link',
+      resourceId: 'account-1',
+    }))
+  })
+
+  it('unbinds a directory account', async () => {
+    directoryMocks.unbindDirectoryAccount.mockResolvedValue({
+      account: {
+        id: 'account-1',
+        externalUserId: '0447654442691174',
+        integrationId: 'dir-1',
+        corpId: 'dingcorp',
+        localUser: null,
+      },
+      previousLocalUser: {
+        id: 'user-1',
+        email: 'alpha@example.com',
+        name: 'Alpha',
+      },
+    })
+
+    const response = await invokeRoute('post', '/accounts/:accountId/unbind', {
+      params: { accountId: 'account-1' },
+      user: {
+        id: 'admin-1',
+        role: 'admin',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.unbindDirectoryAccount).toHaveBeenCalledWith('account-1', {
+      adminUserId: 'admin-1',
+    })
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'unbind',
+      resourceType: 'directory-account-link',
+      resourceId: 'account-1',
+    }))
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        account: {
+          id: 'account-1',
+          externalUserId: '0447654442691174',
+        },
+      },
+    })
   })
 })

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+}))
+
+import { bindDirectoryAccount, unbindDirectoryAccount } from '../../src/directory/directory-sync'
+
+describe('bindDirectoryAccount', () => {
+  beforeEach(() => {
+    pgMocks.query.mockReset()
+    pgMocks.transaction.mockReset()
+  })
+
+  it('writes an auth-compatible DingTalk identity and linked directory mapping', async () => {
+    const clientQuery = vi.fn()
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: '周华',
+          email: null,
+          mobile: '13758875801',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '周华',
+          account_email: null,
+          account_mobile: '13758875801',
+          account_is_active: true,
+          account_updated_at: '2026-04-11T08:00:00.000Z',
+          link_status: 'linked',
+          match_strategy: 'manual_admin',
+          reviewed_by: 'admin-1',
+          review_note: null,
+          link_updated_at: '2026-04-11T08:00:00.000Z',
+          local_user_id: 'user-1',
+          local_user_email: 'alpha@example.com',
+          local_user_name: 'Alpha',
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+
+    clientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const result = await bindDirectoryAccount('account-1', {
+      localUserRef: 'alpha@example.com',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: true,
+    })
+
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_external_identities'),
+      expect.arrayContaining([
+        'dingtalk',
+        'dingcorp:open-1',
+        'union-1',
+        'open-1',
+        'dingcorp',
+        'user-1',
+      ]),
+    )
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_external_auth_grants'),
+      ['dingtalk', 'user-1', 'admin-1'],
+    )
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO directory_account_links'),
+      ['account-1', 'user-1', 'admin-1'],
+    )
+    expect(result).toMatchObject({
+      account: {
+        id: 'account-1',
+        linkStatus: 'linked',
+        matchStrategy: 'manual_admin',
+        localUser: {
+          id: 'user-1',
+          email: 'alpha@example.com',
+        },
+      },
+      previousLocalUser: null,
+    })
+  })
+
+  it('rejects pre-binding when DingTalk identifiers are missing', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: null,
+          open_id: null,
+          external_key: '0447654442691174',
+          name: '周华',
+          email: null,
+          mobile: '13758875801',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+        }],
+      })
+
+    await expect(bindDirectoryAccount('account-1', {
+      localUserRef: 'alpha@example.com',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: true,
+    })).rejects.toThrow('cannot be pre-bound')
+
+    expect(pgMocks.transaction).not.toHaveBeenCalled()
+  })
+
+  it('removes the bound identity and resets the link on unbind', async () => {
+    const clientQuery = vi.fn()
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: '周华',
+          email: null,
+          mobile: '13758875801',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: 'user-1',
+          local_user_email: 'alpha@example.com',
+          local_user_name: 'Alpha',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '周华',
+          account_email: null,
+          account_mobile: '13758875801',
+          account_is_active: true,
+          account_updated_at: '2026-04-11T08:01:00.000Z',
+          link_status: 'unmatched',
+          match_strategy: 'manual_unbound',
+          reviewed_by: null,
+          review_note: null,
+          link_updated_at: '2026-04-11T08:01:00.000Z',
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+
+    clientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const result = await unbindDirectoryAccount('account-1', {
+      adminUserId: 'admin-1',
+    })
+
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM user_external_identities'),
+      ['dingtalk', 'user-1', 'dingcorp:open-1'],
+    )
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO directory_account_links'),
+      ['account-1', 'admin-1'],
+    )
+    expect(result).toMatchObject({
+      account: {
+        id: 'account-1',
+        linkStatus: 'unmatched',
+        matchStrategy: 'manual_unbound',
+        localUser: null,
+      },
+      previousLocalUser: {
+        id: 'user-1',
+        email: 'alpha@example.com',
+      },
+    })
+  })
+})


### PR DESCRIPTION
- add admin directory account listing with DingTalk identifiers, local-user linkage, search, and pagination
- add admin bind and unbind endpoints for directory accounts
- write bind and unbind audit events for directory-account-link operations
- pre-bind DingTalk identities using the auth-compatible external key rule (`corpId:openId` when available)
- reject pre-binding when the synced account lacks both `openId` and `unionId`
- extend directory sync matching to recognize corp-scoped `open_id` and `union_id` so linked users do not fall back to `unmatched`
- add directory management UI support for local-user search, candidate selection, bind, and unbind actions
- add design and verification docs for the DingTalk directory binding flow

Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts`
- `pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`