### PR TITLE
fix(ci): unblock plugin system tests baseline

### DIFF
--- a/packages/core-backend/src/services/AfterSalesApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/AfterSalesApprovalBridgeService.ts
@@ -414,8 +414,13 @@ export class AfterSalesApprovalBridgeService {
           `INSERT INTO approval_assignments
            (instance_id, assignment_type, assignee_id, source_step, is_active, metadata)
            VALUES ($1, 'role', $2, $3, TRUE, $4::jsonb)
-           ON CONFLICT (instance_id, assignment_type, assignee_id, source_step)
-           DO UPDATE SET is_active = TRUE, metadata = EXCLUDED.metadata, updated_at = now()`,
+           ON CONFLICT (instance_id, assignment_type, assignee_id)
+             WHERE is_active = TRUE
+           DO UPDATE SET
+             source_step = EXCLUDED.source_step,
+             is_active = TRUE,
+             metadata = EXCLUDED.metadata,
+             updated_at = now()`,
           [
             approvalId,
             role,

--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -708,8 +708,13 @@ export class ApprovalBridgeService {
         `INSERT INTO approval_assignments
          (instance_id, assignment_type, assignee_id, source_step, is_active, metadata)
          VALUES ($1, 'source_queue', 'plm:source-owned', 0, $2, $3)
-         ON CONFLICT (instance_id, assignment_type, assignee_id, source_step)
-         DO UPDATE SET is_active = EXCLUDED.is_active, metadata = EXCLUDED.metadata, updated_at = now()`,
+         ON CONFLICT (instance_id, assignment_type, assignee_id)
+           WHERE is_active = TRUE
+         DO UPDATE SET
+           source_step = EXCLUDED.source_step,
+           is_active = EXCLUDED.is_active,
+           metadata = EXCLUDED.metadata,
+           updated_at = now()`,
         [
           instanceId,
           bridge.status === 'pending',

--- a/packages/core-backend/tests/unit/approvals-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-routes.test.ts
@@ -36,6 +36,10 @@ vi.mock('../../src/middleware/auth', () => ({
   },
 }))
 
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}))
+
 import { approvalsRouter } from '../../src/routes/approvals'
 
 describe('approvals routes', () => {


### PR DESCRIPTION
## Summary
- bypass `rbacGuard` in `approvals-routes` unit tests so the suite continues to exercise route-specific approval error handling
- align approval assignment upserts with the new active-assignment unique index introduced on `main`
- unblock baseline `Plugin System Tests` failures that are currently also blocking after-sales PR #811

## Verification
- `pnpm --dir /Users/huazhou/Downloads/Github/metasheet2/.worktrees/main-approvals-ci-check --filter @metasheet/core-backend exec vitest run tests/unit/after-sales-approval-bridge.test.ts --reporter=dot`
- confirmed current `main` is already red on the same `Plugin System Tests` workflow and identical `after-sales integration` failures

## Notes
- `tests/unit/approvals-routes.test.ts` cannot be executed reliably inside this sandbox because `supertest` attempts to bind an ephemeral listener and hits `EPERM`; CI is the real verifier for that file
- this PR is intended to unblock the baseline so feature PR #811 can be evaluated on its own diff
