### PR TITLE
docs: add codex conversation handoff

### DIFF
--- a/docs/development/codex-conversation-handoff-20260411.md
+++ b/docs/development/codex-conversation-handoff-20260411.md
@@ -1,0 +1,110 @@
+# Codex Conversation Handoff
+
+Date: 2026-04-11
+
+## Current Recommended Package
+
+- Package: `multitable-onprem-run20-20260407`
+- Release: https://github.com/zensgit/metasheet2/releases/tag/multitable-onprem-run20-20260407
+- Recommended deployment env:
+
+```env
+PRODUCT_MODE=platform
+ENABLE_PLM=0
+```
+
+## Current Delivery Status
+
+The Windows on-prem delivery line is now green end-to-end.
+
+Validated in field:
+
+- `deploy.bat` exit code `0`
+- `pnpm install` resolves runtime deps correctly
+- `bootstrap-admin.bat` exit code `0`
+- admin login succeeds after bootstrap
+
+This closes the `run13 -> run20` Windows reroll chain.
+
+## Important Final Fixes
+
+### Windows packaging / bootstrap chain
+
+- `run17`: stop using `node -e` in Windows bootstrap helper
+- `run18`: move temp `.cjs` execution under package-local `.tmp/node-bootstrap`
+- `run19`: add `bcryptjs` to root runtime dependencies and lock it in package verify
+- `run20`: normalize `process.argv` so temp `.cjs` keeps the old `node -e` indexing semantics
+
+Relevant merged PRs:
+
+- `#709` fix(multitable): stop using node -e in windows bootstrap
+- `#710` fix(multitable): resolve bcryptjs in windows bootstrap
+- `#711` fix(multitable): add bcryptjs to root runtime deps
+- `#712` fix(multitable): preserve argv in windows bootstrap
+
+## Earlier Product / Delivery Milestones
+
+### Platform / attendance delivery
+
+- `run5`: platform shell + approvals/nav fixes considered stable
+- `run8`: reports 2.0 slice with time ranges, trend cards, management stats
+- `run9`: employee self-service dashboard 2.0 slice
+- `run10`: import/export ops summary and preview outcome improvements
+- `run11+`: RC and Windows delivery hardening
+
+### Key stable product behaviors already validated
+
+- attendance works in `platform` mode
+- PLM can be disabled with `ENABLE_PLM=0`
+- employee attendance self-service permissions work
+- approvals inbox no longer loops users back to login
+- attendance overview and reports are split and independently useful
+- Windows deployment and admin bootstrap now work
+
+## Still Open / Non-Blocker Polish
+
+Tracked mainly in:
+
+- Issue: https://github.com/zensgit/metasheet2/issues/651
+
+Known non-blockers still mentioned during validation:
+
+- logout triggers a burst of meaningless `403` requests
+- approvals page may still have console-noise follow-up worth checking
+- new employees without attendance-group assignment need a clearer empty-state prompt
+- mobile / small-screen detection in some admin surfaces is still rough
+- login rate limit is aggressive for dev/test workflows
+- attendance/multitable script naming is still mixed in some places
+
+## Repo / Working State Notes
+
+- Do **not** assume the root worktree is clean.
+- At the time of this handoff, the root repo contains unrelated untracked local files and other in-progress docs.
+- Avoid destructive cleanup from the root worktree.
+- Prefer a fresh dedicated worktree for new slices or release fixes.
+
+## Recommended Next Step
+
+Do **not** continue the Windows bootstrap reroll line unless a new real blocker appears.
+
+Preferred next tracks:
+
+1. RC polish from `#651`
+2. approval-center product work
+3. attendance/product iteration work, but not on the `run20` fix line
+
+## How To Resume On Another Computer
+
+Open this file and tell Codex:
+
+> Continue from `/Users/huazhou/Downloads/Github/metasheet2/docs/development/codex-conversation-handoff-20260411.md`. Treat `multitable-onprem-run20-20260407` as the current recommended package and use issue `#651` as the non-blocker polish backlog.
+
+## Source References
+
+- `/Users/huazhou/Downloads/Github/metasheet2/docs/development/multitable-run5-delivery-summary-20260403.md`
+- `/Users/huazhou/Downloads/Github/metasheet2/docs/development/multitable-windows-bootstrap-admin-design-20260407.md`
+- `/Users/huazhou/Downloads/Github/metasheet2/docs/development/multitable-windows-bootstrap-psql-fix-design-20260407.md`
+- `/Users/huazhou/Downloads/Github/metasheet2/docs/development/multitable-windows-bootstrap-node-cjs-fix-design-20260407.md`
+- `/Users/huazhou/Downloads/Github/metasheet2/docs/development/multitable-windows-bootstrap-modulepath-fix-design-20260407.md`
+- `/Users/huazhou/Downloads/Github/metasheet2/docs/development/multitable-windows-bootstrap-bcrypt-rootdep-design-20260407.md`
+- `/Users/huazhou/Downloads/Github/metasheet2/docs/development/multitable-windows-bootstrap-argv-fix-design-20260407.md`

--- a/docs/development/multitable-session-20260411-handoff.md
+++ b/docs/development/multitable-session-20260411-handoff.md
@@ -1,0 +1,92 @@
+# 多维表开发 Session 记录 — 2026-04-11
+
+> 本文件用于跨设备接续开发。Claude Code 的 memory 系统已同步保存，但仅限同机器。
+> 本文件通过 Git 同步，任何机器 pull 后即可恢复上下文。
+
+## 一、今日完成事项
+
+### PRs 已合并到 main
+| PR | 内容 | Commits |
+|-----|------|---------|
+| #808 | `GET /api/multitable/people-search` + test mock fix + view compat matrix doc | 2 |
+| #826 | Smoke: comment lifecycle + attachment upload 场景 (替代 #810) | 1 |
+| #821 | **Slice 5 scoped permissions** 完整实现 | 5 |
+
+### 六切片交付状态（最终）
+| 切片 | 状态 | 说明 |
+|------|------|------|
+| Slice 1 (A1.1 + B1.1) | ✅ main | 附件 UX 统一所有视图 + commentsScope 消费 |
+| Slice 2 (A2 + B2.1 + B3.1) | ✅ main | 导入闭环 + mentions API + inbox/unread 后端 |
+| Slice 3 (A3 + B2.2 + B3.2) | ✅ main | MetaCommentComposer + threaded comments + InboxView |
+| Slice 4 (A4 + B3.3 + B4) | ✅ main | Jump chain + comment realtime + orphan cleanup + smoke |
+| Slice 5 (C1) | ✅ main | view/field permission tables + canExport + 3-tab UI + 19 tests |
+| Slice 6 (C2) | 未开始 | Automation — 需先统一 workflow 存储模型 |
+
+## 二、Slice 5 架构决策（关键参考）
+
+### 数据库
+- `meta_view_permissions` — per-view read/write/admin grants (UUID PK, pgcrypto)
+- `field_permissions` — per-field visible/readOnly per user or role
+
+### 权限模型
+- **View ACL**: CTE 查询分离 "any assignments exist" 和 "user's effective perms"，实现 fail-closed
+- **Field 合并语义**: AND for visible（任一方可限制），OR for readOnly（任一方可标只读）
+- **canExport**: 默认 = canRead，composable 有 fallbackKey 防 partial rollout
+
+### 代码结构
+- `packages/core-backend/src/multitable/permission-derivation.ts` — 提取的纯函数模块（deriveFieldPermissions, deriveViewPermissions）
+- `packages/core-backend/src/routes/univer-meta.ts` — import 自上述模块，不再内联
+- `packages/core-backend/tests/unit/permission-derivation.test.ts` — 18 个后端 unit tests
+- `apps/web/tests/multitable-workbench-permission-wiring.spec.ts` — 1 个 workbench 集成测试
+
+### 端点
+- `GET /views/:viewId/permissions` — list view permission entries
+- `PUT /views/:viewId/permissions/:subjectType/:subjectId` — set/remove (with subject validation)
+- `GET /sheets/:sheetId/field-permissions` — list field permission entries
+- `PUT /sheets/:sheetId/field-permissions/:fieldId/:subjectType/:subjectId` — upsert/remove (with field-ownership + subject validation)
+- `GET /api/multitable/people-search?q=&baseId=&limit=` — non-admin user search (with ACL gate)
+
+### 前端
+- `MetaSheetPermissionManager.vue` — 3-tab UI (Sheet Access / Field Permissions / View Permissions)
+- `useMultitableCapabilities.ts` — canExport 带 fallbackKey='canRead'
+- `MultitableWorkbench.vue` — 打开 Access 面板时 loadPermissionEntries()
+
+## 三、Review 轮次记录
+
+### PR #821 经历 5 轮 review
+1. **Copilot review** (6 条): CTE 修复 fail-open、scope map 接入、pgcrypto、aria-label、canExport fallback → 全部修复
+2. **Owner review 1**: scope 失控 (52 files) + 缺测试 → 重建干净 PR #821 (17 files) + 11 targeted tests
+3. **Owner review 2**: tests 复制实现不测真实代码 → 改为 import 真实 composable + mount 真实组件
+4. **Owner review 3**: 仍缺后端 derive 函数测试 + workbench wiring 测试 → 提取 permission-derivation.ts + 18 backend tests + 1 wiring test
+5. **Codex fix**: univer-meta.ts 删内联 derive 函数改 import 共享模块 + wiring test 增强验证
+
+## 四、已锁定的开发决策
+
+| 决策 | 内容 |
+|------|------|
+| 重复导入策略 | 默认跳过（按主键字段命中） |
+| 附件替换 | 先传新附件 → patch record → 删旧附件 |
+| Mention composer | 轻量自建（textarea + popup），不用 tiptap |
+| 孤儿附件清理 | setInterval 6h，24h 保留窗口 |
+| View ACL | CTE fail-closed |
+| Field permissions | AND visible, OR readOnly |
+| canExport | = canRead by default |
+| Permission derivation | 提取为独立 .ts 模块，路由 import 使用 |
+
+## 五、下一步选项
+
+1. **Slice 6 (C2 automation)** — 按计划：先统一 workflow 存储模型 → WorkflowDesigner 契约 → multitable trigger。需要先确认 workflow-designer 当前状态
+2. **修 6 个 env 测试** — attendance/api.test 失败是 .env 配置问题（VITE_API_URL 覆盖默认值）
+3. **清理旧分支** — 本地 10+ 个已合并/废弃分支
+4. **多维表阶段性收工** — Track A+B+C1 完成，是自然停止点
+
+## 六、恢复开发指令
+
+在新机器上：
+```bash
+cd metasheet2
+git pull
+# 然后启动 Claude Code
+claude
+# 说：继续多维表开发，参考 docs/development/multitable-session-20260411-handoff.md
+```


### PR DESCRIPTION
## Summary
- add a handoff document that captures the current multitable/on-prem delivery status
- preserve the current recommended package, release-fix history, and remaining polish backlog
- make cross-computer continuation possible from GitHub without relying on the original chat transcript

## Notes
- docs-only change
- no runtime code changes