### PR TITLE
feat(after-sales): refresh ticket edit flow onto current main

### DIFF
--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -3572,17 +3572,6 @@ function buildTicketUpdatePayload() {
   }
 }
 
-function buildTicketUpdatePayload() {
-  return {
-    ticket: {
-      title: toText(ticketEditDraft.value.title),
-      priority: ticketEditDraft.value.priority,
-      source: ticketEditDraft.value.source,
-      status: ticketEditDraft.value.status,
-    },
-  }
-}
-
 function buildServiceRecordListPath() {
   const params = new URLSearchParams()
   const ticketNo = toText(serviceRecordFilters.value.ticketNo)

--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -456,6 +456,7 @@
                         v-model="ticketEditDraft.priority"
                         class="after-sales-view__field-input"
                       >
+                        <option value="low">Low</option>
                         <option value="normal">Normal</option>
                         <option value="high">High</option>
                         <option value="urgent">Urgent</option>
@@ -2395,7 +2396,7 @@ interface TicketDraft {
 
 interface TicketEditDraft {
   title: string
-  priority: 'normal' | 'high' | 'urgent'
+  priority: 'low' | 'normal' | 'high' | 'urgent'
   source: 'web' | 'phone' | 'wechat' | 'email'
   status: 'new' | 'assigned' | 'inProgress' | 'done' | 'closed'
 }
@@ -3149,7 +3150,7 @@ function createTicketDraft(): TicketDraft {
 }
 
 function normalizeTicketPriority(value: unknown): TicketEditDraft['priority'] {
-  return value === 'high' || value === 'urgent' ? value : 'normal'
+  return value === 'low' || value === 'high' || value === 'urgent' ? value : 'normal'
 }
 
 function normalizeTicketSource(value: unknown): TicketEditDraft['source'] {
@@ -3558,6 +3559,17 @@ function matchesPartItemFilters(partItem: PartItemViewModel) {
   }
 
   return true
+}
+
+function buildTicketUpdatePayload() {
+  return {
+    ticket: {
+      title: toText(ticketEditDraft.value.title),
+      priority: ticketEditDraft.value.priority,
+      source: ticketEditDraft.value.source,
+      status: ticketEditDraft.value.status,
+    },
+  }
 }
 
 function buildTicketUpdatePayload() {

--- a/apps/web/tests/AfterSalesView.spec.ts
+++ b/apps/web/tests/AfterSalesView.spec.ts
@@ -889,6 +889,128 @@ describe('AfterSalesView', () => {
     )
   })
 
+  it('preserves low priority when editing an existing ticket', async () => {
+    apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
+      if (path === '/api/after-sales/app-manifest') {
+        return createResponse({
+          id: 'after-sales-default',
+          displayName: 'After Sales',
+          platformDependencies: ['core-backend'],
+          objects: [],
+          workflows: [],
+        })
+      }
+
+      if (path === '/api/after-sales/projects/current') {
+        return createResponse({
+          status: 'installed',
+          projectId: 'tenant:after-sales',
+          displayName: 'After Sales',
+          config: {
+            defaultSlaHours: 24,
+            urgentSlaHours: 4,
+            followUpAfterDays: 7,
+          },
+          installResult: {
+            status: 'installed',
+            createdObjects: [],
+            createdViews: [],
+            warnings: [],
+            reportRef: 'install-006e',
+          },
+          reportRef: 'install-006e',
+        })
+      }
+
+      if (path === '/api/after-sales/tickets' && !options?.method) {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          count: 1,
+          tickets: [
+            {
+              id: 'ticket-1',
+              version: 1,
+              data: {
+                ticketNo: 'AF-001',
+                title: 'Install compressor',
+                status: 'new',
+                priority: 'low',
+                source: 'phone',
+                refundStatus: '',
+                refundAmount: 0,
+              },
+            },
+          ],
+        })
+      }
+
+      if (path === '/api/after-sales/tickets/ticket-1' && options?.method === 'PATCH') {
+        return createResponse({
+          projectId: 'tenant:after-sales',
+          ticket: {
+            id: 'ticket-1',
+            version: 2,
+            data: {
+              ticketNo: 'AF-001',
+              title: 'Updated compressor diagnosis',
+              status: 'assigned',
+              priority: 'low',
+              source: 'phone',
+              refundStatus: '',
+              refundAmount: 0,
+            },
+          },
+        })
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    const mounted = mountAfterSalesView()
+    app = mounted.app
+    container = mounted.container
+
+    await waitForText(container, 'AF-001')
+
+    const editButton = container?.querySelector<HTMLButtonElement>('button[aria-label="Edit ticket AF-001"]')
+    expect(editButton).toBeTruthy()
+    if (!editButton) return
+
+    editButton.click()
+    await flushUi()
+
+    const titleInput = container?.querySelector<HTMLInputElement>('#after-sales-ticket-edit-title-ticket-1')
+    const prioritySelect = container?.querySelector<HTMLSelectElement>('#after-sales-ticket-edit-priority-ticket-1')
+    const statusSelect = container?.querySelector<HTMLSelectElement>('#after-sales-ticket-edit-status-ticket-1')
+    expect(titleInput).toBeTruthy()
+    expect(prioritySelect).toBeTruthy()
+    expect(statusSelect).toBeTruthy()
+    if (!titleInput || !prioritySelect || !statusSelect) return
+
+    expect(prioritySelect.value).toBe('low')
+
+    await setInputValue(titleInput, 'Updated compressor diagnosis')
+    await setSelectValue(statusSelect, 'assigned')
+
+    findButton(container, 'Save changes').click()
+    await waitForText(container, 'Updated ticket AF-001')
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/after-sales/tickets/ticket-1',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({
+          ticket: {
+            title: 'Updated compressor diagnosis',
+            priority: 'low',
+            source: 'phone',
+            status: 'assigned',
+          },
+        }),
+      }),
+    )
+  })
+
   it('keeps the edit draft open when ticket update fails', async () => {
     apiFetchMock.mockImplementation(async (path: string, options?: RequestInit) => {
       if (path === '/api/after-sales/app-manifest') {

--- a/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
@@ -1721,6 +1721,73 @@ describe('plugin-after-sales routes', () => {
     })
   })
 
+  it('preserves low priority when updating a ticket through the multitable patch seam', async () => {
+    const handler = routes.get('PATCH /api/after-sales/tickets/:ticketId')
+    const res = new FakeResponse()
+
+    db.rows.push({
+      id: 'fake-uuid-1',
+      tenant_id: 'tenant_42',
+      app_id: 'after-sales',
+      project_id: 'tenant_42:after-sales',
+      template_id: 'after-sales-default',
+      template_version: '0.1.0',
+      mode: 'enable',
+      status: 'installed',
+      created_objects_json: JSON.stringify(['serviceTicket']),
+      created_views_json: JSON.stringify(['ticket-board']),
+      warnings_json: JSON.stringify([]),
+      display_name: 'After-sales',
+      config_json: JSON.stringify({}),
+      last_install_at: new Date(),
+      created_at: new Date(),
+    })
+
+    await handler?.(buildReq({
+      user: {
+        id: 'writer_42',
+        tenantId: 'tenant_42',
+        role: 'user',
+        roles: ['user'],
+        perms: ['after_sales:write'],
+      },
+      params: {
+        ticketId: 'rec_ticket_001',
+      },
+      body: {
+        ticket: {
+          title: 'Updated low priority diagnosis',
+          priority: 'low',
+          source: 'phone',
+          status: 'assigned',
+        },
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(patchRecord).toHaveBeenCalledWith({
+      sheetId: 'tenant_42:after-sales:serviceTicket:sheet',
+      recordId: 'rec_ticket_001',
+      changes: {
+        [stPk('title')]: 'Updated low priority diagnosis',
+        [stPk('priority')]: 'low',
+        [stPk('source')]: 'phone',
+        [stPk('status')]: 'assigned',
+      },
+    })
+    expect(res.body.data.ticket).toEqual({
+      id: 'rec_ticket_001',
+      version: 4,
+      data: {
+        ticketNo: 'TK-2001',
+        title: 'Updated low priority diagnosis',
+        source: 'phone',
+        priority: 'low',
+        status: 'assigned',
+      },
+    })
+  })
+
   it('returns 404 when updating a missing ticket', async () => {
     const handler = routes.get('PATCH /api/after-sales/tickets/:ticketId')
     const res = new FakeResponse()
@@ -5755,6 +5822,7 @@ describe('plugin-after-sales routes', () => {
         emitTicketOverdue: expect.any(Function),
         emitFollowUpDue: expect.any(Function),
         createTicket: expect.any(Function),
+        updateTicket: expect.any(Function),
         requestTicketRefund: expect.any(Function),
         listTickets: expect.any(Function),
         deleteTicket: expect.any(Function),

--- a/plugins/plugin-after-sales/index.cjs
+++ b/plugins/plugin-after-sales/index.cjs
@@ -586,7 +586,6 @@ async function getFollowUpById(multitableApi, projectId, followUpId) {
     logicalData: await fromPhysicalFollowUpData(multitableApi.provisioning, projectId, record.data),
   }
 }
-
 async function getTicketRecordById(multitableApi, projectId, ticketId) {
   const sheetId = await findObjectSheetId(multitableApi.provisioning, projectId, 'serviceTicket')
   const record = await multitableApi.records.getRecord({

--- a/plugins/plugin-after-sales/lib/event-entry.cjs
+++ b/plugins/plugin-after-sales/lib/event-entry.cjs
@@ -494,7 +494,6 @@ function buildUpdateInstalledAssetCommand(input, existingInstalledAsset) {
     },
   }
 }
-
 function normalizeTicketStatus(value) {
   if (optionalString(value) === 'open') {
     return 'new'


### PR DESCRIPTION
## Summary
- refresh the stale ticket edit flow onto current `main`
- preserve current refund field-policy guards and existing object update/error behavior while landing the edit path
- preserve `low` ticket priority through the edit UI and route seam, and lock the communication registration with `updateTicket`

## Verification
- `pnpm --dir /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-next-major-slice-refresh --filter @metasheet/web exec vitest run tests/AfterSalesView.spec.ts --reporter=dot`
- `pnpm --dir /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-next-major-slice-refresh --filter @metasheet/core-backend exec vitest run tests/unit/after-sales-plugin-routes.test.ts --reporter=dot`
- `pnpm --dir /Users/huazhou/Downloads/Github/metasheet2/.worktrees/after-sales-next-major-slice-refresh --filter @metasheet/core-backend run test:integration:after-sales`

## Notes
- this supersedes the stale local-only `feature/after-sales-next-major-slice` by re-landing its ticket edit flow on top of current `main`
- frontend verification still emits the known Vite websocket bind warning in this sandbox (`EPERM 0.0.0.0:24678`), but the suite passes
