### PR TITLE
docs(approvals): add wave1 execution runbook

### DIFF
--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -243,9 +243,19 @@ const ElButton = defineComponent({
       'data-el-button': this.type || 'default',
       type: 'button',
       disabled: this.disabled || false,
-      onClick: (e: Event) => { e.stopPropagation(); this.$emit('click', e) },
+      onClick: (e: Event) => this.$emit('click', e),
     }, this.$slots.default?.())
   },
+})
+
+const ElIcon = defineComponent({
+  name: 'ElIcon',
+  render() { return h('span', { class: 'el-icon' }, this.$slots.default?.()) },
+})
+
+const ElTooltip = defineComponent({
+  name: 'ElTooltip',
+  render() { return h('span', { 'data-el-tooltip': 'true' }, this.$slots.default?.()) },
 })
 
 const ElAlert = defineComponent({
@@ -283,6 +293,19 @@ const ElDialog = defineComponent({
       this.$slots.default?.(),
       this.$slots.footer?.(),
     ])
+  },
+})
+
+const ElTimeline = defineComponent({
+  name: 'ElTimeline',
+  render() { return h('div', { class: 'el-timeline' }, this.$slots.default?.()) },
+})
+
+const ElTimelineItem = defineComponent({
+  name: 'ElTimelineItem',
+  props: { type: String, icon: null, hollow: Boolean, size: String, timestamp: String, placement: String },
+  render() {
+    return h('div', { class: 'el-timeline-item', 'data-timestamp': this.timestamp ?? '' }, this.$slots.default?.())
   },
 })
 
@@ -327,6 +350,31 @@ const ElUpload = defineComponent({
   render() { return h('div', { 'data-el-upload': 'true' }, this.$slots.default?.()) },
 })
 
+const ElPopconfirm = defineComponent({
+  name: 'ElPopconfirm',
+  props: { title: String, confirmButtonText: String, cancelButtonText: String },
+  emits: ['confirm'],
+  render() {
+    return h('div', { 'data-el-popconfirm': this.title ?? '' }, [
+      h('div', {
+        class: 'el-popconfirm__reference',
+        onClick: () => this.$emit('confirm'),
+      }, this.$slots.reference?.()),
+    ])
+  },
+})
+
+const ElCard = defineComponent({
+  name: 'ElCard',
+  props: { shadow: String },
+  render() {
+    return h('div', { class: 'el-card' }, [
+      this.$slots.header ? h('div', { class: 'el-card__header' }, this.$slots.header()) : null,
+      h('div', { class: 'el-card__body' }, this.$slots.default?.()),
+    ])
+  },
+})
+
 const stubDirective = { mounted() {}, updated() {} }
 
 // ---------------------------------------------------------------------------
@@ -362,15 +410,21 @@ function registerAllStubs(app: VueApp<Element>) {
   app.component('ElSelect', ElSelect)
   app.component('ElOption', ElOption)
   app.component('ElButton', ElButton)
+  app.component('ElIcon', ElIcon)
+  app.component('ElTooltip', ElTooltip)
   app.component('ElAlert', ElAlert)
   app.component('ElEmpty', ElEmpty)
   app.component('ElPagination', ElPagination)
   app.component('ElDivider', ElDivider)
   app.component('ElDialog', ElDialog)
+  app.component('ElTimeline', ElTimeline)
+  app.component('ElTimelineItem', ElTimelineItem)
   app.component('ElForm', ElForm)
   app.component('ElFormItem', ElFormItem)
   app.component('ElDatePicker', ElDatePicker)
   app.component('ElUpload', ElUpload)
+  app.component('ElPopconfirm', ElPopconfirm)
+  app.component('ElCard', ElCard)
   app.directive('loading', stubDirective)
 }
 
@@ -601,10 +655,10 @@ describe('Approval E2E Lifecycle', () => {
       mockActiveTemplate.value = mockPublishedTemplate()
       await mountNewView()
 
-      const infoH2 = container!.querySelector('.approval-new__info h2')
+      const infoH2 = container!.querySelector('.approval-new__info-card h2')
       expect(infoH2?.textContent).toBe('通用审批模板')
 
-      const descP = container!.querySelector('.approval-new__info p')
+      const descP = container!.querySelector('.approval-new__info-desc')
       expect(descP?.textContent).toBe('适用于日常审批流程')
     })
 
@@ -708,7 +762,9 @@ describe('Approval E2E Lifecycle', () => {
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
-      expect(actions).toBeFalsy()
+      expect(actions).toBeTruthy()
+      expect(actions?.querySelectorAll('button').length).toBe(0)
+      expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
 
     it('clicking "通过" opens the approve dialog', async () => {
@@ -1053,7 +1109,9 @@ describe('Approval E2E Lifecycle', () => {
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
-      expect(actions).toBeFalsy()
+      expect(actions).toBeTruthy()
+      expect(actions?.querySelectorAll('button').length).toBe(0)
+      expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
 
     it('rejected approval does not show action buttons', async () => {
@@ -1062,7 +1120,9 @@ describe('Approval E2E Lifecycle', () => {
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
-      expect(actions).toBeFalsy()
+      expect(actions).toBeTruthy()
+      expect(actions?.querySelectorAll('button').length).toBe(0)
+      expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
   })
 

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -244,9 +244,19 @@ const ElButton = defineComponent({
       'data-el-button': this.type || 'default',
       type: 'button',
       disabled: this.disabled || false,
-      onClick: (e: Event) => { e.stopPropagation(); this.$emit('click', e) },
+      onClick: (e: Event) => this.$emit('click', e),
     }, this.$slots.default?.())
   },
+})
+
+const ElIcon = defineComponent({
+  name: 'ElIcon',
+  render() { return h('span', { class: 'el-icon' }, this.$slots.default?.()) },
+})
+
+const ElTooltip = defineComponent({
+  name: 'ElTooltip',
+  render() { return h('span', { 'data-el-tooltip': 'true' }, this.$slots.default?.()) },
 })
 
 const ElAlert = defineComponent({
@@ -286,6 +296,19 @@ const ElDialog = defineComponent({
   },
 })
 
+const ElTimeline = defineComponent({
+  name: 'ElTimeline',
+  render() { return h('div', { class: 'el-timeline' }, this.$slots.default?.()) },
+})
+
+const ElTimelineItem = defineComponent({
+  name: 'ElTimelineItem',
+  props: { type: String, icon: null, hollow: Boolean, size: String, timestamp: String, placement: String },
+  render() {
+    return h('div', { class: 'el-timeline-item', 'data-timestamp': this.timestamp ?? '' }, this.$slots.default?.())
+  },
+})
+
 const ElForm = defineComponent({
   name: 'ElForm',
   props: { model: Object, rules: Object, labelPosition: String },
@@ -313,6 +336,31 @@ const ElUpload = defineComponent({
   name: 'ElUpload',
   props: { action: String, autoUpload: Boolean },
   render() { return h('div', { 'data-el-upload': 'true' }, this.$slots.default?.()) },
+})
+
+const ElPopconfirm = defineComponent({
+  name: 'ElPopconfirm',
+  props: { title: String, confirmButtonText: String, cancelButtonText: String },
+  emits: ['confirm'],
+  render() {
+    return h('div', { 'data-el-popconfirm': this.title ?? '' }, [
+      h('div', {
+        class: 'el-popconfirm__reference',
+        onClick: () => this.$emit('confirm'),
+      }, this.$slots.reference?.()),
+    ])
+  },
+})
+
+const ElCard = defineComponent({
+  name: 'ElCard',
+  props: { shadow: String },
+  render() {
+    return h('div', { class: 'el-card' }, [
+      this.$slots.header ? h('div', { class: 'el-card__header' }, this.$slots.header()) : null,
+      h('div', { class: 'el-card__body' }, this.$slots.default?.()),
+    ])
+  },
 })
 
 const stubDirective = { mounted() {}, updated() {} }
@@ -350,15 +398,21 @@ function registerAllStubs(app: VueApp<Element>) {
   app.component('ElSelect', ElSelect)
   app.component('ElOption', ElOption)
   app.component('ElButton', ElButton)
+  app.component('ElIcon', ElIcon)
+  app.component('ElTooltip', ElTooltip)
   app.component('ElAlert', ElAlert)
   app.component('ElEmpty', ElEmpty)
   app.component('ElPagination', ElPagination)
   app.component('ElDivider', ElDivider)
   app.component('ElDialog', ElDialog)
+  app.component('ElTimeline', ElTimeline)
+  app.component('ElTimelineItem', ElTimelineItem)
   app.component('ElForm', ElForm)
   app.component('ElFormItem', ElFormItem)
   app.component('ElDatePicker', ElDatePicker)
   app.component('ElUpload', ElUpload)
+  app.component('ElPopconfirm', ElPopconfirm)
+  app.component('ElCard', ElCard)
   app.directive('loading', stubDirective)
 }
 
@@ -498,7 +552,9 @@ describe('Approval E2E Permissions', () => {
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
-      expect(actions).toBeFalsy()
+      expect(actions).toBeTruthy()
+      expect(actions?.querySelectorAll('button').length).toBe(0)
+      expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
 
     it('detail page still renders form snapshot and history', async () => {
@@ -632,7 +688,9 @@ describe('Approval E2E Permissions', () => {
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
-      expect(actions).toBeFalsy()
+      expect(actions).toBeTruthy()
+      expect(actions?.querySelectorAll('button').length).toBe(0)
+      expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
 
     it('can execute approve action on an assigned approval', async () => {
@@ -846,7 +904,9 @@ describe('Approval E2E Permissions', () => {
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
-      expect(actions).toBeFalsy()
+      expect(actions).toBeTruthy()
+      expect(actions?.querySelectorAll('button').length).toBe(0)
+      expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
 
     it('rejected approval is always read-only', async () => {
@@ -859,7 +919,9 @@ describe('Approval E2E Permissions', () => {
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
-      expect(actions).toBeFalsy()
+      expect(actions).toBeTruthy()
+      expect(actions?.querySelectorAll('button').length).toBe(0)
+      expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
 
     it('revoked approval is always read-only', async () => {
@@ -872,7 +934,9 @@ describe('Approval E2E Permissions', () => {
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
-      expect(actions).toBeFalsy()
+      expect(actions).toBeTruthy()
+      expect(actions?.querySelectorAll('button').length).toBe(0)
+      expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
 
     it('permission helper creates correct user context', () => {

--- a/docs/development/approval-mvp-wave1-execution-runbook-20260411.md
+++ b/docs/development/approval-mvp-wave1-execution-runbook-20260411.md
@@ -1,0 +1,209 @@
+# 审批 MVP 第一波执行验收 Runbook
+
+> 日期: 2026-04-11
+> 基线: `origin/main`
+> 验证分支: `codex/approval-wave2-acceptance-20260411`
+> 目标: 以真实命令和页面闭环确认审批 MVP 第一波可作为平台原生审批产品验收
+
+---
+
+## 1. 验收范围
+
+本 Runbook 只覆盖第一波已经承诺的范围:
+
+- 平台原生审批模板
+- 审批中心
+- 按模板发起审批
+- 审批详情
+- 统一动作与历史
+- 第一波文档与 API 示例
+
+明确不纳入本轮验收:
+
+- PLM 并入统一 Inbox
+- 考勤并入统一 Inbox
+- 会签 / 或签 / 并行分支
+- 催办 / SLA / 统计报表
+- 移动端专属体验
+
+---
+
+## 2. 验收前提
+
+- 已执行 `pnpm install`
+- PostgreSQL / Redis 可用
+- 后端已完成 migration
+- 具备至少 4 类账号或等价权限夹具:
+  - `approvals:read`
+  - `approvals:write`
+  - `approvals:act`
+  - `approval-templates:manage`
+
+推荐本地启动:
+
+```bash
+pnpm --filter @metasheet/core-backend dev
+pnpm dev
+```
+
+---
+
+## 3. 自动化验收命令
+
+### 后端类型检查
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+本次执行结果: `PASS`
+
+### 后端审批主线单测
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-graph-executor.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  tests/unit/approval-template-routes.test.ts \
+  tests/unit/approvals-routes.test.ts \
+  tests/unit/approvals-bridge-routes.test.ts \
+  --watch=false --reporter=dot
+```
+
+本次执行结果: `PASS`，`43/43` 通过
+
+### 前端类型检查
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+本次执行结果: `PASS`
+
+### 前端审批验收套件
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/approval-center.spec.ts \
+  tests/approval-e2e-lifecycle.spec.ts \
+  tests/approval-e2e-permissions.spec.ts \
+  tests/approval-inbox-auth-guard.spec.ts \
+  --watch=false --reporter=dot
+```
+
+本次执行结果: `PASS`，`78/78` 通过
+
+补充:
+
+- Vitest 输出里有 `WebSocket server error: Port is already in use`
+- 该信息未影响测试结果，属于本地端口占用噪音，不构成审批功能 blocker
+
+---
+
+## 4. 手工验收步骤
+
+### A. 模板管理
+
+1. 打开 `/approval-templates`
+2. 确认模板列表可见，状态筛选可切换
+3. 打开一个 `published` 模板详情
+4. 确认详情页展示:
+   - 模板名称 / key / activeVersionId
+   - 表单字段表格
+   - 审批流程时间线
+5. 若当前账号有 `approvals:write`，确认存在“发起审批”入口
+
+### B. 发起审批
+
+1. 从模板详情点击“发起审批”
+2. 确认 `/approvals/new/:templateId` 正常加载
+3. 逐项确认字段渲染:
+   - text
+   - textarea
+   - number
+   - date
+   - datetime
+   - select
+   - multi-select
+   - user
+   - attachment
+4. 留空必填字段提交，确认前端阻止提交
+5. 填写合法数据后提交
+6. 确认跳转到 `/approvals/:id`
+7. 确认详情页显示 `requestNo`、`formSnapshot`
+
+### C. 审批详情与动作
+
+1. 用审批人账号打开待处理实例
+2. 确认详情页显示:
+   - 标题
+   - 状态标签
+   - 表单快照
+   - 历史时间线
+3. 依次验证动作:
+   - approve
+   - reject
+   - transfer
+   - comment
+4. 用发起人账号验证 `revoke`
+5. 确认动作后:
+   - 历史刷新
+   - 状态更新
+   - 终态实例显示“该审批已结束”提示
+   - 终态实例不再显示可执行按钮
+
+### D. 权限矩阵
+
+1. `approvals:read`
+   - 可看列表和详情
+   - 不可发起
+   - 不可审批
+2. `approvals:write`
+   - 可发起
+   - 不应拥有审批动作
+3. `approvals:act`
+   - 仅对命中 assignment 的 pending 实例可审批
+4. `approval-templates:manage`
+   - 可看模板中心
+   - 可做模板创建 / 编辑 / 发布
+
+### E. 兼容回归
+
+1. PLM 页面仍可访问
+2. 考勤审批流仍可访问
+3. `/workflows` 仍可访问
+4. 旧审批桥接路由单测仍通过
+
+---
+
+## 5. 本轮验收结论
+
+截至 `2026-04-11`，审批 MVP 第一波满足“平台原生审批产品”基线:
+
+- 契约、迁移、运行时、前端壳、文档均已进 `main`
+- 自动化证据覆盖后端核心、前端核心、权限矩阵与生命周期
+- 产品边界已明确锁定为平台原生审批，不把 PLM / 考勤强行并入统一 Inbox
+
+可判定为:
+
+- `工程交付: 可验收`
+- `产品交付: 可进入第一波业务验收`
+- `下一阶段: 不继续扩 Wave 1 核心代码，转 Wave 2 范围拆解`
+
+---
+
+## 6. 当前已知限制
+
+- 统一 Inbox 只展示 `platform` 原生审批
+- 条件分支为 JSON 图解释执行，不是 BPMN 主路径
+- 模板权限仍是全局 `approval-templates:manage`，没有模板级 ACL
+- 审批详情暂无流程图高亮
+- 暂无催办、通知、已读未读、统计分析
+
+---
+
+## 7. 关联文档
+
+- [approval-mvp-wave1-acceptance-checklist-20260411.md](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/approval-wave2-acceptance-20260411/docs/development/approval-mvp-wave1-acceptance-checklist-20260411.md)
+- [approval-mvp-feishu-gap-matrix-20260411.md](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/approval-wave2-acceptance-20260411/docs/development/approval-mvp-feishu-gap-matrix-20260411.md)
+- [approval-api-usage-guide-20260411.md](/Users/huazhou/Downloads/Github/metasheet2/.worktrees/approval-wave2-acceptance-20260411/docs/development/approval-api-usage-guide-20260411.md)

--- a/docs/development/approval-mvp-wave2-scope-breakdown-20260411.md
+++ b/docs/development/approval-mvp-wave2-scope-breakdown-20260411.md
@@ -1,0 +1,250 @@
+# 审批 MVP Wave 2 范围拆解
+
+> 日期: 2026-04-11
+> 基线: Wave 1 已在 `main` 收口
+> 目标: 把“对标飞书审批”的下一阶段工作拆成可并行、可排期、可单独验收的工作包
+
+---
+
+## 1. 排期原则
+
+Wave 2 不再重做 Wave 1 的基础模型，默认沿用:
+
+- `approval_templates`
+- `approval_template_versions`
+- `approval_published_definitions`
+- `approval_instances`
+- `approval_records`
+- `approval_assignments`
+- `ApprovalGraphExecutor`
+
+只有在以下前提成立时才允许动核心模型:
+
+- 现有线性 / 条件分支图无法承载目标能力
+- 兼容成本低于继续打补丁
+- 有明确迁移方案和回滚方案
+
+---
+
+## 2. 建议的 5 个 Wave 2 工作包
+
+### WP1. 审批流程能力扩展
+
+目标:
+
+- 并行分支
+- 会签
+- 或签
+- return 到指定节点
+- 审批人为空自动通过
+
+涉及模块:
+
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/types/approval-product.ts`
+- `packages/openapi/src/paths/approvals.yml`
+- `apps/web/src/views/approval/*`
+
+交付标准:
+
+- 新节点 / 新聚合策略有契约和迁移说明
+- 生命周期和并发测试补齐
+- 历史时间线能表达多审批人结果
+
+优先级: `P0`
+
+---
+
+### WP2. 统一 Inbox 与跨系统接入
+
+目标:
+
+- 把 PLM 审批接入统一 Inbox
+- 评估考勤审批的统一视图策略
+- 明确 `sourceSystem` 分层筛选
+
+涉及模块:
+
+- `packages/core-backend/src/routes/approvals.ts`
+- `packages/core-backend/src/services/ApprovalBridgeService.ts`
+- `packages/core-backend/src/services/AfterSalesApprovalBridgeService.ts`
+- `apps/web/src/views/approval/ApprovalCenterView.vue`
+
+交付标准:
+
+- `platform / plm / attendance` 来源语义清晰
+- 统一列表不会打坏现有模块入口
+- 兼容回归测试覆盖 PLM / 考勤旧路径
+
+优先级: `P0`
+
+---
+
+### WP3. 通知、催办与操作体验
+
+目标:
+
+- 催办
+- 已读 / 未读
+- 红点 / 待办计数
+- 前端更细粒度错误态
+- 操作后反馈和刷新体验
+
+涉及模块:
+
+- `apps/web/src/approvals/*`
+- `apps/web/src/views/approval/*`
+- 通知/消息基础设施
+
+交付标准:
+
+- 403 / 404 / 409 / 500 有明确 UI 分层
+- 催办和未读状态有 API 和前端入口
+- 操作反馈不再只有通用成功/失败 toast
+
+优先级: `P1`
+
+---
+
+### WP4. 模板产品化能力
+
+目标:
+
+- 模板分类 / 分组
+- 模板克隆
+- 模板级 ACL
+- 字段联动与条件显隐
+- 更强的模板设计体验
+
+涉及模块:
+
+- `packages/core-backend/src/routes/approval-templates.ts` 或等价模板路由
+- `apps/web/src/views/approval/TemplateCenterView.vue`
+- `apps/web/src/views/approval/TemplateDetailView.vue`
+
+交付标准:
+
+- 模板中心可按分类管理
+- 模板可见范围不是单一全局 manage 权限
+- 字段条件配置可表达并可被后端验证
+
+优先级: `P1`
+
+---
+
+### WP5. 统计、审计与运营能力
+
+目标:
+
+- 审批耗时统计
+- 瓶颈分析
+- SLA / 超时告警
+- 报表导出
+
+涉及模块:
+
+- 后端聚合查询
+- 报表接口
+- 运维告警 / 指标链路
+
+交付标准:
+
+- 有明确统计口径
+- 有分页和时间维度筛选
+- 不影响 Wave 1 事务路径性能
+
+优先级: `P2`
+
+---
+
+## 3. 不建议放入 Wave 2 的能力
+
+这些能力会显著抬高复杂度，建议继续后移:
+
+- 子流程
+- 任意 DAG 流程
+- 委托 / 代理审批
+- 原生移动端
+- PDF 导出 / 打印
+- 钉钉 / 企微等多外部平台集成
+
+---
+
+## 4. 推荐的实施顺序
+
+### 阶段 2.1
+
+- WP1 审批流程能力扩展
+- WP3 通知与操作体验中的错误态 / 操作反馈
+
+理由:
+
+- 直接提高产品可用性
+- 不需要先扩大跨系统接入面
+
+### 阶段 2.2
+
+- WP2 统一 Inbox 与跨系统接入
+- WP4 模板产品化能力
+
+理由:
+
+- 需要在流程模型稳定后再扩系统边界
+- 模板 ACL 和分类更适合作为第二层产品能力
+
+### 阶段 2.3
+
+- WP5 统计、审计与运营能力
+
+理由:
+
+- 依赖足够的真实审批数据
+- 适合放在核心闭环稳定之后
+
+---
+
+## 5. 建议的并行开发方式
+
+### 主线 owner
+
+负责:
+
+- 流程模型
+- 迁移
+- 兼容边界
+- 跨系统接入
+
+### 并行块
+
+- 前端体验与模板产品壳
+- 统计报表和只读查询
+- 文档、OpenAPI、验收脚本
+
+原则:
+
+- 任何影响 `ApprovalGraphExecutor` 或迁移的改动必须先冻结契约
+- 不允许把 PLM / 考勤统一接入和流程模型扩展混成一条 PR
+
+---
+
+## 6. Wave 2 完成标志
+
+满足以下条件可判定 Wave 2 完成:
+
+- 支持至少一种多审批人策略（会签或或签）
+- 统一 Inbox 至少纳入 `platform + plm`
+- 模板中心具备分类或 ACL 其中一项
+- 操作错误态和催办体验可用
+- 有最小可用的审批统计视图
+
+---
+
+## 7. 与飞书差距的收敛策略
+
+Wave 2 不是追求“功能全量对标”，而是优先收敛 3 个产品差距:
+
+1. 流程表达能力不足
+2. 统一入口不足
+3. 运营能力不足
+
+只要这 3 类收敛，整体产品感会明显接近飞书审批；其余高级能力可留到后续波次。


### PR DESCRIPTION
## Summary
- align approval acceptance specs with the current merged approval UI
- add a wave-1 execution runbook with real verification commands and acceptance steps
- add a wave-2 scope breakdown based on the current wave-1 boundary

## Verification
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts tests/unit/approval-template-routes.test.ts tests/unit/approvals-routes.test.ts tests/unit/approvals-bridge-routes.test.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/web exec vitest run tests/approval-center.spec.ts tests/approval-e2e-lifecycle.spec.ts tests/approval-e2e-permissions.spec.ts tests/approval-inbox-auth-guard.spec.ts --watch=false --reporter=dot