### PR TITLE
feat(plm): federate aml metadata schema discovery

### DIFF
--- a/apps/web/src/components/plm/PlmProductPanel.vue
+++ b/apps/web/src/components/plm/PlmProductPanel.vue
@@ -418,7 +418,7 @@
     <p v-else-if="panel.product.value" class="muted">暂无描述</p>
 
     <details v-if="panel.product.value" class="field-map">
-      <summary>字段对照清单</summary>
+      <summary>字段对照清单（静态）</summary>
       <table class="data-table">
         <thead>
           <tr>
@@ -434,6 +434,37 @@
             <td class="mono">{{ field.key }}</td>
             <td>{{ field.source }}</td>
             <td class="muted">{{ field.fallback }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </details>
+
+    <details v-if="panel.product.value" class="field-map">
+      <summary>模型字段（AML Metadata，{{ panel.productMetadataRows.value.length }}）</summary>
+      <p v-if="panel.productMetadataLoading.value" class="status">模型字段加载中...</p>
+      <p v-else-if="panel.productMetadataError.value" class="status error">{{ panel.productMetadataError.value }}</p>
+      <p v-else-if="!panel.productMetadataRows.value.length" class="muted">当前类型暂无模型字段定义</p>
+      <table v-else class="data-table">
+        <thead>
+          <tr>
+            <th>Label</th>
+            <th>Name</th>
+            <th>Type</th>
+            <th>必填</th>
+            <th>长度</th>
+            <th>默认值</th>
+            <th>当前值</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="field in panel.productMetadataRows.value" :key="field.name">
+            <td>{{ field.label }}</td>
+            <td class="mono">{{ field.name }}</td>
+            <td>{{ field.type }}</td>
+            <td>{{ field.required ? '是' : '否' }}</td>
+            <td>{{ field.length }}</td>
+            <td class="muted">{{ field.defaultValue }}</td>
+            <td>{{ field.currentValue }}</td>
           </tr>
         </tbody>
       </table>

--- a/apps/web/src/services/PlmService.ts
+++ b/apps/web/src/services/PlmService.ts
@@ -37,6 +37,22 @@ export interface GetBomParams {
   effectiveAt?: string
 }
 
+export interface PlmMetadataField {
+  name: string
+  label?: string
+  type?: string
+  required?: boolean
+  length?: number | null
+  default?: unknown
+}
+
+export interface PlmItemMetadata {
+  id: string
+  label?: string
+  is_relationship?: boolean
+  properties: PlmMetadataField[]
+}
+
 export interface ListDocumentsParams {
   productId: string
   role?: string
@@ -118,6 +134,10 @@ class PlmService {
       depth: params.depth,
       effectiveAt: params.effectiveAt,
     })
+  }
+
+  async getMetadata<T = PlmItemMetadata>(itemType: string): Promise<T> {
+    return plmClient.getMetadata<T>(itemType)
   }
 
   async listDocuments<T = Record<string, unknown>>(params: ListDocumentsParams): Promise<PlmListResponse<T>> {

--- a/apps/web/src/services/plm/plmFederationClient.ts
+++ b/apps/web/src/services/plm/plmFederationClient.ts
@@ -14,6 +14,7 @@ type LocalizedFallbackKey =
   | 'listProducts'
   | 'getProduct'
   | 'getBom'
+  | 'getMetadata'
   | 'listDocuments'
   | 'getCadProperties'
   | 'getCadViewState'
@@ -39,6 +40,7 @@ const LOCALIZED_FALLBACKS: Record<LocalizedFallbackKey, LocalizedFallback> = {
   listProducts: { english: 'Failed to load PLM products', localized: '搜索失败' },
   getProduct: { english: 'Failed to load PLM product', localized: '加载产品失败' },
   getBom: { english: 'Failed to load PLM BOM', localized: '加载 BOM 失败' },
+  getMetadata: { english: 'Failed to load PLM metadata', localized: '加载模型字段失败' },
   listDocuments: { english: 'Failed to load PLM documents', localized: '加载文档失败' },
   getCadProperties: { english: 'Failed to load PLM CAD properties', localized: '加载属性失败' },
   getCadViewState: { english: 'Failed to load PLM CAD view state', localized: '加载视图状态失败' },
@@ -128,6 +130,8 @@ export function createLocalizedPlmFederationClient(client: RequestClient = plmRe
       withLocalizedFallback('getProduct', rawClient.getProduct<T>(productId, params)),
     getBom: <T = Record<string, unknown>>(productId: string, params?: Parameters<typeof rawClient.getBom<T>>[1]) =>
       withLocalizedFallback('getBom', rawClient.getBom<T>(productId, params)),
+    getMetadata: <T = Record<string, unknown>>(itemType: string) =>
+      withLocalizedFallback('getMetadata', rawClient.getMetadata<T>(itemType)),
     listDocuments: <T = Record<string, unknown>>(params: Parameters<typeof rawClient.listDocuments<T>>[0]) =>
       withLocalizedFallback('listDocuments', rawClient.listDocuments<T>(params)),
     getCadProperties: <T = Record<string, unknown>>(fileId: string) =>

--- a/apps/web/src/views/PlmProductView.vue
+++ b/apps/web/src/views/PlmProductView.vue
@@ -32,6 +32,7 @@ import PlmSearchPanel from '../components/plm/PlmSearchPanel.vue'
 import PlmSubstitutesPanel from '../components/plm/PlmSubstitutesPanel.vue'
 import PlmWhereUsedPanel from '../components/plm/PlmWhereUsedPanel.vue'
 import { plmService } from '../services/PlmService'
+import type { PlmItemMetadata } from '../services/PlmService'
 import type { PlmTeamFilterPresetBatchResult } from '../services/plm/plmWorkbenchClient'
 import { copyListToClipboard, copyTextToClipboard } from './plm/plmClipboard'
 import { downloadCsvFile } from './plm/plmCsv'
@@ -97,6 +98,7 @@ import {
   mergePlmDeferredRouteQueryPatch,
   resolvePlmDeferredRouteQueryPatch,
 } from './plm/plmRouteHydrationPatch'
+import { buildProductMetadataRows } from './plm/plmProductMetadata'
 import { usePlmWhereUsedPanel } from './plm/usePlmWhereUsedPanel'
 import { usePlmWhereUsedState } from './plm/usePlmWhereUsedState'
 import {
@@ -273,6 +275,9 @@ const itemType = ref(DEFAULT_ITEM_TYPE)
 const product = ref<ProductRecord | null>(null)
 const productLoading = ref(false)
 const productError = ref('')
+const productMetadata = ref<PlmItemMetadata | null>(null)
+const productMetadataLoading = ref(false)
+const productMetadataError = ref('')
 const productView = computed(() => {
   const data = product.value || {}
   const props = data.properties || {}
@@ -355,6 +360,7 @@ const productView = computed(() => {
     updatedAt,
   }
 })
+const productMetadataRows = computed(() => buildProductMetadataRows(product.value, productMetadata.value))
 
 const documentRole = ref('')
 const documentFilter = ref('')
@@ -1375,11 +1381,35 @@ function formatBytes(value?: number): string {
   return `${gb.toFixed(1)} GB`
 }
 
+async function loadProductMetadataSchema(resolvedItemType: string) {
+  if (!resolvedItemType.trim()) {
+    productMetadata.value = null
+    productMetadataError.value = ''
+    productMetadataLoading.value = false
+    return
+  }
+
+  productMetadataLoading.value = true
+  productMetadataError.value = ''
+  try {
+    productMetadata.value = await plmService.getMetadata<PlmItemMetadata>(resolvedItemType)
+  } catch (error: any) {
+    handleAuthError(error)
+    productMetadata.value = null
+    productMetadataError.value = error?.message ?? '加载模型字段失败'
+  } finally {
+    productMetadataLoading.value = false
+  }
+}
+
 function resetAll() {
   productId.value = ''
   productItemNumber.value = ''
   product.value = null
   productError.value = ''
+  productMetadata.value = null
+  productMetadataLoading.value = false
+  productMetadataError.value = ''
   authError.value = ''
   resetDeepLinkState()
   workbenchTeamViewQuery.value = ''
@@ -1645,6 +1675,8 @@ async function loadProduct() {
   syncQueryParams({ productId: productId.value, itemNumber: productItemNumber.value, itemType: itemType.value })
   productLoading.value = true
   productError.value = ''
+  productMetadata.value = null
+  productMetadataError.value = ''
   try {
     const result = await plmService.getProduct<ProductRecord>(resolvedId, {
       itemType: itemType.value || undefined,
@@ -1661,9 +1693,24 @@ async function loadProduct() {
       productId.value = String(result.id)
       syncQueryParams({ productId: productId.value })
     }
-    await Promise.all([loadBom(), loadDocuments(), loadApprovals()])
+    const resolvedItemType = (() => {
+      const viewItemType = typeof productView.value.itemType === 'string'
+        ? productView.value.itemType.trim()
+        : ''
+      if (viewItemType && viewItemType !== '-') return viewItemType
+      const selectedItemType = itemType.value.trim()
+      return selectedItemType || DEFAULT_ITEM_TYPE
+    })()
+    await Promise.all([
+      loadProductMetadataSchema(resolvedItemType),
+      loadBom(),
+      loadDocuments(),
+      loadApprovals(),
+    ])
   } catch (error: any) {
     handleAuthError(error)
+    productMetadata.value = null
+    productMetadataError.value = ''
     productError.value = error?.message || '加载产品失败'
   } finally {
     productLoading.value = false
@@ -5791,6 +5838,9 @@ function applyHydratedPanelDataReset(options: {
     product.value = null
     productLoading.value = false
     productError.value = ''
+    productMetadata.value = null
+    productMetadataLoading.value = false
+    productMetadataError.value = ''
   }
   if (reset.clearBom) {
     bomItems.value = []
@@ -6987,6 +7037,9 @@ const { productPanel } = usePlmProductPanel({
   hasProductCopyValue,
   copyProductField,
   productFieldCatalog,
+  productMetadataLoading,
+  productMetadataError,
+  productMetadataRows,
   formatJson,
 })
 

--- a/apps/web/src/views/plm/plmPanelModels.ts
+++ b/apps/web/src/views/plm/plmPanelModels.ts
@@ -119,6 +119,16 @@ export type PlmProductFieldCatalogEntry = {
   fallback: string
 }
 
+export type PlmProductMetadataRow = {
+  name: string
+  label: string
+  type: string
+  required: boolean
+  length: string
+  defaultValue: string
+  currentValue: string
+}
+
 export type CompareChangeEntry = UnknownRecord & {
   field?: string
   left?: unknown
@@ -830,6 +840,9 @@ export type PlmProductPanelModel = {
   hasProductCopyValue: (kind: ProductCopyKind) => boolean
   copyProductField: (kind: ProductCopyKind) => Promise<void>
   productFieldCatalog: PlmProductFieldCatalogEntry[]
+  productMetadataLoading: Ref<boolean>
+  productMetadataError: Ref<string>
+  productMetadataRows: ComputedRef<PlmProductMetadataRow[]>
   formatJson: (payload: unknown) => string
 }
 

--- a/apps/web/src/views/plm/plmProductMetadata.ts
+++ b/apps/web/src/views/plm/plmProductMetadata.ts
@@ -1,0 +1,48 @@
+import type { PlmItemMetadata } from '../../services/PlmService'
+import type { ProductRecord, PlmProductMetadataRow } from './plmPanelModels'
+
+function readProductFieldValue(product: ProductRecord | null, fieldName: string): unknown {
+  if (!product || !fieldName.trim()) return undefined
+  const topLevelValue = product[fieldName]
+  if (topLevelValue !== undefined && topLevelValue !== null && topLevelValue !== '') {
+    return topLevelValue
+  }
+
+  const properties = product.properties
+  if (!properties || typeof properties !== 'object') return undefined
+  const propertyValue = properties[fieldName]
+  if (propertyValue !== undefined && propertyValue !== null && propertyValue !== '') {
+    return propertyValue
+  }
+  return undefined
+}
+
+export function formatProductMetadataValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') return '-'
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+export function buildProductMetadataRows(
+  product: ProductRecord | null,
+  metadata: PlmItemMetadata | null,
+): PlmProductMetadataRow[] {
+  if (!metadata?.properties?.length) return []
+
+  return metadata.properties
+    .filter((field) => typeof field.name === 'string' && field.name.trim().length > 0)
+    .map((field) => ({
+      name: field.name,
+      label: typeof field.label === 'string' && field.label.trim().length > 0 ? field.label : field.name,
+      type: typeof field.type === 'string' && field.type.trim().length > 0 ? field.type : '-',
+      required: field.required === true,
+      length: typeof field.length === 'number' ? String(field.length) : '-',
+      defaultValue: formatProductMetadataValue(field.default),
+      currentValue: formatProductMetadataValue(readProductFieldValue(product, field.name)),
+    }))
+}

--- a/apps/web/src/views/plm/usePlmProductPanel.ts
+++ b/apps/web/src/views/plm/usePlmProductPanel.ts
@@ -5,6 +5,7 @@ import type {
   PlmDeepLinkPanelOption,
   FilterFieldOption,
   PlmProductFieldCatalogEntry,
+  PlmProductMetadataRow,
   PlmProductPanelModel,
   PlmRecommendedWorkbenchScene,
   PlmWorkbenchSceneSummaryChip,
@@ -121,6 +122,9 @@ type UsePlmProductPanelOptions = {
   hasProductCopyValue: (kind: ProductCopyKind) => boolean
   copyProductField: (kind: ProductCopyKind) => Promise<void>
   productFieldCatalog: PlmProductFieldCatalogEntry[]
+  productMetadataLoading: Ref<boolean>
+  productMetadataError: Ref<string>
+  productMetadataRows: ComputedRef<PlmProductMetadataRow[]>
   formatJson: (payload: unknown) => string
 }
 
@@ -300,6 +304,9 @@ export function usePlmProductPanel(options: UsePlmProductPanelOptions) {
     hasProductCopyValue: options.hasProductCopyValue,
     copyProductField: options.copyProductField,
     productFieldCatalog: options.productFieldCatalog,
+    productMetadataLoading: options.productMetadataLoading,
+    productMetadataError: options.productMetadataError,
+    productMetadataRows: options.productMetadataRows,
     formatJson: options.formatJson,
   }
 

--- a/apps/web/tests/plmProductMetadata.spec.ts
+++ b/apps/web/tests/plmProductMetadata.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { buildProductMetadataRows, formatProductMetadataValue } from '../src/views/plm/plmProductMetadata'
+
+describe('plmProductMetadata helpers', () => {
+  it('builds metadata rows from top-level fields and properties fallback', () => {
+    const rows = buildProductMetadataRows(
+      {
+        item_number: 'TOP-001',
+        properties: {
+          description: 'Property description',
+          cost: 123.45,
+        },
+      },
+      {
+        id: 'Part',
+        label: 'Part',
+        is_relationship: false,
+        properties: [
+          { name: 'item_number', label: '料号', type: 'string', required: true, length: 64, default: null },
+          { name: 'description', label: '描述', type: 'string', required: false, length: 256, default: null },
+          { name: 'cost', label: '成本', type: 'float', required: false, length: 18, default: 0 },
+        ],
+      },
+    )
+
+    expect(rows).toEqual([
+      {
+        name: 'item_number',
+        label: '料号',
+        type: 'string',
+        required: true,
+        length: '64',
+        defaultValue: '-',
+        currentValue: 'TOP-001',
+      },
+      {
+        name: 'description',
+        label: '描述',
+        type: 'string',
+        required: false,
+        length: '256',
+        defaultValue: '-',
+        currentValue: 'Property description',
+      },
+      {
+        name: 'cost',
+        label: '成本',
+        type: 'float',
+        required: false,
+        length: '18',
+        defaultValue: '0',
+        currentValue: '123.45',
+      },
+    ])
+  })
+
+  it('formats empty and structured values for UI display', () => {
+    expect(formatProductMetadataValue(undefined)).toBe('-')
+    expect(formatProductMetadataValue(null)).toBe('-')
+    expect(formatProductMetadataValue('')).toBe('-')
+    expect(formatProductMetadataValue(false)).toBe('false')
+    expect(formatProductMetadataValue({ owner: 'qa' })).toContain('"owner": "qa"')
+  })
+})

--- a/apps/web/tests/plmService.spec.ts
+++ b/apps/web/tests/plmService.spec.ts
@@ -100,6 +100,24 @@ describe('plmService', () => {
     )
   })
 
+  it('loads product metadata through encoded federation GET route', async () => {
+    apiFetchMock.mockResolvedValueOnce(mockJsonResponse(200, {
+      ok: true,
+      data: {
+        id: 'Part',
+        properties: [],
+      },
+    }))
+
+    const result = await plmService.getMetadata('Part/Assembly')
+
+    expect(result.id).toBe('Part')
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/federation/plm/metadata/Part%2FAssembly',
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
+
   it('omits all-status filter and defaults compare sides to item mode', async () => {
     apiFetchMock
       .mockResolvedValueOnce(mockJsonResponse(200, {

--- a/apps/web/tests/usePlmProductPanel.spec.ts
+++ b/apps/web/tests/usePlmProductPanel.spec.ts
@@ -199,6 +199,19 @@ describe('usePlmProductPanel', () => {
           fallback: 'id',
         },
       ],
+      productMetadataLoading: ref(false),
+      productMetadataError: ref(''),
+      productMetadataRows: computed(() => [
+        {
+          name: 'item_number',
+          label: '料号',
+          type: 'string',
+          required: true,
+          length: '64',
+          defaultValue: '-',
+          currentValue: 'PN-1',
+        },
+      ]),
       formatJson: (payload: unknown) => JSON.stringify(payload),
     })
 
@@ -260,6 +273,11 @@ describe('usePlmProductPanel', () => {
     expect(panel.loadProduct).toHaveBeenCalledTimes(1)
     expect(panel.copyProductField).toHaveBeenCalledWith('id')
     expect(panel.resetAll).toHaveBeenCalledTimes(1)
+    expect(panel.productPanel.productMetadataRows.value[0]).toMatchObject({
+      name: 'item_number',
+      label: '料号',
+      currentValue: 'PN-1',
+    })
   })
 
   it('exposes workbench batch actions through the panel contract', async () => {

--- a/docs/development/aml-metadata-federation-design-verification-20260411.md
+++ b/docs/development/aml-metadata-federation-design-verification-20260411.md
@@ -1,0 +1,181 @@
+# AML Metadata Federation Design and Verification
+
+Date: 2026-04-11
+
+## Why This Exists
+
+`aml/metadata` fills a gap in the PLM bridge: callers need item-type schema
+discovery, not just item data. The metadata payload drives form rendering,
+field validation, and downstream mapping logic, so the federation layer needs a
+stable pass-through path from the web service down to Yuantus.
+
+The change set keeps the federation contract contract-first:
+
+1. the consumer asks for metadata through the web service and SDK,
+2. federation normalizes the request and response envelope,
+3. `PLMAdapter` in `yuantus` mode fetches the provider-side AML metadata route,
+4. Pact freezes the consumer-visible interaction so the shape cannot drift.
+
+## Data Flow
+
+The request path is:
+
+`plmService.getMetadata(itemType)`
+-> `plmFederationClient.getMetadata(itemType)`
+-> `GET /api/federation/plm/metadata/:itemType`
+-> `PLMAdapter.getItemMetadata(itemType)`
+-> `GET /api/v1/aml/metadata/:itemType`
+
+The adapter maps the provider response into the canonical federation shape and
+returns it through the existing `ok/data/error` wrapper. In mock mode it returns
+a minimal placeholder object, and in unsupported legacy modes it returns an
+empty result plus an explicit error.
+
+## Change Surface
+
+- `PLMAdapter.getItemMetadata` now resolves item-type schema from Yuantus AML.
+- Federation exposes both `GET /api/plm/metadata/:itemType` and
+  `GET /api/federation/plm/metadata/:itemType` for the same handler.
+- The SDK adds `getMetadata(itemType)` on the PLM federation client.
+- The web service adds `plmService.getMetadata(itemType)` and a matching local
+  type surface.
+- The pact consumer interaction now includes the metadata discovery route, so
+  the contract tests track the live consumer call site instead of an aspirational
+  endpoint.
+
+## Key Contract Shape
+
+Consumer and federation request shape:
+
+```ts
+getMetadata(itemType: string): Promise<PlmItemMetadata>
+```
+
+Canonical metadata payload:
+
+```ts
+interface PlmItemMetadata {
+  id: string
+  label?: string
+  is_relationship?: boolean
+  properties: PlmMetadataField[]
+}
+
+interface PlmMetadataField {
+  name: string
+  label?: string
+  type?: string
+  required?: boolean
+  length?: number | null
+  default?: unknown
+}
+```
+
+Federation returns:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "id": "Part",
+    "label": "Part",
+    "is_relationship": false,
+    "properties": [
+      {
+        "name": "item_number",
+        "label": "料号",
+        "type": "string",
+        "required": true,
+        "length": 64,
+        "default": null
+      }
+    ]
+  }
+}
+```
+
+The Pact interaction locks the provider-side discovery call:
+
+- `GET /api/v1/aml/metadata/Part`
+- response body shape with `id`, `label`, `is_relationship`, and
+  `properties[]`
+
+## Verification
+
+Command run:
+
+```bash
+pnpm exec vitest run \
+  packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts \
+  packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts \
+  packages/core-backend/tests/unit/federation.contract.test.ts \
+  packages/openapi/dist-sdk/tests/client.test.ts \
+  apps/web/tests/plmService.spec.ts
+```
+
+Result:
+
+- `5` test files passed
+- `74` tests passed
+- duration `2.99s`
+
+## Live Adapter Smoke
+
+To avoid spending time on full Express auth/rbac bootstrap, the smoke run used
+the real `PLMAdapter` against a seeded Yuantus provider started from the Pact
+provider test harness. That still proves the non-mock HTTP path and the runtime
+response parser for `getItemMetadata`.
+
+Seeded provider launch:
+
+```bash
+PYTHONPATH=/tmp/yuantus-aml-metadata-sQmruU/src \
+  /Users/huazhou/Downloads/Github/Yuantus/.venv/bin/python - <<'PY'
+from yuantus.api.tests.test_pact_provider_yuantus_plm import _isolated_test_database, _running_provider
+import signal
+
+with _isolated_test_database():
+    with _running_provider() as base_url:
+        print(base_url, flush=True)
+        signal.pause()
+PY
+```
+
+Adapter smoke command:
+
+```bash
+PLM_BASE_URL=http://localhost:61373 \
+PLM_API_MODE=yuantus \
+PLM_TENANT_ID=tenant-1 \
+PLM_ORG_ID=org-1 \
+PLM_USERNAME=metasheet-svc \
+PLM_PASSWORD=secret \
+PLM_ITEM_TYPE=Part \
+  pnpm exec tsx -e "import { PLMAdapter } from './packages/core-backend/src/data-adapters/PLMAdapter'; import { ConfigService } from './packages/core-backend/src/services/ConfigService'; import { Logger } from './packages/core-backend/src/core/logger'; (async () => { const adapter = new PLMAdapter(ConfigService.getInstance(), new Logger('aml-metadata-smoke')); await adapter.connect(); const result = await adapter.getItemMetadata('Part'); console.log(JSON.stringify({ ok: result.error == null, totalCount: result.metadata?.totalCount ?? null, first: result.data[0] ?? null }, null, 2)); })().catch((error) => { console.error(error); process.exit(1); });"
+```
+
+Smoke result:
+
+- `ok: true`
+- `totalCount: 1`
+- returned `Part` metadata with 6 properties:
+  `item_number`, `name`, `description`, `state`, `cost`, `weight`
+
+## Known Limitations
+
+- The pact artifact is still hand-authored; it is not yet generated by
+  `@pact-foundation/pact`.
+- The provider verification depends on seeded Yuantus metadata fixtures, so the
+  response is stable for the contract test but still represents a narrow sample
+  of the provider's schema space.
+- Only the metadata read path is bridged here; there is no write/update schema
+  management surface yet.
+
+## Next Steps
+
+- Expand the provider fixture coverage for additional item types once the next
+  schema-discovery case is needed.
+- Replace the hand-authored pact with generated consumer output when the Pact
+  dependency is approved.
+- Keep the federation and SDK shapes aligned if more metadata fields are added
+  on the provider side.

--- a/docs/development/plm-product-metadata-panel-design-verification-20260411.md
+++ b/docs/development/plm-product-metadata-panel-design-verification-20260411.md
@@ -1,0 +1,89 @@
+# PLM Product Metadata Panel Design and Verification
+
+Date: 2026-04-11
+
+## Goal
+
+Turn the newly added `plmService.getMetadata(itemType)` surface into a real UI
+consumer instead of leaving it only in service and contract tests.
+
+The chosen integration point is the product detail panel in the PLM workspace:
+
+- it already owns `product`, `itemType`, and `loadProduct()`
+- it already renders product summary and a static field catalog
+- it is the narrowest place to surface AML schema discovery without touching
+  BOM, documents, approvals, or CAD panels
+
+## Design
+
+The implementation adds a second, runtime-backed metadata block below the
+existing static “字段对照清单”.
+
+Flow:
+
+1. `loadProduct()` fetches the product as before.
+2. Once the final item type is known, it triggers `plmService.getMetadata(itemType)`.
+3. Metadata loading is independent and non-fatal:
+   - metadata failure does not block BOM/documents/approvals loading
+   - product detail still renders even when schema discovery fails
+4. A small pure helper maps:
+   - metadata field definition
+   - top-level product field value
+   - `product.properties[fieldName]` fallback
+   into UI rows with stable display strings
+
+Rendered columns:
+
+- `label`
+- `name`
+- `type`
+- `required`
+- `length`
+- `defaultValue`
+- `currentValue`
+
+## Files
+
+- `apps/web/src/views/PlmProductView.vue`
+- `apps/web/src/components/plm/PlmProductPanel.vue`
+- `apps/web/src/views/plm/plmPanelModels.ts`
+- `apps/web/src/views/plm/usePlmProductPanel.ts`
+- `apps/web/src/views/plm/plmProductMetadata.ts`
+- `apps/web/tests/plmProductMetadata.spec.ts`
+- `apps/web/tests/usePlmProductPanel.spec.ts`
+
+## Key Decisions
+
+- Keep the old static field catalog.
+  Reason: it still documents the hard-coded normalization rules for the summary
+  card, while the new AML metadata block shows the provider schema and current
+  values.
+- Do not block `loadProduct()` success on metadata.
+  Reason: schema discovery is informative UI, not the primary product fetch.
+- Normalize metadata rows in a pure helper module.
+  Reason: easier testing and less template logic in the page component.
+
+## Verification
+
+Command:
+
+```bash
+pnpm exec vitest run \
+  apps/web/tests/plmProductMetadata.spec.ts \
+  apps/web/tests/usePlmProductPanel.spec.ts \
+  apps/web/tests/plmService.spec.ts
+```
+
+Result:
+
+- `3` test files passed
+- `16` tests passed
+- duration `706ms`
+
+## Limits
+
+- This change only surfaces metadata in the product panel; other panels still
+  use their existing field catalogs.
+- No browser smoke was added in this step; verification is currently unit-level.
+- The metadata block renders provider schema as-is and does not yet support
+  richer field widgets or grouping.

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -41,6 +41,22 @@ export interface PLMQueryOptions {
   itemType?: string
 }
 
+export interface PLMItemMetadataProperty {
+  name: string
+  label?: string
+  type?: string
+  required?: boolean
+  length?: number | null
+  default?: unknown
+}
+
+export interface PLMItemMetadata {
+  id: string
+  label?: string
+  is_relationship?: boolean
+  properties: PLMItemMetadataProperty[]
+}
+
 export interface ApprovalRequest {
   id: string
   request_type: string
@@ -591,6 +607,7 @@ const YUANTUS_SUPPORTED_OPERATIONS = [
   'products',
   'bom',
   'documents',
+  'metadata',
   'details',
   'release_readiness',
   'approvals',
@@ -1592,6 +1609,57 @@ export class PLMAdapter extends HTTPAdapter {
     const result = await this.select<PLMProductRaw>(`${this.productsPath()}${id}`)
     if (result.data.length === 0) return null
     return this.mapProductFields(result.data[0])
+  }
+
+  async getItemMetadata(itemType: string): Promise<QueryResult<PLMItemMetadata>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: itemType,
+          label: itemType,
+          is_relationship: false,
+          properties: [],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+
+    if (this.apiMode !== 'yuantus') {
+      return {
+        data: [],
+        metadata: { totalCount: 0 },
+        error: new Error('PLM metadata is not supported for this PLM API mode'),
+      }
+    }
+
+    const result = await this.query<Record<string, unknown>>(`/api/v1/aml/metadata/${encodeURIComponent(itemType)}`)
+
+    return {
+      data: result.data.map((entry) => ({
+        id: String(entry.id || itemType),
+        label: typeof entry.label === 'string' ? entry.label : String(entry.id || itemType),
+        is_relationship: Boolean(entry.is_relationship),
+        properties: Array.isArray(entry.properties)
+          ? entry.properties
+              .map((property) => {
+                const record = property && typeof property === 'object'
+                  ? property as Record<string, unknown>
+                  : {}
+                return {
+                  name: String(record.name || ''),
+                  label: typeof record.label === 'string' ? record.label : undefined,
+                  type: typeof record.type === 'string' ? record.type : undefined,
+                  required: typeof record.required === 'boolean' ? record.required : undefined,
+                  length: typeof record.length === 'number' ? record.length : null,
+                  default: record.default,
+                }
+              })
+              .filter((property) => property.name.length > 0)
+          : [],
+      })),
+      metadata: { totalCount: result.data.length },
+      error: result.error,
+    }
   }
 
   async getProductDocuments(

--- a/packages/core-backend/src/di/container.ts
+++ b/packages/core-backend/src/di/container.ts
@@ -46,6 +46,9 @@ class AdapterStub {
   async getProducts() { return { data: [], metadata: { totalCount: 0 } } }
   async getProductBOM() { return { data: [], metadata: { totalCount: 0 } } }
   async getProductById() { return null }
+  async getItemMetadata(itemType = 'Part') {
+    return { data: [{ id: itemType, label: itemType, is_relationship: false, properties: [] }], metadata: { totalCount: 1 } }
+  }
   async getProductDocuments() { return { data: [], metadata: { totalCount: 0 } } }
   async getApprovals() { return { data: [], metadata: { totalCount: 0 } } }
   async getApprovalHistory() { return { data: [], metadata: { totalCount: 0 } } }

--- a/packages/core-backend/src/di/identifiers.ts
+++ b/packages/core-backend/src/di/identifiers.ts
@@ -3,7 +3,7 @@ import type { Server as HttpServer } from 'http';
 import type { Socket } from 'socket.io';
 import type { AthenaDocument, DocumentVersion } from '../data-adapters/AthenaAdapter';
 import type { QueryResult } from '../data-adapters/BaseAdapter';
-import type { ApprovalHistoryEntry, ApprovalRequest, BOMItem, PLMProduct } from '../data-adapters/PLMAdapter';
+import type { ApprovalHistoryEntry, ApprovalRequest, BOMItem, PLMItemMetadata, PLMProduct } from '../data-adapters/PLMAdapter';
 import type { ConfigValue } from '../services/ConfigService';
 import type { CollectionDefinition } from '../types/collection';
 import type { Repository } from '../core/database/Repository';
@@ -78,6 +78,7 @@ export interface IPLMAdapterService extends IAdapterLifecycle {
   getProducts(options?: Record<string, unknown>): Promise<QueryResult<PLMProduct>>;
   getProductBOM(productId: string, options?: { depth?: number; effectiveAt?: string }): Promise<QueryResult<BOMItem>>;
   getProductById(productId: string, options?: Record<string, unknown>): Promise<PLMProduct | null>;
+  getItemMetadata(itemType: string): Promise<QueryResult<PLMItemMetadata>>;
   getApprovals(options?: Record<string, unknown>): Promise<QueryResult<ApprovalRequest>>;
   getApprovalById(approvalId: string): Promise<QueryResult<ApprovalRequest>>;
   getApprovalHistory(approvalId: string): Promise<QueryResult<ApprovalHistoryEntry>>;

--- a/packages/core-backend/src/routes/federation.ts
+++ b/packages/core-backend/src/routes/federation.ts
@@ -634,6 +634,75 @@ export function federationRouter(injector?: Injector): Router {
     }
   }
 
+  const handlePlmProductMetadata = async (req: Request, res: Response) => {
+    const metrics = getAdapterMetrics()
+    const startTime = Date.now()
+
+    try {
+      const itemType = req.params.itemType
+      const adapter = await ensurePlmAdapter()
+
+      if (adapter) {
+        const result = await adapter.getItemMetadata(itemType)
+        if (sendAdapterError(res, result.error, 'Failed to get PLM metadata', metrics, 'GET', '/metadata/:itemType', startTime)) {
+          return
+        }
+
+        const metadata = result.data[0]
+        if (!metadata) {
+          return res.status(404).json({
+            ok: false,
+            error: {
+              code: 'NOT_FOUND',
+              message: `Metadata '${itemType}' not found`,
+            },
+          })
+        }
+
+        metrics.recordRequest(
+          { adapter: 'plm', method: 'GET', endpoint: '/metadata/:itemType', status: '200' },
+          Date.now() - startTime,
+        )
+
+        return res.json({
+          ok: true,
+          data: metadata,
+        })
+      }
+
+      metrics.recordRequest(
+        { adapter: 'plm', method: 'GET', endpoint: '/metadata/:itemType', status: '200' },
+        Date.now() - startTime,
+      )
+
+      return res.json({
+        ok: true,
+        data: {
+          id: itemType,
+          label: itemType,
+          is_relationship: false,
+          properties: [],
+        },
+      })
+    } catch (error) {
+      if (sendAdapterError(res, error, 'Failed to get PLM metadata', metrics, 'GET', '/metadata/:itemType', startTime)) {
+        return
+      }
+      metrics.recordRequest(
+        { adapter: 'plm', method: 'GET', endpoint: '/metadata/:itemType', status: '500' },
+        Date.now() - startTime,
+      )
+
+      return res.status(500).json({
+        ok: false,
+        error: {
+          code: 'PLM_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to get PLM metadata',
+        },
+      })
+    }
+  }
+
   const handlePlmProductBom = async (req: Request, res: Response) => {
     const metrics = getAdapterMetrics()
     const startTime = Date.now()
@@ -1068,6 +1137,16 @@ export function federationRouter(injector?: Injector): Router {
     '/api/plm/products/:id',
     rbacGuard('federation', 'read'),
     handlePlmProductDetail
+  )
+
+  /**
+   * GET /api/plm/metadata/:itemType
+   * Alias for PLM item metadata (legacy frontend compatibility)
+   */
+  router.get(
+    '/api/plm/metadata/:itemType',
+    rbacGuard('federation', 'read'),
+    handlePlmProductMetadata
   )
 
   /**
@@ -2124,6 +2203,16 @@ export function federationRouter(injector?: Injector): Router {
   )
 
   /**
+   * GET /api/federation/plm/metadata/:itemType
+   * Get item metadata / schema for a PLM item type
+   */
+  router.get(
+    '/api/federation/plm/metadata/:itemType',
+    rbacGuard('federation', 'read'),
+    handlePlmProductMetadata
+  )
+
+  /**
    * GET /api/federation/plm/products/:id/bom
    * Get BOM (Bill of Materials) for a product
    */
@@ -2725,6 +2814,7 @@ function getDefaultCapabilities(type: 'plm' | 'athena'): string[] {
       'products',
       'bom',
       'documents',
+      'metadata',
       'release_readiness',
       'approvals',
       'approval_history',

--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -19,14 +19,14 @@ Metasheet2 already calls Yuantus PLM in production through `PLMAdapter.ts`
 when running in `apiMode='yuantus'`. Without a contract test, any field
 rename on the Yuantus side would silently break Metasheet at runtime.
 
-This Pact set freezes the **shape** (not the values) of the 6 Wave 1 P0
+This Pact set freezes the **shape** (not the values) of the 7 Wave 1 P0
 endpoints plus the 3 document-semantics endpoints, the release-readiness
 governance endpoint, the 5 BOM-analysis / ECO-approval endpoints, and the 5
 approval-detail / BOM-substitute endpoints, while Wave 5 adds the 9 CAD
 properties / review / diff endpoints as exact fixture examples that
 `PLMAdapter.ts` currently calls for `apiMode='yuantus'`.
-(Codex's PACT_FIRST plan lists 7 endpoints in Wave 1 — see "Discrepancy
-with codex plan" below.)
+(Codex's PACT_FIRST plan lists 7 endpoints in Wave 1, and the consumer now
+calls all 7.)
 
 The companion provider verifier lives in the Yuantus repo at
 `src/yuantus/api/tests/test_pact_provider_yuantus_plm.py`.
@@ -40,7 +40,7 @@ because adding that npm dependency requires explicit approval.
 The `plm-adapter-yuantus.pact.test.ts` vitest test guards six things:
 
 1. The pact JSON exists and parses as Pact v3.
-2. It contains the 29 currently used interactions in the documented order.
+2. It contains the 30 currently used interactions in the documented order.
 3. Every endpoint named in the pact is also referenced by the live
    `packages/core-backend/src/data-adapters/PLMAdapter.ts` source — so the
    pact cannot drift away from what the adapter actually calls.
@@ -53,33 +53,19 @@ The `plm-adapter-yuantus.pact.test.ts` vitest test guards six things:
 7. The Wave 5 additions lock the exact envelope for CAD properties, CAD view
    state, CAD review, CAD history, CAD diff, and CAD mesh stats.
 
-## Discrepancy with codex's PACT_FIRST plan
+## aml/metadata is now live on main
 
-`docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md` lists 7 endpoints in Wave 1
-P0, including `GET /api/v1/aml/metadata/{item_type_name}`. When the
-contract test was first authored that endpoint was included, and the test
-**immediately failed** with:
+`GET /api/v1/aml/metadata/{item_type_name}` was previously parked outside the
+consumer pact because `PLMAdapter.ts` did not call it. This worktree closes
+that gap in the contract-first way:
 
-> PLMAdapter.ts no longer references /api/v1/aml/metadata/; pact has drifted
-> from the consumer.
-
-A grep across `metasheet2/packages/core-backend/src` confirmed no caller.
-The endpoint exists in Yuantus (`router.py:52`) and is intended for
-front-end form rendering, but the metasheet2 adapter does not yet use it.
-
-Per the contract-first principle, the pact must freeze what the consumer
-**actually** calls, not what is planned. The metadata endpoint has been
-moved to Wave 1.5 and will be added to this pact as soon as PLMAdapter
-starts calling it. When that happens:
-
-1. Add the call site in `PLMAdapter.ts`
-2. Add a new interaction back into `pacts/metasheet2-yuantus-plm.json`
-3. Add the path back into `WAVE_1_P0_PATHS` in the test
-4. Re-copy JSON to `Yuantus/contracts/pacts/`
-
-This drift catch is the pact gate working correctly on day one. The cost
-of removing one anticipated endpoint is much smaller than the cost of
-discovering an aspirational pact never matches the consumer.
+1. `PLMAdapter.getItemMetadata(itemType)` now calls the Yuantus metadata route.
+2. Federation exposes `GET /api/federation/plm/metadata/:itemType`.
+3. The SDK and `plmService` now expose `getMetadata(itemType)`.
+4. The pact JSON now includes `GET /api/v1/aml/metadata/Part`.
+5. The provider verifier can seed stable `Property` rows for the `Part`
+   `ItemType`, so the metadata response is meaningful instead of an empty
+   placeholder.
 
 ## Running the test
 
@@ -106,7 +92,7 @@ cd /Users/huazhou/Downloads/Github/Yuantus
 
 ### Current verifier handoff state (2026-04-11)
 
-The consumer artifact now contains all 29 Wave 1-5 interactions. To verify
+The consumer artifact now contains all 30 Wave 1-5 interactions. To verify
 Yuantus against the current artifact, copy this JSON into the Yuantus repo and
 rerun the provider verifier there.
 
@@ -176,12 +162,9 @@ specification of what the generated pact must contain.
 
 ## Still intentionally outside the pact
 
-The following surfaces remain outside the pact:
-
-- `GET /api/v1/aml/metadata/{item_type_name}`
-
-`aml/metadata` remains outside because `PLMAdapter.ts` still does not call it on
-`main`.
+No additional `aml/*` schema-discovery surfaces are parked right now. Future
+schema endpoints should follow the same rule: add the consumer call site first,
+then add the pact interaction in the same change.
 
 ## Forward compatibility note
 

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -9,7 +9,7 @@
     "pactSpecification": {
       "version": "3.0.0"
     },
-    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. NOTE: codex's plan also listed GET /api/v1/aml/metadata/{type} in Wave 1, but PLMAdapter.ts does not currently call it; contract-first principle says we lock what is actually called. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute. Wave 5 adds the nine CAD endpoints already called on main: CAD properties, CAD view state, CAD review, CAD history, CAD diff, and CAD mesh stats. Release-readiness adds the governance drilldown endpoint already called on main: GET /api/v1/release-readiness/items/{item_id}."
+    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. Wave 1 now includes the real schema-discovery call already used by mainline PLMAdapter.getItemMetadata in yuantus mode: GET /api/v1/aml/metadata/{type}. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute. Wave 5 adds the nine CAD endpoints already called on main: CAD properties, CAD view state, CAD review, CAD history, CAD diff, and CAD mesh stats. Release-readiness adds the governance drilldown endpoint already called on main: GET /api/v1/release-readiness/items/{item_id}."
   },
   "interactions": [
     {
@@ -1449,6 +1449,129 @@
               ]
             },
             "$.has_more": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "discover item-type metadata for a Part through AML metadata",
+      "providerStates": [
+        {
+          "name": "the Part item type exposes stable metadata fields"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/aml/metadata/Part",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": "Part",
+          "label": "Part",
+          "is_relationship": false,
+          "properties": [
+            {
+              "name": "item_number",
+              "label": "料号",
+              "type": "string",
+              "required": true,
+              "length": 64,
+              "default": null
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.label": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.is_relationship": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.properties": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.properties[*].name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.properties[*].label": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.properties[*].type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.properties[*].required": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.properties[*].length": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.properties[*].default": {
               "matchers": [
                 {
                   "match": "type"

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -16,8 +16,8 @@
  *      list/detail / BOM-substitute Wave 4 interactions plus the CAD
  *      review/workspace Wave 5 interactions that PLMAdapter currently calls
  *      are present, in the documented order.
- *      (codex's plan also lists `aml/metadata`, but PLMAdapter does not yet
- *      call it; deferred until there is a real consumer call site.)
+ *      including `aml/metadata`, now that PLMAdapter calls the dedicated
+ *      metadata route for item-type schema discovery.
  *   3. The PLMAdapter actually calls every endpoint declared in the pact, so
  *      the contract cannot drift away from the live consumer code without
  *      this test failing.
@@ -79,10 +79,6 @@ interface PactDocument {
 // "planned" or "anticipated" must NOT live in this list — the contract-first
 // principle requires that pact freezes what is actually used, never aspiration.
 //
-// Notable omission from codex's PACT_FIRST plan: GET /api/v1/aml/metadata/{type}
-// is listed as Wave 1 P0 in docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md, but
-// PLMAdapter.ts does not currently invoke it. It is parked for Wave 1.5 / Wave
-// 2 and will be added to this list as soon as the adapter starts calling it.
 const PACT_PATHS = [
   { method: 'POST', path: '/api/v1/auth/login' },
   { method: 'GET', path: '/api/v1/health' },
@@ -93,6 +89,7 @@ const PACT_PATHS = [
   { method: 'GET', path: '/api/v1/file/item/01H000000000000000000000P1' },
   { method: 'GET', path: '/api/v1/file/01H000000000000000000000F1' },
   { method: 'POST', path: '/api/v1/aml/query' },
+  { method: 'GET', path: '/api/v1/aml/metadata/Part' },
   { method: 'GET', path: '/api/v1/release-readiness/items/01H000000000000000000000P1' },
   { method: 'GET', path: '/api/v1/bom/01H000000000000000000000P2/where-used' },
   { method: 'GET', path: '/api/v1/bom/compare/schema' },
@@ -167,6 +164,7 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       '/api/v1/bom/compare/schema',
       '/api/v1/file/item/',
       '/api/v1/aml/query',
+      '/api/v1/aml/metadata/${encodeURIComponent(itemType)}',
       '/api/v1/release-readiness/items/${itemId}',
       '/api/v1/eco',
       '/api/v1/eco/${approvalId}',
@@ -244,6 +242,22 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(body.where).toEqual({ id: '01H000000000000000000000P1' })
     expect(body.expand).toEqual(['Document Part'])
     expect(body.page_size).toBe(1)
+  })
+
+  it('aml/metadata interaction locks the schema-discovery envelope used by getItemMetadata', () => {
+    const pact = loadPact()
+    const metadata = pact.interactions.find(
+      i => i.request.path === '/api/v1/aml/metadata/Part',
+    )
+
+    expect(metadata).toBeDefined()
+    expect(metadata!.request.method).toBe('GET')
+    expect(metadata!.response.body).toEqual({
+      id: 'Part',
+      label: 'Part',
+      is_relationship: false,
+      properties: expect.any(Array),
+    })
   })
 
   it('release-readiness interaction locks the governance drilldown envelope used by federation', () => {

--- a/packages/core-backend/tests/fixtures/federation/contracts.ts
+++ b/packages/core-backend/tests/fixtures/federation/contracts.ts
@@ -35,6 +35,29 @@ export const plmContractFixtures = {
     updated_at: '2026-03-02T00:00:00.000Z',
     itemType: 'Part',
   },
+  productMetadata: {
+    id: 'Part',
+    label: 'Part',
+    is_relationship: false,
+    properties: [
+      {
+        name: 'item_number',
+        label: '料号',
+        type: 'string',
+        required: true,
+        length: 64,
+        default: null,
+      },
+      {
+        name: 'name',
+        label: '名称',
+        type: 'string',
+        required: false,
+        length: 255,
+        default: null,
+      },
+    ],
+  },
   releaseReadiness: {
     item_id: 'prod-1001',
     generated_at: '2026-03-05T00:00:00.000Z',

--- a/packages/core-backend/tests/unit/federation.contract.test.ts
+++ b/packages/core-backend/tests/unit/federation.contract.test.ts
@@ -60,7 +60,7 @@ function createPlmAdapterMock(runtimeStatus: RuntimeStatus = {}) {
     getRuntimeStatus: vi.fn(() => ({
       configured: runtimeStatus.configured ?? true,
       healthSupported: runtimeStatus.healthSupported ?? true,
-      supportedOperations: runtimeStatus.supportedOperations ?? ['products', 'bom', 'documents', 'release_readiness', 'approvals', 'approval_history', 'bom_compare', 'substitutes_add', 'details'],
+      supportedOperations: runtimeStatus.supportedOperations ?? ['products', 'bom', 'documents', 'metadata', 'release_readiness', 'approvals', 'approval_history', 'bom_compare', 'substitutes_add', 'details'],
       ...(runtimeStatus.implementation ? { implementation: runtimeStatus.implementation } : {}),
     })),
     getProducts: vi.fn(async () => ({
@@ -72,6 +72,10 @@ function createPlmAdapterMock(runtimeStatus: RuntimeStatus = {}) {
       metadata: { totalCount: plmContractFixtures.bom.length },
     })),
     getProductById: vi.fn(async () => plmContractFixtures.productDetail),
+    getItemMetadata: vi.fn(async () => ({
+      data: [plmContractFixtures.productMetadata],
+      metadata: { totalCount: 1 },
+    })),
     getReleaseReadiness: vi.fn(async () => ({
       data: [plmContractFixtures.releaseReadiness],
       metadata: { totalCount: 1 },
@@ -328,6 +332,21 @@ describe('Federation contract routes', () => {
       effectiveAt: undefined,
     })
     expect(bomCompareResponse.body.data).toEqual(plmContractFixtures.bomCompare)
+  })
+
+  it('loads PLM item metadata through the dedicated GET route', async () => {
+    const plmAdapter = createPlmAdapterMock()
+    const app = createFederationApp({ plmAdapter })
+
+    const response = await request(app)
+      .get('/api/federation/plm/metadata/Part')
+      .expect(200)
+
+    expect(plmAdapter.getItemMetadata).toHaveBeenCalledWith('Part')
+    expect(response.body).toEqual({
+      ok: true,
+      data: plmContractFixtures.productMetadata,
+    })
   })
 
   it('normalizes empty release readiness results into the canonical federation shape', async () => {

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -21,6 +21,7 @@ describe('PLMAdapter runtime status', () => {
     })
     expect(adapter.getRuntimeStatus().supportedOperations).toContain('release_readiness')
     expect(adapter.getRuntimeStatus().supportedOperations).toContain('approval_history')
+    expect(adapter.getRuntimeStatus().supportedOperations).toContain('metadata')
   })
 
   it('hides yuantus-only capabilities in legacy mode', () => {
@@ -34,6 +35,7 @@ describe('PLMAdapter runtime status', () => {
     expect(adapter.getRuntimeStatus().supportedOperations).not.toContain('approval_history')
     expect(adapter.getRuntimeStatus().supportedOperations).not.toContain('where_used')
     expect(adapter.getRuntimeStatus().supportedOperations).not.toContain('cad_properties')
+    expect(adapter.getRuntimeStatus().supportedOperations).not.toContain('metadata')
   })
 })
 
@@ -273,6 +275,50 @@ describe('PLMAdapter Yuantus documents mapping', () => {
 
     expect(result.data).toHaveLength(1)
     expect(result.data[0].id).toBe('shared-1')
+  })
+})
+
+describe('PLMAdapter Yuantus metadata mapping', () => {
+  it('loads AML item metadata through the dedicated metadata route', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [{
+        id: 'Part',
+        label: 'Part',
+        is_relationship: false,
+        properties: [
+          {
+            name: 'item_number',
+            label: '料号',
+            type: 'string',
+            required: true,
+            length: 64,
+            default: null,
+          },
+        ],
+      }],
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getItemMetadata('Part')
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/aml/metadata/Part')
+    expect(result.error).toBeUndefined()
+    expect(result.metadata?.totalCount).toBe(1)
+    expect(result.data).toEqual([{
+      id: 'Part',
+      label: 'Part',
+      is_relationship: false,
+      properties: [{
+        name: 'item_number',
+        label: '料号',
+        type: 'string',
+        required: true,
+        length: 64,
+        default: null,
+      }],
+    }])
   })
 })
 

--- a/packages/openapi/dist-sdk/client.d.ts
+++ b/packages/openapi/dist-sdk/client.d.ts
@@ -64,6 +64,20 @@ export interface GetPlmBomParams {
     depth?: number;
     effectiveAt?: string;
 }
+export interface PlmMetadataField {
+    name: string;
+    label?: string;
+    type?: string;
+    required?: boolean;
+    length?: number | null;
+    default?: unknown;
+}
+export interface PlmItemMetadata {
+    id: string;
+    label?: string;
+    is_relationship?: boolean;
+    properties: PlmMetadataField[];
+}
 export interface ListPlmDocumentsParams extends PaginationOptions {
     productId: string;
     role?: string;
@@ -208,6 +222,7 @@ export declare function createPlmFederationClient(clientOrOptions: ClientOptions
     listProducts<T = Record<string, unknown>>(params?: ListPlmProductsParams): Promise<PlmListResponse<T>>;
     getProduct<T = Record<string, unknown>>(productId: string, params?: GetPlmProductParams): Promise<T>;
     getBom<T = Record<string, unknown>>(productId: string, params?: GetPlmBomParams): Promise<PlmListResponse<T>>;
+    getMetadata<T = PlmItemMetadata>(itemType: string): Promise<T>;
     listDocuments<T = Record<string, unknown>>(params: ListPlmDocumentsParams): Promise<PlmListResponse<T>>;
     listApprovals<T = Record<string, unknown>>(params?: ListPlmApprovalsParams): Promise<PlmListResponse<T>>;
     getApprovalHistory<T = Record<string, unknown>>(approvalId: string): Promise<PlmApprovalHistoryResponse<T>>;

--- a/packages/openapi/dist-sdk/client.js
+++ b/packages/openapi/dist-sdk/client.js
@@ -226,6 +226,9 @@ export function createPlmFederationClient(clientOrOptions) {
                 effective_at: params.effectiveAt,
             }), 'Failed to load PLM BOM');
         },
+        async getMetadata(itemType) {
+            return requestPlmGet(client, `/api/federation/plm/metadata/${encodeURIComponent(itemType)}`, 'Failed to load PLM metadata');
+        },
         async listDocuments(params) {
             const filters = {};
             if (params.role)

--- a/packages/openapi/dist-sdk/client.ts
+++ b/packages/openapi/dist-sdk/client.ts
@@ -94,6 +94,22 @@ export interface GetPlmBomParams {
   effectiveAt?: string
 }
 
+export interface PlmMetadataField {
+  name: string
+  label?: string
+  type?: string
+  required?: boolean
+  length?: number | null
+  default?: unknown
+}
+
+export interface PlmItemMetadata {
+  id: string
+  label?: string
+  is_relationship?: boolean
+  properties: PlmMetadataField[]
+}
+
 export interface ListPlmDocumentsParams extends PaginationOptions {
   productId: string
   role?: string
@@ -611,6 +627,14 @@ export function createPlmFederationClient(clientOrOptions: ClientOptions | Reque
           effective_at: params.effectiveAt,
         }),
         'Failed to load PLM BOM',
+      )
+    },
+
+    async getMetadata<T = PlmItemMetadata>(itemType: string): Promise<T> {
+      return requestPlmGet<T>(
+        client,
+        `/api/federation/plm/metadata/${encodeURIComponent(itemType)}`,
+        'Failed to load PLM metadata',
       )
     },
 

--- a/packages/openapi/dist-sdk/tests/client.test.ts
+++ b/packages/openapi/dist-sdk/tests/client.test.ts
@@ -75,6 +75,24 @@ describe('createPlmFederationClient', () => {
     )
   })
 
+  it('encodes PLM metadata GET requests', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ ok: true, data: { id: 'Part', properties: [] } }),
+    )
+
+    const client = createPlmFederationClient({
+      baseUrl: 'http://localhost:8910',
+      getToken: () => 'token-meta',
+      fetch: fetchMock,
+    })
+
+    await client.getMetadata('Part/Assembly')
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'http://localhost:8910/api/federation/plm/metadata/Part%2FAssembly',
+    )
+  })
+
   it('omits the approvals status filter when set to all', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       jsonResponse({


### PR DESCRIPTION
## Summary
- recut the stale `#825` branch onto current `main`
- preserve only the intended PLM AML metadata federation + product panel metadata changes
- keep the diff to the 26 intended files instead of the stale branch's polluted rollback/deletion set

## What Changed
- add PLM adapter + federation route support for AML item metadata schema discovery
- surface PLM AML metadata in the product panel UI
- update contract fixtures, pact coverage, dist SDK, and targeted frontend/backend tests
- include design and verification notes for both backend federation and frontend panel delivery

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts tests/unit/federation.contract.test.ts tests/contract/plm-adapter-yuantus.pact.test.ts`
- `pnpm --filter @metasheet/web exec vitest run tests/plmService.spec.ts tests/usePlmProductPanel.spec.ts tests/plmProductMetadata.spec.ts`
- `pnpm exec vitest run packages/openapi/dist-sdk/tests/client.test.ts`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web build`

## Notes
- this PR supersedes `#825`, which was based on a stale branch and had accumulated unrelated deletions versus current `main`
