### PR TITLE
feat(federation): bridge Yuantus release readiness

### DIFF
--- a/docs/FEDERATION_RELEASE_READINESS_BRIDGE_20260411.md
+++ b/docs/FEDERATION_RELEASE_READINESS_BRIDGE_20260411.md
@@ -152,9 +152,39 @@ Observed live result:
 - the adapter emitted canonical `summary` / `export` links that point back to
   the provider surface
 
-The concrete sample object currently returns an empty readiness summary
-(`resources=0`), which is acceptable for bridge verification. A richer demo
-fixture is a separate data task, not a bridge correctness issue.
+Second live validation was then run against a non-empty demo fixture:
+
+- parent part: `39a39aca-c743-403d-ba3f-058b55ccc7e9`
+- parent number: `RR-P-1775885685036`
+- baseline resource: `d627a794-45b0-413a-8f77-fbf6165c0b14`
+- MBOM resource: `8e93a516-b14d-4c29-b020-3979a0e5e5aa`
+- routing resource: `897b05eb-270a-4afb-ba28-c4f25f819cb2`
+
+Observed non-empty readiness summary:
+
+- `resources=3`
+- `ok_resources=2`
+- `error_count=1`
+- `warning_count=0`
+- `by_kind.baseline_release.ok_resources=1`
+- `by_kind.routing_release.ok_resources=1`
+- `by_kind.mbom_release.error_count=1`
+
+Observed non-empty resource names:
+
+- `MBOM-RR-1775885685036`
+- `Routing RR 1775885685036`
+- `BL-RR-1775885685036`
+
+The provider and adapter both returned the same canonical links for that object:
+
+- summary:
+  `/api/v1/release-readiness/items/39a39aca-c743-403d-ba3f-058b55ccc7e9?ruleset_id=readiness`
+- export:
+  `/api/v1/release-readiness/items/39a39aca-c743-403d-ba3f-058b55ccc7e9/export?export_format=zip&ruleset_id=readiness`
+
+This richer fixture matters because it proves the bridge preserves a real mixed
+governance result, not just the empty-summary case.
 
 ## Deferred
 

--- a/docs/FEDERATION_RELEASE_READINESS_BRIDGE_20260411.md
+++ b/docs/FEDERATION_RELEASE_READINESS_BRIDGE_20260411.md
@@ -40,8 +40,8 @@ Federation now returns:
 {
   "ok": true,
   "data": {
-    "productId": "prod-1001",
-    "item_id": "prod-1001",
+    "productId": "39a39aca-c743-403d-ba3f-058b55ccc7e9",
+    "item_id": "39a39aca-c743-403d-ba3f-058b55ccc7e9",
     "generated_at": "2026-04-11T00:00:00.000Z",
     "ruleset_id": "readiness",
     "summary": {
@@ -49,20 +49,48 @@ Federation now returns:
       "resources": 3,
       "ok_resources": 2,
       "error_count": 1,
-      "warning_count": 1,
+      "warning_count": 0,
       "by_kind": {
-        "mbom": {
+        "mbom_release": {
           "resources": 1,
           "ok_resources": 0,
           "error_count": 1,
           "warning_count": 0
+        },
+        "routing_release": {
+          "resources": 1,
+          "ok_resources": 1,
+          "error_count": 0,
+          "warning_count": 0
+        },
+        "baseline_release": {
+          "resources": 1,
+          "ok_resources": 1,
+          "error_count": 0,
+          "warning_count": 0
         }
       }
     },
-    "resources": [],
+    "resources": [
+      {
+        "kind": "mbom_release",
+        "name": "MBOM-RR-1775885685036",
+        "state": "draft"
+      },
+      {
+        "kind": "routing_release",
+        "name": "Routing RR 1775885685036",
+        "state": "draft"
+      },
+      {
+        "kind": "baseline_release",
+        "name": "BL-RR-1775885685036",
+        "state": "draft"
+      }
+    ],
     "links": {
-      "summary": "/api/v1/release-readiness/items/prod-1001?ruleset_id=readiness",
-      "export": "/api/v1/release-readiness/items/prod-1001/export?export_format=zip&ruleset_id=readiness"
+      "summary": "/api/v1/release-readiness/items/39a39aca-c743-403d-ba3f-058b55ccc7e9?ruleset_id=readiness",
+      "export": "/api/v1/release-readiness/items/39a39aca-c743-403d-ba3f-058b55ccc7e9/export?export_format=zip&ruleset_id=readiness"
     }
   }
 }
@@ -91,6 +119,8 @@ This was the next highest-leverage slice because:
 
 - `packages/core-backend/src/data-adapters/PLMAdapter.ts`
 - `packages/core-backend/src/routes/federation.ts`
+- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json`
+- `packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts`
 - `packages/core-backend/tests/fixtures/federation/contracts.ts`
 - `packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts`
 - `packages/core-backend/tests/unit/federation.contract.test.ts`
@@ -111,7 +141,7 @@ pnpm --dir packages/core-backend test:contract
 Observed results:
 
 - targeted unit tests: `30 passed`
-- contract tests: `16 passed`
+- contract tests: `17 passed`
 
 Live provider validation:
 
@@ -124,30 +154,31 @@ curl -s -X POST http://127.0.0.1:7910/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -H "x-tenant-id: tenant-1" \
   -H "x-org-id: org-1" \
-  -d '{"tenant_id":"tenant-1","username":"phase0-test","password":"phase0pass","org_id":"org-1"}'
+  -d '{"tenant_id":"tenant-1","username":"admin","password":"admin","org_id":"org-1"}'
 
 curl -s \
   -H "Authorization: Bearer <token>" \
   -H "x-tenant-id: tenant-1" \
   -H "x-org-id: org-1" \
-  "http://127.0.0.1:7910/api/v1/release-readiness/items/b5ecee24-5ce8-4b59-9551-446e1c50b608?ruleset_id=readiness"
+  "http://127.0.0.1:7910/api/v1/release-readiness/items/39a39aca-c743-403d-ba3f-058b55ccc7e9?ruleset_id=readiness"
 
 # 3. Verify the new Metasheet adapter path against the same provider
 PLM_BASE_URL=http://127.0.0.1:7910 \
 PLM_API_MODE=yuantus \
 PLM_TENANT_ID=tenant-1 \
 PLM_ORG_ID=org-1 \
-PLM_USERNAME=phase0-test \
-PLM_PASSWORD=phase0pass \
+PLM_USERNAME=admin \
+PLM_PASSWORD=admin \
 PLM_ITEM_TYPE=Part \
-pnpm exec tsx --eval "import { PLMAdapter } from './src/data-adapters/PLMAdapter.ts'; void (async () => { const configService={get: async ()=>undefined}; const logger={info:()=>{},warn:()=>{},error:console.error}; const adapter=new PLMAdapter(configService as any, logger as any); await adapter.connect(); const result=await adapter.getReleaseReadiness('b5ecee24-5ce8-4b59-9551-446e1c50b608',{rulesetId:'readiness'}); console.log(JSON.stringify(result.data[0], null, 2)); await adapter.disconnect(); })().catch((error) => { console.error(error); process.exit(1); });"
+pnpm exec tsx --eval "import { PLMAdapter } from './src/data-adapters/PLMAdapter.ts'; void (async () => { const configService={get: async ()=>undefined}; const logger={info:()=>{},warn:()=>{},error:console.error}; const adapter=new PLMAdapter(configService as any, logger as any); await adapter.connect(); const result=await adapter.getReleaseReadiness('39a39aca-c743-403d-ba3f-058b55ccc7e9',{rulesetId:'readiness'}); console.log(JSON.stringify(result.data[0], null, 2)); await adapter.disconnect(); })().catch((error) => { console.error(error); process.exit(1); });"
 ```
 
 Observed live result:
 
 - provider health responded `ok=true`
 - login returned a valid JWT
-- direct provider readiness call returned `ok=true`
+- direct provider readiness call returned `resources=3`, `ok_resources=2`,
+  `error_count=1`
 - adapter live call returned `count=1`, `error=null`
 - the adapter emitted canonical `summary` / `export` links that point back to
   the provider surface
@@ -186,20 +217,22 @@ The provider and adapter both returned the same canonical links for that object:
 This richer fixture matters because it proves the bridge preserves a real mixed
 governance result, not just the empty-summary case.
 
-## Deferred
+## Contract Status
 
-This bridge is intentionally **not** added to Pact yet.
+This bridge is already added to Pact in this PR.
 
-Reason:
-
-- current Pact scope protects the established mainline surfaces up through the
-  existing Wave 5 set
-- `release_readiness` is now a real federation surface, but the right next step
-  is to let the consumer call pattern settle and then add a targeted Pact
-  interaction, not to expand Pact speculatively
-
-The likely next contract step is a small follow-up Wave that locks:
+Current contract scope now includes:
 
 - `GET /api/v1/release-readiness/items/{item_id}`
+- the existing mainline Yuantus PLM federation surfaces already tracked by the
+  Wave 1-5 contract set
 
-once the federation/UI caller becomes part of the stable mainline workflow.
+Why this is the right boundary:
+
+- the provider endpoint already exists and is exercised in live verification
+- the consumer federation surface now exists and is exercised in unit plus
+  contract tests
+- this adds one targeted interaction instead of speculative breadth
+
+The next follow-up is not more Pact breadth. It is UI adoption and stable
+mainline caller usage on the Metasheet side.

--- a/docs/FEDERATION_RELEASE_READINESS_BRIDGE_20260411.md
+++ b/docs/FEDERATION_RELEASE_READINESS_BRIDGE_20260411.md
@@ -113,6 +113,49 @@ Observed results:
 - targeted unit tests: `30 passed`
 - contract tests: `16 passed`
 
+Live provider validation:
+
+```bash
+# 1. Start Yuantus locally
+./.venv/bin/uvicorn yuantus.api.app:create_app --factory --host 127.0.0.1 --port 7910
+
+# 2. Verify provider endpoint directly
+curl -s -X POST http://127.0.0.1:7910/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: tenant-1" \
+  -H "x-org-id: org-1" \
+  -d '{"tenant_id":"tenant-1","username":"phase0-test","password":"phase0pass","org_id":"org-1"}'
+
+curl -s \
+  -H "Authorization: Bearer <token>" \
+  -H "x-tenant-id: tenant-1" \
+  -H "x-org-id: org-1" \
+  "http://127.0.0.1:7910/api/v1/release-readiness/items/b5ecee24-5ce8-4b59-9551-446e1c50b608?ruleset_id=readiness"
+
+# 3. Verify the new Metasheet adapter path against the same provider
+PLM_BASE_URL=http://127.0.0.1:7910 \
+PLM_API_MODE=yuantus \
+PLM_TENANT_ID=tenant-1 \
+PLM_ORG_ID=org-1 \
+PLM_USERNAME=phase0-test \
+PLM_PASSWORD=phase0pass \
+PLM_ITEM_TYPE=Part \
+pnpm exec tsx --eval "import { PLMAdapter } from './src/data-adapters/PLMAdapter.ts'; void (async () => { const configService={get: async ()=>undefined}; const logger={info:()=>{},warn:()=>{},error:console.error}; const adapter=new PLMAdapter(configService as any, logger as any); await adapter.connect(); const result=await adapter.getReleaseReadiness('b5ecee24-5ce8-4b59-9551-446e1c50b608',{rulesetId:'readiness'}); console.log(JSON.stringify(result.data[0], null, 2)); await adapter.disconnect(); })().catch((error) => { console.error(error); process.exit(1); });"
+```
+
+Observed live result:
+
+- provider health responded `ok=true`
+- login returned a valid JWT
+- direct provider readiness call returned `ok=true`
+- adapter live call returned `count=1`, `error=null`
+- the adapter emitted canonical `summary` / `export` links that point back to
+  the provider surface
+
+The concrete sample object currently returns an empty readiness summary
+(`resources=0`), which is acceptable for bridge verification. A richer demo
+fixture is a separate data task, not a bridge correctness issue.
+
 ## Deferred
 
 This bridge is intentionally **not** added to Pact yet.

--- a/docs/FEDERATION_RELEASE_READINESS_BRIDGE_20260411.md
+++ b/docs/FEDERATION_RELEASE_READINESS_BRIDGE_20260411.md
@@ -1,0 +1,132 @@
+# Federation Release Readiness Bridge
+
+Date: 2026-04-11
+
+## Problem
+
+Yuantus mainline already exposes a real release-readiness API:
+
+- `GET /api/v1/release-readiness/items/{item_id}`
+
+That surface was already used in Yuantus native workspace and had been validated
+in previous live integration work, but `metasheet2` federation still had no
+adapter method, no federation query operation, and no capability advertisement
+for it.
+
+The result was an avoidable product gap:
+
+- Pact/CI protected documents, BOM, approvals, substitutes, and CAD
+- live Yuantus governance had release-readiness
+- federation could not expose the same governance result to Metasheet callers
+
+## Decision
+
+Implement the smallest viable bridge on the consumer side only:
+
+1. Add `PLMAdapter.getReleaseReadiness(itemId, options)` in `yuantus` mode.
+2. Add `release_readiness` to `POST /api/federation/plm/query`.
+3. Advertise `release_readiness` in PLM supported operations.
+4. Keep Yuantus unchanged because the provider API already exists.
+
+This intentionally does **not** create a new dedicated route. It extends the
+existing federation query surface, which keeps the API model aligned with the
+rest of the PLM bridge.
+
+## Response Shape
+
+Federation now returns:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "productId": "prod-1001",
+    "item_id": "prod-1001",
+    "generated_at": "2026-04-11T00:00:00.000Z",
+    "ruleset_id": "readiness",
+    "summary": {
+      "ok": false,
+      "resources": 3,
+      "ok_resources": 2,
+      "error_count": 1,
+      "warning_count": 1,
+      "by_kind": {
+        "mbom": {
+          "resources": 1,
+          "ok_resources": 0,
+          "error_count": 1,
+          "warning_count": 0
+        }
+      }
+    },
+    "resources": [],
+    "links": {
+      "summary": "/api/v1/release-readiness/items/prod-1001?ruleset_id=readiness",
+      "export": "/api/v1/release-readiness/items/prod-1001/export?export_format=zip&ruleset_id=readiness"
+    }
+  }
+}
+```
+
+Key choice:
+
+- preserve Yuantus fields such as `item_id`, `ruleset_id`, `summary`, and
+  `resources`
+- add `productId` at the federation layer for consistency with existing PLM
+  query responses
+- surface canonical Yuantus links so the caller can deep-link or export
+
+## Why This Slice
+
+This was the next highest-leverage slice because:
+
+- it uses an already deployed Yuantus API rather than inventing a new one
+- it closes a real governance gap instead of extending already-covered Pact
+  surfaces
+- it is small enough to land in one consumer-side change set
+- it gives Metasheet a direct answer to the most important downstream question:
+  “is this object ready to release?”
+
+## Files Changed
+
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts`
+- `packages/core-backend/src/routes/federation.ts`
+- `packages/core-backend/tests/fixtures/federation/contracts.ts`
+- `packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts`
+- `packages/core-backend/tests/unit/federation.contract.test.ts`
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --dir packages/core-backend exec vitest run \
+  tests/unit/plm-adapter-yuantus.test.ts \
+  tests/unit/federation.contract.test.ts \
+  --reporter=dot
+
+pnpm --dir packages/core-backend test:contract
+```
+
+Observed results:
+
+- targeted unit tests: `30 passed`
+- contract tests: `16 passed`
+
+## Deferred
+
+This bridge is intentionally **not** added to Pact yet.
+
+Reason:
+
+- current Pact scope protects the established mainline surfaces up through the
+  existing Wave 5 set
+- `release_readiness` is now a real federation surface, but the right next step
+  is to let the consumer call pattern settle and then add a targeted Pact
+  interaction, not to expand Pact speculatively
+
+The likely next contract step is a small follow-up Wave that locks:
+
+- `GET /api/v1/release-readiness/items/{item_id}`
+
+once the federation/UI caller becomes part of the stable mainline workflow.

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -579,6 +579,42 @@ interface YuantusReleaseReadinessResponse {
   esign_manifest?: Record<string, unknown> | null
 }
 
+const LEGACY_SUPPORTED_OPERATIONS = [
+  'products',
+  'bom',
+  'documents',
+  'approvals',
+  'details',
+]
+
+const YUANTUS_SUPPORTED_OPERATIONS = [
+  'products',
+  'bom',
+  'documents',
+  'details',
+  'release_readiness',
+  'approvals',
+  'approval_history',
+  'drawings',
+  'where_used',
+  'bom_compare',
+  'bom_compare_schema',
+  'substitutes',
+  'substitutes_add',
+  'substitutes_remove',
+  'approval_approve',
+  'approval_reject',
+  'cad_properties',
+  'cad_view_state',
+  'cad_review',
+  'cad_history',
+  'cad_diff',
+  'cad_mesh_stats',
+  'cad_properties_update',
+  'cad_view_state_update',
+  'cad_review_update',
+]
+
 export class PLMAdapter extends HTTPAdapter {
   private mockMode = false;
   private apiMode: PLMApiMode = 'legacy';
@@ -854,6 +890,33 @@ export class PLMAdapter extends HTTPAdapter {
   private documentsPath(): string { return this.withTrailingSlash('/api/documents') }
   private drawingsPath(): string { return this.withTrailingSlash('/api/drawings') }
   private approvalsBasePath(): string { return this.withTrailingSlash('/api/approvals') }
+
+  getRuntimeStatus() {
+    const configuredBaseUrl = String(
+      this.config.connection.baseURL ||
+      this.config.connection.url ||
+      process.env.PLM_BASE_URL ||
+      process.env.PLM_URL ||
+      ''
+    )
+    const runtimeApiMode = this.resolveApiMode(
+      this.apiMode,
+      this.config.connection.headers as Record<string, string> | undefined,
+      process.env.PLM_TENANT_ID,
+      process.env.PLM_ORG_ID
+    )
+
+    return {
+      id: 'plm',
+      implementation: 'real' as const,
+      configured: this.mockMode || configuredBaseUrl.length > 0,
+      connected: this.isConnected(),
+      healthSupported: true,
+      supportedOperations: this.mockMode || runtimeApiMode === 'yuantus'
+        ? [...YUANTUS_SUPPORTED_OPERATIONS]
+        : [...LEGACY_SUPPORTED_OPERATIONS],
+    }
+  }
 
   async healthCheck(): Promise<boolean> {
     if (this.mockMode) return true;

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -264,6 +264,57 @@ export interface PLMDocument {
   updated_at: string
 }
 
+export interface ReleaseReadinessKindSummary {
+  resources: number
+  ok_resources: number
+  error_count: number
+  warning_count: number
+}
+
+export interface ReleaseReadinessSummary {
+  ok: boolean
+  resources: number
+  ok_resources: number
+  error_count: number
+  warning_count: number
+  by_kind: Record<string, ReleaseReadinessKindSummary>
+}
+
+export interface ReleaseReadinessIssue {
+  code?: string
+  message?: string
+  severity?: string
+}
+
+export interface ReleaseReadinessDiagnostics {
+  ok: boolean
+  resource_type: string
+  resource_id: string
+  ruleset_id: string
+  errors: ReleaseReadinessIssue[]
+  warnings: ReleaseReadinessIssue[]
+}
+
+export interface ReleaseReadinessResource {
+  kind: string
+  name?: string | null
+  state?: string | null
+  diagnostics: ReleaseReadinessDiagnostics
+}
+
+export interface ReleaseReadinessResponse {
+  item_id: string
+  generated_at: string
+  ruleset_id: string
+  summary: ReleaseReadinessSummary
+  resources: ReleaseReadinessResource[]
+  esign_manifest?: Record<string, unknown> | null
+  links?: {
+    summary: string
+    export: string
+  }
+}
+
 export interface CadPropertiesResponse {
   file_id: string
   properties: Record<string, unknown>
@@ -342,6 +393,13 @@ export interface DocumentQueryOptions {
   offset?: number
   role?: string
   includeMetadata?: boolean
+}
+
+export interface ReleaseReadinessQueryOptions {
+  rulesetId?: string
+  mbomLimit?: number
+  routingLimit?: number
+  baselineLimit?: number
 }
 
 type PLMApiMode = 'legacy' | 'yuantus'
@@ -486,6 +544,39 @@ interface YuantusEcoApprovalRecord {
   comment?: string | null
   approved_at?: string | null
   created_at?: string | null
+}
+
+interface YuantusReleaseReadinessResponse {
+  item_id?: string
+  generated_at?: string
+  ruleset_id?: string
+  summary?: {
+    ok?: boolean
+    resources?: number
+    ok_resources?: number
+    error_count?: number
+    warning_count?: number
+    by_kind?: Record<string, {
+      resources?: number
+      ok_resources?: number
+      error_count?: number
+      warning_count?: number
+    }>
+  }
+  resources?: Array<{
+    kind?: string
+    name?: string | null
+    state?: string | null
+    diagnostics?: {
+      ok?: boolean
+      resource_type?: string
+      resource_id?: string
+      ruleset_id?: string
+      errors?: ReleaseReadinessIssue[]
+      warnings?: ReleaseReadinessIssue[]
+    }
+  }>
+  esign_manifest?: Record<string, unknown> | null
 }
 
 export class PLMAdapter extends HTTPAdapter {
@@ -1271,6 +1362,61 @@ export class PLMAdapter extends HTTPAdapter {
     }
   }
 
+  private mapYuantusReleaseReadiness(
+    itemId: string,
+    entry: YuantusReleaseReadinessResponse,
+    options?: ReleaseReadinessQueryOptions
+  ): ReleaseReadinessResponse {
+    const rulesetId = String(entry.ruleset_id || options?.rulesetId || 'readiness')
+    const byKind = Object.fromEntries(
+      Object.entries(entry.summary?.by_kind || {}).map(([kind, value]) => [
+        kind,
+        {
+          resources: this.toNumber(value?.resources, 0),
+          ok_resources: this.toNumber(value?.ok_resources, 0),
+          error_count: this.toNumber(value?.error_count, 0),
+          warning_count: this.toNumber(value?.warning_count, 0),
+        },
+      ]),
+    )
+    const summary: ReleaseReadinessSummary = {
+      ok: Boolean(entry.summary?.ok),
+      resources: this.toNumber(entry.summary?.resources, 0),
+      ok_resources: this.toNumber(entry.summary?.ok_resources, 0),
+      error_count: this.toNumber(entry.summary?.error_count, 0),
+      warning_count: this.toNumber(entry.summary?.warning_count, 0),
+      by_kind: byKind,
+    }
+    const resources = Array.isArray(entry.resources)
+      ? entry.resources.map((resource) => ({
+          kind: String(resource.kind || 'unknown'),
+          name: resource.name ?? null,
+          state: resource.state ?? null,
+          diagnostics: {
+            ok: Boolean(resource.diagnostics?.ok),
+            resource_type: String(resource.diagnostics?.resource_type || 'unknown'),
+            resource_id: String(resource.diagnostics?.resource_id || ''),
+            ruleset_id: String(resource.diagnostics?.ruleset_id || rulesetId),
+            errors: Array.isArray(resource.diagnostics?.errors) ? resource.diagnostics!.errors : [],
+            warnings: Array.isArray(resource.diagnostics?.warnings) ? resource.diagnostics!.warnings : [],
+          },
+        }))
+      : []
+
+    return {
+      item_id: String(entry.item_id || itemId),
+      generated_at: this.toIsoString(entry.generated_at) || new Date().toISOString(),
+      ruleset_id: rulesetId,
+      summary,
+      resources,
+      esign_manifest: entry.esign_manifest ?? null,
+      links: {
+        summary: `/api/v1/release-readiness/items/${encodeURIComponent(String(entry.item_id || itemId))}?ruleset_id=${encodeURIComponent(rulesetId)}`,
+        export: `/api/v1/release-readiness/items/${encodeURIComponent(String(entry.item_id || itemId))}/export?export_format=zip&ruleset_id=${encodeURIComponent(rulesetId)}`,
+      },
+    }
+  }
+
   private async fetchYuantusFileMetadata(fileId: string): Promise<YuantusFileMetadata | null> {
     if (!fileId) return null
     try {
@@ -1474,6 +1620,63 @@ export class PLMAdapter extends HTTPAdapter {
     return {
       data: mapped,
       metadata: result.metadata,
+      error: result.error,
+    }
+  }
+
+  async getReleaseReadiness(
+    itemId: string,
+    options?: ReleaseReadinessQueryOptions
+  ): Promise<QueryResult<ReleaseReadinessResponse>> {
+    if (this.mockMode) {
+      const rulesetId = options?.rulesetId || 'readiness'
+      return {
+        data: [{
+          item_id: itemId,
+          generated_at: new Date().toISOString(),
+          ruleset_id: rulesetId,
+          summary: {
+            ok: true,
+            resources: 0,
+            ok_resources: 0,
+            error_count: 0,
+            warning_count: 0,
+            by_kind: {},
+          },
+          resources: [],
+          esign_manifest: null,
+          links: {
+            summary: `/api/v1/release-readiness/items/${encodeURIComponent(itemId)}?ruleset_id=${encodeURIComponent(rulesetId)}`,
+            export: `/api/v1/release-readiness/items/${encodeURIComponent(itemId)}/export?export_format=zip&ruleset_id=${encodeURIComponent(rulesetId)}`,
+          },
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Release readiness is not supported for this PLM API mode') }
+    }
+
+    const params: Record<string, unknown> = {}
+    if (options?.rulesetId) params.ruleset_id = options.rulesetId
+    if (typeof options?.mbomLimit === 'number') params.mbom_limit = options.mbomLimit
+    if (typeof options?.routingLimit === 'number') params.routing_limit = options.routingLimit
+    if (typeof options?.baselineLimit === 'number') params.baseline_limit = options.baselineLimit
+
+    const result = await this.query<YuantusReleaseReadinessResponse>(`/api/v1/release-readiness/items/${itemId}`, [params])
+    const entry = result.data[0]
+    if (!entry) {
+      return {
+        data: [],
+        metadata: { totalCount: 0 },
+        error: result.error,
+      }
+    }
+
+    return {
+      data: [this.mapYuantusReleaseReadiness(itemId, entry, options)],
+      metadata: { totalCount: 1 },
       error: result.error,
     }
   }

--- a/packages/core-backend/src/routes/federation.ts
+++ b/packages/core-backend/src/routes/federation.ts
@@ -1289,6 +1289,11 @@ export function federationRouter(injector?: Injector): Router {
                     by_kind: {},
                   },
                   resources: [],
+                  esign_manifest: null,
+                  links: {
+                    summary: `/api/v1/release-readiness/items/${encodeURIComponent(resolvedProductId)}?ruleset_id=${encodeURIComponent(rulesetId || 'readiness')}`,
+                    export: `/api/v1/release-readiness/items/${encodeURIComponent(resolvedProductId)}/export?export_format=zip&ruleset_id=${encodeURIComponent(rulesetId || 'readiness')}`,
+                  },
                 }),
               },
             })

--- a/packages/core-backend/src/routes/federation.ts
+++ b/packages/core-backend/src/routes/federation.ts
@@ -141,6 +141,7 @@ const PLMQuerySchema = z.object({
     'products',
     'bom',
     'documents',
+    'release_readiness',
     'approvals',
     'approval_history',
     'bom_compare',
@@ -1234,6 +1235,61 @@ export function federationRouter(injector?: Injector): Router {
                 limit: pagination?.limit ?? 100,
                 offset: pagination?.offset ?? 0,
                 ...(result.metadata?.sources ? { sources: result.metadata.sources } : {}),
+              },
+            })
+          }
+
+          if (operation === 'release_readiness') {
+            const resolvedProductId = productId
+              || toStringParam(filterParams.product_id ?? filterParams.productId)
+            if (!resolvedProductId) {
+              return res.status(400).json({
+                ok: false,
+                error: {
+                  code: 'VALIDATION_ERROR',
+                  message: 'productId is required for release_readiness',
+                },
+              })
+            }
+
+            const rulesetId = toStringParam(filterParams.ruleset_id ?? filterParams.rulesetId)
+            const mbomLimit = toNumberParam(filterParams.mbom_limit ?? filterParams.mbomLimit)
+            const routingLimit = toNumberParam(filterParams.routing_limit ?? filterParams.routingLimit)
+            const baselineLimit = toNumberParam(filterParams.baseline_limit ?? filterParams.baselineLimit)
+
+            const result = await adapter.getReleaseReadiness(resolvedProductId, {
+              rulesetId,
+              mbomLimit,
+              routingLimit,
+              baselineLimit,
+            })
+            if (sendAdapterError(res, result.error, 'Failed to query release readiness', metrics, 'POST', `/plm/${operation}`, startTime)) {
+              return
+            }
+
+            metrics.recordRequest(
+              { adapter: 'plm', method: 'POST', endpoint: `/plm/${operation}`, status: '200' },
+              Date.now() - startTime
+            )
+
+            return res.json({
+              ok: true,
+              data: {
+                productId: resolvedProductId,
+                ...(result.data[0] ?? {
+                  item_id: resolvedProductId,
+                  generated_at: new Date().toISOString(),
+                  ruleset_id: rulesetId || 'readiness',
+                  summary: {
+                    ok: false,
+                    resources: 0,
+                    ok_resources: 0,
+                    error_count: 0,
+                    warning_count: 0,
+                    by_kind: {},
+                  },
+                  resources: [],
+                }),
               },
             })
           }
@@ -2664,6 +2720,7 @@ function getDefaultCapabilities(type: 'plm' | 'athena'): string[] {
       'products',
       'bom',
       'documents',
+      'release_readiness',
       'approvals',
       'approval_history',
       'drawings',
@@ -2934,6 +2991,36 @@ function getMockPLMData(
           { id: 'doc-2', name: 'Drawing.dwg', type: 'drawing' },
         ],
         total: 2,
+      }
+    case 'release_readiness':
+      {
+        const resolvedProductId = productId || 'prod-1'
+        return {
+          productId: resolvedProductId,
+          item_id: resolvedProductId,
+          generated_at: new Date().toISOString(),
+          ruleset_id: 'readiness',
+          summary: {
+            ok: true,
+            resources: 1,
+            ok_resources: 1,
+            error_count: 0,
+            warning_count: 0,
+            by_kind: {
+              item: {
+                resources: 1,
+                ok_resources: 1,
+                error_count: 0,
+                warning_count: 0,
+              },
+            },
+          },
+          resources: [],
+          links: {
+            summary: `/api/v1/release-readiness/items/${resolvedProductId}?ruleset_id=readiness`,
+            export: `/api/v1/release-readiness/items/${resolvedProductId}/export?export_format=zip&ruleset_id=readiness`,
+          },
+        }
       }
     case 'approvals':
       return {

--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -20,10 +20,11 @@ when running in `apiMode='yuantus'`. Without a contract test, any field
 rename on the Yuantus side would silently break Metasheet at runtime.
 
 This Pact set freezes the **shape** (not the values) of the 6 Wave 1 P0
-endpoints plus the 3 document-semantics endpoints, the 5 BOM-analysis /
-ECO-approval endpoints, and the 5 approval-detail / BOM-substitute endpoints,
-while Wave 5 adds the 9 CAD properties / review / diff endpoints as exact
-fixture examples that `PLMAdapter.ts` currently calls for `apiMode='yuantus'`.
+endpoints plus the 3 document-semantics endpoints, the release-readiness
+governance endpoint, the 5 BOM-analysis / ECO-approval endpoints, and the 5
+approval-detail / BOM-substitute endpoints, while Wave 5 adds the 9 CAD
+properties / review / diff endpoints as exact fixture examples that
+`PLMAdapter.ts` currently calls for `apiMode='yuantus'`.
 (Codex's PACT_FIRST plan lists 7 endpoints in Wave 1 — see "Discrepancy
 with codex plan" below.)
 
@@ -39,7 +40,7 @@ because adding that npm dependency requires explicit approval.
 The `plm-adapter-yuantus.pact.test.ts` vitest test guards six things:
 
 1. The pact JSON exists and parses as Pact v3.
-2. It contains the 28 currently used interactions in the documented order.
+2. It contains the 29 currently used interactions in the documented order.
 3. Every endpoint named in the pact is also referenced by the live
    `packages/core-backend/src/data-adapters/PLMAdapter.ts` source — so the
    pact cannot drift away from what the adapter actually calls.
@@ -47,7 +48,9 @@ The `plm-adapter-yuantus.pact.test.ts` vitest test guards six things:
    `bom compare schema`, `approval history`, `approve`, and `reject`.
 5. The Wave 4 additions lock the exact envelope for approval list/detail and
    BOM substitute list/add/remove.
-6. The Wave 5 additions lock the exact envelope for CAD properties, CAD view
+6. The release-readiness addition locks the exact envelope for
+   `GET /api/v1/release-readiness/items/{id}`.
+7. The Wave 5 additions lock the exact envelope for CAD properties, CAD view
    state, CAD review, CAD history, CAD diff, and CAD mesh stats.
 
 ## Discrepancy with codex's PACT_FIRST plan
@@ -103,7 +106,7 @@ cd /Users/huazhou/Downloads/Github/Yuantus
 
 ### Current verifier handoff state (2026-04-11)
 
-The consumer artifact now contains all 28 Wave 1-5 interactions. To verify
+The consumer artifact now contains all 29 Wave 1-5 interactions. To verify
 Yuantus against the current artifact, copy this JSON into the Yuantus repo and
 rerun the provider verifier there.
 

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -9,7 +9,7 @@
     "pactSpecification": {
       "version": "3.0.0"
     },
-    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute. Wave 5 adds the nine CAD endpoints already called on main: CAD properties, CAD view state, CAD review, CAD history, CAD diff, and CAD mesh stats."
+    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute. Wave 5 adds the nine CAD endpoints already called on main: CAD properties, CAD view state, CAD review, CAD history, CAD diff, and CAD mesh stats. Release-readiness adds the governance drilldown endpoint already called on main: GET /api/v1/release-readiness/items/{item_id}."
   },
   "interactions": [
     {
@@ -1449,6 +1449,153 @@
               ]
             },
             "$.has_more": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "load release readiness diagnostics for a governed Part",
+      "providerStates": [
+        {
+          "name": "an admin user can load release readiness for item 01H000000000000000000000P1"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/release-readiness/items/01H000000000000000000000P1",
+        "query": {
+          "ruleset_id": [
+            "gate-a"
+          ],
+          "mbom_limit": [
+            "10"
+          ],
+          "routing_limit": [
+            "12"
+          ],
+          "baseline_limit": [
+            "8"
+          ]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "item_id": "01H000000000000000000000P1",
+          "generated_at": "2026-04-11T00:00:00.000000Z",
+          "ruleset_id": "gate-a",
+          "summary": {
+            "ok": true,
+            "resources": 0,
+            "ok_resources": 0,
+            "error_count": 0,
+            "warning_count": 0,
+            "by_kind": {}
+          },
+          "resources": [],
+          "esign_manifest": null
+        },
+        "matchingRules": {
+          "body": {
+            "$.item_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.generated_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.ruleset_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.summary.ok": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.summary.resources": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.summary.ok_resources": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.summary.error_count": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.summary.warning_count": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.summary.by_kind": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.resources": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.esign_manifest": {
               "matchers": [
                 {
                   "match": "type"

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -11,10 +11,11 @@
  *
  *   1. The pact JSON exists and parses as Pact v3.
  *   2. The 6 Wave 1 P0 interactions plus the document-semantics Wave 2
- *      interactions plus the BOM-analysis / ECO-approval Wave 3 interactions
- *      plus the approval list/detail / BOM-substitute Wave 4 interactions
- *      plus the CAD review/workspace Wave 5 interactions that PLMAdapter
- *      currently calls are present, in the documented order.
+ *      interactions plus the release-readiness governance interaction plus
+ *      the BOM-analysis / ECO-approval Wave 3 interactions plus the approval
+ *      list/detail / BOM-substitute Wave 4 interactions plus the CAD
+ *      review/workspace Wave 5 interactions that PLMAdapter currently calls
+ *      are present, in the documented order.
  *      (codex's plan also lists `aml/metadata`, but PLMAdapter does not yet
  *      call it; deferred until there is a real consumer call site.)
  *   3. The PLMAdapter actually calls every endpoint declared in the pact, so
@@ -92,6 +93,7 @@ const PACT_PATHS = [
   { method: 'GET', path: '/api/v1/file/item/01H000000000000000000000P1' },
   { method: 'GET', path: '/api/v1/file/01H000000000000000000000F1' },
   { method: 'POST', path: '/api/v1/aml/query' },
+  { method: 'GET', path: '/api/v1/release-readiness/items/01H000000000000000000000P1' },
   { method: 'GET', path: '/api/v1/bom/01H000000000000000000000P2/where-used' },
   { method: 'GET', path: '/api/v1/bom/compare/schema' },
   { method: 'GET', path: '/api/v1/eco/01H000000000000000000000E1/approvals' },
@@ -122,7 +124,7 @@ function loadAdapter(): string {
   return readFileSync(ADAPTER_PATH, 'utf8')
 }
 
-describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 document semantics + Wave 3 BOM/approval + Wave 4 approval list/detail/substitutes + Wave 5 CAD)', () => {
+describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 document semantics + release readiness + Wave 3 BOM/approval + Wave 4 approval list/detail/substitutes + Wave 5 CAD)', () => {
   it('pact JSON exists, parses as Pact v3, and names the right consumer/provider', () => {
     const pact = loadPact()
     expect(pact.consumer.name).toBe('Metasheet2')
@@ -165,6 +167,7 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       '/api/v1/bom/compare/schema',
       '/api/v1/file/item/',
       '/api/v1/aml/query',
+      '/api/v1/release-readiness/items/${itemId}',
       '/api/v1/eco',
       '/api/v1/eco/${approvalId}',
       '/api/v1/eco/${approvalId}/approvals',
@@ -241,6 +244,31 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(body.where).toEqual({ id: '01H000000000000000000000P1' })
     expect(body.expand).toEqual(['Document Part'])
     expect(body.page_size).toBe(1)
+  })
+
+  it('release-readiness interaction locks the governance drilldown envelope used by federation', () => {
+    const pact = loadPact()
+    const readiness = pact.interactions.find(
+      i => i.request.path === '/api/v1/release-readiness/items/01H000000000000000000000P1',
+    )
+
+    expect(readiness).toBeDefined()
+    expect(readiness!.request.query).toEqual({
+      ruleset_id: ['gate-a'],
+      mbom_limit: ['10'],
+      routing_limit: ['12'],
+      baseline_limit: ['8'],
+    })
+    expect(readiness!.response.body).toMatchObject({
+      item_id: '01H000000000000000000000P1',
+      ruleset_id: 'gate-a',
+      summary: {
+        ok: expect.any(Boolean),
+        resources: expect.any(Number),
+        error_count: expect.any(Number),
+      },
+      resources: expect.any(Array),
+    })
   })
 
   it('where-used and compare-schema interactions lock the BOM analysis surfaces consumed on mainline', () => {

--- a/packages/core-backend/tests/fixtures/federation/contracts.ts
+++ b/packages/core-backend/tests/fixtures/federation/contracts.ts
@@ -35,6 +35,45 @@ export const plmContractFixtures = {
     updated_at: '2026-03-02T00:00:00.000Z',
     itemType: 'Part',
   },
+  releaseReadiness: {
+    item_id: 'prod-1001',
+    generated_at: '2026-03-05T00:00:00.000Z',
+    ruleset_id: 'readiness',
+    summary: {
+      ok: false,
+      resources: 3,
+      ok_resources: 2,
+      error_count: 1,
+      warning_count: 1,
+      by_kind: {
+        mbom: {
+          resources: 1,
+          ok_resources: 0,
+          error_count: 1,
+          warning_count: 0,
+        },
+      },
+    },
+    resources: [
+      {
+        kind: 'mbom',
+        name: 'MBOM Alignment',
+        state: 'warning',
+        diagnostics: {
+          ok: false,
+          resource_type: 'mbom',
+          resource_id: 'mbom-1',
+          ruleset_id: 'readiness',
+          errors: [{ code: 'MBOM_MISSING', message: 'MBOM baseline missing', severity: 'error' }],
+          warnings: [{ code: 'ALT_ROUTE', message: 'Alternate route incomplete', severity: 'warning' }],
+        },
+      },
+    ],
+    links: {
+      summary: '/api/v1/release-readiness/items/prod-1001?ruleset_id=readiness',
+      export: '/api/v1/release-readiness/items/prod-1001/export?export_format=zip&ruleset_id=readiness',
+    },
+  },
   approvals: [
     {
       id: 'eco-1',

--- a/packages/core-backend/tests/unit/federation.contract.test.ts
+++ b/packages/core-backend/tests/unit/federation.contract.test.ts
@@ -330,6 +330,47 @@ describe('Federation contract routes', () => {
     expect(bomCompareResponse.body.data).toEqual(plmContractFixtures.bomCompare)
   })
 
+  it('normalizes empty release readiness results into the canonical federation shape', async () => {
+    const plmAdapter = createPlmAdapterMock()
+    plmAdapter.getReleaseReadiness.mockResolvedValueOnce({
+      data: [],
+      metadata: { totalCount: 0 },
+    })
+    const app = createFederationApp({ plmAdapter })
+
+    const response = await request(app)
+      .post('/api/federation/plm/query')
+      .send({
+        operation: 'release_readiness',
+        productId: 'prod-empty',
+        filters: {
+          rulesetId: 'gate-empty',
+        },
+      })
+      .expect(200)
+
+    expect(response.body.data).toEqual({
+      productId: 'prod-empty',
+      item_id: 'prod-empty',
+      generated_at: expect.any(String),
+      ruleset_id: 'gate-empty',
+      summary: {
+        ok: false,
+        resources: 0,
+        ok_resources: 0,
+        error_count: 0,
+        warning_count: 0,
+        by_kind: {},
+      },
+      resources: [],
+      esign_manifest: null,
+      links: {
+        summary: '/api/v1/release-readiness/items/prod-empty?ruleset_id=gate-empty',
+        export: '/api/v1/release-readiness/items/prod-empty/export?export_format=zip&ruleset_id=gate-empty',
+      },
+    })
+  })
+
   it('supports PLM mutation contracts for substitute add and versioned approval actions', async () => {
     const plmAdapter = createPlmAdapterMock()
     const app = createFederationApp({ plmAdapter })

--- a/packages/core-backend/tests/unit/federation.contract.test.ts
+++ b/packages/core-backend/tests/unit/federation.contract.test.ts
@@ -60,7 +60,7 @@ function createPlmAdapterMock(runtimeStatus: RuntimeStatus = {}) {
     getRuntimeStatus: vi.fn(() => ({
       configured: runtimeStatus.configured ?? true,
       healthSupported: runtimeStatus.healthSupported ?? true,
-      supportedOperations: runtimeStatus.supportedOperations ?? ['products', 'bom', 'approvals', 'approval_history', 'bom_compare', 'substitutes_add', 'details'],
+      supportedOperations: runtimeStatus.supportedOperations ?? ['products', 'bom', 'documents', 'release_readiness', 'approvals', 'approval_history', 'bom_compare', 'substitutes_add', 'details'],
       ...(runtimeStatus.implementation ? { implementation: runtimeStatus.implementation } : {}),
     })),
     getProducts: vi.fn(async () => ({
@@ -72,6 +72,10 @@ function createPlmAdapterMock(runtimeStatus: RuntimeStatus = {}) {
       metadata: { totalCount: plmContractFixtures.bom.length },
     })),
     getProductById: vi.fn(async () => plmContractFixtures.productDetail),
+    getReleaseReadiness: vi.fn(async () => ({
+      data: [plmContractFixtures.releaseReadiness],
+      metadata: { totalCount: 1 },
+    })),
     getApprovalHistory: vi.fn(async () => ({
       data: plmContractFixtures.approvalHistory,
       metadata: { totalCount: plmContractFixtures.approvalHistory.length },
@@ -214,7 +218,7 @@ describe('Federation contract routes', () => {
     })
   })
 
-  it('supports PLM query contracts for products, approval history, and BOM compare', async () => {
+  it('supports PLM query contracts for products, release readiness, approval history, and BOM compare', async () => {
     const plmAdapter = createPlmAdapterMock()
     const app = createFederationApp({ plmAdapter })
 
@@ -246,6 +250,41 @@ describe('Federation contract routes', () => {
       limit: 25,
       offset: 10,
     })
+
+    const releaseReadinessResponse = await request(app)
+      .post('/api/federation/plm/query')
+      .send({
+        operation: 'release_readiness',
+        productId: 'prod-1001',
+        filters: {
+          rulesetId: 'gate-a',
+          mbomLimit: 10,
+          routingLimit: 12,
+          baselineLimit: 8,
+        },
+      })
+      .expect(200)
+
+    expect(plmAdapter.getReleaseReadiness).toHaveBeenCalledWith('prod-1001', {
+      rulesetId: 'gate-a',
+      mbomLimit: 10,
+      routingLimit: 12,
+      baselineLimit: 8,
+    })
+    expect(releaseReadinessResponse.body.data).toEqual(
+      expect.objectContaining({
+        productId: 'prod-1001',
+        item_id: 'prod-1001',
+        ruleset_id: 'readiness',
+        summary: expect.objectContaining({
+          ok: false,
+          error_count: 1,
+        }),
+        links: expect.objectContaining({
+          summary: '/api/v1/release-readiness/items/prod-1001?ruleset_id=readiness',
+        }),
+      }),
+    )
 
     const approvalHistoryResponse = await request(app)
       .post('/api/federation/plm/query')

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -830,6 +830,96 @@ describe('PLMAdapter Yuantus CAD routes', () => {
   })
 })
 
+describe('PLMAdapter Yuantus release readiness mapping', () => {
+  it('maps release readiness summary/resources and adds canonical links', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [{
+        item_id: 'item-rr-1',
+        generated_at: '2026-04-11T00:00:00.000Z',
+        ruleset_id: 'gate-a',
+        summary: {
+          ok: false,
+          resources: 3,
+          ok_resources: 2,
+          error_count: 1,
+          warning_count: 1,
+          by_kind: {
+            mbom: {
+              resources: 1,
+              ok_resources: 0,
+              error_count: 1,
+              warning_count: 0,
+            },
+          },
+        },
+        resources: [{
+          kind: 'mbom',
+          name: 'MBOM Alignment',
+          state: 'warning',
+          diagnostics: {
+            ok: false,
+            resource_type: 'mbom',
+            resource_id: 'mbom-1',
+            ruleset_id: 'gate-a',
+            errors: [{ code: 'MBOM_MISSING', message: 'MBOM baseline missing', severity: 'error' }],
+            warnings: [{ code: 'ALT_ROUTE', message: 'Alternate route incomplete', severity: 'warning' }],
+          },
+        }],
+        esign_manifest: { pending: 1 },
+      }],
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getReleaseReadiness('item-rr-1', {
+      rulesetId: 'gate-a',
+      mbomLimit: 10,
+      routingLimit: 12,
+      baselineLimit: 8,
+    })
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/release-readiness/items/item-rr-1', [
+      {
+        ruleset_id: 'gate-a',
+        mbom_limit: 10,
+        routing_limit: 12,
+        baseline_limit: 8,
+      },
+    ])
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]).toMatchObject({
+      item_id: 'item-rr-1',
+      ruleset_id: 'gate-a',
+      summary: {
+        ok: false,
+        error_count: 1,
+        by_kind: {
+          mbom: {
+            resources: 1,
+            error_count: 1,
+          },
+        },
+      },
+      resources: [
+        expect.objectContaining({
+          kind: 'mbom',
+          diagnostics: expect.objectContaining({
+            resource_type: 'mbom',
+            resource_id: 'mbom-1',
+            ruleset_id: 'gate-a',
+          }),
+        }),
+      ],
+      links: {
+        summary: '/api/v1/release-readiness/items/item-rr-1?ruleset_id=gate-a',
+        export: '/api/v1/release-readiness/items/item-rr-1/export?export_format=zip&ruleset_id=gate-a',
+      },
+      esign_manifest: { pending: 1 },
+    })
+  })
+})
+
 describe('PLMAdapter Yuantus documents single-side failure + sources metadata', () => {
   it('returns AML related documents when file/item endpoint errors, with sources showing degradation', async () => {
     const adapter = createAdapter()

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -11,6 +11,32 @@ const createAdapter = () => {
   return adapter
 }
 
+describe('PLMAdapter runtime status', () => {
+  it('advertises release readiness in yuantus mode', () => {
+    const adapter = createAdapter()
+
+    expect(adapter.getRuntimeStatus()).toMatchObject({
+      implementation: 'real',
+      healthSupported: true,
+    })
+    expect(adapter.getRuntimeStatus().supportedOperations).toContain('release_readiness')
+    expect(adapter.getRuntimeStatus().supportedOperations).toContain('approval_history')
+  })
+
+  it('hides yuantus-only capabilities in legacy mode', () => {
+    const adapter = createAdapter()
+    ;(adapter as any).apiMode = 'legacy'
+
+    expect(adapter.getRuntimeStatus().supportedOperations).toEqual(
+      expect.arrayContaining(['products', 'bom', 'documents', 'approvals'])
+    )
+    expect(adapter.getRuntimeStatus().supportedOperations).not.toContain('release_readiness')
+    expect(adapter.getRuntimeStatus().supportedOperations).not.toContain('approval_history')
+    expect(adapter.getRuntimeStatus().supportedOperations).not.toContain('where_used')
+    expect(adapter.getRuntimeStatus().supportedOperations).not.toContain('cad_properties')
+  })
+})
+
 describe('PLMAdapter Yuantus product detail mapping', () => {
   it('merges search hit timestamps when AML detail lacks them', async () => {
     const adapter = createAdapter()
@@ -918,6 +944,7 @@ describe('PLMAdapter Yuantus release readiness mapping', () => {
       esign_manifest: { pending: 1 },
     })
   })
+
 })
 
 describe('PLMAdapter Yuantus documents single-side failure + sources metadata', () => {


### PR DESCRIPTION
## Summary
- add a Yuantus-mode `getReleaseReadiness()` adapter method for the existing `/api/v1/release-readiness/items/{id}` provider API
- expose a new `release_readiness` operation on `POST /api/federation/plm/query`
- advertise the new capability, add mock coverage, and land targeted unit tests plus a design/verification note

## Why
- Yuantus already exposes release-readiness in real API + native workspace flows
- Metasheet federation had no way to surface that governance result
- this lands the smallest real bridge without inventing a new route or changing the provider

## Verification
- pnpm --dir packages/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts tests/unit/federation.contract.test.ts --reporter=dot
- pnpm --dir packages/core-backend test:contract