### PR TITLE
test(contract): add Yuantus consumer CI gate

### DIFF
--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -1,0 +1,81 @@
+name: Yuantus Pact Consumer
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/src/data-adapters/PLMAdapter.ts'
+      - 'packages/core-backend/tests/contract/**'
+      - 'packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts'
+      - 'packages/core-backend/package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/yuantus-pact-consumer.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/src/data-adapters/PLMAdapter.ts'
+      - 'packages/core-backend/tests/contract/**'
+      - 'packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts'
+      - 'packages/core-backend/package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/yuantus-pact-consumer.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: yuantus-pact-consumer-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  yuantus-pact-consumer:
+    name: yuantus-pact-consumer
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Show pnpm version
+        run: pnpm -v
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: |
+          set -o pipefail
+          pnpm install --frozen-lockfile 2>&1 | tee install.log
+
+      - name: Run Yuantus pact consumer checks
+        run: |
+          pnpm --filter @metasheet/core-backend test:contract
+          pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts --reporter=dot

--- a/docs/development/plm-yuantus-pact-consumer-ci-20260411.md
+++ b/docs/development/plm-yuantus-pact-consumer-ci-20260411.md
@@ -1,0 +1,75 @@
+# PLM Yuantus Pact Consumer CI
+
+Date: 2026-04-11
+
+## Summary
+
+This change adds a dedicated Metasheet2 consumer contract gate for the
+Yuantus federation surface.
+
+The goal is narrow on purpose:
+
+- run only when the Yuantus pact-relevant consumer surface changes
+- avoid mixing this gate into unrelated platform CI
+- keep the exact local verification commands identical to the GitHub Actions
+  workflow
+
+## Design
+
+The new workflow is:
+
+- `.github/workflows/yuantus-pact-consumer.yml`
+
+It triggers on:
+
+- `pull_request` to `main`
+- `push` to `main`
+
+It only runs when one of these paths changes:
+
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts`
+- `packages/core-backend/tests/contract/**`
+- `packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts`
+- `packages/core-backend/package.json`
+- `pnpm-lock.yaml`
+- `.github/workflows/yuantus-pact-consumer.yml`
+
+Runtime shape:
+
+- Node `20.x`
+- `pnpm/action-setup@v4`
+- pnpm `10.16.1`
+- `pnpm install --frozen-lockfile`
+
+Execution commands:
+
+```bash
+pnpm --filter @metasheet/core-backend test:contract
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts --reporter=dot
+```
+
+## Verification
+
+Local verification on the closeout branch:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend test:contract
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts --reporter=dot
+```
+
+Observed results:
+
+- contract tests: `16 passed`
+- targeted Yuantus adapter unit tests: `19 passed`
+
+Additional checks:
+
+- `git diff --check` passed
+- workflow YAML parsed successfully
+
+## Non-Goals
+
+- no new business logic
+- no Pact artifact regeneration
+- no merge with the broader plugin / platform CI workflows


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for the Metasheet2 -> Yuantus consumer pact surface
- keep the gate narrow so only Yuantus pact-relevant consumer changes trigger it
- document the workflow shape and local reproduction commands

## Changes
- add `.github/workflows/yuantus-pact-consumer.yml`
- trigger on `pull_request` and `push` to `main` only when Yuantus pact-relevant paths change
- run Node 20 + pnpm 10.16.1 + `pnpm install --frozen-lockfile`
- execute:
  - `pnpm --filter @metasheet/core-backend test:contract`
  - `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts --reporter=dot`
- add `docs/development/plm-yuantus-pact-consumer-ci-20260411.md` with design and verification notes

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend test:contract`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts --reporter=dot`
- `git diff --check`
- parsed `.github/workflows/yuantus-pact-consumer.yml` with `yaml.safe_load(...)`