### PR TITLE
feat(approvals): polish approval UI with states, timeline, and permissions

### DIFF
--- a/apps/web/src/approvals/permissions.ts
+++ b/apps/web/src/approvals/permissions.ts
@@ -1,34 +1,57 @@
-/**
- * Approval Permissions Composable
- *
- * Provides reactive permission checks for approval UI gating.
- * Currently hardcoded to true (mock) — will be wired to real RBAC later.
- */
-import { computed, ref } from 'vue'
+import { computed, readonly, ref } from 'vue'
+import { useAuth } from '../composables/useAuth'
 import type { ApprovalProductPermission } from '../types/approval'
-import { APPROVAL_PRODUCT_PERMISSIONS } from '../types/approval'
 
-/**
- * Mock permissions array — replace with real permission source when RBAC is wired.
- */
-const currentPermissions = ref<readonly ApprovalProductPermission[]>([...APPROVAL_PRODUCT_PERMISSIONS])
+type ApprovalAccessSnapshot = {
+  isAdmin: boolean
+  permissions: string[]
+}
 
-function hasPermission(perm: ApprovalProductPermission): boolean {
-  return currentPermissions.value.includes(perm)
+const currentAccess = ref<ApprovalAccessSnapshot>({
+  isAdmin: false,
+  permissions: [],
+})
+
+let listenersBound = false
+
+function refreshApprovalAccess() {
+  const auth = useAuth()
+  const snapshot = auth.getAccessSnapshot()
+  currentAccess.value = {
+    isAdmin: snapshot.isAdmin,
+    permissions: [...snapshot.permissions],
+  }
+}
+
+function bindApprovalAccessRefresh() {
+  if (listenersBound || typeof window === 'undefined') return
+  const refresh = () => refreshApprovalAccess()
+  window.addEventListener('storage', refresh)
+  window.addEventListener('focus', refresh)
+  listenersBound = true
+}
+
+function hasPermission(permission: ApprovalProductPermission): boolean {
+  const access = currentAccess.value
+  return access.isAdmin || access.permissions.includes(permission)
 }
 
 export function useApprovalPermissions() {
+  bindApprovalAccessRefresh()
+  refreshApprovalAccess()
+
   const canRead = computed(() => hasPermission('approvals:read'))
   const canWrite = computed(() => hasPermission('approvals:write'))
   const canAct = computed(() => hasPermission('approvals:act'))
   const canManageTemplates = computed(() => hasPermission('approval-templates:manage'))
 
   return {
-    permissions: currentPermissions,
+    permissions: readonly(currentAccess),
     hasPermission,
     canRead,
     canWrite,
     canAct,
     canManageTemplates,
+    refresh: refreshApprovalAccess,
   }
 }

--- a/apps/web/src/approvals/permissions.ts
+++ b/apps/web/src/approvals/permissions.ts
@@ -1,0 +1,34 @@
+/**
+ * Approval Permissions Composable
+ *
+ * Provides reactive permission checks for approval UI gating.
+ * Currently hardcoded to true (mock) — will be wired to real RBAC later.
+ */
+import { computed, ref } from 'vue'
+import type { ApprovalProductPermission } from '../types/approval'
+import { APPROVAL_PRODUCT_PERMISSIONS } from '../types/approval'
+
+/**
+ * Mock permissions array — replace with real permission source when RBAC is wired.
+ */
+const currentPermissions = ref<readonly ApprovalProductPermission[]>([...APPROVAL_PRODUCT_PERMISSIONS])
+
+function hasPermission(perm: ApprovalProductPermission): boolean {
+  return currentPermissions.value.includes(perm)
+}
+
+export function useApprovalPermissions() {
+  const canRead = computed(() => hasPermission('approvals:read'))
+  const canWrite = computed(() => hasPermission('approvals:write'))
+  const canAct = computed(() => hasPermission('approvals:act'))
+  const canManageTemplates = computed(() => hasPermission('approval-templates:manage'))
+
+  return {
+    permissions: currentPermissions,
+    hasPermission,
+    canRead,
+    canWrite,
+    canAct,
+    canManageTemplates,
+  }
+}

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -12,7 +12,7 @@
           @keyup.enter="handleSearch"
         >
           <template #prefix>
-            <span>🔍</span>
+            <el-icon><Search /></el-icon>
           </template>
         </el-input>
         <el-select
@@ -27,15 +27,38 @@
           <el-option label="已驳回" value="rejected" />
           <el-option label="已撤回" value="revoked" />
         </el-select>
+        <el-button
+          v-if="canWrite"
+          type="primary"
+          style="margin-left: 12px"
+          @click="router.push({ name: 'approval-template-list' })"
+        >
+          发起审批
+        </el-button>
       </div>
     </header>
+
+    <el-alert
+      v-if="store.error"
+      :title="store.error"
+      type="error"
+      show-icon
+      :closable="true"
+      class="approval-center__error"
+      @close="store.error = null"
+    >
+      <template #default>
+        <el-button type="primary" link @click="loadCurrentTab">重新加载</el-button>
+      </template>
+    </el-alert>
 
     <el-tabs v-model="activeTab" class="approval-center__tabs" @tab-change="handleTabChange">
       <el-tab-pane label="待我处理" name="pending">
         <el-table
+          v-loading="store.loading"
           :data="store.pendingApprovals"
-          :loading="store.loading"
           style="width: 100%"
+          max-height="560"
           stripe
           highlight-current-row
           @row-click="handleRowClick"
@@ -59,6 +82,12 @@
               {{ formatDate(row.createdAt) }}
             </template>
           </el-table-column>
+          <template #empty>
+            <el-empty
+              :description="searchText ? '未找到匹配的审批' : '暂无待处理审批'"
+              :image-size="100"
+            />
+          </template>
         </el-table>
         <el-pagination
           class="approval-center__pagination"
@@ -73,9 +102,10 @@
 
       <el-tab-pane label="我发起的" name="mine">
         <el-table
+          v-loading="store.loading"
           :data="store.myApprovals"
-          :loading="store.loading"
           style="width: 100%"
+          max-height="560"
           stripe
           highlight-current-row
           @row-click="handleRowClick"
@@ -99,6 +129,12 @@
               {{ formatDate(row.createdAt) }}
             </template>
           </el-table-column>
+          <template #empty>
+            <el-empty
+              :description="searchText ? '未找到匹配的审批' : '暂无我发起的审批'"
+              :image-size="100"
+            />
+          </template>
         </el-table>
         <el-pagination
           class="approval-center__pagination"
@@ -113,9 +149,10 @@
 
       <el-tab-pane label="抄送我的" name="cc">
         <el-table
+          v-loading="store.loading"
           :data="store.ccApprovals"
-          :loading="store.loading"
           style="width: 100%"
+          max-height="560"
           stripe
           highlight-current-row
           @row-click="handleRowClick"
@@ -139,6 +176,12 @@
               {{ formatDate(row.createdAt) }}
             </template>
           </el-table-column>
+          <template #empty>
+            <el-empty
+              :description="searchText ? '未找到匹配的审批' : '暂无抄送我的审批'"
+              :image-size="100"
+            />
+          </template>
         </el-table>
         <el-pagination
           class="approval-center__pagination"
@@ -153,9 +196,10 @@
 
       <el-tab-pane label="已完成" name="completed">
         <el-table
+          v-loading="store.loading"
           :data="store.completedApprovals"
-          :loading="store.loading"
           style="width: 100%"
+          max-height="560"
           stripe
           highlight-current-row
           @row-click="handleRowClick"
@@ -179,6 +223,12 @@
               {{ formatDate(row.createdAt) }}
             </template>
           </el-table-column>
+          <template #empty>
+            <el-empty
+              :description="searchText ? '未找到匹配的审批' : '暂无已完成审批'"
+              :image-size="100"
+            />
+          </template>
         </el-table>
         <el-pagination
           class="approval-center__pagination"
@@ -197,11 +247,14 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { Search } from '@element-plus/icons-vue'
 import type { UnifiedApprovalDTO, ApprovalStatus } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
+import { useApprovalPermissions } from '../../approvals/permissions'
 
 const router = useRouter()
 const store = useApprovalStore()
+const { canWrite } = useApprovalPermissions()
 
 const activeTab = ref<'pending' | 'mine' | 'cc' | 'completed'>('pending')
 const searchText = ref('')
@@ -306,6 +359,10 @@ onMounted(() => {
 .approval-center__toolbar {
   display: flex;
   align-items: center;
+}
+
+.approval-center__error {
+  margin-bottom: 16px;
 }
 
 .approval-center__tabs {

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -1,7 +1,10 @@
 <template>
-  <section class="approval-detail" v-loading="store.loading">
+  <section class="approval-detail">
     <header class="approval-detail__header">
-      <el-button text @click="goBack">← 返回列表</el-button>
+      <el-button text @click="goBack">
+        <el-icon><ArrowLeft /></el-icon>
+        返回列表
+      </el-button>
       <h1 v-if="approval">{{ approval.title ?? '审批详情' }}</h1>
       <el-tag
         v-if="approval"
@@ -12,88 +15,147 @@
       </el-tag>
     </header>
 
-    <div v-if="store.error" class="approval-detail__error">
-      <el-alert :title="store.error" type="error" show-icon :closable="false" />
-    </div>
+    <el-alert
+      v-if="store.error"
+      :title="store.error"
+      type="error"
+      show-icon
+      :closable="true"
+      class="approval-detail__error"
+      @close="store.error = null"
+    >
+      <template #default>
+        <el-button type="primary" link @click="retryLoad">重新加载</el-button>
+      </template>
+    </el-alert>
 
-    <div v-if="approval" class="approval-detail__body">
-      <!-- Left: form snapshot -->
-      <div class="approval-detail__form">
-        <h2>表单信息</h2>
-        <div class="approval-detail__meta">
-          <div class="approval-detail__meta-item">
-            <span class="approval-detail__label">审批编号</span>
-            <span>{{ approval.requestNo ?? '-' }}</span>
-          </div>
-          <div class="approval-detail__meta-item">
-            <span class="approval-detail__label">发起人</span>
-            <span>{{ approval.requester?.name ?? '-' }}</span>
-          </div>
-          <div class="approval-detail__meta-item">
-            <span class="approval-detail__label">部门</span>
-            <span>{{ approval.requester?.department ?? '-' }}</span>
-          </div>
-          <div class="approval-detail__meta-item">
-            <span class="approval-detail__label">发起时间</span>
-            <span>{{ formatDate(approval.createdAt) }}</span>
-          </div>
-          <div class="approval-detail__meta-item">
-            <span class="approval-detail__label">进度</span>
-            <span>{{ approval.currentStep ?? '-' }} / {{ approval.totalSteps ?? '-' }}</span>
-          </div>
-        </div>
-
-        <el-divider />
-
-        <div v-if="approval.formSnapshot" class="approval-detail__snapshot">
-          <div
-            v-for="(value, key) in approval.formSnapshot"
-            :key="key"
-            class="approval-detail__field"
-          >
-            <span class="approval-detail__label">{{ String(key) }}</span>
-            <span>{{ formatFieldValue(value) }}</span>
-          </div>
-        </div>
-        <el-empty v-else description="暂无表单数据" :image-size="80" />
-      </div>
-
-      <!-- Right: history timeline -->
-      <div class="approval-detail__timeline">
-        <h2>审批流程</h2>
-        <div v-if="store.history.length" class="approval-detail__history">
-          <div
-            v-for="item in store.history"
-            :key="item.id"
-            class="approval-detail__history-item"
-          >
-            <div class="approval-detail__history-dot" :class="`dot--${item.toStatus}`" />
-            <div class="approval-detail__history-content">
-              <div class="approval-detail__history-header">
-                <strong>{{ item.actorName ?? '系统' }}</strong>
-                <el-tag :type="statusTagType(item.toStatus)" size="small">
-                  {{ actionLabel(item.action) }}
-                </el-tag>
-              </div>
-              <p v-if="item.comment" class="approval-detail__history-comment">
-                {{ item.comment }}
-              </p>
-              <time class="approval-detail__history-time">
-                {{ item.occurredAt ? formatDate(item.occurredAt) : '-' }}
-              </time>
+    <div v-loading="store.loading" class="approval-detail__content-wrapper">
+      <div v-if="approval" class="approval-detail__body">
+        <!-- Left: form snapshot -->
+        <div class="approval-detail__form">
+          <h2>表单信息</h2>
+          <div class="approval-detail__meta">
+            <div class="approval-detail__meta-item">
+              <span class="approval-detail__label">审批编号</span>
+              <span>{{ approval.requestNo ?? '-' }}</span>
+            </div>
+            <div class="approval-detail__meta-item">
+              <span class="approval-detail__label">发起人</span>
+              <span>{{ approval.requester?.name ?? '-' }}</span>
+            </div>
+            <div class="approval-detail__meta-item">
+              <span class="approval-detail__label">部门</span>
+              <span>{{ approval.requester?.department ?? '-' }}</span>
+            </div>
+            <div class="approval-detail__meta-item">
+              <span class="approval-detail__label">发起时间</span>
+              <span>{{ formatDate(approval.createdAt) }}</span>
+            </div>
+            <div class="approval-detail__meta-item">
+              <span class="approval-detail__label">进度</span>
+              <span>{{ approval.currentStep ?? '-' }} / {{ approval.totalSteps ?? '-' }}</span>
             </div>
           </div>
-        </div>
-        <el-empty v-else description="暂无审批历史" :image-size="80" />
-      </div>
-    </div>
 
-    <!-- Action bar -->
-    <div v-if="approval && approval.status === 'pending'" class="approval-detail__actions">
-      <el-button type="primary" @click="openActionDialog('approve')">通过</el-button>
-      <el-button type="danger" @click="openActionDialog('reject')">驳回</el-button>
-      <el-button @click="openTransferDialog">转交</el-button>
-      <el-button @click="handleRevoke">撤回</el-button>
+          <el-divider />
+
+          <div v-if="approval.formSnapshot" class="approval-detail__snapshot">
+            <div
+              v-for="(value, key) in approval.formSnapshot"
+              :key="key"
+              class="approval-detail__field"
+            >
+              <span class="approval-detail__label">{{ String(key) }}</span>
+              <span>{{ formatFieldValue(value) }}</span>
+            </div>
+          </div>
+          <el-empty v-else description="暂无表单数据" :image-size="80" />
+        </div>
+
+        <!-- Right: history timeline -->
+        <div class="approval-detail__timeline">
+          <h2>审批流程</h2>
+          <el-timeline v-if="store.history.length">
+            <el-timeline-item
+              v-for="item in store.history"
+              :key="item.id"
+              :type="timelineItemType(item.action, item.toStatus)"
+              :icon="timelineIcon(item.action)"
+              :hollow="item.toStatus === 'pending'"
+              size="large"
+              :timestamp="item.occurredAt ? formatDate(item.occurredAt) : '-'"
+              placement="top"
+            >
+              <div class="approval-detail__timeline-content">
+                <div class="approval-detail__timeline-header">
+                  <strong>{{ item.actorName ?? '系统' }}</strong>
+                  <el-tag :type="statusTagType(item.toStatus)" size="small">
+                    {{ actionLabel(item.action) }}
+                  </el-tag>
+                </div>
+                <p v-if="item.comment" class="approval-detail__timeline-comment">
+                  {{ item.comment }}
+                </p>
+              </div>
+            </el-timeline-item>
+          </el-timeline>
+          <el-empty v-else description="暂无审批历史" :image-size="80" />
+        </div>
+      </div>
+
+      <!-- Action bar -->
+      <div v-if="approval" class="approval-detail__actions">
+        <template v-if="approval.status === 'pending'">
+          <div class="approval-detail__actions-primary">
+            <el-button
+              v-if="canAct"
+              type="success"
+              :loading="store.loading"
+              @click="openActionDialog('approve')"
+            >
+              通过
+            </el-button>
+            <el-button
+              v-if="canAct"
+              type="danger"
+              :loading="store.loading"
+              @click="openActionDialog('reject')"
+            >
+              驳回
+            </el-button>
+          </div>
+          <div class="approval-detail__actions-secondary">
+            <el-button
+              v-if="canAct"
+              type="warning"
+              :loading="store.loading"
+              @click="openTransferDialog"
+            >
+              转交
+            </el-button>
+            <el-popconfirm
+              v-if="isRequester"
+              title="确认撤回此审批？"
+              confirm-button-text="确认"
+              cancel-button-text="取消"
+              @confirm="handleRevoke"
+            >
+              <template #reference>
+                <el-button type="info" :loading="store.loading">撤回</el-button>
+              </template>
+            </el-popconfirm>
+            <el-button plain :loading="store.loading" @click="openCommentDialog">评论</el-button>
+          </div>
+        </template>
+        <el-alert
+          v-else
+          title="该审批已结束"
+          type="info"
+          show-icon
+          :closable="false"
+          style="flex: 1"
+        />
+      </div>
     </div>
 
     <!-- Approve / Reject dialog -->
@@ -115,7 +177,7 @@
       <template #footer>
         <el-button @click="actionDialogVisible = false">取消</el-button>
         <el-button
-          :type="currentAction === 'approve' ? 'primary' : 'danger'"
+          :type="currentAction === 'approve' ? 'success' : 'danger'"
           :loading="store.loading"
           @click="submitAction"
         >
@@ -132,7 +194,10 @@
     >
       <el-form>
         <el-form-item label="转交给">
-          <el-select v-model="transferUserId" placeholder="选择用户" style="width: 100%">
+          <el-select v-model="transferUserId" placeholder="选择用户" filterable style="width: 100%">
+            <template #prefix>
+              <el-icon><Search /></el-icon>
+            </template>
             <el-option label="李四 (部门经理)" value="user_2" />
             <el-option label="王五 (总监)" value="user_3" />
             <el-option label="赵六 (VP)" value="user_4" />
@@ -149,8 +214,32 @@
       </el-form>
       <template #footer>
         <el-button @click="transferDialogVisible = false">取消</el-button>
-        <el-button type="primary" :loading="store.loading" @click="submitTransfer">
+        <el-button type="warning" :loading="store.loading" @click="submitTransfer">
           确认转交
+        </el-button>
+      </template>
+    </el-dialog>
+
+    <!-- Comment dialog -->
+    <el-dialog
+      v-model="commentDialogVisible"
+      title="添加评论"
+      width="480px"
+    >
+      <el-form>
+        <el-form-item label="评论内容">
+          <el-input
+            v-model="actionComment"
+            type="textarea"
+            :rows="3"
+            placeholder="请输入评论内容"
+          />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="commentDialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="store.loading" @click="submitComment">
+          提交评论
         </el-button>
       </template>
     </el-dialog>
@@ -160,17 +249,35 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import {
+  ArrowLeft,
+  Search,
+  Check,
+  Close,
+  Right,
+  ChatDotSquare,
+  Bell,
+  RefreshLeft,
+} from '@element-plus/icons-vue'
 import type { ApprovalActionType } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
+import { useApprovalPermissions } from '../../approvals/permissions'
 
 const route = useRoute()
 const router = useRouter()
 const store = useApprovalStore()
+const { canAct } = useApprovalPermissions()
 
 const approval = computed(() => store.activeApproval)
+const isRequester = computed(() => {
+  // Simple heuristic: mock current user as 'user_1'
+  return approval.value?.requester?.id === 'user_1'
+})
 
 const actionDialogVisible = ref(false)
 const transferDialogVisible = ref(false)
+const commentDialogVisible = ref(false)
 const currentAction = ref<ApprovalActionType>('approve')
 const actionComment = ref('')
 const transferUserId = ref('')
@@ -218,6 +325,27 @@ function actionLabel(action: string) {
   return map[action] ?? action
 }
 
+function timelineItemType(action: string, toStatus: string): string {
+  if (action === 'approve') return 'success'
+  if (action === 'reject') return 'danger'
+  if (action === 'transfer') return 'warning'
+  if (action === 'revoke') return 'warning'
+  if (toStatus === 'pending') return 'primary'
+  return 'info'
+}
+
+function timelineIcon(action: string) {
+  const map: Record<string, any> = {
+    approve: Check,
+    reject: Close,
+    transfer: Right,
+    comment: ChatDotSquare,
+    cc: Bell,
+    revoke: RefreshLeft,
+  }
+  return map[action] ?? undefined
+}
+
 function formatDate(dateStr: string) {
   if (!dateStr) return '-'
   return new Date(dateStr).toLocaleString('zh-CN')
@@ -237,6 +365,12 @@ function goBack() {
   router.push({ name: 'approval-list' })
 }
 
+function retryLoad() {
+  const id = route.params.id as string
+  store.error = null
+  Promise.all([store.loadDetail(id), store.loadHistory(id)])
+}
+
 function openActionDialog(action: 'approve' | 'reject') {
   currentAction.value = action
   actionComment.value = ''
@@ -249,32 +383,68 @@ function openTransferDialog() {
   transferDialogVisible.value = true
 }
 
+function openCommentDialog() {
+  actionComment.value = ''
+  commentDialogVisible.value = true
+}
+
 async function submitAction() {
   const id = route.params.id as string
-  await store.executeAction(id, {
-    action: currentAction.value,
-    comment: actionComment.value || undefined,
-  })
-  actionDialogVisible.value = false
-  await store.loadHistory(id)
+  try {
+    await store.executeAction(id, {
+      action: currentAction.value,
+      comment: actionComment.value || undefined,
+    })
+    ElMessage.success(currentAction.value === 'approve' ? '审批已通过' : '审批已驳回')
+    actionDialogVisible.value = false
+    await store.loadHistory(id)
+  } catch {
+    ElMessage.error('操作失败，请重试')
+  }
 }
 
 async function submitTransfer() {
   if (!transferUserId.value) return
   const id = route.params.id as string
-  await store.executeAction(id, {
-    action: 'transfer',
-    comment: actionComment.value || undefined,
-    targetUserId: transferUserId.value,
-  })
-  transferDialogVisible.value = false
-  await store.loadHistory(id)
+  try {
+    await store.executeAction(id, {
+      action: 'transfer',
+      comment: actionComment.value || undefined,
+      targetUserId: transferUserId.value,
+    })
+    ElMessage.success('已成功转交')
+    transferDialogVisible.value = false
+    await store.loadHistory(id)
+  } catch {
+    ElMessage.error('转交失败，请重试')
+  }
+}
+
+async function submitComment() {
+  if (!actionComment.value.trim()) return
+  const id = route.params.id as string
+  try {
+    await store.executeAction(id, {
+      action: 'comment',
+      comment: actionComment.value,
+    })
+    ElMessage.success('评论已提交')
+    commentDialogVisible.value = false
+    await store.loadHistory(id)
+  } catch {
+    ElMessage.error('评论提交失败，请重试')
+  }
 }
 
 async function handleRevoke() {
   const id = route.params.id as string
-  await store.executeAction(id, { action: 'revoke' })
-  await store.loadHistory(id)
+  try {
+    await store.executeAction(id, { action: 'revoke' })
+    ElMessage.success('审批已撤回')
+    await store.loadHistory(id)
+  } catch {
+    ElMessage.error('撤回失败，请重试')
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -311,9 +481,13 @@ onMounted(async () => {
   margin-bottom: 16px;
 }
 
+.approval-detail__content-wrapper {
+  min-height: 200px;
+}
+
 .approval-detail__body {
   display: grid;
-  grid-template-columns: 1fr 360px;
+  grid-template-columns: 1fr 400px;
   gap: 24px;
 }
 
@@ -361,56 +535,21 @@ onMounted(async () => {
   gap: 4px;
 }
 
-.approval-detail__history {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
+.approval-detail__timeline-content {
+  padding: 0;
 }
 
-.approval-detail__history-item {
-  display: flex;
-  gap: 12px;
-  padding: 12px 0;
-  border-left: 2px solid var(--el-border-color-lighter, #e4e7ed);
-  padding-left: 16px;
-  position: relative;
-}
-
-.approval-detail__history-dot {
-  position: absolute;
-  left: -6px;
-  top: 16px;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--el-color-info, #909399);
-}
-
-.dot--approved { background: var(--el-color-success, #67c23a); }
-.dot--rejected { background: var(--el-color-danger, #f56c6c); }
-.dot--pending { background: var(--el-color-warning, #e6a23c); }
-.dot--revoked { background: var(--el-color-info, #909399); }
-
-.approval-detail__history-content {
-  flex: 1;
-}
-
-.approval-detail__history-header {
+.approval-detail__timeline-header {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 4px;
 }
 
-.approval-detail__history-comment {
-  margin: 4px 0;
+.approval-detail__timeline-comment {
+  margin: 4px 0 0;
   color: var(--el-text-color-regular, #606266);
   font-size: 13px;
-}
-
-.approval-detail__history-time {
-  font-size: 12px;
-  color: var(--el-text-color-secondary, #909399);
 }
 
 .approval-detail__actions {
@@ -420,6 +559,35 @@ onMounted(async () => {
   border: 1px solid var(--el-border-color-lighter, #e4e7ed);
   border-radius: 8px;
   display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
+}
+
+.approval-detail__actions-primary {
+  display: flex;
+  gap: 12px;
+}
+
+.approval-detail__actions-secondary {
+  display: flex;
+  gap: 12px;
+}
+
+/* Responsive: stack on small screens */
+@media (max-width: 768px) {
+  .approval-detail__body {
+    grid-template-columns: 1fr;
+  }
+
+  .approval-detail__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .approval-detail__actions-primary,
+  .approval-detail__actions-secondary {
+    justify-content: center;
+  }
 }
 </style>

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -1,170 +1,212 @@
 <template>
-  <section class="approval-new" v-loading="templateStore.loading || approvalStore.loading">
+  <section class="approval-new">
     <header class="approval-new__header">
-      <el-button text @click="goBack">← 返回</el-button>
+      <el-button text @click="goBack">
+        <el-icon><ArrowLeft /></el-icon>
+        返回
+      </el-button>
       <h1>发起审批</h1>
     </header>
 
-    <div v-if="templateStore.error || approvalStore.error" class="approval-new__error">
-      <el-alert
-        :title="templateStore.error || approvalStore.error || ''"
-        type="error"
-        show-icon
-        :closable="false"
-      />
-    </div>
+    <el-alert
+      v-if="templateStore.error || approvalStore.error"
+      :title="templateStore.error || approvalStore.error || ''"
+      type="error"
+      show-icon
+      :closable="true"
+      class="approval-new__error"
+      @close="templateStore.error = null; approvalStore.error = null"
+    >
+      <template #default>
+        <el-button type="primary" link @click="retryLoad">重新加载</el-button>
+      </template>
+    </el-alert>
 
-    <div v-if="template" class="approval-new__body">
-      <div class="approval-new__info">
-        <h2>{{ template.name }}</h2>
-        <p v-if="template.description">{{ template.description }}</p>
+    <div v-loading="templateStore.loading || approvalStore.loading" class="approval-new__content-wrapper">
+      <div v-if="template" class="approval-new__body">
+        <!-- Template info card -->
+        <el-card class="approval-new__info-card" shadow="never">
+          <template #header>
+            <div class="approval-new__info-header">
+              <h2>{{ template.name }}</h2>
+              <el-tag :type="template.status === 'published' ? 'success' : 'info'" size="small">
+                {{ template.status === 'published' ? '已发布' : template.status }}
+              </el-tag>
+            </div>
+          </template>
+          <p v-if="template.description" class="approval-new__info-desc">{{ template.description }}</p>
+          <p v-else class="approval-new__info-desc approval-new__info-desc--empty">暂无描述</p>
+        </el-card>
+
+        <el-divider content-position="left">填写表单</el-divider>
+
+        <el-form
+          ref="formRef"
+          :model="formData"
+          :rules="formRules"
+          label-position="top"
+          class="approval-new__form"
+        >
+          <el-form-item
+            v-for="field in template.formSchema.fields"
+            :key="field.id"
+            :label="field.label"
+            :prop="field.id"
+            :required="field.required"
+          >
+            <template v-if="field.placeholder" #label>
+              {{ field.label }}
+              <span class="approval-new__field-hint">{{ field.placeholder }}</span>
+            </template>
+
+            <!-- text -->
+            <el-input
+              v-if="field.type === 'text'"
+              v-model="formData[field.id]"
+              :placeholder="field.placeholder || `请输入${field.label}`"
+            />
+
+            <!-- textarea -->
+            <el-input
+              v-else-if="field.type === 'textarea'"
+              v-model="formData[field.id]"
+              type="textarea"
+              :rows="3"
+              :placeholder="field.placeholder || `请输入${field.label}`"
+            />
+
+            <!-- number -->
+            <el-input-number
+              v-else-if="field.type === 'number'"
+              v-model="formData[field.id]"
+              :placeholder="field.placeholder"
+              style="width: 100%"
+            />
+
+            <!-- date -->
+            <el-date-picker
+              v-else-if="field.type === 'date'"
+              v-model="formData[field.id]"
+              type="date"
+              :placeholder="field.placeholder || `请选择${field.label}`"
+              style="width: 100%"
+            />
+
+            <!-- datetime -->
+            <el-date-picker
+              v-else-if="field.type === 'datetime'"
+              v-model="formData[field.id]"
+              type="datetime"
+              :placeholder="field.placeholder || `请选择${field.label}`"
+              style="width: 100%"
+            />
+
+            <!-- select -->
+            <el-select
+              v-else-if="field.type === 'select'"
+              v-model="formData[field.id]"
+              :placeholder="field.placeholder || `请选择${field.label}`"
+              style="width: 100%"
+            >
+              <el-option
+                v-for="opt in (field.options || [])"
+                :key="opt.value"
+                :label="opt.label"
+                :value="opt.value"
+              />
+            </el-select>
+
+            <!-- multi-select -->
+            <el-select
+              v-else-if="field.type === 'multi-select'"
+              v-model="formData[field.id]"
+              multiple
+              :placeholder="field.placeholder || `请选择${field.label}`"
+              style="width: 100%"
+            >
+              <el-option
+                v-for="opt in (field.options || [])"
+                :key="opt.value"
+                :label="opt.label"
+                :value="opt.value"
+              />
+            </el-select>
+
+            <!-- user (placeholder picker) -->
+            <el-select
+              v-else-if="field.type === 'user'"
+              v-model="formData[field.id]"
+              placeholder="选择用户"
+              filterable
+              style="width: 100%"
+            >
+              <template #prefix>
+                <el-icon><Search /></el-icon>
+              </template>
+              <el-option label="张三" value="user_1" />
+              <el-option label="李四" value="user_2" />
+              <el-option label="王五" value="user_3" />
+            </el-select>
+
+            <!-- attachment (drag upload) -->
+            <el-upload
+              v-else-if="field.type === 'attachment'"
+              action="#"
+              :auto-upload="false"
+              drag
+              :on-change="(file: any) => handleFileChange(field.id, file)"
+            >
+              <el-icon class="el-icon--upload"><UploadFilled /></el-icon>
+              <div class="el-upload__text">将文件拖到此处，或<em>点击上传</em></div>
+              <template #tip>
+                <div class="el-upload__tip">支持常见文件格式，单个文件不超过 10MB</div>
+              </template>
+            </el-upload>
+
+            <!-- fallback -->
+            <el-input
+              v-else
+              v-model="formData[field.id]"
+              :placeholder="field.placeholder || `请输入${field.label}`"
+            />
+          </el-form-item>
+
+          <el-divider />
+
+          <el-form-item class="approval-new__submit">
+            <el-button
+              type="primary"
+              :loading="approvalStore.loading"
+              :disabled="!canWrite"
+              @click="handleSubmit"
+            >
+              提交审批
+            </el-button>
+            <el-button @click="goBack">取消</el-button>
+          </el-form-item>
+        </el-form>
       </div>
 
-      <el-form
-        ref="formRef"
-        :model="formData"
-        :rules="formRules"
-        label-position="top"
-        class="approval-new__form"
-      >
-        <el-form-item
-          v-for="field in template.formSchema.fields"
-          :key="field.id"
-          :label="field.label"
-          :prop="field.id"
-          :required="field.required"
-        >
-          <!-- text -->
-          <el-input
-            v-if="field.type === 'text'"
-            v-model="formData[field.id]"
-            :placeholder="field.placeholder || `请输入${field.label}`"
-          />
-
-          <!-- textarea -->
-          <el-input
-            v-else-if="field.type === 'textarea'"
-            v-model="formData[field.id]"
-            type="textarea"
-            :rows="3"
-            :placeholder="field.placeholder || `请输入${field.label}`"
-          />
-
-          <!-- number -->
-          <el-input-number
-            v-else-if="field.type === 'number'"
-            v-model="formData[field.id]"
-            :placeholder="field.placeholder"
-            style="width: 100%"
-          />
-
-          <!-- date -->
-          <el-date-picker
-            v-else-if="field.type === 'date'"
-            v-model="formData[field.id]"
-            type="date"
-            :placeholder="field.placeholder || `请选择${field.label}`"
-            style="width: 100%"
-          />
-
-          <!-- datetime -->
-          <el-date-picker
-            v-else-if="field.type === 'datetime'"
-            v-model="formData[field.id]"
-            type="datetime"
-            :placeholder="field.placeholder || `请选择${field.label}`"
-            style="width: 100%"
-          />
-
-          <!-- select -->
-          <el-select
-            v-else-if="field.type === 'select'"
-            v-model="formData[field.id]"
-            :placeholder="field.placeholder || `请选择${field.label}`"
-            style="width: 100%"
-          >
-            <el-option
-              v-for="opt in (field.options || [])"
-              :key="opt.value"
-              :label="opt.label"
-              :value="opt.value"
-            />
-          </el-select>
-
-          <!-- multi-select -->
-          <el-select
-            v-else-if="field.type === 'multi-select'"
-            v-model="formData[field.id]"
-            multiple
-            :placeholder="field.placeholder || `请选择${field.label}`"
-            style="width: 100%"
-          >
-            <el-option
-              v-for="opt in (field.options || [])"
-              :key="opt.value"
-              :label="opt.label"
-              :value="opt.value"
-            />
-          </el-select>
-
-          <!-- user (placeholder picker) -->
-          <el-select
-            v-else-if="field.type === 'user'"
-            v-model="formData[field.id]"
-            :placeholder="field.placeholder || `请选择${field.label}`"
-            filterable
-            style="width: 100%"
-          >
-            <el-option label="张三" value="user_1" />
-            <el-option label="李四" value="user_2" />
-            <el-option label="王五" value="user_3" />
-          </el-select>
-
-          <!-- attachment (placeholder upload) -->
-          <el-upload
-            v-else-if="field.type === 'attachment'"
-            action="#"
-            :auto-upload="false"
-            :on-change="(file: any) => handleFileChange(field.id, file)"
-          >
-            <el-button type="primary" plain>点击上传</el-button>
-            <template #tip>
-              <div class="el-upload__tip">支持常见文件格式</div>
-            </template>
-          </el-upload>
-
-          <!-- fallback -->
-          <el-input
-            v-else
-            v-model="formData[field.id]"
-            :placeholder="field.placeholder || `请输入${field.label}`"
-          />
-        </el-form-item>
-
-        <el-form-item class="approval-new__submit">
-          <el-button type="primary" :loading="approvalStore.loading" @click="handleSubmit">
-            提交审批
-          </el-button>
-          <el-button @click="goBack">取消</el-button>
-        </el-form-item>
-      </el-form>
+      <el-empty v-else-if="!templateStore.loading" description="未找到审批模板" />
     </div>
-
-    <el-empty v-else-if="!templateStore.loading" description="未找到审批模板" />
   </section>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
 import type { FormInstance, FormRules } from 'element-plus'
+import { ArrowLeft, Search, UploadFilled } from '@element-plus/icons-vue'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
+import { useApprovalPermissions } from '../../approvals/permissions'
 
 const route = useRoute()
 const router = useRouter()
 const approvalStore = useApprovalStore()
 const templateStore = useApprovalTemplateStore()
+const { canWrite } = useApprovalPermissions()
 
 const formRef = ref<FormInstance>()
 const formData = reactive<Record<string, unknown>>({})
@@ -191,21 +233,34 @@ function goBack() {
   router.back()
 }
 
+function retryLoad() {
+  const templateId = route.params.templateId as string
+  templateStore.error = null
+  approvalStore.error = null
+  templateStore.loadTemplate(templateId)
+}
+
 async function handleSubmit() {
   if (formRef.value) {
     try {
       await formRef.value.validate()
     } catch {
+      ElMessage.warning('请检查表单中的必填项')
       return
     }
   }
 
   const templateId = route.params.templateId as string
-  const result = await approvalStore.submitApproval({
-    templateId,
-    formData: { ...formData },
-  })
-  router.push({ name: 'approval-detail', params: { id: result.id } })
+  try {
+    const result = await approvalStore.submitApproval({
+      templateId,
+      formData: { ...formData },
+    })
+    ElMessage.success('审批已提交')
+    router.push({ name: 'approval-detail', params: { id: result.id } })
+  } catch {
+    ElMessage.error('提交审批失败，请重试')
+  }
 }
 
 onMounted(async () => {
@@ -250,19 +305,43 @@ onMounted(async () => {
   margin-bottom: 16px;
 }
 
-.approval-new__info {
-  margin-bottom: 20px;
+.approval-new__content-wrapper {
+  min-height: 200px;
 }
 
-.approval-new__info h2 {
+.approval-new__info-card {
+  margin-bottom: 8px;
+}
+
+.approval-new__info-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.approval-new__info-header h2 {
   font-size: 16px;
   font-weight: 600;
-  margin: 0 0 8px;
+  margin: 0;
 }
 
-.approval-new__info p {
-  color: var(--el-text-color-secondary, #909399);
+.approval-new__info-desc {
+  color: var(--el-text-color-regular, #606266);
   margin: 0;
+  font-size: 14px;
+}
+
+.approval-new__info-desc--empty {
+  color: var(--el-text-color-placeholder, #c0c4cc);
+  font-style: italic;
+}
+
+.approval-new__field-hint {
+  display: block;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--el-text-color-secondary, #909399);
+  margin-top: 2px;
 }
 
 .approval-new__form {
@@ -273,7 +352,7 @@ onMounted(async () => {
 }
 
 .approval-new__submit {
-  margin-top: 24px;
+  margin-top: 8px;
   margin-bottom: 0;
 }
 </style>

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -12,11 +12,38 @@
           @keyup.enter="handleSearch"
         >
           <template #prefix>
-            <span>🔍</span>
+            <el-icon><Search /></el-icon>
           </template>
         </el-input>
+        <el-tooltip
+          v-if="canManageTemplates"
+          content="即将上线"
+          placement="top"
+        >
+          <el-button
+            type="primary"
+            style="margin-left: 12px"
+            disabled
+          >
+            新建模板
+          </el-button>
+        </el-tooltip>
       </div>
     </header>
+
+    <el-alert
+      v-if="store.error"
+      :title="store.error"
+      type="error"
+      show-icon
+      :closable="true"
+      class="template-center__error"
+      @close="store.error = null"
+    >
+      <template #default>
+        <el-button type="primary" link @click="loadData">重新加载</el-button>
+      </template>
+    </el-alert>
 
     <el-tabs v-model="statusTab" class="template-center__tabs" @tab-change="handleTabChange">
       <el-tab-pane label="全部" name="all" />
@@ -29,21 +56,31 @@
       v-loading="store.loading"
       :data="store.templates"
       style="width: 100%"
+      max-height="560"
       stripe
       highlight-current-row
       @row-click="handleRowClick"
     >
       <el-table-column prop="name" label="模板名称" min-width="200" />
-      <el-table-column prop="description" label="描述" min-width="240">
+      <el-table-column prop="description" label="描述" min-width="200">
         <template #default="{ row }">
           {{ row.description ?? '-' }}
         </template>
       </el-table-column>
       <el-table-column label="状态" width="100">
         <template #default="{ row }">
-          <el-tag :type="templateStatusTagType(row.status)" size="small">
+          <el-tag
+            :type="templateStatusTagType(row.status)"
+            size="small"
+            :effect="row.status === 'published' ? 'dark' : 'light'"
+          >
             {{ templateStatusLabel(row.status) }}
           </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="最近更新" width="180">
+        <template #default="{ row }">
+          {{ formatDate(row.updatedAt) }}
         </template>
       </el-table-column>
       <el-table-column label="创建时间" width="180">
@@ -54,9 +91,8 @@
       <el-table-column label="操作" width="120" fixed="right">
         <template #default="{ row }">
           <el-button
-            v-if="row.status === 'published'"
+            v-if="row.status === 'published' && canWrite"
             type="primary"
-            link
             size="small"
             @click.stop="startApproval(row.id)"
           >
@@ -64,6 +100,12 @@
           </el-button>
         </template>
       </el-table-column>
+      <template #empty>
+        <el-empty
+          :description="searchText ? '未找到匹配的模板' : '暂无审批模板，点击新建模板开始'"
+          :image-size="100"
+        />
+      </template>
     </el-table>
 
     <el-pagination
@@ -76,21 +118,20 @@
       :page-size="pageSize"
       @update:current-page="handlePageChange"
     />
-
-    <div v-if="store.error" class="template-center__error">
-      <el-alert :title="store.error" type="error" show-icon />
-    </div>
   </section>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { Search } from '@element-plus/icons-vue'
 import type { ApprovalTemplateListItemDTO, ApprovalTemplateStatus } from '../../types/approval'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
+import { useApprovalPermissions } from '../../approvals/permissions'
 
 const router = useRouter()
 const store = useApprovalTemplateStore()
+const { canWrite, canManageTemplates } = useApprovalPermissions()
 
 const statusTab = ref<'all' | ApprovalTemplateStatus>('all')
 const searchText = ref('')
@@ -100,8 +141,8 @@ const pageSize = ref(10)
 function templateStatusTagType(status: string) {
   const map: Record<string, string> = {
     published: 'success',
-    draft: 'info',
-    archived: 'warning',
+    draft: 'warning',
+    archived: 'info',
   }
   return map[status] ?? ''
 }
@@ -177,6 +218,15 @@ onMounted(() => {
   margin: 0;
 }
 
+.template-center__toolbar {
+  display: flex;
+  align-items: center;
+}
+
+.template-center__error {
+  margin-bottom: 16px;
+}
+
 .template-center__tabs {
   margin-bottom: 16px;
 }
@@ -185,9 +235,5 @@ onMounted(() => {
   margin-top: 16px;
   display: flex;
   justify-content: flex-end;
-}
-
-.template-center__error {
-  margin-top: 16px;
 }
 </style>

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -1,129 +1,155 @@
 <template>
-  <section class="template-detail" v-loading="store.loading">
+  <section class="template-detail">
     <header class="template-detail__header">
-      <el-button text @click="goBack">← 返回模板列表</el-button>
+      <el-button text @click="goBack">
+        <el-icon><ArrowLeft /></el-icon>
+        返回模板列表
+      </el-button>
       <h1 v-if="template">{{ template.name }}</h1>
       <el-tag
         v-if="template"
         :type="statusTagType(template.status)"
         size="large"
+        :effect="template.status === 'published' ? 'dark' : 'light'"
       >
         {{ statusLabel(template.status) }}
       </el-tag>
       <el-button
-        v-if="template && template.status === 'published'"
+        v-if="template && template.status === 'published' && canWrite"
         type="primary"
+        :loading="store.loading"
         @click="startApproval"
       >
         发起审批
       </el-button>
     </header>
 
-    <div v-if="store.error" class="template-detail__error">
-      <el-alert :title="store.error" type="error" show-icon :closable="false" />
-    </div>
+    <el-alert
+      v-if="store.error"
+      :title="store.error"
+      type="error"
+      show-icon
+      :closable="true"
+      class="template-detail__error"
+      @close="store.error = null"
+    >
+      <template #default>
+        <el-button type="primary" link @click="retryLoad">重新加载</el-button>
+      </template>
+    </el-alert>
 
-    <div v-if="template" class="template-detail__body">
-      <!-- Template info -->
-      <div class="template-detail__info">
-        <p v-if="template.description">{{ template.description }}</p>
-        <div class="template-detail__meta">
-          <span>模板 Key: {{ template.key }}</span>
-          <span>当前版本: {{ template.activeVersionId ?? '无' }}</span>
-          <span>创建时间: {{ formatDate(template.createdAt) }}</span>
-          <span>更新时间: {{ formatDate(template.updatedAt) }}</span>
-        </div>
-      </div>
-
-      <div class="template-detail__content">
-        <!-- Form schema section -->
-        <div class="template-detail__section">
-          <h2>表单字段</h2>
-          <el-table :data="template.formSchema.fields" style="width: 100%" stripe>
-            <el-table-column prop="label" label="字段名" min-width="160" />
-            <el-table-column label="类型" width="120">
-              <template #default="{ row }">
-                <el-tag size="small">{{ fieldTypeLabel(row.type) }}</el-tag>
-              </template>
-            </el-table-column>
-            <el-table-column label="必填" width="80">
-              <template #default="{ row }">
-                <el-tag v-if="row.required" type="danger" size="small">必填</el-tag>
-                <span v-else>-</span>
-              </template>
-            </el-table-column>
-            <el-table-column prop="placeholder" label="占位文本" min-width="160">
-              <template #default="{ row }">
-                {{ row.placeholder ?? '-' }}
-              </template>
-            </el-table-column>
-            <el-table-column label="选项" min-width="200">
-              <template #default="{ row }">
-                <span v-if="row.options && row.options.length">
-                  {{ row.options.map((o: any) => o.label).join(', ') }}
-                </span>
-                <span v-else>-</span>
-              </template>
-            </el-table-column>
-          </el-table>
+    <div v-loading="store.loading" class="template-detail__content-wrapper">
+      <div v-if="template" class="template-detail__body">
+        <!-- Template info -->
+        <div class="template-detail__info">
+          <p v-if="template.description">{{ template.description }}</p>
+          <div class="template-detail__meta">
+            <span>模板 Key: {{ template.key }}</span>
+            <span>当前版本: {{ template.activeVersionId ?? '无' }}</span>
+            <span>创建时间: {{ formatDate(template.createdAt) }}</span>
+            <span>更新时间: {{ formatDate(template.updatedAt) }}</span>
+          </div>
         </div>
 
-        <!-- Approval graph section -->
-        <div class="template-detail__section">
-          <h2>审批流程</h2>
-          <div class="template-detail__graph">
-            <div
-              v-for="(node, index) in template.approvalGraph.nodes"
-              :key="node.key"
-              class="template-detail__node"
-            >
-              <div class="template-detail__node-icon" :class="`node-type--${node.type}`">
-                {{ nodeIcon(node.type) }}
-              </div>
-              <div class="template-detail__node-info">
-                <strong>{{ node.name ?? node.key }}</strong>
-                <span class="template-detail__node-type">{{ nodeTypeLabel(node.type) }}</span>
-                <span
-                  v-if="'assigneeType' in node.config && node.config.assigneeType"
-                  class="template-detail__node-assignee"
-                >
-                  {{ (node.config as any).assigneeType === 'role' ? '角色' : '用户' }}:
-                  {{ (node.config as any).assigneeIds?.join(', ') ?? '-' }}
-                </span>
-              </div>
-              <div
-                v-if="index < template.approvalGraph.nodes.length - 1"
-                class="template-detail__edge"
+        <div class="template-detail__content">
+          <!-- Form schema section -->
+          <div class="template-detail__section">
+            <h2>表单字段</h2>
+            <el-table :data="template.formSchema.fields" style="width: 100%" max-height="400" stripe>
+              <el-table-column prop="label" label="字段名" min-width="160" />
+              <el-table-column label="类型" width="120">
+                <template #default="{ row }">
+                  <el-tag size="small">{{ fieldTypeLabel(row.type) }}</el-tag>
+                </template>
+              </el-table-column>
+              <el-table-column label="必填" width="80">
+                <template #default="{ row }">
+                  <el-tag v-if="row.required" type="danger" size="small">必填</el-tag>
+                  <span v-else>-</span>
+                </template>
+              </el-table-column>
+              <el-table-column prop="placeholder" label="占位文本" min-width="160">
+                <template #default="{ row }">
+                  {{ row.placeholder ?? '-' }}
+                </template>
+              </el-table-column>
+              <el-table-column label="选项" min-width="200">
+                <template #default="{ row }">
+                  <span v-if="row.options && row.options.length">
+                    {{ row.options.map((o: any) => o.label).join(', ') }}
+                  </span>
+                  <span v-else>-</span>
+                </template>
+              </el-table-column>
+              <template #empty>
+                <el-empty description="暂无表单字段" :image-size="60" />
+              </template>
+            </el-table>
+          </div>
+
+          <!-- Approval graph section -->
+          <div class="template-detail__section">
+            <h2>审批流程</h2>
+            <el-timeline v-if="template.approvalGraph.nodes.length">
+              <el-timeline-item
+                v-for="node in template.approvalGraph.nodes"
+                :key="node.key"
+                :type="nodeTimelineType(node.type)"
+                :icon="nodeTimelineIcon(node.type)"
+                size="large"
               >
-                ↓
-              </div>
-            </div>
+                <div class="template-detail__node-content">
+                  <strong>{{ node.name ?? node.key }}</strong>
+                  <el-tag size="small" :type="nodeTagType(node.type)">
+                    {{ nodeTypeLabel(node.type) }}
+                  </el-tag>
+                  <span
+                    v-if="'assigneeType' in node.config && node.config.assigneeType"
+                    class="template-detail__node-assignee"
+                  >
+                    {{ (node.config as any).assigneeType === 'role' ? '角色' : '用户' }}:
+                    {{ (node.config as any).assigneeIds?.join(', ') ?? '-' }}
+                  </span>
+                </div>
+              </el-timeline-item>
+            </el-timeline>
+            <el-empty v-else description="暂无审批节点" :image-size="60" />
           </div>
         </div>
       </div>
-    </div>
 
-    <el-empty v-else-if="!store.loading" description="未找到模板" />
+      <el-empty v-else-if="!store.loading" description="未找到模板" />
+    </div>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import {
+  ArrowLeft,
+  Flag,
+  UserFilled,
+  Message,
+  QuestionFilled,
+  CircleCheckFilled,
+} from '@element-plus/icons-vue'
 import type { ApprovalNodeType, FormFieldType } from '../../types/approval'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
+import { useApprovalPermissions } from '../../approvals/permissions'
 
 const route = useRoute()
 const router = useRouter()
 const store = useApprovalTemplateStore()
+const { canWrite } = useApprovalPermissions()
 
 const template = computed(() => store.activeTemplate)
 
 function statusTagType(status: string) {
   const map: Record<string, string> = {
     published: 'success',
-    draft: 'info',
-    archived: 'warning',
+    draft: 'warning',
+    archived: 'info',
   }
   return map[status] ?? ''
 }
@@ -163,15 +189,37 @@ function nodeTypeLabel(type: ApprovalNodeType) {
   return map[type] ?? type
 }
 
-function nodeIcon(type: ApprovalNodeType) {
+function nodeTimelineType(type: ApprovalNodeType): string {
   const map: Record<ApprovalNodeType, string> = {
-    start: 'S',
-    approval: 'A',
-    cc: 'C',
-    condition: '?',
-    end: 'E',
+    start: 'primary',
+    approval: 'warning',
+    cc: 'success',
+    condition: 'danger',
+    end: 'info',
   }
-  return map[type] ?? '?'
+  return map[type] ?? 'info'
+}
+
+function nodeTimelineIcon(type: ApprovalNodeType) {
+  const map: Record<ApprovalNodeType, any> = {
+    start: Flag,
+    approval: UserFilled,
+    cc: Message,
+    condition: QuestionFilled,
+    end: CircleCheckFilled,
+  }
+  return map[type] ?? undefined
+}
+
+function nodeTagType(type: ApprovalNodeType): string {
+  const map: Record<ApprovalNodeType, string> = {
+    start: '',
+    approval: 'warning',
+    cc: 'success',
+    condition: 'danger',
+    end: 'info',
+  }
+  return map[type] ?? ''
 }
 
 function formatDate(dateStr: string) {
@@ -181,6 +229,12 @@ function formatDate(dateStr: string) {
 
 function goBack() {
   router.push({ path: '/approval-templates' })
+}
+
+function retryLoad() {
+  const id = route.params.id as string
+  store.error = null
+  store.loadTemplate(id)
 }
 
 function startApproval() {
@@ -220,6 +274,10 @@ onMounted(() => {
   margin-bottom: 16px;
 }
 
+.template-detail__content-wrapper {
+  min-height: 200px;
+}
+
 .template-detail__info {
   margin-bottom: 20px;
 }
@@ -234,6 +292,7 @@ onMounted(() => {
   gap: 24px;
   font-size: 13px;
   color: var(--el-text-color-secondary, #909399);
+  flex-wrap: wrap;
 }
 
 .template-detail__content {
@@ -255,49 +314,11 @@ onMounted(() => {
   margin: 0 0 16px;
 }
 
-.template-detail__graph {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0;
-}
-
-.template-detail__node {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  position: relative;
-}
-
-.template-detail__node-icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
+.template-detail__node-content {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  font-size: 16px;
-  color: #fff;
-  background: var(--el-color-info, #909399);
-}
-
-.node-type--start { background: var(--el-color-primary, #409eff); }
-.node-type--approval { background: var(--el-color-warning, #e6a23c); }
-.node-type--cc { background: var(--el-color-success, #67c23a); }
-.node-type--condition { background: var(--el-color-danger, #f56c6c); }
-.node-type--end { background: var(--el-color-info, #909399); }
-
-.template-detail__node-info {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 8px;
-}
-
-.template-detail__node-type {
-  font-size: 12px;
-  color: var(--el-text-color-secondary, #909399);
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .template-detail__node-assignee {
@@ -305,9 +326,10 @@ onMounted(() => {
   color: var(--el-text-color-regular, #606266);
 }
 
-.template-detail__edge {
-  font-size: 20px;
-  color: var(--el-text-color-placeholder, #c0c4cc);
-  padding: 4px 0;
+@media (max-width: 768px) {
+  .template-detail__meta {
+    flex-direction: column;
+    gap: 8px;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- 5 个审批页面补空状态/加载态/错误态（含重试）
- ApprovalDetailView: 自定义 div → el-timeline，动作栏左右分组
- 撤回 popconfirm、toast 通知（成功/失败）
- 新增 `useApprovalPermissions()` composable 控制按钮显隐
- TemplateCenterView: 状态 el-tag、"新建模板" disabled+tooltip
- ApprovalNewView: 模板 el-card、el-upload drag、表单校验
- 响应式布局（768px 断点）

## Test plan
- [ ] 5 个页面空/加载/错误态正确
- [ ] 详情页 el-timeline 渲染正确
- [ ] 动作按钮权限控制生效
- [ ] 撤回 popconfirm 弹出
- [ ] 移动端布局不溢出

🤖 Generated with [Claude Code](https://claude.com/claude-code)