### PR TITLE
test(contract): add Wave 5 Yuantus CAD pact

### DIFF
--- a/docs/development/plm-yuantus-wave5-cad-pact-20260411.md
+++ b/docs/development/plm-yuantus-wave5-cad-pact-20260411.md
@@ -1,0 +1,36 @@
+# PLM Yuantus Wave 5 CAD Pact
+
+Date: 2026-04-11
+
+Wave 5 extends the Metasheet2 consumer pact for Yuantus PLM with the nine CAD
+endpoints already called on `main`. The canonical artifact stays in:
+
+- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json`
+
+The pact keeps Metasheet2 as the sole source of truth and uses the exact CAD
+fixtures expected by the current adapter and frontend wiring:
+
+- `F2` properties GET: `material=AL-6061`, `finish=anodized`, `source=imported`, schema `3`
+- `F3` properties PATCH: request sets `material=AL-7075`, `finish=hard-anodized`, `source=manual`; response mirrors it at schema `4`
+- `F4` view-state GET: `hidden_entity_ids=[12,19]`, note `check hole position`, `source=client`, schema `3`
+- `F5` view-state PATCH: request/response `hidden_entity_ids=[12,19]`, note `hide fastener`, `source=client`, `refresh_preview=false`, schema `3`
+- `F6` review GET: `state=pending`, `note=Awaiting review`, `reviewed_by_id=1`
+- `F7` review POST: request `{ state: approved, note: Looks good }`, response mirrors it with `reviewed_by_id=1`
+- `F8` history GET: entries include `cad_properties_update` and `cad_review_update`
+- `F9` diff GET vs `F10`: `added.finish=anodized`, `removed.coating=none`, `changed.weight_kg.from=1.1`, `changed.weight_kg.to=1.2`, schema version `1 -> 2`
+- `F11` mesh-stats GET: `available=true`, `entity_count=2`, `triangle_count=102400`, plus bounds
+
+Provider-state names are kept deterministic so the Yuantus verifier can seed
+fixture-only responses without mutating shared state between interactions.
+
+Verification:
+
+```bash
+cd /tmp/metasheet2-wave5-DTTxfs/packages/core-backend
+npx vitest run tests/contract/plm-adapter-yuantus.pact.test.ts \
+  tests/unit/plm-adapter-yuantus.test.ts
+```
+
+The consumer-side contract test checks the full 28-interaction order, while the
+unit test asserts the CAD request/response examples used by the adapter-facing
+surface.

--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -21,8 +21,9 @@ rename on the Yuantus side would silently break Metasheet at runtime.
 
 This Pact set freezes the **shape** (not the values) of the 6 Wave 1 P0
 endpoints plus the 3 document-semantics endpoints, the 5 BOM-analysis /
-ECO-approval endpoints, and the 5 approval-detail / BOM-substitute endpoints
-that `PLMAdapter.ts` currently calls for `apiMode='yuantus'`.
+ECO-approval endpoints, and the 5 approval-detail / BOM-substitute endpoints,
+while Wave 5 adds the 9 CAD properties / review / diff endpoints as exact
+fixture examples that `PLMAdapter.ts` currently calls for `apiMode='yuantus'`.
 (Codex's PACT_FIRST plan lists 7 endpoints in Wave 1 — see "Discrepancy
 with codex plan" below.)
 
@@ -35,10 +36,10 @@ The pact JSON in `pacts/metasheet2-yuantus-plm.json` is **hand-authored** in
 Pact v3 format. It is **not** yet generated from `@pact-foundation/pact`,
 because adding that npm dependency requires explicit approval.
 
-The `plm-adapter-yuantus.pact.test.ts` vitest test guards four things:
+The `plm-adapter-yuantus.pact.test.ts` vitest test guards six things:
 
 1. The pact JSON exists and parses as Pact v3.
-2. It contains the 19 currently used interactions in the documented order.
+2. It contains the 28 currently used interactions in the documented order.
 3. Every endpoint named in the pact is also referenced by the live
    `packages/core-backend/src/data-adapters/PLMAdapter.ts` source — so the
    pact cannot drift away from what the adapter actually calls.
@@ -46,6 +47,8 @@ The `plm-adapter-yuantus.pact.test.ts` vitest test guards four things:
    `bom compare schema`, `approval history`, `approve`, and `reject`.
 5. The Wave 4 additions lock the exact envelope for approval list/detail and
    BOM substitute list/add/remove.
+6. The Wave 5 additions lock the exact envelope for CAD properties, CAD view
+   state, CAD review, CAD history, CAD diff, and CAD mesh stats.
 
 ## Discrepancy with codex's PACT_FIRST plan
 
@@ -100,7 +103,7 @@ cd /Users/huazhou/Downloads/Github/Yuantus
 
 ### Current verifier handoff state (2026-04-11)
 
-The consumer artifact now contains all 19 Wave 1-4 interactions. To verify
+The consumer artifact now contains all 28 Wave 1-5 interactions. To verify
 Yuantus against the current artifact, copy this JSON into the Yuantus repo and
 rerun the provider verifier there.
 
@@ -128,6 +131,19 @@ Wave 4 extends that pattern:
 
 That keeps the verifier deterministic without introducing per-state mutation
 logic.
+
+Wave 5 applies the same rule to CAD:
+
+- read and write CAD properties use separate file fixtures
+- read and write CAD view state use separate file fixtures
+- read and write CAD review use separate file fixtures
+- history uses a dedicated file with pre-seeded `CadChangeLog` rows
+- diff uses a dedicated left/right file pair
+- mesh stats uses a dedicated file plus a mocked metadata payload behind
+  `FileService.download_file`
+
+That keeps the provider-state handler as a no-op even though Wave 5 includes
+three mutating CAD interactions.
 
 To install `pact-python` and run locally:
 
@@ -160,22 +176,9 @@ specification of what the generated pact must contain.
 The following surfaces remain outside the pact:
 
 - `GET /api/v1/aml/metadata/{item_type_name}`
-- `GET /api/v1/cad/files/{file_id}/properties`
-- `PATCH /api/v1/cad/files/{file_id}/properties`
-- `GET /api/v1/cad/files/{file_id}/view-state`
-- `PATCH /api/v1/cad/files/{file_id}/view-state`
-- `GET /api/v1/cad/files/{file_id}/review`
-- `POST /api/v1/cad/files/{file_id}/review`
-- `GET /api/v1/cad/files/{file_id}/history`
-- `GET /api/v1/cad/files/{file_id}/diff`
-- `GET /api/v1/cad/files/{file_id}/mesh-stats`
 
 `aml/metadata` remains outside because `PLMAdapter.ts` still does not call it on
 `main`.
-
-The CAD routes are real mainline calls, but they are intentionally deferred to
-Wave 5 because they require a larger provider fixture surface than the
-approval/substitute expansion in Wave 4.
 
 ## Forward compatibility note
 

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -9,7 +9,7 @@
     "pactSpecification": {
       "version": "3.0.0"
     },
-    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute."
+    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute. Wave 5 adds the nine CAD endpoints already called on main: CAD properties, CAD view state, CAD review, CAD history, CAD diff, and CAD mesh stats."
   },
   "interactions": [
     {
@@ -32,9 +32,27 @@
         },
         "matchingRules": {
           "body": {
-            "$.tenant_id": { "matchers": [{ "match": "type" }] },
-            "$.username": { "matchers": [{ "match": "type" }] },
-            "$.password": { "matchers": [{ "match": "type" }] }
+            "$.tenant_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.username": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.password": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       },
@@ -52,11 +70,41 @@
         },
         "matchingRules": {
           "body": {
-            "$.access_token": { "matchers": [{ "match": "type" }] },
-            "$.token_type": { "matchers": [{ "match": "type" }] },
-            "$.expires_in": { "matchers": [{ "match": "integer" }] },
-            "$.tenant_id": { "matchers": [{ "match": "type" }] },
-            "$.user_id": { "matchers": [{ "match": "integer" }] }
+            "$.access_token": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.token_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.expires_in": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.tenant_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.user_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            }
           }
         }
       }
@@ -89,12 +137,48 @@
         },
         "matchingRules": {
           "body": {
-            "$.ok": { "matchers": [{ "match": "type" }] },
-            "$.service": { "matchers": [{ "match": "type" }] },
-            "$.version": { "matchers": [{ "match": "type" }] },
-            "$.tenancy_mode": { "matchers": [{ "match": "type" }] },
-            "$.schema_mode": { "matchers": [{ "match": "type" }] },
-            "$.audit_enabled": { "matchers": [{ "match": "type" }] }
+            "$.ok": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.service": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.tenancy_mode": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.schema_mode": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.audit_enabled": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -110,9 +194,15 @@
         "method": "GET",
         "path": "/api/v1/search/",
         "query": {
-          "q": ["bracket"],
-          "item_type": ["Part"],
-          "limit": ["20"]
+          "q": [
+            "bracket"
+          ],
+          "item_type": [
+            "Part"
+          ],
+          "limit": [
+            "20"
+          ]
         },
         "headers": {
           "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
@@ -120,7 +210,12 @@
         "matchingRules": {
           "header": {
             "$.Authorization": {
-              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
             }
           }
         }
@@ -150,19 +245,98 @@
         },
         "matchingRules": {
           "body": {
-            "$.total": { "matchers": [{ "match": "integer" }] },
-            "$.hits": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.hits[*].id": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].item_type_id": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].config_id": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].state": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].item_number": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].name": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].description": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].search_text": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].created_at": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].updated_at": { "matchers": [{ "match": "type" }] },
-            "$.hits[*].properties": { "matchers": [{ "match": "type" }] }
+            "$.total": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.hits": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.hits[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].item_type_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].config_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].item_number": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].description": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].search_text": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].updated_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.hits[*].properties": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -189,13 +363,37 @@
         "matchingRules": {
           "header": {
             "$.Authorization": {
-              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
             }
           },
           "body": {
-            "$.type": { "matchers": [{ "match": "type" }] },
-            "$.action": { "matchers": [{ "match": "regex", "regex": "^(get|add|update|delete)$" }] },
-            "$.id": { "matchers": [{ "match": "type" }] }
+            "$.type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.action": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^(get|add|update|delete)$"
+                }
+              ]
+            },
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       },
@@ -220,12 +418,50 @@
         },
         "matchingRules": {
           "body": {
-            "$.count": { "matchers": [{ "match": "integer", "min": 0 }] },
-            "$.items": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.items[*].id": { "matchers": [{ "match": "type" }] },
-            "$.items[*].type": { "matchers": [{ "match": "type" }] },
-            "$.items[*].state": { "matchers": [{ "match": "type" }] },
-            "$.items[*].properties": { "matchers": [{ "match": "type" }] }
+            "$.count": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.items": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.items[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*].type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*].state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*].properties": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -246,7 +482,12 @@
         "matchingRules": {
           "header": {
             "$.Authorization": {
-              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
             }
           }
         }
@@ -291,29 +532,168 @@
         },
         "matchingRules": {
           "body": {
-            "$.id": { "matchers": [{ "match": "type" }] },
-            "$.item_number": { "matchers": [{ "match": "type" }] },
-            "$.name": { "matchers": [{ "match": "type" }] },
-            "$.state": { "matchers": [{ "match": "type" }] },
-            "$.created_on": { "matchers": [{ "match": "type" }] },
-            "$.modified_on": { "matchers": [{ "match": "type" }] },
-            "$.children": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.children[*].child.id": { "matchers": [{ "match": "type" }] },
-            "$.children[*].child.item_number": { "matchers": [{ "match": "type" }] },
-            "$.children[*].child.name": { "matchers": [{ "match": "type" }] },
-            "$.children[*].child.state": { "matchers": [{ "match": "type" }] },
-            "$.children[*].child.created_on": { "matchers": [{ "match": "type" }] },
-            "$.children[*].child.modified_on": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.id": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.source_id": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.related_id": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.quantity": { "matchers": [{ "match": "number" }] },
-            "$.children[*].relationship.uom": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.find_num": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.refdes": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.created_on": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.modified_on": { "matchers": [{ "match": "type" }] },
-            "$.children[*].relationship.properties": { "matchers": [{ "match": "type" }] }
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.item_number": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.created_on": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.modified_on": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.children[*].child.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].child.item_number": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].child.name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].child.state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].child.created_on": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].child.modified_on": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.source_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.related_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.quantity": {
+              "matchers": [
+                {
+                  "match": "number"
+                }
+              ]
+            },
+            "$.children[*].relationship.uom": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.find_num": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.refdes": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.created_on": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.modified_on": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.children[*].relationship.properties": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -329,10 +709,18 @@
         "method": "GET",
         "path": "/api/v1/bom/compare",
         "query": {
-          "left_type": ["item"],
-          "left_id": ["01H000000000000000000000P1"],
-          "right_type": ["item"],
-          "right_id": ["01H000000000000000000000P2"]
+          "left_type": [
+            "item"
+          ],
+          "left_id": [
+            "01H000000000000000000000P1"
+          ],
+          "right_type": [
+            "item"
+          ],
+          "right_id": [
+            "01H000000000000000000000P2"
+          ]
         },
         "headers": {
           "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
@@ -340,7 +728,12 @@
         "matchingRules": {
           "header": {
             "$.Authorization": {
-              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
             }
           }
         }
@@ -362,12 +755,54 @@
         },
         "matchingRules": {
           "body": {
-            "$.summary.added": { "matchers": [{ "match": "integer", "min": 0 }] },
-            "$.summary.removed": { "matchers": [{ "match": "integer", "min": 0 }] },
-            "$.summary.changed": { "matchers": [{ "match": "integer", "min": 0 }] },
-            "$.added": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.removed": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.changed": { "matchers": [{ "match": "type", "min": 0 }] }
+            "$.summary.added": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.summary.removed": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.summary.changed": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.added": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.removed": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.changed": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            }
           }
         }
       }
@@ -388,7 +823,12 @@
         "matchingRules": {
           "header": {
             "$.Authorization": {
-              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
             }
           }
         }
@@ -418,21 +858,112 @@
         ],
         "matchingRules": {
           "body": {
-            "$": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$[*].id": { "matchers": [{ "match": "type" }] },
-            "$[*].file_id": { "matchers": [{ "match": "type" }] },
-            "$[*].filename": { "matchers": [{ "match": "type" }] },
-            "$[*].file_role": { "matchers": [{ "match": "type" }] },
-            "$[*].description": { "matchers": [{ "match": "type" }] },
-            "$[*].file_type": { "matchers": [{ "match": "type" }] },
-            "$[*].file_size": { "matchers": [{ "match": "integer" }] },
-            "$[*].document_type": { "matchers": [{ "match": "type" }] },
-            "$[*].author": { "matchers": [{ "match": "type" }] },
-            "$[*].source_system": { "matchers": [{ "match": "type" }] },
-            "$[*].source_version": { "matchers": [{ "match": "type" }] },
-            "$[*].document_version": { "matchers": [{ "match": "type" }] },
-            "$[*].preview_url": { "matchers": [{ "match": "type" }] },
-            "$[*].download_url": { "matchers": [{ "match": "type" }] }
+            "$": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].file_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].filename": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].file_role": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].description": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].file_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].file_size": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$[*].document_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].author": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].source_system": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].source_version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].document_version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].preview_url": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].download_url": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -453,7 +984,12 @@
         "matchingRules": {
           "header": {
             "$.Authorization": {
-              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
             }
           }
         }
@@ -495,22 +1031,118 @@
         },
         "matchingRules": {
           "body": {
-            "$.id": { "matchers": [{ "match": "type" }] },
-            "$.filename": { "matchers": [{ "match": "type" }] },
-            "$.file_type": { "matchers": [{ "match": "type" }] },
-            "$.mime_type": { "matchers": [{ "match": "type" }] },
-            "$.file_size": { "matchers": [{ "match": "integer" }] },
-            "$.checksum": { "matchers": [{ "match": "type" }] },
-            "$.document_type": { "matchers": [{ "match": "type" }] },
-            "$.is_native_cad": { "matchers": [{ "match": "type" }] },
-            "$.author": { "matchers": [{ "match": "type" }] },
-            "$.source_system": { "matchers": [{ "match": "type" }] },
-            "$.source_version": { "matchers": [{ "match": "type" }] },
-            "$.document_version": { "matchers": [{ "match": "type" }] },
-            "$.preview_url": { "matchers": [{ "match": "type" }] },
-            "$.conversion_status": { "matchers": [{ "match": "type" }] },
-            "$.viewer_readiness": { "matchers": [{ "match": "type" }] },
-            "$.created_at": { "matchers": [{ "match": "type" }] }
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.filename": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.file_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.mime_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.file_size": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.checksum": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.document_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.is_native_cad": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.author": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.source_system": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.source_version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.document_version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.preview_url": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.conversion_status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.viewer_readiness": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -534,8 +1166,17 @@
           "where": {
             "id": "01H000000000000000000000P1"
           },
-          "select": ["id", "name", "state", "properties", "current_version_id", "config_id"],
-          "expand": ["Document Part"],
+          "select": [
+            "id",
+            "name",
+            "state",
+            "properties",
+            "current_version_id",
+            "config_id"
+          ],
+          "expand": [
+            "Document Part"
+          ],
           "depth": 1,
           "page": 1,
           "page_size": 1
@@ -543,17 +1184,66 @@
         "matchingRules": {
           "header": {
             "$.Authorization": {
-              "matchers": [{ "match": "regex", "regex": "^Bearer .+" }]
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
             }
           },
           "body": {
-            "$.type": { "matchers": [{ "match": "type" }] },
-            "$.where.id": { "matchers": [{ "match": "type" }] },
-            "$.select": { "matchers": [{ "match": "type", "min": 1 }] },
-            "$.expand": { "matchers": [{ "match": "type", "min": 1 }] },
-            "$.depth": { "matchers": [{ "match": "integer" }] },
-            "$.page": { "matchers": [{ "match": "integer" }] },
-            "$.page_size": { "matchers": [{ "match": "integer" }] }
+            "$.type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.where.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.select": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.expand": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.depth": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.page": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.page_size": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            }
           }
         }
       },
@@ -606,28 +1296,165 @@
         },
         "matchingRules": {
           "body": {
-            "$.items": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.items[*].id": { "matchers": [{ "match": "type" }] },
-            "$.items[*].type": { "matchers": [{ "match": "type" }] },
-            "$.items[*].name": { "matchers": [{ "match": "type" }] },
-            "$.items[*].state": { "matchers": [{ "match": "type" }] },
-            "$.items[*].config_id": { "matchers": [{ "match": "type" }] },
-            "$.items[*].properties": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part']": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.items[*]['Document Part'][*].id": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part'][*].type": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part'][*].number": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part'][*].name": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part'][*].generation": { "matchers": [{ "match": "integer" }] },
-            "$.items[*]['Document Part'][*].state": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part'][*].config_id": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part'][*].is_current": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part'][*].properties": { "matchers": [{ "match": "type" }] },
-            "$.items[*]['Document Part'][*]._rel_properties": { "matchers": [{ "match": "type" }] },
-            "$.total": { "matchers": [{ "match": "integer", "min": 0 }] },
-            "$.page": { "matchers": [{ "match": "integer", "min": 1 }] },
-            "$.page_size": { "matchers": [{ "match": "integer", "min": 1 }] },
-            "$.has_more": { "matchers": [{ "match": "type" }] }
+            "$.items": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.items[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*].type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*].name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*].state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*].config_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*].properties": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part']": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].number": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].generation": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].config_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].is_current": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*].properties": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.items[*]['Document Part'][*]._rel_properties": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.total": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.page": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 1
+                }
+              ]
+            },
+            "$.page_size": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 1
+                }
+              ]
+            },
+            "$.has_more": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -690,14 +1517,66 @@
         },
         "matchingRules": {
           "body": {
-            "$.item_id": { "matchers": [{ "match": "type" }] },
-            "$.count": { "matchers": [{ "match": "integer", "min": 0 }] },
-            "$.parents": { "matchers": [{ "match": "type", "min": 1 }] },
-            "$.parents[*].relationship": { "matchers": [{ "match": "type" }] },
-            "$.parents[*].parent": { "matchers": [{ "match": "type" }] },
-            "$.parents[*].level": { "matchers": [{ "match": "integer", "min": 1 }] },
-            "$.recursive": { "matchers": [{ "match": "type" }] },
-            "$.max_levels": { "matchers": [{ "match": "integer", "min": 1 }] }
+            "$.item_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.count": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.parents": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.parents[*].relationship": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.parents[*].parent": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.parents[*].level": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 1
+                }
+              ]
+            },
+            "$.recursive": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.max_levels": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 1
+                }
+              ]
+            }
           }
         }
       }
@@ -770,20 +1649,109 @@
         },
         "matchingRules": {
           "body": {
-            "$.line_fields": { "matchers": [{ "match": "type", "min": 1 }] },
-            "$.line_fields[*].field": { "matchers": [{ "match": "type" }] },
-            "$.line_fields[*].severity": { "matchers": [{ "match": "type" }] },
-            "$.line_fields[*].normalized": { "matchers": [{ "match": "type" }] },
-            "$.line_fields[*].description": { "matchers": [{ "match": "type" }] },
-            "$.compare_modes": { "matchers": [{ "match": "type", "min": 1 }] },
-            "$.compare_modes[*].mode": { "matchers": [{ "match": "type" }] },
-            "$.compare_modes[*].line_key": { "matchers": [{ "match": "type" }] },
-            "$.compare_modes[*].include_relationship_props": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.compare_modes[*].aggregate_quantities": { "matchers": [{ "match": "type" }] },
-            "$.compare_modes[*].aliases": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.compare_modes[*].description": { "matchers": [{ "match": "type" }] },
-            "$.line_key_options": { "matchers": [{ "match": "type", "min": 1 }] },
-            "$.defaults": { "matchers": [{ "match": "type" }] }
+            "$.line_fields": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.line_fields[*].field": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.line_fields[*].severity": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.line_fields[*].normalized": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.line_fields[*].description": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.compare_modes": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.compare_modes[*].mode": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.compare_modes[*].line_key": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.compare_modes[*].include_relationship_props": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.compare_modes[*].aggregate_quantities": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.compare_modes[*].aliases": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.compare_modes[*].description": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.line_key_options": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.defaults": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -834,16 +1802,77 @@
         ],
         "matchingRules": {
           "body": {
-            "$": { "matchers": [{ "match": "type", "min": 1 }] },
-            "$[*].id": { "matchers": [{ "match": "type" }] },
-            "$[*].eco_id": { "matchers": [{ "match": "type" }] },
-            "$[*].stage_id": { "matchers": [{ "match": "type" }] },
-            "$[*].approval_type": { "matchers": [{ "match": "type" }] },
-            "$[*].required_role": { "matchers": [{ "match": "type" }] },
-            "$[*].user_id": { "matchers": [{ "match": "integer" }] },
-            "$[*].status": { "matchers": [{ "match": "type" }] },
-            "$[*].comment": { "matchers": [{ "match": "type" }] },
-            "$[*].created_at": { "matchers": [{ "match": "type" }] }
+            "$": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].eco_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].stage_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].approval_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].required_role": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].user_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$[*].status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].comment": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -913,15 +1942,69 @@
         },
         "matchingRules": {
           "body": {
-            "$.id": { "matchers": [{ "match": "type" }] },
-            "$.eco_id": { "matchers": [{ "match": "type" }] },
-            "$.stage_id": { "matchers": [{ "match": "type" }] },
-            "$.approval_type": { "matchers": [{ "match": "type" }] },
-            "$.user_id": { "matchers": [{ "match": "integer" }] },
-            "$.status": { "matchers": [{ "match": "type" }] },
-            "$.comment": { "matchers": [{ "match": "type" }] },
-            "$.approved_at": { "matchers": [{ "match": "type" }] },
-            "$.created_at": { "matchers": [{ "match": "type" }] }
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.eco_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.stage_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.approval_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.user_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.comment": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.approved_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -991,15 +2074,69 @@
         },
         "matchingRules": {
           "body": {
-            "$.id": { "matchers": [{ "match": "type" }] },
-            "$.eco_id": { "matchers": [{ "match": "type" }] },
-            "$.stage_id": { "matchers": [{ "match": "type" }] },
-            "$.approval_type": { "matchers": [{ "match": "type" }] },
-            "$.user_id": { "matchers": [{ "match": "integer" }] },
-            "$.status": { "matchers": [{ "match": "type" }] },
-            "$.comment": { "matchers": [{ "match": "type" }] },
-            "$.approved_at": { "matchers": [{ "match": "type" }] },
-            "$.created_at": { "matchers": [{ "match": "type" }] }
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.eco_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.stage_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.approval_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.user_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.comment": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.approved_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -1015,10 +2152,18 @@
         "method": "GET",
         "path": "/api/v1/eco",
         "query": {
-          "product_id": ["01H000000000000000000000P1"],
-          "created_by_id": ["1"],
-          "limit": ["25"],
-          "offset": ["0"]
+          "product_id": [
+            "01H000000000000000000000P1"
+          ],
+          "created_by_id": [
+            "1"
+          ],
+          "limit": [
+            "25"
+          ],
+          "offset": [
+            "0"
+          ]
         },
         "headers": {
           "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
@@ -1055,15 +2200,70 @@
         ],
         "matchingRules": {
           "body": {
-            "$": { "matchers": [{ "match": "type", "min": 1 }] },
-            "$[*].id": { "matchers": [{ "match": "type" }] },
-            "$[*].name": { "matchers": [{ "match": "type" }] },
-            "$[*].eco_type": { "matchers": [{ "match": "type" }] },
-            "$[*].product_id": { "matchers": [{ "match": "type" }] },
-            "$[*].state": { "matchers": [{ "match": "type" }] },
-            "$[*].created_by_id": { "matchers": [{ "match": "integer" }] },
-            "$[*].created_at": { "matchers": [{ "match": "type" }] },
-            "$[*].updated_at": { "matchers": [{ "match": "type" }] }
+            "$": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].eco_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].product_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].created_by_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$[*].created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].updated_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -1111,14 +2311,62 @@
         },
         "matchingRules": {
           "body": {
-            "$.id": { "matchers": [{ "match": "type" }] },
-            "$.name": { "matchers": [{ "match": "type" }] },
-            "$.eco_type": { "matchers": [{ "match": "type" }] },
-            "$.product_id": { "matchers": [{ "match": "type" }] },
-            "$.state": { "matchers": [{ "match": "type" }] },
-            "$.created_by_id": { "matchers": [{ "match": "integer" }] },
-            "$.created_at": { "matchers": [{ "match": "type" }] },
-            "$.updated_at": { "matchers": [{ "match": "type" }] }
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.eco_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.product_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.created_by_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.updated_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -1187,16 +2435,78 @@
         },
         "matchingRules": {
           "body": {
-            "$.bom_line_id": { "matchers": [{ "match": "type" }] },
-            "$.count": { "matchers": [{ "match": "integer", "min": 0 }] },
-            "$.substitutes": { "matchers": [{ "match": "type", "min": 0 }] },
-            "$.substitutes[*].id": { "matchers": [{ "match": "type" }] },
-            "$.substitutes[*].relationship": { "matchers": [{ "match": "type" }] },
-            "$.substitutes[*].part": { "matchers": [{ "match": "type" }] },
-            "$.substitutes[*].substitute_part": { "matchers": [{ "match": "type" }] },
-            "$.substitutes[*].rank": { "matchers": [{ "match": "integer" }] },
-            "$.substitutes[*].substitute_number": { "matchers": [{ "match": "type" }] },
-            "$.substitutes[*].substitute_name": { "matchers": [{ "match": "type" }] }
+            "$.bom_line_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.count": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.substitutes": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.substitutes[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.substitutes[*].relationship": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.substitutes[*].part": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.substitutes[*].substitute_part": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.substitutes[*].rank": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.substitutes[*].substitute_number": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.substitutes[*].substitute_name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -1234,8 +2544,20 @@
             }
           },
           "body": {
-            "$.substitute_item_id": { "matchers": [{ "match": "type" }] },
-            "$.properties": { "matchers": [{ "match": "type" }] }
+            "$.substitute_item_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.properties": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       },
@@ -1252,10 +2574,34 @@
         },
         "matchingRules": {
           "body": {
-            "$.ok": { "matchers": [{ "match": "type" }] },
-            "$.substitute_id": { "matchers": [{ "match": "type" }] },
-            "$.bom_line_id": { "matchers": [{ "match": "type" }] },
-            "$.substitute_item_id": { "matchers": [{ "match": "type" }] }
+            "$.ok": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.substitute_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.bom_line_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.substitute_item_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
           }
         }
       }
@@ -1297,8 +2643,485 @@
         },
         "matchingRules": {
           "body": {
-            "$.ok": { "matchers": [{ "match": "type" }] },
-            "$.substitute_id": { "matchers": [{ "match": "type" }] }
+            "$.ok": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.substitute_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch CAD properties for a native CAD file",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F2 has imported properties at schema version 3"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/cad/files/01H000000000000000000000F2/properties",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F2",
+          "properties": {
+            "material": "AL-6061",
+            "finish": "anodized"
+          },
+          "source": "imported",
+          "cad_document_schema_version": 3
+        }
+      }
+    },
+    {
+      "description": "update CAD properties with a manual fixture payload",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F3 accepts manual property updates at schema version 4"
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v1/cad/files/01H000000000000000000000F3/properties",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        },
+        "body": {
+          "properties": {
+            "material": "AL-7075",
+            "finish": "hard-anodized"
+          },
+          "source": "manual"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F3",
+          "properties": {
+            "material": "AL-7075",
+            "finish": "hard-anodized"
+          },
+          "source": "manual",
+          "cad_document_schema_version": 4
+        }
+      }
+    },
+    {
+      "description": "fetch CAD view state with hidden entities and notes",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F4 has client view state fixture at schema version 3"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/cad/files/01H000000000000000000000F4/view-state",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F4",
+          "hidden_entity_ids": [
+            12,
+            19
+          ],
+          "notes": [
+            {
+              "entity_id": 12,
+              "note": "check hole position",
+              "color": "#FFB020"
+            }
+          ],
+          "source": "client",
+          "cad_document_schema_version": 3
+        }
+      }
+    },
+    {
+      "description": "update CAD view state with the current client visibility draft",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F5 accepts client view-state updates at schema version 3"
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v1/cad/files/01H000000000000000000000F5/view-state",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        },
+        "body": {
+          "hidden_entity_ids": [
+            12,
+            19
+          ],
+          "notes": [
+            {
+              "entity_id": 19,
+              "note": "hide fastener",
+              "color": "#4C9AFF"
+            }
+          ],
+          "source": "client",
+          "refresh_preview": false
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F5",
+          "hidden_entity_ids": [
+            12,
+            19
+          ],
+          "notes": [
+            {
+              "entity_id": 19,
+              "note": "hide fastener",
+              "color": "#4C9AFF"
+            }
+          ],
+          "source": "client",
+          "cad_document_schema_version": 3
+        }
+      }
+    },
+    {
+      "description": "fetch CAD review state for a pending review",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F6 has a pending review state"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/cad/files/01H000000000000000000000F6/review",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F6",
+          "state": "pending",
+          "note": "Awaiting review",
+          "reviewed_by_id": 1
+        }
+      }
+    },
+    {
+      "description": "submit an approved CAD review comment",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F7 accepts approved review updates"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/cad/files/01H000000000000000000000F7/review",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        },
+        "body": {
+          "state": "approved",
+          "note": "Looks good"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F7",
+          "state": "approved",
+          "note": "Looks good",
+          "reviewed_by_id": 1
+        }
+      }
+    },
+    {
+      "description": "fetch CAD change history for properties and review updates",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F8 has seeded properties and review history"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/cad/files/01H000000000000000000000F8/history",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F8",
+          "entries": [
+            {
+              "id": "cad-chg-2",
+              "action": "cad_review_update",
+              "payload": {
+                "state": "pending",
+                "note": "Awaiting review",
+                "reviewed_by_id": 1
+              },
+              "created_at": "2026-04-11T00:05:00",
+              "user_id": 1
+            },
+            {
+              "id": "cad-chg-1",
+              "action": "cad_properties_update",
+              "payload": {
+                "properties": {
+                  "material": "AL-6061",
+                  "finish": "anodized"
+                },
+                "source": "imported",
+                "cad_document_schema_version": 3
+              },
+              "created_at": "2026-04-11T00:00:00",
+              "user_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "compare two CAD files and report property deltas",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F9 can be compared against 01H000000000000000000000F10"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/cad/files/01H000000000000000000000F9/diff",
+        "query": {
+          "other_file_id": [
+            "01H000000000000000000000F10"
+          ]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F9",
+          "other_file_id": "01H000000000000000000000F10",
+          "properties": {
+            "added": {
+              "finish": "anodized"
+            },
+            "removed": {
+              "coating": "none"
+            },
+            "changed": {
+              "weight_kg": {
+                "from": 1.1,
+                "to": 1.2
+              }
+            }
+          },
+          "cad_document_schema_version": {
+            "from": 1,
+            "to": 2
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch CAD mesh stats for the rendered model",
+      "providerStates": [
+        {
+          "name": "CAD file 01H000000000000000000000F11 has precomputed mesh stats"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/cad/files/01H000000000000000000000F11/mesh-stats",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "file_id": "01H000000000000000000000F11",
+          "stats": {
+            "available": true,
+            "entity_count": 2,
+            "triangle_count": 102400,
+            "bounds": {
+              "min": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+              },
+              "max": {
+                "x": 120,
+                "y": 80,
+                "z": 40
+              }
+            }
           }
         }
       }

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -12,8 +12,9 @@
  *   1. The pact JSON exists and parses as Pact v3.
  *   2. The 6 Wave 1 P0 interactions plus the document-semantics Wave 2
  *      interactions plus the BOM-analysis / ECO-approval Wave 3 interactions
- *      plus the approval list/detail / BOM-substitute Wave 4 interactions that
- *      PLMAdapter currently calls are present, in the documented order.
+ *      plus the approval list/detail / BOM-substitute Wave 4 interactions
+ *      plus the CAD review/workspace Wave 5 interactions that PLMAdapter
+ *      currently calls are present, in the documented order.
  *      (codex's plan also lists `aml/metadata`, but PLMAdapter does not yet
  *      call it; deferred until there is a real consumer call site.)
  *   3. The PLMAdapter actually calls every endpoint declared in the pact, so
@@ -101,6 +102,15 @@ const PACT_PATHS = [
   { method: 'GET', path: '/api/v1/bom/01H000000000000000000000R1/substitutes' },
   { method: 'POST', path: '/api/v1/bom/01H000000000000000000000R3/substitutes' },
   { method: 'DELETE', path: '/api/v1/bom/01H000000000000000000000R4/substitutes/01H000000000000000000000R6' },
+  { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F2/properties' },
+  { method: 'PATCH', path: '/api/v1/cad/files/01H000000000000000000000F3/properties' },
+  { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F4/view-state' },
+  { method: 'PATCH', path: '/api/v1/cad/files/01H000000000000000000000F5/view-state' },
+  { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F6/review' },
+  { method: 'POST', path: '/api/v1/cad/files/01H000000000000000000000F7/review' },
+  { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F8/history' },
+  { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F9/diff' },
+  { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F11/mesh-stats' },
 ] as const
 
 function loadPact(): PactDocument {
@@ -112,7 +122,7 @@ function loadAdapter(): string {
   return readFileSync(ADAPTER_PATH, 'utf8')
 }
 
-describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 document semantics + Wave 3 BOM/approval + Wave 4 approval list/detail/substitutes)', () => {
+describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 document semantics + Wave 3 BOM/approval + Wave 4 approval list/detail/substitutes + Wave 5 CAD)', () => {
   it('pact JSON exists, parses as Pact v3, and names the right consumer/provider', () => {
     const pact = loadPact()
     expect(pact.consumer.name).toBe('Metasheet2')
@@ -162,6 +172,12 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       '/api/v1/eco/${approvalId}/reject',
       '/api/v1/bom/${bomLineId}/substitutes',
       '/api/v1/bom/${bomLineId}/substitutes/${substituteId}',
+      '/api/v1/cad/files/${fileId}/properties',
+      '/api/v1/cad/files/${fileId}/view-state',
+      '/api/v1/cad/files/${fileId}/review',
+      '/api/v1/cad/files/${fileId}/history',
+      '/api/v1/cad/files/${fileId}/diff',
+      '/api/v1/cad/files/${fileId}/mesh-stats',
       'fetchYuantusFileMetadata',
     ]
     for (const ep of endpointsToFind) {
@@ -336,6 +352,137 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(substitutesRemove!.response.body).toEqual({
       ok: true,
       substitute_id: '01H000000000000000000000R6',
+    })
+  })
+
+  it('CAD interactions lock properties, view state, review, history, diff, and mesh stats for the native workspace', () => {
+    const pact = loadPact()
+    const propertiesGet = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F2/properties'
+        && i.request.method === 'GET',
+    )
+    const propertiesPatch = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F3/properties'
+        && i.request.method === 'PATCH',
+    )
+    const viewStateGet = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F4/view-state'
+        && i.request.method === 'GET',
+    )
+    const viewStatePatch = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F5/view-state'
+        && i.request.method === 'PATCH',
+    )
+    const reviewGet = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F6/review'
+        && i.request.method === 'GET',
+    )
+    const reviewPost = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F7/review'
+        && i.request.method === 'POST',
+    )
+    const historyGet = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F8/history',
+    )
+    const diffGet = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F9/diff',
+    )
+    const meshStatsGet = pact.interactions.find(
+      i => i.request.path === '/api/v1/cad/files/01H000000000000000000000F11/mesh-stats',
+    )
+
+    expect(propertiesGet).toBeDefined()
+    expect(propertiesPatch).toBeDefined()
+    expect(viewStateGet).toBeDefined()
+    expect(viewStatePatch).toBeDefined()
+    expect(reviewGet).toBeDefined()
+    expect(reviewPost).toBeDefined()
+    expect(historyGet).toBeDefined()
+    expect(diffGet).toBeDefined()
+    expect(meshStatsGet).toBeDefined()
+
+    expect(propertiesGet!.response.body).toMatchObject({
+      file_id: '01H000000000000000000000F2',
+      properties: {
+        material: 'AL-6061',
+        finish: 'anodized',
+      },
+      source: 'imported',
+      cad_document_schema_version: 3,
+    })
+    expect(propertiesPatch!.request.body).toEqual({
+      properties: {
+        material: 'AL-7075',
+        finish: 'hard-anodized',
+      },
+      source: 'manual',
+    })
+    expect(viewStateGet!.response.body).toMatchObject({
+      file_id: '01H000000000000000000000F4',
+      hidden_entity_ids: [12, 19],
+      notes: [
+        {
+          entity_id: 12,
+          note: 'check hole position',
+          color: '#FFB020',
+        },
+      ],
+      source: 'client',
+      cad_document_schema_version: 3,
+    })
+    expect(viewStatePatch!.request.body).toEqual({
+      hidden_entity_ids: [12, 19],
+      notes: [
+        {
+          entity_id: 19,
+          note: 'hide fastener',
+          color: '#4C9AFF',
+        },
+      ],
+      source: 'client',
+      refresh_preview: false,
+    })
+    expect(reviewGet!.response.body).toMatchObject({
+      file_id: '01H000000000000000000000F6',
+      state: 'pending',
+      note: 'Awaiting review',
+      reviewed_by_id: 1,
+    })
+    expect(reviewPost!.request.body).toEqual({
+      state: 'approved',
+      note: 'Looks good',
+    })
+    expect((historyGet!.response.body as Record<string, unknown>).entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ action: 'cad_properties_update' }),
+        expect.objectContaining({ action: 'cad_review_update' }),
+      ]),
+    )
+    expect(diffGet!.request.query).toEqual({
+      other_file_id: ['01H000000000000000000000F10'],
+    })
+    expect(diffGet!.response.body).toMatchObject({
+      file_id: '01H000000000000000000000F9',
+      other_file_id: '01H000000000000000000000F10',
+      properties: {
+        added: { finish: 'anodized' },
+        removed: { coating: 'none' },
+        changed: {
+          weight_kg: { from: 1.1, to: 1.2 },
+        },
+      },
+      cad_document_schema_version: {
+        from: 1,
+        to: 2,
+      },
+    })
+    expect(meshStatsGet!.response.body).toMatchObject({
+      file_id: '01H000000000000000000000F11',
+      stats: expect.objectContaining({
+        available: true,
+        entity_count: 2,
+        triangle_count: 102400,
+      }),
     })
   })
 })

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -609,6 +609,227 @@ describe('PLMAdapter Yuantus BOM analysis and approval actions', () => {
   })
 })
 
+describe('PLMAdapter Yuantus CAD routes', () => {
+  it('queries CAD properties, view state, review, history, diff, and mesh stats from dedicated Yuantus endpoints', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn(async (path: string, params?: Array<Record<string, unknown>>) => {
+      if (path === '/api/v1/cad/files/file-props/properties') {
+        return {
+          data: [{
+            file_id: 'file-props',
+            properties: { material: 'AL-6061', finish: 'anodized' },
+            updated_at: '2026-04-11T00:00:00.000Z',
+            source: 'imported',
+            cad_document_schema_version: 3,
+          }],
+        }
+      }
+      if (path === '/api/v1/cad/files/file-view/view-state') {
+        return {
+          data: [{
+            file_id: 'file-view',
+            hidden_entity_ids: [12, 19],
+            notes: [{ entity_id: 12, note: 'check hole position', color: '#FFB020' }],
+            updated_at: '2026-04-11T00:00:00.000Z',
+            source: 'client',
+            cad_document_schema_version: 3,
+          }],
+        }
+      }
+      if (path === '/api/v1/cad/files/file-review/review') {
+        return {
+          data: [{
+            file_id: 'file-review',
+            state: 'pending',
+            note: 'Awaiting review',
+            reviewed_at: '2026-04-11T00:00:00.000Z',
+            reviewed_by_id: 1,
+          }],
+        }
+      }
+      if (path === '/api/v1/cad/files/file-history/history') {
+        return {
+          data: [{
+            file_id: 'file-history',
+            entries: [
+              { id: 'chg-1', action: 'cad_properties_update', payload: { properties: { material: 'AL-6061' } }, created_at: '2026-04-10T00:00:00.000Z', user_id: 1 },
+              { id: 'chg-2', action: 'cad_review_update', payload: { state: 'approved' }, created_at: '2026-04-11T00:00:00.000Z', user_id: 1 },
+            ],
+          }],
+        }
+      }
+      if (path === '/api/v1/cad/files/file-left/diff') {
+        expect(params).toEqual([{ other_file_id: 'file-right' }])
+        return {
+          data: [{
+            file_id: 'file-left',
+            other_file_id: 'file-right',
+            properties: {
+              added: { finish: 'anodized' },
+              removed: { coating: 'none' },
+              changed: { weight_kg: { from: 1.1, to: 1.2 } },
+            },
+            cad_document_schema_version: { from: 1, to: 2 },
+          }],
+        }
+      }
+      if (path === '/api/v1/cad/files/file-mesh/mesh-stats') {
+        return {
+          data: [{
+            file_id: 'file-mesh',
+            stats: {
+              available: true,
+              raw_keys: ['bounds', 'entities', 'triangle_count'],
+              entity_count: 2,
+              triangle_count: 102400,
+              bounds: { min: [0, 0, 0], max: [10, 20, 5] },
+            },
+          }],
+        }
+      }
+      return { data: [] }
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const properties = await adapter.getCadProperties('file-props')
+    const viewState = await adapter.getCadViewState('file-view')
+    const review = await adapter.getCadReview('file-review')
+    const history = await adapter.getCadHistory('file-history')
+    const diff = await adapter.getCadDiff('file-left', 'file-right')
+    const meshStats = await adapter.getCadMeshStats('file-mesh')
+
+    expect(properties.data[0]).toMatchObject({
+      file_id: 'file-props',
+      properties: { material: 'AL-6061', finish: 'anodized' },
+      source: 'imported',
+      cad_document_schema_version: 3,
+    })
+    expect(viewState.data[0]).toMatchObject({
+      file_id: 'file-view',
+      hidden_entity_ids: [12, 19],
+      notes: [{ entity_id: 12, note: 'check hole position', color: '#FFB020' }],
+    })
+    expect(review.data[0]).toMatchObject({
+      file_id: 'file-review',
+      state: 'pending',
+      reviewed_by_id: 1,
+    })
+    expect(history.data[0].entries).toHaveLength(2)
+    expect(diff.data[0]).toMatchObject({
+      file_id: 'file-left',
+      other_file_id: 'file-right',
+      cad_document_schema_version: { from: 1, to: 2 },
+    })
+    expect(meshStats.data[0].stats).toMatchObject({
+      available: true,
+      entity_count: 2,
+      triangle_count: 102400,
+    })
+  })
+
+  it('patches CAD properties and view state, and posts CAD review updates to dedicated Yuantus endpoints', async () => {
+    const adapter = createAdapter()
+    const selectMock = vi.fn(async (path: string, options: Record<string, unknown>) => {
+      if (path === '/api/v1/cad/files/file-props-write/properties') {
+        expect(options).toEqual({
+          method: 'PATCH',
+          data: {
+            properties: { material: 'AL-7075', finish: 'hard-anodized' },
+            source: 'manual',
+          },
+        })
+        return {
+          data: [{
+            file_id: 'file-props-write',
+            properties: { material: 'AL-7075', finish: 'hard-anodized' },
+            updated_at: '2026-04-11T01:00:00.000Z',
+            source: 'manual',
+            cad_document_schema_version: 4,
+          }],
+        }
+      }
+      if (path === '/api/v1/cad/files/file-view-write/view-state') {
+        expect(options).toEqual({
+          method: 'PATCH',
+          data: {
+            hidden_entity_ids: [12, 19],
+            notes: [{ entity_id: 19, note: 'hide fastener', color: '#4C9AFF' }],
+            source: 'client',
+            refresh_preview: false,
+          },
+        })
+        return {
+          data: [{
+            file_id: 'file-view-write',
+            hidden_entity_ids: [12, 19],
+            notes: [{ entity_id: 19, note: 'hide fastener', color: '#4C9AFF' }],
+            updated_at: '2026-04-11T01:00:00.000Z',
+            source: 'client',
+            cad_document_schema_version: 3,
+          }],
+        }
+      }
+      return { data: [] }
+    })
+    const insertMock = vi.fn(async (path: string, payload: Record<string, unknown>) => {
+      if (path === '/api/v1/cad/files/file-review-write/review') {
+        expect(payload).toEqual({
+          state: 'approved',
+          note: 'Looks good',
+        })
+        return {
+          data: [{
+            file_id: 'file-review-write',
+            state: 'approved',
+            note: 'Looks good',
+            reviewed_at: '2026-04-11T01:00:00.000Z',
+            reviewed_by_id: 1,
+          }],
+        }
+      }
+      return { data: [] }
+    })
+
+    ;(adapter as any).select = selectMock
+    ;(adapter as any).insert = insertMock
+
+    const updatedProperties = await adapter.updateCadProperties('file-props-write', {
+      properties: { material: 'AL-7075', finish: 'hard-anodized' },
+      source: 'manual',
+    })
+    const updatedViewState = await adapter.updateCadViewState('file-view-write', {
+      hidden_entity_ids: [12, 19],
+      notes: [{ entity_id: 19, note: 'hide fastener', color: '#4C9AFF' }],
+      source: 'client',
+      refresh_preview: false,
+    })
+    const updatedReview = await adapter.updateCadReview('file-review-write', {
+      state: 'approved',
+      note: 'Looks good',
+    })
+
+    expect(updatedProperties.data[0]).toMatchObject({
+      file_id: 'file-props-write',
+      properties: { material: 'AL-7075', finish: 'hard-anodized' },
+      source: 'manual',
+      cad_document_schema_version: 4,
+    })
+    expect(updatedViewState.data[0]).toMatchObject({
+      file_id: 'file-view-write',
+      hidden_entity_ids: [12, 19],
+      source: 'client',
+      cad_document_schema_version: 3,
+    })
+    expect(updatedReview.data[0]).toMatchObject({
+      file_id: 'file-review-write',
+      state: 'approved',
+      note: 'Looks good',
+      reviewed_by_id: 1,
+    })
+  })
+})
+
 describe('PLMAdapter Yuantus documents single-side failure + sources metadata', () => {
   it('returns AML related documents when file/item endpoint errors, with sources showing degradation', async () => {
     const adapter = createAdapter()


### PR DESCRIPTION
## Summary
- extend the canonical Metasheet2 -> Yuantus pact from 19 to 28 interactions
- add Wave 5 coverage for the CAD properties, view-state, review, history, diff, and mesh-stats routes already called on main
- add CAD-specific PLMAdapter unit coverage and document the Wave 5 scope

## Verification
- `npx vitest run tests/contract/plm-adapter-yuantus.pact.test.ts tests/unit/plm-adapter-yuantus.test.ts`

## Notes
- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json` remains the single source of truth
- the paired Yuantus provider PR syncs this artifact into `contracts/pacts/`
