### PR TITLE
fix(dingtalk): parse department listsub array responses

### DIFF
--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -350,8 +350,12 @@ export async function listDingTalkDepartments(
     config?.baseUrl,
   )
 
-  const result = readNestedPayload(payload)
-  const rawList = Array.isArray(result.list) ? result.list : []
+  const nestedResult = payload.result
+  const rawList = Array.isArray(nestedResult)
+    ? nestedResult
+    : nestedResult && typeof nestedResult === 'object' && Array.isArray((nestedResult as Record<string, unknown>).list)
+      ? (nestedResult as Record<string, unknown>).list as unknown[]
+      : []
   return rawList
     .map((entry) => (entry && typeof entry === 'object' ? entry as Record<string, unknown> : null))
     .filter((entry): entry is Record<string, unknown> => Boolean(entry))

--- a/packages/core-backend/tests/unit/dingtalk-client.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-client.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { listDingTalkDepartments } from '../../src/integrations/dingtalk/client'
+
+describe('DingTalk client department parsing', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('parses department/listsub responses when result is an array', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        errcode: 0,
+        errmsg: 'ok',
+        result: [
+          { dept_id: 1068569133, parent_id: 1, name: '产品部' },
+          { dept_id: 1068569134, parent_id: 1, name: '技术部' },
+        ],
+      }),
+    })
+    global.fetch = fetchMock as typeof fetch
+
+    const departments = await listDingTalkDepartments('token-123', '1')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://oapi.dingtalk.com/topapi/v2/department/listsub?access_token=token-123',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ dept_id: 1 }),
+      }),
+    )
+    expect(departments).toEqual([
+      expect.objectContaining({ id: '1068569133', parentId: '1', name: '产品部' }),
+      expect.objectContaining({ id: '1068569134', parentId: '1', name: '技术部' }),
+    ])
+  })
+
+  it('keeps supporting object-wrapped department lists', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        errcode: 0,
+        errmsg: 'ok',
+        result: {
+          list: [
+            { dept_id: 2001, parent_id: 1, name: '运营部' },
+          ],
+        },
+      }),
+    })
+    global.fetch = fetchMock as typeof fetch
+
+    const departments = await listDingTalkDepartments('token-456', '1')
+
+    expect(departments).toEqual([
+      expect.objectContaining({ id: '2001', parentId: '1', name: '运营部' }),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- fix DingTalk department sync parsing for `topapi/v2/department/listsub`
- support both `result: []` and `result.list` response shapes
- add unit coverage for both response formats

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-client.test.ts`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts`
- production hotfix validation: `testDirectoryIntegration` returned 4 child departments after backend redeploy
- production manual sync completed with `departmentsSynced: 5`, `accountsSynced: 3`

## Context
Before this fix, DingTalk child departments were parsed as an empty array, so directory sync only imported root-level direct members.
