### PR TITLE
fix(ci): preserve real newlines in deploy env rewrite

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -234,7 +234,7 @@ jobs:
             'for key in order:'
             '    if key not in seen:'
             '        updated.append(f"{key}={entries[key]}")'
-            'path.write_text("\\n".join(updated) + "\\n")'
+            'path.write_text("\n".join(updated) + "\n")'
             'PY'
             '  if [[ "${database_url}" == *"@postgres:"* || "${database_url}" == *"@127.0.0.1:"* || "${database_url}" == *"@localhost:"* ]]; then'
             '    echo "[deploy] local-postgres detected; forcing DB_SSL=false in ${ENV_FILE_PATH}"'


### PR DESCRIPTION
## Summary
- fix the remote deploy dotenv rewrite to join lines with real newlines instead of literal \\n sequences
- keep the existing normalization flow intact while preventing `docker/app.env` from being rewritten back into a single line

## Verification
- reproduced the production failure from workflow run `24278887345`
- verified the updated rewrite logic converts a single-line dotenv containing literal `\\n` into a multi-line env file
- manually repaired production `docker/app.env`, deployed commit `13509d0df5791cdb776ce8e20f0e28c0256ae064`, and confirmed backend/web containers run the new image tags
- verified the new DingTalk diagnostics logic in production still reports the real upstream scope issue (root department 1 returns only one direct member)
