### PR TITLE
feat(approvals): add template CRUD skeleton

### DIFF
--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -12,6 +12,7 @@ import { Logger } from '../core/logger'
 import { IPLMAdapter } from '../di/identifiers'
 import { pool } from '../db/pg'
 import { authenticate } from '../middleware/auth'
+import { rbacGuard } from '../rbac/rbac'
 import { REFUND_WORKFLOW_KEY, type AfterSalesApprovalBridgeService } from '../services/AfterSalesApprovalBridgeService'
 import { ApprovalBridgeService, ServiceError } from '../services/ApprovalBridgeService'
 import { ApprovalProductService, resolveApprovalListPaging } from '../services/ApprovalProductService'
@@ -172,7 +173,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   const r = Router()
   const productService = getProductService()
 
-  r.get('/api/approval-templates', authenticate, async (req: Request, res: Response) => {
+  r.get('/api/approval-templates', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
     try {
       const page = parsePaging(req.query.page, 1, Number.MAX_SAFE_INTEGER)
       const pageSize = parsePaging(req.query.pageSize, 20)
@@ -184,7 +185,12 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         offset,
       })
 
-      res.json(result)
+      res.json({
+        data: result.data,
+        total: result.total,
+        limit,
+        offset,
+      })
     } catch (error) {
       handleApprovalsError(
         res,
@@ -195,7 +201,27 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.get('/api/approval-templates/:id', authenticate, async (req: Request, res: Response) => {
+  r.post('/api/approval-templates', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const template = await productService.createTemplate({
+        key: req.body?.key,
+        name: req.body?.name,
+        description: req.body?.description,
+        formSchema: req.body?.formSchema,
+        approvalGraph: req.body?.approvalGraph,
+      })
+      res.status(201).json(template)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_TEMPLATE_CREATE_FAILED',
+        'Failed to create approval template',
+      )
+    }
+  })
+
+  r.get('/api/approval-templates/:id', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
     try {
       const template = await productService.getTemplate(req.params.id)
       if (!template) {
@@ -214,7 +240,43 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.get('/api/approval-templates/:id/versions/:versionId', authenticate, async (req: Request, res: Response) => {
+  r.patch('/api/approval-templates/:id', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const template = await productService.updateTemplate(req.params.id, {
+        key: req.body?.key,
+        name: req.body?.name,
+        description: req.body?.description,
+        formSchema: req.body?.formSchema,
+        approvalGraph: req.body?.approvalGraph,
+      })
+      res.json(template)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_TEMPLATE_UPDATE_FAILED',
+        'Failed to update approval template',
+      )
+    }
+  })
+
+  r.post('/api/approval-templates/:id/publish', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const version = await productService.publishTemplate(req.params.id, {
+        policy: req.body?.policy,
+      })
+      res.json(version)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_TEMPLATE_PUBLISH_FAILED',
+        'Failed to publish approval template',
+      )
+    }
+  })
+
+  r.get('/api/approval-templates/:id/versions/:versionId', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
     try {
       const version = await productService.getTemplateVersion(req.params.id, req.params.versionId)
       if (!version) {
@@ -233,7 +295,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.get('/api/approvals', authenticate, async (req: Request, res: Response) => {
+  r.get('/api/approvals', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
     try {
       if (!pool) {
         return res.status(503).json(
@@ -314,7 +376,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.post('/api/approvals/sync/plm', authenticate, async (req: Request, res: Response) => {
+  r.post('/api/approvals/sync/plm', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
     try {
       const bridgeService = getBridgeService(options)
       if (!bridgeService.hasPlmAdapter()) {
@@ -346,7 +408,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.post('/api/approvals', authenticate, async (req: Request, res: Response) => {
+  r.post('/api/approvals', authenticate, rbacGuard('approvals', 'write'), async (req: Request, res: Response) => {
     try {
       const userId = resolveApprovalActorId(req)
       if (!userId) {
@@ -396,7 +458,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   })
 
   // Legacy endpoint: keep scoped to platform-owned approvals only.
-  r.get('/api/approvals/pending', authenticate, async (req: Request, res: Response) => {
+  r.get('/api/approvals/pending', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
     try {
       if (!pool) {
         return res.status(503).json(
@@ -454,7 +516,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.post('/api/approvals/:id/actions', authenticate, async (req: Request, res: Response) => {
+  r.post('/api/approvals/:id/actions', authenticate, rbacGuard('approvals', 'act'), async (req: Request, res: Response) => {
     try {
       const bridgeService = getBridgeService(options)
 
@@ -564,7 +626,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   })
 
   // Legacy endpoint: local platform approvals only.
-  r.post('/api/approvals/:id/approve', authenticate, async (req: Request, res: Response) => {
+  r.post('/api/approvals/:id/approve', authenticate, rbacGuard('approvals', 'act'), async (req: Request, res: Response) => {
     try {
       if (!pool) {
         return res.status(503).json(
@@ -691,7 +753,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   })
 
   // Legacy endpoint: local platform approvals only.
-  r.post('/api/approvals/:id/reject', authenticate, async (req: Request, res: Response) => {
+  r.post('/api/approvals/:id/reject', authenticate, rbacGuard('approvals', 'act'), async (req: Request, res: Response) => {
     try {
       if (!pool) {
         return res.status(503).json(
@@ -825,7 +887,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.get('/api/approvals/:id', authenticate, async (req: Request, res: Response) => {
+  r.get('/api/approvals/:id', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
     try {
       const bridgeService = getBridgeService(options)
       const approval = await bridgeService.getApproval(req.params.id)

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4,9 +4,14 @@ import type {
   ApprovalTemplateDetailDTO,
   ApprovalTemplateListItemDTO,
   ApprovalTemplateVersionDetailDTO,
+  ApprovalGraph,
   CreateApprovalRequest,
+  CreateApprovalTemplateRequest,
   FormSchema,
+  PublishApprovalTemplateRequest,
   RuntimeGraph,
+  RuntimePolicy,
+  UpdateApprovalTemplateRequest,
 } from '../types/approval-product'
 import { ApprovalGraphExecutor, validateApprovalFormData } from './ApprovalGraphExecutor'
 import type {
@@ -25,6 +30,8 @@ interface ApprovalTemplateListQuery {
   limit: number
   offset: number
 }
+
+type TemplateVersionPreference = 'active' | 'latest'
 
 interface CreateApprovalActor {
   userId: string
@@ -71,6 +78,12 @@ type TemplateBundle = {
   template: TemplateRow
   version: TemplateVersionRow
   publishedDefinition: PublishedDefinitionRow | null
+}
+
+type TemplateMetadataPatch = {
+  key?: string
+  name?: string
+  description?: string | null
 }
 
 type ApprovalRecordInsert = {
@@ -186,6 +199,77 @@ function normalizePage(value: unknown, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
+function normalizeRequiredString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new ServiceError(`${fieldName} is required`, 400, 'VALIDATION_ERROR')
+  }
+  return value.trim()
+}
+
+function normalizeOptionalString(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string') {
+    throw new ServiceError('String value expected', 400, 'VALIDATION_ERROR')
+  }
+  return value.trim()
+}
+
+function assertFormSchema(value: unknown): FormSchema {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !Array.isArray((value as { fields?: unknown }).fields)
+  ) {
+    throw new ServiceError('formSchema must contain fields', 400, 'VALIDATION_ERROR')
+  }
+  return value as FormSchema
+}
+
+function assertApprovalGraph(value: unknown): ApprovalGraph {
+  const graph = value as { nodes?: unknown; edges?: unknown } | null
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !Array.isArray(graph?.nodes) ||
+    !Array.isArray(graph?.edges)
+  ) {
+    throw new ServiceError('approvalGraph must contain nodes and edges', 400, 'VALIDATION_ERROR')
+  }
+  return value as ApprovalGraph
+}
+
+function assertRuntimePolicy(value: unknown): RuntimePolicy {
+  const policy = value as { allowRevoke?: unknown; revokeBeforeNodeKeys?: unknown } | null
+  if (typeof value !== 'object' || value === null || typeof policy?.allowRevoke !== 'boolean') {
+    throw new ServiceError('policy.allowRevoke is required', 400, 'VALIDATION_ERROR')
+  }
+  if (
+    policy.revokeBeforeNodeKeys !== undefined &&
+    (!Array.isArray(policy.revokeBeforeNodeKeys) ||
+      !policy.revokeBeforeNodeKeys.every((item) => typeof item === 'string' && item.trim().length > 0))
+  ) {
+    throw new ServiceError('policy.revokeBeforeNodeKeys must be a string array', 400, 'VALIDATION_ERROR')
+  }
+  return {
+    allowRevoke: policy.allowRevoke,
+    revokeBeforeNodeKeys: Array.isArray(policy.revokeBeforeNodeKeys)
+      ? policy.revokeBeforeNodeKeys.map((item) => item.trim())
+      : undefined,
+  }
+}
+
+function buildRuntimeGraph(approvalGraph: ApprovalGraph, policy: RuntimePolicy): RuntimeGraph {
+  const copied = JSON.parse(JSON.stringify(approvalGraph)) as ApprovalGraph
+  return {
+    ...copied,
+    policy: {
+      allowRevoke: policy.allowRevoke,
+      ...(policy.revokeBeforeNodeKeys ? { revokeBeforeNodeKeys: [...policy.revokeBeforeNodeKeys] } : {}),
+    },
+  }
+}
+
 export class ApprovalProductService {
   async listTemplates(query: ApprovalTemplateListQuery): Promise<{ data: ApprovalTemplateListItemDTO[]; total: number }> {
     if (!pool) throw new Error('Database not available')
@@ -226,7 +310,7 @@ export class ApprovalProductService {
   }
 
   async getTemplate(id: string): Promise<ApprovalTemplateDetailDTO | null> {
-    const bundle = await this.loadTemplateBundle(id)
+    const bundle = await this.loadTemplateBundle(id, undefined, 'latest')
     return bundle ? toApprovalTemplateDetailDTO(bundle) : null
   }
 
@@ -235,10 +319,265 @@ export class ApprovalProductService {
     return bundle ? toApprovalTemplateVersionDetailDTO(bundle) : null
   }
 
+  async createTemplate(request: CreateApprovalTemplateRequest): Promise<ApprovalTemplateDetailDTO> {
+    if (!pool) throw new Error('Database not available')
+
+    const key = normalizeRequiredString(request.key, 'key')
+    const name = normalizeRequiredString(request.name, 'name')
+    const description = normalizeOptionalString(request.description)
+    const formSchema = assertFormSchema(request.formSchema)
+    const approvalGraph = assertApprovalGraph(request.approvalGraph)
+
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+
+      const templateResult = await client.query<TemplateRow>(
+        `INSERT INTO approval_templates (key, name, description, status)
+         VALUES ($1, $2, $3, 'draft')
+         RETURNING *`,
+        [key, name, description ?? null],
+      )
+      let template = templateResult.rows[0]
+
+      const versionResult = await client.query<TemplateVersionRow>(
+        `INSERT INTO approval_template_versions (template_id, version, status, form_schema, approval_graph)
+         VALUES ($1, 1, 'draft', $2, $3)
+         RETURNING *`,
+        [template.id, JSON.stringify(formSchema), JSON.stringify(approvalGraph)],
+      )
+      const version = versionResult.rows[0]
+
+      const updatedTemplateResult = await client.query<TemplateRow>(
+        `UPDATE approval_templates
+         SET latest_version_id = $1, updated_at = now()
+         WHERE id = $2
+         RETURNING *`,
+        [version.id, template.id],
+      )
+      template = updatedTemplateResult.rows[0]
+
+      await client.query('COMMIT')
+
+      return toApprovalTemplateDetailDTO({
+        template,
+        version,
+        publishedDefinition: null,
+      })
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async updateTemplate(id: string, request: UpdateApprovalTemplateRequest): Promise<ApprovalTemplateDetailDTO> {
+    if (!pool) throw new Error('Database not available')
+
+    const metadataPatch: TemplateMetadataPatch = {}
+    if (request.key !== undefined) metadataPatch.key = normalizeRequiredString(request.key, 'key')
+    if (request.name !== undefined) metadataPatch.name = normalizeRequiredString(request.name, 'name')
+    if (request.description !== undefined) metadataPatch.description = normalizeOptionalString(request.description) ?? null
+
+    const formSchema = request.formSchema !== undefined ? assertFormSchema(request.formSchema) : undefined
+    const approvalGraph = request.approvalGraph !== undefined ? assertApprovalGraph(request.approvalGraph) : undefined
+
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+
+      const templateResult = await client.query<TemplateRow>(
+        `SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE`,
+        [id],
+      )
+      let template = templateResult.rows[0]
+      if (!template) {
+        throw new ServiceError('Approval template not found', 404, 'APPROVAL_TEMPLATE_NOT_FOUND')
+      }
+
+      if (Object.keys(metadataPatch).length > 0) {
+        const setClauses: string[] = []
+        const params: unknown[] = []
+        let index = 1
+
+        if (metadataPatch.key !== undefined) {
+          setClauses.push(`key = $${index++}`)
+          params.push(metadataPatch.key)
+        }
+        if (metadataPatch.name !== undefined) {
+          setClauses.push(`name = $${index++}`)
+          params.push(metadataPatch.name)
+        }
+        if (metadataPatch.description !== undefined) {
+          setClauses.push(`description = $${index++}`)
+          params.push(metadataPatch.description)
+        }
+        setClauses.push('updated_at = now()')
+        params.push(id)
+
+        const updatedTemplateResult = await client.query<TemplateRow>(
+          `UPDATE approval_templates
+           SET ${setClauses.join(', ')}
+           WHERE id = $${index}
+           RETURNING *`,
+          params,
+        )
+        template = updatedTemplateResult.rows[0]
+      }
+
+      let version: TemplateVersionRow | null = null
+      const shouldCreateVersion = formSchema !== undefined || approvalGraph !== undefined
+      if (shouldCreateVersion) {
+        const latestVersionResult = await client.query<TemplateVersionRow>(
+          `SELECT *
+           FROM approval_template_versions
+           WHERE template_id = $1
+           ORDER BY version DESC
+           LIMIT 1`,
+          [id],
+        )
+        const latestVersion = latestVersionResult.rows[0]
+        if (!latestVersion) {
+          throw new ServiceError('Approval template version not found', 404, 'APPROVAL_TEMPLATE_VERSION_NOT_FOUND')
+        }
+
+        const maxVersionResult = await client.query<{ max_version: string }>(
+          `SELECT COALESCE(MAX(version), 0)::text AS max_version
+           FROM approval_template_versions
+           WHERE template_id = $1`,
+          [id],
+        )
+        const nextVersion = Number.parseInt(maxVersionResult.rows[0]?.max_version || '0', 10) + 1
+
+        const versionResult = await client.query<TemplateVersionRow>(
+          `INSERT INTO approval_template_versions (template_id, version, status, form_schema, approval_graph)
+           VALUES ($1, $2, 'draft', $3, $4)
+           RETURNING *`,
+          [
+            id,
+            nextVersion,
+            JSON.stringify(formSchema ?? latestVersion.form_schema),
+            JSON.stringify(approvalGraph ?? latestVersion.approval_graph),
+          ],
+        )
+        version = versionResult.rows[0]
+
+        const updatedTemplateResult = await client.query<TemplateRow>(
+          `UPDATE approval_templates
+           SET latest_version_id = $1, updated_at = now()
+           WHERE id = $2
+           RETURNING *`,
+          [version.id, id],
+        )
+        template = updatedTemplateResult.rows[0]
+      } else {
+        const bundle = await this.loadTemplateBundleWithClient(client, id, undefined, 'latest')
+        version = bundle?.version ?? null
+      }
+
+      await client.query('COMMIT')
+
+      if (!version) {
+        throw new ServiceError('Approval template version not found', 404, 'APPROVAL_TEMPLATE_VERSION_NOT_FOUND')
+      }
+
+      return toApprovalTemplateDetailDTO({
+        template,
+        version,
+        publishedDefinition: null,
+      })
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async publishTemplate(id: string, request: PublishApprovalTemplateRequest): Promise<ApprovalTemplateVersionDetailDTO> {
+    if (!pool) throw new Error('Database not available')
+
+    const policy = assertRuntimePolicy(request.policy)
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+
+      const templateResult = await client.query<TemplateRow>(
+        `SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE`,
+        [id],
+      )
+      const template = templateResult.rows[0]
+      if (!template) {
+        throw new ServiceError('Approval template not found', 404, 'APPROVAL_TEMPLATE_NOT_FOUND')
+      }
+      if (!template.latest_version_id) {
+        throw new ServiceError('Approval template has no version to publish', 400, 'APPROVAL_TEMPLATE_VERSION_NOT_FOUND')
+      }
+
+      const versionResult = await client.query<TemplateVersionRow>(
+        `SELECT * FROM approval_template_versions WHERE id = $1 AND template_id = $2`,
+        [template.latest_version_id, id],
+      )
+      const version = versionResult.rows[0]
+      if (!version) {
+        throw new ServiceError('Approval template version not found', 404, 'APPROVAL_TEMPLATE_VERSION_NOT_FOUND')
+      }
+
+      await client.query(
+        `UPDATE approval_published_definitions
+         SET is_active = FALSE
+         WHERE template_id = $1 AND is_active = TRUE`,
+        [id],
+      )
+
+      const runtimeGraph = buildRuntimeGraph(assertApprovalGraph(version.approval_graph), policy)
+
+      const publishedDefinitionResult = await client.query<PublishedDefinitionRow>(
+        `INSERT INTO approval_published_definitions (template_id, template_version_id, runtime_graph, is_active, published_at)
+         VALUES ($1, $2, $3, TRUE, now())
+         RETURNING *`,
+        [id, version.id, JSON.stringify(runtimeGraph)],
+      )
+      const publishedDefinition = publishedDefinitionResult.rows[0]
+
+      const updatedVersionResult = await client.query<TemplateVersionRow>(
+        `UPDATE approval_template_versions
+         SET status = 'published', updated_at = now()
+         WHERE id = $1
+         RETURNING *`,
+        [version.id],
+      )
+      const updatedVersion = updatedVersionResult.rows[0]
+
+      await client.query(
+        `UPDATE approval_templates
+         SET status = 'published',
+             active_version_id = $1,
+             updated_at = now()
+         WHERE id = $2`,
+        [version.id, id],
+      )
+
+      await client.query('COMMIT')
+
+      return toApprovalTemplateVersionDetailDTO({
+        template,
+        version: updatedVersion,
+        publishedDefinition,
+      })
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
   async createApproval(request: CreateApprovalRequest, actor: CreateApprovalActor): Promise<UnifiedApprovalDTO> {
     if (!pool) throw new Error('Database not available')
 
-    const bundle = await this.loadTemplateBundle(request.templateId)
+    const bundle = await this.loadTemplateBundle(request.templateId, undefined, 'active')
     if (!bundle) {
       throw new ServiceError('Approval template not found', 404, 'APPROVAL_TEMPLATE_NOT_FOUND')
     }
@@ -631,27 +970,41 @@ export class ApprovalProductService {
     return result.rows[0]?.request_no || `AP-${normalizePage(Date.now(), 100001)}`
   }
 
-  private async loadTemplateBundle(templateId: string, explicitVersionId?: string): Promise<TemplateBundle | null> {
+  private async loadTemplateBundle(
+    templateId: string,
+    explicitVersionId?: string,
+    preferredVersion: TemplateVersionPreference = 'active',
+  ): Promise<TemplateBundle | null> {
     if (!pool) throw new Error('Database not available')
 
-    const templateResult = await pool.query<TemplateRow>(
+    return this.loadTemplateBundleWithClient(pool, templateId, explicitVersionId, preferredVersion)
+  }
+
+  private async loadTemplateBundleWithClient(
+    client: { query: typeof pool.query },
+    templateId: string,
+    explicitVersionId?: string,
+    preferredVersion: TemplateVersionPreference = 'active',
+  ): Promise<TemplateBundle | null> {
+    const templateResult = await client.query<TemplateRow>(
       `SELECT * FROM approval_templates WHERE id = $1`,
       [templateId],
     )
     const template = templateResult.rows[0]
     if (!template) return null
 
-    const versionId = explicitVersionId || template.active_version_id || template.latest_version_id
+    const versionId = explicitVersionId
+      || (preferredVersion === 'latest' ? template.latest_version_id || template.active_version_id : template.active_version_id || template.latest_version_id)
     if (!versionId) return null
 
-    const versionResult = await pool.query<TemplateVersionRow>(
+    const versionResult = await client.query<TemplateVersionRow>(
       `SELECT * FROM approval_template_versions WHERE id = $1 AND template_id = $2`,
       [versionId, template.id],
     )
     const version = versionResult.rows[0]
     if (!version) return null
 
-    const publishedResult = await pool.query<PublishedDefinitionRow>(
+    const publishedResult = await client.query<PublishedDefinitionRow>(
       `SELECT *
        FROM approval_published_definitions
        WHERE template_version_id = $1

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -189,6 +189,26 @@ export interface ApprovalTemplateDetailDTO extends ApprovalTemplateListItemDTO {
   approvalGraph: ApprovalGraph
 }
 
+export interface CreateApprovalTemplateRequest {
+  key: string
+  name: string
+  description?: string | null
+  formSchema: FormSchema
+  approvalGraph: ApprovalGraph
+}
+
+export interface UpdateApprovalTemplateRequest {
+  key?: string
+  name?: string
+  description?: string | null
+  formSchema?: FormSchema
+  approvalGraph?: ApprovalGraph
+}
+
+export interface PublishApprovalTemplateRequest {
+  policy: RuntimePolicy
+}
+
 export interface ApprovalTemplateVersionDetailDTO {
   id: string
   templateId: string

--- a/packages/core-backend/tests/unit/approval-template-routes.test.ts
+++ b/packages/core-backend/tests/unit/approval-template-routes.test.ts
@@ -1,0 +1,444 @@
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type TemplateRow = {
+  id: string
+  key: string
+  name: string
+  description: string | null
+  status: 'draft' | 'published' | 'archived'
+  active_version_id: string | null
+  latest_version_id: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+type TemplateVersionRow = {
+  id: string
+  template_id: string
+  version: number
+  status: 'draft' | 'published' | 'archived'
+  form_schema: Record<string, unknown>
+  approval_graph: Record<string, unknown>
+  created_at: Date
+  updated_at: Date
+}
+
+type PublishedDefinitionRow = {
+  id: string
+  template_id: string
+  template_version_id: string
+  runtime_graph: Record<string, unknown>
+  is_active: boolean
+  published_at: Date
+}
+
+const routeState = vi.hoisted(() => {
+  const now = () => new Date('2026-04-11T12:00:00.000Z')
+
+  const state = {
+    templates: new Map<string, TemplateRow>(),
+    versions: new Map<string, TemplateVersionRow>(),
+    publishedDefinitions: new Map<string, PublishedDefinitionRow>(),
+    templateSeq: 1,
+    versionSeq: 1,
+    publishedSeq: 1,
+  }
+
+  function reset() {
+    state.templates.clear()
+    state.versions.clear()
+    state.publishedDefinitions.clear()
+    state.templateSeq = 1
+    state.versionSeq = 1
+    state.publishedSeq = 1
+  }
+
+  function createTemplateFixture(overrides?: Partial<TemplateRow>) {
+    const timestamp = now()
+    const template: TemplateRow = {
+      id: `tpl-${state.templateSeq++}`,
+      key: 'travel-request',
+      name: 'Travel Request',
+      description: 'Base template',
+      status: 'draft',
+      active_version_id: null,
+      latest_version_id: null,
+      created_at: timestamp,
+      updated_at: timestamp,
+      ...overrides,
+    }
+    state.templates.set(template.id, template)
+    return template
+  }
+
+  function createVersionFixture(templateId: string, overrides?: Partial<TemplateVersionRow>) {
+    const timestamp = now()
+    const version: TemplateVersionRow = {
+      id: `ver-${state.versionSeq++}`,
+      template_id: templateId,
+      version: 1,
+      status: 'draft',
+      form_schema: {
+        fields: [
+          { id: 'reason', type: 'text', label: 'Reason', required: true },
+        ],
+      },
+      approval_graph: {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'approve_1', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['manager'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approve_1' },
+          { key: 'e2', source: 'approve_1', target: 'end' },
+        ],
+      },
+      created_at: timestamp,
+      updated_at: timestamp,
+      ...overrides,
+    }
+    state.versions.set(version.id, version)
+    return version
+  }
+
+  function normalize(sql: string): string {
+    return sql.replace(/\s+/g, ' ').trim()
+  }
+
+  function parseJson(value: unknown): Record<string, unknown> {
+    if (typeof value === 'string') return JSON.parse(value) as Record<string, unknown>
+    return (value ?? {}) as Record<string, unknown>
+  }
+
+  const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+    const normalized = normalize(sql)
+
+    if (normalized === 'BEGIN' || normalized === 'COMMIT' || normalized === 'ROLLBACK') {
+      return { rows: [], rowCount: 0 }
+    }
+
+    if (normalized.startsWith('SELECT COUNT(*)::text AS count FROM approval_templates')) {
+      return { rows: [{ count: String(state.templates.size) }], rowCount: 1 }
+    }
+
+    if (
+      normalized.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')
+      || normalized.startsWith('SELECT * FROM approval_templates WHERE id = $1')
+    ) {
+      const row = state.templates.get(String(params[0]))
+      return { rows: row ? [row] : [], rowCount: row ? 1 : 0 }
+    }
+
+    if (
+      normalized.startsWith('SELECT * FROM approval_templates ORDER BY updated_at DESC, id DESC')
+      || normalized.startsWith('SELECT * FROM approval_templates WHERE ')
+    ) {
+      const limit = Number(params[params.length - 2] ?? 50)
+      const offset = Number(params[params.length - 1] ?? 0)
+      const rows = Array.from(state.templates.values())
+        .sort((left, right) => right.updated_at.getTime() - left.updated_at.getTime())
+        .slice(offset, offset + limit)
+      return { rows, rowCount: rows.length }
+    }
+
+    if (normalized.startsWith('INSERT INTO approval_templates')) {
+      const timestamp = now()
+      const row: TemplateRow = {
+        id: `tpl-${state.templateSeq++}`,
+        key: String(params[0]),
+        name: String(params[1]),
+        description: params[2] == null ? null : String(params[2]),
+        status: 'draft',
+        active_version_id: null,
+        latest_version_id: null,
+        created_at: timestamp,
+        updated_at: timestamp,
+      }
+      state.templates.set(row.id, row)
+      return { rows: [row], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('UPDATE approval_templates SET latest_version_id = $1, updated_at = now() WHERE id = $2 RETURNING *')) {
+      const row = state.templates.get(String(params[1]))
+      if (!row) return { rows: [], rowCount: 0 }
+      row.latest_version_id = String(params[0])
+      row.updated_at = now()
+      return { rows: [row], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('UPDATE approval_templates SET status = \'published\',')) {
+      const row = state.templates.get(String(params[1]))
+      if (!row) return { rows: [], rowCount: 0 }
+      row.status = 'published'
+      row.active_version_id = String(params[0])
+      row.updated_at = now()
+      return { rows: [], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('UPDATE approval_templates SET') && normalized.includes('RETURNING *')) {
+      const id = String(params[params.length - 1])
+      const row = state.templates.get(id)
+      if (!row) return { rows: [], rowCount: 0 }
+      let index = 0
+      if (normalized.includes('key = $')) row.key = String(params[index++])
+      if (normalized.includes('name = $')) row.name = String(params[index++])
+      if (normalized.includes('description = $')) {
+        const value = params[index++]
+        row.description = value == null ? null : String(value)
+      }
+      row.updated_at = now()
+      return { rows: [row], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('SELECT * FROM approval_template_versions WHERE id = $1 AND template_id = $2')) {
+      const row = state.versions.get(String(params[0]))
+      const rows = row && row.template_id === String(params[1]) ? [row] : []
+      return { rows, rowCount: rows.length }
+    }
+
+    if (normalized.startsWith('SELECT * FROM approval_template_versions WHERE template_id = $1 ORDER BY version DESC LIMIT 1')) {
+      const rows = Array.from(state.versions.values())
+        .filter((row) => row.template_id === String(params[0]))
+        .sort((left, right) => right.version - left.version)
+      return { rows: rows.slice(0, 1), rowCount: rows.length > 0 ? 1 : 0 }
+    }
+
+    if (normalized.startsWith('SELECT COALESCE(MAX(version), 0)::text AS max_version FROM approval_template_versions WHERE template_id = $1')) {
+      const versions = Array.from(state.versions.values()).filter((row) => row.template_id === String(params[0]))
+      const maxVersion = versions.length > 0 ? Math.max(...versions.map((row) => row.version)) : 0
+      return { rows: [{ max_version: String(maxVersion) }], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('INSERT INTO approval_template_versions')) {
+      const timestamp = now()
+      const hasExplicitVersionParam = params.length === 4
+      const row: TemplateVersionRow = {
+        id: `ver-${state.versionSeq++}`,
+        template_id: String(params[0]),
+        version: hasExplicitVersionParam ? Number(params[1]) : 1,
+        status: 'draft',
+        form_schema: parseJson(hasExplicitVersionParam ? params[2] : params[1]),
+        approval_graph: parseJson(hasExplicitVersionParam ? params[3] : params[2]),
+        created_at: timestamp,
+        updated_at: timestamp,
+      }
+      state.versions.set(row.id, row)
+      return { rows: [row], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('UPDATE approval_template_versions SET status = \'published\'')) {
+      const row = state.versions.get(String(params[0]))
+      if (!row) return { rows: [], rowCount: 0 }
+      row.status = 'published'
+      row.updated_at = now()
+      return { rows: [row], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('SELECT * FROM approval_published_definitions WHERE template_version_id = $1')) {
+      const rows = Array.from(state.publishedDefinitions.values())
+        .filter((row) => row.template_version_id === String(params[0]))
+        .sort((left, right) => Number(right.is_active) - Number(left.is_active))
+      return { rows: rows.slice(0, 1), rowCount: rows.length > 0 ? 1 : 0 }
+    }
+
+    if (normalized.startsWith('UPDATE approval_published_definitions SET is_active = FALSE WHERE template_id = $1 AND is_active = TRUE')) {
+      for (const row of state.publishedDefinitions.values()) {
+        if (row.template_id === String(params[0]) && row.is_active) {
+          row.is_active = false
+        }
+      }
+      return { rows: [], rowCount: 0 }
+    }
+
+    if (normalized.startsWith('INSERT INTO approval_published_definitions')) {
+      const row: PublishedDefinitionRow = {
+        id: `pub-${state.publishedSeq++}`,
+        template_id: String(params[0]),
+        template_version_id: String(params[1]),
+        runtime_graph: parseJson(params[2]),
+        is_active: true,
+        published_at: now(),
+      }
+      state.publishedDefinitions.set(row.id, row)
+      return { rows: [row], rowCount: 1 }
+    }
+
+    throw new Error(`Unhandled query: ${normalized}`)
+  })
+
+  const pool = {
+    query,
+    connect: vi.fn(async () => ({
+      query,
+      release: vi.fn(),
+    })),
+  }
+
+  return {
+    reset,
+    state,
+    createTemplateFixture,
+    createVersionFixture,
+    pool,
+  }
+})
+
+vi.mock('../../src/db/pg', () => ({
+  pool: routeState.pool,
+}))
+
+vi.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      id: 'template-admin',
+      sub: 'template-admin',
+      name: 'Template Admin',
+      email: 'template@example.com',
+      permissions: ['*:*'],
+      roles: ['admin'],
+    } as never
+    next()
+  },
+}))
+
+import { approvalsRouter } from '../../src/routes/approvals'
+
+describe('approval template routes', () => {
+  beforeEach(() => {
+    routeState.reset()
+    routeState.pool.query.mockClear()
+    routeState.pool.connect.mockClear()
+  })
+
+  function createApp() {
+    const app = express()
+    app.use(express.json())
+    app.use(approvalsRouter())
+    return app
+  }
+
+  it('creates a template and its first draft version', async () => {
+    const app = createApp()
+
+    const response = await request(app)
+      .post('/api/approval-templates')
+      .send({
+        key: 'expense-approval',
+        name: 'Expense Approval',
+        description: 'Travel and expense approvals',
+        formSchema: {
+          fields: [{ id: 'amount', type: 'number', label: 'Amount', required: true }],
+        },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            { key: 'approve_1', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['finance'] } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'e1', source: 'start', target: 'approve_1' },
+            { key: 'e2', source: 'approve_1', target: 'end' },
+          ],
+        },
+      })
+
+    expect(response.status).toBe(201)
+    expect(response.body.key).toBe('expense-approval')
+    expect(response.body.status).toBe('draft')
+    expect(response.body.latestVersionId).toMatch(/^ver-/)
+    expect(response.body.formSchema.fields).toHaveLength(1)
+  })
+
+  it('patches template metadata and creates a new draft version when graph changes', async () => {
+    const template = routeState.createTemplateFixture()
+    const version = routeState.createVersionFixture(template.id)
+    template.latest_version_id = version.id
+
+    const app = createApp()
+    const response = await request(app)
+      .patch(`/api/approval-templates/${template.id}`)
+      .send({
+        name: 'Travel Request v2',
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            { key: 'approve_1', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['manager'] } },
+            { key: 'cc_1', type: 'cc', config: { targetType: 'role', targetIds: ['finance'] } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'e1', source: 'start', target: 'approve_1' },
+            { key: 'e2', source: 'approve_1', target: 'cc_1' },
+            { key: 'e3', source: 'cc_1', target: 'end' },
+          ],
+        },
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.body.name).toBe('Travel Request v2')
+    expect(response.body.latestVersionId).not.toBe(version.id)
+    expect(routeState.state.versions.size).toBe(2)
+    expect(response.body.approvalGraph.nodes).toHaveLength(4)
+  })
+
+  it('publishes latest template version and injects runtime policy', async () => {
+    const template = routeState.createTemplateFixture()
+    const version = routeState.createVersionFixture(template.id)
+    template.latest_version_id = version.id
+
+    const app = createApp()
+    const response = await request(app)
+      .post(`/api/approval-templates/${template.id}/publish`)
+      .send({
+        policy: {
+          allowRevoke: true,
+          revokeBeforeNodeKeys: ['approve_1'],
+        },
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.body.status).toBe('published')
+    expect(response.body.publishedDefinitionId).toMatch(/^pub-/)
+    expect(response.body.runtimeGraph.policy).toEqual({
+      allowRevoke: true,
+      revokeBeforeNodeKeys: ['approve_1'],
+    })
+    expect(routeState.state.templates.get(template.id)?.active_version_id).toBe(version.id)
+  })
+
+  it('lists templates and fetches version detail', async () => {
+    const template = routeState.createTemplateFixture()
+    const version = routeState.createVersionFixture(template.id)
+    const publishedDefinition: PublishedDefinitionRow = {
+      id: 'pub-1',
+      template_id: template.id,
+      template_version_id: version.id,
+      runtime_graph: {
+        ...version.approval_graph,
+        policy: { allowRevoke: false },
+      },
+      is_active: true,
+      published_at: new Date('2026-04-11T12:00:00.000Z'),
+    }
+    template.latest_version_id = version.id
+    template.active_version_id = version.id
+    template.status = 'published'
+    version.status = 'published'
+    routeState.state.publishedDefinitions.set(publishedDefinition.id, publishedDefinition)
+
+    const app = createApp()
+
+    const listResponse = await request(app).get('/api/approval-templates?page=1&pageSize=20')
+    expect(listResponse.status).toBe(200)
+    expect(listResponse.body.total).toBe(1)
+    expect(listResponse.body.data[0].id).toBe(template.id)
+
+    const versionResponse = await request(app).get(`/api/approval-templates/${template.id}/versions/${version.id}`)
+    expect(versionResponse.status).toBe(200)
+    expect(versionResponse.body.id).toBe(version.id)
+    expect(versionResponse.body.runtimeGraph.policy.allowRevoke).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
@@ -509,9 +509,12 @@ vi.mock('../../src/db/pg', () => ({
 vi.mock('../../src/middleware/auth', () => ({
   authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
     req.user = {
+      id: 'test-user',
       sub: 'test-user',
       name: 'Test User',
       email: 'test@example.com',
+      permissions: ['*:*'],
+      roles: ['admin'],
     } as never
     next()
   },


### PR DESCRIPTION
## Summary
- add platform approval template create/update/publish endpoints on top of the runtime executor branch
- extend ApprovalProductService with latest-version editing and publish-time runtime graph policy injection
- enforce approval product permissions on template and approval routes

## Verification
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-template-routes.test.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approvals-bridge-routes.test.ts --watch=false --reporter=dot
- git diff --check