### PR TITLE
feat(approvals): add frontend product shell

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -1,0 +1,295 @@
+/**
+ * Approval API Client
+ *
+ * Typed functions wrapping /api/approval-templates and /api/approvals endpoints.
+ * Uses apiFetch/apiGet/apiPost from project utils.
+ * Includes mock fallback for development when backend is not available.
+ */
+import { apiGet, apiPost } from '../utils/api'
+import type {
+  ApprovalTemplateListItemDTO,
+  ApprovalTemplateDetailDTO,
+  ApprovalTemplateVersionDetailDTO,
+  UnifiedApprovalDTO,
+  UnifiedApprovalHistoryDTO,
+  CreateApprovalRequest,
+  ApprovalActionRequest,
+  ApprovalStatus,
+  ApprovalTemplateStatus,
+  FormField,
+} from '../types/approval'
+
+// ---------------------------------------------------------------------------
+// Mock-mode flag
+// ---------------------------------------------------------------------------
+const USE_MOCK = import.meta.env.DEV || (globalThis as any).__APPROVAL_MOCK__ === true
+
+// ---------------------------------------------------------------------------
+// Mock data factories
+// ---------------------------------------------------------------------------
+function mockTemplateListItem(index: number): ApprovalTemplateListItemDTO {
+  const statuses: ApprovalTemplateStatus[] = ['published', 'draft', 'archived']
+  return {
+    id: `tpl_${index}`,
+    key: `TPL-${String(index).padStart(3, '0')}`,
+    name: `审批模板 ${index}`,
+    description: index % 2 === 0 ? '通用审批模板' : null,
+    status: statuses[index % statuses.length],
+    activeVersionId: statuses[index % statuses.length] === 'published' ? `ver_${index}_1` : null,
+    latestVersionId: `ver_${index}_1`,
+    createdAt: new Date(Date.now() - index * 86400000).toISOString(),
+    updatedAt: new Date(Date.now() - index * 3600000).toISOString(),
+  }
+}
+
+function mockFormFields(): FormField[] {
+  return [
+    { id: 'fld_reason', type: 'textarea', label: '申请原因', required: true, placeholder: '请填写申请原因' },
+    { id: 'fld_amount', type: 'number', label: '金额', required: true },
+    { id: 'fld_date', type: 'date', label: '期望日期', required: false },
+    { id: 'fld_type', type: 'select', label: '类型', required: true, options: [
+      { label: '采购', value: 'purchase' },
+      { label: '报销', value: 'reimbursement' },
+      { label: '请假', value: 'leave' },
+    ]},
+    { id: 'fld_tags', type: 'multi-select', label: '标签', required: false, options: [
+      { label: '紧急', value: 'urgent' },
+      { label: '常规', value: 'normal' },
+    ]},
+    { id: 'fld_assignee', type: 'user', label: '经办人', required: false },
+    { id: 'fld_attachment', type: 'attachment', label: '附件', required: false },
+  ]
+}
+
+function mockTemplateDetail(id: string): ApprovalTemplateDetailDTO {
+  return {
+    ...mockTemplateListItem(1),
+    id,
+    status: 'published',
+    activeVersionId: 'ver_1_1',
+    formSchema: { fields: mockFormFields() },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeType: 'role', assigneeIds: ['role_manager'] } },
+        { key: 'approval_2', type: 'approval', name: '财务审批', config: { assigneeType: 'user', assigneeIds: ['user_finance'] } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' },
+        { key: 'e2', source: 'approval_1', target: 'approval_2' },
+        { key: 'e3', source: 'approval_2', target: 'end' },
+      ],
+    },
+  }
+}
+
+function mockVersionDetail(templateId: string, versionId: string): ApprovalTemplateVersionDetailDTO {
+  const detail = mockTemplateDetail(templateId)
+  return {
+    id: versionId,
+    templateId,
+    version: 1,
+    status: 'published',
+    formSchema: detail.formSchema,
+    approvalGraph: detail.approvalGraph,
+    runtimeGraph: {
+      ...detail.approvalGraph,
+      policy: { allowRevoke: true, revokeBeforeNodeKeys: ['approval_2'] },
+    },
+    publishedDefinitionId: 'def_1',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+function mockApproval(index: number): UnifiedApprovalDTO {
+  const statuses: ApprovalStatus[] = ['pending', 'approved', 'rejected', 'revoked', 'draft']
+  const status = statuses[index % statuses.length]
+  return {
+    id: `apv_${index}`,
+    sourceSystem: 'platform',
+    externalApprovalId: null,
+    workflowKey: null,
+    businessKey: null,
+    title: `审批申请 #${1000 + index}`,
+    status,
+    requester: { id: 'user_1', name: '张三', department: '研发部', title: '工程师' },
+    subject: null,
+    policy: { rejectCommentRequired: true },
+    currentStep: status === 'pending' ? 1 : null,
+    totalSteps: 2,
+    templateId: 'tpl_1',
+    templateVersionId: 'ver_1_1',
+    publishedDefinitionId: 'def_1',
+    requestNo: `APV-2026-${String(index).padStart(4, '0')}`,
+    formSnapshot: { fld_reason: '出差报销', fld_amount: 5000, fld_type: 'reimbursement' },
+    currentNodeKey: status === 'pending' ? 'approval_1' : null,
+    assignments: status === 'pending' ? [{
+      id: `asgn_${index}`,
+      type: 'approval',
+      assigneeId: 'user_current',
+      sourceStep: 1,
+      nodeKey: 'approval_1',
+      isActive: true,
+      metadata: {},
+    }] : [],
+    createdAt: new Date(Date.now() - index * 86400000).toISOString(),
+    updatedAt: new Date(Date.now() - index * 3600000).toISOString(),
+  }
+}
+
+function mockHistory(approvalId: string): UnifiedApprovalHistoryDTO[] {
+  return [
+    {
+      id: 'hist_1',
+      action: 'created',
+      actorId: 'user_1',
+      actorName: '张三',
+      comment: null,
+      fromStatus: null,
+      toStatus: 'pending',
+      occurredAt: new Date(Date.now() - 86400000).toISOString(),
+      metadata: {},
+    },
+    {
+      id: 'hist_2',
+      action: 'approve',
+      actorId: 'user_2',
+      actorName: '李四',
+      comment: '同意',
+      fromStatus: 'pending',
+      toStatus: 'approved',
+      occurredAt: new Date().toISOString(),
+      metadata: {},
+    },
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Query interfaces
+// ---------------------------------------------------------------------------
+export interface TemplateListQuery {
+  status?: ApprovalTemplateStatus
+  search?: string
+  page?: number
+  pageSize?: number
+}
+
+export interface ApprovalListQuery {
+  tab?: 'pending' | 'mine' | 'cc' | 'completed'
+  status?: ApprovalStatus
+  search?: string
+  page?: number
+  pageSize?: number
+}
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+export async function listTemplates(
+  query?: TemplateListQuery,
+): Promise<{ data: ApprovalTemplateListItemDTO[]; total: number }> {
+  if (USE_MOCK) {
+    let items = Array.from({ length: 12 }, (_, i) => mockTemplateListItem(i + 1))
+    if (query?.status) items = items.filter((t) => t.status === query.status)
+    if (query?.search) {
+      const q = query.search.toLowerCase()
+      items = items.filter((t) => t.name.toLowerCase().includes(q))
+    }
+    const page = query?.page ?? 1
+    const pageSize = query?.pageSize ?? 10
+    const start = (page - 1) * pageSize
+    return { data: items.slice(start, start + pageSize), total: items.length }
+  }
+  const params = new URLSearchParams()
+  if (query?.status) params.set('status', query.status)
+  if (query?.search) params.set('search', query.search)
+  if (query?.page) params.set('page', String(query.page))
+  if (query?.pageSize) params.set('pageSize', String(query.pageSize))
+  const qs = params.toString()
+  return apiGet(`/api/approval-templates${qs ? `?${qs}` : ''}`)
+}
+
+export async function getTemplate(id: string): Promise<ApprovalTemplateDetailDTO> {
+  if (USE_MOCK) return mockTemplateDetail(id)
+  return apiGet(`/api/approval-templates/${id}`)
+}
+
+export async function getTemplateVersion(
+  templateId: string,
+  versionId: string,
+): Promise<ApprovalTemplateVersionDetailDTO> {
+  if (USE_MOCK) return mockVersionDetail(templateId, versionId)
+  return apiGet(`/api/approval-templates/${templateId}/versions/${versionId}`)
+}
+
+export async function listApprovals(
+  query?: ApprovalListQuery,
+): Promise<{ data: UnifiedApprovalDTO[]; total: number }> {
+  if (USE_MOCK) {
+    let items = Array.from({ length: 25 }, (_, i) => mockApproval(i + 1))
+    if (query?.tab === 'pending') items = items.filter((a) => a.status === 'pending')
+    else if (query?.tab === 'mine') items = items.filter((a) => a.requester?.id === 'user_1')
+    else if (query?.tab === 'cc') items = items.slice(0, 3)
+    else if (query?.tab === 'completed') items = items.filter((a) => ['approved', 'rejected', 'revoked'].includes(a.status))
+    if (query?.status) items = items.filter((a) => a.status === query.status)
+    if (query?.search) {
+      const q = query.search.toLowerCase()
+      items = items.filter((a) => (a.title ?? '').toLowerCase().includes(q) || (a.requestNo ?? '').toLowerCase().includes(q))
+    }
+    const page = query?.page ?? 1
+    const pageSize = query?.pageSize ?? 10
+    const start = (page - 1) * pageSize
+    return { data: items.slice(start, start + pageSize), total: items.length }
+  }
+  const params = new URLSearchParams()
+  if (query?.tab) params.set('tab', query.tab)
+  if (query?.status) params.set('status', query.status)
+  if (query?.search) params.set('search', query.search)
+  if (query?.page) params.set('page', String(query.page))
+  if (query?.pageSize) params.set('pageSize', String(query.pageSize))
+  const qs = params.toString()
+  return apiGet(`/api/approvals${qs ? `?${qs}` : ''}`)
+}
+
+export async function getApproval(id: string): Promise<UnifiedApprovalDTO> {
+  if (USE_MOCK) return mockApproval(parseInt(id.replace('apv_', ''), 10) || 1)
+  return apiGet(`/api/approvals/${id}`)
+}
+
+export async function getApprovalHistory(id: string): Promise<UnifiedApprovalHistoryDTO[]> {
+  if (USE_MOCK) return mockHistory(id)
+  return apiGet(`/api/approvals/${id}/history`)
+}
+
+export async function createApproval(req: CreateApprovalRequest): Promise<UnifiedApprovalDTO> {
+  if (USE_MOCK) {
+    return {
+      ...mockApproval(999),
+      id: `apv_${Date.now()}`,
+      status: 'pending',
+      templateId: req.templateId,
+      formSnapshot: req.formData as Record<string, unknown>,
+    }
+  }
+  return apiPost('/api/approvals', req)
+}
+
+export async function dispatchAction(
+  id: string,
+  req: ApprovalActionRequest,
+): Promise<UnifiedApprovalDTO> {
+  if (USE_MOCK) {
+    const base = mockApproval(parseInt(id.replace('apv_', ''), 10) || 1)
+    const statusMap: Record<string, string> = {
+      approve: 'approved',
+      reject: 'rejected',
+      revoke: 'revoked',
+      transfer: 'pending',
+    }
+    return { ...base, status: statusMap[req.action] ?? base.status }
+  }
+  return apiPost(`/api/approvals/${id}/actions`, req)
+}

--- a/apps/web/src/approvals/store.ts
+++ b/apps/web/src/approvals/store.ts
@@ -1,0 +1,189 @@
+/**
+ * Approval Pinia Store
+ *
+ * Manages approval instance state: inbox tabs, detail, history, and actions.
+ */
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import type {
+  UnifiedApprovalDTO,
+  UnifiedApprovalHistoryDTO,
+  CreateApprovalRequest,
+  ApprovalActionRequest,
+} from '../types/approval'
+import {
+  listApprovals,
+  getApproval,
+  getApprovalHistory,
+  createApproval,
+  dispatchAction,
+} from './api'
+import type { ApprovalListQuery } from './api'
+
+export const useApprovalStore = defineStore('approval', () => {
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
+  const approvals = ref<UnifiedApprovalDTO[]>([])
+  const pendingApprovals = ref<UnifiedApprovalDTO[]>([])
+  const myApprovals = ref<UnifiedApprovalDTO[]>([])
+  const ccApprovals = ref<UnifiedApprovalDTO[]>([])
+  const completedApprovals = ref<UnifiedApprovalDTO[]>([])
+  const activeApproval = ref<UnifiedApprovalDTO | null>(null)
+  const history = ref<UnifiedApprovalHistoryDTO[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const totalPending = ref(0)
+  const totalMine = ref(0)
+  const totalCc = ref(0)
+  const totalCompleted = ref(0)
+
+  // ---------------------------------------------------------------------------
+  // Getters
+  // ---------------------------------------------------------------------------
+  const pendingCount = computed(() => pendingApprovals.value.length)
+  const approvalById = computed(() => (id: string) =>
+    approvals.value.find((a) => a.id === id),
+  )
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
+  async function loadPending(query?: Omit<ApprovalListQuery, 'tab'>) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await listApprovals({ ...query, tab: 'pending' })
+      pendingApprovals.value = result.data
+      totalPending.value = result.total
+    } catch (e: any) {
+      error.value = e.message ?? '加载待处理审批失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadMine(query?: Omit<ApprovalListQuery, 'tab'>) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await listApprovals({ ...query, tab: 'mine' })
+      myApprovals.value = result.data
+      totalMine.value = result.total
+    } catch (e: any) {
+      error.value = e.message ?? '加载我发起的审批失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadCc(query?: Omit<ApprovalListQuery, 'tab'>) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await listApprovals({ ...query, tab: 'cc' })
+      ccApprovals.value = result.data
+      totalCc.value = result.total
+    } catch (e: any) {
+      error.value = e.message ?? '加载抄送审批失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadCompleted(query?: Omit<ApprovalListQuery, 'tab'>) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await listApprovals({ ...query, tab: 'completed' })
+      completedApprovals.value = result.data
+      totalCompleted.value = result.total
+    } catch (e: any) {
+      error.value = e.message ?? '加载已完成审批失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadDetail(id: string) {
+    loading.value = true
+    error.value = null
+    try {
+      activeApproval.value = await getApproval(id)
+    } catch (e: any) {
+      error.value = e.message ?? '加载审批详情失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadHistory(id: string) {
+    loading.value = true
+    error.value = null
+    try {
+      history.value = await getApprovalHistory(id)
+    } catch (e: any) {
+      error.value = e.message ?? '加载审批历史失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function submitApproval(req: CreateApprovalRequest): Promise<UnifiedApprovalDTO> {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await createApproval(req)
+      return result
+    } catch (e: any) {
+      error.value = e.message ?? '提交审批失败'
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function executeAction(id: string, req: ApprovalActionRequest): Promise<UnifiedApprovalDTO> {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await dispatchAction(id, req)
+      activeApproval.value = result
+      return result
+    } catch (e: any) {
+      error.value = e.message ?? '执行审批操作失败'
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    // State
+    approvals,
+    pendingApprovals,
+    myApprovals,
+    ccApprovals,
+    completedApprovals,
+    activeApproval,
+    history,
+    loading,
+    error,
+    totalPending,
+    totalMine,
+    totalCc,
+    totalCompleted,
+    // Getters
+    pendingCount,
+    approvalById,
+    // Actions
+    loadPending,
+    loadMine,
+    loadCc,
+    loadCompleted,
+    loadDetail,
+    loadHistory,
+    submitApproval,
+    executeAction,
+  }
+})

--- a/apps/web/src/approvals/templateStore.ts
+++ b/apps/web/src/approvals/templateStore.ts
@@ -1,0 +1,85 @@
+/**
+ * Approval Template Pinia Store
+ *
+ * Manages approval template state: list, detail, and versions.
+ */
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type {
+  ApprovalTemplateListItemDTO,
+  ApprovalTemplateDetailDTO,
+  ApprovalTemplateVersionDetailDTO,
+} from '../types/approval'
+import {
+  listTemplates,
+  getTemplate,
+  getTemplateVersion,
+} from './api'
+import type { TemplateListQuery } from './api'
+
+export const useApprovalTemplateStore = defineStore('approvalTemplate', () => {
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
+  const templates = ref<ApprovalTemplateListItemDTO[]>([])
+  const activeTemplate = ref<ApprovalTemplateDetailDTO | null>(null)
+  const activeVersion = ref<ApprovalTemplateVersionDetailDTO | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const total = ref(0)
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
+  async function loadTemplates(query?: TemplateListQuery) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await listTemplates(query)
+      templates.value = result.data
+      total.value = result.total
+    } catch (e: any) {
+      error.value = e.message ?? '加载审批模板列表失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadTemplate(id: string) {
+    loading.value = true
+    error.value = null
+    try {
+      activeTemplate.value = await getTemplate(id)
+    } catch (e: any) {
+      error.value = e.message ?? '加载审批模板详情失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadVersion(templateId: string, versionId: string) {
+    loading.value = true
+    error.value = null
+    try {
+      activeVersion.value = await getTemplateVersion(templateId, versionId)
+    } catch (e: any) {
+      error.value = e.message ?? '加载模板版本失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    // State
+    templates,
+    activeTemplate,
+    activeVersion,
+    loading,
+    error,
+    total,
+    // Actions
+    loadTemplates,
+    loadTemplate,
+    loadVersion,
+  }
+})

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -178,8 +178,32 @@ export const appRoutes: RouteRecordRaw[] = [
   {
     path: '/approvals',
     name: 'approval-list',
-    component: () => import('../views/ApprovalInboxView.vue'),
+    component: () => import('../views/approval/ApprovalCenterView.vue'),
     meta: { title: 'Approvals', titleZh: '审批中心', requiresAuth: true }
+  },
+  {
+    path: '/approvals/new/:templateId',
+    name: 'approval-create',
+    component: () => import('../views/approval/ApprovalNewView.vue'),
+    meta: { title: 'New Approval', titleZh: '发起审批', requiresAuth: true }
+  },
+  {
+    path: '/approvals/:id',
+    name: 'approval-detail',
+    component: () => import('../views/approval/ApprovalDetailView.vue'),
+    meta: { title: 'Approval Detail', titleZh: '审批详情', requiresAuth: true }
+  },
+  {
+    path: '/approval-templates',
+    name: 'approval-template-list',
+    component: () => import('../views/approval/TemplateCenterView.vue'),
+    meta: { title: 'Approval Templates', titleZh: '审批模板', requiresAuth: true }
+  },
+  {
+    path: '/approval-templates/:id',
+    name: 'approval-template-detail',
+    component: () => import('../views/approval/TemplateDetailView.vue'),
+    meta: { title: 'Template Detail', titleZh: '模板详情', requiresAuth: true }
   },
   {
     path: '/admin/plugins',

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -1,0 +1,320 @@
+<template>
+  <section class="approval-center">
+    <header class="approval-center__header">
+      <h1>审批中心</h1>
+      <div class="approval-center__toolbar">
+        <el-input
+          v-model="searchText"
+          placeholder="搜索审批编号或标题"
+          clearable
+          style="width: 240px"
+          @clear="handleSearch"
+          @keyup.enter="handleSearch"
+        >
+          <template #prefix>
+            <span>🔍</span>
+          </template>
+        </el-input>
+        <el-select
+          v-model="statusFilter"
+          placeholder="状态筛选"
+          clearable
+          style="width: 140px; margin-left: 12px"
+          @change="handleSearch"
+        >
+          <el-option label="待处理" value="pending" />
+          <el-option label="已通过" value="approved" />
+          <el-option label="已驳回" value="rejected" />
+          <el-option label="已撤回" value="revoked" />
+        </el-select>
+      </div>
+    </header>
+
+    <el-tabs v-model="activeTab" class="approval-center__tabs" @tab-change="handleTabChange">
+      <el-tab-pane label="待我处理" name="pending">
+        <el-table
+          :data="store.pendingApprovals"
+          :loading="store.loading"
+          style="width: 100%"
+          stripe
+          highlight-current-row
+          @row-click="handleRowClick"
+        >
+          <el-table-column prop="requestNo" label="审批编号" width="180" />
+          <el-table-column prop="title" label="标题" min-width="200" />
+          <el-table-column label="发起人" width="120">
+            <template #default="{ row }">
+              {{ row.requester?.name ?? '-' }}
+            </template>
+          </el-table-column>
+          <el-table-column label="状态" width="100">
+            <template #default="{ row }">
+              <el-tag :type="statusTagType(row.status)" size="small" :data-status="row.status">
+                {{ statusLabel(row.status) }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column label="发起时间" width="180">
+            <template #default="{ row }">
+              {{ formatDate(row.createdAt) }}
+            </template>
+          </el-table-column>
+        </el-table>
+        <el-pagination
+          class="approval-center__pagination"
+          background
+          layout="total, prev, pager, next"
+          :total="store.totalPending"
+          :current-page="currentPage"
+          :page-size="pageSize"
+          @update:current-page="handlePageChange"
+        />
+      </el-tab-pane>
+
+      <el-tab-pane label="我发起的" name="mine">
+        <el-table
+          :data="store.myApprovals"
+          :loading="store.loading"
+          style="width: 100%"
+          stripe
+          highlight-current-row
+          @row-click="handleRowClick"
+        >
+          <el-table-column prop="requestNo" label="审批编号" width="180" />
+          <el-table-column prop="title" label="标题" min-width="200" />
+          <el-table-column label="发起人" width="120">
+            <template #default="{ row }">
+              {{ row.requester?.name ?? '-' }}
+            </template>
+          </el-table-column>
+          <el-table-column label="状态" width="100">
+            <template #default="{ row }">
+              <el-tag :type="statusTagType(row.status)" size="small" :data-status="row.status">
+                {{ statusLabel(row.status) }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column label="发起时间" width="180">
+            <template #default="{ row }">
+              {{ formatDate(row.createdAt) }}
+            </template>
+          </el-table-column>
+        </el-table>
+        <el-pagination
+          class="approval-center__pagination"
+          background
+          layout="total, prev, pager, next"
+          :total="store.totalMine"
+          :current-page="currentPage"
+          :page-size="pageSize"
+          @update:current-page="handlePageChange"
+        />
+      </el-tab-pane>
+
+      <el-tab-pane label="抄送我的" name="cc">
+        <el-table
+          :data="store.ccApprovals"
+          :loading="store.loading"
+          style="width: 100%"
+          stripe
+          highlight-current-row
+          @row-click="handleRowClick"
+        >
+          <el-table-column prop="requestNo" label="审批编号" width="180" />
+          <el-table-column prop="title" label="标题" min-width="200" />
+          <el-table-column label="发起人" width="120">
+            <template #default="{ row }">
+              {{ row.requester?.name ?? '-' }}
+            </template>
+          </el-table-column>
+          <el-table-column label="状态" width="100">
+            <template #default="{ row }">
+              <el-tag :type="statusTagType(row.status)" size="small" :data-status="row.status">
+                {{ statusLabel(row.status) }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column label="发起时间" width="180">
+            <template #default="{ row }">
+              {{ formatDate(row.createdAt) }}
+            </template>
+          </el-table-column>
+        </el-table>
+        <el-pagination
+          class="approval-center__pagination"
+          background
+          layout="total, prev, pager, next"
+          :total="store.totalCc"
+          :current-page="currentPage"
+          :page-size="pageSize"
+          @update:current-page="handlePageChange"
+        />
+      </el-tab-pane>
+
+      <el-tab-pane label="已完成" name="completed">
+        <el-table
+          :data="store.completedApprovals"
+          :loading="store.loading"
+          style="width: 100%"
+          stripe
+          highlight-current-row
+          @row-click="handleRowClick"
+        >
+          <el-table-column prop="requestNo" label="审批编号" width="180" />
+          <el-table-column prop="title" label="标题" min-width="200" />
+          <el-table-column label="发起人" width="120">
+            <template #default="{ row }">
+              {{ row.requester?.name ?? '-' }}
+            </template>
+          </el-table-column>
+          <el-table-column label="状态" width="100">
+            <template #default="{ row }">
+              <el-tag :type="statusTagType(row.status)" size="small" :data-status="row.status">
+                {{ statusLabel(row.status) }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column label="发起时间" width="180">
+            <template #default="{ row }">
+              {{ formatDate(row.createdAt) }}
+            </template>
+          </el-table-column>
+        </el-table>
+        <el-pagination
+          class="approval-center__pagination"
+          background
+          layout="total, prev, pager, next"
+          :total="store.totalCompleted"
+          :current-page="currentPage"
+          :page-size="pageSize"
+          @update:current-page="handlePageChange"
+        />
+      </el-tab-pane>
+    </el-tabs>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import type { UnifiedApprovalDTO, ApprovalStatus } from '../../types/approval'
+import { useApprovalStore } from '../../approvals/store'
+
+const router = useRouter()
+const store = useApprovalStore()
+
+const activeTab = ref<'pending' | 'mine' | 'cc' | 'completed'>('pending')
+const searchText = ref('')
+const statusFilter = ref<ApprovalStatus | ''>('')
+const currentPage = ref(1)
+const pageSize = ref(10)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function statusTagType(status: string) {
+  const map: Record<string, string> = {
+    pending: 'warning',
+    approved: 'success',
+    rejected: 'danger',
+    revoked: 'info',
+    draft: 'info',
+    cancelled: 'info',
+  }
+  return map[status] ?? ''
+}
+
+function statusLabel(status: string) {
+  const map: Record<string, string> = {
+    pending: '待处理',
+    approved: '已通过',
+    rejected: '已驳回',
+    revoked: '已撤回',
+    draft: '草稿',
+    cancelled: '已取消',
+  }
+  return map[status] ?? status
+}
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return '-'
+  return new Date(dateStr).toLocaleString('zh-CN')
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+function loadCurrentTab() {
+  const query = {
+    search: searchText.value || undefined,
+    status: (statusFilter.value || undefined) as ApprovalStatus | undefined,
+    page: currentPage.value,
+    pageSize: pageSize.value,
+  }
+  switch (activeTab.value) {
+    case 'pending': store.loadPending(query); break
+    case 'mine': store.loadMine(query); break
+    case 'cc': store.loadCc(query); break
+    case 'completed': store.loadCompleted(query); break
+  }
+}
+
+function handleTabChange() {
+  currentPage.value = 1
+  loadCurrentTab()
+}
+
+function handleSearch() {
+  currentPage.value = 1
+  loadCurrentTab()
+}
+
+function handlePageChange(page: number) {
+  currentPage.value = page
+  loadCurrentTab()
+}
+
+function handleRowClick(row: UnifiedApprovalDTO) {
+  router.push({ name: 'approval-detail', params: { id: row.id } })
+}
+
+onMounted(() => {
+  loadCurrentTab()
+})
+</script>
+
+<style scoped>
+.approval-center {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.approval-center__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.approval-center__header h1 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.approval-center__toolbar {
+  display: flex;
+  align-items: center;
+}
+
+.approval-center__tabs {
+  margin-top: 8px;
+}
+
+.approval-center__pagination {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
+</style>

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -1,0 +1,425 @@
+<template>
+  <section class="approval-detail" v-loading="store.loading">
+    <header class="approval-detail__header">
+      <el-button text @click="goBack">← 返回列表</el-button>
+      <h1 v-if="approval">{{ approval.title ?? '审批详情' }}</h1>
+      <el-tag
+        v-if="approval"
+        :type="statusTagType(approval.status)"
+        size="large"
+      >
+        {{ statusLabel(approval.status) }}
+      </el-tag>
+    </header>
+
+    <div v-if="store.error" class="approval-detail__error">
+      <el-alert :title="store.error" type="error" show-icon :closable="false" />
+    </div>
+
+    <div v-if="approval" class="approval-detail__body">
+      <!-- Left: form snapshot -->
+      <div class="approval-detail__form">
+        <h2>表单信息</h2>
+        <div class="approval-detail__meta">
+          <div class="approval-detail__meta-item">
+            <span class="approval-detail__label">审批编号</span>
+            <span>{{ approval.requestNo ?? '-' }}</span>
+          </div>
+          <div class="approval-detail__meta-item">
+            <span class="approval-detail__label">发起人</span>
+            <span>{{ approval.requester?.name ?? '-' }}</span>
+          </div>
+          <div class="approval-detail__meta-item">
+            <span class="approval-detail__label">部门</span>
+            <span>{{ approval.requester?.department ?? '-' }}</span>
+          </div>
+          <div class="approval-detail__meta-item">
+            <span class="approval-detail__label">发起时间</span>
+            <span>{{ formatDate(approval.createdAt) }}</span>
+          </div>
+          <div class="approval-detail__meta-item">
+            <span class="approval-detail__label">进度</span>
+            <span>{{ approval.currentStep ?? '-' }} / {{ approval.totalSteps ?? '-' }}</span>
+          </div>
+        </div>
+
+        <el-divider />
+
+        <div v-if="approval.formSnapshot" class="approval-detail__snapshot">
+          <div
+            v-for="(value, key) in approval.formSnapshot"
+            :key="key"
+            class="approval-detail__field"
+          >
+            <span class="approval-detail__label">{{ String(key) }}</span>
+            <span>{{ formatFieldValue(value) }}</span>
+          </div>
+        </div>
+        <el-empty v-else description="暂无表单数据" :image-size="80" />
+      </div>
+
+      <!-- Right: history timeline -->
+      <div class="approval-detail__timeline">
+        <h2>审批流程</h2>
+        <div v-if="store.history.length" class="approval-detail__history">
+          <div
+            v-for="item in store.history"
+            :key="item.id"
+            class="approval-detail__history-item"
+          >
+            <div class="approval-detail__history-dot" :class="`dot--${item.toStatus}`" />
+            <div class="approval-detail__history-content">
+              <div class="approval-detail__history-header">
+                <strong>{{ item.actorName ?? '系统' }}</strong>
+                <el-tag :type="statusTagType(item.toStatus)" size="small">
+                  {{ actionLabel(item.action) }}
+                </el-tag>
+              </div>
+              <p v-if="item.comment" class="approval-detail__history-comment">
+                {{ item.comment }}
+              </p>
+              <time class="approval-detail__history-time">
+                {{ item.occurredAt ? formatDate(item.occurredAt) : '-' }}
+              </time>
+            </div>
+          </div>
+        </div>
+        <el-empty v-else description="暂无审批历史" :image-size="80" />
+      </div>
+    </div>
+
+    <!-- Action bar -->
+    <div v-if="approval && approval.status === 'pending'" class="approval-detail__actions">
+      <el-button type="primary" @click="openActionDialog('approve')">通过</el-button>
+      <el-button type="danger" @click="openActionDialog('reject')">驳回</el-button>
+      <el-button @click="openTransferDialog">转交</el-button>
+      <el-button @click="handleRevoke">撤回</el-button>
+    </div>
+
+    <!-- Approve / Reject dialog -->
+    <el-dialog
+      v-model="actionDialogVisible"
+      :title="actionDialogTitle"
+      width="480px"
+    >
+      <el-form>
+        <el-form-item label="审批意见">
+          <el-input
+            v-model="actionComment"
+            type="textarea"
+            :rows="3"
+            placeholder="请输入审批意见"
+          />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="actionDialogVisible = false">取消</el-button>
+        <el-button
+          :type="currentAction === 'approve' ? 'primary' : 'danger'"
+          :loading="store.loading"
+          @click="submitAction"
+        >
+          确认
+        </el-button>
+      </template>
+    </el-dialog>
+
+    <!-- Transfer dialog -->
+    <el-dialog
+      v-model="transferDialogVisible"
+      title="转交审批"
+      width="480px"
+    >
+      <el-form>
+        <el-form-item label="转交给">
+          <el-select v-model="transferUserId" placeholder="选择用户" style="width: 100%">
+            <el-option label="李四 (部门经理)" value="user_2" />
+            <el-option label="王五 (总监)" value="user_3" />
+            <el-option label="赵六 (VP)" value="user_4" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="转交说明">
+          <el-input
+            v-model="actionComment"
+            type="textarea"
+            :rows="2"
+            placeholder="请输入转交说明"
+          />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="transferDialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="store.loading" @click="submitTransfer">
+          确认转交
+        </el-button>
+      </template>
+    </el-dialog>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { ApprovalActionType } from '../../types/approval'
+import { useApprovalStore } from '../../approvals/store'
+
+const route = useRoute()
+const router = useRouter()
+const store = useApprovalStore()
+
+const approval = computed(() => store.activeApproval)
+
+const actionDialogVisible = ref(false)
+const transferDialogVisible = ref(false)
+const currentAction = ref<ApprovalActionType>('approve')
+const actionComment = ref('')
+const transferUserId = ref('')
+
+const actionDialogTitle = computed(() =>
+  currentAction.value === 'approve' ? '审批通过' : '审批驳回',
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function statusTagType(status: string) {
+  const map: Record<string, string> = {
+    pending: 'warning',
+    approved: 'success',
+    rejected: 'danger',
+    revoked: 'info',
+    draft: 'info',
+    cancelled: 'info',
+  }
+  return map[status] ?? ''
+}
+
+function statusLabel(status: string) {
+  const map: Record<string, string> = {
+    pending: '待处理',
+    approved: '已通过',
+    rejected: '已驳回',
+    revoked: '已撤回',
+    draft: '草稿',
+    cancelled: '已取消',
+  }
+  return map[status] ?? status
+}
+
+function actionLabel(action: string) {
+  const map: Record<string, string> = {
+    created: '发起',
+    approve: '通过',
+    reject: '驳回',
+    transfer: '转交',
+    revoke: '撤回',
+    comment: '评论',
+  }
+  return map[action] ?? action
+}
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return '-'
+  return new Date(dateStr).toLocaleString('zh-CN')
+}
+
+function formatFieldValue(value: unknown): string {
+  if (value === null || value === undefined) return '-'
+  if (Array.isArray(value)) return value.join(', ')
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+function goBack() {
+  router.push({ name: 'approval-list' })
+}
+
+function openActionDialog(action: 'approve' | 'reject') {
+  currentAction.value = action
+  actionComment.value = ''
+  actionDialogVisible.value = true
+}
+
+function openTransferDialog() {
+  transferUserId.value = ''
+  actionComment.value = ''
+  transferDialogVisible.value = true
+}
+
+async function submitAction() {
+  const id = route.params.id as string
+  await store.executeAction(id, {
+    action: currentAction.value,
+    comment: actionComment.value || undefined,
+  })
+  actionDialogVisible.value = false
+  await store.loadHistory(id)
+}
+
+async function submitTransfer() {
+  if (!transferUserId.value) return
+  const id = route.params.id as string
+  await store.executeAction(id, {
+    action: 'transfer',
+    comment: actionComment.value || undefined,
+    targetUserId: transferUserId.value,
+  })
+  transferDialogVisible.value = false
+  await store.loadHistory(id)
+}
+
+async function handleRevoke() {
+  const id = route.params.id as string
+  await store.executeAction(id, { action: 'revoke' })
+  await store.loadHistory(id)
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+onMounted(async () => {
+  const id = route.params.id as string
+  await Promise.all([store.loadDetail(id), store.loadHistory(id)])
+})
+</script>
+
+<style scoped>
+.approval-detail {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.approval-detail__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.approval-detail__header h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+  flex: 1;
+}
+
+.approval-detail__error {
+  margin-bottom: 16px;
+}
+
+.approval-detail__body {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: 24px;
+}
+
+.approval-detail__form,
+.approval-detail__timeline {
+  background: #fff;
+  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.approval-detail__form h2,
+.approval-detail__timeline h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 16px;
+}
+
+.approval-detail__meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.approval-detail__meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.approval-detail__label {
+  font-size: 12px;
+  color: var(--el-text-color-secondary, #909399);
+}
+
+.approval-detail__snapshot {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.approval-detail__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.approval-detail__history {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.approval-detail__history-item {
+  display: flex;
+  gap: 12px;
+  padding: 12px 0;
+  border-left: 2px solid var(--el-border-color-lighter, #e4e7ed);
+  padding-left: 16px;
+  position: relative;
+}
+
+.approval-detail__history-dot {
+  position: absolute;
+  left: -6px;
+  top: 16px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--el-color-info, #909399);
+}
+
+.dot--approved { background: var(--el-color-success, #67c23a); }
+.dot--rejected { background: var(--el-color-danger, #f56c6c); }
+.dot--pending { background: var(--el-color-warning, #e6a23c); }
+.dot--revoked { background: var(--el-color-info, #909399); }
+
+.approval-detail__history-content {
+  flex: 1;
+}
+
+.approval-detail__history-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.approval-detail__history-comment {
+  margin: 4px 0;
+  color: var(--el-text-color-regular, #606266);
+  font-size: 13px;
+}
+
+.approval-detail__history-time {
+  font-size: 12px;
+  color: var(--el-text-color-secondary, #909399);
+}
+
+.approval-detail__actions {
+  margin-top: 24px;
+  padding: 16px 20px;
+  background: #fff;
+  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border-radius: 8px;
+  display: flex;
+  gap: 12px;
+}
+</style>

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -1,0 +1,279 @@
+<template>
+  <section class="approval-new" v-loading="templateStore.loading || approvalStore.loading">
+    <header class="approval-new__header">
+      <el-button text @click="goBack">← 返回</el-button>
+      <h1>发起审批</h1>
+    </header>
+
+    <div v-if="templateStore.error || approvalStore.error" class="approval-new__error">
+      <el-alert
+        :title="templateStore.error || approvalStore.error || ''"
+        type="error"
+        show-icon
+        :closable="false"
+      />
+    </div>
+
+    <div v-if="template" class="approval-new__body">
+      <div class="approval-new__info">
+        <h2>{{ template.name }}</h2>
+        <p v-if="template.description">{{ template.description }}</p>
+      </div>
+
+      <el-form
+        ref="formRef"
+        :model="formData"
+        :rules="formRules"
+        label-position="top"
+        class="approval-new__form"
+      >
+        <el-form-item
+          v-for="field in template.formSchema.fields"
+          :key="field.id"
+          :label="field.label"
+          :prop="field.id"
+          :required="field.required"
+        >
+          <!-- text -->
+          <el-input
+            v-if="field.type === 'text'"
+            v-model="formData[field.id]"
+            :placeholder="field.placeholder || `请输入${field.label}`"
+          />
+
+          <!-- textarea -->
+          <el-input
+            v-else-if="field.type === 'textarea'"
+            v-model="formData[field.id]"
+            type="textarea"
+            :rows="3"
+            :placeholder="field.placeholder || `请输入${field.label}`"
+          />
+
+          <!-- number -->
+          <el-input-number
+            v-else-if="field.type === 'number'"
+            v-model="formData[field.id]"
+            :placeholder="field.placeholder"
+            style="width: 100%"
+          />
+
+          <!-- date -->
+          <el-date-picker
+            v-else-if="field.type === 'date'"
+            v-model="formData[field.id]"
+            type="date"
+            :placeholder="field.placeholder || `请选择${field.label}`"
+            style="width: 100%"
+          />
+
+          <!-- datetime -->
+          <el-date-picker
+            v-else-if="field.type === 'datetime'"
+            v-model="formData[field.id]"
+            type="datetime"
+            :placeholder="field.placeholder || `请选择${field.label}`"
+            style="width: 100%"
+          />
+
+          <!-- select -->
+          <el-select
+            v-else-if="field.type === 'select'"
+            v-model="formData[field.id]"
+            :placeholder="field.placeholder || `请选择${field.label}`"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="opt in (field.options || [])"
+              :key="opt.value"
+              :label="opt.label"
+              :value="opt.value"
+            />
+          </el-select>
+
+          <!-- multi-select -->
+          <el-select
+            v-else-if="field.type === 'multi-select'"
+            v-model="formData[field.id]"
+            multiple
+            :placeholder="field.placeholder || `请选择${field.label}`"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="opt in (field.options || [])"
+              :key="opt.value"
+              :label="opt.label"
+              :value="opt.value"
+            />
+          </el-select>
+
+          <!-- user (placeholder picker) -->
+          <el-select
+            v-else-if="field.type === 'user'"
+            v-model="formData[field.id]"
+            :placeholder="field.placeholder || `请选择${field.label}`"
+            filterable
+            style="width: 100%"
+          >
+            <el-option label="张三" value="user_1" />
+            <el-option label="李四" value="user_2" />
+            <el-option label="王五" value="user_3" />
+          </el-select>
+
+          <!-- attachment (placeholder upload) -->
+          <el-upload
+            v-else-if="field.type === 'attachment'"
+            action="#"
+            :auto-upload="false"
+            :on-change="(file: any) => handleFileChange(field.id, file)"
+          >
+            <el-button type="primary" plain>点击上传</el-button>
+            <template #tip>
+              <div class="el-upload__tip">支持常见文件格式</div>
+            </template>
+          </el-upload>
+
+          <!-- fallback -->
+          <el-input
+            v-else
+            v-model="formData[field.id]"
+            :placeholder="field.placeholder || `请输入${field.label}`"
+          />
+        </el-form-item>
+
+        <el-form-item class="approval-new__submit">
+          <el-button type="primary" :loading="approvalStore.loading" @click="handleSubmit">
+            提交审批
+          </el-button>
+          <el-button @click="goBack">取消</el-button>
+        </el-form-item>
+      </el-form>
+    </div>
+
+    <el-empty v-else-if="!templateStore.loading" description="未找到审批模板" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { FormInstance, FormRules } from 'element-plus'
+import { useApprovalStore } from '../../approvals/store'
+import { useApprovalTemplateStore } from '../../approvals/templateStore'
+
+const route = useRoute()
+const router = useRouter()
+const approvalStore = useApprovalStore()
+const templateStore = useApprovalTemplateStore()
+
+const formRef = ref<FormInstance>()
+const formData = reactive<Record<string, unknown>>({})
+const template = computed(() => templateStore.activeTemplate)
+
+const formRules = computed<FormRules>(() => {
+  const rules: FormRules = {}
+  if (!template.value) return rules
+  for (const field of template.value.formSchema.fields) {
+    if (field.required) {
+      rules[field.id] = [
+        { required: true, message: `请填写${field.label}`, trigger: 'blur' },
+      ]
+    }
+  }
+  return rules
+})
+
+function handleFileChange(fieldId: string, file: any) {
+  formData[fieldId] = file?.raw ?? null
+}
+
+function goBack() {
+  router.back()
+}
+
+async function handleSubmit() {
+  if (formRef.value) {
+    try {
+      await formRef.value.validate()
+    } catch {
+      return
+    }
+  }
+
+  const templateId = route.params.templateId as string
+  const result = await approvalStore.submitApproval({
+    templateId,
+    formData: { ...formData },
+  })
+  router.push({ name: 'approval-detail', params: { id: result.id } })
+}
+
+onMounted(async () => {
+  const templateId = route.params.templateId as string
+  await templateStore.loadTemplate(templateId)
+  // Initialize form with default values
+  if (template.value) {
+    for (const field of template.value.formSchema.fields) {
+      if (field.defaultValue !== undefined) {
+        formData[field.id] = field.defaultValue
+      } else if (field.type === 'multi-select') {
+        formData[field.id] = []
+      } else {
+        formData[field.id] = undefined
+      }
+    }
+  }
+})
+</script>
+
+<style scoped>
+.approval-new {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.approval-new__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.approval-new__header h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.approval-new__error {
+  margin-bottom: 16px;
+}
+
+.approval-new__info {
+  margin-bottom: 20px;
+}
+
+.approval-new__info h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.approval-new__info p {
+  color: var(--el-text-color-secondary, #909399);
+  margin: 0;
+}
+
+.approval-new__form {
+  background: #fff;
+  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border-radius: 8px;
+  padding: 24px;
+}
+
+.approval-new__submit {
+  margin-top: 24px;
+  margin-bottom: 0;
+}
+</style>

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -1,0 +1,193 @@
+<template>
+  <section class="template-center">
+    <header class="template-center__header">
+      <h1>审批模板</h1>
+      <div class="template-center__toolbar">
+        <el-input
+          v-model="searchText"
+          placeholder="搜索模板名称"
+          clearable
+          style="width: 240px"
+          @clear="handleSearch"
+          @keyup.enter="handleSearch"
+        >
+          <template #prefix>
+            <span>🔍</span>
+          </template>
+        </el-input>
+      </div>
+    </header>
+
+    <el-tabs v-model="statusTab" class="template-center__tabs" @tab-change="handleTabChange">
+      <el-tab-pane label="全部" name="all" />
+      <el-tab-pane label="已发布" name="published" />
+      <el-tab-pane label="草稿" name="draft" />
+      <el-tab-pane label="已归档" name="archived" />
+    </el-tabs>
+
+    <el-table
+      v-loading="store.loading"
+      :data="store.templates"
+      style="width: 100%"
+      stripe
+      highlight-current-row
+      @row-click="handleRowClick"
+    >
+      <el-table-column prop="name" label="模板名称" min-width="200" />
+      <el-table-column prop="description" label="描述" min-width="240">
+        <template #default="{ row }">
+          {{ row.description ?? '-' }}
+        </template>
+      </el-table-column>
+      <el-table-column label="状态" width="100">
+        <template #default="{ row }">
+          <el-tag :type="templateStatusTagType(row.status)" size="small">
+            {{ templateStatusLabel(row.status) }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="创建时间" width="180">
+        <template #default="{ row }">
+          {{ formatDate(row.createdAt) }}
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="120" fixed="right">
+        <template #default="{ row }">
+          <el-button
+            v-if="row.status === 'published'"
+            type="primary"
+            link
+            size="small"
+            @click.stop="startApproval(row.id)"
+          >
+            发起审批
+          </el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-pagination
+      v-if="store.total > pageSize"
+      class="template-center__pagination"
+      background
+      layout="total, prev, pager, next"
+      :total="store.total"
+      :current-page="currentPage"
+      :page-size="pageSize"
+      @update:current-page="handlePageChange"
+    />
+
+    <div v-if="store.error" class="template-center__error">
+      <el-alert :title="store.error" type="error" show-icon />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import type { ApprovalTemplateListItemDTO, ApprovalTemplateStatus } from '../../types/approval'
+import { useApprovalTemplateStore } from '../../approvals/templateStore'
+
+const router = useRouter()
+const store = useApprovalTemplateStore()
+
+const statusTab = ref<'all' | ApprovalTemplateStatus>('all')
+const searchText = ref('')
+const currentPage = ref(1)
+const pageSize = ref(10)
+
+function templateStatusTagType(status: string) {
+  const map: Record<string, string> = {
+    published: 'success',
+    draft: 'info',
+    archived: 'warning',
+  }
+  return map[status] ?? ''
+}
+
+function templateStatusLabel(status: string) {
+  const map: Record<string, string> = {
+    published: '已发布',
+    draft: '草稿',
+    archived: '已归档',
+  }
+  return map[status] ?? status
+}
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return '-'
+  return new Date(dateStr).toLocaleString('zh-CN')
+}
+
+function loadData() {
+  store.loadTemplates({
+    status: statusTab.value === 'all' ? undefined : statusTab.value,
+    search: searchText.value || undefined,
+    page: currentPage.value,
+    pageSize: pageSize.value,
+  })
+}
+
+function handleTabChange() {
+  currentPage.value = 1
+  loadData()
+}
+
+function handleSearch() {
+  currentPage.value = 1
+  loadData()
+}
+
+function handlePageChange(page: number) {
+  currentPage.value = page
+  loadData()
+}
+
+function handleRowClick(row: ApprovalTemplateListItemDTO) {
+  router.push({ path: `/approval-templates/${row.id}` })
+}
+
+function startApproval(templateId: string) {
+  router.push({ path: `/approvals/new/${templateId}` })
+}
+
+onMounted(() => {
+  loadData()
+})
+</script>
+
+<style scoped>
+.template-center {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.template-center__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.template-center__header h1 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.template-center__tabs {
+  margin-bottom: 16px;
+}
+
+.template-center__pagination {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.template-center__error {
+  margin-top: 16px;
+}
+</style>

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -1,0 +1,313 @@
+<template>
+  <section class="template-detail" v-loading="store.loading">
+    <header class="template-detail__header">
+      <el-button text @click="goBack">← 返回模板列表</el-button>
+      <h1 v-if="template">{{ template.name }}</h1>
+      <el-tag
+        v-if="template"
+        :type="statusTagType(template.status)"
+        size="large"
+      >
+        {{ statusLabel(template.status) }}
+      </el-tag>
+      <el-button
+        v-if="template && template.status === 'published'"
+        type="primary"
+        @click="startApproval"
+      >
+        发起审批
+      </el-button>
+    </header>
+
+    <div v-if="store.error" class="template-detail__error">
+      <el-alert :title="store.error" type="error" show-icon :closable="false" />
+    </div>
+
+    <div v-if="template" class="template-detail__body">
+      <!-- Template info -->
+      <div class="template-detail__info">
+        <p v-if="template.description">{{ template.description }}</p>
+        <div class="template-detail__meta">
+          <span>模板 Key: {{ template.key }}</span>
+          <span>当前版本: {{ template.activeVersionId ?? '无' }}</span>
+          <span>创建时间: {{ formatDate(template.createdAt) }}</span>
+          <span>更新时间: {{ formatDate(template.updatedAt) }}</span>
+        </div>
+      </div>
+
+      <div class="template-detail__content">
+        <!-- Form schema section -->
+        <div class="template-detail__section">
+          <h2>表单字段</h2>
+          <el-table :data="template.formSchema.fields" style="width: 100%" stripe>
+            <el-table-column prop="label" label="字段名" min-width="160" />
+            <el-table-column label="类型" width="120">
+              <template #default="{ row }">
+                <el-tag size="small">{{ fieldTypeLabel(row.type) }}</el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column label="必填" width="80">
+              <template #default="{ row }">
+                <el-tag v-if="row.required" type="danger" size="small">必填</el-tag>
+                <span v-else>-</span>
+              </template>
+            </el-table-column>
+            <el-table-column prop="placeholder" label="占位文本" min-width="160">
+              <template #default="{ row }">
+                {{ row.placeholder ?? '-' }}
+              </template>
+            </el-table-column>
+            <el-table-column label="选项" min-width="200">
+              <template #default="{ row }">
+                <span v-if="row.options && row.options.length">
+                  {{ row.options.map((o: any) => o.label).join(', ') }}
+                </span>
+                <span v-else>-</span>
+              </template>
+            </el-table-column>
+          </el-table>
+        </div>
+
+        <!-- Approval graph section -->
+        <div class="template-detail__section">
+          <h2>审批流程</h2>
+          <div class="template-detail__graph">
+            <div
+              v-for="(node, index) in template.approvalGraph.nodes"
+              :key="node.key"
+              class="template-detail__node"
+            >
+              <div class="template-detail__node-icon" :class="`node-type--${node.type}`">
+                {{ nodeIcon(node.type) }}
+              </div>
+              <div class="template-detail__node-info">
+                <strong>{{ node.name ?? node.key }}</strong>
+                <span class="template-detail__node-type">{{ nodeTypeLabel(node.type) }}</span>
+                <span
+                  v-if="'assigneeType' in node.config && node.config.assigneeType"
+                  class="template-detail__node-assignee"
+                >
+                  {{ (node.config as any).assigneeType === 'role' ? '角色' : '用户' }}:
+                  {{ (node.config as any).assigneeIds?.join(', ') ?? '-' }}
+                </span>
+              </div>
+              <div
+                v-if="index < template.approvalGraph.nodes.length - 1"
+                class="template-detail__edge"
+              >
+                ↓
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <el-empty v-else-if="!store.loading" description="未找到模板" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { ApprovalNodeType, FormFieldType } from '../../types/approval'
+import { useApprovalTemplateStore } from '../../approvals/templateStore'
+
+const route = useRoute()
+const router = useRouter()
+const store = useApprovalTemplateStore()
+
+const template = computed(() => store.activeTemplate)
+
+function statusTagType(status: string) {
+  const map: Record<string, string> = {
+    published: 'success',
+    draft: 'info',
+    archived: 'warning',
+  }
+  return map[status] ?? ''
+}
+
+function statusLabel(status: string) {
+  const map: Record<string, string> = {
+    published: '已发布',
+    draft: '草稿',
+    archived: '已归档',
+  }
+  return map[status] ?? status
+}
+
+function fieldTypeLabel(type: FormFieldType) {
+  const map: Record<FormFieldType, string> = {
+    text: '文本',
+    textarea: '多行文本',
+    number: '数字',
+    date: '日期',
+    datetime: '日期时间',
+    select: '单选',
+    'multi-select': '多选',
+    user: '用户',
+    attachment: '附件',
+  }
+  return map[type] ?? type
+}
+
+function nodeTypeLabel(type: ApprovalNodeType) {
+  const map: Record<ApprovalNodeType, string> = {
+    start: '开始',
+    approval: '审批',
+    cc: '抄送',
+    condition: '条件',
+    end: '结束',
+  }
+  return map[type] ?? type
+}
+
+function nodeIcon(type: ApprovalNodeType) {
+  const map: Record<ApprovalNodeType, string> = {
+    start: 'S',
+    approval: 'A',
+    cc: 'C',
+    condition: '?',
+    end: 'E',
+  }
+  return map[type] ?? '?'
+}
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return '-'
+  return new Date(dateStr).toLocaleString('zh-CN')
+}
+
+function goBack() {
+  router.push({ path: '/approval-templates' })
+}
+
+function startApproval() {
+  if (template.value) {
+    router.push({ path: `/approvals/new/${template.value.id}` })
+  }
+}
+
+onMounted(() => {
+  const id = route.params.id as string
+  store.loadTemplate(id)
+})
+</script>
+
+<style scoped>
+.template-detail {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.template-detail__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.template-detail__header h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+  flex: 1;
+}
+
+.template-detail__error {
+  margin-bottom: 16px;
+}
+
+.template-detail__info {
+  margin-bottom: 20px;
+}
+
+.template-detail__info p {
+  color: var(--el-text-color-regular, #606266);
+  margin: 0 0 12px;
+}
+
+.template-detail__meta {
+  display: flex;
+  gap: 24px;
+  font-size: 13px;
+  color: var(--el-text-color-secondary, #909399);
+}
+
+.template-detail__content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.template-detail__section {
+  background: #fff;
+  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.template-detail__section h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 16px;
+}
+
+.template-detail__graph {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+}
+
+.template-detail__node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+.template-detail__node-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 16px;
+  color: #fff;
+  background: var(--el-color-info, #909399);
+}
+
+.node-type--start { background: var(--el-color-primary, #409eff); }
+.node-type--approval { background: var(--el-color-warning, #e6a23c); }
+.node-type--cc { background: var(--el-color-success, #67c23a); }
+.node-type--condition { background: var(--el-color-danger, #f56c6c); }
+.node-type--end { background: var(--el-color-info, #909399); }
+
+.template-detail__node-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.template-detail__node-type {
+  font-size: 12px;
+  color: var(--el-text-color-secondary, #909399);
+}
+
+.template-detail__node-assignee {
+  font-size: 12px;
+  color: var(--el-text-color-regular, #606266);
+}
+
+.template-detail__edge {
+  font-size: 20px;
+  color: var(--el-text-color-placeholder, #c0c4cc);
+  padding: 4px 0;
+}
+</style>

--- a/apps/web/tests/approval-center.spec.ts
+++ b/apps/web/tests/approval-center.spec.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: pushSpy,
+      back: vi.fn(),
+    }),
+    useRoute: () => ({
+      params: {},
+      query: {},
+      path: '/approvals',
+      meta: {},
+    }),
+  }
+})
+
+// Mock the approval store
+const mockPendingApprovals = ref<any[]>([])
+const mockMyApprovals = ref<any[]>([])
+const mockCcApprovals = ref<any[]>([])
+const mockCompletedApprovals = ref<any[]>([])
+const mockLoading = ref(false)
+const mockError = ref<string | null>(null)
+const loadPendingSpy = vi.fn().mockResolvedValue(undefined)
+const loadMineSpy = vi.fn().mockResolvedValue(undefined)
+const loadCcSpy = vi.fn().mockResolvedValue(undefined)
+const loadCompletedSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../src/approvals/store', () => ({
+  useApprovalStore: () => ({
+    approvals: ref([]),
+    pendingApprovals: mockPendingApprovals,
+    myApprovals: mockMyApprovals,
+    ccApprovals: mockCcApprovals,
+    completedApprovals: mockCompletedApprovals,
+    activeApproval: ref(null),
+    history: ref([]),
+    loading: mockLoading,
+    error: mockError,
+    totalPending: ref(0),
+    totalMine: ref(0),
+    totalCc: ref(0),
+    totalCompleted: ref(0),
+    pendingCount: ref(0),
+    approvalById: ref(() => undefined),
+    loadPending: loadPendingSpy,
+    loadMine: loadMineSpy,
+    loadCc: loadCcSpy,
+    loadCompleted: loadCompletedSpy,
+    loadDetail: vi.fn(),
+    loadHistory: vi.fn(),
+    submitApproval: vi.fn(),
+    executeAction: vi.fn(),
+  }),
+}))
+
+// Stub Element Plus components
+const ElTabs = defineComponent({
+  name: 'ElTabs',
+  props: { modelValue: String },
+  emits: ['update:modelValue', 'tab-change'],
+  render() {
+    return h('div', { 'data-el-tabs': this.modelValue }, this.$slots.default?.())
+  },
+})
+
+const ElTabPane = defineComponent({
+  name: 'ElTabPane',
+  props: { label: String, name: String },
+  render() {
+    return h('div', { 'data-tab-pane': this.name, 'data-tab-label': this.label }, this.$slots.default?.())
+  },
+})
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: Array, loading: Boolean, stripe: Boolean, highlightCurrentRow: Boolean },
+  emits: ['row-click'],
+  render() {
+    return h('div', { 'data-el-table': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number], minWidth: [String, Number], fixed: String },
+  render() {
+    // Do not invoke scoped slots — they expect { row } context from el-table
+    return h('div', { 'data-column': this.prop || this.label })
+  },
+})
+
+const ElTag = defineComponent({
+  name: 'ElTag',
+  props: { type: String, size: String },
+  render() {
+    return h('span', { 'data-el-tag': this.type, class: `el-tag--${this.type}` }, this.$slots.default?.())
+  },
+})
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: String, placeholder: String, clearable: Boolean, type: String, rows: Number },
+  emits: ['update:modelValue', 'clear'],
+  render() {
+    return h('input', { 'data-el-input': 'true' })
+  },
+})
+
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: { modelValue: [String, Array], placeholder: String, clearable: Boolean, multiple: Boolean, filterable: Boolean },
+  emits: ['update:modelValue', 'change'],
+  render() {
+    return h('select', { 'data-el-select': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() {
+    return h('option', { value: this.value }, this.label)
+  },
+})
+
+const ElPagination = defineComponent({
+  name: 'ElPagination',
+  props: { background: Boolean, layout: String, total: Number, currentPage: Number, pageSize: Number },
+  emits: ['update:currentPage'],
+  render() {
+    return h('div', { 'data-el-pagination': 'true' })
+  },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, text: Boolean, link: Boolean, plain: Boolean, size: String, loading: Boolean, disabled: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', { 'data-el-button': this.type || 'default', onClick: (e: Event) => this.$emit('click', e) }, this.$slots.default?.())
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, type: String, showIcon: Boolean, closable: Boolean },
+  render() {
+    return h('div', { 'data-el-alert': this.type }, this.title)
+  },
+})
+
+const ElEmpty = defineComponent({
+  name: 'ElEmpty',
+  props: { description: String, imageSize: Number },
+  render() {
+    return h('div', { 'data-el-empty': 'true' }, this.description)
+  },
+})
+
+const stubDirective = { mounted() {}, updated() {} }
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('ApprovalCenterView', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    mockPendingApprovals.value = []
+    mockMyApprovals.value = []
+    mockCcApprovals.value = []
+    mockCompletedApprovals.value = []
+    mockLoading.value = false
+    mockError.value = null
+    loadPendingSpy.mockClear()
+    loadMineSpy.mockClear()
+    loadCcSpy.mockClear()
+    loadCompletedSpy.mockClear()
+    pushSpy.mockClear()
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalCenterView } = await import('../src/views/approval/ApprovalCenterView.vue')
+    const Host = defineComponent({
+      setup() {
+        return () => h(ApprovalCenterView as any)
+      },
+    })
+    app = createApp(Host)
+    app.component('ElTabs', ElTabs)
+    app.component('ElTabPane', ElTabPane)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElInput', ElInput)
+    app.component('ElSelect', ElSelect)
+    app.component('ElOption', ElOption)
+    app.component('ElPagination', ElPagination)
+    app.component('ElButton', ElButton)
+    app.component('ElAlert', ElAlert)
+    app.component('ElEmpty', ElEmpty)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  it('renders 4 tabs', async () => {
+    await mountView()
+    const panes = container!.querySelectorAll('[data-tab-pane]')
+    expect(panes.length).toBe(4)
+
+    const labels = Array.from(panes).map((p) => p.getAttribute('data-tab-label'))
+    expect(labels).toContain('待我处理')
+    expect(labels).toContain('我发起的')
+    expect(labels).toContain('抄送我的')
+    expect(labels).toContain('已完成')
+  })
+
+  it('calls loadPending on mount', async () => {
+    await mountView()
+    expect(loadPendingSpy).toHaveBeenCalled()
+  })
+
+  it('renders pending approvals with status tags', async () => {
+    mockPendingApprovals.value = [
+      {
+        id: 'apv_1',
+        requestNo: 'APV-2026-0001',
+        title: '出差报销',
+        status: 'pending',
+        requester: { name: '张三' },
+        createdAt: '2026-04-10T08:00:00Z',
+        assignments: [],
+      },
+      {
+        id: 'apv_2',
+        requestNo: 'APV-2026-0002',
+        title: '采购申请',
+        status: 'approved',
+        requester: { name: '李四' },
+        createdAt: '2026-04-09T08:00:00Z',
+        assignments: [],
+      },
+    ]
+    await mountView()
+    // The table should exist in the pending tab
+    const tables = container!.querySelectorAll('[data-el-table]')
+    expect(tables.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders the header with title', async () => {
+    await mountView()
+    const header = container!.querySelector('.approval-center__header h1')
+    expect(header?.textContent).toBe('审批中心')
+  })
+
+  it('renders search input and status filter', async () => {
+    await mountView()
+    expect(container!.querySelector('[data-el-input]')).toBeTruthy()
+    expect(container!.querySelector('[data-el-select]')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary\n- add the platform-native approval product shell on top of the frozen approval contracts\n- register approval center, request creation/detail, and template center/detail routes\n- wire template and approval stores with typed API helpers and dev mock fallback\n- gate approval navigation links and route metadata with the frozen approval permissions\n\n## Verification\n- pnpm --filter @metasheet/web exec vue-tsc --noEmit\n- pnpm --filter @metasheet/web exec vitest run tests/approval-center.spec.ts --watch=false --reporter=dot\n- git diff --check