### PR TITLE
test(contract): add Wave 4 Yuantus approval substitutes pact

### DIFF
--- a/docs/development/plm-yuantus-wave4-eco-substitutes-pact-20260411.md
+++ b/docs/development/plm-yuantus-wave4-eco-substitutes-pact-20260411.md
@@ -1,0 +1,84 @@
+# PLM Yuantus Wave 4 Pact
+
+Date: 2026-04-11
+
+## Scope
+
+Wave 4 extends the Metasheet2 -> Yuantus consumer pact for the next real
+mainline calls already present in `PLMAdapter.ts`, limited to:
+
+- `GET /api/v1/eco`
+- `GET /api/v1/eco/{id}`
+- `GET /api/v1/bom/{bom_line_id}/substitutes`
+- `POST /api/v1/bom/{bom_line_id}/substitutes`
+- `DELETE /api/v1/bom/{bom_line_id}/substitutes/{substitute_id}`
+
+This intentionally does **not** include the CAD file APIs yet. Those routes are
+real, but they require a larger fixture surface and would dilute a fast,
+low-risk Wave 4.
+
+The pact count moves from 14 to 19 interactions.
+
+## Why These 5 Endpoints
+
+They are already consumed on `main`:
+
+- approval list: `PLMAdapter.getApprovals()`
+- approval detail: `PLMAdapter.getApprovalById()`
+- substitute list: `PLMAdapter.getBomSubstitutes()`
+- substitute add: `PLMAdapter.addBomSubstitute()`
+- substitute remove: `PLMAdapter.removeBomSubstitute()`
+
+This keeps the contract-first rule intact: only freeze surfaces the live
+consumer actually calls.
+
+## Design Notes
+
+1. Approval list/detail use the raw ECO routes as they exist today.
+`Yuantus` does not currently guarantee fields like `created_by_name` or
+`version` on those routes, so Wave 4 does not lock them as required contract
+fields.
+
+2. Substitute delete uses a dedicated BOM line fixture.
+The provider verifier seeds one BOM line for read, one empty BOM line for add,
+and one separate BOM line for delete. That avoids inter-test coupling while
+keeping the provider state handler as a no-op.
+
+3. The pact artifact remains canonical in `metasheet2`.
+`Yuantus/contracts/pacts/metasheet2-yuantus-plm.json` is still a synchronized
+copy, not a second source-of-truth.
+
+## Files Changed
+
+- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json`
+- `packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts`
+- `packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts`
+- `packages/core-backend/tests/contract/README.md`
+- `docs/development/plm-yuantus-wave4-eco-substitutes-pact-20260411.md`
+
+## Verification
+
+Run from `packages/core-backend`:
+
+```bash
+npx vitest run \
+  tests/contract/plm-adapter-yuantus.pact.test.ts \
+  tests/unit/plm-adapter-yuantus.test.ts
+```
+
+Expected result for this wave:
+
+- `2` test files passed
+- `28` tests passed
+
+## Deferred To Wave 5
+
+- `GET /api/v1/cad/files/{file_id}/properties`
+- `PATCH /api/v1/cad/files/{file_id}/properties`
+- `GET /api/v1/cad/files/{file_id}/view-state`
+- `PATCH /api/v1/cad/files/{file_id}/view-state`
+- `GET /api/v1/cad/files/{file_id}/review`
+- `POST /api/v1/cad/files/{file_id}/review`
+- `GET /api/v1/cad/files/{file_id}/history`
+- `GET /api/v1/cad/files/{file_id}/diff`
+- `GET /api/v1/cad/files/{file_id}/mesh-stats`

--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -20,16 +20,16 @@ when running in `apiMode='yuantus'`. Without a contract test, any field
 rename on the Yuantus side would silently break Metasheet at runtime.
 
 This Pact set freezes the **shape** (not the values) of the 6 Wave 1 P0
-endpoints plus the 3 document-semantics endpoints and the 5 BOM-analysis /
-ECO-approval endpoints that `PLMAdapter.ts` currently calls for
-`apiMode='yuantus'`.
+endpoints plus the 3 document-semantics endpoints, the 5 BOM-analysis /
+ECO-approval endpoints, and the 5 approval-detail / BOM-substitute endpoints
+that `PLMAdapter.ts` currently calls for `apiMode='yuantus'`.
 (Codex's PACT_FIRST plan lists 7 endpoints in Wave 1 — see "Discrepancy
 with codex plan" below.)
 
 The companion provider verifier lives in the Yuantus repo at
 `src/yuantus/api/tests/test_pact_provider_yuantus_plm.py`.
 
-## Current implementation note (2026-04-07)
+## Current implementation note (2026-04-11)
 
 The pact JSON in `pacts/metasheet2-yuantus-plm.json` is **hand-authored** in
 Pact v3 format. It is **not** yet generated from `@pact-foundation/pact`,
@@ -38,12 +38,14 @@ because adding that npm dependency requires explicit approval.
 The `plm-adapter-yuantus.pact.test.ts` vitest test guards four things:
 
 1. The pact JSON exists and parses as Pact v3.
-2. It contains the 14 currently used interactions in the documented order.
+2. It contains the 19 currently used interactions in the documented order.
 3. Every endpoint named in the pact is also referenced by the live
    `packages/core-backend/src/data-adapters/PLMAdapter.ts` source — so the
    pact cannot drift away from what the adapter actually calls.
 4. The Wave 3 additions lock the exact envelope for `where-used`,
    `bom compare schema`, `approval history`, `approve`, and `reject`.
+5. The Wave 4 additions lock the exact envelope for approval list/detail and
+   BOM substitute list/add/remove.
 
 ## Discrepancy with codex's PACT_FIRST plan
 
@@ -96,12 +98,14 @@ cd /Users/huazhou/Downloads/Github/Yuantus
    src/yuantus/api/tests/test_pact_provider_yuantus_plm.py
 ```
 
-### Current verifier state (2026-04-11)
+### Current verifier handoff state (2026-04-11)
 
-Wired end-to-end with `pact-python 3.2.1`. The provider verifier now starts
-the FastAPI app, seeds an isolated test DB, and replays all 14 interactions.
+The consumer artifact now contains all 19 Wave 1-4 interactions. To verify
+Yuantus against the current artifact, copy this JSON into the Yuantus repo and
+rerun the provider verifier there.
 
-**Current result: 14 passing, 0 failing.**
+This worktree did **not** rerun provider verification, so do not treat the old
+Wave 3 verifier count as evidence for the new Wave 4 interactions.
 
 Wave 3 adds coverage for:
 
@@ -114,6 +118,16 @@ Wave 3 adds coverage for:
 The provider keeps its state handler as a no-op by using distinct seeded ECO
 fixtures for `history`, `approve`, and `reject`, so mutating approval actions
 cannot contaminate later interactions in the same verifier run.
+
+Wave 4 extends that pattern:
+
+- list/detail approvals use separate ECO fixtures from history/action checks
+- substitute list uses a pre-seeded substitute relation
+- substitute add targets a fresh substitute item
+- substitute remove targets a different pre-seeded substitute relation
+
+That keeps the verifier deterministic without introducing per-state mutation
+logic.
 
 To install `pact-python` and run locally:
 
@@ -143,13 +157,25 @@ specification of what the generated pact must contain.
 
 ## Still intentionally outside the pact
 
-The following surfaces remain outside the pact because `PLMAdapter.ts` does
-not currently call them on `main`:
+The following surfaces remain outside the pact:
 
 - `GET /api/v1/aml/metadata/{item_type_name}`
-- `GET /api/v1/bom/{line_id}/substitutes`
-- `POST /api/v1/bom/{line_id}/substitutes`
-- `DELETE /api/v1/bom/substitutes/{substitute_id}`
+- `GET /api/v1/cad/files/{file_id}/properties`
+- `PATCH /api/v1/cad/files/{file_id}/properties`
+- `GET /api/v1/cad/files/{file_id}/view-state`
+- `PATCH /api/v1/cad/files/{file_id}/view-state`
+- `GET /api/v1/cad/files/{file_id}/review`
+- `POST /api/v1/cad/files/{file_id}/review`
+- `GET /api/v1/cad/files/{file_id}/history`
+- `GET /api/v1/cad/files/{file_id}/diff`
+- `GET /api/v1/cad/files/{file_id}/mesh-stats`
+
+`aml/metadata` remains outside because `PLMAdapter.ts` still does not call it on
+`main`.
+
+The CAD routes are real mainline calls, but they are intentionally deferred to
+Wave 5 because they require a larger provider fixture surface than the
+approval/substitute expansion in Wave 4.
 
 ## Forward compatibility note
 

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -9,7 +9,7 @@
     "pactSpecification": {
       "version": "3.0.0"
     },
-    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called. Wave 2 now adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']."
+    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute."
   },
   "interactions": [
     {
@@ -1000,6 +1000,305 @@
             "$.comment": { "matchers": [{ "match": "type" }] },
             "$.approved_at": { "matchers": [{ "match": "type" }] },
             "$.created_at": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "list ECO approval requests through the ECO collection endpoint",
+      "providerStates": [
+        {
+          "name": "at least one ECO approval request exists for product 01H000000000000000000000P1"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/eco",
+        "query": {
+          "product_id": ["01H000000000000000000000P1"],
+          "created_by_id": ["1"],
+          "limit": ["25"],
+          "offset": ["0"]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": [
+          {
+            "id": "01H000000000000000000000E1",
+            "name": "History ECO",
+            "eco_type": "bom",
+            "product_id": "01H000000000000000000000P1",
+            "state": "progress",
+            "created_by_id": 1,
+            "created_at": "2026-04-11T00:00:00.000Z",
+            "updated_at": "2026-04-11T00:00:00.000Z"
+          }
+        ],
+        "matchingRules": {
+          "body": {
+            "$": { "matchers": [{ "match": "type", "min": 1 }] },
+            "$[*].id": { "matchers": [{ "match": "type" }] },
+            "$[*].name": { "matchers": [{ "match": "type" }] },
+            "$[*].eco_type": { "matchers": [{ "match": "type" }] },
+            "$[*].product_id": { "matchers": [{ "match": "type" }] },
+            "$[*].state": { "matchers": [{ "match": "type" }] },
+            "$[*].created_by_id": { "matchers": [{ "match": "integer" }] },
+            "$[*].created_at": { "matchers": [{ "match": "type" }] },
+            "$[*].updated_at": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch one ECO approval request by id through the ECO detail endpoint",
+      "providerStates": [
+        {
+          "name": "ECO 01H000000000000000000000E2 exists for approval detail lookup"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/eco/01H000000000000000000000E2",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": "01H000000000000000000000E2",
+          "name": "Approve ECO",
+          "eco_type": "bom",
+          "product_id": "01H000000000000000000000P1",
+          "state": "progress",
+          "created_by_id": 1,
+          "created_at": "2026-04-11T00:00:00.000Z",
+          "updated_at": "2026-04-11T00:00:00.000Z"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": { "matchers": [{ "match": "type" }] },
+            "$.name": { "matchers": [{ "match": "type" }] },
+            "$.eco_type": { "matchers": [{ "match": "type" }] },
+            "$.product_id": { "matchers": [{ "match": "type" }] },
+            "$.state": { "matchers": [{ "match": "type" }] },
+            "$.created_by_id": { "matchers": [{ "match": "integer" }] },
+            "$.created_at": { "matchers": [{ "match": "type" }] },
+            "$.updated_at": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "list BOM substitutes for one BOM line",
+      "providerStates": [
+        {
+          "name": "BOM line 01H000000000000000000000R1 has at least one substitute entry"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/bom/01H000000000000000000000R1/substitutes",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "bom_line_id": "01H000000000000000000000R1",
+          "count": 1,
+          "substitutes": [
+            {
+              "id": "01H000000000000000000000R5",
+              "relationship": {
+                "id": "01H000000000000000000000R5",
+                "source_id": "01H000000000000000000000R1",
+                "related_id": "01H000000000000000000000P3",
+                "properties": {
+                  "rank": 1,
+                  "note": "preferred alternate"
+                }
+              },
+              "part": {
+                "id": "01H000000000000000000000P3",
+                "item_number": "P-0003",
+                "name": "Alt Bracket Assembly"
+              },
+              "substitute_part": {
+                "id": "01H000000000000000000000P3",
+                "item_number": "P-0003",
+                "name": "Alt Bracket Assembly"
+              },
+              "rank": 1,
+              "substitute_number": "P-0003",
+              "substitute_name": "Alt Bracket Assembly"
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.bom_line_id": { "matchers": [{ "match": "type" }] },
+            "$.count": { "matchers": [{ "match": "integer", "min": 0 }] },
+            "$.substitutes": { "matchers": [{ "match": "type", "min": 0 }] },
+            "$.substitutes[*].id": { "matchers": [{ "match": "type" }] },
+            "$.substitutes[*].relationship": { "matchers": [{ "match": "type" }] },
+            "$.substitutes[*].part": { "matchers": [{ "match": "type" }] },
+            "$.substitutes[*].substitute_part": { "matchers": [{ "match": "type" }] },
+            "$.substitutes[*].rank": { "matchers": [{ "match": "integer" }] },
+            "$.substitutes[*].substitute_number": { "matchers": [{ "match": "type" }] },
+            "$.substitutes[*].substitute_name": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "add a BOM substitute with optional relationship properties",
+      "providerStates": [
+        {
+          "name": "BOM line 01H000000000000000000000R3 can accept substitute item 01H000000000000000000000P3"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/bom/01H000000000000000000000R3/substitutes",
+        "headers": {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "body": {
+          "substitute_item_id": "01H000000000000000000000P3",
+          "properties": {
+            "rank": 1,
+            "note": "new alternate"
+          }
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.substitute_item_id": { "matchers": [{ "match": "type" }] },
+            "$.properties": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "ok": true,
+          "substitute_id": "01H000000000000000000000R7",
+          "bom_line_id": "01H000000000000000000000R3",
+          "substitute_item_id": "01H000000000000000000000P3"
+        },
+        "matchingRules": {
+          "body": {
+            "$.ok": { "matchers": [{ "match": "type" }] },
+            "$.substitute_id": { "matchers": [{ "match": "type" }] },
+            "$.bom_line_id": { "matchers": [{ "match": "type" }] },
+            "$.substitute_item_id": { "matchers": [{ "match": "type" }] }
+          }
+        }
+      }
+    },
+    {
+      "description": "remove an existing BOM substitute by substitute relationship id",
+      "providerStates": [
+        {
+          "name": "BOM line 01H000000000000000000000R4 has removable substitute 01H000000000000000000000R6"
+        }
+      ],
+      "request": {
+        "method": "DELETE",
+        "path": "/api/v1/bom/01H000000000000000000000R4/substitutes/01H000000000000000000000R6",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "ok": true,
+          "substitute_id": "01H000000000000000000000R6"
+        },
+        "matchingRules": {
+          "body": {
+            "$.ok": { "matchers": [{ "match": "type" }] },
+            "$.substitute_id": { "matchers": [{ "match": "type" }] }
           }
         }
       }

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -12,7 +12,8 @@
  *   1. The pact JSON exists and parses as Pact v3.
  *   2. The 6 Wave 1 P0 interactions plus the document-semantics Wave 2
  *      interactions plus the BOM-analysis / ECO-approval Wave 3 interactions
- *      that PLMAdapter currently calls are present, in the documented order.
+ *      plus the approval list/detail / BOM-substitute Wave 4 interactions that
+ *      PLMAdapter currently calls are present, in the documented order.
  *      (codex's plan also lists `aml/metadata`, but PLMAdapter does not yet
  *      call it; deferred until there is a real consumer call site.)
  *   3. The PLMAdapter actually calls every endpoint declared in the pact, so
@@ -95,6 +96,11 @@ const PACT_PATHS = [
   { method: 'GET', path: '/api/v1/eco/01H000000000000000000000E1/approvals' },
   { method: 'POST', path: '/api/v1/eco/01H000000000000000000000E2/approve' },
   { method: 'POST', path: '/api/v1/eco/01H000000000000000000000E3/reject' },
+  { method: 'GET', path: '/api/v1/eco' },
+  { method: 'GET', path: '/api/v1/eco/01H000000000000000000000E2' },
+  { method: 'GET', path: '/api/v1/bom/01H000000000000000000000R1/substitutes' },
+  { method: 'POST', path: '/api/v1/bom/01H000000000000000000000R3/substitutes' },
+  { method: 'DELETE', path: '/api/v1/bom/01H000000000000000000000R4/substitutes/01H000000000000000000000R6' },
 ] as const
 
 function loadPact(): PactDocument {
@@ -106,7 +112,7 @@ function loadAdapter(): string {
   return readFileSync(ADAPTER_PATH, 'utf8')
 }
 
-describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 document semantics + Wave 3 BOM/approval)', () => {
+describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 document semantics + Wave 3 BOM/approval + Wave 4 approval list/detail/substitutes)', () => {
   it('pact JSON exists, parses as Pact v3, and names the right consumer/provider', () => {
     const pact = loadPact()
     expect(pact.consumer.name).toBe('Metasheet2')
@@ -149,9 +155,13 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       '/api/v1/bom/compare/schema',
       '/api/v1/file/item/',
       '/api/v1/aml/query',
+      '/api/v1/eco',
+      '/api/v1/eco/${approvalId}',
       '/api/v1/eco/${approvalId}/approvals',
       '/api/v1/eco/${approvalId}/approve',
       '/api/v1/eco/${approvalId}/reject',
+      '/api/v1/bom/${bomLineId}/substitutes',
+      '/api/v1/bom/${bomLineId}/substitutes/${substituteId}',
       'fetchYuantusFileMetadata',
     ]
     for (const ep of endpointsToFind) {
@@ -267,6 +277,65 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(reject!.request.body).toEqual({
       version: 8,
       comment: 'Missing test evidence',
+    })
+  })
+
+  it('approval list/detail and BOM substitute interactions lock the extra mainline surfaces used by bridge + federation', () => {
+    const pact = loadPact()
+    const approvalsList = pact.interactions.find(
+      i => i.request.path === '/api/v1/eco',
+    )
+    const approvalDetail = pact.interactions.find(
+      i => i.request.path === '/api/v1/eco/01H000000000000000000000E2',
+    )
+    const substitutesList = pact.interactions.find(
+      i => i.request.path === '/api/v1/bom/01H000000000000000000000R1/substitutes'
+        && i.request.method === 'GET',
+    )
+    const substitutesAdd = pact.interactions.find(
+      i => i.request.path === '/api/v1/bom/01H000000000000000000000R3/substitutes'
+        && i.request.method === 'POST',
+    )
+    const substitutesRemove = pact.interactions.find(
+      i => i.request.path === '/api/v1/bom/01H000000000000000000000R4/substitutes/01H000000000000000000000R6',
+    )
+
+    expect(approvalsList).toBeDefined()
+    expect(approvalDetail).toBeDefined()
+    expect(substitutesList).toBeDefined()
+    expect(substitutesAdd).toBeDefined()
+    expect(substitutesRemove).toBeDefined()
+
+    expect(approvalsList!.request.query).toEqual({
+      product_id: ['01H000000000000000000000P1'],
+      created_by_id: ['1'],
+      limit: ['25'],
+      offset: ['0'],
+    })
+    expect((approvalsList!.response.body as Array<Record<string, unknown>>)[0]).toMatchObject({
+      id: '01H000000000000000000000E1',
+      eco_type: 'bom',
+      product_id: '01H000000000000000000000P1',
+    })
+    expect(approvalDetail!.response.body).toMatchObject({
+      id: '01H000000000000000000000E2',
+      name: 'Approve ECO',
+    })
+    expect(substitutesList!.response.body).toMatchObject({
+      bom_line_id: '01H000000000000000000000R1',
+      count: 1,
+      substitutes: [expect.objectContaining({ id: '01H000000000000000000000R5' })],
+    })
+    expect(substitutesAdd!.request.body).toEqual({
+      substitute_item_id: '01H000000000000000000000P3',
+      properties: {
+        rank: 1,
+        note: 'new alternate',
+      },
+    })
+    expect(substitutesRemove!.response.body).toEqual({
+      ok: true,
+      substitute_id: '01H000000000000000000000R6',
     })
   })
 })

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -251,7 +251,7 @@ describe('PLMAdapter Yuantus documents mapping', () => {
 })
 
 describe('PLMAdapter Yuantus approvals mapping', () => {
-  it('maps ECO approvals and filters by status', async () => {
+  it('maps ECO approvals, forwards collection filters, and filters by status', async () => {
     const adapter = createAdapter()
     const queryMock = vi.fn().mockResolvedValue({
       data: [
@@ -260,19 +260,98 @@ describe('PLMAdapter Yuantus approvals mapping', () => {
         { id: 'eco-3', name: 'ECO Three', state: 'in_review', version: '3', created_by_id: '9', created_at: '2026-01-03T00:00:00.000Z' },
       ],
     })
+    const getProductByIdSpy = vi.spyOn(adapter, 'getProductById').mockResolvedValue({
+      id: 'prod-1',
+      name: 'Mapped Product',
+      code: 'P-0001',
+      partNumber: 'P-0001',
+      version: 'A',
+      status: 'Released',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+    })
 
     ;(adapter as any).query = queryMock
 
-    const approved = await adapter.getApprovals({ status: 'approved' })
+    const approved = await adapter.getApprovals({
+      status: 'approved',
+      productId: 'prod-1',
+      requesterId: '7',
+      limit: 25,
+      offset: 25,
+    })
+
+    expect(queryMock).toHaveBeenNthCalledWith(1, '/api/v1/eco', [
+      {
+        product_id: 'prod-1',
+        created_by_id: '7',
+        limit: 25,
+        offset: 25,
+      },
+    ])
+    expect(getProductByIdSpy).toHaveBeenCalledWith('prod-1')
     expect(approved.data).toHaveLength(1)
     expect(approved.data[0].status).toBe('approved')
     expect(approved.data[0].requester_id).toBe('7')
     expect(approved.data[0].version).toBe(12)
+    expect(approved.data[0].product_number).toBe('P-0001')
 
     const all = await adapter.getApprovals()
+    expect(queryMock).toHaveBeenNthCalledWith(2, '/api/v1/eco', [{}])
     expect(all.data).toHaveLength(3)
     expect(all.data.map((entry) => entry.status)).toEqual(['approved', 'rejected', 'pending'])
     expect(all.data.map((entry) => entry.version)).toEqual([12, undefined, 3])
+  })
+
+  it('loads one ECO approval request by id from the ECO detail endpoint', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'eco-2',
+          name: 'Approve ECO',
+          eco_type: 'bom',
+          state: 'progress',
+          version: 7,
+          created_by_id: 8,
+          created_by_name: 'Requester Eight',
+          created_at: '2026-04-11T00:00:00.000Z',
+          product_id: 'prod-1',
+        },
+      ],
+    })
+
+    const getProductByIdSpy = vi.spyOn(adapter, 'getProductById').mockResolvedValue({
+      id: 'prod-1',
+      name: 'Mounting Bracket',
+      code: 'P-0001',
+      partNumber: 'P-0001',
+      version: 'A',
+      status: 'Released',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getApprovalById('eco-2')
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/eco/eco-2')
+    expect(getProductByIdSpy).toHaveBeenCalledWith('prod-1')
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        id: 'eco-2',
+        request_type: 'bom',
+        title: 'Approve ECO',
+        requester_id: '8',
+        requester_name: 'Requester Eight',
+        status: 'pending',
+        version: 7,
+        product_id: 'prod-1',
+        product_number: 'P-0001',
+        product_name: 'Mounting Bracket',
+      }),
+    ])
   })
 })
 
@@ -437,6 +516,95 @@ describe('PLMAdapter Yuantus BOM analysis and approval actions', () => {
       compare_modes: [expect.objectContaining({ mode: 'summarized' })],
       line_key_options: ['child_config', 'child_id'],
       defaults: expect.objectContaining({ max_levels: 10 }),
+    })
+  })
+
+  it('lists BOM substitutes from the dedicated BOM substitutes endpoint', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [{
+        bom_line_id: 'bom-line-1',
+        count: 1,
+        substitutes: [{
+          id: 'sub-rel-1',
+          relationship: {
+            id: 'sub-rel-1',
+            source_id: 'bom-line-1',
+            related_id: 'part-sub-1',
+            properties: { rank: 1, note: 'Preferred alternate' },
+          },
+          part: {
+            id: 'part-sub-1',
+            item_number: 'P-0003',
+            name: 'Nut M6',
+          },
+          substitute_part: {
+            id: 'part-sub-1',
+            item_number: 'P-0003',
+            name: 'Nut M6',
+          },
+          rank: 1,
+          substitute_number: 'P-0003',
+          substitute_name: 'Nut M6',
+        }],
+      }],
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getBomSubstitutes('bom-line-1')
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/bom/bom-line-1/substitutes')
+    expect(result.data[0]).toMatchObject({
+      bom_line_id: 'bom-line-1',
+      count: 1,
+      substitutes: [expect.objectContaining({ id: 'sub-rel-1', rank: 1 })],
+    })
+  })
+
+  it('posts add/remove substitute mutations to the BOM substitutes endpoints', async () => {
+    const adapter = createAdapter()
+    const insertMock = vi.fn().mockResolvedValue({
+      data: [{
+        ok: true,
+        substitute_id: 'sub-rel-new',
+        bom_line_id: 'bom-line-1',
+        substitute_item_id: 'part-sub-2',
+      }],
+    })
+    const deleteMock = vi.fn().mockResolvedValue({
+      data: [{
+        ok: true,
+        substitute_id: 'sub-rel-remove',
+      }],
+    })
+
+    ;(adapter as any).insert = insertMock
+    ;(adapter as any).delete = deleteMock
+
+    const added = await adapter.addBomSubstitute('bom-line-1', 'part-sub-2', {
+      rank: 2,
+      note: 'Field alternate',
+    })
+    const removed = await adapter.removeBomSubstitute('bom-line-1', 'sub-rel-remove')
+
+    expect(insertMock).toHaveBeenCalledWith('/api/v1/bom/bom-line-1/substitutes', {
+      substitute_item_id: 'part-sub-2',
+      properties: {
+        rank: 2,
+        note: 'Field alternate',
+      },
+    })
+    expect(deleteMock).toHaveBeenCalledWith('/api/v1/bom/bom-line-1/substitutes/sub-rel-remove', {})
+    expect(added.data[0]).toMatchObject({
+      ok: true,
+      substitute_id: 'sub-rel-new',
+      bom_line_id: 'bom-line-1',
+      substitute_item_id: 'part-sub-2',
+    })
+    expect(removed.data[0]).toEqual({
+      ok: true,
+      substitute_id: 'sub-rel-remove',
     })
   })
 })


### PR DESCRIPTION
## Summary
- extend the canonical Metasheet2 -> Yuantus pact from 14 to 19 interactions
- add Wave 4 coverage for ECO list/detail and BOM substitute list/add/remove
- document the Wave 4 scope and keep CAD APIs deferred to Wave 5 because they need a larger fixture surface

## Verification
- `npx vitest run tests/contract/plm-adapter-yuantus.pact.test.ts tests/unit/plm-adapter-yuantus.test.ts`

## Notes
- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json` remains the single source of truth
- the synchronized Yuantus provider copy is updated in the paired provider PR
