### PR TITLE
feat(approvals): add template runtime tables

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260411120000_approval_templates_and_instance_extensions.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260411120000_approval_templates_and_instance_extensions.ts
@@ -1,0 +1,143 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+const approvalInstanceColumns = [
+  'current_node_key',
+  'form_snapshot',
+  'request_no',
+  'published_definition_id',
+  'template_version_id',
+  'template_id',
+]
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`CREATE TABLE IF NOT EXISTS approval_templates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'archived')),
+    active_version_id UUID,
+    latest_version_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  )`.execute(db)
+
+  await sql`CREATE TABLE IF NOT EXISTS approval_template_versions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    template_id UUID NOT NULL REFERENCES approval_templates(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'archived')),
+    form_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
+    approval_graph JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (template_id, version)
+  )`.execute(db)
+
+  await sql`CREATE TABLE IF NOT EXISTS approval_published_definitions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    template_id UUID NOT NULL REFERENCES approval_templates(id) ON DELETE CASCADE,
+    template_version_id UUID NOT NULL REFERENCES approval_template_versions(id) ON DELETE CASCADE,
+    runtime_graph JSONB NOT NULL DEFAULT '{}'::jsonb,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    published_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  )`.execute(db)
+
+  await sql`ALTER TABLE approval_templates
+    ADD CONSTRAINT approval_templates_active_version_fk
+    FOREIGN KEY (active_version_id) REFERENCES approval_template_versions(id) ON DELETE SET NULL`.execute(db).catch(() => undefined)
+
+  await sql`ALTER TABLE approval_templates
+    ADD CONSTRAINT approval_templates_latest_version_fk
+    FOREIGN KEY (latest_version_id) REFERENCES approval_template_versions(id) ON DELETE SET NULL`.execute(db).catch(() => undefined)
+
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_templates_key
+    ON approval_templates(key)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_approval_templates_status_updated
+    ON approval_templates(status, updated_at DESC)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_approval_template_versions_template
+    ON approval_template_versions(template_id, version DESC)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_approval_published_definitions_template_version
+    ON approval_published_definitions(template_version_id, published_at DESC)`.execute(db)
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_published_definitions_active_template
+    ON approval_published_definitions(template_id)
+    WHERE is_active = TRUE`.execute(db)
+
+  await sql`CREATE SEQUENCE IF NOT EXISTS approval_request_no_seq START WITH 100001 INCREMENT BY 1`.execute(db)
+
+  await sql`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS template_id UUID REFERENCES approval_templates(id) ON DELETE SET NULL`.execute(db)
+  await sql`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS template_version_id UUID REFERENCES approval_template_versions(id) ON DELETE SET NULL`.execute(db)
+  await sql`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS published_definition_id UUID REFERENCES approval_published_definitions(id) ON DELETE SET NULL`.execute(db)
+  await sql`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS request_no TEXT`.execute(db)
+  await sql`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS form_snapshot JSONB`.execute(db)
+  await sql`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS current_node_key TEXT`.execute(db)
+
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_instances_request_no
+    ON approval_instances(request_no)
+    WHERE request_no IS NOT NULL`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_approval_instances_template_status
+    ON approval_instances(template_id, status, updated_at DESC)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_approval_instances_published_definition
+    ON approval_instances(published_definition_id)`.execute(db)
+
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (action IN ('approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc'))`.execute(db)
+
+  await sql`ALTER TABLE approval_assignments ADD COLUMN IF NOT EXISTS node_key TEXT`.execute(db)
+
+  await sql`DO $$
+  DECLARE
+    record_row RECORD;
+  BEGIN
+    FOR record_row IN
+      SELECT conname
+      FROM pg_constraint
+      WHERE conrelid = 'approval_assignments'::regclass
+        AND contype = 'u'
+    LOOP
+      EXECUTE format('ALTER TABLE approval_assignments DROP CONSTRAINT IF EXISTS %I', record_row.conname);
+    END LOOP;
+  END$$`.execute(db)
+
+  await sql`DROP INDEX IF EXISTS idx_approval_assignments_active_unique`.execute(db)
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_assignments_active_unique
+    ON approval_assignments(instance_id, assignment_type, assignee_id)
+    WHERE is_active = TRUE`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_approval_assignments_active_unique`.execute(db)
+  await sql`ALTER TABLE approval_assignments DROP COLUMN IF EXISTS node_key`.execute(db)
+
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (action IN ('approve', 'reject', 'return', 'revoke', 'transfer', 'sign'))`.execute(db)
+
+  await sql`DROP INDEX IF EXISTS idx_approval_instances_published_definition`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_instances_template_status`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_instances_request_no`.execute(db)
+
+  for (const column of approvalInstanceColumns) {
+    await sql.raw(`ALTER TABLE approval_instances DROP COLUMN IF EXISTS ${column}`).execute(db)
+  }
+
+  await sql`DROP SEQUENCE IF EXISTS approval_request_no_seq`.execute(db)
+
+  await sql`DROP INDEX IF EXISTS idx_approval_published_definitions_active_template`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_published_definitions_template_version`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_template_versions_template`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_templates_status_updated`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_templates_key`.execute(db)
+
+  await sql`DROP TABLE IF EXISTS approval_published_definitions CASCADE`.execute(db)
+  await sql`DROP TABLE IF EXISTS approval_template_versions CASCADE`.execute(db)
+  await sql`DROP TABLE IF EXISTS approval_templates CASCADE`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -10,6 +10,7 @@ export type CreatedAt = ColumnType<Date, string | undefined, never>
 export type UpdatedAt = ColumnType<Date, string | undefined, Date | string>
 export type NullableTimestamp = ColumnType<Date, string | undefined, Date | string | null> | null
 type JsonObjectColumn = JSONColumnType<Record<string, unknown> | null, Record<string, unknown> | null, Record<string, unknown> | null>
+type JsonObjectArrayColumn = JSONColumnType<Record<string, unknown>[] | null, Record<string, unknown>[] | null, Record<string, unknown>[] | null>
 
 export interface Database {
   // Core tables
@@ -67,6 +68,13 @@ export interface Database {
   workflow_instances: WorkflowInstancesTable
   workflow_tokens: WorkflowTokensTable
   workflow_incidents: WorkflowIncidentsTable
+  // Approval tables
+  approval_templates: ApprovalTemplatesTable
+  approval_template_versions: ApprovalTemplateVersionsTable
+  approval_published_definitions: ApprovalPublishedDefinitionsTable
+  approval_instances: ApprovalInstancesTable
+  approval_records: ApprovalRecordsTable
+  approval_assignments: ApprovalAssignmentsTable
   // Attendance tables
   attendance_events: AttendanceEventsTable
   attendance_records: AttendanceRecordsTable
@@ -858,6 +866,110 @@ export interface SystemConfigsTable {
   value: string
   is_encrypted: boolean
   description: string | null
+  created_at: CreatedAt
+  updated_at: UpdatedAt
+}
+
+// ============================================
+// Approval Tables
+// ============================================
+
+export interface ApprovalTemplatesTable {
+  id: Generated<string>
+  key: string
+  name: string
+  description: string | null
+  status: 'draft' | 'published' | 'archived'
+  active_version_id: string | null
+  latest_version_id: string | null
+  created_at: CreatedAt
+  updated_at: UpdatedAt
+}
+
+export interface ApprovalTemplateVersionsTable {
+  id: Generated<string>
+  template_id: string
+  version: number
+  status: 'draft' | 'published' | 'archived'
+  form_schema: JsonObjectColumn
+  approval_graph: JsonObjectColumn
+  created_at: CreatedAt
+  updated_at: UpdatedAt
+}
+
+export interface ApprovalPublishedDefinitionsTable {
+  id: Generated<string>
+  template_id: string
+  template_version_id: string
+  runtime_graph: JsonObjectColumn
+  is_active: boolean
+  published_at: CreatedAt
+  created_at: CreatedAt
+  updated_at: UpdatedAt
+}
+
+export interface ApprovalInstancesTable {
+  id: string
+  status: string
+  version: number
+  source_system: string
+  external_approval_id: string | null
+  workflow_key: string | null
+  business_key: string | null
+  title: string | null
+  requester_snapshot: JsonObjectColumn
+  subject_snapshot: JsonObjectColumn
+  policy_snapshot: JsonObjectColumn
+  metadata: JsonObjectColumn
+  current_step: number
+  total_steps: number
+  source_updated_at: NullableTimestamp
+  last_synced_at: NullableTimestamp
+  sync_status: string
+  sync_error: string | null
+  template_id: string | null
+  template_version_id: string | null
+  published_definition_id: string | null
+  request_no: string | null
+  form_snapshot: JsonObjectColumn
+  current_node_key: string | null
+  created_at: CreatedAt
+  updated_at: UpdatedAt
+}
+
+export interface ApprovalRecordsTable {
+  id: Generated<number>
+  instance_id: string
+  action: 'approve' | 'reject' | 'return' | 'revoke' | 'transfer' | 'sign' | 'comment' | 'cc'
+  actor_id: string
+  actor_name: string | null
+  comment: string | null
+  reason: string | null
+  from_status: string | null
+  to_status: string
+  version: number | null
+  from_version: number | null
+  to_version: number
+  target_user_id: string | null
+  target_step_id: string | null
+  attachments: JsonObjectArrayColumn
+  metadata: JsonObjectColumn
+  ip_address: string | null
+  user_agent: string | null
+  platform: string | null
+  occurred_at: CreatedAt
+  created_at: CreatedAt
+}
+
+export interface ApprovalAssignmentsTable {
+  id: Generated<string>
+  instance_id: string
+  assignment_type: 'user' | 'role' | 'source_queue'
+  assignee_id: string
+  source_step: number
+  node_key: string | null
+  is_active: boolean
+  metadata: JsonObjectColumn
   created_at: CreatedAt
   updated_at: UpdatedAt
 }


### PR DESCRIPTION
## Summary
- add approval template, template version, and published definition tables
- extend approval_instances for template/runtime identity plus request metadata
- update approval_records and approval_assignments schema for first-wave approval runtime needs
- add approval tables to Kysely db/types

## Verification
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- git diff --check

## Notes
- stacked on #801 because the migration depends on the frozen approval v1 contract types
- this PR does not implement executor or routes yet