### PR TITLE
feat(approvals): freeze platform approval v1 contracts

### DIFF
--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -28,6 +28,7 @@
  */
 
 import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router'
+import type { ApprovalStatus, ApprovalTemplateStatus } from '../types/approval'
 
 /**
  * Route Names Constants
@@ -63,6 +64,8 @@ export const AppRouteNames = {
   APPROVAL_LIST: 'approval-list',
   APPROVAL_DETAIL: 'approval-detail',
   APPROVAL_CREATE: 'approval-create',
+  APPROVAL_TEMPLATE_LIST: 'approval-template-list',
+  APPROVAL_TEMPLATE_DETAIL: 'approval-template-detail',
   APPROVAL_PENDING: 'approval-pending',
   APPROVAL_HISTORY: 'approval-history',
 
@@ -118,6 +121,8 @@ export interface AppRouteParams {
 
   // Approval routes
   'approval-detail': { id: string }
+  'approval-create': { templateId: string }
+  'approval-template-detail': { id: string }
 
   // User routes
   'user-profile': { id?: string } // optional, defaults to current user
@@ -134,7 +139,7 @@ export interface AppRouteParams {
   'workflow-list': Record<string, never>
   'workflow-create': Record<string, never>
   'approval-list': Record<string, never>
-  'approval-create': Record<string, never>
+  'approval-template-list': Record<string, never>
   'approval-pending': Record<string, never>
   'approval-history': Record<string, never>
   'attendance': Record<string, never>
@@ -188,9 +193,20 @@ export interface AppRouteQuery {
 
   // Approval list filters
   'approval-list': {
-    status?: 'pending' | 'approved' | 'rejected'
+    status?: ApprovalStatus
     search?: string
-    sortBy?: 'createdAt' | 'updatedAt'
+    requesterId?: string
+    assignee?: string
+    ccRecipientId?: string
+    templateId?: string
+    sortBy?: 'createdAt' | 'updatedAt' | 'requestNo'
+    sortOrder?: 'asc' | 'desc'
+  }
+
+  'approval-template-list': {
+    search?: string
+    status?: ApprovalTemplateStatus
+    sortBy?: 'createdAt' | 'updatedAt' | 'name'
     sortOrder?: 'asc' | 'desc'
   }
 
@@ -395,7 +411,9 @@ export const ROUTE_PATHS = {
   // Approval
   APPROVAL_LIST: '/approvals',
   APPROVAL_DETAIL: '/approvals/:id',
-  APPROVAL_CREATE: '/approvals/create',
+  APPROVAL_CREATE: '/approvals/new/:templateId',
+  APPROVAL_TEMPLATE_LIST: '/approval-templates',
+  APPROVAL_TEMPLATE_DETAIL: '/approval-templates/:id',
   APPROVAL_PENDING: '/approvals/pending',
   APPROVAL_HISTORY: '/approvals/history',
 

--- a/apps/web/src/stores/types.ts
+++ b/apps/web/src/stores/types.ts
@@ -1,3 +1,10 @@
+import type {
+  CreateApprovalRequest,
+  UnifiedApprovalDTO,
+  UnifiedApprovalHistoryDTO,
+  ApprovalStatus,
+} from '../types/approval'
+
 /**
  * Pinia Store Type Definitions
  *
@@ -121,28 +128,36 @@ export interface WorkflowActions {
  * Approval Store Types
  */
 export interface ApprovalState {
-  approvals: Approval[]
-  pendingApprovals: Approval[]
-  myApprovals: Approval[]
+  approvals: UnifiedApprovalDTO[]
+  pendingApprovals: UnifiedApprovalDTO[]
+  myApprovals: UnifiedApprovalDTO[]
+  ccApprovals: UnifiedApprovalDTO[]
+  completedApprovals: UnifiedApprovalDTO[]
+  activeApproval: UnifiedApprovalDTO | null
+  history: UnifiedApprovalHistoryDTO[]
   loading: boolean
   error: string | null
 }
 
 export interface ApprovalGetters {
   pendingCount: (state: ApprovalState) => number
-  approvalById: (state: ApprovalState) => (id: string) => Approval | undefined
-  approvalsByStatus: (state: ApprovalState) => (status: ApprovalStatus) => Approval[]
-  myPendingApprovals: (state: ApprovalState) => Approval[]
+  approvalById: (state: ApprovalState) => (id: string) => UnifiedApprovalDTO | undefined
+  approvalsByStatus: (state: ApprovalState) => (status: ApprovalStatus) => UnifiedApprovalDTO[]
+  myPendingApprovals: (state: ApprovalState) => UnifiedApprovalDTO[]
 }
 
 export interface ApprovalActions {
   loadApprovals(): Promise<void>
   loadMyApprovals(): Promise<void>
-  createApproval(data: CreateApprovalRequest): Promise<Approval>
+  loadCcApprovals(): Promise<void>
+  loadCompletedApprovals(): Promise<void>
+  createApproval(data: CreateApprovalRequest): Promise<UnifiedApprovalDTO>
   approveRequest(id: string, comment?: string): Promise<void>
   rejectRequest(id: string, reason: string): Promise<void>
-  cancelApproval(id: string): Promise<void>
-  loadApprovalHistory(id: string): Promise<ApprovalHistory[]>
+  transferRequest(id: string, targetUserId: string, comment?: string): Promise<void>
+  revokeRequest(id: string, comment?: string): Promise<void>
+  commentOnApproval(id: string, comment: string): Promise<void>
+  loadApprovalHistory(id: string): Promise<UnifiedApprovalHistoryDTO[]>
 }
 
 /**
@@ -241,29 +256,6 @@ export interface WorkflowExecution {
   completedAt?: Date
 }
 
-export interface Approval {
-  id: string
-  title: string
-  description?: string
-  status: ApprovalStatus
-  requesterId: string
-  approverId?: string
-  createdAt: Date
-  updatedAt: Date
-  decidedAt?: Date
-}
-
-export type ApprovalStatus = 'pending' | 'approved' | 'rejected' | 'cancelled'
-
-export interface ApprovalHistory {
-  id: string
-  approvalId: string
-  action: 'created' | 'approved' | 'rejected' | 'cancelled'
-  userId: string
-  comment?: string
-  timestamp: Date
-}
-
 export interface Notification {
   id: string
   type: 'info' | 'success' | 'warning' | 'error'
@@ -312,13 +304,6 @@ export interface UpdateWorkflowRequest {
   description?: string
   definition?: any
   status?: 'active' | 'inactive'
-}
-
-export interface CreateApprovalRequest {
-  title: string
-  description?: string
-  approverId: string
-  metadata?: any
 }
 
 /**

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -1,0 +1,203 @@
+export const APPROVAL_PRODUCT_PERMISSIONS = [
+  'approvals:read',
+  'approvals:write',
+  'approvals:act',
+  'approval-templates:manage',
+] as const
+
+export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[number]
+
+export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'end'
+export type ApprovalAssigneeType = 'user' | 'role'
+export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment'
+export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
+export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
+export type FormFieldType =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'date'
+  | 'datetime'
+  | 'select'
+  | 'multi-select'
+  | 'user'
+  | 'attachment'
+
+export interface ApprovalNode {
+  key: string
+  type: ApprovalNodeType
+  name?: string
+  config: ApprovalNodeConfig | ConditionNodeConfig | CcNodeConfig | Record<string, never>
+}
+
+export interface ApprovalNodeConfig {
+  assigneeType: ApprovalAssigneeType
+  assigneeIds: string[]
+}
+
+export interface ConditionNodeConfig {
+  branches: ConditionBranch[]
+  defaultEdgeKey?: string
+}
+
+export interface ConditionBranch {
+  edgeKey: string
+  rules: ConditionRule[]
+  conjunction?: 'and' | 'or'
+}
+
+export interface ConditionRule {
+  fieldId: string
+  operator: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'isEmpty'
+  value?: unknown
+}
+
+export interface CcNodeConfig {
+  targetType: ApprovalAssigneeType
+  targetIds: string[]
+}
+
+export interface ApprovalEdge {
+  key: string
+  source: string
+  target: string
+}
+
+export interface ApprovalGraph {
+  nodes: ApprovalNode[]
+  edges: ApprovalEdge[]
+}
+
+export interface RuntimePolicy {
+  allowRevoke: boolean
+  revokeBeforeNodeKeys?: string[]
+}
+
+export interface RuntimeGraph extends ApprovalGraph {
+  policy: RuntimePolicy
+}
+
+export interface FormOption {
+  label: string
+  value: string
+}
+
+export interface FormField {
+  id: string
+  type: FormFieldType
+  label: string
+  required?: boolean
+  placeholder?: string
+  defaultValue?: unknown
+  options?: FormOption[]
+  props?: Record<string, unknown>
+}
+
+export interface FormSchema {
+  fields: FormField[]
+}
+
+export interface ApprovalRequesterSnapshot {
+  id?: string
+  name?: string
+  department?: string
+  title?: string
+  [key: string]: unknown
+}
+
+export interface ApprovalSubjectSnapshot {
+  [key: string]: unknown
+}
+
+export interface ApprovalPolicySnapshot {
+  rejectCommentRequired?: boolean
+  sourceOfTruth?: string
+  [key: string]: unknown
+}
+
+export interface ApprovalAssignmentDTO {
+  id: string
+  type: string
+  assigneeId: string
+  sourceStep: number
+  nodeKey?: string | null
+  isActive: boolean
+  metadata: Record<string, unknown>
+}
+
+export interface UnifiedApprovalDTO {
+  id: string
+  sourceSystem: string
+  externalApprovalId: string | null
+  workflowKey: string | null
+  businessKey: string | null
+  title: string | null
+  status: string
+  requester: ApprovalRequesterSnapshot | null
+  subject: ApprovalSubjectSnapshot | null
+  policy: ApprovalPolicySnapshot | null
+  currentStep: number | null
+  totalSteps: number | null
+  templateId?: string | null
+  templateVersionId?: string | null
+  publishedDefinitionId?: string | null
+  requestNo?: string | null
+  formSnapshot?: Record<string, unknown> | null
+  currentNodeKey?: string | null
+  assignments: ApprovalAssignmentDTO[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface UnifiedApprovalHistoryDTO {
+  id: string
+  action: string
+  actorId: string | null
+  actorName: string | null
+  comment: string | null
+  fromStatus: string | null
+  toStatus: string
+  occurredAt: string | null
+  metadata: Record<string, unknown>
+}
+
+export interface CreateApprovalRequest {
+  templateId: string
+  formData: Record<string, unknown>
+}
+
+export interface ApprovalActionRequest {
+  action: ApprovalActionType
+  comment?: string
+  targetUserId?: string
+}
+
+export interface ApprovalTemplateListItemDTO {
+  id: string
+  key: string
+  name: string
+  description: string | null
+  status: ApprovalTemplateStatus
+  activeVersionId: string | null
+  latestVersionId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ApprovalTemplateDetailDTO extends ApprovalTemplateListItemDTO {
+  formSchema: FormSchema
+  approvalGraph: ApprovalGraph
+}
+
+export interface ApprovalTemplateVersionDetailDTO {
+  id: string
+  templateId: string
+  version: number
+  status: ApprovalTemplateStatus
+  formSchema: FormSchema
+  approvalGraph: ApprovalGraph
+  runtimeGraph: RuntimeGraph | null
+  publishedDefinitionId: string | null
+  createdAt: string
+  updatedAt: string
+}

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -1,0 +1,203 @@
+export const APPROVAL_PRODUCT_PERMISSIONS = [
+  'approvals:read',
+  'approvals:write',
+  'approvals:act',
+  'approval-templates:manage',
+] as const
+
+export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[number]
+
+export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'end'
+export type ApprovalAssigneeType = 'user' | 'role'
+export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment'
+export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
+export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
+export type FormFieldType =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'date'
+  | 'datetime'
+  | 'select'
+  | 'multi-select'
+  | 'user'
+  | 'attachment'
+
+export interface ApprovalNode {
+  key: string
+  type: ApprovalNodeType
+  name?: string
+  config: ApprovalNodeConfig | ConditionNodeConfig | CcNodeConfig | Record<string, never>
+}
+
+export interface ApprovalNodeConfig {
+  assigneeType: ApprovalAssigneeType
+  assigneeIds: string[]
+}
+
+export interface ConditionNodeConfig {
+  branches: ConditionBranch[]
+  defaultEdgeKey?: string
+}
+
+export interface ConditionBranch {
+  edgeKey: string
+  rules: ConditionRule[]
+  conjunction?: 'and' | 'or'
+}
+
+export interface ConditionRule {
+  fieldId: string
+  operator: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'isEmpty'
+  value?: unknown
+}
+
+export interface CcNodeConfig {
+  targetType: ApprovalAssigneeType
+  targetIds: string[]
+}
+
+export interface ApprovalEdge {
+  key: string
+  source: string
+  target: string
+}
+
+export interface ApprovalGraph {
+  nodes: ApprovalNode[]
+  edges: ApprovalEdge[]
+}
+
+export interface RuntimePolicy {
+  allowRevoke: boolean
+  revokeBeforeNodeKeys?: string[]
+}
+
+export interface RuntimeGraph extends ApprovalGraph {
+  policy: RuntimePolicy
+}
+
+export interface FormOption {
+  label: string
+  value: string
+}
+
+export interface FormField {
+  id: string
+  type: FormFieldType
+  label: string
+  required?: boolean
+  placeholder?: string
+  defaultValue?: unknown
+  options?: FormOption[]
+  props?: Record<string, unknown>
+}
+
+export interface FormSchema {
+  fields: FormField[]
+}
+
+export interface ApprovalRequesterSnapshot {
+  id?: string
+  name?: string
+  department?: string
+  title?: string
+  [key: string]: unknown
+}
+
+export interface ApprovalSubjectSnapshot {
+  [key: string]: unknown
+}
+
+export interface ApprovalPolicySnapshot {
+  rejectCommentRequired?: boolean
+  sourceOfTruth?: string
+  [key: string]: unknown
+}
+
+export interface ApprovalAssignmentDTO {
+  id: string
+  type: string
+  assigneeId: string
+  sourceStep: number
+  nodeKey?: string | null
+  isActive: boolean
+  metadata: Record<string, unknown>
+}
+
+export interface UnifiedApprovalDTO {
+  id: string
+  sourceSystem: string
+  externalApprovalId: string | null
+  workflowKey: string | null
+  businessKey: string | null
+  title: string | null
+  status: string
+  requester: ApprovalRequesterSnapshot | null
+  subject: ApprovalSubjectSnapshot | null
+  policy: ApprovalPolicySnapshot | null
+  currentStep: number | null
+  totalSteps: number | null
+  templateId?: string | null
+  templateVersionId?: string | null
+  publishedDefinitionId?: string | null
+  requestNo?: string | null
+  formSnapshot?: Record<string, unknown> | null
+  currentNodeKey?: string | null
+  assignments: ApprovalAssignmentDTO[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface UnifiedApprovalHistoryDTO {
+  id: string
+  action: string
+  actorId: string | null
+  actorName: string | null
+  comment: string | null
+  fromStatus: string | null
+  toStatus: string
+  occurredAt: string | null
+  metadata: Record<string, unknown>
+}
+
+export interface CreateApprovalRequest {
+  templateId: string
+  formData: Record<string, unknown>
+}
+
+export interface ApprovalActionRequest {
+  action: ApprovalActionType
+  comment?: string
+  targetUserId?: string
+}
+
+export interface ApprovalTemplateListItemDTO {
+  id: string
+  key: string
+  name: string
+  description: string | null
+  status: ApprovalTemplateStatus
+  activeVersionId: string | null
+  latestVersionId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ApprovalTemplateDetailDTO extends ApprovalTemplateListItemDTO {
+  formSchema: FormSchema
+  approvalGraph: ApprovalGraph
+}
+
+export interface ApprovalTemplateVersionDetailDTO {
+  id: string
+  templateId: string
+  version: number
+  status: ApprovalTemplateStatus
+  formSchema: FormSchema
+  approvalGraph: ApprovalGraph
+  runtimeGraph: RuntimeGraph | null
+  publishedDefinitionId: string | null
+  createdAt: string
+  updatedAt: string
+}

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2224,6 +2224,526 @@ components:
             $ref: '#/components/schemas/MultitableRelatedRecord'
       required:
         - updated
+    ApprovalNodeConfig:
+      type: object
+      properties:
+        assigneeType:
+          type: string
+          enum:
+            - user
+            - role
+        assigneeIds:
+          type: array
+          items:
+            type: string
+      required:
+        - assigneeType
+        - assigneeIds
+    ApprovalConditionRule:
+      type: object
+      properties:
+        fieldId:
+          type: string
+        operator:
+          type: string
+          enum:
+            - eq
+            - neq
+            - gt
+            - gte
+            - lt
+            - lte
+            - in
+            - isEmpty
+        value:
+          nullable: true
+      required:
+        - fieldId
+        - operator
+    ApprovalConditionBranch:
+      type: object
+      properties:
+        edgeKey:
+          type: string
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalConditionRule'
+        conjunction:
+          type: string
+          enum:
+            - and
+            - or
+      required:
+        - edgeKey
+        - rules
+    ApprovalConditionNodeConfig:
+      type: object
+      properties:
+        branches:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalConditionBranch'
+        defaultEdgeKey:
+          type: string
+      required:
+        - branches
+    ApprovalCcNodeConfig:
+      type: object
+      properties:
+        targetType:
+          type: string
+          enum:
+            - user
+            - role
+        targetIds:
+          type: array
+          items:
+            type: string
+      required:
+        - targetType
+        - targetIds
+    ApprovalNode:
+      type: object
+      properties:
+        key:
+          type: string
+        type:
+          type: string
+          enum:
+            - start
+            - approval
+            - cc
+            - condition
+            - end
+        name:
+          type: string
+        config:
+          type: object
+          additionalProperties: true
+      required:
+        - key
+        - type
+        - config
+    ApprovalEdge:
+      type: object
+      properties:
+        key:
+          type: string
+        source:
+          type: string
+        target:
+          type: string
+      required:
+        - key
+        - source
+        - target
+    ApprovalGraph:
+      type: object
+      properties:
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalNode'
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalEdge'
+      required:
+        - nodes
+        - edges
+    RuntimePolicy:
+      type: object
+      properties:
+        allowRevoke:
+          type: boolean
+        revokeBeforeNodeKeys:
+          type: array
+          items:
+            type: string
+      required:
+        - allowRevoke
+    RuntimeGraph:
+      allOf:
+        - $ref: '#/components/schemas/ApprovalGraph'
+        - type: object
+          properties:
+            policy:
+              $ref: '#/components/schemas/RuntimePolicy'
+          required:
+            - policy
+    FormOption:
+      type: object
+      properties:
+        label:
+          type: string
+        value:
+          type: string
+      required:
+        - label
+        - value
+    FormField:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum:
+            - text
+            - textarea
+            - number
+            - date
+            - datetime
+            - select
+            - multi-select
+            - user
+            - attachment
+        label:
+          type: string
+        required:
+          type: boolean
+        placeholder:
+          type: string
+        defaultValue:
+          nullable: true
+        options:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormOption'
+        props:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - type
+        - label
+    FormSchema:
+      type: object
+      properties:
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormField'
+      required:
+        - fields
+    ApprovalRequesterSnapshot:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        department:
+          type: string
+        title:
+          type: string
+      additionalProperties: true
+    ApprovalSubjectSnapshot:
+      type: object
+      additionalProperties: true
+    ApprovalPolicySnapshot:
+      type: object
+      properties:
+        rejectCommentRequired:
+          type: boolean
+        sourceOfTruth:
+          type: string
+      additionalProperties: true
+    ApprovalAssignmentDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        assigneeId:
+          type: string
+        sourceStep:
+          type: integer
+        nodeKey:
+          type: string
+          nullable: true
+        isActive:
+          type: boolean
+        metadata:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - type
+        - assigneeId
+        - sourceStep
+        - isActive
+        - metadata
+    UnifiedApprovalDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        sourceSystem:
+          type: string
+        externalApprovalId:
+          type: string
+          nullable: true
+        workflowKey:
+          type: string
+          nullable: true
+        businessKey:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: string
+        requester:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalRequesterSnapshot'
+          nullable: true
+        subject:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalSubjectSnapshot'
+          nullable: true
+        policy:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalPolicySnapshot'
+          nullable: true
+        currentStep:
+          type: integer
+          nullable: true
+        totalSteps:
+          type: integer
+          nullable: true
+        templateId:
+          type: string
+          nullable: true
+        templateVersionId:
+          type: string
+          nullable: true
+        publishedDefinitionId:
+          type: string
+          nullable: true
+        requestNo:
+          type: string
+          nullable: true
+        formSnapshot:
+          type: object
+          nullable: true
+          additionalProperties: true
+        currentNodeKey:
+          type: string
+          nullable: true
+        assignments:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalAssignmentDTO'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sourceSystem
+        - status
+        - assignments
+        - createdAt
+        - updatedAt
+    UnifiedApprovalHistoryDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+        actorId:
+          type: string
+          nullable: true
+        actorName:
+          type: string
+          nullable: true
+        comment:
+          type: string
+          nullable: true
+        fromStatus:
+          type: string
+          nullable: true
+        toStatus:
+          type: string
+        occurredAt:
+          type: string
+          format: date-time
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - action
+        - toStatus
+        - metadata
+    CreateApprovalRequest:
+      type: object
+      properties:
+        templateId:
+          type: string
+        formData:
+          type: object
+          additionalProperties: true
+      required:
+        - templateId
+        - formData
+    ApprovalActionRequest:
+      type: object
+      properties:
+        action:
+          type: string
+          enum:
+            - approve
+            - reject
+            - transfer
+            - revoke
+            - comment
+        comment:
+          type: string
+        targetUserId:
+          type: string
+      required:
+        - action
+    ApprovalTemplateListItem:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum:
+            - draft
+            - published
+            - archived
+        activeVersionId:
+          type: string
+          nullable: true
+        latestVersionId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - key
+        - name
+        - status
+        - activeVersionId
+        - latestVersionId
+        - createdAt
+        - updatedAt
+    ApprovalTemplateDetail:
+      allOf:
+        - $ref: '#/components/schemas/ApprovalTemplateListItem'
+        - type: object
+          properties:
+            formSchema:
+              $ref: '#/components/schemas/FormSchema'
+            approvalGraph:
+              $ref: '#/components/schemas/ApprovalGraph'
+          required:
+            - formSchema
+            - approvalGraph
+    CreateApprovalTemplateRequest:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+      required:
+        - key
+        - name
+        - formSchema
+        - approvalGraph
+    UpdateApprovalTemplateRequest:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+    PublishApprovalTemplateRequest:
+      type: object
+      properties:
+        policy:
+          $ref: '#/components/schemas/RuntimePolicy'
+      required:
+        - policy
+    ApprovalTemplateVersionDetail:
+      type: object
+      properties:
+        id:
+          type: string
+        templateId:
+          type: string
+        version:
+          type: integer
+        status:
+          type: string
+          enum:
+            - draft
+            - published
+            - archived
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+        runtimeGraph:
+          allOf:
+            - $ref: '#/components/schemas/RuntimeGraph'
+          nullable: true
+        publishedDefinitionId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - templateId
+        - version
+        - status
+        - formSchema
+        - approvalGraph
+        - createdAt
+        - updatedAt
   responses:
     Unauthorized:
       description: Unauthorized - Missing or invalid JWT token
@@ -2630,8 +3150,118 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/approvals:
+    get:
+      summary: List platform approval instances
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+        - in: query
+          name: requesterId
+          schema:
+            type: string
+        - in: query
+          name: assignee
+          schema:
+            type: string
+        - in: query
+          name: ccRecipientId
+          schema:
+            type: string
+        - in: query
+          name: templateId
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/UnifiedApprovalDTO'
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required:
+                      - items
+                      - total
+                      - limit
+                      - offset
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    post:
+      summary: Create approval request from a published template
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApprovalRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /api/approvals/pending:
     get:
+      deprecated: true
       summary: Get pending approvals for current actor
       security:
         - bearerAuth: []
@@ -2658,6 +3288,19 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required:
+                  - ok
+                  - data
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2666,8 +3309,58 @@ paths:
           $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /api/approvals/{id}/actions:
+    post:
+      summary: Execute an approval action with optimistic locking
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApprovalActionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Version conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /api/approvals/{id}/approve:
     post:
+      deprecated: true
       summary: Approve instance with optimistic locking
       security:
         - bearerAuth: []
@@ -2690,39 +3383,12 @@ paths:
                   type: string
                 metadata:
                   type: object
+                  additionalProperties: true
               required:
                 - version
-            examples:
-              approve:
-                value:
-                  version: 0
-                  comment: LGTM
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        example: demo-1
-                      status:
-                        type: string
-                        example: approved
-                      version:
-                        type: integer
-                        example: 1
-                      prevVersion:
-                        type: integer
-                        example: 0
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
@@ -2737,18 +3403,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                conflict:
-                  value:
-                    ok: false
-                    error:
-                      code: APPROVAL_VERSION_CONFLICT
-                      message: Approval instance version mismatch
-                      currentVersion: 1
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
   /api/approvals/{id}/reject:
     post:
+      deprecated: true
       summary: Reject instance with optimistic locking
       security:
         - bearerAuth: []
@@ -2764,7 +3423,6 @@ paths:
           application/json:
             schema:
               type: object
-              description: Either `reason` or `comment` must be supplied.
               properties:
                 version:
                   type: integer
@@ -2774,39 +3432,12 @@ paths:
                   type: string
                 metadata:
                   type: object
+                  additionalProperties: true
               required:
                 - version
-            examples:
-              reject:
-                value:
-                  version: 1
-                  comment: Needs revision
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        example: demo-1
-                      status:
-                        type: string
-                        example: rejected
-                      version:
-                        type: integer
-                        example: 2
-                      prevVersion:
-                        type: integer
-                        example: 1
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
@@ -2821,18 +3452,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                conflict:
-                  value:
-                    ok: false
-                    error:
-                      code: APPROVAL_VERSION_CONFLICT
-                      message: Approval instance version mismatch
-                      currentVersion: 2
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
   /api/approvals/{id}/return:
     post:
+      deprecated: true
       summary: Return instance with optimistic locking
       security:
         - bearerAuth: []
@@ -2856,37 +3480,21 @@ paths:
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        example: demo-1
-                      status:
-                        type: string
-                        example: RETURNED
-                      version:
-                        type: integer
-                        example: 3
-                      prevVersion:
-                        type: integer
-                        example: 2
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          $ref: '#/components/responses/ValidationError'
+          description: Version conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approvals/{id}/revoke:
     post:
+      deprecated: true
       summary: Revoke instance with optimistic locking
       security:
         - bearerAuth: []
@@ -2910,38 +3518,21 @@ paths:
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        example: demo-1
-                      status:
-                        type: string
-                        example: REVOKED
-                      version:
-                        type: integer
-                        example: 4
-                      prevVersion:
-                        type: integer
-                        example: 3
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          $ref: '#/components/responses/ValidationError'
+          description: Version conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approvals/{id}/history:
     get:
-      summary: Get approval history (from approval_records)
+      summary: Get approval history
       security:
         - bearerAuth: []
       parameters:
@@ -2977,78 +3568,275 @@ paths:
                       items:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              example: rec-1
-                            occurred_at:
-                              type: string
-                              format: date-time
-                              example: '2025-09-19T09:12:00Z'
-                            actor_id:
-                              type: string
-                              example: u1
-                            actor_name:
-                              type: string
-                              example: Reviewer One
-                            action:
-                              type: string
-                              example: approve
-                            comment:
-                              type: string
-                              example: LGTM
-                            from_status:
-                              type: string
-                              example: PENDING
-                            to_status:
-                              type: string
-                              example: APPROVED
-                            version:
-                              type: integer
-                              example: 1
-                            from_version:
-                              type: integer
-                              nullable: true
-                              example: 0
-                            to_version:
-                              type: integer
-                              example: 1
-                      page:
-                        type: integer
-                        example: 1
-                      pageSize:
-                        type: integer
-                        example: 50
+                          $ref: '#/components/schemas/UnifiedApprovalHistoryDTO'
                       total:
                         type: integer
-                        example: 4
-              examples:
-                sample:
-                  value:
-                    ok: true
-                    data:
-                      items:
-                        - id: rec-1
-                          occurred_at: '2025-09-19T09:12:00Z'
-                          actor_id: u1
-                          actor_name: Reviewer One
-                          action: approve
-                          comment: LGTM
-                          from_status: PENDING
-                          to_status: APPROVED
-                          version: 1
-                          from_version: 0
-                          to_version: 1
-                      page: 1
-                      pageSize: 50
-                      total: 4
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+                    required:
+                      - items
+                required:
+                  - ok
+                  - data
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /api/approval-templates:
+    get:
+      summary: List approval templates
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: search
+          schema:
+            type: string
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum:
+              - draft
+              - published
+              - archived
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ApprovalTemplateListItem'
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required:
+                      - items
+                      - total
+                      - limit
+                      - offset
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      summary: Create approval template
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApprovalTemplateRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/approval-templates/{id}:
+    get:
+      summary: Get approval template detail
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      summary: Update approval template draft
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateApprovalTemplateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/approval-templates/{id}/publish:
+    post:
+      summary: Publish approval template
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublishApprovalTemplateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateVersionDetail'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/approval-templates/{id}/versions/{versionId}:
+    get:
+      summary: Get approval template version detail
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: versionId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateVersionDetail'
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /api/attendance/punch:
     x-plugin: plugin-attendance
     post:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3233,6 +3233,758 @@
         "required": [
           "updated"
         ]
+      },
+      "ApprovalNodeConfig": {
+        "type": "object",
+        "properties": {
+          "assigneeType": {
+            "type": "string",
+            "enum": [
+              "user",
+              "role"
+            ]
+          },
+          "assigneeIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "assigneeType",
+          "assigneeIds"
+        ]
+      },
+      "ApprovalConditionRule": {
+        "type": "object",
+        "properties": {
+          "fieldId": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string",
+            "enum": [
+              "eq",
+              "neq",
+              "gt",
+              "gte",
+              "lt",
+              "lte",
+              "in",
+              "isEmpty"
+            ]
+          },
+          "value": {
+            "nullable": true
+          }
+        },
+        "required": [
+          "fieldId",
+          "operator"
+        ]
+      },
+      "ApprovalConditionBranch": {
+        "type": "object",
+        "properties": {
+          "edgeKey": {
+            "type": "string"
+          },
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApprovalConditionRule"
+            }
+          },
+          "conjunction": {
+            "type": "string",
+            "enum": [
+              "and",
+              "or"
+            ]
+          }
+        },
+        "required": [
+          "edgeKey",
+          "rules"
+        ]
+      },
+      "ApprovalConditionNodeConfig": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApprovalConditionBranch"
+            }
+          },
+          "defaultEdgeKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "branches"
+        ]
+      },
+      "ApprovalCcNodeConfig": {
+        "type": "object",
+        "properties": {
+          "targetType": {
+            "type": "string",
+            "enum": [
+              "user",
+              "role"
+            ]
+          },
+          "targetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "targetType",
+          "targetIds"
+        ]
+      },
+      "ApprovalNode": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "start",
+              "approval",
+              "cc",
+              "condition",
+              "end"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "key",
+          "type",
+          "config"
+        ]
+      },
+      "ApprovalEdge": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "source",
+          "target"
+        ]
+      },
+      "ApprovalGraph": {
+        "type": "object",
+        "properties": {
+          "nodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApprovalNode"
+            }
+          },
+          "edges": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApprovalEdge"
+            }
+          }
+        },
+        "required": [
+          "nodes",
+          "edges"
+        ]
+      },
+      "RuntimePolicy": {
+        "type": "object",
+        "properties": {
+          "allowRevoke": {
+            "type": "boolean"
+          },
+          "revokeBeforeNodeKeys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "allowRevoke"
+        ]
+      },
+      "RuntimeGraph": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApprovalGraph"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "policy": {
+                "$ref": "#/components/schemas/RuntimePolicy"
+              }
+            },
+            "required": [
+              "policy"
+            ]
+          }
+        ]
+      },
+      "FormOption": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "FormField": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "text",
+              "textarea",
+              "number",
+              "date",
+              "datetime",
+              "select",
+              "multi-select",
+              "user",
+              "attachment"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "defaultValue": {
+            "nullable": true
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormOption"
+            }
+          },
+          "props": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "label"
+        ]
+      },
+      "FormSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormField"
+            }
+          }
+        },
+        "required": [
+          "fields"
+        ]
+      },
+      "ApprovalRequesterSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "ApprovalSubjectSnapshot": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "ApprovalPolicySnapshot": {
+        "type": "object",
+        "properties": {
+          "rejectCommentRequired": {
+            "type": "boolean"
+          },
+          "sourceOfTruth": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "ApprovalAssignmentDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "assigneeId": {
+            "type": "string"
+          },
+          "sourceStep": {
+            "type": "integer"
+          },
+          "nodeKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "assigneeId",
+          "sourceStep",
+          "isActive",
+          "metadata"
+        ]
+      },
+      "UnifiedApprovalDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sourceSystem": {
+            "type": "string"
+          },
+          "externalApprovalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "workflowKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "businessKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "requester": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApprovalRequesterSnapshot"
+              }
+            ],
+            "nullable": true
+          },
+          "subject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApprovalSubjectSnapshot"
+              }
+            ],
+            "nullable": true
+          },
+          "policy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApprovalPolicySnapshot"
+              }
+            ],
+            "nullable": true
+          },
+          "currentStep": {
+            "type": "integer",
+            "nullable": true
+          },
+          "totalSteps": {
+            "type": "integer",
+            "nullable": true
+          },
+          "templateId": {
+            "type": "string",
+            "nullable": true
+          },
+          "templateVersionId": {
+            "type": "string",
+            "nullable": true
+          },
+          "publishedDefinitionId": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestNo": {
+            "type": "string",
+            "nullable": true
+          },
+          "formSnapshot": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true
+          },
+          "currentNodeKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApprovalAssignmentDTO"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "sourceSystem",
+          "status",
+          "assignments",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UnifiedApprovalHistoryDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "actorId": {
+            "type": "string",
+            "nullable": true
+          },
+          "actorName": {
+            "type": "string",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "fromStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "toStatus": {
+            "type": "string"
+          },
+          "occurredAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "id",
+          "action",
+          "toStatus",
+          "metadata"
+        ]
+      },
+      "CreateApprovalRequest": {
+        "type": "object",
+        "properties": {
+          "templateId": {
+            "type": "string"
+          },
+          "formData": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "templateId",
+          "formData"
+        ]
+      },
+      "ApprovalActionRequest": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "approve",
+              "reject",
+              "transfer",
+              "revoke",
+              "comment"
+            ]
+          },
+          "comment": {
+            "type": "string"
+          },
+          "targetUserId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "ApprovalTemplateListItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "published",
+              "archived"
+            ]
+          },
+          "activeVersionId": {
+            "type": "string",
+            "nullable": true
+          },
+          "latestVersionId": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "key",
+          "name",
+          "status",
+          "activeVersionId",
+          "latestVersionId",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ApprovalTemplateDetail": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApprovalTemplateListItem"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "formSchema": {
+                "$ref": "#/components/schemas/FormSchema"
+              },
+              "approvalGraph": {
+                "$ref": "#/components/schemas/ApprovalGraph"
+              }
+            },
+            "required": [
+              "formSchema",
+              "approvalGraph"
+            ]
+          }
+        ]
+      },
+      "CreateApprovalTemplateRequest": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "formSchema": {
+            "$ref": "#/components/schemas/FormSchema"
+          },
+          "approvalGraph": {
+            "$ref": "#/components/schemas/ApprovalGraph"
+          }
+        },
+        "required": [
+          "key",
+          "name",
+          "formSchema",
+          "approvalGraph"
+        ]
+      },
+      "UpdateApprovalTemplateRequest": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "formSchema": {
+            "$ref": "#/components/schemas/FormSchema"
+          },
+          "approvalGraph": {
+            "$ref": "#/components/schemas/ApprovalGraph"
+          }
+        }
+      },
+      "PublishApprovalTemplateRequest": {
+        "type": "object",
+        "properties": {
+          "policy": {
+            "$ref": "#/components/schemas/RuntimePolicy"
+          }
+        },
+        "required": [
+          "policy"
+        ]
+      },
+      "ApprovalTemplateVersionDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "templateId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "published",
+              "archived"
+            ]
+          },
+          "formSchema": {
+            "$ref": "#/components/schemas/FormSchema"
+          },
+          "approvalGraph": {
+            "$ref": "#/components/schemas/ApprovalGraph"
+          },
+          "runtimeGraph": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeGraph"
+              }
+            ],
+            "nullable": true
+          },
+          "publishedDefinitionId": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "templateId",
+          "version",
+          "status",
+          "formSchema",
+          "approvalGraph",
+          "createdAt",
+          "updatedAt"
+        ]
       }
     },
     "responses": {
@@ -3885,8 +4637,185 @@
         }
       }
     },
+    "/api/approvals": {
+      "get": {
+        "summary": "List platform approval instances",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "requesterId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "assignee",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ccRecipientId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "templateId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/UnifiedApprovalDTO"
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "total",
+                        "limit",
+                        "offset"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create approval request from a published template",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApprovalRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/UnifiedApprovalDTO"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
     "/api/approvals/pending": {
       "get": {
+        "deprecated": true,
         "summary": "Get pending approvals for current actor",
         "security": [
           {
@@ -3929,7 +4858,27 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/UnifiedApprovalDTO"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -3946,8 +4895,89 @@
         }
       }
     },
+    "/api/approvals/{id}/actions": {
+      "post": {
+        "summary": "Execute an approval action with optimistic locking",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/UnifiedApprovalDTO"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "description": "Version conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
     "/api/approvals/{id}/approve": {
       "post": {
+        "deprecated": true,
         "summary": "Approve instance with optimistic locking",
         "security": [
           {
@@ -3978,61 +5008,20 @@
                     "type": "string"
                   },
                   "metadata": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                   }
                 },
                 "required": [
                   "version"
                 ]
-              },
-              "examples": {
-                "approve": {
-                  "value": {
-                    "version": 0,
-                    "comment": "LGTM"
-                  }
-                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "example": "demo-1"
-                        },
-                        "status": {
-                          "type": "string",
-                          "example": "approved"
-                        },
-                        "version": {
-                          "type": "integer",
-                          "example": 1
-                        },
-                        "prevVersion": {
-                          "type": "integer",
-                          "example": 0
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            "description": "OK"
           },
           "400": {
             "$ref": "#/components/responses/ValidationError"
@@ -4052,18 +5041,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                },
-                "examples": {
-                  "conflict": {
-                    "value": {
-                      "ok": false,
-                      "error": {
-                        "code": "APPROVAL_VERSION_CONFLICT",
-                        "message": "Approval instance version mismatch",
-                        "currentVersion": 1
-                      }
-                    }
-                  }
                 }
               }
             }
@@ -4076,6 +5053,7 @@
     },
     "/api/approvals/{id}/reject": {
       "post": {
+        "deprecated": true,
         "summary": "Reject instance with optimistic locking",
         "security": [
           {
@@ -4098,7 +5076,6 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Either `reason` or `comment` must be supplied.",
                 "properties": {
                   "version": {
                     "type": "integer"
@@ -4110,61 +5087,20 @@
                     "type": "string"
                   },
                   "metadata": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                   }
                 },
                 "required": [
                   "version"
                 ]
-              },
-              "examples": {
-                "reject": {
-                  "value": {
-                    "version": 1,
-                    "comment": "Needs revision"
-                  }
-                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "example": "demo-1"
-                        },
-                        "status": {
-                          "type": "string",
-                          "example": "rejected"
-                        },
-                        "version": {
-                          "type": "integer",
-                          "example": 2
-                        },
-                        "prevVersion": {
-                          "type": "integer",
-                          "example": 1
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            "description": "OK"
           },
           "400": {
             "$ref": "#/components/responses/ValidationError"
@@ -4184,18 +5120,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                },
-                "examples": {
-                  "conflict": {
-                    "value": {
-                      "ok": false,
-                      "error": {
-                        "code": "APPROVAL_VERSION_CONFLICT",
-                        "message": "Approval instance version mismatch",
-                        "currentVersion": 2
-                      }
-                    }
-                  }
                 }
               }
             }
@@ -4208,6 +5132,7 @@
     },
     "/api/approvals/{id}/return": {
       "post": {
+        "deprecated": true,
         "summary": "Return instance with optimistic locking",
         "security": [
           {
@@ -4244,41 +5169,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "example": "demo-1"
-                        },
-                        "status": {
-                          "type": "string",
-                          "example": "RETURNED"
-                        },
-                        "version": {
-                          "type": "integer",
-                          "example": 3
-                        },
-                        "prevVersion": {
-                          "type": "integer",
-                          "example": 2
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            "description": "OK"
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -4287,13 +5181,21 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/ValidationError"
+            "description": "Version conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/approvals/{id}/revoke": {
       "post": {
+        "deprecated": true,
         "summary": "Revoke instance with optimistic locking",
         "security": [
           {
@@ -4330,41 +5232,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "example": "demo-1"
-                        },
-                        "status": {
-                          "type": "string",
-                          "example": "REVOKED"
-                        },
-                        "version": {
-                          "type": "integer",
-                          "example": 4
-                        },
-                        "prevVersion": {
-                          "type": "integer",
-                          "example": 3
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            "description": "OK"
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -4373,14 +5244,21 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/ValidationError"
+            "description": "Version conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/approvals/{id}/history": {
       "get": {
-        "summary": "Get approval history (from approval_records)",
+        "summary": "Get approval history",
         "security": [
           {
             "bearerAuth": []
@@ -4430,99 +5308,28 @@
                         "items": {
                           "type": "array",
                           "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "example": "rec-1"
-                              },
-                              "occurred_at": {
-                                "type": "string",
-                                "format": "date-time",
-                                "example": "2025-09-19T09:12:00Z"
-                              },
-                              "actor_id": {
-                                "type": "string",
-                                "example": "u1"
-                              },
-                              "actor_name": {
-                                "type": "string",
-                                "example": "Reviewer One"
-                              },
-                              "action": {
-                                "type": "string",
-                                "example": "approve"
-                              },
-                              "comment": {
-                                "type": "string",
-                                "example": "LGTM"
-                              },
-                              "from_status": {
-                                "type": "string",
-                                "example": "PENDING"
-                              },
-                              "to_status": {
-                                "type": "string",
-                                "example": "APPROVED"
-                              },
-                              "version": {
-                                "type": "integer",
-                                "example": 1
-                              },
-                              "from_version": {
-                                "type": "integer",
-                                "nullable": true,
-                                "example": 0
-                              },
-                              "to_version": {
-                                "type": "integer",
-                                "example": 1
-                              }
-                            }
+                            "$ref": "#/components/schemas/UnifiedApprovalHistoryDTO"
                           }
-                        },
-                        "page": {
-                          "type": "integer",
-                          "example": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "example": 50
                         },
                         "total": {
-                          "type": "integer",
-                          "example": 4
+                          "type": "integer"
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
                         }
-                      }
+                      },
+                      "required": [
+                        "items"
+                      ]
                     }
-                  }
-                },
-                "examples": {
-                  "sample": {
-                    "value": {
-                      "ok": true,
-                      "data": {
-                        "items": [
-                          {
-                            "id": "rec-1",
-                            "occurred_at": "2025-09-19T09:12:00Z",
-                            "actor_id": "u1",
-                            "actor_name": "Reviewer One",
-                            "action": "approve",
-                            "comment": "LGTM",
-                            "from_status": "PENDING",
-                            "to_status": "APPROVED",
-                            "version": 1,
-                            "from_version": 0,
-                            "to_version": 1
-                          }
-                        ],
-                        "page": 1,
-                        "pageSize": 50,
-                        "total": 4
-                      }
-                    }
-                  }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
                 }
               }
             }
@@ -4533,8 +5340,413 @@
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
           "503": {
             "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/api/approval-templates": {
+      "get": {
+        "summary": "List approval templates",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "published",
+                "archived"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ApprovalTemplateListItem"
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "total",
+                        "limit",
+                        "offset"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create approval template",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApprovalTemplateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ApprovalTemplateDetail"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/approval-templates/{id}": {
+      "get": {
+        "summary": "Get approval template detail",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ApprovalTemplateDetail"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update approval template draft",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateApprovalTemplateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ApprovalTemplateDetail"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/approval-templates/{id}/publish": {
+      "post": {
+        "summary": "Publish approval template",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishApprovalTemplateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ApprovalTemplateVersionDetail"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/approval-templates/{id}/versions/{versionId}": {
+      "get": {
+        "summary": "Get approval template version detail",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ApprovalTemplateVersionDetail"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           }
         }
       }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2224,6 +2224,526 @@ components:
             $ref: '#/components/schemas/MultitableRelatedRecord'
       required:
         - updated
+    ApprovalNodeConfig:
+      type: object
+      properties:
+        assigneeType:
+          type: string
+          enum:
+            - user
+            - role
+        assigneeIds:
+          type: array
+          items:
+            type: string
+      required:
+        - assigneeType
+        - assigneeIds
+    ApprovalConditionRule:
+      type: object
+      properties:
+        fieldId:
+          type: string
+        operator:
+          type: string
+          enum:
+            - eq
+            - neq
+            - gt
+            - gte
+            - lt
+            - lte
+            - in
+            - isEmpty
+        value:
+          nullable: true
+      required:
+        - fieldId
+        - operator
+    ApprovalConditionBranch:
+      type: object
+      properties:
+        edgeKey:
+          type: string
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalConditionRule'
+        conjunction:
+          type: string
+          enum:
+            - and
+            - or
+      required:
+        - edgeKey
+        - rules
+    ApprovalConditionNodeConfig:
+      type: object
+      properties:
+        branches:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalConditionBranch'
+        defaultEdgeKey:
+          type: string
+      required:
+        - branches
+    ApprovalCcNodeConfig:
+      type: object
+      properties:
+        targetType:
+          type: string
+          enum:
+            - user
+            - role
+        targetIds:
+          type: array
+          items:
+            type: string
+      required:
+        - targetType
+        - targetIds
+    ApprovalNode:
+      type: object
+      properties:
+        key:
+          type: string
+        type:
+          type: string
+          enum:
+            - start
+            - approval
+            - cc
+            - condition
+            - end
+        name:
+          type: string
+        config:
+          type: object
+          additionalProperties: true
+      required:
+        - key
+        - type
+        - config
+    ApprovalEdge:
+      type: object
+      properties:
+        key:
+          type: string
+        source:
+          type: string
+        target:
+          type: string
+      required:
+        - key
+        - source
+        - target
+    ApprovalGraph:
+      type: object
+      properties:
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalNode'
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalEdge'
+      required:
+        - nodes
+        - edges
+    RuntimePolicy:
+      type: object
+      properties:
+        allowRevoke:
+          type: boolean
+        revokeBeforeNodeKeys:
+          type: array
+          items:
+            type: string
+      required:
+        - allowRevoke
+    RuntimeGraph:
+      allOf:
+        - $ref: '#/components/schemas/ApprovalGraph'
+        - type: object
+          properties:
+            policy:
+              $ref: '#/components/schemas/RuntimePolicy'
+          required:
+            - policy
+    FormOption:
+      type: object
+      properties:
+        label:
+          type: string
+        value:
+          type: string
+      required:
+        - label
+        - value
+    FormField:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum:
+            - text
+            - textarea
+            - number
+            - date
+            - datetime
+            - select
+            - multi-select
+            - user
+            - attachment
+        label:
+          type: string
+        required:
+          type: boolean
+        placeholder:
+          type: string
+        defaultValue:
+          nullable: true
+        options:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormOption'
+        props:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - type
+        - label
+    FormSchema:
+      type: object
+      properties:
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormField'
+      required:
+        - fields
+    ApprovalRequesterSnapshot:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        department:
+          type: string
+        title:
+          type: string
+      additionalProperties: true
+    ApprovalSubjectSnapshot:
+      type: object
+      additionalProperties: true
+    ApprovalPolicySnapshot:
+      type: object
+      properties:
+        rejectCommentRequired:
+          type: boolean
+        sourceOfTruth:
+          type: string
+      additionalProperties: true
+    ApprovalAssignmentDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        assigneeId:
+          type: string
+        sourceStep:
+          type: integer
+        nodeKey:
+          type: string
+          nullable: true
+        isActive:
+          type: boolean
+        metadata:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - type
+        - assigneeId
+        - sourceStep
+        - isActive
+        - metadata
+    UnifiedApprovalDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        sourceSystem:
+          type: string
+        externalApprovalId:
+          type: string
+          nullable: true
+        workflowKey:
+          type: string
+          nullable: true
+        businessKey:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: string
+        requester:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalRequesterSnapshot'
+          nullable: true
+        subject:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalSubjectSnapshot'
+          nullable: true
+        policy:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalPolicySnapshot'
+          nullable: true
+        currentStep:
+          type: integer
+          nullable: true
+        totalSteps:
+          type: integer
+          nullable: true
+        templateId:
+          type: string
+          nullable: true
+        templateVersionId:
+          type: string
+          nullable: true
+        publishedDefinitionId:
+          type: string
+          nullable: true
+        requestNo:
+          type: string
+          nullable: true
+        formSnapshot:
+          type: object
+          nullable: true
+          additionalProperties: true
+        currentNodeKey:
+          type: string
+          nullable: true
+        assignments:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalAssignmentDTO'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sourceSystem
+        - status
+        - assignments
+        - createdAt
+        - updatedAt
+    UnifiedApprovalHistoryDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+        actorId:
+          type: string
+          nullable: true
+        actorName:
+          type: string
+          nullable: true
+        comment:
+          type: string
+          nullable: true
+        fromStatus:
+          type: string
+          nullable: true
+        toStatus:
+          type: string
+        occurredAt:
+          type: string
+          format: date-time
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - action
+        - toStatus
+        - metadata
+    CreateApprovalRequest:
+      type: object
+      properties:
+        templateId:
+          type: string
+        formData:
+          type: object
+          additionalProperties: true
+      required:
+        - templateId
+        - formData
+    ApprovalActionRequest:
+      type: object
+      properties:
+        action:
+          type: string
+          enum:
+            - approve
+            - reject
+            - transfer
+            - revoke
+            - comment
+        comment:
+          type: string
+        targetUserId:
+          type: string
+      required:
+        - action
+    ApprovalTemplateListItem:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum:
+            - draft
+            - published
+            - archived
+        activeVersionId:
+          type: string
+          nullable: true
+        latestVersionId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - key
+        - name
+        - status
+        - activeVersionId
+        - latestVersionId
+        - createdAt
+        - updatedAt
+    ApprovalTemplateDetail:
+      allOf:
+        - $ref: '#/components/schemas/ApprovalTemplateListItem'
+        - type: object
+          properties:
+            formSchema:
+              $ref: '#/components/schemas/FormSchema'
+            approvalGraph:
+              $ref: '#/components/schemas/ApprovalGraph'
+          required:
+            - formSchema
+            - approvalGraph
+    CreateApprovalTemplateRequest:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+      required:
+        - key
+        - name
+        - formSchema
+        - approvalGraph
+    UpdateApprovalTemplateRequest:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+    PublishApprovalTemplateRequest:
+      type: object
+      properties:
+        policy:
+          $ref: '#/components/schemas/RuntimePolicy'
+      required:
+        - policy
+    ApprovalTemplateVersionDetail:
+      type: object
+      properties:
+        id:
+          type: string
+        templateId:
+          type: string
+        version:
+          type: integer
+        status:
+          type: string
+          enum:
+            - draft
+            - published
+            - archived
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+        runtimeGraph:
+          allOf:
+            - $ref: '#/components/schemas/RuntimeGraph'
+          nullable: true
+        publishedDefinitionId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - templateId
+        - version
+        - status
+        - formSchema
+        - approvalGraph
+        - createdAt
+        - updatedAt
   responses:
     Unauthorized:
       description: Unauthorized - Missing or invalid JWT token
@@ -2630,8 +3150,118 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/approvals:
+    get:
+      summary: List platform approval instances
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+        - in: query
+          name: requesterId
+          schema:
+            type: string
+        - in: query
+          name: assignee
+          schema:
+            type: string
+        - in: query
+          name: ccRecipientId
+          schema:
+            type: string
+        - in: query
+          name: templateId
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/UnifiedApprovalDTO'
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required:
+                      - items
+                      - total
+                      - limit
+                      - offset
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    post:
+      summary: Create approval request from a published template
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApprovalRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /api/approvals/pending:
     get:
+      deprecated: true
       summary: Get pending approvals for current actor
       security:
         - bearerAuth: []
@@ -2658,6 +3288,19 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required:
+                  - ok
+                  - data
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2666,8 +3309,58 @@ paths:
           $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /api/approvals/{id}/actions:
+    post:
+      summary: Execute an approval action with optimistic locking
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApprovalActionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Version conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /api/approvals/{id}/approve:
     post:
+      deprecated: true
       summary: Approve instance with optimistic locking
       security:
         - bearerAuth: []
@@ -2690,39 +3383,12 @@ paths:
                   type: string
                 metadata:
                   type: object
+                  additionalProperties: true
               required:
                 - version
-            examples:
-              approve:
-                value:
-                  version: 0
-                  comment: LGTM
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        example: demo-1
-                      status:
-                        type: string
-                        example: approved
-                      version:
-                        type: integer
-                        example: 1
-                      prevVersion:
-                        type: integer
-                        example: 0
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
@@ -2737,18 +3403,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                conflict:
-                  value:
-                    ok: false
-                    error:
-                      code: APPROVAL_VERSION_CONFLICT
-                      message: Approval instance version mismatch
-                      currentVersion: 1
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
   /api/approvals/{id}/reject:
     post:
+      deprecated: true
       summary: Reject instance with optimistic locking
       security:
         - bearerAuth: []
@@ -2764,7 +3423,6 @@ paths:
           application/json:
             schema:
               type: object
-              description: Either `reason` or `comment` must be supplied.
               properties:
                 version:
                   type: integer
@@ -2774,39 +3432,12 @@ paths:
                   type: string
                 metadata:
                   type: object
+                  additionalProperties: true
               required:
                 - version
-            examples:
-              reject:
-                value:
-                  version: 1
-                  comment: Needs revision
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        example: demo-1
-                      status:
-                        type: string
-                        example: rejected
-                      version:
-                        type: integer
-                        example: 2
-                      prevVersion:
-                        type: integer
-                        example: 1
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
@@ -2821,18 +3452,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                conflict:
-                  value:
-                    ok: false
-                    error:
-                      code: APPROVAL_VERSION_CONFLICT
-                      message: Approval instance version mismatch
-                      currentVersion: 2
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
   /api/approvals/{id}/return:
     post:
+      deprecated: true
       summary: Return instance with optimistic locking
       security:
         - bearerAuth: []
@@ -2856,37 +3480,21 @@ paths:
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        example: demo-1
-                      status:
-                        type: string
-                        example: RETURNED
-                      version:
-                        type: integer
-                        example: 3
-                      prevVersion:
-                        type: integer
-                        example: 2
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          $ref: '#/components/responses/ValidationError'
+          description: Version conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approvals/{id}/revoke:
     post:
+      deprecated: true
       summary: Revoke instance with optimistic locking
       security:
         - bearerAuth: []
@@ -2910,38 +3518,21 @@ paths:
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        example: demo-1
-                      status:
-                        type: string
-                        example: REVOKED
-                      version:
-                        type: integer
-                        example: 4
-                      prevVersion:
-                        type: integer
-                        example: 3
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          $ref: '#/components/responses/ValidationError'
+          description: Version conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approvals/{id}/history:
     get:
-      summary: Get approval history (from approval_records)
+      summary: Get approval history
       security:
         - bearerAuth: []
       parameters:
@@ -2977,78 +3568,275 @@ paths:
                       items:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              example: rec-1
-                            occurred_at:
-                              type: string
-                              format: date-time
-                              example: '2025-09-19T09:12:00Z'
-                            actor_id:
-                              type: string
-                              example: u1
-                            actor_name:
-                              type: string
-                              example: Reviewer One
-                            action:
-                              type: string
-                              example: approve
-                            comment:
-                              type: string
-                              example: LGTM
-                            from_status:
-                              type: string
-                              example: PENDING
-                            to_status:
-                              type: string
-                              example: APPROVED
-                            version:
-                              type: integer
-                              example: 1
-                            from_version:
-                              type: integer
-                              nullable: true
-                              example: 0
-                            to_version:
-                              type: integer
-                              example: 1
-                      page:
-                        type: integer
-                        example: 1
-                      pageSize:
-                        type: integer
-                        example: 50
+                          $ref: '#/components/schemas/UnifiedApprovalHistoryDTO'
                       total:
                         type: integer
-                        example: 4
-              examples:
-                sample:
-                  value:
-                    ok: true
-                    data:
-                      items:
-                        - id: rec-1
-                          occurred_at: '2025-09-19T09:12:00Z'
-                          actor_id: u1
-                          actor_name: Reviewer One
-                          action: approve
-                          comment: LGTM
-                          from_status: PENDING
-                          to_status: APPROVED
-                          version: 1
-                          from_version: 0
-                          to_version: 1
-                      page: 1
-                      pageSize: 50
-                      total: 4
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+                    required:
+                      - items
+                required:
+                  - ok
+                  - data
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /api/approval-templates:
+    get:
+      summary: List approval templates
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: search
+          schema:
+            type: string
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum:
+              - draft
+              - published
+              - archived
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ApprovalTemplateListItem'
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required:
+                      - items
+                      - total
+                      - limit
+                      - offset
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      summary: Create approval template
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApprovalTemplateRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/approval-templates/{id}:
+    get:
+      summary: Get approval template detail
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      summary: Update approval template draft
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateApprovalTemplateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/approval-templates/{id}/publish:
+    post:
+      summary: Publish approval template
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublishApprovalTemplateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateVersionDetail'
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/approval-templates/{id}/versions/{versionId}:
+    get:
+      summary: Get approval template version detail
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: versionId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateVersionDetail'
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /api/attendance/punch:
     x-plugin: plugin-attendance
     post:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2145,6 +2145,434 @@ components:
             $ref: '#/components/schemas/MultitableRelatedRecord'
       required:
         - updated
+    ApprovalNodeConfig:
+      type: object
+      properties:
+        assigneeType:
+          type: string
+          enum: [user, role]
+        assigneeIds:
+          type: array
+          items:
+            type: string
+      required: [assigneeType, assigneeIds]
+    ApprovalConditionRule:
+      type: object
+      properties:
+        fieldId:
+          type: string
+        operator:
+          type: string
+          enum: [eq, neq, gt, gte, lt, lte, in, isEmpty]
+        value:
+          nullable: true
+      required: [fieldId, operator]
+    ApprovalConditionBranch:
+      type: object
+      properties:
+        edgeKey:
+          type: string
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalConditionRule'
+        conjunction:
+          type: string
+          enum: [and, or]
+      required: [edgeKey, rules]
+    ApprovalConditionNodeConfig:
+      type: object
+      properties:
+        branches:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalConditionBranch'
+        defaultEdgeKey:
+          type: string
+      required: [branches]
+    ApprovalCcNodeConfig:
+      type: object
+      properties:
+        targetType:
+          type: string
+          enum: [user, role]
+        targetIds:
+          type: array
+          items:
+            type: string
+      required: [targetType, targetIds]
+    ApprovalNode:
+      type: object
+      properties:
+        key:
+          type: string
+        type:
+          type: string
+          enum: [start, approval, cc, condition, end]
+        name:
+          type: string
+        config:
+          type: object
+          additionalProperties: true
+      required: [key, type, config]
+    ApprovalEdge:
+      type: object
+      properties:
+        key:
+          type: string
+        source:
+          type: string
+        target:
+          type: string
+      required: [key, source, target]
+    ApprovalGraph:
+      type: object
+      properties:
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalNode'
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalEdge'
+      required: [nodes, edges]
+    RuntimePolicy:
+      type: object
+      properties:
+        allowRevoke:
+          type: boolean
+        revokeBeforeNodeKeys:
+          type: array
+          items:
+            type: string
+      required: [allowRevoke]
+    RuntimeGraph:
+      allOf:
+        - $ref: '#/components/schemas/ApprovalGraph'
+        - type: object
+          properties:
+            policy:
+              $ref: '#/components/schemas/RuntimePolicy'
+          required: [policy]
+    FormOption:
+      type: object
+      properties:
+        label:
+          type: string
+        value:
+          type: string
+      required: [label, value]
+    FormField:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [text, textarea, number, date, datetime, select, multi-select, user, attachment]
+        label:
+          type: string
+        required:
+          type: boolean
+        placeholder:
+          type: string
+        defaultValue:
+          nullable: true
+        options:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormOption'
+        props:
+          type: object
+          additionalProperties: true
+      required: [id, type, label]
+    FormSchema:
+      type: object
+      properties:
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormField'
+      required: [fields]
+    ApprovalRequesterSnapshot:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        department:
+          type: string
+        title:
+          type: string
+      additionalProperties: true
+    ApprovalSubjectSnapshot:
+      type: object
+      additionalProperties: true
+    ApprovalPolicySnapshot:
+      type: object
+      properties:
+        rejectCommentRequired:
+          type: boolean
+        sourceOfTruth:
+          type: string
+      additionalProperties: true
+    ApprovalAssignmentDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        assigneeId:
+          type: string
+        sourceStep:
+          type: integer
+        nodeKey:
+          type: string
+          nullable: true
+        isActive:
+          type: boolean
+        metadata:
+          type: object
+          additionalProperties: true
+      required: [id, type, assigneeId, sourceStep, isActive, metadata]
+    UnifiedApprovalDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        sourceSystem:
+          type: string
+        externalApprovalId:
+          type: string
+          nullable: true
+        workflowKey:
+          type: string
+          nullable: true
+        businessKey:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: string
+        requester:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalRequesterSnapshot'
+          nullable: true
+        subject:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalSubjectSnapshot'
+          nullable: true
+        policy:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalPolicySnapshot'
+          nullable: true
+        currentStep:
+          type: integer
+          nullable: true
+        totalSteps:
+          type: integer
+          nullable: true
+        templateId:
+          type: string
+          nullable: true
+        templateVersionId:
+          type: string
+          nullable: true
+        publishedDefinitionId:
+          type: string
+          nullable: true
+        requestNo:
+          type: string
+          nullable: true
+        formSnapshot:
+          type: object
+          nullable: true
+          additionalProperties: true
+        currentNodeKey:
+          type: string
+          nullable: true
+        assignments:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalAssignmentDTO'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sourceSystem
+        - status
+        - assignments
+        - createdAt
+        - updatedAt
+    UnifiedApprovalHistoryDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+        actorId:
+          type: string
+          nullable: true
+        actorName:
+          type: string
+          nullable: true
+        comment:
+          type: string
+          nullable: true
+        fromStatus:
+          type: string
+          nullable: true
+        toStatus:
+          type: string
+        occurredAt:
+          type: string
+          format: date-time
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+      required: [id, action, toStatus, metadata]
+    CreateApprovalRequest:
+      type: object
+      properties:
+        templateId:
+          type: string
+        formData:
+          type: object
+          additionalProperties: true
+      required: [templateId, formData]
+    ApprovalActionRequest:
+      type: object
+      properties:
+        action:
+          type: string
+          enum: [approve, reject, transfer, revoke, comment]
+        comment:
+          type: string
+        targetUserId:
+          type: string
+      required: [action]
+    ApprovalTemplateListItem:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [draft, published, archived]
+        activeVersionId:
+          type: string
+          nullable: true
+        latestVersionId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required: [id, key, name, status, activeVersionId, latestVersionId, createdAt, updatedAt]
+    ApprovalTemplateDetail:
+      allOf:
+        - $ref: '#/components/schemas/ApprovalTemplateListItem'
+        - type: object
+          properties:
+            formSchema:
+              $ref: '#/components/schemas/FormSchema'
+            approvalGraph:
+              $ref: '#/components/schemas/ApprovalGraph'
+          required: [formSchema, approvalGraph]
+    CreateApprovalTemplateRequest:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+      required: [key, name, formSchema, approvalGraph]
+    UpdateApprovalTemplateRequest:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+    PublishApprovalTemplateRequest:
+      type: object
+      properties:
+        policy:
+          $ref: '#/components/schemas/RuntimePolicy'
+      required: [policy]
+    ApprovalTemplateVersionDetail:
+      type: object
+      properties:
+        id:
+          type: string
+        templateId:
+          type: string
+        version:
+          type: integer
+        status:
+          type: string
+          enum: [draft, published, archived]
+        formSchema:
+          $ref: '#/components/schemas/FormSchema'
+        approvalGraph:
+          $ref: '#/components/schemas/ApprovalGraph'
+        runtimeGraph:
+          allOf:
+            - $ref: '#/components/schemas/RuntimeGraph'
+          nullable: true
+        publishedDefinitionId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - templateId
+        - version
+        - status
+        - formSchema
+        - approvalGraph
+        - createdAt
+        - updatedAt
   responses:
     Unauthorized:
       description: Unauthorized - Missing or invalid JWT token

--- a/packages/openapi/src/paths/approvals.yml
+++ b/packages/openapi/src/paths/approvals.yml
@@ -1,6 +1,101 @@
 paths:
+  /api/approvals:
+    get:
+      summary: List platform approval instances
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+        - in: query
+          name: requesterId
+          schema:
+            type: string
+        - in: query
+          name: assignee
+          schema:
+            type: string
+        - in: query
+          name: ccRecipientId
+          schema:
+            type: string
+        - in: query
+          name: templateId
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/UnifiedApprovalDTO'
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required: [items, total, limit, offset]
+                required: [ok, data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '503': { $ref: '#/components/responses/ServiceUnavailable' }
+    post:
+      summary: Create approval request from a published template
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApprovalRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required: [ok, data]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '503': { $ref: '#/components/responses/ServiceUnavailable' }
   /api/approvals/pending:
     get:
+      deprecated: true
       summary: Get pending approvals for current actor
       security:
         - bearerAuth: []
@@ -18,22 +113,80 @@ paths:
         - in: path
           name: id
           required: true
-          schema: { type: string }
+          schema:
+            type: string
       responses:
-        '200': { description: OK }
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required: [ok, data]
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+        '503': { $ref: '#/components/responses/ServiceUnavailable' }
+  /api/approvals/{id}/actions:
+    post:
+      summary: Execute an approval action with optimistic locking
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApprovalActionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UnifiedApprovalDTO'
+                required: [ok, data]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409':
+          description: Version conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '503': { $ref: '#/components/responses/ServiceUnavailable' }
   /api/approvals/{id}/approve:
     post:
+      deprecated: true
       summary: Approve instance with optimistic locking
-      security: [ { bearerAuth: [] } ]
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: id
           required: true
-          schema: { type: string }
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -41,197 +194,156 @@ paths:
             schema:
               type: object
               properties:
-                version: { type: integer }
-                comment: { type: string }
-                metadata: { type: object }
+                version:
+                  type: integer
+                comment:
+                  type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
               required: [version]
-            examples:
-              approve:
-                value:
-                  version: 0
-                  comment: 'LGTM'
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok: { type: boolean, example: true }
-                  data:
-                    type: object
-                    properties:
-                      id: { type: string, example: demo-1 }
-                      status: { type: string, example: approved }
-                      version: { type: integer, example: 1 }
-                      prevVersion: { type: integer, example: 0 }
+        '200': { description: OK }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '409':
           description: Version conflict
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ErrorResponse' }
-              examples:
-                conflict:
-                  value:
-                    ok: false
-                    error:
-                      code: APPROVAL_VERSION_CONFLICT
-                      message: Approval instance version mismatch
-                      currentVersion: 1
-        '401': { $ref: '#/components/responses/Unauthorized' }
-        '403': { $ref: '#/components/responses/Forbidden' }
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '503': { $ref: '#/components/responses/ServiceUnavailable' }
   /api/approvals/{id}/reject:
     post:
+      deprecated: true
       summary: Reject instance with optimistic locking
-      security: [ { bearerAuth: [] } ]
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: id
           required: true
-          schema: { type: string }
+          schema:
+            type: string
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              description: Either `reason` or `comment` must be supplied.
               properties:
-                version: { type: integer }
-                reason: { type: string }
-                comment: { type: string }
-                metadata: { type: object }
+                version:
+                  type: integer
+                reason:
+                  type: string
+                comment:
+                  type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
               required: [version]
-            examples:
-              reject:
-                value:
-                  version: 1
-                  comment: 'Needs revision'
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok: { type: boolean, example: true }
-                  data:
-                    type: object
-                    properties:
-                      id: { type: string, example: demo-1 }
-                      status: { type: string, example: rejected }
-                      version: { type: integer, example: 2 }
-                      prevVersion: { type: integer, example: 1 }
+        '200': { description: OK }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '409':
           description: Version conflict
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ErrorResponse' }
-              examples:
-                conflict:
-                  value:
-                    ok: false
-                    error:
-                      code: APPROVAL_VERSION_CONFLICT
-                      message: Approval instance version mismatch
-                      currentVersion: 2
-        '401': { $ref: '#/components/responses/Unauthorized' }
-        '403': { $ref: '#/components/responses/Forbidden' }
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '503': { $ref: '#/components/responses/ServiceUnavailable' }
   /api/approvals/{id}/return:
     post:
+      deprecated: true
       summary: Return instance with optimistic locking
-      security: [ { bearerAuth: [] } ]
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: id
           required: true
-          schema: { type: string }
+          schema:
+            type: string
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              properties: { version: { type: integer } }
+              properties:
+                version:
+                  type: integer
               required: [version]
       responses:
-        '200':
-          description: OK
+        '200': { description: OK }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '409':
+          description: Version conflict
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  ok: { type: boolean, example: true }
-                  data:
-                    type: object
-                    properties:
-                      id: { type: string, example: demo-1 }
-                      status: { type: string, example: RETURNED }
-                      version: { type: integer, example: 3 }
-                      prevVersion: { type: integer, example: 2 }
-        '409': { $ref: '#/components/responses/ValidationError' }
-        '401': { $ref: '#/components/responses/Unauthorized' }
-        '403': { $ref: '#/components/responses/Forbidden' }
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approvals/{id}/revoke:
     post:
+      deprecated: true
       summary: Revoke instance with optimistic locking
-      security: [ { bearerAuth: [] } ]
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: id
           required: true
-          schema: { type: string }
+          schema:
+            type: string
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              properties: { version: { type: integer } }
+              properties:
+                version:
+                  type: integer
               required: [version]
       responses:
-        '200':
-          description: OK
+        '200': { description: OK }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '409':
+          description: Version conflict
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  ok: { type: boolean, example: true }
-                  data:
-                    type: object
-                    properties:
-                      id: { type: string, example: demo-1 }
-                      status: { type: string, example: REVOKED }
-                      version: { type: integer, example: 4 }
-                      prevVersion: { type: integer, example: 3 }
-        '409': { $ref: '#/components/responses/ValidationError' }
-        '401': { $ref: '#/components/responses/Unauthorized' }
-        '403': { $ref: '#/components/responses/Forbidden' }
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approvals/{id}/history:
     get:
-      summary: Get approval history (from approval_records)
-      security: [ { bearerAuth: [] } ]
+      summary: Get approval history
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: id
           required: true
-          schema: { type: string }
+          schema:
+            type: string
         - in: query
           name: page
-          schema: { type: integer, default: 1 }
+          schema:
+            type: integer
+            default: 1
         - in: query
           name: pageSize
-          schema: { type: integer, default: 50 }
+          schema:
+            type: integer
+            default: 50
       responses:
         '200':
           description: OK
@@ -240,49 +352,236 @@ paths:
               schema:
                 type: object
                 properties:
-                  ok: { type: boolean, example: true }
+                  ok:
+                    type: boolean
+                    example: true
                   data:
                     type: object
                     properties:
                       items:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            id: { type: string, example: rec-1 }
-                            occurred_at: { type: string, format: date-time, example: '2025-09-19T09:12:00Z' }
-                            actor_id: { type: string, example: u1 }
-                            actor_name: { type: string, example: Reviewer One }
-                            action: { type: string, example: approve }
-                            comment: { type: string, example: LGTM }
-                            from_status: { type: string, example: PENDING }
-                            to_status: { type: string, example: APPROVED }
-                            version: { type: integer, example: 1 }
-                            from_version: { type: integer, nullable: true, example: 0 }
-                            to_version: { type: integer, example: 1 }
-                      page: { type: integer, example: 1 }
-                      pageSize: { type: integer, example: 50 }
-                      total: { type: integer, example: 4 }
-              examples:
-                sample:
-                  value:
-                    ok: true
-                    data:
-                      items:
-                        - id: 'rec-1'
-                          occurred_at: '2025-09-19T09:12:00Z'
-                          actor_id: 'u1'
-                          actor_name: 'Reviewer One'
-                          action: 'approve'
-                          comment: 'LGTM'
-                          from_status: 'PENDING'
-                          to_status: 'APPROVED'
-                          version: 1
-                          from_version: 0
-                          to_version: 1
-                      page: 1
-                      pageSize: 50
-                      total: 4
-        '403': { $ref: '#/components/responses/Forbidden' }
+                          $ref: '#/components/schemas/UnifiedApprovalHistoryDTO'
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+                    required: [items]
+                required: [ok, data]
         '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
         '503': { $ref: '#/components/responses/ServiceUnavailable' }
+  /api/approval-templates:
+    get:
+      summary: List approval templates
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: search
+          schema:
+            type: string
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [draft, published, archived]
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ApprovalTemplateListItem'
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required: [items, total, limit, offset]
+                required: [ok, data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    post:
+      summary: Create approval template
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApprovalTemplateRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required: [ok, data]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /api/approval-templates/{id}:
+    get:
+      summary: Get approval template detail
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required: [ok, data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    patch:
+      summary: Update approval template draft
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateApprovalTemplateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateDetail'
+                required: [ok, data]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /api/approval-templates/{id}/publish:
+    post:
+      summary: Publish approval template
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublishApprovalTemplateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateVersionDetail'
+                required: [ok, data]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /api/approval-templates/{id}/versions/{versionId}:
+    get:
+      summary: Get approval template version detail
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: versionId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/ApprovalTemplateVersionDetail'
+                required: [ok, data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }


### PR DESCRIPTION
## Summary
- freeze platform-native approval v1 contracts for the first-wave Feishu-style approval product
- add backend/web contract types for approval graph, runtime graph, form schema, template DTOs, approval DTO v2, and create/action requests
- update router/store placeholders and OpenAPI draft for approval templates plus unified /api/approvals routes

## Verification
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm exec tsx packages/openapi/tools/build.ts
- git diff --check

## Notes
- dist-sdk build still fails on pre-existing unresolved OpenAPI refs in attendance/comments/plm-workbench paths; this branch does not introduce those failures
- this PR is contract-freeze only and does not claim runtime or migration implementation yet