### PR TITLE
feat(approvals): add template runtime executor

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260411123000_add_created_action_to_approval_records.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260411123000_add_created_action_to_approval_records.ts
@@ -1,0 +1,16 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc'))`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (action IN ('approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc'))`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -940,7 +940,7 @@ export interface ApprovalInstancesTable {
 export interface ApprovalRecordsTable {
   id: Generated<number>
   instance_id: string
-  action: 'approve' | 'reject' | 'return' | 'revoke' | 'transfer' | 'sign' | 'comment' | 'cc'
+  action: 'created' | 'approve' | 'reject' | 'return' | 'revoke' | 'transfer' | 'sign' | 'comment' | 'cc'
   actor_id: string
   actor_name: string | null
   comment: string | null

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -14,6 +14,7 @@ import { pool } from '../db/pg'
 import { authenticate } from '../middleware/auth'
 import { REFUND_WORKFLOW_KEY, type AfterSalesApprovalBridgeService } from '../services/AfterSalesApprovalBridgeService'
 import { ApprovalBridgeService, ServiceError } from '../services/ApprovalBridgeService'
+import { ApprovalProductService, resolveApprovalListPaging } from '../services/ApprovalProductService'
 import {
   APPROVAL_ERROR_CODES,
   type ApprovalBridgePlmAdapter,
@@ -88,6 +89,12 @@ function resolveApprovalActorName(req: Request, fallbackId: string): string {
   return normalized.length > 0 ? normalized : fallbackId
 }
 
+function resolveApprovalActorRoles(req: Request): string[] {
+  return Array.isArray(req.user?.roles)
+    ? req.user!.roles.filter((role): role is string => typeof role === 'string' && role.trim().length > 0)
+    : []
+}
+
 function approvalVersionConflictResponse(currentVersion: number) {
   return {
     ok: false,
@@ -133,6 +140,10 @@ function getBridgeService(options?: ApprovalRouterOptions): ApprovalBridgeServic
   return new ApprovalBridgeService(resolvePlmAdapter(options))
 }
 
+function getProductService(): ApprovalProductService {
+  return new ApprovalProductService()
+}
+
 function handleApprovalsError(
   res: Response,
   error: unknown,
@@ -159,6 +170,68 @@ function handleApprovalsError(
 
 export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   const r = Router()
+  const productService = getProductService()
+
+  r.get('/api/approval-templates', authenticate, async (req: Request, res: Response) => {
+    try {
+      const page = parsePaging(req.query.page, 1, Number.MAX_SAFE_INTEGER)
+      const pageSize = parsePaging(req.query.pageSize, 20)
+      const { limit, offset } = resolveApprovalListPaging(page, pageSize)
+      const result = await productService.listTemplates({
+        status: typeof req.query.status === 'string' ? req.query.status : undefined,
+        search: typeof req.query.search === 'string' ? req.query.search : undefined,
+        limit,
+        offset,
+      })
+
+      res.json(result)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_TEMPLATE_LIST_FAILED',
+        'Failed to list approval templates',
+      )
+    }
+  })
+
+  r.get('/api/approval-templates/:id', authenticate, async (req: Request, res: Response) => {
+    try {
+      const template = await productService.getTemplate(req.params.id)
+      if (!template) {
+        return res.status(404).json(
+          approvalErrorResponse('APPROVAL_TEMPLATE_NOT_FOUND', 'Approval template not found'),
+        )
+      }
+      res.json(template)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_TEMPLATE_FETCH_FAILED',
+        'Failed to fetch approval template',
+      )
+    }
+  })
+
+  r.get('/api/approval-templates/:id/versions/:versionId', authenticate, async (req: Request, res: Response) => {
+    try {
+      const version = await productService.getTemplateVersion(req.params.id, req.params.versionId)
+      if (!version) {
+        return res.status(404).json(
+          approvalErrorResponse('APPROVAL_TEMPLATE_VERSION_NOT_FOUND', 'Approval template version not found'),
+        )
+      }
+      res.json(version)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_TEMPLATE_VERSION_FETCH_FAILED',
+        'Failed to fetch approval template version',
+      )
+    }
+  })
 
   r.get('/api/approvals', authenticate, async (req: Request, res: Response) => {
     try {
@@ -173,8 +246,18 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       const workflowKey = typeof req.query.workflowKey === 'string' ? req.query.workflowKey : undefined
       const businessKey = typeof req.query.businessKey === 'string' ? req.query.businessKey : undefined
       const assignee = typeof req.query.assignee === 'string' ? req.query.assignee : undefined
-      const limit = parsePaging(req.query.limit, 50)
-      const offset = parsePaging(req.query.offset, 0, Number.MAX_SAFE_INTEGER)
+      const tab = typeof req.query.tab === 'string' ? req.query.tab as 'pending' | 'mine' | 'cc' | 'completed' : undefined
+      const search = typeof req.query.search === 'string' ? req.query.search : undefined
+      const page = parsePaging(req.query.page, 1, Number.MAX_SAFE_INTEGER)
+      const pageSize = parsePaging(req.query.pageSize, 20)
+      const { limit, offset } = req.query.page || req.query.pageSize
+        ? resolveApprovalListPaging(page, pageSize)
+        : {
+            limit: parsePaging(req.query.limit, 50),
+            offset: parsePaging(req.query.offset, 0, Number.MAX_SAFE_INTEGER),
+          }
+      const actorId = resolveApprovalActorId(req)
+      const actorRoles = resolveApprovalActorRoles(req)
 
       if (sourceSystem === 'plm' && assignee) {
         return res.status(400).json({
@@ -201,11 +284,15 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       }
 
       const result = await bridgeService.listApprovals({
-        sourceSystem,
+        sourceSystem: sourceSystem ?? (tab ? 'platform' : undefined),
         status,
         workflowKey,
         businessKey,
         assignee,
+        search,
+        tab,
+        actorId: actorId || undefined,
+        actorRoles,
         limit,
         offset,
       })
@@ -255,6 +342,55 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         error,
         'PLM_APPROVAL_SYNC_FAILED',
         'Failed to sync PLM approvals',
+      )
+    }
+  })
+
+  r.post('/api/approvals', authenticate, async (req: Request, res: Response) => {
+    try {
+      const userId = resolveApprovalActorId(req)
+      if (!userId) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
+
+      const templateId = typeof req.body?.templateId === 'string' ? req.body.templateId.trim() : ''
+      const formData =
+        req.body?.formData && typeof req.body.formData === 'object' && !Array.isArray(req.body.formData)
+          ? req.body.formData as Record<string, unknown>
+          : null
+
+      if (!templateId || !formData) {
+        return res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'templateId and formData are required',
+          },
+        })
+      }
+
+      const approval = await productService.createApproval(
+        { templateId, formData },
+        {
+          userId,
+          userName: resolveApprovalActorName(req, userId),
+          email: typeof req.user?.email === 'string' ? req.user.email : undefined,
+          department: typeof req.user?.department === 'string' ? req.user.department : undefined,
+          roles: resolveApprovalActorRoles(req),
+          permissions: Array.isArray(req.user?.permissions)
+            ? req.user!.permissions.filter((permission): permission is string => typeof permission === 'string')
+            : undefined,
+        },
+      )
+
+      res.status(201).json(approval)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_CREATE_FAILED',
+        'Failed to create approval request',
       )
     }
   })
@@ -330,19 +466,21 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       }
 
       const action = req.body?.action
-      if (action !== 'approve' && action !== 'reject') {
+      if (!['approve', 'reject', 'transfer', 'revoke', 'comment'].includes(String(action))) {
         return res.status(400).json({
           error: {
             code: 'VALIDATION_ERROR',
-            message: 'action must be approve or reject',
+            message: 'action must be approve, reject, transfer, revoke, or comment',
           },
         })
       }
 
       const comment = typeof req.body?.comment === 'string' ? req.body.comment : undefined
+      const targetUserId = typeof req.body?.targetUserId === 'string' ? req.body.targetUserId.trim() : undefined
       const actor = {
         userId,
         userName: resolveApprovalActorName(req, userId),
+        roles: resolveApprovalActorRoles(req),
         ip: req.ip || null,
         userAgent: req.get('user-agent') || null,
       }
@@ -358,6 +496,14 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
           existingAfterSales.sourceSystem === 'after-sales' &&
           existingAfterSales.workflowKey === REFUND_WORKFLOW_KEY
         ) {
+          if (action !== 'approve' && action !== 'reject') {
+            return res.status(400).json({
+              error: {
+                code: 'VALIDATION_ERROR',
+                message: 'after-sales approvals only support approve or reject',
+              },
+            })
+          }
           const result = await afterSalesBridge.submitRefundApprovalDecision({
             approvalId: req.params.id,
             action,
@@ -372,14 +518,38 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       }
 
       if (!approval) {
-        approval = await bridgeService.dispatchAction(
-          req.params.id,
-          {
-            action,
-            comment,
-          },
-          actor,
-        )
+        const templateRuntimeInstance = isPlmApprovalId(req.params.id)
+          ? false
+          : await productService.isTemplateRuntimeInstance(req.params.id)
+        if (templateRuntimeInstance) {
+          approval = await productService.dispatchAction(
+            req.params.id,
+            {
+              action,
+              comment,
+              targetUserId,
+            },
+            actor,
+          )
+        } else {
+          if (action !== 'approve' && action !== 'reject') {
+            return res.status(400).json({
+              error: {
+                code: 'VALIDATION_ERROR',
+                message: 'legacy approvals only support approve or reject',
+              },
+            })
+          }
+          approval = await bridgeService.dispatchAction(
+            req.params.id,
+            {
+              action,
+              comment,
+              targetUserId,
+            },
+            actor,
+          )
+        }
       }
 
       res.json(approval)

--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -125,11 +125,18 @@ function toUnifiedDTO(
     policy: row.policy_snapshot || null,
     currentStep: row.current_step,
     totalSteps: row.total_steps,
+    templateId: row.template_id,
+    templateVersionId: row.template_version_id,
+    publishedDefinitionId: row.published_definition_id,
+    requestNo: row.request_no,
+    formSnapshot: row.form_snapshot || null,
+    currentNodeKey: row.current_node_key,
     assignments: assignments.map((assignment) => ({
       id: assignment.id,
       type: assignment.assignment_type,
       assigneeId: assignment.assignee_id,
       sourceStep: assignment.source_step,
+      nodeKey: assignment.node_key,
       isActive: assignment.is_active,
       metadata: assignment.metadata || {},
     })),
@@ -242,6 +249,73 @@ export class ApprovalBridgeService {
         )`,
       )
       params.push(options.assignee)
+    }
+    if (options?.search) {
+      conditions.push(`(COALESCE(request_no, '') ILIKE $${paramIndex} OR COALESCE(title, '') ILIKE $${paramIndex})`)
+      params.push(`%${options.search}%`)
+      paramIndex += 1
+    }
+    if (options?.tab && options.actorId) {
+      const actorRoles = options.actorRoles && options.actorRoles.length > 0 ? options.actorRoles : ['__none__']
+      const actorIdParam = paramIndex++
+      params.push(options.actorId)
+      const actorRolesParam = paramIndex++
+      params.push(actorRoles)
+      conditions.push(`COALESCE(source_system, 'platform') = 'platform'`)
+
+      if (options.tab === 'pending') {
+        conditions.push(`status = 'pending'`)
+        conditions.push(
+          `id IN (
+            SELECT instance_id
+            FROM approval_assignments
+            WHERE is_active = TRUE
+              AND (
+                (assignment_type = 'user' AND assignee_id = $${actorIdParam})
+                OR (assignment_type = 'role' AND assignee_id = ANY($${actorRolesParam}))
+              )
+          )`,
+        )
+      } else if (options.tab === 'mine') {
+        conditions.push(`requester_snapshot->>'id' = $${actorIdParam}`)
+      } else if (options.tab === 'cc') {
+        conditions.push(
+          `id IN (
+            SELECT instance_id
+            FROM approval_records
+            WHERE action = 'cc'
+              AND (
+                (metadata->>'targetType' = 'user' AND metadata->>'targetId' = $${actorIdParam})
+                OR (metadata->>'targetType' = 'role' AND metadata->>'targetId' = ANY($${actorRolesParam}))
+              )
+          )`,
+        )
+      } else if (options.tab === 'completed') {
+        conditions.push(`status <> 'pending'`)
+        conditions.push(
+          `(
+            requester_snapshot->>'id' = $${actorIdParam}
+            OR id IN (
+              SELECT instance_id FROM approval_records WHERE actor_id = $${actorIdParam}
+            )
+            OR id IN (
+              SELECT instance_id
+              FROM approval_records
+              WHERE action = 'cc'
+                AND (
+                  (metadata->>'targetType' = 'user' AND metadata->>'targetId' = $${actorIdParam})
+                  OR (metadata->>'targetType' = 'role' AND metadata->>'targetId' = ANY($${actorRolesParam}))
+                )
+            )
+            OR id IN (
+              SELECT instance_id
+              FROM approval_assignments
+              WHERE (assignment_type = 'user' AND assignee_id = $${actorIdParam})
+                 OR (assignment_type = 'role' AND assignee_id = ANY($${actorRolesParam}))
+            )
+          )`,
+        )
+      }
     }
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -1,0 +1,357 @@
+import type {
+  ApprovalEdge,
+  ApprovalNode,
+  ApprovalNodeConfig,
+  ConditionBranch,
+  ConditionRule,
+  FormField,
+  FormSchema,
+  RuntimeGraph,
+} from '../types/approval-product'
+
+export interface ApprovalGraphAssignment {
+  assignmentType: 'user' | 'role'
+  assigneeId: string
+  nodeKey: string
+  sourceStep: number
+}
+
+export interface ApprovalCcEvent {
+  nodeKey: string
+  targetType: 'user' | 'role'
+  targetId: string
+}
+
+export interface ApprovalGraphResolution {
+  status: 'pending' | 'approved'
+  currentNodeKey: string | null
+  currentStep: number | null
+  totalSteps: number
+  assignments: ApprovalGraphAssignment[]
+  ccEvents: ApprovalCcEvent[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isApprovalNodeConfig(config: unknown): config is ApprovalNodeConfig {
+  return isRecord(config)
+    && (config.assigneeType === 'user' || config.assigneeType === 'role')
+    && Array.isArray(config.assigneeIds)
+}
+
+function isConditionBranch(value: unknown): value is ConditionBranch {
+  return isRecord(value)
+    && typeof value.edgeKey === 'string'
+    && Array.isArray(value.rules)
+}
+
+function isNonEmptyStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string' && entry.trim().length > 0)
+}
+
+function normalizeComparableValue(value: unknown): number | string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.getTime()
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return ''
+    const numeric = Number(trimmed)
+    if (Number.isFinite(numeric) && trimmed === String(numeric)) {
+      return numeric
+    }
+    const epoch = Date.parse(trimmed)
+    if (!Number.isNaN(epoch) && /[-:TZ]/.test(trimmed)) {
+      return epoch
+    }
+    return trimmed
+  }
+  return null
+}
+
+function isEmptyValue(value: unknown): boolean {
+  return value === null
+    || value === undefined
+    || value === ''
+    || (Array.isArray(value) && value.length === 0)
+}
+
+function evaluateRule(rule: ConditionRule, formData: Record<string, unknown>): boolean {
+  const formValue = formData[rule.fieldId]
+
+  switch (rule.operator) {
+    case 'isEmpty':
+      return isEmptyValue(formValue)
+    case 'eq':
+      return formValue === rule.value
+    case 'neq':
+      return formValue !== rule.value
+    case 'in':
+      if (Array.isArray(rule.value)) {
+        const allowedValues = rule.value as unknown[]
+        if (Array.isArray(formValue)) {
+          return formValue.some((entry) => allowedValues.includes(entry))
+        }
+        return allowedValues.includes(formValue)
+      }
+      if (Array.isArray(formValue)) {
+        return formValue.includes(rule.value)
+      }
+      return false
+    case 'gt':
+    case 'gte':
+    case 'lt':
+    case 'lte': {
+      const left = normalizeComparableValue(formValue)
+      const right = normalizeComparableValue(rule.value)
+      if (left === null || right === null) return false
+      if (rule.operator === 'gt') return left > right
+      if (rule.operator === 'gte') return left >= right
+      if (rule.operator === 'lt') return left < right
+      return left <= right
+    }
+    default:
+      return false
+  }
+}
+
+function validateFieldType(field: FormField, value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null
+  }
+
+  switch (field.type) {
+    case 'text':
+    case 'textarea':
+    case 'user':
+    case 'attachment':
+      return typeof value === 'string' || isRecord(value) ? null : `${field.id} must be a string`
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value) ? null : `${field.id} must be a number`
+    case 'date':
+    case 'datetime':
+      return typeof value === 'string' || value instanceof Date ? null : `${field.id} must be a date value`
+    case 'select':
+      if (typeof value !== 'string') return `${field.id} must be a string`
+      if (field.options?.length && !field.options.some((option) => option.value === value)) {
+        return `${field.id} must be one of the configured options`
+      }
+      return null
+    case 'multi-select':
+      if (!Array.isArray(value) || !value.every((entry) => typeof entry === 'string')) {
+        return `${field.id} must be an array of strings`
+      }
+      if (field.options?.length && value.some((entry) => !field.options!.some((option) => option.value === entry))) {
+        return `${field.id} must contain only configured options`
+      }
+      return null
+    default:
+      return null
+  }
+}
+
+export function validateApprovalFormData(formSchema: FormSchema, formData: Record<string, unknown>): string[] {
+  const errors: string[] = []
+
+  for (const field of formSchema.fields) {
+    const value = formData[field.id]
+    if (field.required && isEmptyValue(value)) {
+      errors.push(`${field.id} is required`)
+      continue
+    }
+    const typeError = validateFieldType(field, value)
+    if (typeError) {
+      errors.push(typeError)
+    }
+  }
+
+  return errors
+}
+
+export class ApprovalGraphExecutor {
+  private readonly nodeMap = new Map<string, ApprovalNode>()
+  private readonly outgoingEdges = new Map<string, ApprovalEdge[]>()
+  private readonly approvalNodeOrder: string[]
+
+  constructor(
+    private readonly runtimeGraph: RuntimeGraph,
+    private readonly formData: Record<string, unknown>,
+  ) {
+    for (const node of runtimeGraph.nodes) {
+      this.nodeMap.set(node.key, node)
+    }
+    for (const edge of runtimeGraph.edges) {
+      const existing = this.outgoingEdges.get(edge.source) || []
+      existing.push(edge)
+      this.outgoingEdges.set(edge.source, existing)
+    }
+    this.approvalNodeOrder = runtimeGraph.nodes
+      .filter((node) => node.type === 'approval')
+      .map((node) => node.key)
+  }
+
+  get totalSteps(): number {
+    return this.approvalNodeOrder.length
+  }
+
+  resolveInitialState(): ApprovalGraphResolution {
+    const start = this.runtimeGraph.nodes.find((node) => node.type === 'start')
+    if (!start) {
+      throw new Error('Runtime graph must contain a start node')
+    }
+    return this.resolveFromNode(start.key)
+  }
+
+  resolveAfterApprove(currentNodeKey: string): ApprovalGraphResolution {
+    const next = this.firstTargetForNode(currentNodeKey)
+    if (!next) {
+      return {
+        status: 'approved',
+        currentNodeKey: null,
+        currentStep: this.totalSteps,
+        totalSteps: this.totalSteps,
+        assignments: [],
+        ccEvents: [],
+      }
+    }
+    return this.resolveFromNode(next)
+  }
+
+  buildTransferAssignments(currentNodeKey: string, targetUserId: string): ApprovalGraphAssignment[] {
+    const currentStep = this.stepIndexForNode(currentNodeKey)
+    return [{
+      assignmentType: 'user',
+      assigneeId: targetUserId,
+      nodeKey: currentNodeKey,
+      sourceStep: currentStep,
+    }]
+  }
+
+  private resolveFromNode(nodeKey: string): ApprovalGraphResolution {
+    const ccEvents: ApprovalCcEvent[] = []
+    let currentKey: string | null = nodeKey
+
+    while (currentKey) {
+      const node = this.nodeMap.get(currentKey)
+      if (!node) {
+        throw new Error(`Runtime graph references unknown node ${currentKey}`)
+      }
+
+      if (node.type === 'start') {
+        currentKey = this.firstTargetForNode(node.key)
+        continue
+      }
+
+      if (node.type === 'condition') {
+        currentKey = this.resolveConditionTarget(node)
+        continue
+      }
+
+      if (node.type === 'cc') {
+        const ccConfig = node.config as unknown as Record<string, unknown>
+        const targetIds = ccConfig.targetIds
+        const targetType = ccConfig.targetType
+        if (!isNonEmptyStringArray(targetIds) || (targetType !== 'user' && targetType !== 'role')) {
+          throw new Error(`CC node ${node.key} has invalid config`)
+        }
+        for (const targetId of targetIds) {
+          ccEvents.push({
+            nodeKey: node.key,
+            targetType,
+            targetId,
+          })
+        }
+        currentKey = this.firstTargetForNode(node.key)
+        continue
+      }
+
+      if (node.type === 'approval') {
+        const approvalConfig = isApprovalNodeConfig(node.config) ? node.config : null
+        if (!approvalConfig) {
+          throw new Error(`Approval node ${node.key} has invalid config`)
+        }
+        const sourceStep = this.stepIndexForNode(node.key)
+        return {
+          status: 'pending',
+          currentNodeKey: node.key,
+          currentStep: sourceStep,
+          totalSteps: this.totalSteps,
+          assignments: approvalConfig.assigneeIds.map((assigneeId) => ({
+            assignmentType: approvalConfig.assigneeType,
+            assigneeId,
+            nodeKey: node.key,
+            sourceStep,
+          })),
+          ccEvents,
+        }
+      }
+
+      if (node.type === 'end') {
+        return {
+          status: 'approved',
+          currentNodeKey: null,
+          currentStep: this.totalSteps,
+          totalSteps: this.totalSteps,
+          assignments: [],
+          ccEvents,
+        }
+      }
+
+      throw new Error(`Unsupported node type ${node.type}`)
+    }
+
+    return {
+      status: 'approved',
+      currentNodeKey: null,
+      currentStep: this.totalSteps,
+      totalSteps: this.totalSteps,
+      assignments: [],
+      ccEvents,
+    }
+  }
+
+  private resolveConditionTarget(node: ApprovalNode): string | null {
+    const config = node.config as unknown as Record<string, unknown>
+    const rawBranches = config.branches
+    const branches = Array.isArray(rawBranches)
+      ? rawBranches.filter(isConditionBranch)
+      : []
+
+    for (const branch of branches) {
+      const conjunction = branch.conjunction === 'or' ? 'or' : 'and'
+      const result = conjunction === 'or'
+        ? branch.rules.some((rule) => evaluateRule(rule, this.formData))
+        : branch.rules.every((rule) => evaluateRule(rule, this.formData))
+      if (result) {
+        return this.targetForEdge(branch.edgeKey)
+      }
+    }
+
+    const defaultEdgeKey = config.defaultEdgeKey
+    if (typeof defaultEdgeKey === 'string' && defaultEdgeKey.trim()) {
+      return this.targetForEdge(defaultEdgeKey)
+    }
+
+    return this.firstTargetForNode(node.key)
+  }
+
+  private firstTargetForNode(nodeKey: string): string | null {
+    const edge = this.outgoingEdges.get(nodeKey)?.[0]
+    return edge?.target || null
+  }
+
+  private targetForEdge(edgeKey: string): string | null {
+    const edge = this.runtimeGraph.edges.find((entry) => entry.key === edgeKey)
+    return edge?.target || null
+  }
+
+  private stepIndexForNode(nodeKey: string): number {
+    const index = this.approvalNodeOrder.indexOf(nodeKey)
+    return index >= 0 ? index + 1 : 0
+  }
+}

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1,0 +1,753 @@
+import crypto from 'crypto'
+import { pool } from '../db/pg'
+import type {
+  ApprovalTemplateDetailDTO,
+  ApprovalTemplateListItemDTO,
+  ApprovalTemplateVersionDetailDTO,
+  CreateApprovalRequest,
+  FormSchema,
+  RuntimeGraph,
+} from '../types/approval-product'
+import { ApprovalGraphExecutor, validateApprovalFormData } from './ApprovalGraphExecutor'
+import type {
+  ApprovalActionRequest,
+  ApprovalAssignmentDTO,
+  ApprovalAssignmentRow,
+  ApprovalInstanceRow,
+  UnifiedApprovalDTO,
+} from './approval-bridge-types'
+import { APPROVAL_ERROR_CODES } from './approval-bridge-types'
+import { ServiceError } from './ApprovalBridgeService'
+
+interface ApprovalTemplateListQuery {
+  status?: string
+  search?: string
+  limit: number
+  offset: number
+}
+
+interface CreateApprovalActor {
+  userId: string
+  userName?: string
+  email?: string
+  department?: string
+  roles?: string[]
+  permissions?: string[]
+}
+
+type TemplateRow = {
+  id: string
+  key: string
+  name: string
+  description: string | null
+  status: 'draft' | 'published' | 'archived'
+  active_version_id: string | null
+  latest_version_id: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+type TemplateVersionRow = {
+  id: string
+  template_id: string
+  version: number
+  status: 'draft' | 'published' | 'archived'
+  form_schema: Record<string, unknown>
+  approval_graph: Record<string, unknown>
+  created_at: Date
+  updated_at: Date
+}
+
+type PublishedDefinitionRow = {
+  id: string
+  template_id: string
+  template_version_id: string
+  runtime_graph: Record<string, unknown>
+  is_active: boolean
+  published_at: Date
+}
+
+type TemplateBundle = {
+  template: TemplateRow
+  version: TemplateVersionRow
+  publishedDefinition: PublishedDefinitionRow | null
+}
+
+type ApprovalRecordInsert = {
+  action: string
+  actorId: string | null
+  actorName: string | null
+  comment: string | null
+  fromStatus: string | null
+  toStatus: string
+  fromVersion: number | null
+  toVersion: number
+  metadata: Record<string, unknown>
+  targetUserId?: string | null
+}
+
+function toNullableRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function asFormSchema(value: Record<string, unknown>): FormSchema {
+  return value as unknown as FormSchema
+}
+
+function asRuntimeGraph(value: Record<string, unknown>): RuntimeGraph {
+  return value as unknown as RuntimeGraph
+}
+
+function toApprovalTemplateListItemDTO(row: TemplateRow): ApprovalTemplateListItemDTO {
+  return {
+    id: row.id,
+    key: row.key,
+    name: row.name,
+    description: row.description,
+    status: row.status,
+    activeVersionId: row.active_version_id,
+    latestVersionId: row.latest_version_id,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  }
+}
+
+function toApprovalTemplateDetailDTO(bundle: TemplateBundle): ApprovalTemplateDetailDTO {
+  return {
+    ...toApprovalTemplateListItemDTO(bundle.template),
+    formSchema: asFormSchema(bundle.version.form_schema),
+    approvalGraph: bundle.version.approval_graph as unknown as ApprovalTemplateDetailDTO['approvalGraph'],
+  }
+}
+
+function toApprovalTemplateVersionDetailDTO(bundle: TemplateBundle): ApprovalTemplateVersionDetailDTO {
+  return {
+    id: bundle.version.id,
+    templateId: bundle.version.template_id,
+    version: bundle.version.version,
+    status: bundle.version.status,
+    formSchema: asFormSchema(bundle.version.form_schema),
+    approvalGraph: bundle.version.approval_graph as unknown as ApprovalTemplateVersionDetailDTO['approvalGraph'],
+    runtimeGraph: bundle.publishedDefinition ? asRuntimeGraph(bundle.publishedDefinition.runtime_graph) : null,
+    publishedDefinitionId: bundle.publishedDefinition?.id || null,
+    createdAt: bundle.version.created_at.toISOString(),
+    updatedAt: bundle.version.updated_at.toISOString(),
+  }
+}
+
+function toUnifiedApprovalDTO(
+  row: ApprovalInstanceRow,
+  assignments: ApprovalAssignmentDTO[],
+): UnifiedApprovalDTO {
+  return {
+    id: row.id,
+    sourceSystem: row.source_system,
+    externalApprovalId: row.external_approval_id,
+    workflowKey: row.workflow_key,
+    businessKey: row.business_key,
+    title: row.title,
+    status: row.status,
+    requester: toNullableRecord(row.requester_snapshot),
+    subject: toNullableRecord(row.subject_snapshot),
+    policy: toNullableRecord(row.policy_snapshot),
+    currentStep: row.current_step,
+    totalSteps: row.total_steps,
+    templateId: row.template_id,
+    templateVersionId: row.template_version_id,
+    publishedDefinitionId: row.published_definition_id,
+    requestNo: row.request_no,
+    formSnapshot: toNullableRecord(row.form_snapshot),
+    currentNodeKey: row.current_node_key,
+    assignments,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  }
+}
+
+function assignmentMatchesActor(
+  assignment: ApprovalAssignmentRow,
+  actorId: string,
+  actorRoles: string[],
+): boolean {
+  if (!assignment.is_active) return false
+  if (assignment.assignment_type === 'user') {
+    return assignment.assignee_id === actorId
+  }
+  if (assignment.assignment_type === 'role') {
+    return actorRoles.includes(assignment.assignee_id)
+  }
+  return false
+}
+
+function normalizePage(value: unknown, fallback: number): number {
+  const parsed = Number.parseInt(String(value || ''), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export class ApprovalProductService {
+  async listTemplates(query: ApprovalTemplateListQuery): Promise<{ data: ApprovalTemplateListItemDTO[]; total: number }> {
+    if (!pool) throw new Error('Database not available')
+
+    const conditions: string[] = []
+    const params: unknown[] = []
+    let index = 1
+
+    if (query.status) {
+      conditions.push(`status = $${index++}`)
+      params.push(query.status)
+    }
+    if (query.search) {
+      conditions.push(`(name ILIKE $${index} OR key ILIKE $${index})`)
+      params.push(`%${query.search}%`)
+      index += 1
+    }
+
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''
+
+    const totalResult = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM approval_templates ${where}`,
+      params,
+    )
+    const result = await pool.query<TemplateRow>(
+      `SELECT *
+       FROM approval_templates
+       ${where}
+       ORDER BY updated_at DESC, id DESC
+       LIMIT $${index++} OFFSET $${index++}`,
+      [...params, query.limit, query.offset],
+    )
+
+    return {
+      data: result.rows.map(toApprovalTemplateListItemDTO),
+      total: Number.parseInt(totalResult.rows[0]?.count || '0', 10),
+    }
+  }
+
+  async getTemplate(id: string): Promise<ApprovalTemplateDetailDTO | null> {
+    const bundle = await this.loadTemplateBundle(id)
+    return bundle ? toApprovalTemplateDetailDTO(bundle) : null
+  }
+
+  async getTemplateVersion(templateId: string, versionId: string): Promise<ApprovalTemplateVersionDetailDTO | null> {
+    const bundle = await this.loadTemplateBundle(templateId, versionId)
+    return bundle ? toApprovalTemplateVersionDetailDTO(bundle) : null
+  }
+
+  async createApproval(request: CreateApprovalRequest, actor: CreateApprovalActor): Promise<UnifiedApprovalDTO> {
+    if (!pool) throw new Error('Database not available')
+
+    const bundle = await this.loadTemplateBundle(request.templateId)
+    if (!bundle) {
+      throw new ServiceError('Approval template not found', 404, 'APPROVAL_TEMPLATE_NOT_FOUND')
+    }
+    if (bundle.template.status !== 'published' || !bundle.publishedDefinition || !bundle.publishedDefinition.is_active) {
+      throw new ServiceError('Approval template is not published', 409, 'APPROVAL_TEMPLATE_NOT_PUBLISHED')
+    }
+
+    const formSchema = asFormSchema(bundle.version.form_schema)
+    const validationErrors = validateApprovalFormData(formSchema, request.formData)
+    if (validationErrors.length > 0) {
+      throw new ServiceError(
+        'Approval form data is invalid',
+        400,
+        'VALIDATION_ERROR',
+        { errors: validationErrors },
+      )
+    }
+
+    const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
+    const executor = new ApprovalGraphExecutor(runtimeGraph, request.formData)
+    const initial = executor.resolveInitialState()
+    const instanceId = crypto.randomUUID()
+    const requestNo = await this.allocateRequestNo()
+
+    const requesterSnapshot = {
+      id: actor.userId,
+      name: actor.userName || actor.userId,
+      email: actor.email,
+      department: actor.department,
+      roles: actor.roles || [],
+      permissions: actor.permissions || [],
+    }
+
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+
+      await client.query(
+        `INSERT INTO approval_instances
+         (id, status, version, source_system, external_approval_id, workflow_key, business_key, title,
+          requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+          current_step, total_steps, sync_status, sync_error,
+          template_id, template_version_id, published_definition_id, request_no, form_snapshot, current_node_key,
+          created_at, updated_at)
+         VALUES
+         ($1, $2, 0, 'platform', NULL, 'approval-product-template', $3, $4,
+          $5, $6, $7, $8,
+          $9, $10, 'ok', NULL,
+          $11, $12, $13, $14, $15, $16,
+          now(), now())`,
+        [
+          instanceId,
+          initial.status,
+          bundle.template.key,
+          bundle.template.name,
+          JSON.stringify(requesterSnapshot),
+          JSON.stringify({ templateId: bundle.template.id, templateKey: bundle.template.key }),
+          JSON.stringify({ rejectCommentRequired: true, allowRevoke: runtimeGraph.policy.allowRevoke, sourceOfTruth: 'platform' }),
+          JSON.stringify({ templateKey: bundle.template.key }),
+          initial.currentStep ?? 0,
+          initial.totalSteps,
+          bundle.template.id,
+          bundle.version.id,
+          bundle.publishedDefinition.id,
+          requestNo,
+          JSON.stringify(request.formData),
+          initial.currentNodeKey,
+        ],
+      )
+
+      await this.insertAssignments(client, instanceId, initial.assignments)
+      await this.insertCcEvents(client, instanceId, 0, initial.status, initial.ccEvents)
+      await this.insertApprovalRecord(client, instanceId, {
+        action: 'created',
+        actorId: actor.userId,
+        actorName: actor.userName || actor.userId,
+        comment: null,
+        fromStatus: null,
+        toStatus: initial.status,
+        fromVersion: null,
+        toVersion: 0,
+        metadata: {
+          nodeKey: 'start',
+          requestNo,
+        },
+      })
+
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+
+    const approval = await this.getApproval(instanceId)
+    if (!approval) {
+      throw new ServiceError('Approval not found after creation', 500, 'APPROVAL_CREATE_FAILED')
+    }
+    return approval
+  }
+
+  async dispatchAction(
+    id: string,
+    request: ApprovalActionRequest,
+    actor: CreateApprovalActor & { ip?: string | null; userAgent?: string | null },
+  ): Promise<UnifiedApprovalDTO> {
+    if (!pool) throw new Error('Database not available')
+
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+
+      const instanceResult = await client.query<ApprovalInstanceRow>(
+        `SELECT * FROM approval_instances WHERE id = $1 AND COALESCE(source_system, 'platform') = 'platform' FOR UPDATE`,
+        [id],
+      )
+      const instance = instanceResult.rows[0]
+      if (!instance) {
+        throw new ServiceError('Approval not found', 404, APPROVAL_ERROR_CODES.APPROVAL_NOT_FOUND)
+      }
+      if (!instance.published_definition_id) {
+        throw new ServiceError('Approval is not managed by the template runtime', 409, 'APPROVAL_RUNTIME_UNSUPPORTED')
+      }
+
+      const runtimeResult = await client.query<PublishedDefinitionRow>(
+        `SELECT * FROM approval_published_definitions WHERE id = $1`,
+        [instance.published_definition_id],
+      )
+      const runtime = runtimeResult.rows[0]
+      if (!runtime) {
+        throw new ServiceError('Published definition not found', 404, 'APPROVAL_PUBLISHED_DEFINITION_NOT_FOUND')
+      }
+
+      const assignments = await client.query<ApprovalAssignmentRow>(
+        `SELECT * FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY created_at ASC`,
+        [id],
+      )
+
+      const actorRoles = actor.roles || []
+      const actorCanAct = assignments.rows.some((assignment) => assignmentMatchesActor(assignment, actor.userId, actorRoles))
+      const actorName = actor.userName || actor.userId
+
+      if (request.action !== 'revoke' && !actorCanAct) {
+        throw new ServiceError('Approval assignment not found for actor', 403, 'APPROVAL_ASSIGNMENT_REQUIRED')
+      }
+
+      const runtimeGraph = asRuntimeGraph(runtime.runtime_graph)
+      const executor = new ApprovalGraphExecutor(runtimeGraph, toNullableRecord(instance.form_snapshot) || {})
+      const currentNodeKey = instance.current_node_key
+      const nextVersion = instance.version + 1
+
+      if (request.action === 'comment') {
+        await this.insertApprovalRecord(client, id, {
+          action: 'comment',
+          actorId: actor.userId,
+          actorName,
+          comment: request.comment || null,
+          fromStatus: instance.status,
+          toStatus: instance.status,
+          fromVersion: instance.version,
+          toVersion: instance.version,
+          metadata: { nodeKey: currentNodeKey },
+        }, actor)
+        await client.query('COMMIT')
+        return (await this.getApproval(id))!
+      }
+
+      if (request.action === 'transfer') {
+        if (!request.targetUserId) {
+          throw new ServiceError('targetUserId is required for transfer', 400, 'VALIDATION_ERROR')
+        }
+        if (!currentNodeKey) {
+          throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
+        }
+        await client.query(
+          `UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND is_active = TRUE`,
+          [id],
+        )
+        await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, request.targetUserId))
+        await this.insertApprovalRecord(client, id, {
+          action: 'transfer',
+          actorId: actor.userId,
+          actorName,
+          comment: request.comment || null,
+          fromStatus: instance.status,
+          toStatus: instance.status,
+          fromVersion: instance.version,
+          toVersion: instance.version,
+          metadata: { nodeKey: currentNodeKey },
+          targetUserId: request.targetUserId,
+        }, actor)
+        await client.query('COMMIT')
+        return (await this.getApproval(id))!
+      }
+
+      if (request.action === 'revoke') {
+        const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+        if (requesterId !== actor.userId) {
+          throw new ServiceError('Only the requester can revoke this approval', 403, 'APPROVAL_REVOKE_FORBIDDEN')
+        }
+        const handledResult = await client.query<{ count: string }>(
+          `SELECT COUNT(*)::text AS count
+           FROM approval_records
+           WHERE instance_id = $1
+             AND action IN ('approve', 'reject', 'transfer')
+             AND metadata->>'nodeKey' = $2`,
+          [id, currentNodeKey],
+        )
+        if (Number.parseInt(handledResult.rows[0]?.count || '0', 10) > 0) {
+          throw new ServiceError('Approval can no longer be revoked', 409, 'APPROVAL_REVOKE_WINDOW_CLOSED')
+        }
+
+        await client.query(
+          `UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND is_active = TRUE`,
+          [id],
+        )
+        await client.query(
+          `UPDATE approval_instances
+           SET status = 'revoked',
+               version = $2,
+               current_node_key = NULL,
+               current_step = total_steps,
+               updated_at = now()
+           WHERE id = $1`,
+          [id, nextVersion],
+        )
+        await this.insertApprovalRecord(client, id, {
+          action: 'revoke',
+          actorId: actor.userId,
+          actorName,
+          comment: request.comment || null,
+          fromStatus: instance.status,
+          toStatus: 'revoked',
+          fromVersion: instance.version,
+          toVersion: nextVersion,
+          metadata: { nodeKey: currentNodeKey },
+        }, actor)
+        await client.query('COMMIT')
+        return (await this.getApproval(id))!
+      }
+
+      if (instance.status !== 'pending') {
+        throw new ServiceError(
+          `Cannot ${request.action}: current status is ${instance.status}`,
+          409,
+          APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION,
+        )
+      }
+
+      if (request.action === 'reject' && !request.comment?.trim()) {
+        throw new ServiceError('Rejection comment is required', 400, APPROVAL_ERROR_CODES.REJECT_COMMENT_REQUIRED)
+      }
+
+      await client.query(
+        `UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND is_active = TRUE`,
+        [id],
+      )
+
+      if (request.action === 'reject') {
+        await client.query(
+          `UPDATE approval_instances
+           SET status = 'rejected',
+               version = $2,
+               current_node_key = NULL,
+               current_step = total_steps,
+               updated_at = now()
+           WHERE id = $1`,
+          [id, nextVersion],
+        )
+        await this.insertApprovalRecord(client, id, {
+          action: 'reject',
+          actorId: actor.userId,
+          actorName,
+          comment: request.comment || null,
+          fromStatus: instance.status,
+          toStatus: 'rejected',
+          fromVersion: instance.version,
+          toVersion: nextVersion,
+          metadata: { nodeKey: currentNodeKey },
+        }, actor)
+        await client.query('COMMIT')
+        return (await this.getApproval(id))!
+      }
+
+      if (!currentNodeKey) {
+        throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
+      }
+
+      const resolution = executor.resolveAfterApprove(currentNodeKey)
+      await client.query(
+        `UPDATE approval_instances
+         SET status = $2,
+             version = $3,
+             current_node_key = $4,
+             current_step = $5,
+             total_steps = $6,
+             updated_at = now()
+         WHERE id = $1`,
+        [
+          id,
+          resolution.status,
+          nextVersion,
+          resolution.currentNodeKey,
+          resolution.currentStep ?? instance.total_steps,
+          resolution.totalSteps,
+        ],
+      )
+      await this.insertAssignments(client, id, resolution.assignments)
+      await this.insertApprovalRecord(client, id, {
+        action: 'approve',
+        actorId: actor.userId,
+        actorName,
+        comment: request.comment || null,
+        fromStatus: instance.status,
+        toStatus: resolution.status,
+        fromVersion: instance.version,
+        toVersion: nextVersion,
+        metadata: { nodeKey: currentNodeKey, nextNodeKey: resolution.currentNodeKey },
+      }, actor)
+      await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
+
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+
+    const approval = await this.getApproval(id)
+    if (!approval) {
+      throw new ServiceError('Approval not found after action', 404, APPROVAL_ERROR_CODES.APPROVAL_NOT_FOUND)
+    }
+    return approval
+  }
+
+  async getApproval(id: string): Promise<UnifiedApprovalDTO | null> {
+    if (!pool) throw new Error('Database not available')
+
+    const result = await pool.query<ApprovalInstanceRow>(
+      `SELECT * FROM approval_instances WHERE id = $1`,
+      [id],
+    )
+    const row = result.rows[0]
+    if (!row) return null
+
+    const assignmentsResult = await pool.query<ApprovalAssignmentRow>(
+      `SELECT * FROM approval_assignments WHERE instance_id = $1 ORDER BY created_at ASC`,
+      [id],
+    )
+
+    return toUnifiedApprovalDTO(
+      row,
+      assignmentsResult.rows.map((assignment) => ({
+        id: assignment.id,
+        type: assignment.assignment_type,
+        assigneeId: assignment.assignee_id,
+        sourceStep: assignment.source_step,
+        nodeKey: assignment.node_key,
+        isActive: assignment.is_active,
+        metadata: assignment.metadata || {},
+      })),
+    )
+  }
+
+  async isTemplateRuntimeInstance(id: string): Promise<boolean> {
+    if (!pool) throw new Error('Database not available')
+
+    const result = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS(
+        SELECT 1
+        FROM approval_instances
+        WHERE id = $1
+          AND COALESCE(source_system, 'platform') = 'platform'
+          AND published_definition_id IS NOT NULL
+      ) AS exists`,
+      [id],
+    )
+
+    return Boolean(result.rows[0]?.exists)
+  }
+
+  private async allocateRequestNo(): Promise<string> {
+    if (!pool) throw new Error('Database not available')
+
+    const result = await pool.query<{ request_no: string }>(
+      `SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`,
+    )
+    return result.rows[0]?.request_no || `AP-${normalizePage(Date.now(), 100001)}`
+  }
+
+  private async loadTemplateBundle(templateId: string, explicitVersionId?: string): Promise<TemplateBundle | null> {
+    if (!pool) throw new Error('Database not available')
+
+    const templateResult = await pool.query<TemplateRow>(
+      `SELECT * FROM approval_templates WHERE id = $1`,
+      [templateId],
+    )
+    const template = templateResult.rows[0]
+    if (!template) return null
+
+    const versionId = explicitVersionId || template.active_version_id || template.latest_version_id
+    if (!versionId) return null
+
+    const versionResult = await pool.query<TemplateVersionRow>(
+      `SELECT * FROM approval_template_versions WHERE id = $1 AND template_id = $2`,
+      [versionId, template.id],
+    )
+    const version = versionResult.rows[0]
+    if (!version) return null
+
+    const publishedResult = await pool.query<PublishedDefinitionRow>(
+      `SELECT *
+       FROM approval_published_definitions
+       WHERE template_version_id = $1
+       ORDER BY is_active DESC, published_at DESC
+       LIMIT 1`,
+      [version.id],
+    )
+
+    return {
+      template,
+      version,
+      publishedDefinition: publishedResult.rows[0] || null,
+    }
+  }
+
+  private async insertAssignments(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    assignments: Array<{ assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string; sourceStep: number }>,
+  ): Promise<void> {
+    for (const assignment of assignments) {
+      await client.query(
+        `INSERT INTO approval_assignments
+         (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, metadata, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, TRUE, '{}'::jsonb, now(), now())`,
+        [
+          instanceId,
+          assignment.assignmentType,
+          assignment.assigneeId,
+          assignment.sourceStep,
+          assignment.nodeKey,
+        ],
+      )
+    }
+  }
+
+  private async insertCcEvents(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    version: number,
+    status: string,
+    ccEvents: Array<{ nodeKey: string; targetType: 'user' | 'role'; targetId: string }>,
+  ): Promise<void> {
+    for (const event of ccEvents) {
+      await this.insertApprovalRecord(client, instanceId, {
+        action: 'cc',
+        actorId: 'system',
+        actorName: 'System',
+        comment: null,
+        fromStatus: status,
+        toStatus: status,
+        fromVersion: version,
+        toVersion: version,
+        metadata: {
+          nodeKey: event.nodeKey,
+          targetType: event.targetType,
+          targetId: event.targetId,
+        },
+      })
+    }
+  }
+
+  private async insertApprovalRecord(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    record: ApprovalRecordInsert,
+    actor?: { ip?: string | null; userAgent?: string | null },
+  ): Promise<void> {
+    await client.query(
+      `INSERT INTO approval_records
+       (instance_id, action, actor_id, actor_name, comment, from_status, to_status, from_version, to_version, metadata, target_user_id, ip_address, user_agent)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+      [
+        instanceId,
+        record.action,
+        record.actorId || 'system',
+        record.actorName,
+        record.comment,
+        record.fromStatus,
+        record.toStatus,
+        record.fromVersion,
+        record.toVersion,
+        JSON.stringify(record.metadata),
+        record.targetUserId || null,
+        actor?.ip || null,
+        actor?.userAgent || null,
+      ],
+    )
+  }
+}
+
+export function resolveApprovalListPaging(page: unknown, pageSize: unknown): { limit: number; offset: number } {
+  const normalizedPage = normalizePage(page, 1)
+  const normalizedPageSize = normalizePage(pageSize, 20)
+  return {
+    limit: normalizedPageSize,
+    offset: (normalizedPage - 1) * normalizedPageSize,
+  }
+}

--- a/packages/core-backend/src/services/approval-bridge-types.ts
+++ b/packages/core-backend/src/services/approval-bridge-types.ts
@@ -21,8 +21,14 @@ export interface UnifiedApprovalDTO {
   requester: ApprovalRequesterSnapshot | null
   subject: ApprovalSubjectSnapshot | null
   policy: ApprovalPolicySnapshot | null
-  currentStep: number
-  totalSteps: number
+  currentStep: number | null
+  totalSteps: number | null
+  templateId?: string | null
+  templateVersionId?: string | null
+  publishedDefinitionId?: string | null
+  requestNo?: string | null
+  formSnapshot?: Record<string, unknown> | null
+  currentNodeKey?: string | null
   assignments: ApprovalAssignmentDTO[]
   createdAt: string
   updatedAt: string
@@ -51,6 +57,7 @@ export interface ApprovalAssignmentDTO {
   type: string
   assigneeId: string
   sourceStep: number
+  nodeKey?: string | null
   isActive: boolean
   metadata: Record<string, unknown>
 }
@@ -77,6 +84,10 @@ export interface ApprovalQueryOptions {
   workflowKey?: string
   businessKey?: string
   assignee?: string
+  search?: string
+  tab?: 'pending' | 'mine' | 'cc' | 'completed'
+  actorId?: string
+  actorRoles?: string[]
   limit?: number
   offset?: number
 }
@@ -94,8 +105,9 @@ export interface PlmSyncOptions {
 // ── Action Request ──
 
 export interface ApprovalActionRequest {
-  action: 'approve' | 'reject'
+  action: 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment'
   comment?: string
+  targetUserId?: string
 }
 
 export interface ApprovalBridgePlmAdapter {
@@ -137,6 +149,12 @@ export interface ApprovalInstanceRow {
   last_synced_at: Date | null
   sync_status: string
   sync_error: string | null
+  template_id: string | null
+  template_version_id: string | null
+  published_definition_id: string | null
+  request_no: string | null
+  form_snapshot: Record<string, unknown> | null
+  current_node_key: string | null
   created_at: Date
   updated_at: Date
 }
@@ -147,6 +165,7 @@ export interface ApprovalAssignmentRow {
   assignment_type: string
   assignee_id: string
   source_step: number
+  node_key: string | null
   is_active: boolean
   metadata: Record<string, unknown>
   created_at: Date

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { ApprovalGraphExecutor, validateApprovalFormData } from '../../src/services/ApprovalGraphExecutor'
+import type { FormSchema, RuntimeGraph } from '../../src/types/approval-product'
+
+describe('ApprovalGraphExecutor', () => {
+  it('resolves the initial approval node after condition and cc nodes', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [
+              {
+                edgeKey: 'edge-security',
+                rules: [{ fieldId: 'accessScope', operator: 'eq', value: 'tenant-admin' }],
+              },
+            ],
+            defaultEdgeKey: 'edge-it',
+          },
+        },
+        { key: 'notify', type: 'cc', config: { targetType: 'role', targetIds: ['ops'] } },
+        { key: 'security-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['security'] } },
+        { key: 'it-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-2'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-security', source: 'route', target: 'notify' },
+        { key: 'edge-it', source: 'route', target: 'it-review' },
+        { key: 'edge-notify-security', source: 'notify', target: 'security-review' },
+        { key: 'edge-security-end', source: 'security-review', target: 'end' },
+        { key: 'edge-it-end', source: 'it-review', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+      },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, { accessScope: 'tenant-admin' })
+    const initial = executor.resolveInitialState()
+
+    expect(initial.status).toBe('pending')
+    expect(initial.currentNodeKey).toBe('security-review')
+    expect(initial.currentStep).toBe(1)
+    expect(initial.totalSteps).toBe(2)
+    expect(initial.assignments).toEqual([
+      {
+        assignmentType: 'role',
+        assigneeId: 'security',
+        nodeKey: 'security-review',
+        sourceStep: 1,
+      },
+    ])
+    expect(initial.ccEvents).toEqual([
+      {
+        nodeKey: 'notify',
+        targetType: 'role',
+        targetId: 'ops',
+      },
+    ])
+  })
+
+  it('advances to approved when the next node is end', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'manager-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-1'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-manager', source: 'start', target: 'manager-review' },
+        { key: 'edge-manager-end', source: 'manager-review', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+      },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const next = executor.resolveAfterApprove('manager-review')
+
+    expect(next.status).toBe('approved')
+    expect(next.currentNodeKey).toBeNull()
+    expect(next.currentStep).toBe(1)
+    expect(next.assignments).toEqual([])
+  })
+})
+
+describe('validateApprovalFormData', () => {
+  it('reports required, type, and option errors', () => {
+    const formSchema: FormSchema = {
+      fields: [
+        { id: 'reason', type: 'textarea', label: 'Reason', required: true },
+        { id: 'amount', type: 'number', label: 'Amount', required: true },
+        {
+          id: 'type',
+          type: 'select',
+          label: 'Type',
+          options: [
+            { label: 'Purchase', value: 'purchase' },
+            { label: 'Travel', value: 'travel' },
+          ],
+        },
+      ],
+    }
+
+    const errors = validateApprovalFormData(formSchema, {
+      amount: 'not-a-number',
+      type: 'unsupported',
+    })
+
+    expect(errors).toEqual([
+      'reason is required',
+      'amount must be a number',
+      'type must be one of the configured options',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- add the platform approval graph executor and form validation helpers
- add runtime service support for published template reads, request creation, and template-managed approval actions
- extend approvals routes for approval templates, page-based platform inbox queries, and POST /api/approvals creation
- keep PLM bridge behavior intact while routing template runtime instances through the new executor

## Verification
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approvals-bridge-routes.test.ts --watch=false --reporter=dot
- git diff --check