### PR TITLE
fix(after-sales): harden tenant context handling

### DIFF
--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -3897,7 +3897,7 @@ async function loadManifest() {
   manifest.value = await readEnvelope<AfterSalesManifest>('/api/after-sales/app-manifest')
 }
 
-async function loadRefundApproval(projectId: string, ticketId: string): Promise<ApprovalSnapshot | null> {
+async function loadRefundApproval(ticketId: string): Promise<ApprovalSnapshot | null> {
   try {
     const payload = await readEnvelope<{ approval: ApprovalSnapshot | null }>(
       `/api/after-sales/tickets/${encodeURIComponent(ticketId)}/refund-approval`,
@@ -3923,7 +3923,7 @@ async function loadTicketsForCurrentState(state: CurrentResponse): Promise<void>
       rows.map(async (ticket) => {
         const approval =
           toText(ticket?.data?.refundStatus) === 'pending'
-            ? await loadRefundApproval(state.projectId || placeholderProjectId, ticket.id)
+            ? await loadRefundApproval(ticket.id)
             : null
         return normalizeTicket(ticket, approval)
       }),

--- a/docs/after-sales-tenant-hardening-design-verification.md
+++ b/docs/after-sales-tenant-hardening-design-verification.md
@@ -82,7 +82,7 @@ Runtime tenant resolution now uses:
 
 After `loadCurrent()`, the adapter also reuses `current.projectId` when available to derive the effective runtime `projectId`.
 
-Invalid non-tenant-scoped `projectId` values now fail fast.
+Invalid non-tenant-scoped `projectId` values now fail fast, and an explicit `payload.projectId` must match the resolved `tenantId`.
 
 ### 6. Frontend adjustment
 
@@ -115,7 +115,7 @@ The refund-approval read path is now keyed only by `ticketId`, which matches the
 1. Targeted backend/unit verification
 
 ```bash
-cd /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening
+cd <repo-root>
 pnpm --filter @metasheet/core-backend exec vitest run \
   tests/unit/AuthService.test.ts \
   tests/unit/auth-login-routes.test.ts \
@@ -133,7 +133,7 @@ Result:
 2. Real-DB after-sales integration verification
 
 ```bash
-cd /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening
+cd <repo-root>
 DATABASE_URL=postgresql:///metasheet_test \
 pnpm --filter @metasheet/core-backend exec vitest \
   --config vitest.integration.config.ts \
@@ -149,7 +149,7 @@ Result:
 3. Core backend TypeScript build
 
 ```bash
-cd /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening
+cd <repo-root>
 pnpm --filter @metasheet/core-backend build
 ```
 
@@ -160,7 +160,7 @@ Result:
 4. Patch hygiene
 
 ```bash
-git -C /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening diff --check
+git -C <repo-root> diff --check
 ```
 
 Result:
@@ -172,7 +172,7 @@ Result:
 Frontend workspace type-check is not clean, but the failures are pre-existing and unrelated to this slice:
 
 ```bash
-cd /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening
+cd <repo-root>
 pnpm --filter @metasheet/web type-check
 ```
 
@@ -188,8 +188,8 @@ No type-check error was reported for `apps/web/src/views/AfterSalesView.vue`.
 
 This worktree required local `node_modules` symlinks to reuse the main workspace dependencies:
 
-- `.worktrees/after-sales-tenant-hardening/node_modules`
-- `.worktrees/after-sales-tenant-hardening/packages/core-backend/node_modules`
-- `.worktrees/after-sales-tenant-hardening/apps/web/node_modules`
+- `<repo-root>/.worktrees/after-sales-tenant-hardening/node_modules`
+- `<repo-root>/.worktrees/after-sales-tenant-hardening/packages/core-backend/node_modules`
+- `<repo-root>/.worktrees/after-sales-tenant-hardening/apps/web/node_modules`
 
 These are local environment conveniences only and are not part of the code change.

--- a/docs/after-sales-tenant-hardening-design-verification.md
+++ b/docs/after-sales-tenant-hardening-design-verification.md
@@ -1,0 +1,178 @@
+# After-Sales Tenant Hardening
+
+## Scope
+
+This slice hardens tenant semantics for the after-sales plugin and removes the last silent fallback to `'default'` in the HTTP/runtime path.
+
+It intentionally keeps the v1 pseudo project id shape unchanged:
+
+- `projectId = ${tenantId}:${appId}`
+
+It does not introduce schema migrations.
+
+## Design
+
+### 1. Trusted token and request propagation
+
+`/api/auth/dev-token` now accepts an optional `tenantId` query parameter and embeds it into the issued JWT payload.
+
+`AuthService.verifyToken()` preserves `tenantId` from trusted tokens and returns it on `req.user`.
+
+`jwtAuthMiddleware` continues to assign the authenticated user object to `req.user`, so the tenant claim is available to downstream routes.
+
+### 2. CoreAPI tenant seam
+
+`CoreAPI` now exposes:
+
+- `tenant.getTenantId(): string | undefined`
+- `tenant.requireTenantId(): string`
+
+The implementation is backed by `tenantContext` AsyncLocalStorage in `MetaSheetServer.createCoreAPI()`.
+
+### 3. HTTP tenant ALS establishment
+
+After JWT auth, `MetaSheetServer` now establishes tenant ALS for requests whose authenticated user carries a non-empty `tenantId`.
+
+If the request has no tenant claim, no ALS context is established.
+
+This keeps the server neutral for non-tenant-aware endpoints while allowing tenant-aware plugins to read tenant context from `context.api.tenant`.
+
+### 4. After-sales strict tenant resolution
+
+`plugins/plugin-after-sales/index.cjs` no longer falls back to `'default'`.
+
+HTTP routes now resolve tenant in this order:
+
+1. `context.api.tenant.getTenantId()`
+2. `req.user.tenantId`
+3. otherwise `401 UNAUTHORIZED` with `tenantId not found`
+
+This turns missing tenant state into an explicit failure instead of silently writing into the wrong tenant namespace.
+
+`resolveTenantIdFromProject()` is now strict and throws `VALIDATION_ERROR` when `projectId` is absent or lacks a tenant prefix.
+
+### 5. Workflow adapter strict runtime resolution
+
+`plugins/plugin-after-sales/lib/workflow-adapter.cjs` no longer resolves tenant to `'default'`.
+
+Runtime tenant resolution now uses:
+
+1. `payload.tenantId`
+2. `payload.ticket.tenantId`
+3. `payload.approval.tenantId`
+4. tenant parsed from `payload.projectId`
+5. `context.api.tenant.getTenantId()`
+6. otherwise `VALIDATION_ERROR`
+
+After `loadCurrent()`, the adapter also reuses `current.projectId` when available to derive the effective runtime `projectId`.
+
+Invalid non-tenant-scoped `projectId` values now fail fast.
+
+### 6. Frontend adjustment
+
+`AfterSalesView.vue` no longer passes a placeholder project id when loading refund approval snapshots.
+
+The refund-approval read path is now keyed only by `ticketId`, which matches the backend route contract and avoids reintroducing fake tenant/project semantics into runtime reads.
+
+## Files Changed
+
+- `apps/web/src/views/AfterSalesView.vue`
+- `packages/core-backend/src/auth/AuthService.ts`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/routes/auth.ts`
+- `packages/core-backend/src/types/express.d.ts`
+- `packages/core-backend/src/types/plugin.ts`
+- `packages/core-backend/tests/integration/after-sales-plugin.install.test.ts`
+- `packages/core-backend/tests/unit/AuthService.test.ts`
+- `packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts`
+- `packages/core-backend/tests/unit/after-sales-workflow-adapter.test.ts`
+- `packages/core-backend/tests/unit/auth-login-routes.test.ts`
+- `packages/core-backend/tests/unit/jwt-middleware.test.ts`
+- `plugins/plugin-after-sales/index.cjs`
+- `plugins/plugin-after-sales/lib/workflow-adapter.cjs`
+
+## Verification
+
+### Passed
+
+1. Targeted backend/unit verification
+
+```bash
+cd /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/AuthService.test.ts \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/jwt-middleware.test.ts \
+  tests/unit/after-sales-plugin-routes.test.ts \
+  tests/unit/after-sales-workflow-adapter.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+- `5` test files passed
+- `155` tests passed
+
+2. Real-DB after-sales integration verification
+
+```bash
+cd /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening
+DATABASE_URL=postgresql:///metasheet_test \
+pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/after-sales-plugin.install.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+- `1` integration file passed
+- `25` tests passed
+
+3. Core backend TypeScript build
+
+```bash
+cd /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+- passed
+
+4. Patch hygiene
+
+```bash
+git -C /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening diff --check
+```
+
+Result:
+
+- passed
+
+### Not clean yet
+
+Frontend workspace type-check is not clean, but the failures are pre-existing and unrelated to this slice:
+
+```bash
+cd /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-tenant-hardening
+pnpm --filter @metasheet/web type-check
+```
+
+Current failures are in unrelated PLM/realtime files, for example:
+
+- missing module `socket.io-client`
+- missing module `@metasheet/sdk/client`
+- existing implicit `any` / `unknown` issues in `src/services/plm/*`
+
+No type-check error was reported for `apps/web/src/views/AfterSalesView.vue`.
+
+## Local Environment Notes
+
+This worktree required local `node_modules` symlinks to reuse the main workspace dependencies:
+
+- `.worktrees/after-sales-tenant-hardening/node_modules`
+- `.worktrees/after-sales-tenant-hardening/packages/core-backend/node_modules`
+- `.worktrees/after-sales-tenant-hardening/apps/web/node_modules`
+
+These are local environment conveniences only and are not part of the code change.

--- a/docs/after-sales-tenant-hardening-design-verification.md
+++ b/docs/after-sales-tenant-hardening-design-verification.md
@@ -20,6 +20,22 @@ It does not introduce schema migrations.
 
 `jwtAuthMiddleware` continues to assign the authenticated user object to `req.user`, so the tenant claim is available to downstream routes.
 
+### 1.1 Auth session tenant bridge
+
+Normal auth flows now also read `x-tenant-id` from the request and carry it into session token issuance.
+
+That bridge now covers:
+
+- `/api/auth/login`
+- `/api/auth/register`
+- `/api/auth/invite/accept`
+- `/api/auth/dingtalk/callback`
+- `/api/auth/dev-token` as a header fallback when the query parameter is absent
+
+`jwtAuthMiddleware` also backfills `req.user.tenantId` from `x-tenant-id` when a trusted legacy token is valid but lacks a tenant claim.
+
+This keeps the after-sales routes strict while preserving compatibility for existing tenant-less auth sessions that still send an explicit tenant header.
+
 ### 2. CoreAPI tenant seam
 
 `CoreAPI` now exposes:
@@ -78,6 +94,7 @@ The refund-approval read path is now keyed only by `ticketId`, which matches the
 
 - `apps/web/src/views/AfterSalesView.vue`
 - `packages/core-backend/src/auth/AuthService.ts`
+- `packages/core-backend/src/auth/jwt-middleware.ts`
 - `packages/core-backend/src/index.ts`
 - `packages/core-backend/src/routes/auth.ts`
 - `packages/core-backend/src/types/express.d.ts`
@@ -111,7 +128,7 @@ pnpm --filter @metasheet/core-backend exec vitest run \
 Result:
 
 - `5` test files passed
-- `155` tests passed
+- `158` tests passed
 
 2. Real-DB after-sales integration verification
 

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -244,7 +244,7 @@ export class AuthService {
   async login(
     email: string,
     password: string,
-    options: { ipAddress?: string | null; userAgent?: string | null } = {},
+    options: { ipAddress?: string | null; userAgent?: string | null; tenantId?: string | null } = {},
   ): Promise<{ user: User; token: string } | null> {
     try {
       const user = await this.getUserByEmail(email)
@@ -264,7 +264,10 @@ export class AuthService {
       }
 
       const sessionId = crypto.randomUUID()
-      const token = this.createToken(user, { sid: sessionId })
+      const tenantId = typeof options.tenantId === 'string' && options.tenantId.trim().length > 0
+        ? options.tenantId.trim()
+        : undefined
+      const token = this.createToken(tenantId ? { ...user, tenantId } : user, { sid: sessionId })
       const payload = this.readTokenPayload(token)
       if (payload?.exp) {
         await createUserSession(user.id, {
@@ -279,7 +282,7 @@ export class AuthService {
       await this.updateLastLogin(user.id)
 
       // 返回用户信息（不包含密码hash）
-      const safeUser = this.sanitizeUser(user)
+      const safeUser = this.sanitizeUser(tenantId ? { ...user, tenantId } : user)
       return { user: safeUser, token }
     } catch (error) {
       this.logger.error('Login error', error instanceof Error ? error : undefined)

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -21,6 +21,7 @@ export interface User {
   name: string
   role: string
   permissions: string[]
+  tenantId?: string
   is_active?: boolean
   created_at: Date
   updated_at: Date
@@ -37,6 +38,7 @@ export interface TokenPayload {
   userId: string
   email: string
   role: string
+  tenantId?: string
   sid?: string
   iat: number
   exp: number
@@ -107,6 +109,12 @@ export class AuthService {
       .filter(Boolean)
   }
 
+  private normalizeClaimString(value: unknown): string | undefined {
+    if (typeof value !== 'string') return undefined
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+  }
+
   private buildTrustedTokenUser(
     payload: TokenPayload & { id?: string; sub?: string; roles?: unknown; perms?: unknown; name?: unknown; email?: unknown; role?: unknown },
   ): User | null {
@@ -131,6 +139,7 @@ export class AuthService {
       typeof payload.name === 'string' && payload.name.trim().length > 0
         ? payload.name.trim()
         : 'Trusted Token User'
+    const tenantId = this.normalizeClaimString(payload.tenantId)
 
     return {
       id: userId,
@@ -138,6 +147,7 @@ export class AuthService {
       name,
       role,
       permissions,
+      ...(tenantId ? { tenantId } : {}),
       is_active: true,
       created_at: new Date(0),
       updated_at: new Date(0),
@@ -205,6 +215,7 @@ export class AuthService {
       userId: user.id,
       email: user.email,
       role: user.role,
+      ...(typeof user.tenantId === 'string' && user.tenantId.trim().length > 0 ? { tenantId: user.tenantId.trim() } : {}),
       ...(typeof options.sid === 'string' && options.sid.trim().length > 0 ? { sid: options.sid.trim() } : {}),
     }
 
@@ -578,7 +589,10 @@ export class AuthService {
         }
       }
 
-      const refreshedToken = this.createToken(user, { sid: sessionId })
+      const refreshedUser = this.normalizeClaimString(payload.tenantId)
+        ? { ...user, tenantId: this.normalizeClaimString(payload.tenantId) }
+        : user
+      const refreshedToken = this.createToken(refreshedUser, { sid: sessionId })
       const refreshedPayload = this.readTokenPayload(refreshedToken)
       if (refreshedPayload?.exp) {
         await createUserSession(user.id, {

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from 'express'
+import { extractTenantFromHeaders } from '../db/sharding/tenant-context'
 import { metrics } from '../metrics/metrics'
 import { authService } from './AuthService'
 
@@ -48,6 +49,11 @@ export async function jwtAuthMiddleware(req: Request, res: Response, next: NextF
       metrics.jwtAuthFail.inc({ reason: 'invalid_token' })
       metrics.authFailures.inc()
       return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Invalid token' } })
+    }
+
+    const headerTenantId = extractTenantFromHeaders(req.headers as Record<string, unknown> | undefined)
+    if (!user.tenantId && headerTenantId) {
+      user.tenantId = headerTenantId
     }
 
     req.user = user as Express.Request['user']

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -67,6 +67,7 @@ import { getPoolStats } from './db/pg'
 import { isDatabaseSchemaError } from './utils/database-errors'
 import { startOperationAuditRetention } from './audit/operation-audit-retention'
 import { startMultitableAttachmentCleanup } from './multitable/attachment-orphan-retention'
+import { tenantContext } from './db/sharding/tenant-context'
 import { attendanceAuditMiddleware, attendanceSecurityMiddleware } from './middleware/attendance-production'
 import { approvalsRouter } from './routes/approvals'
 import { authRouter } from './routes/auth'
@@ -209,6 +210,10 @@ export class MetaSheetServer {
 
     return {
       injector: this.injector,
+      tenant: {
+        getTenantId: () => tenantContext.getTenantId(),
+        requireTenantId: () => tenantContext.requireTenantId(),
+      },
       formula: {
         calculate: (name, ...args) => this.injector.get(IFormulaService).calculate(name, ...args),
         calculateFormula: (exp, resolver) => this.injector.get(IFormulaService).calculateFormula(exp, resolver),
@@ -722,6 +727,18 @@ export class MetaSheetServer {
       if (isWhitelisted(req.path)) return next()
       if (req.path.startsWith('/api/')) return jwtAuthMiddleware(req, res, next)
       return next()
+    })
+
+    this.app.use((req: Request, _res: Response, next: NextFunction) => {
+      const tenantId = typeof req.user?.tenantId === 'string' && req.user.tenantId.trim().length > 0
+        ? req.user.tenantId.trim()
+        : undefined
+      if (!tenantId) {
+        return next()
+      }
+      tenantContext.runAsync(tenantId, async () => {
+        next()
+      }).catch(next)
     })
 
     // Attendance production guards (audit + security). Must run after auth so req.user is available.

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -46,6 +46,7 @@ authRouter.get('/dev-token', async (req: Request, res: Response) => {
   }
 
   const userId = typeof req.query.userId === 'string' && req.query.userId.trim() ? req.query.userId.trim() : 'dev-user'
+  const tenantId = typeof req.query.tenantId === 'string' && req.query.tenantId.trim() ? req.query.tenantId.trim() : undefined
   const rolesParam = typeof req.query.roles === 'string' ? req.query.roles : 'admin'
   const permsParam = typeof req.query.perms === 'string'
     ? req.query.perms
@@ -63,6 +64,7 @@ authRouter.get('/dev-token', async (req: Request, res: Response) => {
     id: userId,
     roles: roles.length > 0 ? roles : ['admin'],
     perms,
+    ...(tenantId ? { tenantId } : {}),
     sid: randomUUID(),
   }
 

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -25,6 +25,7 @@ import { createUserSession, getUserSession, listUserSessions, revokeUserSession,
 import { revokeUserSessions } from '../auth/session-revocation'
 import { FEATURE_FLAGS } from '../config/flags'
 import { Logger } from '../core/logger'
+import { extractTenantFromHeaders } from '../db/sharding/tenant-context'
 import { query } from '../db/pg'
 import { listUserPermissions } from '../rbac/service'
 import { secretManager } from '../security/SecretManager'
@@ -46,7 +47,9 @@ authRouter.get('/dev-token', async (req: Request, res: Response) => {
   }
 
   const userId = typeof req.query.userId === 'string' && req.query.userId.trim() ? req.query.userId.trim() : 'dev-user'
-  const tenantId = typeof req.query.tenantId === 'string' && req.query.tenantId.trim() ? req.query.tenantId.trim() : undefined
+  const tenantId =
+    (typeof req.query.tenantId === 'string' && req.query.tenantId.trim() ? req.query.tenantId.trim() : undefined)
+    || resolveRequestTenantId(req)
   const rolesParam = typeof req.query.roles === 'string' ? req.query.roles : 'admin'
   const permsParam = typeof req.query.perms === 'string'
     ? req.query.perms
@@ -110,6 +113,10 @@ function getClientIP(req: Request): string {
     return forwarded.split(',')[0].trim()
   }
   return req.ip || req.socket.remoteAddress || 'unknown'
+}
+
+function resolveRequestTenantId(req: Request): string | undefined {
+  return extractTenantFromHeaders(req.headers as Record<string, unknown> | undefined)
 }
 
 function checkRateLimit(key: string, maxAttempts: number): { allowed: boolean; retryAfter?: number } {
@@ -249,7 +256,9 @@ async function loadAuthPermissions(userId: string): Promise<string[]> {
 
 async function issueAuthSessionToken(user: User, req: Request): Promise<string> {
   const sessionId = randomUUID()
-  const token = authService.createToken(user, { sid: sessionId })
+  const tenantId = resolveRequestTenantId(req)
+  const tokenUser = tenantId ? { ...user, tenantId } : user
+  const token = authService.createToken(tokenUser, { sid: sessionId })
   const payload = authService.readTokenPayload(token)
 
   if (payload?.exp) {
@@ -312,6 +321,7 @@ authRouter.post('/login', loginRateLimiter, async (req: Request, res: Response) 
     const result = await authService.login(cleanEmail, password, {
       ipAddress: ip,
       userAgent: req.headers['user-agent'] || null,
+      tenantId: resolveRequestTenantId(req),
     })
 
     if (!result) {
@@ -405,7 +415,8 @@ authRouter.post('/register', registerRateLimiter, async (req: Request, res: Resp
     }
 
     // 注册成功，自动生成token
-    const token = authService.createToken(user)
+    const tenantId = resolveRequestTenantId(req)
+    const token = authService.createToken(tenantId ? { ...user, tenantId } : user)
     logger.info(`Successful registration for ${cleanEmail} from ${ip}`)
 
     res.status(201).json({
@@ -558,6 +569,7 @@ authRouter.post('/invite/accept', async (req: Request, res: Response) => {
     const result = await authService.login(payload.email, password, {
       ipAddress: ip,
       userAgent: req.headers['user-agent'] || null,
+      tenantId: resolveRequestTenantId(req),
     })
     if (!result) {
       return res.status(500).json({

--- a/packages/core-backend/src/types/express.d.ts
+++ b/packages/core-backend/src/types/express.d.ts
@@ -20,6 +20,7 @@ declare global {
         id?: string | number
         sub?: string // JWT subject claim (user ID)
         userId?: string // Alternative user ID field
+        tenantId?: string
         email?: string
         name?: string
         role?: string

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -331,6 +331,10 @@ export interface CoreAPI {
   http: HttpAPI
   database: DatabaseAPI
   multitable?: MultitableAPI
+  tenant?: {
+    getTenantId(): string | undefined
+    requireTenantId(): string
+  }
   auth: AuthAPI
   events: EventAPI
   storage: StorageAPI

--- a/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
+++ b/packages/core-backend/tests/integration/after-sales-plugin.install.test.ts
@@ -72,7 +72,10 @@ function requestJson(
 }
 
 async function issueDevToken(baseUrl: string, query: string): Promise<string> {
-  const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?${query}`)
+  const tenantScopedQuery = query.includes('tenantId=')
+    ? query
+    : `${query}&tenantId=${encodeURIComponent(TENANT_ID)}`
+  const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?${tenantScopedQuery}`)
   const token = (tokenRes.body as { token?: string } | undefined)?.token
   expect(token).toBeTruthy()
   return String(token)
@@ -86,7 +89,7 @@ function stableMetaId(prefix: string, ...parts: string[]): string {
   return `${prefix}_${digest}`.slice(0, 50)
 }
 
-const TENANT_ID = 'default'
+const TENANT_ID = 'tenant_42'
 const APP_ID = 'after-sales'
 const PLUGIN_ID = 'plugin-after-sales'
 const PROJECT_ID = `${TENANT_ID}:${APP_ID}`
@@ -391,7 +394,7 @@ describe('after-sales plugin install integration', () => {
     )
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-install-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-install-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -854,7 +857,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-non-admin&roles=user&perms=after_sales:read`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-non-admin&roles=user&perms=after_sales:read&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -885,7 +888,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool || !server) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-reinstall-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-reinstall-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -1040,7 +1043,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-part-item-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-part-item-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -1191,7 +1194,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -1495,7 +1498,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-update-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-update-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -1598,7 +1601,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-refund-reject-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-refund-reject-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -1758,7 +1761,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -1930,7 +1933,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-delete-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-ticket-delete-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2038,7 +2041,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-delete-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-delete-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2160,7 +2163,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-update-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-service-record-update-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2294,7 +2297,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-create-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-create-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2410,7 +2413,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-update-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-update-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2546,7 +2549,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-delete-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-installed-asset-delete-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2647,7 +2650,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-list-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-list-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2729,7 +2732,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-list-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-list-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2820,7 +2823,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-create-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-create-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -2937,7 +2940,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-delete-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-delete-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -3016,7 +3019,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-edit-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-edit-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -3120,7 +3123,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-due-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-follow-up-due-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -3251,7 +3254,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-create-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-create-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -3357,7 +3360,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-update-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-update-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()
@@ -3453,7 +3456,7 @@ describe('after-sales plugin install integration', () => {
     if (!baseUrl || !pool) return
 
     const tokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-delete-it&roles=admin&perms=*:*`,
+      `${baseUrl}/api/auth/dev-token?userId=after-sales-customer-delete-it&roles=admin&perms=*:*&tenantId=${TENANT_ID}`,
     )
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     expect(token).toBeTruthy()

--- a/packages/core-backend/tests/unit/AuthService.test.ts
+++ b/packages/core-backend/tests/unit/AuthService.test.ts
@@ -189,6 +189,7 @@ describe('AuthService.verifyToken', () => {
       id: 'dev-admin',
       roles: ['admin'],
       perms: ['multitable:read', 'multitable:write'],
+      tenantId: 'tenant_42',
       sid: 'dev-session',
       iat: 0,
       exp: 0,
@@ -199,6 +200,7 @@ describe('AuthService.verifyToken', () => {
 
     expect(user).toBeTruthy()
     expect(user?.id).toBe('dev-admin')
+    expect(user?.tenantId).toBe('tenant_42')
     expect(user?.role).toBe('admin')
     expect(user?.permissions).toEqual(['multitable:read', 'multitable:write'])
     expect(poolMocks.query).not.toHaveBeenCalled()

--- a/packages/core-backend/tests/unit/AuthService.test.ts
+++ b/packages/core-backend/tests/unit/AuthService.test.ts
@@ -393,3 +393,38 @@ describe('AuthService.register', () => {
     )
   })
 })
+
+describe('AuthService.createToken', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    jwtMocks.sign.mockReset()
+    jwtMocks.sign.mockReturnValue('signed-token')
+    secretManagerMocks.get.mockReset()
+    secretManagerMocks.get.mockReturnValue('unit-test-secret-abcdefghijklmnopqrstuvwxyz123456')
+  })
+
+  it('includes tenantId when present on the authenticated user', () => {
+    const auth = new AuthService()
+
+    const token = auth.createToken({
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+      role: 'admin',
+      permissions: ['*:*'],
+      tenantId: 'tenant_42',
+      created_at: new Date('2026-04-11T00:00:00.000Z'),
+      updated_at: new Date('2026-04-11T00:00:00.000Z'),
+    })
+
+    expect(token).toBe('signed-token')
+    expect(jwtMocks.sign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        tenantId: 'tenant_42',
+      }),
+      expect.any(String),
+      expect.any(Object),
+    )
+  })
+})

--- a/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
@@ -52,6 +52,10 @@ interface FakeContext {
     http: {
       addRoute: (method: string, path: string, handler: RegisteredHandler) => void
     }
+    tenant?: {
+      getTenantId: () => string | undefined
+      requireTenantId: () => string
+    }
     multitable?: {
       provisioning?: {
         getObjectSheetId: (projectId: string, objectId: string) => string
@@ -667,6 +671,12 @@ function createContext(): {
           routes.set(`${method} ${path}`, handler)
         },
       },
+      tenant: {
+        getTenantId: vi.fn(() => undefined),
+        requireTenantId: vi.fn(() => {
+          throw new Error('tenant context not set')
+        }),
+      },
       multitable: {
         provisioning: {
           getObjectSheetId,
@@ -865,10 +875,9 @@ describe('plugin-after-sales routes', () => {
     })
   })
 
-  it('warns once per request when tenantId is missing and falls back to default', async () => {
+  it('returns 401 when tenantId is missing from both request and tenant context', async () => {
     const handler = routes.get('GET /api/after-sales/projects/current')
-    const firstRes = new FakeResponse()
-    const secondRes = new FakeResponse()
+    const res = new FakeResponse()
     const req = buildReq({
       method: 'GET',
       path: '/api/after-sales/projects/current',
@@ -880,20 +889,45 @@ describe('plugin-after-sales routes', () => {
       },
     })
 
-    await handler?.(req, firstRes)
-    await handler?.(req, secondRes)
+    await handler?.(req, res)
 
-    expect(firstRes.statusCode).toBe(200)
-    expect(secondRes.statusCode).toBe(200)
-    expect(currentContext.logger.warn).toHaveBeenCalledTimes(1)
-    expect(currentContext.logger.warn).toHaveBeenCalledWith(
-      'After-sales request missing tenantId; falling back to default',
-      expect.objectContaining({
-        method: 'GET',
-        path: '/api/after-sales/projects/current',
-        userId: 'user_42',
+    expect(res.statusCode).toBe(401)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'tenantId not found',
+      },
+    })
+  })
+
+  it('uses tenant context when req.user.tenantId is missing', async () => {
+    const handler = routes.get('GET /api/after-sales/projects/current')
+    const res = new FakeResponse()
+    currentContext.api.tenant = {
+      getTenantId: () => 'tenant_ctx',
+      requireTenantId: () => 'tenant_ctx',
+    }
+
+    await handler?.(
+      buildReq({
+        user: {
+          id: 'user_42',
+          role: 'admin',
+          roles: ['admin'],
+          perms: ['*:*', 'after_sales:admin'],
+        },
       }),
+      res,
     )
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        status: 'not-installed',
+      },
+    })
   })
 
   it('surfaces ledger-read-failed for current when the ledger read throws', async () => {

--- a/packages/core-backend/tests/unit/after-sales-workflow-adapter.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-workflow-adapter.test.ts
@@ -279,6 +279,62 @@ describe('after-sales workflow adapter', () => {
     })
   })
 
+  it('throws VALIDATION_ERROR when payload.tenantId is present but projectId is not tenant scoped', async () => {
+    const context = createContext()
+    const runtime = adapter.createWorkflowRuntime(context, {
+      loadCurrent: vi.fn(async () => ({
+        status: 'not-installed',
+        config: null,
+      })),
+    })
+
+    await expect(
+      runtime.onTicketCreated({
+        tenantId: 'tenant_42',
+        projectId: 'after-sales',
+        ticketNo: 'TK-1006',
+        ticket: {
+          id: 'ticket_006',
+          ticketNo: 'TK-1006',
+          title: 'Voltage instability',
+          priority: 'normal',
+          assigneeCandidates: [{ id: 'tech_006', type: 'user' }],
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'projectId must include a tenant prefix',
+    })
+  })
+
+  it('throws VALIDATION_ERROR when payload.projectId tenant prefix mismatches tenantId', async () => {
+    const context = createContext()
+    const runtime = adapter.createWorkflowRuntime(context, {
+      loadCurrent: vi.fn(async () => ({
+        status: 'not-installed',
+        config: null,
+      })),
+    })
+
+    await expect(
+      runtime.onTicketCreated({
+        tenantId: 'tenant_42',
+        projectId: 'tenant_other:after-sales',
+        ticketNo: 'TK-1007',
+        ticket: {
+          id: 'ticket_007',
+          ticketNo: 'TK-1007',
+          title: 'Cooling failure',
+          priority: 'normal',
+          assigneeCandidates: [{ id: 'tech_007', type: 'user' }],
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'projectId tenant prefix does not match tenantId',
+    })
+  })
+
   it('skips an automation handler when the install-time rule is disabled', async () => {
     const listRules = vi.fn(async () => [
       {

--- a/packages/core-backend/tests/unit/after-sales-workflow-adapter.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-workflow-adapter.test.ts
@@ -15,6 +15,9 @@ function createContext(queryImpl?: (sql: string, params?: unknown[]) => Promise<
       database: {
         query: vi.fn(queryImpl || (async () => [])),
       },
+      tenant: {
+        getTenantId: vi.fn(() => undefined),
+      },
       events: {
         emit: vi.fn(),
         on: vi.fn((eventName: string) => `sub:${eventName}`),
@@ -157,6 +160,123 @@ describe('after-sales workflow adapter', () => {
         workflowId: 'refund-approval',
       }),
     )
+  })
+
+  it('resolves tenantId from projectId when the payload omits an explicit tenant claim', async () => {
+    const context = createContext()
+    const loadCurrent = vi.fn(async () => ({
+      status: 'installed',
+      projectId: 'tenant_42:after-sales',
+      config: {
+        defaultSlaHours: 24,
+        urgentSlaHours: 4,
+      },
+    }))
+    const runtime = adapter.createWorkflowRuntime(context, { loadCurrent })
+
+    await runtime.onTicketCreated({
+      projectId: 'tenant_42:after-sales',
+      ticketNo: 'TK-1002',
+      ticket: {
+        id: 'ticket_002',
+        ticketNo: 'TK-1002',
+        title: 'Broken valve',
+        priority: 'normal',
+        assigneeCandidates: [{ id: 'tech_002', type: 'user' }],
+      },
+    })
+
+    expect(loadCurrent).toHaveBeenCalledWith(context, 'tenant_42', 'after-sales')
+    expect(context.api.events.emit).toHaveBeenCalledWith(
+      'ticket.assigned',
+      expect.objectContaining({
+        tenantId: 'tenant_42',
+        projectId: 'tenant_42:after-sales',
+      }),
+    )
+  })
+
+  it('falls back to tenant context when payload carries no tenant information', async () => {
+    const context = createContext()
+    context.api.tenant.getTenantId = vi.fn(() => 'tenant_ctx')
+    const loadCurrent = vi.fn(async () => ({
+      status: 'not-installed',
+      config: null,
+    }))
+    const runtime = adapter.createWorkflowRuntime(context, { loadCurrent })
+
+    await runtime.onTicketCreated({
+      ticketNo: 'TK-1003',
+      ticket: {
+        id: 'ticket_003',
+        ticketNo: 'TK-1003',
+        title: 'Loose wiring',
+        priority: 'normal',
+        assigneeCandidates: [{ id: 'tech_003', type: 'user' }],
+      },
+    })
+
+    expect(loadCurrent).toHaveBeenCalledWith(context, 'tenant_ctx', 'after-sales')
+    expect(context.api.events.emit).toHaveBeenCalledWith(
+      'ticket.assigned',
+      expect.objectContaining({
+        tenantId: 'tenant_ctx',
+        projectId: 'tenant_ctx:after-sales',
+      }),
+    )
+  })
+
+  it('throws VALIDATION_ERROR when tenantId cannot be resolved', async () => {
+    const context = createContext()
+    const runtime = adapter.createWorkflowRuntime(context, {
+      loadCurrent: vi.fn(async () => ({
+        status: 'not-installed',
+        config: null,
+      })),
+    })
+
+    await expect(
+      runtime.onTicketCreated({
+        ticketNo: 'TK-1004',
+        ticket: {
+          id: 'ticket_004',
+          ticketNo: 'TK-1004',
+          title: 'Sensor alarm',
+          priority: 'normal',
+          assigneeCandidates: [{ id: 'tech_004', type: 'user' }],
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'tenantId not found',
+    })
+  })
+
+  it('throws VALIDATION_ERROR when projectId is not tenant scoped', async () => {
+    const context = createContext()
+    const runtime = adapter.createWorkflowRuntime(context, {
+      loadCurrent: vi.fn(async () => ({
+        status: 'not-installed',
+        config: null,
+      })),
+    })
+
+    await expect(
+      runtime.onTicketCreated({
+        projectId: 'after-sales',
+        ticketNo: 'TK-1005',
+        ticket: {
+          id: 'ticket_005',
+          ticketNo: 'TK-1005',
+          title: 'Compressor noise',
+          priority: 'normal',
+          assigneeCandidates: [{ id: 'tech_005', type: 'user' }],
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'projectId must include a tenant prefix',
+    })
   })
 
   it('skips an automation handler when the install-time rule is disabled', async () => {
@@ -338,6 +458,8 @@ describe('after-sales workflow adapter', () => {
     })
 
     await runtime.onTicketAssigned({
+      tenantId: 'tenant_42',
+      projectId: 'tenant_42:after-sales',
       ticketNo: 'TK-1001',
       ticket: {
         assignedTo: 'tech_001',
@@ -346,6 +468,8 @@ describe('after-sales workflow adapter', () => {
     })
 
     await runtime.onServiceRecorded({
+      tenantId: 'tenant_42',
+      projectId: 'tenant_42:after-sales',
       serviceRecord: {
         id: 'sr_001',
         ticketNo: 'TK-1001',
@@ -353,6 +477,8 @@ describe('after-sales workflow adapter', () => {
     })
 
     await runtime.onApprovalPending({
+      tenantId: 'tenant_42',
+      projectId: 'tenant_42:after-sales',
       approval: {
         id: 'afs:1',
       },
@@ -362,6 +488,8 @@ describe('after-sales workflow adapter', () => {
     })
 
     await runtime.onTicketOverdue({
+      tenantId: 'tenant_42',
+      projectId: 'tenant_42:after-sales',
       ticketNo: 'TK-1001',
       ticket: {
         id: 'ticket_001',
@@ -375,6 +503,8 @@ describe('after-sales workflow adapter', () => {
     })
 
     await runtime.onFollowUpDue({
+      tenantId: 'tenant_42',
+      projectId: 'tenant_42:after-sales',
       ticketNo: 'TK-1001',
       followUpOwner: {
         id: 'owner_001',

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -243,6 +243,32 @@ describe('auth login routes', () => {
     })
   })
 
+  it('issues a dev token with an optional tenant claim', async () => {
+    const response = await invokeRoute('get', '/dev-token', {
+      query: {
+        userId: 'dev-user',
+        tenantId: 'tenant_42',
+        roles: 'admin',
+        perms: '*:*',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect((response.body as Record<string, any>).payload).toMatchObject({
+      id: 'dev-user',
+      tenantId: 'tenant_42',
+      roles: ['admin'],
+      perms: ['*:*'],
+    })
+    expect(sessionRegistryMocks.createUserSession).toHaveBeenCalledWith(
+      'dev-user',
+      expect.objectContaining({
+        sessionId: expect.any(String),
+        ipAddress: '127.0.0.1',
+      }),
+    )
+  })
+
   it('returns feature payload on me for a valid token', async () => {
     authServiceMocks.verifyToken.mockResolvedValue({
       id: 'user-1',

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -243,6 +243,41 @@ describe('auth login routes', () => {
     })
   })
 
+  it('forwards x-tenant-id into the normal login flow', async () => {
+    authServiceMocks.login.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        email: 'admin@example.com',
+        name: 'Admin',
+        role: 'admin',
+        permissions: ['attendance:admin'],
+        tenantId: 'tenant_42',
+        created_at: new Date('2026-03-13T00:00:00.000Z'),
+        updated_at: new Date('2026-03-13T00:00:00.000Z'),
+      },
+      token: 'jwt-login-token',
+    })
+
+    const response = await invokeRoute('post', '/login', {
+      headers: {
+        'x-tenant-id': 'tenant_42',
+      },
+      body: {
+        email: 'admin@example.com',
+        password: 'WelcomePass9A',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(authServiceMocks.login).toHaveBeenCalledWith(
+      'admin@example.com',
+      'WelcomePass9A',
+      expect.objectContaining({
+        tenantId: 'tenant_42',
+      }),
+    )
+  })
+
   it('issues a dev token with an optional tenant claim', async () => {
     const response = await invokeRoute('get', '/dev-token', {
       query: {
@@ -568,6 +603,7 @@ describe('auth login routes', () => {
 
     const response = await invokeRoute('post', '/dingtalk/callback', {
       headers: {
+        'x-tenant-id': 'tenant_42',
         'user-agent': 'Vitest Browser',
       },
       body: {
@@ -586,6 +622,7 @@ describe('auth login routes', () => {
         email: 'manager@example.com',
         role: 'admin',
         permissions: ['attendance:admin', 'workflow:read'],
+        tenantId: 'tenant_42',
       }),
       expect.objectContaining({ sid: expect.any(String) }),
     )

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -1,6 +1,24 @@
-import { describe, expect, it } from 'vitest'
+import type { Request, Response, NextFunction } from 'express'
+import { describe, expect, it, vi } from 'vitest'
 
-import { isWhitelisted } from '../../src/auth/jwt-middleware'
+const authServiceMocks = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}))
+
+const metricsMocks = vi.hoisted(() => ({
+  jwtAuthFail: { inc: vi.fn() },
+  authFailures: { inc: vi.fn() },
+}))
+
+vi.mock('../../src/auth/AuthService', () => ({
+  authService: authServiceMocks,
+}))
+
+vi.mock('../../src/metrics/metrics', () => ({
+  metrics: metricsMocks,
+}))
+
+import { isWhitelisted, jwtAuthMiddleware } from '../../src/auth/jwt-middleware'
 
 describe('jwt auth whitelist', () => {
   it('allows DingTalk launch without a bearer token', () => {
@@ -10,5 +28,40 @@ describe('jwt auth whitelist', () => {
 
   it('allows DingTalk callback without a bearer token', () => {
     expect(isWhitelisted('/api/auth/dingtalk/callback')).toBe(true)
+  })
+})
+
+describe('jwt auth middleware', () => {
+  it('preserves tenantId on authenticated requests', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'tenant-user@example.com',
+      name: 'Tenant User',
+      role: 'admin',
+      permissions: ['*:*'],
+      tenantId: 'tenant_42',
+      created_at: new Date('2026-04-11T00:00:00.000Z'),
+      updated_at: new Date('2026-04-11T00:00:00.000Z'),
+    })
+
+    const req = {
+      headers: {
+        authorization: 'Bearer tenant-token',
+      },
+    } as unknown as Request
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response
+    const next = vi.fn() as NextFunction
+
+    await jwtAuthMiddleware(req, res, next)
+
+    expect(authServiceMocks.verifyToken).toHaveBeenCalledWith('tenant-token')
+    expect(req.user).toMatchObject({
+      id: 'user-1',
+      tenantId: 'tenant_42',
+    })
+    expect(next).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -64,4 +64,36 @@ describe('jwt auth middleware', () => {
     })
     expect(next).toHaveBeenCalledTimes(1)
   })
+
+  it('backfills tenantId from x-tenant-id for legacy tenant-less tokens', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-2',
+      email: 'legacy@example.com',
+      name: 'Legacy User',
+      role: 'admin',
+      permissions: ['*:*'],
+      created_at: new Date('2026-04-11T00:00:00.000Z'),
+      updated_at: new Date('2026-04-11T00:00:00.000Z'),
+    })
+
+    const req = {
+      headers: {
+        authorization: 'Bearer legacy-token',
+        'x-tenant-id': 'tenant_legacy',
+      },
+    } as unknown as Request
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response
+    const next = vi.fn() as NextFunction
+
+    await jwtAuthMiddleware(req, res, next)
+
+    expect(req.user).toMatchObject({
+      id: 'user-2',
+      tenantId: 'tenant_legacy',
+    })
+    expect(next).toHaveBeenCalledTimes(1)
+  })
 })

--- a/plugins/plugin-after-sales/index.cjs
+++ b/plugins/plugin-after-sales/index.cjs
@@ -126,37 +126,29 @@ async function toPhysicalCustomerData(provisioning, projectId, logicalData) {
 
 let activeContext = null
 let workflowSubscriptionIds = []
-const TENANT_FALLBACK_WARNED = Symbol('after-sales-tenant-fallback-warned')
 
 // --------------------------------------------------------------------------
 // Local helpers
 // --------------------------------------------------------------------------
 
-/**
- * v1 tenantId extraction. Matches the existing convention used by
- * packages/core-backend/src/routes/plm-workbench.ts and workflow.ts.
- *
- * TODO(phase-1b): replace with AsyncLocalStorage tenantContext.getTenantId()
- * once the plugin-context injection is available for plugins.
- */
-function getTenantId(req, logger) {
-  const tenantId = req && req.user && req.user.tenantId != null
+function getTenantId(context, req, res) {
+  const contextTenantId = context
+    && context.api
+    && context.api.tenant
+    && typeof context.api.tenant.getTenantId === 'function'
+    ? context.api.tenant.getTenantId()
+    : ''
+  if (typeof contextTenantId === 'string' && contextTenantId.trim()) {
+    return contextTenantId.trim()
+  }
+
+  const requestTenantId = req && req.user && req.user.tenantId != null
     ? String(req.user.tenantId).trim()
     : ''
-  if (tenantId) return tenantId
+  if (requestTenantId) return requestTenantId
 
-  if (req && !req[TENANT_FALLBACK_WARNED]) {
-    req[TENANT_FALLBACK_WARNED] = true
-    logger && typeof logger.warn === 'function' && logger.warn(
-      'After-sales request missing tenantId; falling back to default',
-      {
-        method: req.method || null,
-        path: req.path || null,
-        userId: getUserId(req),
-      },
-    )
-  }
-  return 'default'
+  sendTenantUnauthorized(res)
+  return null
 }
 
 function getUserId(req) {
@@ -337,6 +329,13 @@ function sendUnauthorized(res) {
   res.status(401).json({
     ok: false,
     error: { code: 'UNAUTHORIZED', message: 'User ID not found' },
+  })
+}
+
+function sendTenantUnauthorized(res) {
+  res.status(401).json({
+    ok: false,
+    error: { code: 'UNAUTHORIZED', message: 'tenantId not found' },
   })
 }
 
@@ -601,9 +600,18 @@ async function getTicketRecordById(multitableApi, projectId, ticketId) {
 }
 
 function resolveTenantIdFromProject(projectId) {
-  if (typeof projectId !== 'string') return 'default'
+  if (typeof projectId !== 'string') {
+    const error = new Error('projectId must be a non-empty tenant-scoped identifier')
+    error.code = 'VALIDATION_ERROR'
+    throw error
+  }
   const [tenantId] = projectId.split(':')
-  return tenantId || 'default'
+  if (!tenantId || !tenantId.trim()) {
+    const error = new Error('projectId must include a tenant prefix')
+    error.code = 'VALIDATION_ERROR'
+    throw error
+  }
+  return tenantId.trim()
 }
 
 async function handleRefundApprovalDecisionCallback(context, input) {
@@ -738,7 +746,8 @@ module.exports = {
             sendUnauthorized(res)
             return
           }
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           res.json({ ok: true, data: current })
         } catch (err) {
@@ -798,7 +807,9 @@ module.exports = {
               ? body.config
               : {}
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const blueprint = getDefaultBlueprint()
 
           const result = await installer.runInstall({
@@ -854,7 +865,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -910,7 +923,9 @@ module.exports = {
             throw new Error('automationRegistry service unavailable on plugin context')
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -969,7 +984,9 @@ module.exports = {
             throw new Error('automationRegistry service unavailable on plugin context')
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1049,7 +1066,9 @@ module.exports = {
             throw new Error('automationRegistry service unavailable on plugin context')
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1134,7 +1153,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1274,7 +1295,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1394,7 +1417,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1499,7 +1524,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1579,7 +1606,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1685,7 +1714,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1791,7 +1822,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -1874,7 +1907,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2012,7 +2047,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2155,7 +2192,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2250,7 +2289,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2389,7 +2430,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2492,7 +2535,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2645,7 +2690,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2755,7 +2802,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2843,7 +2892,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -2945,7 +2996,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -3035,7 +3088,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -3134,7 +3189,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -3287,7 +3344,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -3377,7 +3436,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -3473,7 +3534,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -3622,7 +3685,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -3728,7 +3793,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || !isOperationalAfterSalesStatus(current.status)) {
             res.status(409).json({
@@ -3817,7 +3884,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || current.status === 'not-installed') {
             res.status(409).json({
@@ -3931,7 +4000,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const current = await installer.loadCurrent(context, tenantId, appManifest.id)
           if (!current || current.status === 'not-installed') {
             res.status(409).json({
@@ -3986,7 +4057,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const payload = buildTicketCreatedEventPayload((req && req.body) || {}, {
             tenantId,
             projectId: installer.getProjectId(tenantId, appManifest.id),
@@ -4032,7 +4105,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const payload = buildRefundRequestedEventPayload((req && req.body) || {}, {
             tenantId,
             projectId: installer.getProjectId(tenantId, appManifest.id),
@@ -4078,7 +4153,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const payload = buildTicketOverdueEventPayload((req && req.body) || {}, {
             tenantId,
             projectId: installer.getProjectId(tenantId, appManifest.id),
@@ -4124,7 +4201,9 @@ module.exports = {
             return
           }
 
-          const tenantId = getTenantId(req, context.logger)
+          const tenantId = getTenantId(context, req, res)
+
+          if (!tenantId) return
           const payload = buildFollowUpDueEventPayload((req && req.body) || {}, {
             tenantId,
             projectId: installer.getProjectId(tenantId, appManifest.id),

--- a/plugins/plugin-after-sales/lib/workflow-adapter.cjs
+++ b/plugins/plugin-after-sales/lib/workflow-adapter.cjs
@@ -65,12 +65,12 @@ function parseTenantIdFromProjectId(projectId) {
   return value.slice(0, separatorIndex).trim()
 }
 
-function resolveTenantIdFromPayload(payload) {
+function resolveTenantIdFromPayload(payload, requestedProjectTenantId = '') {
   return (
     getScalarString(payload, 'tenantId') ||
     getScalarString(getNamespacedObject(payload, 'ticket'), 'tenantId') ||
     getScalarString(getNamespacedObject(payload, 'approval'), 'tenantId') ||
-    parseTenantIdFromProjectId(getScalarString(payload, 'projectId'))
+    requestedProjectTenantId
   )
 }
 
@@ -164,7 +164,11 @@ async function resolveRoleRecipients(context, roleSlugs) {
 
 async function resolveRuntimeInstallContext(context, payload, options = {}) {
   const appId = options.appId || DEFAULT_APP_ID
-  const payloadTenantId = resolveTenantIdFromPayload(payload)
+  const requestedProjectId = getScalarString(payload, 'projectId')
+  const requestedProjectTenantId = requestedProjectId
+    ? parseTenantIdFromProjectId(requestedProjectId)
+    : ''
+  const payloadTenantId = resolveTenantIdFromPayload(payload, requestedProjectTenantId)
   const contextTenantId = resolveTenantIdFromContext(context)
   const tenantLookupId = payloadTenantId || contextTenantId
 
@@ -184,8 +188,11 @@ async function resolveRuntimeInstallContext(context, payload, options = {}) {
       throw createValidationError('tenantId not found')
     }
     const config = normalizeTemplateConfig(current && current.status !== 'not-installed' ? current.config : null)
+    if (requestedProjectId && requestedProjectTenantId !== tenantId) {
+      throw createValidationError('projectId tenant prefix does not match tenantId')
+    }
     const projectId =
-      getScalarString(payload, 'projectId') ||
+      requestedProjectId ||
       currentProjectId ||
       installer.getProjectId(tenantId, appId)
 

--- a/plugins/plugin-after-sales/lib/workflow-adapter.cjs
+++ b/plugins/plugin-after-sales/lib/workflow-adapter.cjs
@@ -49,13 +49,38 @@ function getScalarString(payload, field) {
   return typeof payload?.[field] === 'string' && payload[field].trim() ? payload[field].trim() : ''
 }
 
-function resolveTenantId(payload) {
+function createValidationError(message) {
+  const error = new Error(message)
+  error.code = 'VALIDATION_ERROR'
+  return error
+}
+
+function parseTenantIdFromProjectId(projectId) {
+  const value = typeof projectId === 'string' ? projectId.trim() : ''
+  if (!value) return ''
+  const separatorIndex = value.indexOf(':')
+  if (separatorIndex <= 0) {
+    throw createValidationError('projectId must include a tenant prefix')
+  }
+  return value.slice(0, separatorIndex).trim()
+}
+
+function resolveTenantIdFromPayload(payload) {
   return (
     getScalarString(payload, 'tenantId') ||
     getScalarString(getNamespacedObject(payload, 'ticket'), 'tenantId') ||
     getScalarString(getNamespacedObject(payload, 'approval'), 'tenantId') ||
-    'default'
+    parseTenantIdFromProjectId(getScalarString(payload, 'projectId'))
   )
+}
+
+function resolveTenantIdFromContext(context) {
+  const tenantApi = context?.api?.tenant
+  if (!tenantApi || typeof tenantApi.getTenantId !== 'function') {
+    return ''
+  }
+  const tenantId = tenantApi.getTenantId()
+  return typeof tenantId === 'string' && tenantId.trim() ? tenantId.trim() : ''
 }
 
 function resolveRequestedAssignee(ticket) {
@@ -139,14 +164,29 @@ async function resolveRoleRecipients(context, roleSlugs) {
 
 async function resolveRuntimeInstallContext(context, payload, options = {}) {
   const appId = options.appId || DEFAULT_APP_ID
-  const tenantId = resolveTenantId(payload)
+  const payloadTenantId = resolveTenantIdFromPayload(payload)
+  const contextTenantId = resolveTenantIdFromContext(context)
+  const tenantLookupId = payloadTenantId || contextTenantId
+
+  if (!tenantLookupId) {
+    throw createValidationError('tenantId not found')
+  }
 
   try {
-    const current = await (options.loadCurrent || installer.loadCurrent)(context, tenantId, appId)
+    const current = await (options.loadCurrent || installer.loadCurrent)(context, tenantLookupId, appId)
+    const currentProjectId =
+      current && current.status !== 'not-installed'
+        ? getScalarString(current, 'projectId')
+        : ''
+    const currentTenantId = parseTenantIdFromProjectId(currentProjectId)
+    const tenantId = payloadTenantId || currentTenantId || contextTenantId
+    if (!tenantId) {
+      throw createValidationError('tenantId not found')
+    }
     const config = normalizeTemplateConfig(current && current.status !== 'not-installed' ? current.config : null)
     const projectId =
       getScalarString(payload, 'projectId') ||
-      (current && current.status !== 'not-installed' ? current.projectId : '') ||
+      currentProjectId ||
       installer.getProjectId(tenantId, appId)
 
     return {
@@ -156,10 +196,13 @@ async function resolveRuntimeInstallContext(context, payload, options = {}) {
       current,
     }
   } catch (error) {
+    if (error && error.code === 'VALIDATION_ERROR') {
+      throw error
+    }
     context.logger?.warn?.('after-sales workflow adapter falling back to default config', error)
     return {
-      tenantId,
-      projectId: installer.getProjectId(tenantId, appId),
+      tenantId: tenantLookupId,
+      projectId: installer.getProjectId(tenantLookupId, appId),
       config: normalizeTemplateConfig(null),
       current: null,
     }


### PR DESCRIPTION
## Summary
- remove the silent `default` tenant fallback from after-sales
- propagate `tenantId` through trusted or dev tokens, normal auth session issuance, JWT request state, tenant ALS, and `CoreAPI.tenant`
- harden workflow runtime tenant parsing and document the slice in `docs/after-sales-tenant-hardening-design-verification.md`

## What Changed
- `packages/core-backend/src/routes/auth.ts`: `/api/auth/dev-token` accepts optional `tenantId`, normal auth flows (`/login`, `/register`, `/invite/accept`, `/dingtalk/callback`) now read `x-tenant-id`, and session tokens carry the explicit tenant when present
- `packages/core-backend/src/auth/AuthService.ts`: login can issue tenant-scoped session tokens and trusted token verification preserves `tenantId`
- `packages/core-backend/src/auth/jwt-middleware.ts`: backfills `req.user.tenantId` from `x-tenant-id` for valid legacy tenant-less tokens
- `packages/core-backend/src/index.ts` + `packages/core-backend/src/types/plugin.ts`: add `CoreAPI.tenant` and establish tenant ALS after JWT auth
- `plugins/plugin-after-sales/index.cjs`: resolve tenant from `context.api.tenant` / `req.user.tenantId`, otherwise return `401 tenantId not found`
- `plugins/plugin-after-sales/lib/workflow-adapter.cjs`: remove the `default` fallback, enforce tenant-scoped `projectId`, and validate any explicit runtime `payload.projectId` against the resolved tenant scope
- `apps/web/src/views/AfterSalesView.vue`: stop passing placeholder `projectId` into refund approval reads
- update unit + integration coverage for strict tenant semantics and auth compatibility bridging

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/AuthService.test.ts tests/unit/auth-login-routes.test.ts tests/unit/jwt-middleware.test.ts tests/unit/after-sales-plugin-routes.test.ts tests/unit/after-sales-workflow-adapter.test.ts --reporter=dot` (`5` files / `160` tests passed)
- `DATABASE_URL=postgresql:///metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot` (`1` file / `25` tests passed)
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

## Notes
- `pnpm --filter @metasheet/web type-check` still fails on pre-existing unrelated PLM/realtime issues (`socket.io-client`, `@metasheet/sdk/client`, and existing type errors outside this slice)
- full design/verification notes are in `docs/after-sales-tenant-hardening-design-verification.md`
