### PR TITLE
fix(approvals): harden phase 1 runtime and mock validation

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -104,7 +104,7 @@ function mockVersionDetail(templateId: string, versionId: string): ApprovalTempl
 }
 
 function mockApproval(index: number): UnifiedApprovalDTO {
-  const statuses: ApprovalStatus[] = ['pending', 'approved', 'rejected', 'revoked', 'draft']
+  const statuses: ApprovalStatus[] = ['pending', 'approved', 'rejected', 'revoked', 'cancelled']
   const status = statuses[index % statuses.length]
   return {
     id: `apv_${index}`,
@@ -122,7 +122,7 @@ function mockApproval(index: number): UnifiedApprovalDTO {
     templateId: 'tpl_1',
     templateVersionId: 'ver_1_1',
     publishedDefinitionId: 'def_1',
-    requestNo: `APV-2026-${String(index).padStart(4, '0')}`,
+    requestNo: `AP-${String(100000 + index)}`,
     formSnapshot: { fld_reason: '出差报销', fld_amount: 5000, fld_type: 'reimbursement' },
     currentNodeKey: status === 'pending' ? 'approval_1' : null,
     assignments: status === 'pending' ? [{

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -218,7 +218,6 @@ function statusTagType(status: string) {
     approved: 'success',
     rejected: 'danger',
     revoked: 'info',
-    draft: 'info',
     cancelled: 'info',
   }
   return map[status] ?? ''
@@ -230,7 +229,6 @@ function statusLabel(status: string) {
     approved: '已通过',
     rejected: '已驳回',
     revoked: '已撤回',
-    draft: '草稿',
     cancelled: '已取消',
   }
   return map[status] ?? status

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -188,7 +188,6 @@ function statusTagType(status: string) {
     approved: 'success',
     rejected: 'danger',
     revoked: 'info',
-    draft: 'info',
     cancelled: 'info',
   }
   return map[status] ?? ''
@@ -200,7 +199,6 @@ function statusLabel(status: string) {
     approved: '已通过',
     rejected: '已驳回',
     revoked: '已撤回',
-    draft: '草稿',
     cancelled: '已取消',
   }
   return map[status] ?? status

--- a/apps/web/tests/approval-center.spec.ts
+++ b/apps/web/tests/approval-center.spec.ts
@@ -248,7 +248,7 @@ describe('ApprovalCenterView', () => {
     mockPendingApprovals.value = [
       {
         id: 'apv_1',
-        requestNo: 'APV-2026-0001',
+        requestNo: 'AP-100001',
         title: '出差报销',
         status: 'pending',
         requester: { name: '张三' },
@@ -257,7 +257,7 @@ describe('ApprovalCenterView', () => {
       },
       {
         id: 'apv_2',
-        requestNo: 'APV-2026-0002',
+        requestNo: 'AP-100002',
         title: '采购申请',
         status: 'approved',
         requester: { name: '李四' },

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -51,6 +51,10 @@ function isNonEmptyStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === 'string' && entry.trim().length > 0)
 }
 
+function looksLikeComparableDateString(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}(?:$|[T\s].*)/.test(value)
+}
+
 function normalizeComparableValue(value: unknown): number | string | null {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value
@@ -66,7 +70,7 @@ function normalizeComparableValue(value: unknown): number | string | null {
       return numeric
     }
     const epoch = Date.parse(trimmed)
-    if (!Number.isNaN(epoch) && /[-:TZ]/.test(trimmed)) {
+    if (!Number.isNaN(epoch) && looksLikeComparableDateString(trimmed)) {
       return epoch
     }
     return trimmed
@@ -135,7 +139,12 @@ function validateFieldType(field: FormField, value: unknown): string | null {
       return typeof value === 'number' && Number.isFinite(value) ? null : `${field.id} must be a number`
     case 'date':
     case 'datetime':
-      return typeof value === 'string' || value instanceof Date ? null : `${field.id} must be a date value`
+      if (typeof value === 'string') {
+        return Number.isNaN(Date.parse(value.trim())) ? `${field.id} must be a date value` : null
+      }
+      return value instanceof Date && !Number.isNaN(value.getTime())
+        ? null
+        : `${field.id} must be a date value`
     case 'select':
       if (typeof value !== 'string') return `${field.id} must be a string`
       if (field.options?.length && !field.options.some((option) => option.value === value)) {
@@ -155,6 +164,90 @@ function validateFieldType(field: FormField, value: unknown): string | null {
   }
 }
 
+function getFieldPropNumber(field: FormField, key: string): number | null {
+  const raw = field.props?.[key]
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function getFieldPropString(field: FormField, key: string): string | null {
+  const raw = field.props?.[key]
+  return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : null
+}
+
+function validateFieldConstraints(field: FormField, value: unknown): string[] {
+  if (value === undefined || value === null) {
+    return []
+  }
+
+  switch (field.type) {
+    case 'text':
+    case 'textarea': {
+      if (typeof value !== 'string') return []
+      const errors: string[] = []
+      const minLength = getFieldPropNumber(field, 'minLength')
+      const maxLength = getFieldPropNumber(field, 'maxLength')
+      const pattern = getFieldPropString(field, 'pattern')
+
+      if (minLength !== null && value.length < minLength) {
+        errors.push(`${field.id} must be at least ${minLength} characters`)
+      }
+      if (maxLength !== null && value.length > maxLength) {
+        errors.push(`${field.id} must be at most ${maxLength} characters`)
+      }
+      if (pattern) {
+        try {
+          if (!new RegExp(pattern).test(value)) {
+            errors.push(`${field.id} does not match the required pattern`)
+          }
+        } catch {
+          // Ignore invalid admin-configured regex patterns here and treat them as non-enforced.
+        }
+      }
+      return errors
+    }
+    case 'number': {
+      if (typeof value !== 'number' || !Number.isFinite(value)) return []
+      const errors: string[] = []
+      const min = getFieldPropNumber(field, 'min')
+      const max = getFieldPropNumber(field, 'max')
+
+      if (min !== null && value < min) {
+        errors.push(`${field.id} must be at least ${min}`)
+      }
+      if (max !== null && value > max) {
+        errors.push(`${field.id} must be at most ${max}`)
+      }
+      return errors
+    }
+    case 'date':
+    case 'datetime': {
+      const valueComparable = normalizeComparableValue(value)
+      if (valueComparable === null) return []
+
+      const errors: string[] = []
+      const min = getFieldPropString(field, 'min')
+      const max = getFieldPropString(field, 'max')
+      const minComparable = min ? normalizeComparableValue(min) : null
+      const maxComparable = max ? normalizeComparableValue(max) : null
+
+      if (typeof valueComparable === 'number' && typeof minComparable === 'number' && valueComparable < minComparable) {
+        errors.push(`${field.id} must be on or after ${min}`)
+      }
+      if (typeof valueComparable === 'number' && typeof maxComparable === 'number' && valueComparable > maxComparable) {
+        errors.push(`${field.id} must be on or before ${max}`)
+      }
+      return errors
+    }
+    default:
+      return []
+  }
+}
+
 export function validateApprovalFormData(formSchema: FormSchema, formData: Record<string, unknown>): string[] {
   const errors: string[] = []
 
@@ -167,7 +260,9 @@ export function validateApprovalFormData(formSchema: FormSchema, formData: Recor
     const typeError = validateFieldType(field, value)
     if (typeError) {
       errors.push(typeError)
+      continue
     }
+    errors.push(...validateFieldConstraints(field, value))
   }
 
   return errors

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -99,18 +99,280 @@ type ApprovalRecordInsert = {
   targetUserId?: string | null
 }
 
+type ApprovalDbClient = {
+  query: typeof pool.query
+  release: () => void
+}
+
+type ValidationContext = {
+  status: number
+  code: string
+}
+
+const REQUEST_VALIDATION_CONTEXT: ValidationContext = {
+  status: 400,
+  code: 'VALIDATION_ERROR',
+}
+
+const STORED_FORM_SCHEMA_CONTEXT: ValidationContext = {
+  status: 500,
+  code: 'APPROVAL_TEMPLATE_SCHEMA_INVALID',
+}
+
+const STORED_GRAPH_CONTEXT: ValidationContext = {
+  status: 500,
+  code: 'APPROVAL_TEMPLATE_GRAPH_INVALID',
+}
+
+const STORED_RUNTIME_CONTEXT: ValidationContext = {
+  status: 500,
+  code: 'APPROVAL_RUNTIME_GRAPH_INVALID',
+}
+
+const FORM_FIELD_TYPES = new Set([
+  'text',
+  'textarea',
+  'number',
+  'date',
+  'datetime',
+  'select',
+  'multi-select',
+  'user',
+  'attachment',
+])
+
+const APPROVAL_NODE_TYPES = new Set(['start', 'approval', 'cc', 'condition', 'end'])
+const CONDITION_OPERATORS = new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'isEmpty'])
+
 function toNullableRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null
 }
 
-function asFormSchema(value: Record<string, unknown>): FormSchema {
-  return value as unknown as FormSchema
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function asRuntimeGraph(value: Record<string, unknown>): RuntimeGraph {
-  return value as unknown as RuntimeGraph
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function failValidation(context: ValidationContext, message: string): never {
+  throw new ServiceError(message, context.status, context.code)
+}
+
+function deepFreeze<T>(value: T): T {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => deepFreeze(entry))
+    return Object.freeze(value)
+  }
+  if (value && typeof value === 'object') {
+    Object.values(value as Record<string, unknown>).forEach((entry) => deepFreeze(entry))
+    return Object.freeze(value)
+  }
+  return value
+}
+
+async function rollbackQuietly(client: ApprovalDbClient | null): Promise<void> {
+  if (!client) return
+  try {
+    await client.query('ROLLBACK')
+  } catch {
+    // Ignore rollback errors so the original failure is preserved.
+  }
+}
+
+function normalizeFormField(
+  value: unknown,
+  index: number,
+  context: ValidationContext,
+): FormSchema['fields'][number] {
+  if (!isRecord(value)) {
+    failValidation(context, `formSchema.fields[${index}] must be an object`)
+  }
+  if (!isNonEmptyString(value.id)) {
+    failValidation(context, `formSchema.fields[${index}].id is required`)
+  }
+  if (!FORM_FIELD_TYPES.has(String(value.type))) {
+    failValidation(context, `formSchema.fields[${index}].type is invalid`)
+  }
+  if (!isNonEmptyString(value.label)) {
+    failValidation(context, `formSchema.fields[${index}].label is required`)
+  }
+  if (value.required !== undefined && typeof value.required !== 'boolean') {
+    failValidation(context, `formSchema.fields[${index}].required must be a boolean`)
+  }
+  if (value.placeholder !== undefined && typeof value.placeholder !== 'string') {
+    failValidation(context, `formSchema.fields[${index}].placeholder must be a string`)
+  }
+  if (
+    value.options !== undefined &&
+    (!Array.isArray(value.options)
+      || value.options.some(
+        (option, optionIndex) =>
+          !isRecord(option)
+          || !isNonEmptyString(option.label)
+          || !isNonEmptyString(option.value)
+          || optionIndex < 0,
+      ))
+  ) {
+    failValidation(context, `formSchema.fields[${index}].options must be an array of label/value pairs`)
+  }
+  if (value.props !== undefined && !isRecord(value.props)) {
+    failValidation(context, `formSchema.fields[${index}].props must be an object`)
+  }
+
+  return {
+    id: value.id.trim(),
+    type: value.type as FormSchema['fields'][number]['type'],
+    label: value.label.trim(),
+    ...(value.required !== undefined ? { required: value.required } : {}),
+    ...(value.placeholder !== undefined ? { placeholder: value.placeholder } : {}),
+    ...(value.defaultValue !== undefined ? { defaultValue: value.defaultValue } : {}),
+    ...(Array.isArray(value.options)
+      ? {
+          options: value.options.map((option) => ({
+            label: (option as { label: string }).label.trim(),
+            value: (option as { value: string }).value.trim(),
+          })),
+        }
+      : {}),
+    ...(isRecord(value.props) ? { props: { ...value.props } } : {}),
+  } as FormSchema['fields'][number]
+}
+
+function assertFormSchema(value: unknown, context: ValidationContext = REQUEST_VALIDATION_CONTEXT): FormSchema {
+  if (!isRecord(value) || !Array.isArray(value.fields)) {
+    failValidation(context, 'formSchema must contain fields')
+  }
+
+  return {
+    fields: value.fields.map((field, index) => normalizeFormField(field, index, context)),
+  }
+}
+
+function normalizeApprovalGraph(value: unknown, context: ValidationContext): ApprovalGraph {
+  if (!isRecord(value) || !Array.isArray(value.nodes) || !Array.isArray(value.edges)) {
+    failValidation(context, 'approvalGraph must contain nodes and edges')
+  }
+
+  const nodes = value.nodes.map((node, index) => {
+    if (!isRecord(node)) {
+      failValidation(context, `approvalGraph.nodes[${index}] must be an object`)
+    }
+    if (!isNonEmptyString(node.key)) {
+      failValidation(context, `approvalGraph.nodes[${index}].key is required`)
+    }
+    if (!APPROVAL_NODE_TYPES.has(String(node.type))) {
+      failValidation(context, `approvalGraph.nodes[${index}].type is invalid`)
+    }
+    if (!isRecord(node.config)) {
+      failValidation(context, `approvalGraph.nodes[${index}].config must be an object`)
+    }
+
+    const normalizedNode = {
+      key: node.key.trim(),
+      type: node.type as ApprovalGraph['nodes'][number]['type'],
+      ...(typeof node.name === 'string' && node.name.trim().length > 0 ? { name: node.name.trim() } : {}),
+      config: {} as Record<string, unknown>,
+    }
+
+    switch (node.type) {
+      case 'approval':
+        if ((node.config.assigneeType !== 'user' && node.config.assigneeType !== 'role')
+          || !Array.isArray(node.config.assigneeIds)
+          || node.config.assigneeIds.some((entry) => !isNonEmptyString(entry))) {
+          failValidation(context, `approvalGraph.nodes[${index}].config must define assigneeType and assigneeIds`)
+        }
+        normalizedNode.config = {
+          assigneeType: node.config.assigneeType,
+          assigneeIds: node.config.assigneeIds.map((entry) => entry.trim()),
+        }
+        break
+      case 'cc':
+        if ((node.config.targetType !== 'user' && node.config.targetType !== 'role')
+          || !Array.isArray(node.config.targetIds)
+          || node.config.targetIds.some((entry) => !isNonEmptyString(entry))) {
+          failValidation(context, `approvalGraph.nodes[${index}].config must define targetType and targetIds`)
+        }
+        normalizedNode.config = {
+          targetType: node.config.targetType,
+          targetIds: node.config.targetIds.map((entry) => entry.trim()),
+        }
+        break
+      case 'condition':
+        if (!Array.isArray(node.config.branches)) {
+          failValidation(context, `approvalGraph.nodes[${index}].config.branches must be an array`)
+        }
+        normalizedNode.config = {
+          branches: node.config.branches.map((branch, branchIndex) => {
+            if (!isRecord(branch) || !isNonEmptyString(branch.edgeKey) || !Array.isArray(branch.rules)) {
+              failValidation(context, `approvalGraph.nodes[${index}].config.branches[${branchIndex}] is invalid`)
+            }
+            if (branch.conjunction !== undefined && branch.conjunction !== 'and' && branch.conjunction !== 'or') {
+              failValidation(context, `approvalGraph.nodes[${index}].config.branches[${branchIndex}].conjunction is invalid`)
+            }
+            return {
+              edgeKey: branch.edgeKey.trim(),
+              ...(branch.conjunction ? { conjunction: branch.conjunction } : {}),
+              rules: branch.rules.map((rule, ruleIndex) => {
+                if (!isRecord(rule) || !isNonEmptyString(rule.fieldId) || !CONDITION_OPERATORS.has(String(rule.operator))) {
+                  failValidation(
+                    context,
+                    `approvalGraph.nodes[${index}].config.branches[${branchIndex}].rules[${ruleIndex}] is invalid`,
+                  )
+                }
+                return {
+                  fieldId: rule.fieldId.trim(),
+                  operator: rule.operator,
+                  ...(rule.value !== undefined ? { value: rule.value } : {}),
+                }
+              }),
+            }
+          }),
+          ...(isNonEmptyString(node.config.defaultEdgeKey)
+            ? { defaultEdgeKey: node.config.defaultEdgeKey.trim() }
+            : {}),
+        }
+        break
+      default:
+        normalizedNode.config = {}
+        break
+    }
+
+    return normalizedNode as ApprovalGraph['nodes'][number]
+  })
+
+  const nodeKeys = new Set(nodes.map((node) => node.key))
+  if (nodeKeys.size !== nodes.length) {
+    failValidation(context, 'approvalGraph node keys must be unique')
+  }
+
+  const edges = value.edges.map((edge, index) => {
+    if (!isRecord(edge) || !isNonEmptyString(edge.key) || !isNonEmptyString(edge.source) || !isNonEmptyString(edge.target)) {
+      failValidation(context, `approvalGraph.edges[${index}] is invalid`)
+    }
+    return {
+      key: edge.key.trim(),
+      source: edge.source.trim(),
+      target: edge.target.trim(),
+    }
+  })
+
+  const edgeKeys = new Set(edges.map((edge) => edge.key))
+  if (edgeKeys.size !== edges.length) {
+    failValidation(context, 'approvalGraph edge keys must be unique')
+  }
+  if (edges.some((edge) => !nodeKeys.has(edge.source) || !nodeKeys.has(edge.target))) {
+    failValidation(context, 'approvalGraph edges must reference known nodes')
+  }
+
+  return { nodes, edges }
+}
+
+function asApprovalGraph(value: Record<string, unknown>): ApprovalGraph {
+  return normalizeApprovalGraph(value, STORED_GRAPH_CONTEXT)
 }
 
 function toApprovalTemplateListItemDTO(row: TemplateRow): ApprovalTemplateListItemDTO {
@@ -131,7 +393,7 @@ function toApprovalTemplateDetailDTO(bundle: TemplateBundle): ApprovalTemplateDe
   return {
     ...toApprovalTemplateListItemDTO(bundle.template),
     formSchema: asFormSchema(bundle.version.form_schema),
-    approvalGraph: bundle.version.approval_graph as unknown as ApprovalTemplateDetailDTO['approvalGraph'],
+    approvalGraph: asApprovalGraph(bundle.version.approval_graph),
   }
 }
 
@@ -142,7 +404,7 @@ function toApprovalTemplateVersionDetailDTO(bundle: TemplateBundle): ApprovalTem
     version: bundle.version.version,
     status: bundle.version.status,
     formSchema: asFormSchema(bundle.version.form_schema),
-    approvalGraph: bundle.version.approval_graph as unknown as ApprovalTemplateVersionDetailDTO['approvalGraph'],
+    approvalGraph: asApprovalGraph(bundle.version.approval_graph),
     runtimeGraph: bundle.publishedDefinition ? asRuntimeGraph(bundle.publishedDefinition.runtime_graph) : null,
     publishedDefinitionId: bundle.publishedDefinition?.id || null,
     createdAt: bundle.version.created_at.toISOString(),
@@ -215,41 +477,28 @@ function normalizeOptionalString(value: unknown): string | null | undefined {
   return value.trim()
 }
 
-function assertFormSchema(value: unknown): FormSchema {
-  if (
-    typeof value !== 'object' ||
-    value === null ||
-    !Array.isArray((value as { fields?: unknown }).fields)
-  ) {
-    throw new ServiceError('formSchema must contain fields', 400, 'VALIDATION_ERROR')
-  }
-  return value as FormSchema
+function assertApprovalGraph(value: unknown, context: ValidationContext = REQUEST_VALIDATION_CONTEXT): ApprovalGraph {
+  return normalizeApprovalGraph(value, context)
 }
 
-function assertApprovalGraph(value: unknown): ApprovalGraph {
-  const graph = value as { nodes?: unknown; edges?: unknown } | null
-  if (
-    typeof value !== 'object' ||
-    value === null ||
-    !Array.isArray(graph?.nodes) ||
-    !Array.isArray(graph?.edges)
-  ) {
-    throw new ServiceError('approvalGraph must contain nodes and edges', 400, 'VALIDATION_ERROR')
-  }
-  return value as ApprovalGraph
+function asFormSchema(value: Record<string, unknown>): FormSchema {
+  return assertFormSchema(value, STORED_FORM_SCHEMA_CONTEXT)
 }
 
-function assertRuntimePolicy(value: unknown): RuntimePolicy {
+function assertRuntimePolicy(
+  value: unknown,
+  context: ValidationContext = REQUEST_VALIDATION_CONTEXT,
+): RuntimePolicy {
   const policy = value as { allowRevoke?: unknown; revokeBeforeNodeKeys?: unknown } | null
   if (typeof value !== 'object' || value === null || typeof policy?.allowRevoke !== 'boolean') {
-    throw new ServiceError('policy.allowRevoke is required', 400, 'VALIDATION_ERROR')
+    failValidation(context, 'policy.allowRevoke is required')
   }
   if (
     policy.revokeBeforeNodeKeys !== undefined &&
     (!Array.isArray(policy.revokeBeforeNodeKeys) ||
       !policy.revokeBeforeNodeKeys.every((item) => typeof item === 'string' && item.trim().length > 0))
   ) {
-    throw new ServiceError('policy.revokeBeforeNodeKeys must be a string array', 400, 'VALIDATION_ERROR')
+    failValidation(context, 'policy.revokeBeforeNodeKeys must be a string array')
   }
   return {
     allowRevoke: policy.allowRevoke,
@@ -259,15 +508,35 @@ function assertRuntimePolicy(value: unknown): RuntimePolicy {
   }
 }
 
+function asRuntimeGraph(value: Record<string, unknown>): RuntimeGraph {
+  if (!isRecord(value)) {
+    failValidation(STORED_RUNTIME_CONTEXT, 'runtimeGraph must be an object')
+  }
+
+  const graph = assertApprovalGraph(
+    {
+      nodes: value.nodes,
+      edges: value.edges,
+    },
+    STORED_RUNTIME_CONTEXT,
+  )
+  const policy = assertRuntimePolicy(value.policy, STORED_RUNTIME_CONTEXT)
+
+  return deepFreeze({
+    ...graph,
+    policy,
+  })
+}
+
 function buildRuntimeGraph(approvalGraph: ApprovalGraph, policy: RuntimePolicy): RuntimeGraph {
   const copied = JSON.parse(JSON.stringify(approvalGraph)) as ApprovalGraph
-  return {
+  return deepFreeze({
     ...copied,
     policy: {
       allowRevoke: policy.allowRevoke,
       ...(policy.revokeBeforeNodeKeys ? { revokeBeforeNodeKeys: [...policy.revokeBeforeNodeKeys] } : {}),
     },
-  }
+  })
 }
 
 export class ApprovalProductService {
@@ -328,8 +597,9 @@ export class ApprovalProductService {
     const formSchema = assertFormSchema(request.formSchema)
     const approvalGraph = assertApprovalGraph(request.approvalGraph)
 
-    const client = await pool.connect()
+    let client: ApprovalDbClient | null = null
     try {
+      client = await pool.connect()
       await client.query('BEGIN')
 
       const templateResult = await client.query<TemplateRow>(
@@ -365,10 +635,10 @@ export class ApprovalProductService {
         publishedDefinition: null,
       })
     } catch (error) {
-      await client.query('ROLLBACK')
+      await rollbackQuietly(client)
       throw error
     } finally {
-      client.release()
+      client?.release()
     }
   }
 
@@ -383,8 +653,9 @@ export class ApprovalProductService {
     const formSchema = request.formSchema !== undefined ? assertFormSchema(request.formSchema) : undefined
     const approvalGraph = request.approvalGraph !== undefined ? assertApprovalGraph(request.approvalGraph) : undefined
 
-    const client = await pool.connect()
+    let client: ApprovalDbClient | null = null
     try {
+      client = await pool.connect()
       await client.query('BEGIN')
 
       const templateResult = await client.query<TemplateRow>(
@@ -488,10 +759,10 @@ export class ApprovalProductService {
         publishedDefinition: null,
       })
     } catch (error) {
-      await client.query('ROLLBACK')
+      await rollbackQuietly(client)
       throw error
     } finally {
-      client.release()
+      client?.release()
     }
   }
 
@@ -499,8 +770,9 @@ export class ApprovalProductService {
     if (!pool) throw new Error('Database not available')
 
     const policy = assertRuntimePolicy(request.policy)
-    const client = await pool.connect()
+    let client: ApprovalDbClient | null = null
     try {
+      client = await pool.connect()
       await client.query('BEGIN')
 
       const templateResult = await client.query<TemplateRow>(
@@ -531,7 +803,7 @@ export class ApprovalProductService {
         [id],
       )
 
-      const runtimeGraph = buildRuntimeGraph(assertApprovalGraph(version.approval_graph), policy)
+      const runtimeGraph = buildRuntimeGraph(asApprovalGraph(version.approval_graph), policy)
 
       const publishedDefinitionResult = await client.query<PublishedDefinitionRow>(
         `INSERT INTO approval_published_definitions (template_id, template_version_id, runtime_graph, is_active, published_at)
@@ -567,10 +839,10 @@ export class ApprovalProductService {
         publishedDefinition,
       })
     } catch (error) {
-      await client.query('ROLLBACK')
+      await rollbackQuietly(client)
       throw error
     } finally {
-      client.release()
+      client?.release()
     }
   }
 
@@ -611,8 +883,9 @@ export class ApprovalProductService {
       permissions: actor.permissions || [],
     }
 
-    const client = await pool.connect()
+    let client: ApprovalDbClient | null = null
     try {
+      client = await pool.connect()
       await client.query('BEGIN')
 
       await client.query(
@@ -667,10 +940,10 @@ export class ApprovalProductService {
 
       await client.query('COMMIT')
     } catch (error) {
-      await client.query('ROLLBACK')
+      await rollbackQuietly(client)
       throw error
     } finally {
-      client.release()
+      client?.release()
     }
 
     const approval = await this.getApproval(instanceId)
@@ -687,8 +960,9 @@ export class ApprovalProductService {
   ): Promise<UnifiedApprovalDTO> {
     if (!pool) throw new Error('Database not available')
 
-    const client = await pool.connect()
+    let client: ApprovalDbClient | null = null
     try {
+      client = await pool.connect()
       await client.query('BEGIN')
 
       const instanceResult = await client.query<ApprovalInstanceRow>(
@@ -775,9 +1049,21 @@ export class ApprovalProductService {
       }
 
       if (request.action === 'revoke') {
+        if (!runtimeGraph.policy.allowRevoke) {
+          throw new ServiceError('Approval cannot be revoked for this template', 409, 'APPROVAL_REVOKE_DISABLED')
+        }
         const requesterId = toNullableRecord(instance.requester_snapshot)?.id
         if (requesterId !== actor.userId) {
           throw new ServiceError('Only the requester can revoke this approval', 403, 'APPROVAL_REVOKE_FORBIDDEN')
+        }
+        if (!currentNodeKey) {
+          throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
+        }
+        if (
+          runtimeGraph.policy.revokeBeforeNodeKeys?.length &&
+          !runtimeGraph.policy.revokeBeforeNodeKeys.includes(currentNodeKey)
+        ) {
+          throw new ServiceError('Approval can no longer be revoked', 409, 'APPROVAL_REVOKE_WINDOW_CLOSED')
         }
         const handledResult = await client.query<{ count: string }>(
           `SELECT COUNT(*)::text AS count
@@ -902,10 +1188,10 @@ export class ApprovalProductService {
 
       await client.query('COMMIT')
     } catch (error) {
-      await client.query('ROLLBACK')
+      await rollbackQuietly(client)
       throw error
     } finally {
-      client.release()
+      client?.release()
     }
 
     const approval = await this.getApproval(id)

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -86,6 +86,53 @@ describe('ApprovalGraphExecutor', () => {
     expect(next.currentStep).toBe(1)
     expect(next.assignments).toEqual([])
   })
+
+  it('evaluates date-only condition rules as comparable dates', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [
+              {
+                edgeKey: 'edge-sla',
+                rules: [{ fieldId: 'requestedAt', operator: 'gte', value: '2026-04-11' }],
+              },
+            ],
+            defaultEdgeKey: 'edge-standard',
+          },
+        },
+        { key: 'sla-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['sla-reviewers'] } },
+        { key: 'standard-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard-reviewers'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-sla', source: 'route', target: 'sla-review' },
+        { key: 'edge-standard', source: 'route', target: 'standard-review' },
+        { key: 'edge-sla-end', source: 'sla-review', target: 'end' },
+        { key: 'edge-standard-end', source: 'standard-review', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+      },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, { requestedAt: '2026-04-11' })
+    const initial = executor.resolveInitialState()
+
+    expect(initial.currentNodeKey).toBe('sla-review')
+    expect(initial.assignments).toEqual([
+      {
+        assignmentType: 'role',
+        assigneeId: 'sla-reviewers',
+        nodeKey: 'sla-review',
+        sourceStep: 1,
+      },
+    ])
+  })
 })
 
 describe('validateApprovalFormData', () => {
@@ -115,6 +162,55 @@ describe('validateApprovalFormData', () => {
       'reason is required',
       'amount must be a number',
       'type must be one of the configured options',
+    ])
+  })
+
+  it('enforces pattern, length, numeric, and date window constraints from field props', () => {
+    const formSchema: FormSchema = {
+      fields: [
+        {
+          id: 'ticketCode',
+          type: 'text',
+          label: 'Ticket Code',
+          required: true,
+          props: {
+            minLength: 6,
+            maxLength: 12,
+            pattern: '^REQ-[0-9]+$',
+          },
+        },
+        {
+          id: 'amount',
+          type: 'number',
+          label: 'Amount',
+          props: {
+            min: 100,
+            max: 500,
+          },
+        },
+        {
+          id: 'requestedAt',
+          type: 'date',
+          label: 'Requested At',
+          props: {
+            min: '2026-04-10',
+            max: '2026-04-12',
+          },
+        },
+      ],
+    }
+
+    const errors = validateApprovalFormData(formSchema, {
+      ticketCode: 'REQ',
+      amount: 50,
+      requestedAt: '2026-04-09',
+    })
+
+    expect(errors).toEqual([
+      'ticketCode must be at least 6 characters',
+      'ticketCode does not match the required pattern',
+      'amount must be at least 100',
+      'requestedAt must be on or after 2026-04-10',
     ])
   })
 })

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgState = vi.hoisted(() => ({
+  client: {
+    query: vi.fn(),
+    release: vi.fn(),
+  },
+  pool: {
+    query: vi.fn(),
+    connect: vi.fn(),
+  },
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: pgState.pool,
+}))
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+function buildRuntimeGraph(policyOverrides?: Record<string, unknown>) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+    ],
+    policy: {
+      allowRevoke: true,
+      ...policyOverrides,
+    },
+  }
+}
+
+describe('ApprovalProductService', () => {
+  beforeEach(() => {
+    pgState.pool.connect.mockReset()
+    pgState.pool.query.mockReset()
+    pgState.client.query.mockReset()
+    pgState.client.release.mockReset()
+    pgState.pool.connect.mockResolvedValue(pgState.client)
+  })
+
+  it('blocks revoke when the published runtime policy disables it', async () => {
+    const runtimeGraph = buildRuntimeGraph({ allowRevoke: false })
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'apr-1',
+            status: 'pending',
+            version: 2,
+            source_system: 'platform',
+            external_approval_id: null,
+            workflow_key: 'approval-product-template',
+            business_key: 'travel-request',
+            title: 'Travel Request',
+            requester_snapshot: { id: 'user-1', name: 'Owner One' },
+            subject_snapshot: {},
+            policy_snapshot: { allowRevoke: false },
+            metadata: {},
+            current_step: 1,
+            total_steps: 1,
+            source_updated_at: null,
+            last_synced_at: null,
+            sync_status: 'ok',
+            sync_error: null,
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            published_definition_id: 'pub-1',
+            request_no: 'AP-100001',
+            form_snapshot: {},
+            current_node_key: 'approval_1',
+            created_at: new Date('2026-04-11T00:00:00.000Z'),
+            updated_at: new Date('2026-04-11T00:05:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return { rows: [], rowCount: 0 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await expect(service.dispatchAction('apr-1', { action: 'revoke' }, { userId: 'user-1' }))
+      .rejects
+      .toMatchObject({
+        message: 'Approval cannot be revoked for this template',
+        statusCode: 409,
+        code: 'APPROVAL_REVOKE_DISABLED',
+      })
+
+    expect(pgState.client.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks revoke when the current node is outside the runtime revoke window', async () => {
+    const runtimeGraph = buildRuntimeGraph({ revokeBeforeNodeKeys: ['approval_2'] })
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'apr-1',
+            status: 'pending',
+            version: 3,
+            source_system: 'platform',
+            external_approval_id: null,
+            workflow_key: 'approval-product-template',
+            business_key: 'travel-request',
+            title: 'Travel Request',
+            requester_snapshot: { id: 'user-1', name: 'Owner One' },
+            subject_snapshot: {},
+            policy_snapshot: { allowRevoke: true },
+            metadata: {},
+            current_step: 1,
+            total_steps: 1,
+            source_updated_at: null,
+            last_synced_at: null,
+            sync_status: 'ok',
+            sync_error: null,
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            published_definition_id: 'pub-1',
+            request_no: 'AP-100001',
+            form_snapshot: {},
+            current_node_key: 'approval_1',
+            created_at: new Date('2026-04-11T00:00:00.000Z'),
+            updated_at: new Date('2026-04-11T00:05:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return { rows: [], rowCount: 0 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await expect(service.dispatchAction('apr-1', { action: 'revoke' }, { userId: 'user-1' }))
+      .rejects
+      .toMatchObject({
+        message: 'Approval can no longer be revoked',
+        statusCode: 409,
+        code: 'APPROVAL_REVOKE_WINDOW_CLOSED',
+      })
+
+    expect(pgState.client.release).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- enforce runtime revoke policy and node-window checks for template approvals
- harden stored form/runtime graph validation and strengthen approval form constraint checks
- fix date-only condition comparisons and remove invalid approval mock draft status

## Verification
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts tests/unit/approval-template-routes.test.ts tests/unit/approvals-bridge-routes.test.ts tests/unit/approvals-routes.test.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/web exec vitest run tests/approval-center.spec.ts --watch=false --reporter=dot