### PR TITLE
fix(after-sales): fail fast when integration infra is missing

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
         run: |
-          test -n "$DATABASE_URL"
+          : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
       - name: Start core backend (background)
@@ -233,6 +233,7 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
         run: |
+          : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend test:integration:after-sales
 
       - name: Upload after-sales integration artifacts

--- a/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
+++ b/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
@@ -92,6 +92,19 @@ const PLUGIN_ID = 'plugin-after-sales'
 const PROJECT_ID = `${TENANT_ID}:${APP_ID}`
 const SUPERVISOR_USER_ID = 'after-sales-service-record-supervisor-it'
 const SUPERVISOR_EMAIL = 'after-sales-supervisor-it@example.com'
+const REQUIRED_SCHEMA_TABLES = [
+  'plugin_after_sales_template_installs',
+  'meta_bases',
+  'meta_sheets',
+  'meta_fields',
+  'meta_views',
+  'meta_records',
+  'approval_instances',
+  'approval_records',
+  'approval_assignments',
+  'plugin_automation_rule_registry',
+  'plugin_field_policy_registry',
+] as const
 const OBJECT_IDS = ['serviceTicket', 'installedAsset', 'customer', 'serviceRecord', 'partItem', 'followUp']
 const VIEW_IDS = [
   { objectId: 'serviceTicket', viewId: 'ticket-board' },
@@ -296,16 +309,23 @@ describe('after-sales plugin install integration', () => {
   }
 
   beforeAll(async () => {
-    if (!process.env.DATABASE_URL) return
+    const databaseUrl = process.env.DATABASE_URL?.trim()
+    if (!databaseUrl) {
+      throw new Error('DATABASE_URL is required for after-sales plugin install integration tests')
+    }
 
     const canListen: boolean = await new Promise((resolve) => {
       const s = net.createServer()
       s.once('error', () => resolve(false))
       s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
     })
-    if (!canListen) return
+    if (!canListen) {
+      throw new Error(
+        'after-sales plugin install integration tests require an available 127.0.0.1 loopback port',
+      )
+    }
 
-    pool = new Pool({ connectionString: process.env.DATABASE_URL })
+    pool = new Pool({ connectionString: databaseUrl })
 
     try {
       const tables = await pool.query<{ name: string | null }>(
@@ -321,7 +341,12 @@ describe('after-sales plugin install integration', () => {
          UNION ALL SELECT to_regclass('public.plugin_automation_rule_registry') AS name
          UNION ALL SELECT to_regclass('public.plugin_field_policy_registry') AS name`,
       )
-      if (tables.rows.some((row) => !row.name)) return
+      const missingTables = REQUIRED_SCHEMA_TABLES.filter((_tableName, index) => !tables.rows[index]?.name)
+      if (missingTables.length > 0) {
+        throw new Error(
+          `Missing required tables for after-sales plugin install integration tests: ${missingTables.join(', ')}. Run pnpm --filter @metasheet/core-backend db:migrate`,
+        )
+      }
       schemaReady = true
 
       await cleanupAfterSalesInstallArtifacts()
@@ -336,10 +361,24 @@ describe('after-sales plugin install integration', () => {
       await server.start()
 
       const address = server.getAddress()
-      if (!address || typeof address === 'string') return
+      if (!address || typeof address === 'string') {
+        throw new Error(
+          'after-sales plugin install integration server did not expose a TCP address',
+        )
+      }
       baseUrl = `http://127.0.0.1:${address.port}`
-    } catch {
+    } catch (error) {
       baseUrl = ''
+      schemaReady = false
+      if (server) {
+        await server.stop().catch(() => undefined)
+        server = undefined
+      }
+      if (pool) {
+        await pool.end().catch(() => undefined)
+        pool = undefined
+      }
+      throw error
     }
   })
 
@@ -361,8 +400,15 @@ describe('after-sales plugin install integration', () => {
     await cleanupAfterSalesInstallArtifacts()
   })
 
+  function requireTestInfra(): { baseUrl: string; pool: Pool } {
+    if (!schemaReady || !baseUrl || !pool) {
+      throw new Error('after-sales plugin install integration test infrastructure is not ready')
+    }
+    return { baseUrl, pool }
+  }
+
   async function seedSupervisorRecipient() {
-    if (!pool) return
+    const { pool } = requireTestInfra()
     await pool.query(
       `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
        VALUES ($1, $2, $3, $4, $5, '[]'::jsonb, TRUE, FALSE)
@@ -384,7 +430,7 @@ describe('after-sales plugin install integration', () => {
   }
 
   it('installs the after-sales template into real multitable tables and exposes current state', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const adminRoleBeforeRes = await pool.query<{ name: string }>(
       `SELECT name FROM roles WHERE id = 'admin'`,
@@ -638,7 +684,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('reads and updates runtime admin state against the live automation and field-policy registries', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const adminToken = await issueDevToken(
       baseUrl,
@@ -811,7 +857,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('rejects runtime admin for non-admin callers', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const adminToken = await issueDevToken(
       baseUrl,
@@ -851,7 +897,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('rejects install for non-admin callers', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-non-admin&roles=user&perms=after_sales:read`,
@@ -1037,7 +1083,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates, lists, updates, and deletes part items through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-part-item-it&roles=admin&perms=*:*`,
@@ -1188,7 +1234,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates a ticket and requests refund through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-it&roles=admin&perms=*:*`,
@@ -1492,7 +1538,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('updates a ticket through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-update-it&roles=admin&perms=*:*`,
@@ -1595,7 +1641,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('marks refund status as rejected when the approval action rejects the request', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-refund-reject-it&roles=admin&perms=*:*`,
@@ -1755,7 +1801,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates and lists service records through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-it&roles=admin&perms=*:*`,
@@ -1927,7 +1973,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates and deletes tickets through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-delete-it&roles=admin&perms=*:*`,
@@ -2035,7 +2081,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates and deletes service records through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-delete-it&roles=admin&perms=*:*`,
@@ -2157,7 +2203,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('updates service records through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-update-it&roles=admin&perms=*:*`,
@@ -2291,7 +2337,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates installed assets through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-create-it&roles=admin&perms=*:*`,
@@ -2407,7 +2453,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('updates installed assets through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-update-it&roles=admin&perms=*:*`,
@@ -2543,7 +2589,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates and deletes installed assets through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-delete-it&roles=admin&perms=*:*`,
@@ -2644,7 +2690,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('lists customers through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-list-it&roles=admin&perms=*:*`,
@@ -2726,7 +2772,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('lists follow-ups through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-list-it&roles=admin&perms=*:*`,
@@ -2817,7 +2863,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates follow-ups through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-create-it&roles=admin&perms=*:*`,
@@ -2934,7 +2980,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates and deletes follow-ups through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-delete-it&roles=admin&perms=*:*`,
@@ -3013,7 +3059,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('updates follow-ups through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-edit-it&roles=admin&perms=*:*`,
@@ -3117,7 +3163,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('emits followup.due notifications from real follow-up records', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-due-it&roles=admin&perms=*:*`,
@@ -3248,7 +3294,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('creates customers through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-create-it&roles=admin&perms=*:*`,
@@ -3354,7 +3400,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('updates customers through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-update-it&roles=admin&perms=*:*`,
@@ -3450,7 +3496,7 @@ describe('after-sales plugin install integration', () => {
   })
 
   it('deletes customers through the real after-sales routes', async () => {
-    if (!baseUrl || !pool) return
+    const { baseUrl, pool } = requireTestInfra()
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-delete-it&roles=admin&perms=*:*`,


### PR DESCRIPTION
## Summary
- make `after-sales-plugin.install.test.ts` fail fast when `DATABASE_URL`, loopback binding, or required schema tables are missing
- replace per-test silent `return` guards with a shared `requireTestInfra()` assertion so infra gaps surface as suite failures
- make the plugin CI workflow emit an explicit `DATABASE_URL` error before running the required after-sales integration job

## Verification
- `unset DATABASE_URL && /Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/node_modules/.bin/vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`  
  Fails with `DATABASE_URL is required for after-sales plugin install integration tests`
- `DATABASE_URL=postgresql:///metasheet_test /Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/node_modules/.bin/tsx src/db/migrate.ts`
- `DATABASE_URL=postgresql:///metasheet_test /Users/huazhou/Downloads/Github/metasheet2/packages/core-backend/node_modules/.bin/vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot`
