### PR TITLE
test(approvals): add E2E lifecycle and permission verification tests

### DIFF
--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -512,7 +512,7 @@ describe('Approval E2E Lifecycle', () => {
       const graphHeading = headings.find((h) => h.textContent === '审批流程')
       expect(graphHeading).toBeTruthy()
 
-      const nodes = container!.querySelectorAll('.template-detail__node')
+      const nodes = container!.querySelectorAll('.el-timeline-item')
       expect(nodes.length).toBe(4) // start, approval_1, approval_2, end
     })
   })
@@ -934,11 +934,11 @@ describe('Approval E2E Lifecycle', () => {
       mockHistory.value = mockHistoryItems()
       await mountDetailView()
 
-      const historyItems = container!.querySelectorAll('.approval-detail__history-item')
+      const historyItems = container!.querySelectorAll('.el-timeline-item')
       expect(historyItems.length).toBe(2)
 
       // The second history item should have a comment
-      const commentEl = historyItems[1].querySelector('.approval-detail__history-comment')
+      const commentEl = historyItems[1].querySelector('.approval-detail__timeline-comment')
       expect(commentEl?.textContent).toBe('同意报销')
     })
 
@@ -948,7 +948,7 @@ describe('Approval E2E Lifecycle', () => {
       mockHistory.value = mockHistoryItems()
       await mountDetailView()
 
-      const historyItems = container!.querySelectorAll('.approval-detail__history-item')
+      const historyItems = container!.querySelectorAll('.el-timeline-item')
       const firstActor = historyItems[0].querySelector('strong')
       expect(firstActor?.textContent).toBe('张三')
     })

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -5,7 +5,7 @@
  * Uses the same component-level E2E pattern as approval-center.spec.ts.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
 import {
   mockPendingApproval,
   mockApprovedApproval,
@@ -121,6 +121,35 @@ vi.mock('../src/approvals/templateStore', () => ({
 }))
 
 // ---------------------------------------------------------------------------
+// Approval permissions mock
+// ---------------------------------------------------------------------------
+const mockPermissionState = ref({
+  canRead: true,
+  canWrite: true,
+  canAct: true,
+  canManageTemplates: true,
+})
+
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({
+    permissions: computed(() => mockPermissionState.value),
+    hasPermission: (perm: string) => {
+      const map = {
+        'approvals:read': mockPermissionState.value.canRead,
+        'approvals:write': mockPermissionState.value.canWrite,
+        'approvals:act': mockPermissionState.value.canAct,
+        'approval-templates:manage': mockPermissionState.value.canManageTemplates,
+      } as const
+      return map[perm as keyof typeof map] ?? false
+    },
+    canRead: computed(() => mockPermissionState.value.canRead),
+    canWrite: computed(() => mockPermissionState.value.canWrite),
+    canAct: computed(() => mockPermissionState.value.canAct),
+    canManageTemplates: computed(() => mockPermissionState.value.canManageTemplates),
+  }),
+}))
+
+// ---------------------------------------------------------------------------
 // Element Plus stubs (same pattern as approval-center.spec.ts)
 // ---------------------------------------------------------------------------
 const ElTabs = defineComponent({
@@ -212,6 +241,7 @@ const ElButton = defineComponent({
   render() {
     return h('button', {
       'data-el-button': this.type || 'default',
+      type: 'button',
       disabled: this.disabled || false,
       onClick: (e: Event) => { e.stopPropagation(); this.$emit('click', e) },
     }, this.$slots.default?.())
@@ -309,6 +339,18 @@ async function flushUi(cycles = 6): Promise<void> {
   }
 }
 
+function queryHistoryItems(container: HTMLDivElement | null) {
+  const timelineItems = container?.querySelectorAll('.el-timeline-item') ?? []
+  if (timelineItems.length > 0) return Array.from(timelineItems)
+  return Array.from(container?.querySelectorAll('.approval-detail__history-item') ?? [])
+}
+
+function queryTemplateGraphNodes(container: HTMLDivElement | null) {
+  const timelineItems = container?.querySelectorAll('.el-timeline-item') ?? []
+  if (timelineItems.length > 0) return Array.from(timelineItems)
+  return Array.from(container?.querySelectorAll('.template-detail__node') ?? [])
+}
+
 function registerAllStubs(app: VueApp<Element>) {
   app.component('ElTabs', ElTabs)
   app.component('ElTabPane', ElTabPane)
@@ -354,6 +396,12 @@ describe('Approval E2E Lifecycle', () => {
     mockTemplateLoading.value = false
     mockTemplateError.value = null
     mockTemplateTotal.value = 0
+    mockPermissionState.value = {
+      canRead: true,
+      canWrite: true,
+      canAct: true,
+      canManageTemplates: true,
+    }
 
     // Reset route state
     routeParams = {}
@@ -512,7 +560,7 @@ describe('Approval E2E Lifecycle', () => {
       const graphHeading = headings.find((h) => h.textContent === '审批流程')
       expect(graphHeading).toBeTruthy()
 
-      const nodes = container!.querySelectorAll('.el-timeline-item')
+      const nodes = queryTemplateGraphNodes(container)
       expect(nodes.length).toBe(4) // start, approval_1, approval_2, end
     })
   })
@@ -934,11 +982,11 @@ describe('Approval E2E Lifecycle', () => {
       mockHistory.value = mockHistoryItems()
       await mountDetailView()
 
-      const historyItems = container!.querySelectorAll('.el-timeline-item')
+      const historyItems = queryHistoryItems(container)
       expect(historyItems.length).toBe(2)
 
       // The second history item should have a comment
-      const commentEl = historyItems[1].querySelector('.approval-detail__timeline-comment')
+      const commentEl = historyItems[1].querySelector('.approval-detail__timeline-comment, .approval-detail__history-comment')
       expect(commentEl?.textContent).toBe('同意报销')
     })
 
@@ -948,7 +996,7 @@ describe('Approval E2E Lifecycle', () => {
       mockHistory.value = mockHistoryItems()
       await mountDetailView()
 
-      const historyItems = container!.querySelectorAll('.el-timeline-item')
+      const historyItems = queryHistoryItems(container)
       const firstActor = historyItems[0].querySelector('strong')
       expect(firstActor?.textContent).toBe('张三')
     })

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -1,0 +1,1084 @@
+/**
+ * Approval E2E Lifecycle Verification Tests
+ *
+ * Full lifecycle coverage: template -> publish -> initiate -> approve/reject/transfer/comment/revoke
+ * Uses the same component-level E2E pattern as approval-center.spec.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import {
+  mockPendingApproval,
+  mockApprovedApproval,
+  mockRejectedApproval,
+  mockRevokedApproval,
+  mockPublishedTemplate,
+  mockDraftTemplate,
+  mockHistoryItems,
+  CURRENT_USER_ID,
+  REQUESTER_USER_ID,
+} from './helpers/approval-test-fixtures'
+
+// ---------------------------------------------------------------------------
+// Router mock
+// ---------------------------------------------------------------------------
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+const backSpy = vi.fn()
+let routeParams: Record<string, string> = {}
+let routeQuery: Record<string, string> = {}
+let routePath = '/approvals'
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: pushSpy,
+      back: backSpy,
+    }),
+    useRoute: () => ({
+      params: routeParams,
+      query: routeQuery,
+      path: routePath,
+      meta: {},
+    }),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Approval store mock
+// ---------------------------------------------------------------------------
+const mockActiveApproval = ref<any>(null)
+const mockHistory = ref<any[]>([])
+const mockLoading = ref(false)
+const mockError = ref<string | null>(null)
+const mockPendingApprovals = ref<any[]>([])
+const mockMyApprovals = ref<any[]>([])
+const mockCcApprovals = ref<any[]>([])
+const mockCompletedApprovals = ref<any[]>([])
+
+const loadDetailSpy = vi.fn().mockResolvedValue(undefined)
+const loadHistorySpy = vi.fn().mockResolvedValue(undefined)
+const submitApprovalSpy = vi.fn()
+const executeActionSpy = vi.fn()
+const loadPendingSpy = vi.fn().mockResolvedValue(undefined)
+const loadMineSpy = vi.fn().mockResolvedValue(undefined)
+const loadCcSpy = vi.fn().mockResolvedValue(undefined)
+const loadCompletedSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../src/approvals/store', () => ({
+  useApprovalStore: () => ({
+    get approvals() { return [] },
+    get pendingApprovals() { return mockPendingApprovals.value },
+    get myApprovals() { return mockMyApprovals.value },
+    get ccApprovals() { return mockCcApprovals.value },
+    get completedApprovals() { return mockCompletedApprovals.value },
+    get activeApproval() { return mockActiveApproval.value },
+    get history() { return mockHistory.value },
+    get loading() { return mockLoading.value },
+    get error() { return mockError.value },
+    get totalPending() { return mockPendingApprovals.value.length },
+    get totalMine() { return mockMyApprovals.value.length },
+    get totalCc() { return mockCcApprovals.value.length },
+    get totalCompleted() { return mockCompletedApprovals.value.length },
+    get pendingCount() { return mockPendingApprovals.value.length },
+    approvalById: () => undefined,
+    loadPending: loadPendingSpy,
+    loadMine: loadMineSpy,
+    loadCc: loadCcSpy,
+    loadCompleted: loadCompletedSpy,
+    loadDetail: loadDetailSpy,
+    loadHistory: loadHistorySpy,
+    submitApproval: submitApprovalSpy,
+    executeAction: executeActionSpy,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Template store mock
+// ---------------------------------------------------------------------------
+const mockActiveTemplate = ref<any>(null)
+const mockTemplates = ref<any[]>([])
+const mockTemplateLoading = ref(false)
+const mockTemplateError = ref<string | null>(null)
+const mockTemplateTotal = ref(0)
+
+const loadTemplatesSpy = vi.fn().mockResolvedValue(undefined)
+const loadTemplateSpy = vi.fn().mockResolvedValue(undefined)
+const loadVersionSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../src/approvals/templateStore', () => ({
+  useApprovalTemplateStore: () => ({
+    get templates() { return mockTemplates.value },
+    get activeTemplate() { return mockActiveTemplate.value },
+    get activeVersion() { return null },
+    get loading() { return mockTemplateLoading.value },
+    get error() { return mockTemplateError.value },
+    get total() { return mockTemplateTotal.value },
+    loadTemplates: loadTemplatesSpy,
+    loadTemplate: loadTemplateSpy,
+    loadVersion: loadVersionSpy,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Element Plus stubs (same pattern as approval-center.spec.ts)
+// ---------------------------------------------------------------------------
+const ElTabs = defineComponent({
+  name: 'ElTabs',
+  props: { modelValue: String },
+  emits: ['update:modelValue', 'tab-change'],
+  render() { return h('div', { 'data-el-tabs': this.modelValue }, this.$slots.default?.()) },
+})
+
+const ElTabPane = defineComponent({
+  name: 'ElTabPane',
+  props: { label: String, name: String },
+  render() { return h('div', { 'data-tab-pane': this.name, 'data-tab-label': this.label }, this.$slots.default?.()) },
+})
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: Array, loading: Boolean, stripe: Boolean, highlightCurrentRow: Boolean },
+  emits: ['row-click'],
+  render() { return h('div', { 'data-el-table': 'true' }, this.$slots.default?.()) },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number], minWidth: [String, Number], fixed: String },
+  render() { return h('div', { 'data-column': this.prop || this.label }) },
+})
+
+const ElTag = defineComponent({
+  name: 'ElTag',
+  props: { type: String, size: String },
+  render() { return h('span', { 'data-el-tag': this.type, class: `el-tag--${this.type}` }, this.$slots.default?.()) },
+})
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: [String, Number], placeholder: String, clearable: Boolean, type: String, rows: Number },
+  emits: ['update:modelValue', 'clear'],
+  render() {
+    return h('input', {
+      'data-el-input': 'true',
+      value: this.modelValue ?? '',
+      onInput: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLInputElement).value),
+    })
+  },
+})
+
+const ElInputNumber = defineComponent({
+  name: 'ElInputNumber',
+  props: { modelValue: Number, placeholder: String },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      'data-el-input-number': 'true',
+      type: 'number',
+      value: this.modelValue ?? '',
+      onInput: (e: Event) => this.$emit('update:modelValue', Number((e.target as HTMLInputElement).value)),
+    })
+  },
+})
+
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: { modelValue: [String, Array], placeholder: String, clearable: Boolean, multiple: Boolean, filterable: Boolean },
+  emits: ['update:modelValue', 'change'],
+  render() {
+    return h('select', {
+      'data-el-select': 'true',
+      value: Array.isArray(this.modelValue) ? '' : this.modelValue ?? '',
+      onChange: (e: Event) => {
+        const val = (e.target as HTMLSelectElement).value
+        this.$emit('update:modelValue', val)
+        this.$emit('change', val)
+      },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() { return h('option', { value: this.value }, this.label) },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, text: Boolean, link: Boolean, plain: Boolean, size: String, loading: Boolean, disabled: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      'data-el-button': this.type || 'default',
+      disabled: this.disabled || false,
+      onClick: (e: Event) => { e.stopPropagation(); this.$emit('click', e) },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, type: String, showIcon: Boolean, closable: Boolean },
+  render() { return h('div', { 'data-el-alert': this.type }, this.title) },
+})
+
+const ElEmpty = defineComponent({
+  name: 'ElEmpty',
+  props: { description: String, imageSize: Number },
+  render() { return h('div', { 'data-el-empty': 'true' }, this.description) },
+})
+
+const ElPagination = defineComponent({
+  name: 'ElPagination',
+  props: { background: Boolean, layout: String, total: Number, currentPage: Number, pageSize: Number },
+  emits: ['update:currentPage'],
+  render() { return h('div', { 'data-el-pagination': 'true' }) },
+})
+
+const ElDivider = defineComponent({
+  name: 'ElDivider',
+  render() { return h('hr', { 'data-el-divider': 'true' }) },
+})
+
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String, width: String },
+  emits: ['update:modelValue'],
+  render() {
+    if (!this.modelValue) return h('div', { style: 'display:none', 'data-el-dialog': this.title })
+    return h('div', { 'data-el-dialog': this.title, 'data-dialog-visible': 'true' }, [
+      h('div', { class: 'el-dialog__title' }, this.title),
+      this.$slots.default?.(),
+      this.$slots.footer?.(),
+    ])
+  },
+})
+
+const ElForm = defineComponent({
+  name: 'ElForm',
+  props: { model: Object, rules: Object, labelPosition: String },
+  setup(_props, { expose }) {
+    expose({ validate: () => Promise.resolve(true) })
+    return {}
+  },
+  render() { return h('form', { 'data-el-form': 'true' }, this.$slots.default?.()) },
+})
+
+const ElFormItem = defineComponent({
+  name: 'ElFormItem',
+  props: { label: String, prop: String, required: Boolean },
+  render() {
+    return h('div', { 'data-el-form-item': this.prop || this.label }, [
+      h('label', this.label),
+      this.$slots.default?.(),
+    ])
+  },
+})
+
+const ElDatePicker = defineComponent({
+  name: 'ElDatePicker',
+  props: { modelValue: [String, Date], type: String, placeholder: String },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      'data-el-date-picker': 'true',
+      type: 'date',
+      value: this.modelValue ?? '',
+      onInput: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLInputElement).value),
+    })
+  },
+})
+
+const ElUpload = defineComponent({
+  name: 'ElUpload',
+  props: { action: String, autoUpload: Boolean },
+  render() { return h('div', { 'data-el-upload': 'true' }, this.$slots.default?.()) },
+})
+
+const stubDirective = { mounted() {}, updated() {} }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function registerAllStubs(app: VueApp<Element>) {
+  app.component('ElTabs', ElTabs)
+  app.component('ElTabPane', ElTabPane)
+  app.component('ElTable', ElTable)
+  app.component('ElTableColumn', ElTableColumn)
+  app.component('ElTag', ElTag)
+  app.component('ElInput', ElInput)
+  app.component('ElInputNumber', ElInputNumber)
+  app.component('ElSelect', ElSelect)
+  app.component('ElOption', ElOption)
+  app.component('ElButton', ElButton)
+  app.component('ElAlert', ElAlert)
+  app.component('ElEmpty', ElEmpty)
+  app.component('ElPagination', ElPagination)
+  app.component('ElDivider', ElDivider)
+  app.component('ElDialog', ElDialog)
+  app.component('ElForm', ElForm)
+  app.component('ElFormItem', ElFormItem)
+  app.component('ElDatePicker', ElDatePicker)
+  app.component('ElUpload', ElUpload)
+  app.directive('loading', stubDirective)
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+describe('Approval E2E Lifecycle', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    // Reset all reactive state
+    mockActiveApproval.value = null
+    mockHistory.value = []
+    mockLoading.value = false
+    mockError.value = null
+    mockPendingApprovals.value = []
+    mockMyApprovals.value = []
+    mockCcApprovals.value = []
+    mockCompletedApprovals.value = []
+    mockActiveTemplate.value = null
+    mockTemplates.value = []
+    mockTemplateLoading.value = false
+    mockTemplateError.value = null
+    mockTemplateTotal.value = 0
+
+    // Reset route state
+    routeParams = {}
+    routeQuery = {}
+    routePath = '/approvals'
+
+    // Reset spies
+    pushSpy.mockClear()
+    backSpy.mockClear()
+    loadDetailSpy.mockClear()
+    loadHistorySpy.mockClear()
+    submitApprovalSpy.mockClear()
+    executeActionSpy.mockClear()
+    loadPendingSpy.mockClear()
+    loadMineSpy.mockClear()
+    loadCcSpy.mockClear()
+    loadCompletedSpy.mockClear()
+    loadTemplatesSpy.mockClear()
+    loadTemplateSpy.mockClear()
+    loadVersionSpy.mockClear()
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // Mount helpers
+  // -------------------------------------------------------------------------
+  async function mountDetailView() {
+    const { default: ApprovalDetailView } = await import('../src/views/approval/ApprovalDetailView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalDetailView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  async function mountNewView() {
+    const { default: ApprovalNewView } = await import('../src/views/approval/ApprovalNewView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalNewView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  async function mountTemplateCenterView() {
+    const { default: TemplateCenterView } = await import('../src/views/approval/TemplateCenterView.vue')
+    const Host = defineComponent({ setup: () => () => h(TemplateCenterView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  async function mountTemplateDetailView() {
+    const { default: TemplateDetailView } = await import('../src/views/approval/TemplateDetailView.vue')
+    const Host = defineComponent({ setup: () => () => h(TemplateDetailView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  // =========================================================================
+  // 1. Template lifecycle
+  // =========================================================================
+  describe('Template lifecycle', () => {
+    it('loads template list on mount and calls loadTemplates', async () => {
+      await mountTemplateCenterView()
+      expect(loadTemplatesSpy).toHaveBeenCalled()
+    })
+
+    it('renders template center with header', async () => {
+      await mountTemplateCenterView()
+      const header = container!.querySelector('.template-center__header h1')
+      expect(header?.textContent).toBe('审批模板')
+    })
+
+    it('renders status tabs (all / published / draft / archived)', async () => {
+      await mountTemplateCenterView()
+      const panes = container!.querySelectorAll('[data-tab-pane]')
+      const labels = Array.from(panes).map((p) => p.getAttribute('data-tab-label'))
+      expect(labels).toContain('全部')
+      expect(labels).toContain('已发布')
+      expect(labels).toContain('草稿')
+      expect(labels).toContain('已归档')
+    })
+
+    it('loads template detail and shows published template info', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      expect(loadTemplateSpy).toHaveBeenCalledWith('tpl_1')
+      const header = container!.querySelector('.template-detail__header h1')
+      expect(header?.textContent).toBe('通用审批模板')
+    })
+
+    it('published template shows "发起审批" button in detail', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      const buttons = Array.from(container!.querySelectorAll('button'))
+      const startBtn = buttons.find((b) => b.textContent?.includes('发起审批'))
+      expect(startBtn).toBeTruthy()
+    })
+
+    it('draft template does NOT show "发起审批" button in detail', async () => {
+      routeParams = { id: 'tpl_draft_1' }
+      mockActiveTemplate.value = mockDraftTemplate()
+      await mountTemplateDetailView()
+
+      const buttons = Array.from(container!.querySelectorAll('button'))
+      const startBtn = buttons.find((b) => b.textContent?.includes('发起审批'))
+      expect(startBtn).toBeFalsy()
+    })
+
+    it('clicking "发起审批" navigates to /approvals/new/:templateId', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      const buttons = Array.from(container!.querySelectorAll('button'))
+      const startBtn = buttons.find((b) => b.textContent?.includes('发起审批'))
+      startBtn!.click()
+      await flushUi()
+
+      expect(pushSpy).toHaveBeenCalledWith({ path: '/approvals/new/tpl_1' })
+    })
+
+    it('template detail renders form fields table', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      const section = container!.querySelector('.template-detail__section h2')
+      expect(section?.textContent).toBe('表单字段')
+    })
+
+    it('template detail renders approval graph nodes', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      const headings = Array.from(container!.querySelectorAll('.template-detail__section h2'))
+      const graphHeading = headings.find((h) => h.textContent === '审批流程')
+      expect(graphHeading).toBeTruthy()
+
+      const nodes = container!.querySelectorAll('.template-detail__node')
+      expect(nodes.length).toBe(4) // start, approval_1, approval_2, end
+    })
+  })
+
+  // =========================================================================
+  // 2. Approval initiate
+  // =========================================================================
+  describe('Approval initiate', () => {
+    it('loads template on mount when navigating to /approvals/new/:templateId', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      routePath = '/approvals/new/tpl_1'
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountNewView()
+
+      expect(loadTemplateSpy).toHaveBeenCalledWith('tpl_1')
+    })
+
+    it('renders form fields from template schema', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountNewView()
+
+      const formItems = container!.querySelectorAll('[data-el-form-item]')
+      expect(formItems.length).toBeGreaterThanOrEqual(4) // 4 schema fields + submit item
+    })
+
+    it('renders the "发起审批" header', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountNewView()
+
+      const h1 = container!.querySelector('.approval-new__header h1')
+      expect(h1?.textContent).toBe('发起审批')
+    })
+
+    it('renders template name and description', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountNewView()
+
+      const infoH2 = container!.querySelector('.approval-new__info h2')
+      expect(infoH2?.textContent).toBe('通用审批模板')
+
+      const descP = container!.querySelector('.approval-new__info p')
+      expect(descP?.textContent).toBe('适用于日常审批流程')
+    })
+
+    it('submit button calls submitApproval with templateId and formData', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+
+      const resultApproval = mockPendingApproval({ id: 'apv_new_1' })
+      submitApprovalSpy.mockResolvedValue(resultApproval)
+
+      await mountNewView()
+
+      const buttons = Array.from(container!.querySelectorAll('button'))
+      const submitBtn = buttons.find((b) => b.textContent?.includes('提交审批'))
+      expect(submitBtn).toBeTruthy()
+
+      submitBtn!.click()
+      await flushUi()
+
+      expect(submitApprovalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          templateId: 'tpl_1',
+          formData: expect.any(Object),
+        }),
+      )
+    })
+
+    it('after successful submit, navigates to detail page', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+
+      const resultApproval = mockPendingApproval({ id: 'apv_new_1' })
+      submitApprovalSpy.mockResolvedValue(resultApproval)
+
+      await mountNewView()
+
+      const buttons = Array.from(container!.querySelectorAll('button'))
+      const submitBtn = buttons.find((b) => b.textContent?.includes('提交审批'))
+      submitBtn!.click()
+      await flushUi()
+
+      expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-detail', params: { id: 'apv_new_1' } })
+    })
+
+    it('cancel button calls router.back()', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountNewView()
+
+      const buttons = Array.from(container!.querySelectorAll('button'))
+      const cancelBtn = buttons.find((b) => b.textContent?.includes('取消'))
+      cancelBtn!.click()
+      await flushUi()
+
+      expect(backSpy).toHaveBeenCalled()
+    })
+  })
+
+  // =========================================================================
+  // 3. Approve flow
+  // =========================================================================
+  describe('Approve flow', () => {
+    it('loads detail and history on mount', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      mockHistory.value = mockHistoryItems()
+      await mountDetailView()
+
+      expect(loadDetailSpy).toHaveBeenCalledWith('apv_pending_1')
+      expect(loadHistorySpy).toHaveBeenCalledWith('apv_pending_1')
+    })
+
+    it('renders approval title and status tag', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const h1 = container!.querySelector('.approval-detail__header h1')
+      expect(h1?.textContent).toBe('出差报销申请')
+
+      const tag = container!.querySelector('.approval-detail__header [data-el-tag]')
+      expect(tag?.textContent).toContain('待处理')
+    })
+
+    it('shows action buttons when status is pending', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const buttons = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+      const labels = buttons.map((b) => b.textContent?.trim())
+      expect(labels).toContain('通过')
+      expect(labels).toContain('驳回')
+      expect(labels).toContain('转交')
+      expect(labels).toContain('撤回')
+    })
+
+    it('does not show action buttons when status is approved', async () => {
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval()
+      await mountDetailView()
+
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeFalsy()
+    })
+
+    it('clicking "通过" opens the approve dialog', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const approveBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '通过')
+      approveBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      expect(dialog).toBeTruthy()
+      expect(dialog?.querySelector('.el-dialog__title')?.textContent).toBe('审批通过')
+    })
+
+    it('confirming approve calls executeAction with action=approve', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockApprovedApproval())
+
+      await mountDetailView()
+
+      // Open approve dialog
+      const approveBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '通过')
+      approveBtn!.click()
+      await flushUi()
+
+      // Find and click confirm button inside dialog
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.trim() === '确认')
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', {
+        action: 'approve',
+        comment: undefined,
+      })
+    })
+
+    it('entering comment before approving sends comment in action', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockApprovedApproval())
+
+      await mountDetailView()
+
+      // Open approve dialog
+      const approveBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '通过')
+      approveBtn!.click()
+      await flushUi()
+
+      // Enter comment in the dialog's textarea
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const textarea = dialog!.querySelector('[data-el-input]') as HTMLInputElement
+      if (textarea) {
+        const nativeInputEvent = new Event('input', { bubbles: true })
+        Object.defineProperty(nativeInputEvent, 'target', { value: { value: '同意报销' } })
+        textarea.dispatchEvent(nativeInputEvent)
+        await flushUi()
+      }
+
+      // Click confirm
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.trim() === '确认')
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', expect.objectContaining({
+        action: 'approve',
+      }))
+    })
+
+    it('after approve, loadHistory is called to refresh timeline', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockApprovedApproval())
+
+      await mountDetailView()
+      loadHistorySpy.mockClear()
+
+      const approveBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '通过')
+      approveBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.trim() === '确认')
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(loadHistorySpy).toHaveBeenCalledWith('apv_pending_1')
+    })
+  })
+
+  // =========================================================================
+  // 4. Reject flow
+  // =========================================================================
+  describe('Reject flow', () => {
+    it('clicking "驳回" opens the reject dialog', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const rejectBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '驳回')
+      rejectBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      expect(dialog).toBeTruthy()
+      expect(dialog?.querySelector('.el-dialog__title')?.textContent).toBe('审批驳回')
+    })
+
+    it('confirming reject calls executeAction with action=reject', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockRejectedApproval())
+
+      await mountDetailView()
+
+      // Open reject dialog
+      const rejectBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '驳回')
+      rejectBtn!.click()
+      await flushUi()
+
+      // Click confirm (danger button)
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.trim() === '确认')
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', {
+        action: 'reject',
+        comment: undefined,
+      })
+    })
+
+    it('after reject, loadHistory is refreshed', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockRejectedApproval())
+
+      await mountDetailView()
+      loadHistorySpy.mockClear()
+
+      const rejectBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '驳回')
+      rejectBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.trim() === '确认')
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(loadHistorySpy).toHaveBeenCalledWith('apv_pending_1')
+    })
+  })
+
+  // =========================================================================
+  // 5. Transfer flow
+  // =========================================================================
+  describe('Transfer flow', () => {
+    it('clicking "转交" opens the transfer dialog', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const transferBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '转交')
+      transferBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-el-dialog="转交审批"]')
+      expect(dialog).toBeTruthy()
+      expect(dialog?.getAttribute('data-dialog-visible')).toBe('true')
+    })
+
+    it('transfer dialog contains user selector with options', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const transferBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '转交')
+      transferBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="转交审批"]')
+      const options = dialog!.querySelectorAll('option')
+      expect(options.length).toBeGreaterThanOrEqual(3) // user_2, user_3, user_4
+    })
+
+    it('confirming transfer calls executeAction with action=transfer and targetUserId', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockPendingApproval())
+
+      await mountDetailView()
+
+      // Open transfer dialog
+      const transferBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '转交')
+      transferBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="转交审批"]')
+
+      // Select a user
+      const select = dialog!.querySelector('[data-el-select]') as HTMLSelectElement
+      select.value = 'user_2'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi()
+
+      // Click confirm transfer
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('确认转交'))
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', expect.objectContaining({
+        action: 'transfer',
+        targetUserId: 'user_2',
+      }))
+    })
+
+    it('after transfer, loadHistory is refreshed', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockPendingApproval())
+
+      await mountDetailView()
+      loadHistorySpy.mockClear()
+
+      const transferBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '转交')
+      transferBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="转交审批"]')
+      const select = dialog!.querySelector('[data-el-select]') as HTMLSelectElement
+      select.value = 'user_2'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi()
+
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('确认转交'))
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(loadHistorySpy).toHaveBeenCalledWith('apv_pending_1')
+    })
+  })
+
+  // =========================================================================
+  // 6. Comment flow (via approve action with comment-only intent)
+  // =========================================================================
+  describe('Comment flow', () => {
+    it('history items render correctly with comments', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      mockHistory.value = mockHistoryItems()
+      await mountDetailView()
+
+      const historyItems = container!.querySelectorAll('.approval-detail__history-item')
+      expect(historyItems.length).toBe(2)
+
+      // The second history item should have a comment
+      const commentEl = historyItems[1].querySelector('.approval-detail__history-comment')
+      expect(commentEl?.textContent).toBe('同意报销')
+    })
+
+    it('history renders actor names', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      mockHistory.value = mockHistoryItems()
+      await mountDetailView()
+
+      const historyItems = container!.querySelectorAll('.approval-detail__history-item')
+      const firstActor = historyItems[0].querySelector('strong')
+      expect(firstActor?.textContent).toBe('张三')
+    })
+
+    it('empty history shows "暂无审批历史" placeholder', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      mockHistory.value = []
+      await mountDetailView()
+
+      const empty = container!.querySelector('.approval-detail__timeline [data-el-empty]')
+      expect(empty?.textContent).toContain('暂无审批历史')
+    })
+  })
+
+  // =========================================================================
+  // 7. Revoke flow
+  // =========================================================================
+  describe('Revoke flow', () => {
+    it('clicking "撤回" calls executeAction with action=revoke directly', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockRevokedApproval())
+
+      await mountDetailView()
+
+      const revokeBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '撤回')
+      revokeBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', { action: 'revoke' })
+    })
+
+    it('after revoke, loadHistory is refreshed', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockRevokedApproval())
+
+      await mountDetailView()
+      loadHistorySpy.mockClear()
+
+      const revokeBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '撤回')
+      revokeBtn!.click()
+      await flushUi()
+
+      expect(loadHistorySpy).toHaveBeenCalledWith('apv_pending_1')
+    })
+
+    it('revoked approval does not show action buttons', async () => {
+      routeParams = { id: 'apv_revoked_1' }
+      mockActiveApproval.value = mockRevokedApproval()
+      await mountDetailView()
+
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeFalsy()
+    })
+
+    it('rejected approval does not show action buttons', async () => {
+      routeParams = { id: 'apv_rejected_1' }
+      mockActiveApproval.value = mockRejectedApproval()
+      await mountDetailView()
+
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeFalsy()
+    })
+  })
+
+  // =========================================================================
+  // Cross-cutting: Detail view rendering
+  // =========================================================================
+  describe('Detail view rendering', () => {
+    it('renders form snapshot fields', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const snapshot = container!.querySelector('.approval-detail__snapshot')
+      expect(snapshot).toBeTruthy()
+
+      const fields = snapshot!.querySelectorAll('.approval-detail__field')
+      expect(fields.length).toBe(3) // fld_reason, fld_amount, fld_type
+    })
+
+    it('renders meta info (requestNo, requester, department, progress)', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const metaItems = container!.querySelectorAll('.approval-detail__meta-item')
+      expect(metaItems.length).toBeGreaterThanOrEqual(4) // requestNo, requester, department, time, progress
+
+      const metaText = Array.from(metaItems).map((el) => el.textContent)
+      expect(metaText.some((t) => t?.includes('APV-2026-0001'))).toBe(true)
+      expect(metaText.some((t) => t?.includes('张三'))).toBe(true)
+      expect(metaText.some((t) => t?.includes('研发部'))).toBe(true)
+    })
+
+    it('back button navigates to approval list', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const backBtn = Array.from(container!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('返回列表'))
+      backBtn!.click()
+      await flushUi()
+
+      expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-list' })
+    })
+
+    it('error state shows error alert', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      mockError.value = '加载审批详情失败'
+      await mountDetailView()
+
+      const alert = container!.querySelector('[data-el-alert="error"]')
+      expect(alert).toBeTruthy()
+      expect(alert?.textContent).toContain('加载审批详情失败')
+    })
+
+    it('missing form snapshot shows empty placeholder', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval({ formSnapshot: null })
+      await mountDetailView()
+
+      const empty = container!.querySelector('.approval-detail__form [data-el-empty]')
+      expect(empty?.textContent).toContain('暂无表单数据')
+    })
+  })
+})

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -452,7 +452,7 @@ describe('Approval E2E Permissions', () => {
       const snapshot = container!.querySelector('.approval-detail__snapshot')
       expect(snapshot).toBeTruthy()
 
-      const historyItems = container!.querySelectorAll('.approval-detail__history-item')
+      const historyItems = container!.querySelectorAll('.el-timeline-item')
       expect(historyItems.length).toBe(2)
     })
 
@@ -653,7 +653,7 @@ describe('Approval E2E Permissions', () => {
       const timeline = container!.querySelector('.approval-detail__timeline h2')
       expect(timeline?.textContent).toBe('审批流程')
 
-      const items = container!.querySelectorAll('.approval-detail__history-item')
+      const items = container!.querySelectorAll('.el-timeline-item')
       expect(items.length).toBe(2)
     })
   })
@@ -718,7 +718,7 @@ describe('Approval E2E Permissions', () => {
       mockActiveTemplate.value = mockPublishedTemplate()
       await mountTemplateDetailView()
 
-      const nodes = container!.querySelectorAll('.template-detail__node')
+      const nodes = container!.querySelectorAll('.el-timeline-item')
       expect(nodes.length).toBe(4) // start + 2 approval + end
     })
 

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -1,0 +1,837 @@
+/**
+ * Approval E2E Permission Matrix Verification Tests
+ *
+ * Tests the permission model: read-only, writer, actor, template-manager.
+ *
+ * Strategy: since the current views do not consume a permission context directly
+ * (no `v-if="hasPermission('...')"` guards in the SFC templates), we test the
+ * permission matrix by controlling what the mock stores expose. This verifies
+ * that the view components render (or omit) affordances based on the data shape
+ * that a permission-aware backend / store would provide.
+ *
+ * Uses the same component-level E2E pattern as approval-center.spec.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import {
+  mockPendingApproval,
+  mockApprovedApproval,
+  mockPublishedTemplate,
+  mockDraftTemplate,
+  mockHistoryItems,
+  mockPermissions,
+  CURRENT_USER_ID,
+} from './helpers/approval-test-fixtures'
+
+// ---------------------------------------------------------------------------
+// Router mock
+// ---------------------------------------------------------------------------
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+const backSpy = vi.fn()
+let routeParams: Record<string, string> = {}
+let routeQuery: Record<string, string> = {}
+let routePath = '/approvals'
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: pushSpy,
+      back: backSpy,
+    }),
+    useRoute: () => ({
+      params: routeParams,
+      query: routeQuery,
+      path: routePath,
+      meta: {},
+    }),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Approval store mock
+// ---------------------------------------------------------------------------
+const mockActiveApproval = ref<any>(null)
+const mockHistoryRef = ref<any[]>([])
+const mockLoading = ref(false)
+const mockError = ref<string | null>(null)
+const mockPendingApprovals = ref<any[]>([])
+const mockMyApprovals = ref<any[]>([])
+const mockCcApprovals = ref<any[]>([])
+const mockCompletedApprovals = ref<any[]>([])
+
+const loadDetailSpy = vi.fn().mockResolvedValue(undefined)
+const loadHistorySpy = vi.fn().mockResolvedValue(undefined)
+const submitApprovalSpy = vi.fn()
+const executeActionSpy = vi.fn()
+const loadPendingSpy = vi.fn().mockResolvedValue(undefined)
+const loadMineSpy = vi.fn().mockResolvedValue(undefined)
+const loadCcSpy = vi.fn().mockResolvedValue(undefined)
+const loadCompletedSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../src/approvals/store', () => ({
+  useApprovalStore: () => ({
+    get approvals() { return [] },
+    get pendingApprovals() { return mockPendingApprovals.value },
+    get myApprovals() { return mockMyApprovals.value },
+    get ccApprovals() { return mockCcApprovals.value },
+    get completedApprovals() { return mockCompletedApprovals.value },
+    get activeApproval() { return mockActiveApproval.value },
+    get history() { return mockHistoryRef.value },
+    get loading() { return mockLoading.value },
+    get error() { return mockError.value },
+    get totalPending() { return mockPendingApprovals.value.length },
+    get totalMine() { return mockMyApprovals.value.length },
+    get totalCc() { return mockCcApprovals.value.length },
+    get totalCompleted() { return mockCompletedApprovals.value.length },
+    get pendingCount() { return mockPendingApprovals.value.length },
+    approvalById: () => undefined,
+    loadPending: loadPendingSpy,
+    loadMine: loadMineSpy,
+    loadCc: loadCcSpy,
+    loadCompleted: loadCompletedSpy,
+    loadDetail: loadDetailSpy,
+    loadHistory: loadHistorySpy,
+    submitApproval: submitApprovalSpy,
+    executeAction: executeActionSpy,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Template store mock
+// ---------------------------------------------------------------------------
+const mockActiveTemplate = ref<any>(null)
+const mockTemplates = ref<any[]>([])
+const mockTemplateLoading = ref(false)
+const mockTemplateError = ref<string | null>(null)
+const mockTemplateTotal = ref(0)
+
+const loadTemplatesSpy = vi.fn().mockResolvedValue(undefined)
+const loadTemplateSpy = vi.fn().mockResolvedValue(undefined)
+const loadVersionSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../src/approvals/templateStore', () => ({
+  useApprovalTemplateStore: () => ({
+    get templates() { return mockTemplates.value },
+    get activeTemplate() { return mockActiveTemplate.value },
+    get activeVersion() { return null },
+    get loading() { return mockTemplateLoading.value },
+    get error() { return mockTemplateError.value },
+    get total() { return mockTemplateTotal.value },
+    loadTemplates: loadTemplatesSpy,
+    loadTemplate: loadTemplateSpy,
+    loadVersion: loadVersionSpy,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Element Plus stubs
+// ---------------------------------------------------------------------------
+const ElTabs = defineComponent({
+  name: 'ElTabs',
+  props: { modelValue: String },
+  emits: ['update:modelValue', 'tab-change'],
+  render() { return h('div', { 'data-el-tabs': this.modelValue }, this.$slots.default?.()) },
+})
+
+const ElTabPane = defineComponent({
+  name: 'ElTabPane',
+  props: { label: String, name: String },
+  render() { return h('div', { 'data-tab-pane': this.name, 'data-tab-label': this.label }, this.$slots.default?.()) },
+})
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: Array, loading: Boolean, stripe: Boolean, highlightCurrentRow: Boolean },
+  emits: ['row-click'],
+  render() { return h('div', { 'data-el-table': 'true' }, this.$slots.default?.()) },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number], minWidth: [String, Number], fixed: String },
+  render() { return h('div', { 'data-column': this.prop || this.label }) },
+})
+
+const ElTag = defineComponent({
+  name: 'ElTag',
+  props: { type: String, size: String },
+  render() { return h('span', { 'data-el-tag': this.type }, this.$slots.default?.()) },
+})
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: [String, Number], placeholder: String, clearable: Boolean, type: String, rows: Number },
+  emits: ['update:modelValue', 'clear'],
+  render() { return h('input', { 'data-el-input': 'true' }) },
+})
+
+const ElInputNumber = defineComponent({
+  name: 'ElInputNumber',
+  props: { modelValue: Number, placeholder: String },
+  emits: ['update:modelValue'],
+  render() { return h('input', { 'data-el-input-number': 'true', type: 'number' }) },
+})
+
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: { modelValue: [String, Array], placeholder: String, clearable: Boolean, multiple: Boolean, filterable: Boolean },
+  emits: ['update:modelValue', 'change'],
+  render() {
+    return h('select', {
+      'data-el-select': 'true',
+      value: Array.isArray(this.modelValue) ? '' : this.modelValue ?? '',
+      onChange: (e: Event) => {
+        const val = (e.target as HTMLSelectElement).value
+        this.$emit('update:modelValue', val)
+        this.$emit('change', val)
+      },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() { return h('option', { value: this.value }, this.label) },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, text: Boolean, link: Boolean, plain: Boolean, size: String, loading: Boolean, disabled: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      'data-el-button': this.type || 'default',
+      disabled: this.disabled || false,
+      onClick: (e: Event) => { e.stopPropagation(); this.$emit('click', e) },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, type: String, showIcon: Boolean, closable: Boolean },
+  render() { return h('div', { 'data-el-alert': this.type }, this.title) },
+})
+
+const ElEmpty = defineComponent({
+  name: 'ElEmpty',
+  props: { description: String, imageSize: Number },
+  render() { return h('div', { 'data-el-empty': 'true' }, this.description) },
+})
+
+const ElPagination = defineComponent({
+  name: 'ElPagination',
+  props: { background: Boolean, layout: String, total: Number, currentPage: Number, pageSize: Number },
+  emits: ['update:currentPage'],
+  render() { return h('div', { 'data-el-pagination': 'true' }) },
+})
+
+const ElDivider = defineComponent({
+  name: 'ElDivider',
+  render() { return h('hr', { 'data-el-divider': 'true' }) },
+})
+
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String, width: String },
+  emits: ['update:modelValue'],
+  render() {
+    if (!this.modelValue) return h('div', { style: 'display:none', 'data-el-dialog': this.title })
+    return h('div', { 'data-el-dialog': this.title, 'data-dialog-visible': 'true' }, [
+      this.$slots.default?.(),
+      this.$slots.footer?.(),
+    ])
+  },
+})
+
+const ElForm = defineComponent({
+  name: 'ElForm',
+  props: { model: Object, rules: Object, labelPosition: String },
+  setup(_props, { expose }) {
+    expose({ validate: () => Promise.resolve(true) })
+    return {}
+  },
+  render() { return h('form', { 'data-el-form': 'true' }, this.$slots.default?.()) },
+})
+
+const ElFormItem = defineComponent({
+  name: 'ElFormItem',
+  props: { label: String, prop: String, required: Boolean },
+  render() { return h('div', { 'data-el-form-item': this.prop || this.label }, [h('label', this.label), this.$slots.default?.()]) },
+})
+
+const ElDatePicker = defineComponent({
+  name: 'ElDatePicker',
+  props: { modelValue: [String, Date], type: String, placeholder: String },
+  emits: ['update:modelValue'],
+  render() { return h('input', { 'data-el-date-picker': 'true', type: 'date' }) },
+})
+
+const ElUpload = defineComponent({
+  name: 'ElUpload',
+  props: { action: String, autoUpload: Boolean },
+  render() { return h('div', { 'data-el-upload': 'true' }, this.$slots.default?.()) },
+})
+
+const stubDirective = { mounted() {}, updated() {} }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function registerAllStubs(app: VueApp<Element>) {
+  app.component('ElTabs', ElTabs)
+  app.component('ElTabPane', ElTabPane)
+  app.component('ElTable', ElTable)
+  app.component('ElTableColumn', ElTableColumn)
+  app.component('ElTag', ElTag)
+  app.component('ElInput', ElInput)
+  app.component('ElInputNumber', ElInputNumber)
+  app.component('ElSelect', ElSelect)
+  app.component('ElOption', ElOption)
+  app.component('ElButton', ElButton)
+  app.component('ElAlert', ElAlert)
+  app.component('ElEmpty', ElEmpty)
+  app.component('ElPagination', ElPagination)
+  app.component('ElDivider', ElDivider)
+  app.component('ElDialog', ElDialog)
+  app.component('ElForm', ElForm)
+  app.component('ElFormItem', ElFormItem)
+  app.component('ElDatePicker', ElDatePicker)
+  app.component('ElUpload', ElUpload)
+  app.directive('loading', stubDirective)
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+describe('Approval E2E Permissions', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    mockActiveApproval.value = null
+    mockHistoryRef.value = []
+    mockLoading.value = false
+    mockError.value = null
+    mockPendingApprovals.value = []
+    mockMyApprovals.value = []
+    mockCcApprovals.value = []
+    mockCompletedApprovals.value = []
+    mockActiveTemplate.value = null
+    mockTemplates.value = []
+    mockTemplateLoading.value = false
+    mockTemplateError.value = null
+    mockTemplateTotal.value = 0
+
+    routeParams = {}
+    routeQuery = {}
+    routePath = '/approvals'
+
+    pushSpy.mockClear()
+    backSpy.mockClear()
+    loadDetailSpy.mockClear()
+    loadHistorySpy.mockClear()
+    submitApprovalSpy.mockClear()
+    executeActionSpy.mockClear()
+    loadPendingSpy.mockClear()
+    loadMineSpy.mockClear()
+    loadCcSpy.mockClear()
+    loadCompletedSpy.mockClear()
+    loadTemplatesSpy.mockClear()
+    loadTemplateSpy.mockClear()
+    loadVersionSpy.mockClear()
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // Mount helpers
+  // -------------------------------------------------------------------------
+  async function mountCenterView() {
+    const { default: ApprovalCenterView } = await import('../src/views/approval/ApprovalCenterView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalCenterView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  async function mountDetailView() {
+    const { default: ApprovalDetailView } = await import('../src/views/approval/ApprovalDetailView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalDetailView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  async function mountNewView() {
+    const { default: ApprovalNewView } = await import('../src/views/approval/ApprovalNewView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalNewView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  async function mountTemplateCenterView() {
+    const { default: TemplateCenterView } = await import('../src/views/approval/TemplateCenterView.vue')
+    const Host = defineComponent({ setup: () => () => h(TemplateCenterView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  async function mountTemplateDetailView() {
+    const { default: TemplateDetailView } = await import('../src/views/approval/TemplateDetailView.vue')
+    const Host = defineComponent({ setup: () => () => h(TemplateDetailView as any) })
+    app = createApp(Host)
+    registerAllStubs(app)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  // =========================================================================
+  // 1. Read-only user (approvals:read only)
+  // =========================================================================
+  describe('Read-only user (approvals:read)', () => {
+    it('can see the approval list (center view renders)', async () => {
+      const perms = mockPermissions(['approvals:read'])
+      mockPendingApprovals.value = [mockPendingApproval()]
+      await mountCenterView()
+
+      const header = container!.querySelector('.approval-center__header h1')
+      expect(header?.textContent).toBe('审批中心')
+      expect(loadPendingSpy).toHaveBeenCalled()
+    })
+
+    it('can see approval list tabs', async () => {
+      await mountCenterView()
+      const panes = container!.querySelectorAll('[data-tab-pane]')
+      expect(panes.length).toBe(4)
+    })
+
+    it('detail page with non-pending status shows NO action buttons', async () => {
+      // Read-only: viewing an approved approval -> no buttons
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval()
+      await mountDetailView()
+
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeFalsy()
+    })
+
+    it('detail page still renders form snapshot and history', async () => {
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval({
+        formSnapshot: { fld_reason: '出差报销', fld_amount: 5000 },
+      })
+      mockHistoryRef.value = mockHistoryItems()
+      await mountDetailView()
+
+      const snapshot = container!.querySelector('.approval-detail__snapshot')
+      expect(snapshot).toBeTruthy()
+
+      const historyItems = container!.querySelectorAll('.approval-detail__history-item')
+      expect(historyItems.length).toBe(2)
+    })
+
+    it('template center renders without "发起审批" button for draft templates', async () => {
+      // Template center shows a table. Only published templates have a "发起审批" link button.
+      // Draft templates should not show it. We verify by providing only draft templates.
+      mockTemplates.value = [
+        { ...mockDraftTemplate(), id: 'tpl_d1', name: '草稿模板' },
+      ]
+      await mountTemplateCenterView()
+
+      // The table renders. Since the column uses scoped slots that are not invoked by our stub,
+      // we verify the table exists and loadTemplates was called.
+      expect(loadTemplatesSpy).toHaveBeenCalled()
+      const table = container!.querySelector('[data-el-table]')
+      expect(table).toBeTruthy()
+    })
+  })
+
+  // =========================================================================
+  // 2. Writer (approvals:read + approvals:write)
+  // =========================================================================
+  describe('Writer (approvals:read + approvals:write)', () => {
+    it('can load the new-approval form (ApprovalNewView)', async () => {
+      const perms = mockPermissions(['approvals:read', 'approvals:write'])
+      routeParams = { templateId: 'tpl_1' }
+      routePath = '/approvals/new/tpl_1'
+      mockActiveTemplate.value = mockPublishedTemplate()
+
+      await mountNewView()
+
+      const h1 = container!.querySelector('.approval-new__header h1')
+      expect(h1?.textContent).toBe('发起审批')
+      expect(loadTemplateSpy).toHaveBeenCalledWith('tpl_1')
+    })
+
+    it('can fill and submit the approval form', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      submitApprovalSpy.mockResolvedValue(mockPendingApproval({ id: 'apv_new_writer' }))
+
+      await mountNewView()
+
+      const submitBtn = Array.from(container!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('提交审批'))
+      expect(submitBtn).toBeTruthy()
+
+      submitBtn!.click()
+      await flushUi()
+
+      expect(submitApprovalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ templateId: 'tpl_1' }),
+      )
+    })
+
+    it('after submitting, navigates to the new approval detail', async () => {
+      routeParams = { templateId: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      submitApprovalSpy.mockResolvedValue(mockPendingApproval({ id: 'apv_new_writer' }))
+
+      await mountNewView()
+
+      const submitBtn = Array.from(container!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('提交审批'))
+      submitBtn!.click()
+      await flushUi()
+
+      expect(pushSpy).toHaveBeenCalledWith({
+        name: 'approval-detail',
+        params: { id: 'apv_new_writer' },
+      })
+    })
+
+    it('writer viewing a pending approval with no assignment sees action buttons (view-level)', async () => {
+      // The current detail view shows action buttons purely based on status === 'pending'.
+      // A writer without approvals:act should NOT be able to act, but the current view
+      // shows buttons for any pending approval. This test documents the current behavior.
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval({
+        assignments: [], // No assignments for this user
+      })
+      await mountDetailView()
+
+      // Current behavior: action bar is visible when status is 'pending'
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeTruthy()
+    })
+  })
+
+  // =========================================================================
+  // 3. Actor (approvals:read + approvals:act)
+  // =========================================================================
+  describe('Actor (approvals:read + approvals:act)', () => {
+    it('sees approve/reject/transfer buttons when viewing a pending assigned approval', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval() // Has active assignment for current user
+      await mountDetailView()
+
+      const buttons = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+      const labels = buttons.map((b) => b.textContent?.trim())
+      expect(labels).toContain('通过')
+      expect(labels).toContain('驳回')
+      expect(labels).toContain('转交')
+    })
+
+    it('does not see action buttons for a non-pending approval', async () => {
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval()
+      await mountDetailView()
+
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeFalsy()
+    })
+
+    it('can execute approve action on an assigned approval', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockApprovedApproval())
+
+      await mountDetailView()
+
+      const approveBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '通过')
+      approveBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.trim() === '确认')
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', {
+        action: 'approve',
+        comment: undefined,
+      })
+    })
+
+    it('can execute reject action on an assigned approval', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockApprovedApproval())
+
+      await mountDetailView()
+
+      const rejectBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '驳回')
+      rejectBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.trim() === '确认')
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', {
+        action: 'reject',
+        comment: undefined,
+      })
+    })
+
+    it('can transfer an assigned approval to another user', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockPendingApproval())
+
+      await mountDetailView()
+
+      const transferBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '转交')
+      transferBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="转交审批"]')
+      const select = dialog!.querySelector('[data-el-select]') as HTMLSelectElement
+      select.value = 'user_3'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi()
+
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('确认转交'))
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', expect.objectContaining({
+        action: 'transfer',
+        targetUserId: 'user_3',
+      }))
+    })
+
+    it('history timeline is always visible for any approval', async () => {
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval()
+      mockHistoryRef.value = mockHistoryItems()
+      await mountDetailView()
+
+      const timeline = container!.querySelector('.approval-detail__timeline h2')
+      expect(timeline?.textContent).toBe('审批流程')
+
+      const items = container!.querySelectorAll('.approval-detail__history-item')
+      expect(items.length).toBe(2)
+    })
+  })
+
+  // =========================================================================
+  // 4. Template manager (approval-templates:manage)
+  // =========================================================================
+  describe('Template manager (approval-templates:manage)', () => {
+    it('template center renders and loads templates', async () => {
+      mockTemplates.value = [
+        mockPublishedTemplate(),
+        mockDraftTemplate(),
+      ]
+      mockTemplateTotal.value = 2
+      await mountTemplateCenterView()
+
+      expect(loadTemplatesSpy).toHaveBeenCalled()
+      const header = container!.querySelector('.template-center__header h1')
+      expect(header?.textContent).toBe('审批模板')
+    })
+
+    it('template center has search input', async () => {
+      await mountTemplateCenterView()
+      const searchInput = container!.querySelector('.template-center__toolbar [data-el-input]')
+      expect(searchInput).toBeTruthy()
+    })
+
+    it('template detail view renders all info for a published template', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      // Template name
+      const h1 = container!.querySelector('.template-detail__header h1')
+      expect(h1?.textContent).toBe('通用审批模板')
+
+      // Status tag (published)
+      const statusTag = container!.querySelector('.template-detail__header [data-el-tag]')
+      expect(statusTag?.textContent).toContain('已发布')
+
+      // "发起审批" button present for published
+      const startBtn = Array.from(container!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('发起审批'))
+      expect(startBtn).toBeTruthy()
+    })
+
+    it('template detail view for a draft template shows no "发起审批" button', async () => {
+      routeParams = { id: 'tpl_draft_1' }
+      mockActiveTemplate.value = mockDraftTemplate()
+      await mountTemplateDetailView()
+
+      const h1 = container!.querySelector('.template-detail__header h1')
+      expect(h1?.textContent).toBe('草稿审批模板')
+
+      const startBtn = Array.from(container!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('发起审批'))
+      expect(startBtn).toBeFalsy()
+    })
+
+    it('template detail view renders graph nodes', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      const nodes = container!.querySelectorAll('.template-detail__node')
+      expect(nodes.length).toBe(4) // start + 2 approval + end
+    })
+
+    it('template detail view renders form fields info section', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      const headings = Array.from(container!.querySelectorAll('.template-detail__section h2'))
+      const fieldsHeading = headings.find((h) => h.textContent === '表单字段')
+      expect(fieldsHeading).toBeTruthy()
+    })
+
+    it('template detail shows meta info (key, version, dates)', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      const meta = container!.querySelector('.template-detail__meta')
+      expect(meta).toBeTruthy()
+      expect(meta?.textContent).toContain('TPL-001')
+    })
+
+    it('back button navigates to /approval-templates', async () => {
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountTemplateDetailView()
+
+      const backBtn = Array.from(container!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('返回模板列表'))
+      backBtn!.click()
+      await flushUi()
+
+      expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates' })
+    })
+  })
+
+  // =========================================================================
+  // 5. Cross-permission edge cases
+  // =========================================================================
+  describe('Cross-permission edge cases', () => {
+    it('approved approval is always read-only regardless of permissions', async () => {
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval()
+      await mountDetailView()
+
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeFalsy()
+    })
+
+    it('rejected approval is always read-only', async () => {
+      routeParams = { id: 'apv_rejected_1' }
+      mockActiveApproval.value = {
+        ...mockPendingApproval(),
+        id: 'apv_rejected_1',
+        status: 'rejected',
+      }
+      await mountDetailView()
+
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeFalsy()
+    })
+
+    it('revoked approval is always read-only', async () => {
+      routeParams = { id: 'apv_revoked_1' }
+      mockActiveApproval.value = {
+        ...mockPendingApproval(),
+        id: 'apv_revoked_1',
+        status: 'revoked',
+      }
+      await mountDetailView()
+
+      const actions = container!.querySelector('.approval-detail__actions')
+      expect(actions).toBeFalsy()
+    })
+
+    it('permission helper creates correct user context', () => {
+      const readOnly = mockPermissions(['approvals:read'])
+      expect(readOnly.userId).toBe(CURRENT_USER_ID)
+      expect(readOnly.hasPermission('approvals:read')).toBe(true)
+      expect(readOnly.hasPermission('approvals:write')).toBe(false)
+      expect(readOnly.hasPermission('approvals:act')).toBe(false)
+
+      const writer = mockPermissions(['approvals:read', 'approvals:write'])
+      expect(writer.hasPermission('approvals:write')).toBe(true)
+      expect(writer.hasPermission('approvals:act')).toBe(false)
+
+      const actor = mockPermissions(['approvals:read', 'approvals:act'])
+      expect(actor.hasPermission('approvals:act')).toBe(true)
+      expect(actor.hasPermission('approvals:write')).toBe(false)
+
+      const manager = mockPermissions(['approval-templates:manage'])
+      expect(manager.hasPermission('approval-templates:manage')).toBe(true)
+    })
+
+    it('new-approval view shows empty state when template not found', async () => {
+      routeParams = { templateId: 'tpl_nonexistent' }
+      mockActiveTemplate.value = null
+      mockTemplateLoading.value = false
+      await mountNewView()
+
+      const empty = container!.querySelector('[data-el-empty]')
+      expect(empty?.textContent).toContain('未找到审批模板')
+    })
+
+    it('template detail shows empty state when template not found', async () => {
+      routeParams = { id: 'tpl_nonexistent' }
+      mockActiveTemplate.value = null
+      mockTemplateLoading.value = false
+      await mountTemplateDetailView()
+
+      const empty = container!.querySelector('[data-el-empty]')
+      expect(empty?.textContent).toContain('未找到模板')
+    })
+  })
+})

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -12,7 +12,7 @@
  * Uses the same component-level E2E pattern as approval-center.spec.ts.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
 import {
   mockPendingApproval,
   mockApprovedApproval,
@@ -126,6 +126,44 @@ vi.mock('../src/approvals/templateStore', () => ({
 }))
 
 // ---------------------------------------------------------------------------
+// Approval permissions mock
+// ---------------------------------------------------------------------------
+const mockPermissionState = ref({
+  canRead: true,
+  canWrite: true,
+  canAct: true,
+  canManageTemplates: true,
+})
+
+function setMockPermissions(perms: string[]) {
+  mockPermissionState.value = {
+    canRead: perms.includes('approvals:read'),
+    canWrite: perms.includes('approvals:write'),
+    canAct: perms.includes('approvals:act'),
+    canManageTemplates: perms.includes('approval-templates:manage'),
+  }
+}
+
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({
+    permissions: computed(() => mockPermissionState.value),
+    hasPermission: (perm: string) => {
+      const map = {
+        'approvals:read': mockPermissionState.value.canRead,
+        'approvals:write': mockPermissionState.value.canWrite,
+        'approvals:act': mockPermissionState.value.canAct,
+        'approval-templates:manage': mockPermissionState.value.canManageTemplates,
+      } as const
+      return map[perm as keyof typeof map] ?? false
+    },
+    canRead: computed(() => mockPermissionState.value.canRead),
+    canWrite: computed(() => mockPermissionState.value.canWrite),
+    canAct: computed(() => mockPermissionState.value.canAct),
+    canManageTemplates: computed(() => mockPermissionState.value.canManageTemplates),
+  }),
+}))
+
+// ---------------------------------------------------------------------------
 // Element Plus stubs
 // ---------------------------------------------------------------------------
 const ElTabs = defineComponent({
@@ -204,6 +242,7 @@ const ElButton = defineComponent({
   render() {
     return h('button', {
       'data-el-button': this.type || 'default',
+      type: 'button',
       disabled: this.disabled || false,
       onClick: (e: Event) => { e.stopPropagation(); this.$emit('click', e) },
     }, this.$slots.default?.())
@@ -288,6 +327,18 @@ async function flushUi(cycles = 6): Promise<void> {
   }
 }
 
+function queryHistoryItems(container: HTMLDivElement | null) {
+  const timelineItems = container?.querySelectorAll('.el-timeline-item') ?? []
+  if (timelineItems.length > 0) return Array.from(timelineItems)
+  return Array.from(container?.querySelectorAll('.approval-detail__history-item') ?? [])
+}
+
+function queryTemplateGraphNodes(container: HTMLDivElement | null) {
+  const timelineItems = container?.querySelectorAll('.el-timeline-item') ?? []
+  if (timelineItems.length > 0) return Array.from(timelineItems)
+  return Array.from(container?.querySelectorAll('.template-detail__node') ?? [])
+}
+
 function registerAllStubs(app: VueApp<Element>) {
   app.component('ElTabs', ElTabs)
   app.component('ElTabPane', ElTabPane)
@@ -332,6 +383,12 @@ describe('Approval E2E Permissions', () => {
     mockTemplateLoading.value = false
     mockTemplateError.value = null
     mockTemplateTotal.value = 0
+    setMockPermissions([
+      'approvals:read',
+      'approvals:write',
+      'approvals:act',
+      'approval-templates:manage',
+    ])
 
     routeParams = {}
     routeQuery = {}
@@ -417,6 +474,7 @@ describe('Approval E2E Permissions', () => {
   describe('Read-only user (approvals:read)', () => {
     it('can see the approval list (center view renders)', async () => {
       const perms = mockPermissions(['approvals:read'])
+      setMockPermissions(perms.permissions)
       mockPendingApprovals.value = [mockPendingApproval()]
       await mountCenterView()
 
@@ -426,12 +484,14 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('can see approval list tabs', async () => {
+      setMockPermissions(['approvals:read'])
       await mountCenterView()
       const panes = container!.querySelectorAll('[data-tab-pane]')
       expect(panes.length).toBe(4)
     })
 
     it('detail page with non-pending status shows NO action buttons', async () => {
+      setMockPermissions(['approvals:read'])
       // Read-only: viewing an approved approval -> no buttons
       routeParams = { id: 'apv_approved_1' }
       mockActiveApproval.value = mockApprovedApproval()
@@ -442,6 +502,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('detail page still renders form snapshot and history', async () => {
+      setMockPermissions(['approvals:read'])
       routeParams = { id: 'apv_approved_1' }
       mockActiveApproval.value = mockApprovedApproval({
         formSnapshot: { fld_reason: '出差报销', fld_amount: 5000 },
@@ -452,11 +513,12 @@ describe('Approval E2E Permissions', () => {
       const snapshot = container!.querySelector('.approval-detail__snapshot')
       expect(snapshot).toBeTruthy()
 
-      const historyItems = container!.querySelectorAll('.el-timeline-item')
+      const historyItems = queryHistoryItems(container)
       expect(historyItems.length).toBe(2)
     })
 
     it('template center renders without "发起审批" button for draft templates', async () => {
+      setMockPermissions(['approvals:read'])
       // Template center shows a table. Only published templates have a "发起审批" link button.
       // Draft templates should not show it. We verify by providing only draft templates.
       mockTemplates.value = [
@@ -478,6 +540,7 @@ describe('Approval E2E Permissions', () => {
   describe('Writer (approvals:read + approvals:write)', () => {
     it('can load the new-approval form (ApprovalNewView)', async () => {
       const perms = mockPermissions(['approvals:read', 'approvals:write'])
+      setMockPermissions(perms.permissions)
       routeParams = { templateId: 'tpl_1' }
       routePath = '/approvals/new/tpl_1'
       mockActiveTemplate.value = mockPublishedTemplate()
@@ -490,6 +553,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('can fill and submit the approval form', async () => {
+      setMockPermissions(['approvals:read', 'approvals:write'])
       routeParams = { templateId: 'tpl_1' }
       mockActiveTemplate.value = mockPublishedTemplate()
       submitApprovalSpy.mockResolvedValue(mockPendingApproval({ id: 'apv_new_writer' }))
@@ -509,6 +573,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('after submitting, navigates to the new approval detail', async () => {
+      setMockPermissions(['approvals:read', 'approvals:write'])
       routeParams = { templateId: 'tpl_1' }
       mockActiveTemplate.value = mockPublishedTemplate()
       submitApprovalSpy.mockResolvedValue(mockPendingApproval({ id: 'apv_new_writer' }))
@@ -527,6 +592,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('writer viewing a pending approval with no assignment sees action buttons (view-level)', async () => {
+      setMockPermissions(['approvals:read', 'approvals:write'])
       // The current detail view shows action buttons purely based on status === 'pending'.
       // A writer without approvals:act should NOT be able to act, but the current view
       // shows buttons for any pending approval. This test documents the current behavior.
@@ -547,6 +613,7 @@ describe('Approval E2E Permissions', () => {
   // =========================================================================
   describe('Actor (approvals:read + approvals:act)', () => {
     it('sees approve/reject/transfer buttons when viewing a pending assigned approval', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
       routeParams = { id: 'apv_pending_1' }
       mockActiveApproval.value = mockPendingApproval() // Has active assignment for current user
       await mountDetailView()
@@ -559,6 +626,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('does not see action buttons for a non-pending approval', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
       routeParams = { id: 'apv_approved_1' }
       mockActiveApproval.value = mockApprovedApproval()
       await mountDetailView()
@@ -568,6 +636,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('can execute approve action on an assigned approval', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
       routeParams = { id: 'apv_pending_1' }
       mockActiveApproval.value = mockPendingApproval()
       executeActionSpy.mockResolvedValue(mockApprovedApproval())
@@ -592,6 +661,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('can execute reject action on an assigned approval', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
       routeParams = { id: 'apv_pending_1' }
       mockActiveApproval.value = mockPendingApproval()
       executeActionSpy.mockResolvedValue(mockApprovedApproval())
@@ -616,6 +686,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('can transfer an assigned approval to another user', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
       routeParams = { id: 'apv_pending_1' }
       mockActiveApproval.value = mockPendingApproval()
       executeActionSpy.mockResolvedValue(mockPendingApproval())
@@ -645,6 +716,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('history timeline is always visible for any approval', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
       routeParams = { id: 'apv_approved_1' }
       mockActiveApproval.value = mockApprovedApproval()
       mockHistoryRef.value = mockHistoryItems()
@@ -653,7 +725,7 @@ describe('Approval E2E Permissions', () => {
       const timeline = container!.querySelector('.approval-detail__timeline h2')
       expect(timeline?.textContent).toBe('审批流程')
 
-      const items = container!.querySelectorAll('.el-timeline-item')
+      const items = queryHistoryItems(container)
       expect(items.length).toBe(2)
     })
   })
@@ -663,6 +735,7 @@ describe('Approval E2E Permissions', () => {
   // =========================================================================
   describe('Template manager (approval-templates:manage)', () => {
     it('template center renders and loads templates', async () => {
+      setMockPermissions(['approval-templates:manage'])
       mockTemplates.value = [
         mockPublishedTemplate(),
         mockDraftTemplate(),
@@ -676,12 +749,14 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('template center has search input', async () => {
+      setMockPermissions(['approval-templates:manage'])
       await mountTemplateCenterView()
       const searchInput = container!.querySelector('.template-center__toolbar [data-el-input]')
       expect(searchInput).toBeTruthy()
     })
 
     it('template detail view renders all info for a published template', async () => {
+      setMockPermissions(['approval-templates:manage', 'approvals:write'])
       routeParams = { id: 'tpl_1' }
       mockActiveTemplate.value = mockPublishedTemplate()
       await mountTemplateDetailView()
@@ -701,6 +776,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('template detail view for a draft template shows no "发起审批" button', async () => {
+      setMockPermissions(['approval-templates:manage'])
       routeParams = { id: 'tpl_draft_1' }
       mockActiveTemplate.value = mockDraftTemplate()
       await mountTemplateDetailView()
@@ -714,15 +790,17 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('template detail view renders graph nodes', async () => {
+      setMockPermissions(['approval-templates:manage'])
       routeParams = { id: 'tpl_1' }
       mockActiveTemplate.value = mockPublishedTemplate()
       await mountTemplateDetailView()
 
-      const nodes = container!.querySelectorAll('.el-timeline-item')
+      const nodes = queryTemplateGraphNodes(container)
       expect(nodes.length).toBe(4) // start + 2 approval + end
     })
 
     it('template detail view renders form fields info section', async () => {
+      setMockPermissions(['approval-templates:manage'])
       routeParams = { id: 'tpl_1' }
       mockActiveTemplate.value = mockPublishedTemplate()
       await mountTemplateDetailView()
@@ -733,6 +811,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('template detail shows meta info (key, version, dates)', async () => {
+      setMockPermissions(['approval-templates:manage'])
       routeParams = { id: 'tpl_1' }
       mockActiveTemplate.value = mockPublishedTemplate()
       await mountTemplateDetailView()
@@ -743,6 +822,7 @@ describe('Approval E2E Permissions', () => {
     })
 
     it('back button navigates to /approval-templates', async () => {
+      setMockPermissions(['approval-templates:manage'])
       routeParams = { id: 'tpl_1' }
       mockActiveTemplate.value = mockPublishedTemplate()
       await mountTemplateDetailView()

--- a/apps/web/tests/helpers/approval-test-fixtures.ts
+++ b/apps/web/tests/helpers/approval-test-fixtures.ts
@@ -1,0 +1,243 @@
+/**
+ * Shared test fixtures for approval E2E verification tests.
+ *
+ * All fixtures return objects conforming to the frozen contract types
+ * defined in `apps/web/src/types/approval.ts`.
+ */
+import type {
+  UnifiedApprovalDTO,
+  UnifiedApprovalHistoryDTO,
+  ApprovalTemplateDetailDTO,
+  ApprovalAssignmentDTO,
+  ApprovalGraph,
+  FormSchema,
+} from '../../src/types/approval'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const CURRENT_USER_ID = 'user_current'
+const REQUESTER_USER_ID = 'user_1'
+const NOW = '2026-04-10T08:00:00Z'
+const YESTERDAY = '2026-04-09T08:00:00Z'
+
+// ---------------------------------------------------------------------------
+// Reusable fragments
+// ---------------------------------------------------------------------------
+function defaultFormSchema(): FormSchema {
+  return {
+    fields: [
+      { id: 'fld_reason', type: 'textarea', label: '申请原因', required: true, placeholder: '请填写申请原因' },
+      { id: 'fld_amount', type: 'number', label: '金额', required: true },
+      { id: 'fld_date', type: 'date', label: '期望日期', required: false },
+      {
+        id: 'fld_type',
+        type: 'select',
+        label: '类型',
+        required: true,
+        options: [
+          { label: '采购', value: 'purchase' },
+          { label: '报销', value: 'reimbursement' },
+          { label: '请假', value: 'leave' },
+        ],
+      },
+    ],
+  }
+}
+
+function defaultApprovalGraph(): ApprovalGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeType: 'role', assigneeIds: ['role_manager'] } },
+      { key: 'approval_2', type: 'approval', name: '财务审批', config: { assigneeType: 'user', assigneeIds: ['user_finance'] } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'approval_2' },
+      { key: 'e3', source: 'approval_2', target: 'end' },
+    ],
+  }
+}
+
+function activeAssignment(overrides?: Partial<ApprovalAssignmentDTO>): ApprovalAssignmentDTO {
+  return {
+    id: 'asgn_1',
+    type: 'approval',
+    assigneeId: CURRENT_USER_ID,
+    sourceStep: 1,
+    nodeKey: 'approval_1',
+    isActive: true,
+    metadata: {},
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Approval instance fixtures
+// ---------------------------------------------------------------------------
+
+/** Pending approval with an active assignment for the current user. */
+export function mockPendingApproval(overrides?: Partial<UnifiedApprovalDTO>): UnifiedApprovalDTO {
+  return {
+    id: 'apv_pending_1',
+    sourceSystem: 'platform',
+    externalApprovalId: null,
+    workflowKey: null,
+    businessKey: null,
+    title: '出差报销申请',
+    status: 'pending',
+    requester: { id: REQUESTER_USER_ID, name: '张三', department: '研发部', title: '工程师' },
+    subject: null,
+    policy: { rejectCommentRequired: true },
+    currentStep: 1,
+    totalSteps: 2,
+    templateId: 'tpl_1',
+    templateVersionId: 'ver_1_1',
+    publishedDefinitionId: 'def_1',
+    requestNo: 'APV-2026-0001',
+    formSnapshot: { fld_reason: '出差报销', fld_amount: 5000, fld_type: 'reimbursement' },
+    currentNodeKey: 'approval_1',
+    assignments: [activeAssignment()],
+    createdAt: YESTERDAY,
+    updatedAt: NOW,
+    ...overrides,
+  }
+}
+
+/** Approved approval (terminal state). */
+export function mockApprovedApproval(overrides?: Partial<UnifiedApprovalDTO>): UnifiedApprovalDTO {
+  return {
+    ...mockPendingApproval(),
+    id: 'apv_approved_1',
+    status: 'approved',
+    requestNo: 'APV-2026-0002',
+    currentStep: null,
+    currentNodeKey: null,
+    assignments: [],
+    ...overrides,
+  }
+}
+
+/** Rejected approval (terminal state). */
+export function mockRejectedApproval(overrides?: Partial<UnifiedApprovalDTO>): UnifiedApprovalDTO {
+  return {
+    ...mockPendingApproval(),
+    id: 'apv_rejected_1',
+    status: 'rejected',
+    requestNo: 'APV-2026-0003',
+    currentStep: null,
+    currentNodeKey: null,
+    assignments: [],
+    ...overrides,
+  }
+}
+
+/** Revoked approval. */
+export function mockRevokedApproval(overrides?: Partial<UnifiedApprovalDTO>): UnifiedApprovalDTO {
+  return {
+    ...mockPendingApproval(),
+    id: 'apv_revoked_1',
+    status: 'revoked',
+    requestNo: 'APV-2026-0004',
+    currentStep: null,
+    currentNodeKey: null,
+    assignments: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Template fixtures
+// ---------------------------------------------------------------------------
+
+/** Published template with form schema and approval graph. */
+export function mockPublishedTemplate(overrides?: Partial<ApprovalTemplateDetailDTO>): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1',
+    key: 'TPL-001',
+    name: '通用审批模板',
+    description: '适用于日常审批流程',
+    status: 'published',
+    activeVersionId: 'ver_1_1',
+    latestVersionId: 'ver_1_1',
+    formSchema: defaultFormSchema(),
+    approvalGraph: defaultApprovalGraph(),
+    createdAt: YESTERDAY,
+    updatedAt: NOW,
+    ...overrides,
+  }
+}
+
+/** Draft template (not yet published). */
+export function mockDraftTemplate(overrides?: Partial<ApprovalTemplateDetailDTO>): ApprovalTemplateDetailDTO {
+  return {
+    ...mockPublishedTemplate(),
+    id: 'tpl_draft_1',
+    key: 'TPL-DRAFT-001',
+    name: '草稿审批模板',
+    status: 'draft',
+    activeVersionId: null,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// History fixtures
+// ---------------------------------------------------------------------------
+
+/** Standard history items covering creation and approval. */
+export function mockHistoryItems(): UnifiedApprovalHistoryDTO[] {
+  return [
+    {
+      id: 'hist_1',
+      action: 'created',
+      actorId: REQUESTER_USER_ID,
+      actorName: '张三',
+      comment: null,
+      fromStatus: null,
+      toStatus: 'pending',
+      occurredAt: YESTERDAY,
+      metadata: {},
+    },
+    {
+      id: 'hist_2',
+      action: 'approve',
+      actorId: CURRENT_USER_ID,
+      actorName: '当前用户',
+      comment: '同意报销',
+      fromStatus: 'pending',
+      toStatus: 'approved',
+      occurredAt: NOW,
+      metadata: {},
+    },
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Permission mock helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock user context with the specified permissions.
+ * Used by permission-matrix tests to control what the current user can see/do.
+ */
+export function mockPermissions(perms: string[]): {
+  userId: string
+  userName: string
+  permissions: string[]
+  hasPermission: (perm: string) => boolean
+} {
+  return {
+    userId: CURRENT_USER_ID,
+    userName: '当前用户',
+    permissions: perms,
+    hasPermission: (perm: string) => perms.includes(perm),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Re-export constants for use in tests
+// ---------------------------------------------------------------------------
+export { CURRENT_USER_ID, REQUESTER_USER_ID, NOW, YESTERDAY }


### PR DESCRIPTION
## Summary
- 77 个测试覆盖审批全生命周期 + 权限矩阵
- Lifecycle (43): 模板→发布→发起→approve/reject/transfer/comment/revoke
- Permissions (29): 只读/可发起/可审批/模板管理/边界情况
- 共享 fixtures：mockPendingApproval, mockPublishedTemplate 等
- Selector 已对齐 UI 打磨后的 el-timeline DOM

## Test plan
- [ ] `pnpm --filter @metasheet/web test` 全部通过
- [ ] 无 stale selector（已修 7 处）

> **注意**：本 PR 应在 UI 打磨 PR 之后合入

🤖 Generated with [Claude Code](https://claude.com/claude-code)