### PR TITLE
feat(dingtalk): secure integrations and add namespace admission

### DIFF
--- a/apps/web/src/views/RoleDelegationView.vue
+++ b/apps/web/src/views/RoleDelegationView.vue
@@ -109,6 +109,40 @@
           </div>
 
           <div class="delegation-page__section">
+            <h3>插件使用准入</h3>
+            <p class="delegation-page__hint">这里控制成员是否可进入对应插件命名空间。钉钉登录是平台准入，和插件使用是两层不同的开关。</p>
+            <div v-if="selectedAccess.namespaceAdmissions?.length > 0" class="delegation-page__role-list">
+              <article v-for="admission in selectedAccess.namespaceAdmissions || []" :key="admission.namespace" class="delegation-page__role-card delegation-page__role-card--namespace">
+                <strong>{{ admission.namespace }}</strong>
+                <span v-if="admission.updatedAt">更新时间：{{ admission.updatedAt }}</span>
+                <div class="delegation-page__chips">
+                  <span class="delegation-page__chip" :class="{ 'delegation-page__chip--success': admission.hasRole, 'delegation-page__chip--danger': !admission.hasRole }">
+                    {{ admission.hasRole ? '已分配角色' : '未分配角色' }}
+                  </span>
+                  <span class="delegation-page__chip" :class="{ 'delegation-page__chip--success': admission.enabled, 'delegation-page__chip--danger': !admission.enabled }">
+                    {{ admission.enabled ? '插件使用已开通' : '插件使用未开通' }}
+                  </span>
+                  <span class="delegation-page__chip" :class="{ 'delegation-page__chip--success': admission.effective, 'delegation-page__chip--danger': !admission.effective }">
+                    {{ admission.effective ? '当前实际可用' : '当前不可用' }}
+                  </span>
+                </div>
+                <p>只有角色和开通状态同时满足，插件才算真正可用。</p>
+                <div class="delegation-page__role-actions">
+                  <button class="delegation-page__button" type="button" :disabled="busy || admission.enabled" @click="void updateNamespaceAdmission(admission, true)">
+                    开通插件使用
+                  </button>
+                  <button class="delegation-page__button delegation-page__button--secondary" type="button" :disabled="busy || !admission.enabled" @click="void updateNamespaceAdmission(admission, false)">
+                    关闭插件使用
+                  </button>
+                </div>
+              </article>
+            </div>
+            <div v-else class="delegation-page__empty">
+              暂无插件使用准入信息
+            </div>
+          </div>
+
+          <div class="delegation-page__section">
             <h3>委派操作</h3>
             <div class="delegation-page__role-actions">
               <select v-model="selectedRoleId" class="delegation-page__input">
@@ -533,6 +567,15 @@ type DelegatedUserAccess = {
   user: ManagedUser
   roles: string[]
   delegableRoles: string[]
+  namespaceAdmissions: NamespaceAdmission[]
+}
+
+type NamespaceAdmission = {
+  namespace: string
+  enabled: boolean
+  effective: boolean
+  hasRole: boolean
+  updatedAt: string | null
 }
 
 type DelegatedAdminScopeConfig = {
@@ -898,6 +941,48 @@ async function selectUser(userId: string): Promise<void> {
     selectedAccess.value = null
     selectedScopeConfig.value = null
     setStatus(error instanceof Error ? error.message : '加载成员委派权限失败', 'error')
+  }
+}
+
+async function updateNamespaceAdmission(admission: NamespaceAdmission, enabled: boolean): Promise<void> {
+  if (!selectedUserId.value) return
+  busy.value = true
+  try {
+    const response = await apiFetch(`/api/admin/role-delegation/users/${encodeURIComponent(selectedUserId.value)}/namespaces/${encodeURIComponent(admission.namespace)}/admission`, {
+      method: 'PATCH',
+      body: JSON.stringify({ enabled }),
+    })
+    const payload = await readJson(response)
+    if (!response.ok || payload.ok !== true) {
+      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '保存插件使用准入失败'))
+    }
+
+    const data = payload.data as Record<string, unknown> | undefined
+    if (data?.namespaceAdmissions !== undefined && selectedAccess.value) {
+      selectedAccess.value = {
+        ...selectedAccess.value,
+        ...(data as DelegatedUserAccess),
+        namespaceAdmissions: Array.isArray(data.namespaceAdmissions)
+          ? data.namespaceAdmissions.map((item) => {
+              const record = item as Record<string, unknown>
+              return {
+                namespace: String(record.namespace || ''),
+                enabled: record.enabled === true,
+                effective: typeof record.effective === 'boolean' ? record.effective : record.enabled === true && record.hasRole === true,
+                hasRole: record.hasRole === true || record.has_role === true,
+                updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : typeof record.updated_at === 'string' ? record.updated_at : null,
+              } as NamespaceAdmission
+            }).filter((item) => item.namespace)
+          : selectedAccess.value.namespaceAdmissions,
+      }
+    } else if (selectedUserId.value) {
+      await selectUser(selectedUserId.value)
+    }
+    setStatus(enabled ? `已开通 ${admission.namespace} 插件使用` : `已关闭 ${admission.namespace} 插件使用`)
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '保存插件使用准入失败', 'error')
+  } finally {
+    busy.value = false
   }
 }
 

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -229,6 +229,47 @@
           <div class="user-admin__section">
             <div class="user-admin__section-head">
               <div>
+                <h3>插件使用</h3>
+                <p class="user-admin__hint">这里控制成员是否可进入具体插件命名空间。钉钉登录只决定能否扫码进入平台，不等于插件权限。</p>
+              </div>
+              <button class="user-admin__button user-admin__button--secondary" type="button" :disabled="loadingAdmission || !access" @click="void loadMemberAdmission(access.user.id)">
+                {{ loadingAdmission ? '刷新中...' : '刷新插件准入' }}
+              </button>
+            </div>
+            <div v-if="memberAdmission?.namespaceAdmissions?.length" class="user-admin__role-list">
+              <article v-for="admission in memberAdmission.namespaceAdmissions || []" :key="admission.namespace" class="user-admin__role-card user-admin__role-card--namespace">
+                <strong>{{ admission.namespace }}</strong>
+                <span v-if="admission.updatedAt">更新时间：{{ formatDate(admission.updatedAt) }}</span>
+                <div class="user-admin__chips">
+                  <span class="user-admin__chip" :class="{ 'user-admin__chip--success': admission.hasRole, 'user-admin__chip--danger': !admission.hasRole }">
+                    {{ admission.hasRole ? '已分配角色' : '未分配角色' }}
+                  </span>
+                  <span class="user-admin__chip" :class="{ 'user-admin__chip--success': admission.enabled, 'user-admin__chip--danger': !admission.enabled }">
+                    {{ admission.enabled ? '插件使用已开通' : '插件使用未开通' }}
+                  </span>
+                  <span class="user-admin__chip" :class="{ 'user-admin__chip--success': admission.effective, 'user-admin__chip--danger': !admission.effective }">
+                    {{ admission.effective ? '当前实际可用' : '当前不可用' }}
+                  </span>
+                </div>
+                <p>只有角色和开通状态同时满足时，成员才能使用对应插件。</p>
+                <div class="user-admin__role-actions">
+                  <button class="user-admin__button" type="button" :disabled="busy || admission.enabled" @click="void updateNamespaceAdmission(admission, true)">
+                    开通插件使用
+                  </button>
+                  <button class="user-admin__button user-admin__button--secondary" type="button" :disabled="busy || !admission.enabled" @click="void updateNamespaceAdmission(admission, false)">
+                    关闭插件使用
+                  </button>
+                </div>
+              </article>
+            </div>
+            <div v-else class="user-admin__empty">
+              暂无插件使用准入信息
+            </div>
+          </div>
+
+          <div class="user-admin__section">
+            <div class="user-admin__section-head">
+              <div>
                 <h3>管理员能力</h3>
                 <p class="user-admin__hint">考勤管理员和平台管理员分开控制，互不隐含。平台管理员变更后建议重新登录一次。</p>
               </div>
@@ -470,6 +511,15 @@ type MemberAdmission = {
   businessRoleIds: string[]
   directoryMemberships: MemberDirectoryMembership[]
   dingtalk: DingTalkAccess
+  namespaceAdmissions: NamespaceAdmission[]
+}
+
+type NamespaceAdmission = {
+  namespace: string
+  enabled: boolean
+  effective: boolean
+  hasRole: boolean
+  updatedAt: string | null
 }
 
 type CreateUserForm = {
@@ -598,6 +648,34 @@ function formatDate(value: string | null | undefined): string {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return `${date.toLocaleDateString('zh-CN')} ${date.toLocaleTimeString('zh-CN', { hour12: false })}`
+}
+
+function normalizeNamespaceAdmissions(value: unknown): NamespaceAdmission[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => {
+      const record = item as Record<string, unknown>
+      const namespace = String(record.namespace || '').trim()
+      if (!namespace) return null
+
+      const hasRole = record.hasRole === true || record.has_role === true
+      const enabled = record.enabled === true
+      const effective = typeof record.effective === 'boolean' ? record.effective : enabled && hasRole
+      const updatedAt = typeof record.updatedAt === 'string'
+        ? record.updatedAt
+        : typeof record.updated_at === 'string'
+          ? record.updated_at
+          : null
+
+      return {
+        namespace,
+        enabled,
+        effective,
+        hasRole,
+        updatedAt,
+      }
+    })
+    .filter((item): item is NamespaceAdmission => item !== null)
 }
 
 function buildInviteUrl(token: string): string {
@@ -813,12 +891,47 @@ async function loadMemberAdmission(userId?: string): Promise<void> {
       throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '加载成员准入失败'))
     }
 
-    memberAdmission.value = payload.data as MemberAdmission
+    const data = payload.data as Record<string, unknown> | undefined
+    memberAdmission.value = {
+      ...(data as MemberAdmission),
+      namespaceAdmissions: normalizeNamespaceAdmissions(data?.namespaceAdmissions),
+    }
   } catch (error) {
     memberAdmission.value = null
     setStatus(error instanceof Error ? error.message : '加载成员准入失败', 'error')
   } finally {
     loadingAdmission.value = false
+  }
+}
+
+async function updateNamespaceAdmission(admission: NamespaceAdmission, enabled: boolean): Promise<void> {
+  if (!access.value) return
+  busy.value = true
+  try {
+    const response = await apiFetch(`/api/admin/users/${encodeURIComponent(access.value.user.id)}/namespaces/${encodeURIComponent(admission.namespace)}/admission`, {
+      method: 'PATCH',
+      body: JSON.stringify({ enabled }),
+    })
+    const payload = await readJson(response)
+    if (!response.ok || payload.ok !== true) {
+      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '更新插件使用准入失败'))
+    }
+
+    const data = payload.data as Record<string, unknown> | undefined
+    if (data?.namespaceAdmissions !== undefined) {
+      memberAdmission.value = {
+        ...(memberAdmission.value as MemberAdmission),
+        ...(data as MemberAdmission),
+        namespaceAdmissions: normalizeNamespaceAdmissions(data.namespaceAdmissions),
+      }
+    } else {
+      await loadMemberAdmission(access.value.user.id)
+    }
+    setStatus(enabled ? `已开通 ${admission.namespace} 插件使用` : `已关闭 ${admission.namespace} 插件使用`)
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '更新插件使用准入失败', 'error')
+  } finally {
+    busy.value = false
   }
 }
 

--- a/apps/web/tests/roleDelegationView.spec.ts
+++ b/apps/web/tests/roleDelegationView.spec.ts
@@ -187,6 +187,32 @@ function createApiImplementation(callLog: string[]) {
           roles: [],
           memberGroups: [],
           delegableRoles: [],
+          namespaceAdmissions: [
+            {
+              namespace: 'crm',
+              enabled: false,
+              effective: false,
+              hasRole: true,
+              updatedAt: '2026-04-09T00:00:00.000Z',
+            },
+          ],
+        },
+      })
+    }
+
+    if (pathname === '/api/admin/role-delegation/users/user-1/namespaces/crm/admission') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          namespaceAdmissions: [
+            {
+              namespace: 'crm',
+              enabled: true,
+              effective: true,
+              hasRole: true,
+              updatedAt: '2026-04-10T00:00:00.000Z',
+            },
+          ],
         },
       })
     }
@@ -292,5 +318,19 @@ describe('RoleDelegationView', () => {
 
     expect(container?.textContent).toContain('请选择一个成员')
     expect(container?.textContent).not.toContain('alpha@example.com')
+  })
+
+  it('shows namespace admission controls for delegated members and can toggle plugin usage', async () => {
+    await mountView()
+
+    expect(container?.textContent).toContain('插件使用准入')
+    expect(container?.textContent).toContain('插件使用未开通')
+    expect(container?.textContent).toContain('当前不可用')
+
+    findButtonByText(container!, '开通插件使用').click()
+    await waitForCondition(() => callLog.some((url) => url.includes('/api/admin/role-delegation/users/user-1/namespaces/crm/admission')))
+
+    expect(container?.textContent).toContain('已开通 crm 插件使用')
+    expect(container?.textContent).toContain('当前实际可用')
   })
 })

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import UserManagementView from '../src/views/UserManagementView.vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    hasAdminAccess: () => true,
+  }),
+}))
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+async function flushUi(cycles = 8): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function waitForCondition(predicate: () => boolean, attempts = 40): Promise<void> {
+  for (let index = 0; index < attempts; index += 1) {
+    await flushUi(2)
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error('Condition not reached in time')
+}
+
+function createJsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  }
+}
+
+function findButtonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes(text))
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${text}`)
+  }
+  return button
+}
+
+function createApiImplementation(callLog: string[]) {
+  return async (input: unknown) => {
+    const rawUrl = String(input)
+    callLog.push(rawUrl)
+    const url = new URL(rawUrl, 'http://localhost')
+    const pathname = url.pathname
+
+    if (pathname === '/api/admin/roles') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'crm_admin',
+              name: 'CRM 管理员',
+              memberCount: 1,
+              permissions: ['crm:admin'],
+            },
+          ],
+        },
+      })
+    }
+
+    if (pathname === '/api/admin/access-presets') {
+      return createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      })
+    }
+
+    if (pathname === '/api/admin/users') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+              role: 'user',
+              is_active: true,
+            },
+          ],
+        },
+      })
+    }
+
+    if (pathname === '/api/admin/users/user-1/access') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          user: {
+            id: 'user-1',
+            email: 'alpha@example.com',
+            name: 'Alpha',
+            role: 'user',
+            is_active: true,
+          },
+          roles: ['crm_admin'],
+          permissions: ['crm:admin'],
+          isAdmin: false,
+        },
+      })
+    }
+
+    if (pathname === '/api/admin/invites') {
+      return createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      })
+    }
+
+    if (pathname === '/api/admin/users/user-1/sessions') {
+      return createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      })
+    }
+
+    if (pathname === '/api/admin/users/user-1/dingtalk-access') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          userId: 'user-1',
+          requireGrant: true,
+          grant: {
+            exists: true,
+            enabled: true,
+            grantedBy: 'admin-1',
+            createdAt: '2026-04-09T00:00:00.000Z',
+            updatedAt: '2026-04-09T00:00:00.000Z',
+          },
+          identity: {
+            exists: true,
+            corpId: 'dingcorp',
+            lastLoginAt: '2026-04-09T00:00:00.000Z',
+            createdAt: '2026-04-09T00:00:00.000Z',
+            updatedAt: '2026-04-09T00:00:00.000Z',
+          },
+        },
+      })
+    }
+
+    if (pathname === '/api/admin/users/user-1/member-admission') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          userId: 'user-1',
+          accountEnabled: true,
+          platformAdminEnabled: false,
+          attendanceAdminEnabled: false,
+          businessRoleIds: ['crm_admin'],
+          directoryMemberships: [],
+          dingtalk: {
+            userId: 'user-1',
+            requireGrant: true,
+            grant: {
+              exists: true,
+              enabled: true,
+              grantedBy: 'admin-1',
+              createdAt: '2026-04-09T00:00:00.000Z',
+              updatedAt: '2026-04-09T00:00:00.000Z',
+            },
+            identity: {
+              exists: true,
+              corpId: 'dingcorp',
+              lastLoginAt: '2026-04-09T00:00:00.000Z',
+              createdAt: '2026-04-09T00:00:00.000Z',
+              updatedAt: '2026-04-09T00:00:00.000Z',
+            },
+          },
+          namespaceAdmissions: [
+            {
+              namespace: 'crm',
+              enabled: false,
+              effective: false,
+              hasRole: true,
+              updatedAt: '2026-04-09T00:00:00.000Z',
+            },
+          ],
+        },
+      })
+    }
+
+    if (pathname === '/api/admin/users/user-1/namespaces/crm/admission') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          namespaceAdmissions: [
+            {
+              namespace: 'crm',
+              enabled: true,
+              effective: true,
+              hasRole: true,
+              updatedAt: '2026-04-10T00:00:00.000Z',
+            },
+          ],
+        },
+      })
+    }
+
+    throw new Error(`Unhandled apiFetch call: ${rawUrl}`)
+  }
+}
+
+describe('UserManagementView', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+  let callLog: string[] = []
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    callLog = []
+    apiFetchMock.mockImplementation(createApiImplementation(callLog))
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('distinguishes DingTalk login from plugin usage and can open namespace admission', async () => {
+    app = createApp(UserManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await waitForCondition(() => callLog.includes('/api/admin/users/user-1/member-admission'))
+
+    expect(container?.textContent).toContain('钉钉扫码登录')
+    expect(container?.textContent).toContain('插件使用')
+    expect(container?.textContent).toContain('已开通钉钉扫码')
+    expect(container?.textContent).toContain('插件使用未开通')
+    expect(container?.textContent).toContain('当前不可用')
+
+    findButtonByText(container!, '开通插件使用').click()
+    await waitForCondition(() => callLog.some((url) => url.includes('/api/admin/users/user-1/namespaces/crm/admission')))
+
+    expect(container?.textContent).toContain('已开通 crm 插件使用')
+    expect(container?.textContent).toContain('当前实际可用')
+  })
+})

--- a/docs/development/dingtalk-secure-admission-deployment-20260411.md
+++ b/docs/development/dingtalk-secure-admission-deployment-20260411.md
@@ -1,0 +1,196 @@
+# DingTalk Secure Admission Deployment
+
+日期: 2026-04-11
+
+## 目标
+
+将 PR `#803` 的 DingTalk 安全加固与 namespace admission 改动安全发布到服务器，并保留直接回滚路径。
+
+关联对象：
+
+- PR: `https://github.com/zensgit/metasheet2/pull/803`
+- 分支: `codex/dingtalk-secure-admission-20260411`
+- 提交: `4572cc489`
+
+## 发布前检查
+
+### 1. 环境变量
+
+确认生产 `docker/app.env` 使用真实换行，不是字面量 `\n`，并包含以下变量：
+
+- `ENCRYPTION_KEY`
+- `ENCRYPTION_SALT`
+- `DINGTALK_CLIENT_ID`
+- `DINGTALK_CLIENT_SECRET`
+- `DINGTALK_CORP_ID`
+- `DINGTALK_ALLOWED_CORP_IDS`
+- `DINGTALK_REDIRECT_URI`
+- `DINGTALK_AUTH_AUTO_LINK_EMAIL=1`
+- `DINGTALK_AUTH_AUTO_PROVISION=0`
+- `DINGTALK_AUTH_REQUIRE_GRANT=1`
+
+关键约束：
+
+- `DINGTALK_CORP_ID` 必须包含在 `DINGTALK_ALLOWED_CORP_IDS` 中
+- `DINGTALK_REDIRECT_URI` 必须与钉钉开发者平台配置一致，路径为 `/login/dingtalk/callback`
+
+建议执行：
+
+```bash
+scripts/ops/validate-env-file.sh
+docker compose config
+scripts/ops/attendance-preflight.sh
+```
+
+### 2. 备份
+
+发布前先做三类备份：
+
+- 备份根目录 `.env`
+- 备份 `docker/app.env`
+- 导出一份压缩数据库快照
+
+### 3. 当前版本记录
+
+记录：
+
+- 当前运行镜像 tag
+- 目标镜像 tag / commit
+- 当前后端健康检查结果
+
+## 条件化迁移修复
+
+正常情况下，直接执行迁移即可。
+
+```bash
+pnpm --filter @metasheet/core-backend migrate
+```
+
+只有当出现类似错误时，才进入本节：
+
+```text
+corrupted migrations: expected previously executed migration ...
+```
+
+### 本次已处理过的典型问题
+
+问题模式：
+
+- `zzzz20260404100000_extend_approval_tables_for_bridge` 的 schema 已经在库里
+- 但 `kysely_migration` 缺少这条记录
+- Kysely 因此拒绝继续执行后续迁移
+
+先核查，不要直接写库：
+
+1. 确认 `approval_assignments` 表已存在
+2. 确认 `approval_instances` 上 bridge 扩展字段和索引已存在
+3. 确认缺失的只是 `kysely_migration` 账目
+
+若以上都成立，可只补 ledger，不重复改 schema：
+
+```sql
+INSERT INTO kysely_migration(name, "timestamp")
+SELECT 'zzzz20260404100000_extend_approval_tables_for_bridge', '2026-04-04T02:34:52.657Z'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM kysely_migration
+  WHERE name = 'zzzz20260404100000_extend_approval_tables_for_bridge'
+);
+```
+
+说明：
+
+- `kysely_migration.timestamp` 在本仓库当前实现里是 `varchar`
+- Kysely 会先按时间戳解析排序，时间戳相同时再按 migration name 排序
+- 这里使用与 `zzzz20260404121000_create_meta_comment_reads` 相同的时间戳，是为了让 `04100000` 稳定排在 `04121000` 前面
+
+补账后重新执行：
+
+```bash
+pnpm --filter @metasheet/core-backend migrate
+```
+
+## 发布顺序
+
+### 1. 数据库先行
+
+先完成数据库动作，再切服务：
+
+```bash
+pnpm --filter @metasheet/core-backend migrate
+pnpm --filter @metasheet/core-backend exec tsx scripts/encrypt-dingtalk-integration-secrets.ts
+```
+
+预期：
+
+- `user_namespace_admissions` 已创建
+- 旧目录/考勤集成 secret 已兼容 `enc:` 存储
+- 历史有角色的插件成员已完成 `seed_backfill`
+
+### 2. 后端先切
+
+后端更新后先检查：
+
+```bash
+curl http://127.0.0.1:8900/health
+```
+
+同时验证：
+
+- `/api/auth/dingtalk/launch` 返回 `200`
+- DingTalk 凭证可成功换取 access token
+
+### 3. 前端后切
+
+在后端健康且 DingTalk 登录入口正常后，再切 web。
+
+## 发布后冒烟
+
+### 平台管理
+
+- 打开 `/admin/users`
+- 选择成员，确认能看到：
+  - `钉钉扫码登录`
+  - `插件使用`
+  - `成员准入`
+
+### 委派管理
+
+- 打开 `/admin/role-delegation`
+- 选择成员，确认能看到：
+  - `插件使用准入`
+  - 命名空间与委派范围说明
+
+### DingTalk 安全基线
+
+- 用 allowlist 外的 `corpId` 创建目录/考勤集成，接口应拒绝
+- 查看 DingTalk 机器人日志，不应暴露：
+  - `access_token`
+  - `sign`
+  - `timestamp`
+
+### 数据验证
+
+- `user_namespace_admissions` 表存在
+- 本次迁移记录已写入 `kysely_migration`
+- 历史目录/考勤集成仍可正常读取与同步
+
+## 回滚
+
+回滚顺序：
+
+1. 停止当前服务
+2. 恢复 `.env` 与 `docker/app.env`
+3. 切回旧镜像 tag
+4. 如数据库变更必须撤销，再从发布前快照恢复数据库
+
+回滚前提：
+
+- 旧镜像仍保留在本机
+- 配置文件备份可用
+- 数据库快照可用
+
+## 备注
+
+- 本地开发态的默认 `/api/auth/dev-token` 用户是 `dev-user`，若库中不存在该用户，部分 admin 接口会返回 `403`
+- 这不影响生产发布，但会影响本地浏览器联调，建议本地验收使用数据库中真实存在的管理员会话

--- a/docs/development/dingtalk-secure-admission-design-20260411.md
+++ b/docs/development/dingtalk-secure-admission-design-20260411.md
@@ -1,0 +1,195 @@
+# DingTalk Secure Admission Design
+
+日期: 2026-04-11
+
+## 目标
+
+本次改动同时解决两类问题：
+
+1. 钉钉集成安全基线不足
+   - 目录同步与考勤集成的 `appSecret` 以明文 JSON 保存。
+   - 钉钉机器人通知日志会打印完整 webhook URL。
+   - `DINGTALK_ALLOWED_CORP_IDS` 仅在文档中存在，运行时未真正生效。
+
+2. 插件权限缺少“开通”层
+   - 现有模型只有账号启用、角色、权限。
+   - 平台管理员与插件管理员无法对“某个成员是否允许使用某个插件命名空间”做独立开关。
+   - 角色被撤销后，原开通状态不会自动收敛。
+
+## 设计原则
+
+### 钉钉集成安全
+
+- 持久化永远写入 `enc:<base64>` 格式。
+- 读取兼容老数据：
+  - 明文可读。
+  - `enc:` 前缀自动解密。
+- 不在服务启动时偷偷改库。
+- 提供一次性运维脚本做历史数据加密迁移。
+- 运行时 Corp allowlist 统一在服务端判定，不靠前端兜底。
+
+### 命名空间准入
+
+- 生效权限 = 账号启用 + 至少一个命名空间角色 + admission enabled。
+- `admin` 仍然是平台全局管理员，直接绕过 namespace admission。
+- admission 不会因为分配角色而自动开启。
+- 当用户失去某命名空间最后一个角色时，系统自动关闭该 namespace admission。
+- 平台管理员和委派插件管理员都能操作 admission，但委派管理员只能处理自己命名空间且在授权组织范围内的成员。
+
+## 数据模型
+
+新增表：`user_namespace_admissions`
+
+- `id uuid primary key`
+- `user_id text not null references users(id) on delete cascade`
+- `namespace text not null`
+- `enabled boolean not null default false`
+- `source text not null default 'platform_admin'`
+- `granted_by text`
+- `updated_by text`
+- `created_at timestamptz not null default now()`
+- `updated_at timestamptz not null default now()`
+- unique: `(user_id, namespace)`
+
+迁移回填：
+
+- 从 `user_roles + role_permissions` 推导受控命名空间。
+- 为已有角色成员插入 `enabled = true, source = 'seed_backfill'`。
+- 这样历史已在使用中的插件成员不会被一次升级直接锁死。
+
+## 运行时规则
+
+### 命名空间识别
+
+- 角色命名空间：
+  - `role_id === namespace`
+  - 或 `role_id` 以 `${namespace}_` 开头
+  - 或该角色的 `role_permissions` 包含 `${namespace}:*`
+- 权限命名空间：
+  - 取 `permission_code` 的资源前缀，即 `resource:action` 中的 `resource`
+
+### 不受 admission 控制的共享资源
+
+当前明确排除：
+
+- `spreadsheet`
+- `spreadsheets`
+- `multitable`
+- `workflow`
+- `approvals`
+- `comments`
+- `permissions`
+- `roles`
+- `admin`
+- 以及一批平台基础资源如 `auth`、`audit`、`health`、`notifications`
+
+因此：
+
+- `attendance:*`、`crm:*`、`plm:*`、`after_sales:*` 这类插件/业务命名空间受 admission 控制。
+- 多维表、流程、评论等平台共享能力不受这套 admission 影响。
+
+## 后端改动
+
+### 钉钉与目录
+
+- `packages/core-backend/src/integrations/dingtalk/client.ts`
+  - `DINGTALK_ALLOWED_CORP_IDS` 运行时生效。
+  - `DINGTALK_CORP_ID` 不在 allowlist 中时，OAuth 配置视为不可用。
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+  - 目录集成 `appSecret` 改为加密存储。
+  - 读老数据兼容明文。
+  - 创建、更新、测试前校验 `corpId` 是否在 allowlist。
+
+- `plugins/plugin-attendance/index.cjs`
+  - 考勤集成 `appSecret` 改为加密存储。
+  - 列表响应不再回传明文 secret，只暴露 `appSecretConfigured`。
+  - 创建、更新、同步时校验 `corpId` allowlist。
+  - DingTalk 请求失败日志中的敏感 query 参数被脱敏。
+
+- `packages/core-backend/src/services/NotificationService.ts`
+  - DingTalk 机器人 webhook 日志改为脱敏 URL，隐藏 `access_token/sign/timestamp`。
+
+### RBAC 与 admission
+
+- 新增共享模块：
+  - `packages/core-backend/src/rbac/namespace-admission.ts`
+  - `packages/core-backend/src/security/encrypted-secrets.ts`
+  - `packages/core-backend/src/integrations/dingtalk/runtime-policy.ts`
+
+- `packages/core-backend/src/rbac/service.ts`
+  - `listUserPermissions()` 会过滤掉未通过 namespace admission 的权限。
+  - `userHasPermission()` 直接变成 admission-aware。
+
+- `packages/core-backend/src/rbac/rbac.ts`
+  - 即使走 `req.user.permissions` 或 trusted token claims，也会再做 namespace admission 判定。
+  - 避免绕过 `listUserPermissions()` 的短路路径漏掉 admission。
+
+### 管理后台 API
+
+- 平台管理员：
+  - `PATCH /api/admin/users/:userId/namespaces/:namespace/admission`
+
+- 委派插件管理员：
+  - `PATCH /api/admin/role-delegation/users/:userId/namespaces/:namespace/admission`
+
+- 快照返回增强：
+  - `GET /api/admin/users/:userId/member-admission`
+  - `GET /api/admin/role-delegation/users/:userId/access`
+
+返回的 `namespaceAdmissions` 结构：
+
+- `namespace`
+- `enabled`
+- `effective`
+- `hasRole`
+- `updatedAt`
+- 以及内部可追踪字段 `source/grantedBy/updatedBy/createdAt`
+
+- 自动收敛：
+  - 平台管理员角色撤销接口
+  - 委派角色撤销接口
+  - 都会在撤销最后一个命名空间角色后自动关闭该 namespace admission
+
+## 前端改动
+
+- `apps/web/src/views/UserManagementView.vue`
+  - 平台管理员可看到“钉钉登录”和“插件使用”两个独立层次。
+  - 展示 namespace admission，并直接开关。
+
+- `apps/web/src/views/RoleDelegationView.vue`
+  - 插件管理员在委派视图中可查看并修改自己命名空间下成员的 admission。
+
+## 运维与迁移
+
+### 数据库迁移
+
+执行常规迁移即可：
+
+```bash
+pnpm --filter @metasheet/core-backend migrate
+```
+
+### 历史 secret 加密脚本
+
+对已经存在的目录/考勤集成明文 `appSecret` 做一次性重写：
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsx scripts/encrypt-dingtalk-integration-secrets.ts
+```
+
+### 关键环境变量
+
+- `ENCRYPTION_KEY`
+- `ENCRYPTION_SALT`
+- `DINGTALK_ALLOWED_CORP_IDS`
+- `DINGTALK_CLIENT_ID`
+- `DINGTALK_CLIENT_SECRET`
+- `DINGTALK_REDIRECT_URI`
+- `DINGTALK_CORP_ID`
+
+## 风险与边界
+
+- 如果历史环境没有 `role_permissions`，命名空间识别会退化，需先保证 RBAC 元数据完整。
+- 钉钉 OAuth 当前用户接口不返回 corpId，因此 OAuth 登录阶段只能校验服务端配置的 corpId，而不能对回调用户逐人比对 corpId。
+- 考勤集成要想启用 allowlist，配置里需要带 `corpId`，否则在启用 allowlist 时会被拒绝。

--- a/docs/development/dingtalk-secure-admission-verification-20260411.md
+++ b/docs/development/dingtalk-secure-admission-verification-20260411.md
@@ -1,0 +1,96 @@
+# DingTalk Secure Admission Verification
+
+日期: 2026-04-11
+
+## 编译检查
+
+后端 TypeScript 编译通过：
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+考勤插件 CJS 语法检查通过：
+
+```bash
+node -c plugins/plugin-attendance/index.cjs
+```
+
+## 后端定向测试
+
+执行命令：
+
+```bash
+cd packages/core-backend
+../../node_modules/.bin/vitest run \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/notification-service-dingtalk.test.ts \
+  tests/unit/dingtalk-client-policy.test.ts \
+  tests/unit/rbac-namespace-admission.test.ts \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/dingtalk-oauth-login-gates.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts
+```
+
+结果：
+
+- 8 个测试文件
+- 86 个测试
+- 全部通过
+
+覆盖重点：
+
+- Corp allowlist 在 DingTalk OAuth 配置层生效
+- namespace admission 对权限列表和直接权限检查生效
+- 平台管理员与委派插件管理员 admission API 可用
+- 角色撤销后 admission 自动关闭
+- DingTalk 机器人日志不再泄露 access token
+- 目录绑定与 DingTalk 登录授权链路未回归
+
+## 前端定向测试
+
+执行命令：
+
+```bash
+cd apps/web
+../../node_modules/.bin/vitest run tests/userManagementView.spec.ts tests/roleDelegationView.spec.ts
+```
+
+结果：
+
+- 2 个测试文件
+- 5 个测试
+- 全部通过
+
+覆盖重点：
+
+- 平台用户管理页展示并切换 namespace admission
+- 委派插件管理员页面展示并切换 namespace admission
+
+## 人工检查建议
+
+上线前建议再做一轮人工验证：
+
+1. 平台管理员给成员分配 `crm_operator`，但不打开 `crm` admission。
+   预期：成员仍不能进入 CRM 插件功能。
+
+2. 平台管理员打开 `crm` admission。
+   预期：成员获得 CRM 插件使用权限。
+
+3. 撤销成员最后一个 `crm_*` 角色。
+   预期：`crm` admission 自动关闭。
+
+4. 使用不在 `DINGTALK_ALLOWED_CORP_IDS` 内的 corpId 新建目录/考勤集成。
+   预期：接口拒绝。
+
+5. 查看 DingTalk 通知日志。
+   预期：日志里只看到脱敏后的 webhook URL。
+
+6. 对历史目录/考勤集成执行加密脚本后再次查看列表与同步。
+   预期：旧集成仍能正常读取和同步，不暴露明文 secret。
+
+## 未跑项目
+
+- 未执行整个 workspace 的全量前端测试，因为仓库当前存在与本任务无关的既有失败项。
+- 未做真实 DingTalk 线上回调联调，本次验证停留在本地定向单测与编译层。

--- a/docs/development/dingtalk-secure-admission-verification-20260411.md
+++ b/docs/development/dingtalk-secure-admission-verification-20260411.md
@@ -68,6 +68,74 @@ cd apps/web
 - 平台用户管理页展示并切换 namespace admission
 - 委派插件管理员页面展示并切换 namespace admission
 
+## 数据库迁移验证
+
+本地数据库最初存在一处既有迁移账目漂移：
+
+- `zzzz20260404100000_extend_approval_tables_for_bridge` 的 schema 实际已在库中
+- 但 `kysely_migration` 缺少这条记录
+- 导致 `pnpm --filter @metasheet/core-backend migrate` 被 Kysely 判定为顺序损坏
+
+核查结果：
+
+- `approval_instances` 扩展字段已存在
+- `approval_assignments` 表及索引已存在
+- 因此不需要重复执行业务 schema 变更，只需补 migration ledger
+
+处理后再次执行：
+
+```bash
+pnpm --filter @metasheet/core-backend migrate
+```
+
+结果：
+
+- 历史缺口账目修复后，迁移恢复正常
+- `zzzz20260411120000_create_user_namespace_admissions` 执行成功
+- 同时补齐了本地库里之前积压的数条 2026-04 迁移
+
+额外执行：
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsx scripts/encrypt-dingtalk-integration-secrets.ts
+```
+
+结果：
+
+- `directoryUpdated = 0`
+- `attendanceUpdated = 0`
+- 说明当前本地数据无需再做 secret 重写
+
+## 浏览器人工验收
+
+启动本地服务：
+
+```bash
+pnpm --filter @metasheet/core-backend dev
+VITE_API_URL=http://127.0.0.1:7778 pnpm --filter @metasheet/web dev -- --host 127.0.0.1
+```
+
+浏览器验收结论：
+
+- `http://127.0.0.1:8899/admin/users`
+  - 页面成功加载“用户管理”
+  - 选中成员后可见“成员准入”“插件使用”“钉钉扫码登录”等分层文案
+  - 空状态文案正确区分：
+    - `暂无插件使用准入信息`
+    - `未开通钉钉扫码`
+    - `未绑定钉钉身份`
+
+- `http://127.0.0.1:8899/admin/role-delegation`
+  - 页面成功加载“角色委派”
+  - 可见插件管理员范围、平台成员集、模板覆盖等既有区域
+  - 可见新增“插件使用准入”区块与“两层开关”说明文案
+
+验收说明：
+
+- 浏览器验收使用了数据库中真实存在的管理员用户会话
+- 默认开发态 `/api/auth/dev-token` 返回的 `dev-user` 不在当前本地库中，部分后台接口会返回 `403`
+- 这不影响本次改动的功能判断，但意味着本地 admin 页面联调时应优先使用真实管理员会话
+
 ## 人工检查建议
 
 上线前建议再做一轮人工验证：
@@ -93,4 +161,4 @@ cd apps/web
 ## 未跑项目
 
 - 未执行整个 workspace 的全量前端测试，因为仓库当前存在与本任务无关的既有失败项。
-- 未做真实 DingTalk 线上回调联调，本次验证停留在本地定向单测与编译层。
+- 未做真实 DingTalk 线上回调联调，本次验证停留在本地定向单测、编译、迁移与浏览器人工验收层。

--- a/packages/core-backend/scripts/encrypt-dingtalk-integration-secrets.ts
+++ b/packages/core-backend/scripts/encrypt-dingtalk-integration-secrets.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env tsx
+import pg from 'pg'
+import { normalizeStoredSecretValue } from '../src/security/encrypted-secrets'
+
+const { Pool } = pg as any
+
+type IntegrationRow = {
+  id: string
+  config: Record<string, unknown> | null
+}
+
+function normalizeConfig(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? { ...(value as Record<string, unknown>) }
+    : {}
+}
+
+function readSecret(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+async function rewriteDirectoryIntegrations(pool: any): Promise<number> {
+  const { rows } = await pool.query<IntegrationRow>('SELECT id, config FROM directory_integrations')
+  let updated = 0
+
+  for (const row of rows) {
+    const config = normalizeConfig(row.config)
+    const appSecret = readSecret(config.appSecret)
+    if (!appSecret) continue
+
+    const nextSecret = normalizeStoredSecretValue(appSecret)
+    if (nextSecret === appSecret) continue
+
+    config.appSecret = nextSecret
+    await pool.query(
+      'UPDATE directory_integrations SET config = $2::jsonb, updated_at = NOW() WHERE id = $1',
+      [row.id, JSON.stringify(config)],
+    )
+    updated += 1
+  }
+
+  return updated
+}
+
+async function rewriteAttendanceIntegrations(pool: any): Promise<number> {
+  const { rows } = await pool.query<IntegrationRow>('SELECT id, config FROM attendance_integrations')
+  let updated = 0
+
+  for (const row of rows) {
+    const config = normalizeConfig(row.config)
+    const appSecret = readSecret(config.appSecret ?? config.appsecret ?? config.app_secret)
+    if (!appSecret) continue
+
+    const nextSecret = normalizeStoredSecretValue(appSecret)
+    if (nextSecret === appSecret) continue
+
+    config.appSecret = nextSecret
+    delete config.appsecret
+    delete config.app_secret
+
+    await pool.query(
+      'UPDATE attendance_integrations SET config = $2::jsonb, updated_at = NOW() WHERE id = $1',
+      [row.id, JSON.stringify(config)],
+    )
+    updated += 1
+  }
+
+  return updated
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required')
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl })
+  try {
+    const [directoryUpdated, attendanceUpdated] = await Promise.all([
+      rewriteDirectoryIntegrations(pool),
+      rewriteAttendanceIntegrations(pool),
+    ])
+    console.log(JSON.stringify({
+      ok: true,
+      directoryUpdated,
+      attendanceUpdated,
+    }))
+  } finally {
+    await pool.end()
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/packages/core-backend/src/db/migrations/zzzz20260411120000_create_user_namespace_admissions.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260411120000_create_user_namespace_admissions.ts
@@ -1,0 +1,98 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const PLATFORM_ADMIN_ROLE_ID = 'admin'
+const NON_NAMESPACED_PERMISSION_RESOURCES = [
+  'admin',
+  'approvals',
+  'audit',
+  'auth',
+  'cache',
+  'comments',
+  'demo',
+  'events',
+  'files',
+  'health',
+  'meta',
+  'metrics',
+  'multitable',
+  'notification',
+  'notifications',
+  'permission',
+  'permissions',
+  'role',
+  'roles',
+  'session',
+  'sessions',
+  'snapshot',
+  'snapshots',
+  'spreadsheet',
+  'spreadsheets',
+  'workflow',
+]
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const exists = await checkTableExists(db, 'user_namespace_admissions')
+  if (!exists) {
+    await db.schema
+      .createTable('user_namespace_admissions')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('user_id', 'text', (col) => col.notNull().references('users.id').onDelete('cascade'))
+      .addColumn('namespace', 'text', (col) => col.notNull())
+      .addColumn('enabled', 'boolean', (col) => col.notNull().defaultTo(false))
+      .addColumn('source', 'text', (col) => col.notNull().defaultTo('platform_admin'))
+      .addColumn('granted_by', 'text')
+      .addColumn('updated_by', 'text')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+
+  await createIndexIfNotExists(db, 'idx_user_namespace_admissions_user_id', 'user_namespace_admissions', 'user_id')
+  await createIndexIfNotExists(db, 'idx_user_namespace_admissions_namespace', 'user_namespace_admissions', 'namespace')
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_user_namespace_admissions_user_namespace
+    ON user_namespace_admissions(user_id, namespace)
+  `.execute(db)
+
+  await sql`
+    WITH controlled_role_namespaces AS (
+      SELECT DISTINCT
+        ur.user_id,
+        split_part(rp.permission_code, ':', 1) AS namespace
+      FROM user_roles ur
+      JOIN role_permissions rp ON rp.role_id = ur.role_id
+      WHERE position(':' IN rp.permission_code) > 0
+        AND split_part(rp.permission_code, ':', 1) <> ${PLATFORM_ADMIN_ROLE_ID}
+        AND split_part(rp.permission_code, ':', 1) NOT IN (${sql.join(NON_NAMESPACED_PERMISSION_RESOURCES.map((value) => sql`${value}`), sql`, `)})
+      UNION
+      SELECT DISTINCT
+        ur.user_id,
+        left(ur.role_id, length(ur.role_id) - length('_admin')) AS namespace
+      FROM user_roles ur
+      WHERE ur.role_id LIKE '%\_admin' ESCAPE '\'
+        AND ur.role_id <> ${PLATFORM_ADMIN_ROLE_ID}
+        AND left(ur.role_id, length(ur.role_id) - length('_admin')) NOT IN (${sql.join(NON_NAMESPACED_PERMISSION_RESOURCES.map((value) => sql`${value}`), sql`, `)})
+    )
+    INSERT INTO user_namespace_admissions
+      (user_id, namespace, enabled, source, created_at, updated_at)
+    SELECT
+      user_id,
+      namespace,
+      TRUE,
+      'seed_backfill',
+      NOW(),
+      NOW()
+    FROM controlled_role_namespaces
+    WHERE namespace <> ''
+    ON CONFLICT (user_id, namespace) DO NOTHING
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('user_namespace_admissions').ifExists().cascade().execute()
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -8,6 +8,8 @@ import {
   type DingTalkDepartment,
   type DingTalkDirectoryUser,
 } from '../integrations/dingtalk/client'
+import { assertDingTalkCorpAllowed } from '../integrations/dingtalk/runtime-policy'
+import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../security/encrypted-secrets'
 
 const logger = new Logger('DirectorySync')
 const DEFAULT_ORG_ID = 'default'
@@ -298,7 +300,8 @@ function normalizePageSize(value: unknown): number {
 function parseIntegrationConfig(row: Pick<DirectoryIntegrationRow, 'config'>): DirectoryIntegrationConfig {
   const config = parseJsonRecord(row.config)
   const appKey = normalizeText(config.appKey)
-  const appSecret = normalizeText(config.appSecret)
+  const rawAppSecret = normalizeText(config.appSecret)
+  const appSecret = rawAppSecret ? decryptStoredSecretValue(rawAppSecret) : ''
   const rootDepartmentId = normalizeText(config.rootDepartmentId) || DEFAULT_ROOT_DEPARTMENT_ID
   const baseUrl = normalizeOptionalText(config.baseUrl) ?? undefined
   const pageSize = normalizePageSize(config.pageSize)
@@ -426,6 +429,7 @@ function normalizeIntegrationInput(
   if (!corpId) throw new Error('corpId is required')
   if (!appKey) throw new Error('appKey is required')
   if (!appSecret) throw new Error('appSecret is required')
+  assertDingTalkCorpAllowed(corpId, { context: 'Directory integration corpId' })
 
   return {
     ...input,
@@ -506,7 +510,7 @@ export async function createDirectoryIntegration(input: DirectoryIntegrationInpu
       normalized.corpId,
       JSON.stringify({
         appKey: normalized.appKey,
-        appSecret: normalized.appSecret,
+        appSecret: normalizeStoredSecretValue(normalized.appSecret),
         rootDepartmentId: normalized.rootDepartmentId,
         baseUrl: normalized.baseUrl ?? null,
         pageSize: normalized.pageSize,
@@ -549,7 +553,7 @@ export async function updateDirectoryIntegration(
       normalized.corpId,
       JSON.stringify({
         appKey: normalized.appKey,
-        appSecret: normalized.appSecret,
+        appSecret: normalizeStoredSecretValue(normalized.appSecret),
         rootDepartmentId: normalized.rootDepartmentId,
         baseUrl: normalized.baseUrl ?? null,
         pageSize: normalized.pageSize,

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -1,4 +1,5 @@
 import { Logger } from '../../core/logger'
+import { assertDingTalkCorpAllowed } from './runtime-policy'
 
 const logger = new Logger('DingTalkClient')
 
@@ -184,6 +185,7 @@ export function readDingTalkOauthConfig(): DingTalkOauthConfig {
   if (!clientId) throw new Error('DINGTALK_CLIENT_ID or DINGTALK_APP_KEY is not configured')
   if (!clientSecret) throw new Error('DINGTALK_CLIENT_SECRET or DINGTALK_APP_SECRET is not configured')
   if (!redirectUri) throw new Error('DINGTALK_REDIRECT_URI is not configured')
+  assertDingTalkCorpAllowed(corpId, { allowEmpty: true, context: 'DINGTALK_CORP_ID' })
 
   return {
     clientId,
@@ -194,11 +196,20 @@ export function readDingTalkOauthConfig(): DingTalkOauthConfig {
 }
 
 export function isDingTalkConfigured(): boolean {
-  return Boolean(
-    readStringEnv('DINGTALK_CLIENT_ID', 'DINGTALK_APP_KEY') &&
-    readStringEnv('DINGTALK_CLIENT_SECRET', 'DINGTALK_APP_SECRET') &&
-    readStringEnv('DINGTALK_REDIRECT_URI'),
-  )
+  const clientId = readStringEnv('DINGTALK_CLIENT_ID', 'DINGTALK_APP_KEY')
+  const clientSecret = readStringEnv('DINGTALK_CLIENT_SECRET', 'DINGTALK_APP_SECRET')
+  const redirectUri = readStringEnv('DINGTALK_REDIRECT_URI')
+  if (!clientId || !clientSecret || !redirectUri) return false
+
+  try {
+    assertDingTalkCorpAllowed(readStringEnv('DINGTALK_CORP_ID') || null, {
+      allowEmpty: true,
+      context: 'DINGTALK_CORP_ID',
+    })
+    return true
+  } catch {
+    return false
+  }
 }
 
 export async function exchangeCodeForUserAccessToken(

--- a/packages/core-backend/src/integrations/dingtalk/runtime-policy.ts
+++ b/packages/core-backend/src/integrations/dingtalk/runtime-policy.ts
@@ -1,0 +1,83 @@
+const DINGTALK_WEBHOOK_SENSITIVE_QUERY_KEYS = new Set(['access_token', 'timestamp', 'sign'])
+
+export class DingTalkCorpNotAllowedError extends Error {
+  readonly statusCode = 403
+  readonly code = 'DINGTALK_CORP_NOT_ALLOWED'
+  readonly corpId: string | null
+
+  constructor(message: string, corpId: string | null) {
+    super(message)
+    this.name = 'DingTalkCorpNotAllowedError'
+    this.corpId = corpId
+  }
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+export function readDingTalkAllowedCorpIds(): string[] {
+  return Array.from(new Set(
+    normalizeText(process.env.DINGTALK_ALLOWED_CORP_IDS)
+      .split(/[\s,]+/)
+      .map((item) => item.trim())
+      .filter(Boolean),
+  ))
+}
+
+export function isDingTalkCorpAllowed(corpId: string | null | undefined): boolean {
+  const allowedCorpIds = readDingTalkAllowedCorpIds()
+  if (allowedCorpIds.length === 0) return true
+
+  const normalizedCorpId = normalizeText(corpId)
+  if (!normalizedCorpId) return false
+  return allowedCorpIds.includes(normalizedCorpId)
+}
+
+export function assertDingTalkCorpAllowed(
+  corpId: string | null | undefined,
+  options: {
+    allowEmpty?: boolean
+    context?: string
+  } = {},
+): void {
+  const normalizedCorpId = normalizeText(corpId)
+  const allowedCorpIds = readDingTalkAllowedCorpIds()
+
+  if (allowedCorpIds.length === 0) return
+  if (!normalizedCorpId) {
+    if (options.allowEmpty) return
+    const context = options.context || 'DingTalk corpId'
+    throw new DingTalkCorpNotAllowedError(
+      `${context} is required when DINGTALK_ALLOWED_CORP_IDS is configured`,
+      null,
+    )
+  }
+  if (allowedCorpIds.includes(normalizedCorpId)) return
+
+  const context = options.context || 'DingTalk corpId'
+  throw new DingTalkCorpNotAllowedError(
+    `${context} ${normalizedCorpId} is not allowed by DINGTALK_ALLOWED_CORP_IDS`,
+    normalizedCorpId,
+  )
+}
+
+export function maskDingTalkWebhookUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    for (const key of DINGTALK_WEBHOOK_SENSITIVE_QUERY_KEYS) {
+      if (parsed.searchParams.has(key)) {
+        parsed.searchParams.set(key, '***')
+      }
+    }
+    if (parsed.password) {
+      parsed.password = '***'
+    }
+    return parsed.toString()
+  } catch {
+    return String(url || '').replace(
+      /([?&](?:access_token|timestamp|sign)=)[^&]+/gi,
+      '$1***',
+    )
+  }
+}

--- a/packages/core-backend/src/rbac/__tests__/rbac.test.ts
+++ b/packages/core-backend/src/rbac/__tests__/rbac.test.ts
@@ -1,12 +1,17 @@
 import type { NextFunction, Request, Response } from 'express'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { rbacGuard, rbacGuardAll, rbacGuardAny } from '../rbac'
+import * as namespaceAdmission from '../namespace-admission'
 import * as rbacService from '../service'
 
 vi.mock('../service', () => ({
   isAdmin: vi.fn().mockResolvedValue(false),
   userHasPermission: vi.fn().mockResolvedValue(false),
   listUserPermissions: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../namespace-admission', () => ({
+  isPermissionAllowedByNamespaceAdmission: vi.fn().mockResolvedValue(true),
 }))
 
 function createResponse(): Response {
@@ -24,6 +29,7 @@ function createRequest(user?: Express.Request['user']): Request {
 describe('rbacGuard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(namespaceAdmission.isPermissionAllowedByNamespaceAdmission).mockResolvedValue(true)
   })
 
   it('allows admin role from the authenticated request user without extra RBAC queries', async () => {
@@ -71,6 +77,7 @@ describe('rbacGuard', () => {
 describe('rbacGuardAny', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(namespaceAdmission.isPermissionAllowedByNamespaceAdmission).mockResolvedValue(true)
   })
 
   it('allows when any requested permission is already present on req.user', async () => {
@@ -90,6 +97,7 @@ describe('rbacGuardAny', () => {
 describe('rbacGuardAll', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(namespaceAdmission.isPermissionAllowedByNamespaceAdmission).mockResolvedValue(true)
   })
 
   it('allows when req.user already has a global wildcard permission', async () => {

--- a/packages/core-backend/src/rbac/namespace-admission.ts
+++ b/packages/core-backend/src/rbac/namespace-admission.ts
@@ -1,0 +1,412 @@
+import { Logger } from '../core/logger'
+import { query } from '../db/pg'
+import { isDatabaseSchemaError } from '../utils/database-errors'
+
+const logger = new Logger('NamespaceAdmission')
+
+const PLATFORM_ADMIN_ROLE_ID = 'admin'
+const DELEGATED_ADMIN_ROLE_SUFFIX = '_admin'
+const allowDegradation = process.env.RBAC_OPTIONAL === '1'
+
+const NON_NAMESPACED_PERMISSION_RESOURCES = new Set([
+  'admin',
+  'approvals',
+  'audit',
+  'auth',
+  'cache',
+  'comments',
+  'demo',
+  'events',
+  'files',
+  'health',
+  'meta',
+  'metrics',
+  'multitable',
+  'notification',
+  'notifications',
+  'permission',
+  'permissions',
+  'role',
+  'roles',
+  'session',
+  'sessions',
+  'snapshot',
+  'snapshots',
+  'spreadsheet',
+  'spreadsheets',
+  'workflow',
+])
+
+type UserRolePermissionRow = {
+  role_id: string
+  permission_code: string | null
+}
+
+type NamespaceAdmissionRow = {
+  namespace: string
+  enabled: boolean
+  source: string | null
+  granted_by: string | null
+  updated_by: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export type NamespaceAdmissionSnapshot = {
+  namespace: string
+  enabled: boolean
+  effective: boolean
+  hasRole: boolean
+  source: string | null
+  grantedBy: string | null
+  updatedBy: string | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+type UserNamespaceRoleContext = {
+  isAdmin: boolean
+  roleIds: string[]
+  controlledNamespaces: string[]
+}
+
+let readDegraded = false
+let admissionsTableUnavailable = false
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
+}
+
+function logReadDegradation(message: string): void {
+  if (readDegraded) return
+  readDegraded = true
+  logger.warn(message)
+}
+
+function handleReadFailure(error: unknown, message: string): boolean {
+  if (isDatabaseSchemaError(error) && allowDegradation) {
+    logReadDegradation(message)
+    return true
+  }
+  return false
+}
+
+export function normalizeNamespace(value: unknown): string {
+  return normalizeString(value)
+}
+
+export function deriveDelegatedAdminNamespace(roleId: string): string | null {
+  const normalizedRoleId = normalizeString(roleId)
+  if (!normalizedRoleId || normalizedRoleId === PLATFORM_ADMIN_ROLE_ID) return null
+  if (!normalizedRoleId.endsWith(DELEGATED_ADMIN_ROLE_SUFFIX)) return null
+  const namespace = normalizedRoleId.slice(0, -DELEGATED_ADMIN_ROLE_SUFFIX.length).trim()
+  return namespace || null
+}
+
+export function roleIdMatchesNamespace(roleId: string, namespace: string): boolean {
+  const normalizedRoleId = normalizeString(roleId)
+  const normalizedNamespace = normalizeNamespace(namespace)
+  if (!normalizedRoleId || !normalizedNamespace) return false
+  return normalizedRoleId === normalizedNamespace || normalizedRoleId.startsWith(`${normalizedNamespace}_`)
+}
+
+export function roleIdMatchesNamespaces(roleId: string, namespaces: string[]): boolean {
+  return namespaces.some((namespace) => roleIdMatchesNamespace(roleId, namespace))
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return Array.from(new Set(Array.from(values).filter(Boolean))).sort()
+}
+
+function derivePermissionResource(permissionCode: string): string | null {
+  const normalizedCode = normalizeString(permissionCode)
+  if (!normalizedCode || normalizedCode === '*:*') return null
+  const separatorIndex = normalizedCode.indexOf(':')
+  if (separatorIndex <= 0) return null
+  return normalizedCode.slice(0, separatorIndex).trim() || null
+}
+
+export function isNamespaceAdmissionControlledResource(resource: string | null | undefined): boolean {
+  const normalizedResource = normalizeString(resource)
+  if (!normalizedResource || normalizedResource === '*') return false
+  return !NON_NAMESPACED_PERMISSION_RESOURCES.has(normalizedResource)
+}
+
+export function derivePermissionNamespace(permissionCode: string): string | null {
+  const resource = derivePermissionResource(permissionCode)
+  return isNamespaceAdmissionControlledResource(resource) ? resource : null
+}
+
+async function fetchUserNamespaceRoleContext(userId: string): Promise<UserNamespaceRoleContext> {
+  try {
+    const result = await query<UserRolePermissionRow>(
+      `SELECT ur.role_id, rp.permission_code
+       FROM user_roles ur
+       LEFT JOIN role_permissions rp ON rp.role_id = ur.role_id
+       WHERE ur.user_id = $1`,
+      [userId],
+    )
+
+    const roleIds = new Set<string>()
+    const namespaces = new Set<string>()
+    for (const row of result.rows) {
+      const roleId = normalizeString(row.role_id)
+      if (!roleId) continue
+      roleIds.add(roleId)
+
+      const delegatedAdminNamespace = deriveDelegatedAdminNamespace(roleId)
+      if (delegatedAdminNamespace && isNamespaceAdmissionControlledResource(delegatedAdminNamespace)) {
+        namespaces.add(delegatedAdminNamespace)
+      }
+
+      const permissionNamespace = derivePermissionNamespace(row.permission_code ?? '')
+      if (permissionNamespace) {
+        namespaces.add(permissionNamespace)
+      }
+    }
+
+    return {
+      isAdmin: roleIds.has(PLATFORM_ADMIN_ROLE_ID),
+      roleIds: uniqueSorted(roleIds),
+      controlledNamespaces: uniqueSorted(namespaces),
+    }
+  } catch (error) {
+    if (handleReadFailure(error, 'Namespace admission degraded: user_roles/role_permissions unavailable')) {
+      return {
+        isAdmin: false,
+        roleIds: [],
+        controlledNamespaces: [],
+      }
+    }
+    throw error
+  }
+}
+
+async function fetchNamespaceAdmissions(userId: string): Promise<Map<string, NamespaceAdmissionRow>> {
+  try {
+    const result = await query<NamespaceAdmissionRow>(
+      `SELECT namespace, enabled, source, granted_by, updated_by, created_at, updated_at
+       FROM user_namespace_admissions
+       WHERE user_id = $1`,
+      [userId],
+    )
+    admissionsTableUnavailable = false
+    return new Map(
+      result.rows
+        .map((row) => [normalizeNamespace(row.namespace), row] as const)
+        .filter(([namespace]) => Boolean(namespace)),
+    )
+  } catch (error) {
+    if (handleReadFailure(error, 'Namespace admission degraded: user_namespace_admissions unavailable')) {
+      admissionsTableUnavailable = true
+      return new Map()
+    }
+    throw error
+  }
+}
+
+export async function listRoleNamespaces(roleId: string): Promise<string[]> {
+  const namespaces = new Set<string>()
+  const delegatedAdminNamespace = deriveDelegatedAdminNamespace(roleId)
+  if (delegatedAdminNamespace && isNamespaceAdmissionControlledResource(delegatedAdminNamespace)) {
+    namespaces.add(delegatedAdminNamespace)
+  }
+
+  try {
+    const result = await query<{ permission_code: string | null }>(
+      'SELECT permission_code FROM role_permissions WHERE role_id = $1',
+      [roleId],
+    )
+    for (const row of result.rows) {
+      const permissionNamespace = derivePermissionNamespace(row.permission_code ?? '')
+      if (permissionNamespace) {
+        namespaces.add(permissionNamespace)
+      }
+    }
+  } catch (error) {
+    if (!handleReadFailure(error, 'Namespace admission degraded: role_permissions unavailable')) {
+      throw error
+    }
+  }
+
+  return uniqueSorted(namespaces)
+}
+
+export async function userHasNamespaceRole(userId: string, namespace: string): Promise<boolean> {
+  const normalizedNamespace = normalizeNamespace(namespace)
+  if (!normalizedNamespace) return false
+
+  try {
+    const result = await query<{ allowed: boolean }>(
+      `SELECT TRUE AS allowed
+       FROM user_roles ur
+       LEFT JOIN role_permissions rp ON rp.role_id = ur.role_id
+       WHERE ur.user_id = $1
+         AND (
+           ur.role_id = $2
+           OR ur.role_id LIKE $3 ESCAPE '\\'
+           OR rp.permission_code LIKE $4
+         )
+       LIMIT 1`,
+      [
+        userId,
+        normalizedNamespace,
+        `${escapeLikePattern(normalizedNamespace)}\\_%`,
+        `${normalizedNamespace}:%`,
+      ],
+    )
+    return result.rows.length > 0
+  } catch (error) {
+    if (handleReadFailure(error, 'Namespace admission degraded: namespace role lookup unavailable')) {
+      return false
+    }
+    throw error
+  }
+}
+
+export async function listUserNamespaceAdmissionSnapshots(userId: string): Promise<NamespaceAdmissionSnapshot[]> {
+  const [roleContext, admissions] = await Promise.all([
+    fetchUserNamespaceRoleContext(userId),
+    fetchNamespaceAdmissions(userId),
+  ])
+
+  const namespaces = new Set<string>([
+    ...roleContext.controlledNamespaces,
+    ...admissions.keys(),
+  ])
+
+  return uniqueSorted(namespaces).map((namespace) => {
+    const record = admissions.get(namespace)
+    const enabled = admissionsTableUnavailable ? roleContext.isAdmin || roleContext.controlledNamespaces.includes(namespace) : record?.enabled === true
+    const hasRole = roleContext.controlledNamespaces.includes(namespace)
+    return {
+      namespace,
+      enabled,
+      effective: roleContext.isAdmin || (enabled && hasRole),
+      hasRole,
+      source: record?.source ?? null,
+      grantedBy: record?.granted_by ?? null,
+      updatedBy: record?.updated_by ?? null,
+      createdAt: record?.created_at ?? null,
+      updatedAt: record?.updated_at ?? null,
+    }
+  })
+}
+
+export async function userHasEffectiveNamespaceAccess(userId: string, namespace: string): Promise<boolean> {
+  const normalizedNamespace = normalizeNamespace(namespace)
+  if (!normalizedNamespace) return false
+
+  const [roleContext, admissions] = await Promise.all([
+    fetchUserNamespaceRoleContext(userId),
+    fetchNamespaceAdmissions(userId),
+  ])
+
+  if (roleContext.isAdmin) return true
+  if (!roleContext.controlledNamespaces.includes(normalizedNamespace)) return false
+  if (admissionsTableUnavailable) return true
+  return admissions.get(normalizedNamespace)?.enabled === true
+}
+
+export async function isPermissionAllowedByNamespaceAdmission(userId: string, permissionCode: string): Promise<boolean> {
+  const namespace = derivePermissionNamespace(permissionCode)
+  if (!namespace) return true
+  return userHasEffectiveNamespaceAccess(userId, namespace)
+}
+
+export async function filterPermissionCodesByNamespaceAdmission(userId: string, permissionCodes: string[]): Promise<string[]> {
+  const normalizedCodes = Array.from(new Set(
+    permissionCodes
+      .map((code) => normalizeString(code))
+      .filter(Boolean),
+  ))
+  if (normalizedCodes.length === 0) return []
+
+  const [roleContext, admissions] = await Promise.all([
+    fetchUserNamespaceRoleContext(userId),
+    fetchNamespaceAdmissions(userId),
+  ])
+
+  if (roleContext.isAdmin) return normalizedCodes
+  if (admissionsTableUnavailable) return normalizedCodes
+
+  return normalizedCodes.filter((permissionCode) => {
+    const namespace = derivePermissionNamespace(permissionCode)
+    if (!namespace) return true
+    return roleContext.controlledNamespaces.includes(namespace) && admissions.get(namespace)?.enabled === true
+  })
+}
+
+export async function setUserNamespaceAdmission(options: {
+  userId: string
+  namespace: string
+  enabled: boolean
+  actorId?: string | null
+  source?: string | null
+}): Promise<NamespaceAdmissionSnapshot[]> {
+  const userId = normalizeString(options.userId)
+  const namespace = normalizeNamespace(options.namespace)
+  if (!userId) throw new Error('userId is required')
+  if (!namespace) throw new Error('namespace is required')
+
+  await query(
+    `INSERT INTO user_namespace_admissions
+       (user_id, namespace, enabled, source, granted_by, updated_by, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
+     ON CONFLICT (user_id, namespace)
+     DO UPDATE SET
+       enabled = EXCLUDED.enabled,
+       source = EXCLUDED.source,
+       granted_by = CASE
+         WHEN EXCLUDED.enabled THEN EXCLUDED.granted_by
+         ELSE user_namespace_admissions.granted_by
+       END,
+       updated_by = EXCLUDED.updated_by,
+       updated_at = NOW()`,
+    [
+      userId,
+      namespace,
+      options.enabled,
+      options.source ?? 'platform_admin',
+      options.enabled ? options.actorId ?? null : null,
+      options.actorId ?? null,
+    ],
+  )
+
+  return listUserNamespaceAdmissionSnapshots(userId)
+}
+
+export async function disableNamespaceAdmissionsWithoutRoles(options: {
+  userId: string
+  namespaces: string[]
+  actorId?: string | null
+  source?: string | null
+}): Promise<string[]> {
+  const userId = normalizeString(options.userId)
+  if (!userId) return []
+
+  const disabledNamespaces: string[] = []
+  for (const namespace of uniqueSorted(options.namespaces.map((item) => normalizeNamespace(item)))) {
+    if (!namespace) continue
+    if (await userHasNamespaceRole(userId, namespace)) continue
+
+    await query(
+      `UPDATE user_namespace_admissions
+       SET enabled = FALSE,
+           source = $3,
+           updated_by = $4,
+           updated_at = NOW()
+       WHERE user_id = $1
+         AND namespace = $2
+         AND enabled = TRUE`,
+      [userId, namespace, options.source ?? 'role_unassigned', options.actorId ?? null],
+    )
+    disabledNamespaces.push(namespace)
+  }
+
+  return disabledNamespaces
+}

--- a/packages/core-backend/src/rbac/rbac.ts
+++ b/packages/core-backend/src/rbac/rbac.ts
@@ -6,6 +6,7 @@
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
 import { userHasPermission, isAdmin, listUserPermissions } from './service'
 import { Logger } from '../core/logger'
+import { isPermissionAllowedByNamespaceAdmission } from './namespace-admission'
 
 const logger = new Logger('RBACGuard')
 const trustTokenClaims = process.env.RBAC_TOKEN_TRUST === 'true' || process.env.RBAC_TOKEN_TRUST === '1'
@@ -66,12 +67,18 @@ export function rbacGuard(resourceOrPermission: string, action?: string): Reques
       // Trust the authenticated request user first. jwtAuthMiddleware refreshes
       // role/permission data on each request, and development fallback users only
       // exist on req.user (not in RBAC tables).
-      if (requestUserHasResolvedPermission(req.user, permissionCode)) {
+      if (
+        requestUserHasResolvedPermission(req.user, permissionCode)
+        && await isPermissionAllowedByNamespaceAdmission(userId, permissionCode)
+      ) {
         next()
         return
       }
 
-      if (trustedTokenClaimsAllowPermission(req.user, permissionCode)) {
+      if (
+        trustedTokenClaimsAllowPermission(req.user, permissionCode)
+        && await isPermissionAllowedByNamespaceAdmission(userId, permissionCode)
+      ) {
         next()
         return
       }
@@ -113,9 +120,18 @@ export function rbacGuardAny(permissionCodes: string[]): RequestHandler {
       }
 
       const requestUser = req.user
-      if (requestUserIsAdmin(requestUser) || permissionCodes.some((code) => requestUserHasResolvedPermission(requestUser, code))) {
+      if (requestUserIsAdmin(requestUser)) {
         next()
         return
+      }
+      for (const code of permissionCodes) {
+        if (
+          requestUserHasResolvedPermission(requestUser, code)
+          && await isPermissionAllowedByNamespaceAdmission(userId, code)
+        ) {
+          next()
+          return
+        }
       }
 
       if (trustTokenClaims) {
@@ -125,9 +141,11 @@ export function rbacGuardAny(permissionCodes: string[]): RequestHandler {
         }
 
         const tokenPerms = normalizeStringArray((requestUser as { perms?: unknown } | undefined)?.perms)
-        if (permissionCodes.some((code) => hasPermissionCode(tokenPerms, code))) {
-          next()
-          return
+        for (const code of permissionCodes) {
+          if (hasPermissionCode(tokenPerms, code) && await isPermissionAllowedByNamespaceAdmission(userId, code)) {
+            next()
+            return
+          }
         }
       }
 
@@ -170,7 +188,21 @@ export function rbacGuardAll(permissionCodes: string[]): RequestHandler {
       }
 
       const requestUser = req.user
-      if (requestUserIsAdmin(requestUser) || permissionCodes.every((code) => requestUserHasResolvedPermission(requestUser, code))) {
+      if (requestUserIsAdmin(requestUser)) {
+        next()
+        return
+      }
+      let requestUserHasAll = true
+      for (const code of permissionCodes) {
+        if (
+          !requestUserHasResolvedPermission(requestUser, code)
+          || !await isPermissionAllowedByNamespaceAdmission(userId, code)
+        ) {
+          requestUserHasAll = false
+          break
+        }
+      }
+      if (requestUserHasAll) {
         next()
         return
       }
@@ -182,7 +214,14 @@ export function rbacGuardAll(permissionCodes: string[]): RequestHandler {
         }
 
         const tokenPerms = normalizeStringArray((requestUser as { perms?: unknown } | undefined)?.perms)
-        if (permissionCodes.every((code) => hasPermissionCode(tokenPerms, code))) {
+        let tokenHasAll = true
+        for (const code of permissionCodes) {
+          if (!hasPermissionCode(tokenPerms, code) || !await isPermissionAllowedByNamespaceAdmission(userId, code)) {
+            tokenHasAll = false
+            break
+          }
+        }
+        if (tokenHasAll) {
           next()
           return
         }

--- a/packages/core-backend/src/rbac/rbac.ts
+++ b/packages/core-backend/src/rbac/rbac.ts
@@ -67,10 +67,10 @@ export function rbacGuard(resourceOrPermission: string, action?: string): Reques
       // Trust the authenticated request user first. jwtAuthMiddleware refreshes
       // role/permission data on each request, and development fallback users only
       // exist on req.user (not in RBAC tables).
-      if (
-        requestUserHasResolvedPermission(req.user, permissionCode)
-        && await isPermissionAllowedByNamespaceAdmission(userId, permissionCode)
-      ) {
+      // req.user is already hydrated by auth with the effective permission set.
+      // Re-checking namespace admission here double-filters development users
+      // and request-scoped permission snapshots that were already resolved.
+      if (requestUserHasResolvedPermission(req.user, permissionCode)) {
         next()
         return
       }
@@ -125,10 +125,7 @@ export function rbacGuardAny(permissionCodes: string[]): RequestHandler {
         return
       }
       for (const code of permissionCodes) {
-        if (
-          requestUserHasResolvedPermission(requestUser, code)
-          && await isPermissionAllowedByNamespaceAdmission(userId, code)
-        ) {
+        if (requestUserHasResolvedPermission(requestUser, code)) {
           next()
           return
         }
@@ -194,10 +191,7 @@ export function rbacGuardAll(permissionCodes: string[]): RequestHandler {
       }
       let requestUserHasAll = true
       for (const code of permissionCodes) {
-        if (
-          !requestUserHasResolvedPermission(requestUser, code)
-          || !await isPermissionAllowedByNamespaceAdmission(userId, code)
-        ) {
+        if (!requestUserHasResolvedPermission(requestUser, code)) {
           requestUserHasAll = false
           break
         }

--- a/packages/core-backend/src/rbac/rbac.ts
+++ b/packages/core-backend/src/rbac/rbac.ts
@@ -58,9 +58,16 @@ export function rbacGuard(resourceOrPermission: string, action?: string): Reques
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const userId = req.user?.id?.toString()
+      const requestUser = req.user
 
       if (!userId) {
         res.status(401).json({ error: 'Authentication required' })
+        return
+      }
+
+      // Global admins bypass namespace admission and RBAC table lookups.
+      if (requestUserIsAdmin(requestUser)) {
+        next()
         return
       }
 
@@ -68,7 +75,7 @@ export function rbacGuard(resourceOrPermission: string, action?: string): Reques
       // role/permission data on each request, and development fallback users only
       // exist on req.user (not in RBAC tables).
       if (
-        requestUserHasResolvedPermission(req.user, permissionCode)
+        requestUserHasResolvedPermission(requestUser, permissionCode)
         && await isPermissionAllowedByNamespaceAdmission(userId, permissionCode)
       ) {
         next()
@@ -76,7 +83,7 @@ export function rbacGuard(resourceOrPermission: string, action?: string): Reques
       }
 
       if (
-        trustedTokenClaimsAllowPermission(req.user, permissionCode)
+        trustedTokenClaimsAllowPermission(requestUser, permissionCode)
         && await isPermissionAllowedByNamespaceAdmission(userId, permissionCode)
       ) {
         next()

--- a/packages/core-backend/src/rbac/service.ts
+++ b/packages/core-backend/src/rbac/service.ts
@@ -2,6 +2,10 @@ import { pool } from '../db/pg'
 import { metrics } from '../metrics/metrics'
 import { Logger } from '../core/logger'
 import { isDatabaseSchemaError } from '../utils/database-errors'
+import {
+  filterPermissionCodesByNamespaceAdmission,
+  isPermissionAllowedByNamespaceAdmission,
+} from './namespace-admission'
 
 const logger = new Logger('RBACService')
 
@@ -32,6 +36,10 @@ export async function isAdmin(userId: string): Promise<boolean> {
 export async function userHasPermission(userId: string, code: string): Promise<boolean> {
   if (!pool) return false
   try {
+    if (!await isPermissionAllowedByNamespaceAdmission(userId, code)) {
+      return false
+    }
+
     // direct user permission
     const direct = await pool.query('SELECT 1 FROM user_permissions WHERE user_id = $1 AND permission_code = $2 LIMIT 1', [userId, code])
     if (direct.rows.length > 0) return true
@@ -86,8 +94,9 @@ export async function listUserPermissions(userId: string): Promise<string[]> {
     const legacy = await pool.query('SELECT permissions FROM users WHERE id = $1', [userId])
     const legacyPerms = Array.isArray(legacy.rows[0]?.permissions) ? legacy.rows[0].permissions : []
     const merged = Array.from(new Set([...codes, ...legacyPerms]))
-    cache.set(key, { codes: merged, exp: now + TTL_MS })
-    return merged
+    const filtered = await filterPermissionCodesByNamespaceAdmission(userId, merged)
+    cache.set(key, { codes: filtered, exp: now + TTL_MS })
+    return filtered
   } catch (error) {
     if (isDatabaseSchemaError(error) && allowDegradation) {
       if (!rbacDegraded) {

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -12,6 +12,16 @@ import { auditLog } from '../audit/audit'
 import { authenticate } from '../middleware/auth'
 import { query } from '../db/pg'
 import { invalidateUserPerms, isAdmin as isRbacAdmin, listUserPermissions } from '../rbac/service'
+import {
+  deriveDelegatedAdminNamespace,
+  disableNamespaceAdmissionsWithoutRoles,
+  isNamespaceAdmissionControlledResource,
+  listRoleNamespaces,
+  listUserNamespaceAdmissionSnapshots,
+  normalizeNamespace,
+  roleIdMatchesNamespaces as matchRoleIdToNamespaces,
+  setUserNamespaceAdmission,
+} from '../rbac/namespace-admission'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
@@ -232,11 +242,10 @@ type CreateUserRequestBody = {
   isActive?: boolean
 }
 
-const ADMIN_AUDIT_RESOURCE_TYPES = ['user', 'user-role', 'user-auth-grant', 'user-password', 'user-session', 'user-invite', 'role', 'permission', 'permission-template', 'delegated-admin-scope', 'delegated-admin-scope-template', 'platform-member-group', 'delegated-admin-group-scope'] as const
+const ADMIN_AUDIT_RESOURCE_TYPES = ['user', 'user-role', 'user-auth-grant', 'user-namespace-admission', 'user-password', 'user-session', 'user-invite', 'role', 'permission', 'permission-template', 'delegated-admin-scope', 'delegated-admin-scope-template', 'platform-member-group', 'delegated-admin-group-scope'] as const
 const DINGTALK_PROVIDER = 'dingtalk'
 const PLATFORM_ADMIN_ROLE_ID = 'admin'
 const ATTENDANCE_ROLE_IDS = new Set(['attendance_employee', 'attendance_approver', 'attendance_admin'])
-const DELEGATED_ADMIN_ROLE_SUFFIX = '_admin'
 
 function getRequestUserId(req: Request): string {
   const raw = req.user as Record<string, unknown> | undefined
@@ -431,14 +440,13 @@ async function fetchDingTalkAccessSnapshot(userId: string) {
 function deriveDelegableNamespaces(roleIds: string[]): string[] {
   return Array.from(new Set(
     roleIds
-      .filter((roleId) => roleId.endsWith(DELEGATED_ADMIN_ROLE_SUFFIX) && roleId !== PLATFORM_ADMIN_ROLE_ID)
-      .map((roleId) => roleId.slice(0, -DELEGATED_ADMIN_ROLE_SUFFIX.length))
-      .filter(Boolean),
+      .map((roleId) => deriveDelegatedAdminNamespace(roleId))
+      .filter((namespace): namespace is string => Boolean(namespace)),
   )).sort()
 }
 
 function roleIdMatchesNamespaces(roleId: string, namespaces: string[]): boolean {
-  return namespaces.some((namespace) => roleId === namespace || roleId.startsWith(`${namespace}_`))
+  return matchRoleIdToNamespaces(roleId, namespaces)
 }
 
 async function fetchDelegatedRoleCatalog(namespaces?: string[]) {
@@ -1224,6 +1232,12 @@ function deriveMatchingNamespacesForRole(roleId: string, namespaces: string[]): 
   return namespaces.filter((namespace) => roleIdMatchesNamespaces(roleId, [namespace]))
 }
 
+async function fetchVisibleNamespaceAdmissions(userId: string, namespaces?: string[]) {
+  const admissions = await listUserNamespaceAdmissionSnapshots(userId)
+  if (!Array.isArray(namespaces)) return admissions
+  return admissions.filter((admission) => namespaces.includes(admission.namespace))
+}
+
 async function ensureRoleDelegationAdmin(req: Request, res: Response): Promise<{
   actorId: string
   isPlatformAdmin: boolean
@@ -1313,12 +1327,13 @@ async function fetchDirectoryMemberships(userId: string) {
 }
 
 async function fetchMemberAdmissionSnapshot(userId: string) {
-  const [profile, roles, directoryMemberships, dingtalkAccess, memberGroups] = await Promise.all([
+  const [profile, roles, directoryMemberships, dingtalkAccess, memberGroups, namespaceAdmissions] = await Promise.all([
     fetchUserProfile(userId),
     fetchUserRoleIds(userId),
     fetchDirectoryMemberships(userId),
     fetchDingTalkAccessSnapshot(userId),
     fetchPlatformMemberGroupMembershipsForUser(userId),
+    listUserNamespaceAdmissionSnapshots(userId),
   ])
   if (!profile) return null
 
@@ -1331,6 +1346,7 @@ async function fetchMemberAdmissionSnapshot(userId: string) {
     memberGroups,
     directoryMemberships,
     dingtalk: dingtalkAccess,
+    namespaceAdmissions,
   }
 }
 
@@ -2160,9 +2176,13 @@ export function adminUsersRouter(): Router {
       const visibleMemberGroupIds = delegation.isPlatformAdmin
         ? undefined
         : deriveVisibleDelegatedMemberGroupIds(groupAssignments)
-      const [snapshot, memberGroups] = await Promise.all([
+      const [snapshot, memberGroups, namespaceAdmissions] = await Promise.all([
         fetchUserAccessSnapshot(userId),
         fetchPlatformMemberGroupMembershipsForUser(userId, visibleMemberGroupIds),
+        fetchVisibleNamespaceAdmissions(
+          userId,
+          delegation.isPlatformAdmin ? undefined : delegation.delegableNamespaces,
+        ),
       ])
       if (!snapshot) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
 
@@ -2180,12 +2200,91 @@ export function adminUsersRouter(): Router {
         user: snapshot.user,
         roles: snapshot.roles,
         memberGroups,
+        namespaceAdmissions,
         delegableRoles: delegation.isPlatformAdmin
           ? snapshot.roles
           : snapshot.roles.filter((roleId) => roleIdMatchesNamespaces(roleId, delegation.delegableNamespaces)),
       })
     } catch (error) {
       return jsonError(res, 500, 'ROLE_DELEGATION_ACCESS_FAILED', (error as Error)?.message || 'Failed to load delegated user access')
+    }
+  })
+
+  r.patch('/api/admin/role-delegation/users/:userId/namespaces/:namespace/admission', authenticate, async (req: Request, res: Response) => {
+    const delegation = await ensureRoleDelegationAdmin(req, res)
+    if (!delegation) return
+
+    try {
+      const userId = String(req.params.userId || '').trim()
+      const namespace = normalizeNamespace(req.params.namespace)
+      const enabled = req.body?.enabled
+      if (!userId) return jsonError(res, 400, 'USER_ID_REQUIRED', 'userId is required')
+      if (!namespace) return jsonError(res, 400, 'NAMESPACE_REQUIRED', 'namespace is required')
+      if (typeof enabled !== 'boolean') return jsonError(res, 400, 'ENABLED_REQUIRED', 'enabled boolean is required')
+      if (!isNamespaceAdmissionControlledResource(namespace)) {
+        return jsonError(res, 400, 'NAMESPACE_NOT_SUPPORTED', 'namespace is not managed by plugin admission controls')
+      }
+      if (!delegation.isPlatformAdmin && !delegation.delegableNamespaces.includes(namespace)) {
+        return jsonError(res, 403, 'ROLE_DELEGATION_FORBIDDEN', 'Namespace is outside your delegated admin scope')
+      }
+
+      const [profile, scopeAssignments, groupAssignments] = await Promise.all([
+        fetchUserProfile(userId),
+        delegation.isPlatformAdmin
+          ? Promise.resolve([])
+          : fetchDelegatedScopeAssignments(delegation.actorId, delegation.delegableNamespaces),
+        delegation.isPlatformAdmin
+          ? Promise.resolve([])
+          : fetchDelegatedGroupAssignments(delegation.actorId, delegation.delegableNamespaces),
+      ])
+      if (!profile) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
+      if (!delegation.isPlatformAdmin && !hasDelegatedAudienceAssignments(scopeAssignments, groupAssignments)) {
+        return jsonError(res, 403, 'ROLE_DELEGATION_SCOPE_REQUIRED', 'No delegated department or member-group scope is configured for your plugin admin role')
+      }
+      if (!delegation.isPlatformAdmin) {
+        const allowed = await isUserWithinDelegatedScope(delegation.actorId, [namespace], userId)
+        if (!allowed) {
+          return jsonError(res, 403, 'ROLE_DELEGATION_USER_OUT_OF_SCOPE', 'User is outside your delegated department or member-group scope')
+        }
+      }
+
+      const namespaceAdmissions = await setUserNamespaceAdmission({
+        userId,
+        namespace,
+        enabled,
+        actorId: delegation.actorId,
+        source: delegation.isPlatformAdmin ? 'platform_admin' : 'delegated_admin',
+      })
+      invalidateUserPerms(userId)
+
+      await auditLog({
+        actorId: delegation.actorId,
+        actorType: 'user',
+        action: enabled ? 'grant' : 'revoke',
+        resourceType: 'user-namespace-admission',
+        resourceId: `${userId}:${namespace}`,
+        meta: {
+          adminUserId: delegation.actorId,
+          userId,
+          namespace,
+          enabled,
+          delegated: !delegation.isPlatformAdmin,
+          delegableNamespaces: delegation.delegableNamespaces,
+        },
+      })
+
+      return jsonOk(res, {
+        actorId: delegation.actorId,
+        isPlatformAdmin: delegation.isPlatformAdmin,
+        delegableNamespaces: delegation.delegableNamespaces,
+        scopeAssignments,
+        groupAssignments,
+        namespaceAdmissions: delegation.isPlatformAdmin
+          ? namespaceAdmissions
+          : namespaceAdmissions.filter((admission) => delegation.delegableNamespaces.includes(admission.namespace)),
+      })
+    } catch (error) {
+      return jsonError(res, 500, 'ROLE_DELEGATION_ADMISSION_FAILED', (error as Error)?.message || 'Failed to update delegated namespace admission')
     }
   })
 
@@ -2244,6 +2343,14 @@ export function adminUsersRouter(): Router {
       if (roleId === PLATFORM_ADMIN_ROLE_ID) {
         await syncLegacyAdminProfile(userId, action === 'assign')
       }
+      const disabledNamespaces = action === 'assign'
+        ? []
+        : await disableNamespaceAdmissionsWithoutRoles({
+          userId,
+          namespaces: await listRoleNamespaces(roleId),
+          actorId: delegation.actorId,
+          source: 'role_unassigned',
+        })
       invalidateUserPerms(userId)
 
       await auditLog({
@@ -2258,12 +2365,17 @@ export function adminUsersRouter(): Router {
           roleId,
           delegated: !delegation.isPlatformAdmin,
           delegableNamespaces: delegation.delegableNamespaces,
+          disabledNamespaces,
         },
       })
 
-      const [snapshot, memberGroups] = await Promise.all([
+      const [snapshot, memberGroups, namespaceAdmissions] = await Promise.all([
         fetchUserAccessSnapshot(userId),
         fetchPlatformMemberGroupMembershipsForUser(userId),
+        fetchVisibleNamespaceAdmissions(
+          userId,
+          delegation.isPlatformAdmin ? undefined : delegation.delegableNamespaces,
+        ),
       ])
       const roleCatalog = await fetchDelegatedRoleCatalog(
         delegation.isPlatformAdmin ? undefined : delegation.delegableNamespaces,
@@ -2279,6 +2391,7 @@ export function adminUsersRouter(): Router {
         user: snapshot?.user ?? profile,
         roles: snapshot?.roles ?? [],
         memberGroups,
+        namespaceAdmissions,
         delegableRoles: delegation.isPlatformAdmin
           ? snapshot?.roles ?? []
           : (snapshot?.roles ?? []).filter((candidateRoleId) => roleIdMatchesNamespaces(candidateRoleId, delegation.delegableNamespaces)),
@@ -2802,6 +2915,57 @@ export function adminUsersRouter(): Router {
     }
   })
 
+  r.patch('/api/admin/users/:userId/namespaces/:namespace/admission', authenticate, async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const userId = String(req.params.userId || '').trim()
+      const namespace = normalizeNamespace(req.params.namespace)
+      const enabled = req.body?.enabled
+      if (!userId) return jsonError(res, 400, 'USER_ID_REQUIRED', 'userId is required')
+      if (!namespace) return jsonError(res, 400, 'NAMESPACE_REQUIRED', 'namespace is required')
+      if (typeof enabled !== 'boolean') return jsonError(res, 400, 'ENABLED_REQUIRED', 'enabled boolean is required')
+      if (!isNamespaceAdmissionControlledResource(namespace)) {
+        return jsonError(res, 400, 'NAMESPACE_NOT_SUPPORTED', 'namespace is not managed by plugin admission controls')
+      }
+
+      const profile = await fetchUserProfile(userId)
+      if (!profile) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
+
+      const namespaceAdmissions = await setUserNamespaceAdmission({
+        userId,
+        namespace,
+        enabled,
+        actorId: adminUserId,
+        source: 'platform_admin',
+      })
+      invalidateUserPerms(userId)
+
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: enabled ? 'grant' : 'revoke',
+        resourceType: 'user-namespace-admission',
+        resourceId: `${userId}:${namespace}`,
+        meta: {
+          adminUserId,
+          userId,
+          namespace,
+          enabled,
+        },
+      })
+
+      return jsonOk(res, {
+        actorId: adminUserId,
+        userId,
+        namespaceAdmissions,
+      })
+    } catch (error) {
+      return jsonError(res, 500, 'MEMBER_NAMESPACE_ADMISSION_FAILED', (error as Error)?.message || 'Failed to update namespace admission')
+    }
+  })
+
   r.patch('/api/admin/users/:userId/dingtalk-grant', authenticate, async (req: Request, res: Response) => {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
@@ -2873,6 +3037,7 @@ export function adminUsersRouter(): Router {
       if (roleId === PLATFORM_ADMIN_ROLE_ID) {
         await syncLegacyAdminProfile(userId, true)
       }
+      const disabledNamespaces: string[] = []
       invalidateUserPerms(userId)
 
       await auditLog({
@@ -2885,6 +3050,7 @@ export function adminUsersRouter(): Router {
           adminUserId,
           userId,
           roleId,
+          disabledNamespaces,
         },
       })
 
@@ -2920,6 +3086,12 @@ export function adminUsersRouter(): Router {
       if (roleId === PLATFORM_ADMIN_ROLE_ID) {
         await syncLegacyAdminProfile(userId, false)
       }
+      const disabledNamespaces = await disableNamespaceAdmissionsWithoutRoles({
+        userId,
+        namespaces: await listRoleNamespaces(roleId),
+        actorId: adminUserId,
+        source: 'role_unassigned',
+      })
       invalidateUserPerms(userId)
 
       await auditLog({
@@ -2932,6 +3104,7 @@ export function adminUsersRouter(): Router {
           adminUserId,
           userId,
           roleId,
+          disabledNamespaces,
         },
       })
 

--- a/packages/core-backend/src/security/encrypted-secrets.ts
+++ b/packages/core-backend/src/security/encrypted-secrets.ts
@@ -1,0 +1,65 @@
+import crypto from 'node:crypto'
+
+const SECRET_PREFIX = 'enc:'
+const ENCRYPTION_ALGORITHM = 'aes-256-gcm'
+const KEY_ITERATIONS = 100_000
+const KEY_LENGTH = 32
+const IV_LENGTH = 16
+const AUTH_TAG_LENGTH = 16
+
+function getEncryptionSalt(): Buffer {
+  return Buffer.from(process.env.ENCRYPTION_SALT || 'default-salt-change-in-production')
+}
+
+function getEncryptionKey(): Buffer {
+  const masterKey = process.env.ENCRYPTION_KEY || 'default-key-change-in-production'
+  return crypto.pbkdf2Sync(masterKey, getEncryptionSalt(), KEY_ITERATIONS, KEY_LENGTH, 'sha256')
+}
+
+export function isEncryptedSecretValue(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith(SECRET_PREFIX)
+}
+
+function encryptRawSecretValue(plaintext: string): string {
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv(ENCRYPTION_ALGORITHM, getEncryptionKey(), iv)
+
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ])
+  const authTag = cipher.getAuthTag()
+
+  return Buffer.concat([iv, authTag, ciphertext]).toString('base64')
+}
+
+function decryptRawSecretValue(ciphertext: string): string {
+  const payload = Buffer.from(ciphertext, 'base64')
+  const iv = payload.subarray(0, IV_LENGTH)
+  const authTag = payload.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH)
+  const encrypted = payload.subarray(IV_LENGTH + AUTH_TAG_LENGTH)
+
+  const decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, getEncryptionKey(), iv)
+  decipher.setAuthTag(authTag)
+
+  return Buffer.concat([
+    decipher.update(encrypted),
+    decipher.final(),
+  ]).toString('utf8')
+}
+
+export function encryptStoredSecretValue(plaintext: string): string {
+  return `${SECRET_PREFIX}${encryptRawSecretValue(plaintext)}`
+}
+
+export function decryptStoredSecretValue(value: string): string {
+  if (!isEncryptedSecretValue(value)) return value
+  return decryptRawSecretValue(value.slice(SECRET_PREFIX.length))
+}
+
+export function normalizeStoredSecretValue(value: string): string {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  if (!normalized) return ''
+  if (isEncryptedSecretValue(normalized)) return normalized
+  return encryptStoredSecretValue(normalized)
+}

--- a/packages/core-backend/src/services/AfterSalesApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/AfterSalesApprovalBridgeService.ts
@@ -410,26 +410,36 @@ export class AfterSalesApprovalBridgeService {
       )
 
       for (const [index, role] of (command.assignmentRoles || DEFAULT_ASSIGNMENT_ROLES).entries()) {
-        await trx.query(
-          `INSERT INTO approval_assignments
-           (instance_id, assignment_type, assignee_id, source_step, is_active, metadata)
-           VALUES ($1, 'role', $2, $3, TRUE, $4::jsonb)
-           ON CONFLICT (instance_id, assignment_type, assignee_id)
-           WHERE is_active = TRUE
-           DO UPDATE SET
-             source_step = EXCLUDED.source_step,
-             is_active = TRUE,
-             metadata = EXCLUDED.metadata,
-             updated_at = now()`,
+        const metadata = JSON.stringify({
+          sourceSystem: command.sourceSystem,
+          workflowKey: REFUND_WORKFLOW_KEY,
+        })
+
+        const updated = await trx.query(
+          `UPDATE approval_assignments
+           SET source_step = $3,
+               is_active = TRUE,
+               metadata = $4::jsonb,
+               updated_at = now()
+           WHERE instance_id = $1
+             AND assignment_type = 'role'
+             AND assignee_id = $2
+             AND is_active = TRUE`,
           [
             approvalId,
             role,
             index + 1,
-            JSON.stringify({
-              sourceSystem: command.sourceSystem,
-              workflowKey: REFUND_WORKFLOW_KEY,
-            }),
+            metadata,
           ],
+        )
+
+        if ((updated.rowCount ?? 0) > 0) continue
+
+        await trx.query(
+          `INSERT INTO approval_assignments
+           (instance_id, assignment_type, assignee_id, source_step, is_active, metadata)
+           VALUES ($1, 'role', $2, $3, TRUE, $4::jsonb)`,
+          [approvalId, role, index + 1, metadata],
         )
       }
     })

--- a/packages/core-backend/src/services/AfterSalesApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/AfterSalesApprovalBridgeService.ts
@@ -414,8 +414,13 @@ export class AfterSalesApprovalBridgeService {
           `INSERT INTO approval_assignments
            (instance_id, assignment_type, assignee_id, source_step, is_active, metadata)
            VALUES ($1, 'role', $2, $3, TRUE, $4::jsonb)
-           ON CONFLICT (instance_id, assignment_type, assignee_id, source_step)
-           DO UPDATE SET is_active = TRUE, metadata = EXCLUDED.metadata, updated_at = now()`,
+           ON CONFLICT (instance_id, assignment_type, assignee_id)
+           WHERE is_active = TRUE
+           DO UPDATE SET
+             source_step = EXCLUDED.source_step,
+             is_active = TRUE,
+             metadata = EXCLUDED.metadata,
+             updated_at = now()`,
           [
             approvalId,
             role,

--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -708,8 +708,13 @@ export class ApprovalBridgeService {
         `INSERT INTO approval_assignments
          (instance_id, assignment_type, assignee_id, source_step, is_active, metadata)
          VALUES ($1, 'source_queue', 'plm:source-owned', 0, $2, $3)
-         ON CONFLICT (instance_id, assignment_type, assignee_id, source_step)
-         DO UPDATE SET is_active = EXCLUDED.is_active, metadata = EXCLUDED.metadata, updated_at = now()`,
+         ON CONFLICT (instance_id, assignment_type, assignee_id)
+         WHERE is_active = TRUE
+         DO UPDATE SET
+           source_step = EXCLUDED.source_step,
+           is_active = EXCLUDED.is_active,
+           metadata = EXCLUDED.metadata,
+           updated_at = now()`,
         [
           instanceId,
           bridge.status === 'pending',

--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -704,23 +704,37 @@ export class ApprovalBridgeService {
         ],
       )
 
-      await client.query(
-        `INSERT INTO approval_assignments
-         (instance_id, assignment_type, assignee_id, source_step, is_active, metadata)
-         VALUES ($1, 'source_queue', 'plm:source-owned', 0, $2, $3)
-         ON CONFLICT (instance_id, assignment_type, assignee_id)
-         WHERE is_active = TRUE
-         DO UPDATE SET
-           source_step = EXCLUDED.source_step,
-           is_active = EXCLUDED.is_active,
-           metadata = EXCLUDED.metadata,
-           updated_at = now()`,
+      const assignmentMetadata = JSON.stringify({ sourceSystem: 'plm' })
+
+      const activeAssignmentUpdated = await client.query(
+        `UPDATE approval_assignments
+         SET source_step = 0,
+             is_active = $2,
+             metadata = $3::jsonb,
+             updated_at = now()
+         WHERE instance_id = $1
+           AND assignment_type = 'source_queue'
+           AND assignee_id = 'plm:source-owned'
+           AND is_active = TRUE`,
         [
           instanceId,
           bridge.status === 'pending',
-          JSON.stringify({ sourceSystem: 'plm' }),
+          assignmentMetadata,
         ],
       )
+
+      if ((activeAssignmentUpdated.rowCount ?? 0) === 0) {
+        await client.query(
+          `INSERT INTO approval_assignments
+           (instance_id, assignment_type, assignee_id, source_step, is_active, metadata)
+           VALUES ($1, 'source_queue', 'plm:source-owned', 0, $2, $3::jsonb)`,
+          [
+            instanceId,
+            bridge.status === 'pending',
+            assignmentMetadata,
+          ],
+        )
+      }
 
       await client.query('COMMIT')
     } catch (error) {

--- a/packages/core-backend/src/services/NotificationService.ts
+++ b/packages/core-backend/src/services/NotificationService.ts
@@ -20,6 +20,7 @@ import type {
 } from '../types/plugin'
 import { Logger } from '../core/logger'
 import { BackoffStrategy } from '../utils/BackoffStrategy'
+import { maskDingTalkWebhookUrl } from '../integrations/dingtalk/runtime-policy'
 
 /**
  * Email notification payload
@@ -378,7 +379,8 @@ export class DingTalkNotificationChannel implements NotificationChannel {
 
   private async sendRobotMessage(url: string, secret: string | undefined, payload: DingTalkRobotPayload): Promise<void> {
     const signedUrl = buildSignedDingTalkWebhookUrl(url, secret)
-    this.logger.info(`Sending dingtalk robot message to ${url}`)
+    const maskedUrl = maskDingTalkWebhookUrl(url)
+    this.logger.info(`Sending dingtalk robot message to ${maskedUrl}`)
     await postJsonWithRetry({
       url: signedUrl,
       payload,
@@ -386,7 +388,7 @@ export class DingTalkNotificationChannel implements NotificationChannel {
       maxAttempts: resolvePositiveInt(this.config.maxAttempts, 3, 1, 6),
       retryDelayMs: resolvePositiveInt(this.config.retryDelayMs, 750, 50, 10_000),
       logger: this.logger,
-      context: `DingTalk delivery failed for ${url}`,
+      context: `DingTalk delivery failed for ${maskedUrl}`,
       responseValidator: validateDingTalkRobotResponse,
     })
   }

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -26,6 +26,17 @@ const auditMocks = vi.hoisted(() => ({
   auditLog: vi.fn(),
 }))
 
+const namespaceAdmissionMocks = vi.hoisted(() => ({
+  deriveDelegatedAdminNamespace: vi.fn(),
+  disableNamespaceAdmissionsWithoutRoles: vi.fn(),
+  isNamespaceAdmissionControlledResource: vi.fn(),
+  listRoleNamespaces: vi.fn(),
+  listUserNamespaceAdmissionSnapshots: vi.fn(),
+  normalizeNamespace: vi.fn(),
+  roleIdMatchesNamespaces: vi.fn(),
+  setUserNamespaceAdmission: vi.fn(),
+}))
+
 const inviteMocks = vi.hoisted(() => ({
   issueInviteToken: vi.fn(() => 'invite-token-fixed'),
   isInviteTokenExpired: vi.fn((token: string) => token === 'eyJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiaW52aXRlIiwiZXhwIjoxfQ.sig'),
@@ -52,6 +63,17 @@ vi.mock('bcryptjs', () => bcryptMocks)
 
 vi.mock('../../src/audit/audit', () => ({
   auditLog: auditMocks.auditLog,
+}))
+
+vi.mock('../../src/rbac/namespace-admission', () => ({
+  deriveDelegatedAdminNamespace: namespaceAdmissionMocks.deriveDelegatedAdminNamespace,
+  disableNamespaceAdmissionsWithoutRoles: namespaceAdmissionMocks.disableNamespaceAdmissionsWithoutRoles,
+  isNamespaceAdmissionControlledResource: namespaceAdmissionMocks.isNamespaceAdmissionControlledResource,
+  listRoleNamespaces: namespaceAdmissionMocks.listRoleNamespaces,
+  listUserNamespaceAdmissionSnapshots: namespaceAdmissionMocks.listUserNamespaceAdmissionSnapshots,
+  normalizeNamespace: namespaceAdmissionMocks.normalizeNamespace,
+  roleIdMatchesNamespaces: namespaceAdmissionMocks.roleIdMatchesNamespaces,
+  setUserNamespaceAdmission: namespaceAdmissionMocks.setUserNamespaceAdmission,
 }))
 
 vi.mock('../../src/auth/invite-tokens', () => ({
@@ -161,6 +183,28 @@ describe('admin-users routes', () => {
     rbacMocks.invalidateUserPerms.mockReset()
     bcryptMocks.hash.mockReset()
     auditMocks.auditLog.mockReset()
+    namespaceAdmissionMocks.deriveDelegatedAdminNamespace.mockReset()
+    namespaceAdmissionMocks.deriveDelegatedAdminNamespace.mockImplementation((roleId: string) => (
+      typeof roleId === 'string' && roleId.endsWith('_admin') && roleId !== 'admin'
+        ? roleId.slice(0, -'_admin'.length)
+        : null
+    ))
+    namespaceAdmissionMocks.disableNamespaceAdmissionsWithoutRoles.mockReset()
+    namespaceAdmissionMocks.disableNamespaceAdmissionsWithoutRoles.mockResolvedValue([])
+    namespaceAdmissionMocks.isNamespaceAdmissionControlledResource.mockReset()
+    namespaceAdmissionMocks.isNamespaceAdmissionControlledResource.mockImplementation((namespace: string) => Boolean(namespace))
+    namespaceAdmissionMocks.listRoleNamespaces.mockReset()
+    namespaceAdmissionMocks.listRoleNamespaces.mockResolvedValue([])
+    namespaceAdmissionMocks.listUserNamespaceAdmissionSnapshots.mockReset()
+    namespaceAdmissionMocks.listUserNamespaceAdmissionSnapshots.mockResolvedValue([])
+    namespaceAdmissionMocks.normalizeNamespace.mockReset()
+    namespaceAdmissionMocks.normalizeNamespace.mockImplementation((value: unknown) => String(value ?? '').trim())
+    namespaceAdmissionMocks.roleIdMatchesNamespaces.mockReset()
+    namespaceAdmissionMocks.roleIdMatchesNamespaces.mockImplementation((roleId: string, namespaces: string[]) => (
+      Array.isArray(namespaces) && namespaces.some((namespace) => roleId === namespace || roleId.startsWith(`${namespace}_`))
+    ))
+    namespaceAdmissionMocks.setUserNamespaceAdmission.mockReset()
+    namespaceAdmissionMocks.setUserNamespaceAdmission.mockResolvedValue([])
     inviteMocks.issueInviteToken.mockClear()
     inviteMocks.isInviteTokenExpired.mockClear()
     inviteMocks.isInviteTokenExpired.mockImplementation((token: string) => token === 'eyJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiaW52aXRlIiwiZXhwIjoxfQ.sig')
@@ -309,6 +353,19 @@ describe('admin-users routes', () => {
     vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1')
     vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '0')
     rbacMocks.isAdmin.mockResolvedValue(true)
+    namespaceAdmissionMocks.listUserNamespaceAdmissionSnapshots.mockResolvedValue([
+      {
+        namespace: 'crm',
+        enabled: true,
+        effective: true,
+        hasRole: true,
+        source: 'seed_backfill',
+        grantedBy: null,
+        updatedBy: null,
+        createdAt: '2026-03-12T00:00:00.000Z',
+        updatedAt: '2026-03-12T00:00:00.000Z',
+      },
+    ])
     pgMocks.query
       .mockResolvedValueOnce({
         rows: [{
@@ -388,6 +445,14 @@ describe('admin-users routes', () => {
         grant: { exists: true, enabled: true },
         identity: { exists: true, corpId: 'ding-corp' },
       },
+      namespaceAdmissions: [
+        expect.objectContaining({
+          namespace: 'crm',
+          enabled: true,
+          effective: true,
+          hasRole: true,
+        }),
+      ],
     })
   })
 
@@ -459,6 +524,19 @@ describe('admin-users routes', () => {
     rbacMocks.isAdmin
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(false)
+    namespaceAdmissionMocks.listUserNamespaceAdmissionSnapshots.mockResolvedValue([
+      {
+        namespace: 'crm',
+        enabled: true,
+        effective: true,
+        hasRole: true,
+        source: 'platform_admin',
+        grantedBy: 'admin-1',
+        updatedBy: 'admin-1',
+        createdAt: '2026-03-12T00:00:00.000Z',
+        updatedAt: '2026-03-12T00:00:00.000Z',
+      },
+    ])
     pgMocks.query
       .mockResolvedValueOnce({
         rows: [{ role_id: 'crm_admin' }],
@@ -530,6 +608,134 @@ describe('admin-users routes', () => {
         name: 'CRM 经理层',
       }),
     ])
+    expect((response.body as Record<string, any>).data.namespaceAdmissions).toEqual([
+      expect.objectContaining({
+        namespace: 'crm',
+        enabled: true,
+      }),
+    ])
+  })
+
+  it('updates platform namespace admission and writes audit log', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    namespaceAdmissionMocks.setUserNamespaceAdmission.mockResolvedValue([
+      {
+        namespace: 'crm',
+        enabled: true,
+        effective: true,
+        hasRole: true,
+        source: 'platform_admin',
+        grantedBy: 'admin-1',
+        updatedBy: 'admin-1',
+        createdAt: '2026-03-12T00:00:00.000Z',
+        updatedAt: '2026-03-12T00:05:00.000Z',
+      },
+    ])
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [{
+        id: 'user-1',
+        email: 'alpha@example.com',
+        name: 'Alpha',
+        role: 'user',
+        is_active: true,
+        is_admin: false,
+        last_login_at: null,
+        created_at: '2026-03-12T00:00:00.000Z',
+        updated_at: '2026-03-12T00:00:00.000Z',
+      }],
+    })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/namespaces/:namespace/admission', {
+      params: { userId: 'user-1', namespace: 'crm' },
+      body: { enabled: true },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(namespaceAdmissionMocks.setUserNamespaceAdmission).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-1',
+      namespace: 'crm',
+      enabled: true,
+      actorId: 'admin-1',
+      source: 'platform_admin',
+    }))
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'grant',
+      resourceType: 'user-namespace-admission',
+      resourceId: 'user-1:crm',
+    }))
+  })
+
+  it('updates delegated namespace admission within visible scope', async () => {
+    state.authUser = {
+      id: 'crm-admin-1',
+      role: 'user',
+    }
+    rbacMocks.isAdmin.mockResolvedValue(false)
+    namespaceAdmissionMocks.setUserNamespaceAdmission.mockResolvedValue([
+      {
+        namespace: 'crm',
+        enabled: true,
+        effective: true,
+        hasRole: true,
+        source: 'delegated_admin',
+        grantedBy: 'crm-admin-1',
+        updatedBy: 'crm-admin-1',
+        createdAt: '2026-03-12T00:00:00.000Z',
+        updatedAt: '2026-03-12T00:05:00.000Z',
+      },
+    ])
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{ role_id: 'crm_admin' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'scope-1',
+          admin_user_id: 'crm-admin-1',
+          namespace: 'crm',
+          directory_department_id: 'dept-1',
+          created_by: 'admin-1',
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+          integration_id: 'integration-1',
+          integration_name: 'DingTalk CN',
+          provider: 'dingtalk',
+          corp_id: 'ding-corp',
+          external_department_id: '1001',
+          department_name: '研发部',
+          department_full_path: '总部 / 研发部',
+          department_is_active: true,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ allowed: true }] })
+
+    const response = await invokeRoute('patch', '/api/admin/role-delegation/users/:userId/namespaces/:namespace/admission', {
+      params: { userId: 'user-1', namespace: 'crm' },
+      body: { enabled: true },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(namespaceAdmissionMocks.setUserNamespaceAdmission).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-1',
+      namespace: 'crm',
+      enabled: true,
+      actorId: 'crm-admin-1',
+      source: 'delegated_admin',
+    }))
   })
 
   it('rejects delegated role assignment outside allowed namespaces', async () => {
@@ -1515,6 +1721,8 @@ describe('admin-users routes', () => {
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false)
     rbacMocks.listUserPermissions.mockResolvedValue(['attendance:read'])
+    namespaceAdmissionMocks.listRoleNamespaces.mockResolvedValue(['attendance'])
+    namespaceAdmissionMocks.disableNamespaceAdmissionsWithoutRoles.mockResolvedValue(['attendance'])
     pgMocks.query
       .mockResolvedValueOnce({
         rows: [{
@@ -1556,6 +1764,9 @@ describe('admin-users routes', () => {
       action: 'revoke',
       resourceType: 'user-role',
       resourceId: 'user-1:attendance_admin',
+      meta: expect.objectContaining({
+        disabledNamespaces: ['attendance'],
+      }),
     }))
   })
 
@@ -2234,7 +2445,7 @@ describe('admin-users routes', () => {
     expect(String(pgMocks.query.mock.calls[0]?.[0] || '')).toContain('created_at >=')
     expect(String(pgMocks.query.mock.calls[0]?.[0] || '')).toContain('created_at <=')
     expect(pgMocks.query.mock.calls[0]?.[1]?.slice(0, 3)).toEqual([
-      ['user', 'user-role', 'user-auth-grant', 'user-password', 'user-session', 'user-invite', 'role', 'permission', 'permission-template', 'delegated-admin-scope', 'delegated-admin-scope-template', 'platform-member-group', 'delegated-admin-group-scope'],
+      ['user', 'user-role', 'user-auth-grant', 'user-namespace-admission', 'user-password', 'user-session', 'user-invite', 'role', 'permission', 'permission-template', 'delegated-admin-scope', 'delegated-admin-scope-template', 'platform-member-group', 'delegated-admin-group-scope'],
       '2026-03-10T00:00:00.000Z',
       '2026-03-12T23:59:59.999Z',
     ])

--- a/packages/core-backend/tests/unit/after-sales-approval-bridge.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-approval-bridge.test.ts
@@ -162,6 +162,24 @@ function createDbFixture(existingPendingId?: string) {
       })
       return { rows: [], rowCount: 1 }
     }
+    if (normalized.startsWith('UPDATE approval_assignments')) {
+      const [instanceId, assigneeId, sourceStep, metadata] = params as [string, string, number, string]
+      let updated = 0
+      for (const assignment of assignments) {
+        if (
+          assignment.instance_id === instanceId
+          && assignment.assignment_type === 'role'
+          && assignment.assignee_id === assigneeId
+          && assignment.is_active
+        ) {
+          assignment.source_step = sourceStep
+          assignment.is_active = true
+          assignment.metadata = JSON.parse(metadata)
+          updated += 1
+        }
+      }
+      return { rows: [], rowCount: updated }
+    }
     throw new Error(`Unhandled transaction query: ${normalized}`)
   })
 

--- a/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
@@ -350,6 +350,23 @@ const routeState = vi.hoisted(() => {
       return { rows: [], rowCount: 1 }
     }
 
+    if (normalized.startsWith('UPDATE approval_assignments')) {
+      const instanceId = String(params[0])
+      const key = `${instanceId}:source_queue:plm:source-owned:0`
+      const existing = state.assignments.get(key)
+      if (!existing || !existing.is_active) {
+        return { rows: [], rowCount: 0 }
+      }
+      state.assignments.set(key, {
+        ...existing,
+        source_step: 0,
+        is_active: Boolean(params[1]),
+        metadata: parseJson(params[2]),
+        updated_at: now(),
+      })
+      return { rows: [], rowCount: 1 }
+    }
+
     if (normalized.startsWith('UPDATE approval_instances SET sync_status = \'error\'')) {
       const row = state.instances.get(String(params[1]))
       if (row) {

--- a/packages/core-backend/tests/unit/approvals-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-routes.test.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import express, { type Express } from 'express'
 import request from 'supertest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -36,14 +36,15 @@ vi.mock('../../src/middleware/auth', () => ({
   },
 }))
 
-import { approvalsRouter } from '../../src/routes/approvals'
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}))
 
 describe('approvals routes', () => {
-  const app = express()
-  app.use(express.json())
-  app.use(approvalsRouter())
+  let app: Express
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules()
     authState.user = {
       id: 'user-1',
       tenantId: 'tenant-a',
@@ -54,6 +55,11 @@ describe('approvals routes', () => {
     pgState.client.query.mockReset()
     pgState.client.release.mockReset()
     pgState.pool.connect.mockResolvedValue(pgState.client)
+
+    const { approvalsRouter } = await import('../../src/routes/approvals')
+    app = express()
+    app.use(express.json())
+    app.use(approvalsRouter())
   })
 
   it('requires version for approval actions', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-client-policy.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-client-policy.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isDingTalkConfigured, readDingTalkOauthConfig } from '../../src/integrations/dingtalk/client'
+
+describe('dingtalk client runtime policy', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('reports DingTalk as unavailable when corpId is outside the allowlist', () => {
+    vi.stubEnv('DINGTALK_CLIENT_ID', 'client-id')
+    vi.stubEnv('DINGTALK_CLIENT_SECRET', 'client-secret')
+    vi.stubEnv('DINGTALK_REDIRECT_URI', 'https://example.com/callback')
+    vi.stubEnv('DINGTALK_CORP_ID', 'dingcorp-blocked')
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', 'dingcorp-allowed')
+
+    expect(isDingTalkConfigured()).toBe(false)
+    expect(() => readDingTalkOauthConfig()).toThrow('not allowed by DINGTALK_ALLOWED_CORP_IDS')
+  })
+
+  it('allows DingTalk when corpId matches the configured allowlist', () => {
+    vi.stubEnv('DINGTALK_CLIENT_ID', 'client-id')
+    vi.stubEnv('DINGTALK_CLIENT_SECRET', 'client-secret')
+    vi.stubEnv('DINGTALK_REDIRECT_URI', 'https://example.com/callback')
+    vi.stubEnv('DINGTALK_CORP_ID', 'dingcorp-allowed')
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', 'dingcorp-allowed, dingcorp-2')
+
+    expect(isDingTalkConfigured()).toBe(true)
+    expect(readDingTalkOauthConfig()).toMatchObject({
+      clientId: 'client-id',
+      corpId: 'dingcorp-allowed',
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/notification-service-dingtalk.test.ts
+++ b/packages/core-backend/tests/unit/notification-service-dingtalk.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Logger } from '../../src/core/logger'
 import {
   DingTalkNotificationChannel,
   NotificationServiceImpl,
@@ -85,6 +86,37 @@ describe('DingTalk notification channel', () => {
     expect(parsed.searchParams.get('access_token')).toBe('robot-token')
     expect(parsed.searchParams.get('timestamp')).toBe('1760000000000')
     expect(parsed.searchParams.get('sign')).toBeTruthy()
+  })
+
+  it('masks dingtalk webhook secrets in logs', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ errcode: 0, errmsg: 'ok' }),
+    })
+    global.fetch = fetchMock as typeof fetch
+    const infoSpy = vi.spyOn(Logger.prototype, 'info').mockImplementation(() => undefined)
+    vi.spyOn(Date, 'now').mockReturnValue(1_760_000_000_000)
+
+    const service = new NotificationServiceImpl()
+    service.registerChannel(new DingTalkNotificationChannel({ secret: 'secret-123' }))
+
+    await service.send({
+      channel: 'dingtalk',
+      subject: 'Ops Alert',
+      content: 'Latency exceeds threshold.',
+      recipients: [
+        {
+          id: 'https://oapi.dingtalk.com/robot/send?access_token=robot-token',
+          type: 'group',
+        },
+      ],
+    })
+
+    const messages = infoSpy.mock.calls.map((call) => String(call[0] ?? ''))
+    expect(messages.some((message) => message.includes('access_token=***'))).toBe(true)
+    expect(messages.some((message) => message.includes('robot-token'))).toBe(false)
   })
 
   it('does not retry non-retryable dingtalk webhook failures', async () => {

--- a/packages/core-backend/tests/unit/rbac-namespace-admission.test.ts
+++ b/packages/core-backend/tests/unit/rbac-namespace-admission.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  query: vi.fn(),
+  cacheHits: vi.fn(),
+  cacheMiss: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: {
+    query: state.poolQuery,
+  },
+  query: state.query,
+}))
+
+vi.mock('../../src/metrics/metrics', () => ({
+  metrics: {
+    rbacPermCacheHits: { inc: state.cacheHits },
+    rbacPermCacheMiss: { inc: state.cacheMiss },
+  },
+}))
+
+import { listUserPermissions, userHasPermission } from '../../src/rbac/service'
+
+describe('rbac namespace admission', () => {
+  beforeEach(() => {
+    state.poolQuery.mockReset()
+    state.query.mockReset()
+    state.cacheHits.mockReset()
+    state.cacheMiss.mockReset()
+  })
+
+  it('filters namespaced permissions by role plus admission status', async () => {
+    state.poolQuery
+      .mockResolvedValueOnce({
+        rows: [
+          { code: 'attendance:read' },
+          { code: 'crm:read' },
+          { code: 'workflow:read' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ permissions: ['attendance:write', 'spreadsheets:read'] }],
+      })
+
+    state.query
+      .mockResolvedValueOnce({
+        rows: [
+          { role_id: 'attendance_employee', permission_code: 'attendance:read' },
+          { role_id: 'crm_operator', permission_code: 'crm:read' },
+          { role_id: 'user', permission_code: 'spreadsheets:read' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            namespace: 'attendance',
+            enabled: true,
+            source: 'seed_backfill',
+            granted_by: null,
+            updated_by: null,
+            created_at: '2026-04-11T00:00:00.000Z',
+            updated_at: '2026-04-11T00:00:00.000Z',
+          },
+          {
+            namespace: 'crm',
+            enabled: false,
+            source: 'platform_admin',
+            granted_by: 'admin-1',
+            updated_by: 'admin-1',
+            created_at: '2026-04-11T00:00:00.000Z',
+            updated_at: '2026-04-11T00:00:00.000Z',
+          },
+        ],
+      })
+
+    const permissions = await listUserPermissions('user-1')
+
+    expect(permissions).toEqual([
+      'attendance:read',
+      'workflow:read',
+      'attendance:write',
+      'spreadsheets:read',
+    ])
+  })
+
+  it('denies direct namespaced permissions when namespace admission is disabled', async () => {
+    state.query
+      .mockResolvedValueOnce({
+        rows: [{ role_id: 'crm_operator', permission_code: 'crm:read' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          namespace: 'crm',
+          enabled: false,
+          source: 'platform_admin',
+          granted_by: 'admin-1',
+          updated_by: 'admin-1',
+          created_at: '2026-04-11T00:00:00.000Z',
+          updated_at: '2026-04-11T00:00:00.000Z',
+        }],
+      })
+
+    const allowed = await userHasPermission('user-1', 'crm:read')
+
+    expect(allowed).toBe(false)
+    expect(state.poolQuery).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -1,4 +1,5 @@
-const { randomUUID } = require('crypto')
+const crypto = require('crypto')
+const { randomUUID } = crypto
 const fs = require('fs')
 const fsp = require('fs/promises')
 const path = require('path')
@@ -593,12 +594,97 @@ function ensureNumberArray(value) {
   return []
 }
 
+const SECRET_PREFIX = 'enc:'
+const SECRET_ENCRYPTION_ALGORITHM = 'aes-256-gcm'
+const SECRET_KEY_ITERATIONS = 100000
+const SECRET_KEY_LENGTH = 32
+const SECRET_IV_LENGTH = 16
+const SECRET_AUTH_TAG_LENGTH = 16
+const DINGTALK_LOG_MASK_QUERY_KEYS = new Set(['access_token', 'appsecret', 'sign', 'timestamp'])
+
+function normalizeTextValue(value) {
+  return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function isEncryptedSecretValue(value) {
+  return typeof value === 'string' && value.startsWith(SECRET_PREFIX)
+}
+
+function getIntegrationSecretKey() {
+  const masterKey = process.env.ENCRYPTION_KEY || 'default-key-change-in-production'
+  const salt = Buffer.from(process.env.ENCRYPTION_SALT || 'default-salt-change-in-production')
+  return crypto.pbkdf2Sync(masterKey, salt, SECRET_KEY_ITERATIONS, SECRET_KEY_LENGTH, 'sha256')
+}
+
+function encryptIntegrationSecretValue(plaintext) {
+  const iv = crypto.randomBytes(SECRET_IV_LENGTH)
+  const cipher = crypto.createCipheriv(SECRET_ENCRYPTION_ALGORITHM, getIntegrationSecretKey(), iv)
+  const encrypted = Buffer.concat([cipher.update(String(plaintext ?? ''), 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+  return `${SECRET_PREFIX}${Buffer.concat([iv, authTag, encrypted]).toString('base64')}`
+}
+
+function decryptIntegrationSecretValue(value) {
+  if (!isEncryptedSecretValue(value)) return String(value ?? '')
+  const payload = Buffer.from(value.slice(SECRET_PREFIX.length), 'base64')
+  const iv = payload.subarray(0, SECRET_IV_LENGTH)
+  const authTag = payload.subarray(SECRET_IV_LENGTH, SECRET_IV_LENGTH + SECRET_AUTH_TAG_LENGTH)
+  const encrypted = payload.subarray(SECRET_IV_LENGTH + SECRET_AUTH_TAG_LENGTH)
+  const decipher = crypto.createDecipheriv(SECRET_ENCRYPTION_ALGORITHM, getIntegrationSecretKey(), iv)
+  decipher.setAuthTag(authTag)
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8')
+}
+
+function normalizeStoredIntegrationSecretValue(value) {
+  const normalized = normalizeTextValue(value)
+  if (!normalized) return ''
+  return isEncryptedSecretValue(normalized) ? normalized : encryptIntegrationSecretValue(normalized)
+}
+
+function readDingTalkAllowedCorpIds() {
+  return Array.from(new Set(
+    normalizeTextValue(process.env.DINGTALK_ALLOWED_CORP_IDS)
+      .split(/[\s,]+/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+  ))
+}
+
+function assertDingTalkCorpAllowed(corpId, { allowEmpty = false, context = 'DingTalk corpId' } = {}) {
+  const allowedCorpIds = readDingTalkAllowedCorpIds()
+  if (!allowedCorpIds.length) return
+
+  const normalizedCorpId = normalizeTextValue(corpId)
+  if (!normalizedCorpId) {
+    if (allowEmpty) return
+    throw new Error(`${context} is required when DINGTALK_ALLOWED_CORP_IDS is configured`)
+  }
+  if (allowedCorpIds.includes(normalizedCorpId)) return
+  throw new Error(`${context} ${normalizedCorpId} is not allowed by DINGTALK_ALLOWED_CORP_IDS`)
+}
+
+function maskDingTalkUrlForLog(url) {
+  try {
+    const parsed = new URL(url)
+    for (const key of DINGTALK_LOG_MASK_QUERY_KEYS) {
+      if (parsed.searchParams.has(key)) {
+        parsed.searchParams.set(key, '***')
+      }
+    }
+    return parsed.toString()
+  } catch {
+    return String(url ?? '').replace(/([?&](?:access_token|appsecret|sign|timestamp)=)[^&]+/gi, '$1***')
+  }
+}
+
 function normalizeIntegrationConfig(config) {
   if (!config || typeof config !== 'object') return {}
+  const appSecret = config.appSecret ?? config.appsecret ?? config.app_secret
   return {
     ...config,
     appKey: config.appKey ?? config.appkey ?? config.app_key,
-    appSecret: config.appSecret ?? config.appsecret ?? config.app_secret,
+    appSecret: normalizeTextValue(appSecret) ? decryptIntegrationSecretValue(String(appSecret)) : '',
+    corpId: config.corpId ?? config.corp_id ?? null,
     baseUrl: config.baseUrl ?? config.base_url ?? 'https://oapi.dingtalk.com',
     userIds: ensureStringArray(config.userIds ?? config.user_ids ?? config.users),
     columnIds: ensureStringArray(config.columnIds ?? config.column_id_list ?? config.columns).map((id) => String(id)),
@@ -609,6 +695,15 @@ function normalizeIntegrationConfig(config) {
     userMap: config.userMap ?? config.user_map ?? undefined,
     timezone: config.timezone ?? 'Asia/Shanghai',
     source: config.source ?? 'dingtalk_api',
+  }
+}
+
+function normalizeIntegrationConfigForStorage(config) {
+  const normalized = normalizeIntegrationConfig(config)
+  return {
+    ...normalized,
+    corpId: normalizeTextValue(normalized.corpId) || null,
+    appSecret: normalized.appSecret ? normalizeStoredIntegrationSecretValue(normalized.appSecret) : '',
   }
 }
 
@@ -654,6 +749,7 @@ async function readDingTalkJsonSafely(response) {
 
 async function requestDingTalkJsonWithRetry({ url, method = 'GET', headers, body, timeoutMs = ATTENDANCE_DINGTALK_HTTP_TIMEOUT_MS }) {
   let lastError = null
+  const maskedUrl = maskDingTalkUrlForLog(url)
   for (let attempt = 1; attempt <= ATTENDANCE_DINGTALK_HTTP_MAX_ATTEMPTS; attempt += 1) {
     try {
       const response = await fetch(url, {
@@ -667,7 +763,7 @@ async function requestDingTalkJsonWithRetry({ url, method = 'GET', headers, body
         const message = data?.errmsg || `HTTP ${response.status}`
         if (attempt < ATTENDANCE_DINGTALK_HTTP_MAX_ATTEMPTS && shouldRetryDingTalkRequest({ status: response.status, errcode: data?.errcode })) {
           const delay = calculateDingTalkRetryDelay(attempt)
-          logger.warn('Retrying DingTalk request', { url, attempt, delay, status: response.status, errcode: data?.errcode, message })
+          logger.warn('Retrying DingTalk request', { url: maskedUrl, attempt, delay, status: response.status, errcode: data?.errcode, message })
           await sleepMs(delay)
           continue
         }
@@ -678,7 +774,7 @@ async function requestDingTalkJsonWithRetry({ url, method = 'GET', headers, body
       lastError = error
       if (attempt >= ATTENDANCE_DINGTALK_HTTP_MAX_ATTEMPTS) break
       const delay = calculateDingTalkRetryDelay(attempt)
-      logger.warn('DingTalk request attempt failed', { url, attempt, delay, error: error?.message || String(error) })
+      logger.warn('DingTalk request attempt failed', { url: maskedUrl, attempt, delay, error: error?.message || String(error) })
       await sleepMs(delay)
     }
   }
@@ -3067,14 +3163,19 @@ function mapImportBatchRow(row) {
 		  return rows[0] ?? null
 		}
 
-	function mapIntegrationRow(row) {
+function mapIntegrationRow(row) {
+  const config = normalizeIntegrationConfig(row.config)
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
     name: row.name,
     type: row.type,
     status: row.status,
-    config: normalizeMetadata(row.config),
+    config: {
+      ...config,
+      appSecret: undefined,
+      appSecretConfigured: Boolean(config.appSecret),
+    },
     lastSyncAt: row.last_sync_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -15830,15 +15931,18 @@ module.exports = {
         const orgId = getOrgId(req)
         const payload = parsed.data
         const status = payload.status ?? 'active'
-        const config = payload.config ?? {}
+        const config = normalizeIntegrationConfig(payload.config ?? {})
 
         try {
+          if (payload.type === 'dingtalk') {
+            assertDingTalkCorpAllowed(config.corpId, { context: 'Attendance integration corpId' })
+          }
           const rows = await db.query(
             `INSERT INTO attendance_integrations
              (org_id, name, type, status, config, created_at, updated_at)
              VALUES ($1, $2, $3, $4, $5::jsonb, now(), now())
              RETURNING *`,
-            [orgId, payload.name, payload.type, status, JSON.stringify(config)]
+            [orgId, payload.name, payload.type, status, JSON.stringify(normalizeIntegrationConfigForStorage(config))]
           )
           const mapped = rows.length ? mapIntegrationRow(rows[0]) : null
           res.json({ ok: true, data: mapped })
@@ -15874,19 +15978,30 @@ module.exports = {
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Integration not found' } })
             return
           }
-          const current = mapIntegrationRow(existing[0])
+          const currentConfig = normalizeIntegrationConfig(existing[0].config)
+          const requestedConfig = parsed.data.config ? normalizeIntegrationConfig(parsed.data.config) : null
           const next = {
-            name: parsed.data.name ?? current.name,
-            type: parsed.data.type ?? current.type,
-            status: parsed.data.status ?? current.status,
-            config: parsed.data.config ?? current.config,
+            name: parsed.data.name ?? existing[0].name,
+            type: parsed.data.type ?? existing[0].type,
+            status: parsed.data.status ?? existing[0].status,
+            config: requestedConfig
+              ? {
+                ...currentConfig,
+                ...requestedConfig,
+                appSecret: requestedConfig.appSecret || currentConfig.appSecret,
+                corpId: requestedConfig.corpId ?? currentConfig.corpId ?? null,
+              }
+              : currentConfig,
+          }
+          if (next.type === 'dingtalk') {
+            assertDingTalkCorpAllowed(next.config.corpId, { context: 'Attendance integration corpId' })
           }
           const rows = await db.query(
             `UPDATE attendance_integrations
              SET name = $3, type = $4, status = $5, config = $6::jsonb, updated_at = now()
              WHERE id = $1 AND org_id = $2
              RETURNING *`,
-            [integrationId, orgId, next.name, next.type, next.status, JSON.stringify(next.config)]
+            [integrationId, orgId, next.name, next.type, next.status, JSON.stringify(normalizeIntegrationConfigForStorage(next.config))]
           )
           res.json({ ok: true, data: mapIntegrationRow(rows[0]) })
         } catch (error) {
@@ -16005,11 +16120,12 @@ module.exports = {
             return
           }
           run = await createIntegrationRun(db, { orgId, integrationId })
-          const config = normalizeIntegrationConfig(integration.config)
+          const config = normalizeIntegrationConfig(rows[0].config)
           const fromDate = normalizeDingTalkDateRange(parsed.data.from, new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10))
           const toDate = normalizeDingTalkDateRange(parsed.data.to, new Date().toISOString().slice(0, 10))
 
           if (integration.type === 'dingtalk') {
+            assertDingTalkCorpAllowed(config.corpId, { context: 'Attendance integration corpId' })
             const accessToken = await fetchDingTalkAccessToken({
               appKey: config.appKey,
               appSecret: config.appSecret,


### PR DESCRIPTION
## Summary
- secure DingTalk directory and attendance integration secrets with encrypted storage and add a one-off re-encryption script
- enforce `DINGTALK_ALLOWED_CORP_IDS` at runtime for OAuth config, directory integrations, and attendance integrations
- add namespace admission as a second gate on top of roles and wire platform/delegated admin APIs plus UI controls
- mask DingTalk robot webhook secrets in logs and document the design, deployment, and verification flow

## Verification
- `pnpm --filter @metasheet/core-backend build`
- `node -c plugins/plugin-attendance/index.cjs`
- `cd packages/core-backend && ../../node_modules/.bin/vitest run tests/unit/admin-users-routes.test.ts tests/unit/notification-service-dingtalk.test.ts tests/unit/dingtalk-client-policy.test.ts tests/unit/rbac-namespace-admission.test.ts tests/unit/auth-login-routes.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts`
- `cd apps/web && ../../node_modules/.bin/vitest run tests/userManagementView.spec.ts tests/roleDelegationView.spec.ts`
- `pnpm --filter @metasheet/core-backend migrate`
- `pnpm --filter @metasheet/core-backend exec tsx scripts/encrypt-dingtalk-integration-secrets.ts`
- browser smoke on `/admin/users` and `/admin/role-delegation` with a DB-backed admin session

## Notes
- The local DB had a pre-existing Kysely migration ledger drift: `zzzz20260404100000_extend_approval_tables_for_bridge` schema was already present, but its `kysely_migration` row was missing.
- After confirming the schema existed, I backfilled only the missing migration ledger row and reran `pnpm --filter @metasheet/core-backend migrate` successfully.
- Added/update docs:
  - `docs/development/dingtalk-secure-admission-design-20260411.md`
  - `docs/development/dingtalk-secure-admission-deployment-20260411.md`
  - `docs/development/dingtalk-secure-admission-verification-20260411.md`
