### PR TITLE
fix: suppress false DingTalk root-member warning

### DIFF
--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -571,4 +571,60 @@ describe('DirectoryManagementView', () => {
     )
     expect(container?.textContent).toContain('已解除绑定')
   })
+
+  it('does not show the sparse root-member warning when child departments are present', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(createTestResultPayload({
+        departmentSampleCount: 4,
+        sampledDepartments: [
+          { id: '1068569133', name: '产品部' },
+          { id: '1068569134', name: '技术部' },
+        ],
+        diagnostics: {
+          rootDepartmentChildCount: 4,
+          rootDepartmentDirectUserCount: 1,
+          rootDepartmentDirectUserHasMore: false,
+          rootDepartmentDirectUserCountWithAccessLimit: 1,
+          rootDepartmentDirectUserHasMoreWithAccessLimit: false,
+          sampledRootDepartmentUsers: [
+            { userId: '0447654442691174', name: '周华' },
+          ],
+          sampledRootDepartmentUsersWithAccessLimit: [
+            { userId: '0447654442691174', name: '周华' },
+          ],
+        },
+        warnings: [],
+      })))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const testButton = Array.from(container?.querySelectorAll('button') ?? []).find((button) => button.textContent?.includes('测试连通性'))
+    expect(testButton).toBeTruthy()
+    testButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    await flushUi(6)
+
+    expect(container?.textContent).toContain('根部门子部门 4')
+    expect(container?.textContent).toContain('根部门直属成员 1')
+    expect(container?.textContent).not.toContain('根部门 1 当前仅返回 1 个直属成员')
+  })
 })

--- a/docs/development/dingtalk-directory-warning-suppression-20260411.md
+++ b/docs/development/dingtalk-directory-warning-suppression-20260411.md
@@ -1,0 +1,57 @@
+# DingTalk Directory Warning Suppression
+
+## Background
+
+After the DingTalk department parser hotfix, the directory test endpoint can correctly return child departments under the configured root department. The previous warning logic still treated "root department only returns 1 direct member" as suspicious even when child departments were present.
+
+That warning is misleading for the common DingTalk hierarchy where the root department has very few direct members and most users belong to child departments.
+
+## Design
+
+The warning builder now evaluates two separate conditions:
+
+1. whether the root department returns any child departments
+2. whether the root department returns suspiciously few direct members
+
+The sparse direct-member warning is now emitted only when both conditions hold:
+
+- `departmentSampleCount === 0`
+- `rootDepartmentDirectUserCount <= 1 && !rootDepartmentDirectUserHasMore`
+
+This keeps the warning aligned with likely misconfiguration or app-scope problems, while avoiding false positives for healthy multi-department tenants.
+
+## Code Changes
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+  - exports `buildDirectoryIntegrationTestWarnings` for direct unit coverage
+  - suppresses sparse root-member warnings when child departments are present
+- `packages/core-backend/tests/unit/directory-sync-warnings.test.ts`
+  - covers the no-child-departments path
+  - covers the child-departments-present path
+- `apps/web/tests/directoryManagementView.spec.ts`
+  - adds a UI regression test to ensure the misleading warning is not rendered
+
+## Validation
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-warnings.test.ts tests/unit/admin-directory-routes.test.ts
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts
+```
+
+Observed result:
+
+- backend test files passed: `2`
+- backend tests passed: `10`
+- frontend test files passed: `1`
+- frontend tests passed: `7`
+
+## Expected Outcome
+
+For a DingTalk tenant where the root department has child departments and only one direct member, the diagnostics should still show:
+
+- root department child count
+- root department direct member count
+
+But it should no longer show the sparse root-member warning unless the root department also fails to return child departments.

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -593,7 +593,7 @@ async function resolveDirectoryTestCurrentConfig(input: DirectoryIntegrationTest
   return parseIntegrationConfig(current)
 }
 
-function buildDirectoryIntegrationTestWarnings(result: {
+export function buildDirectoryIntegrationTestWarnings(result: {
   rootDepartmentId: string
   departmentSampleCount: number
   rootDepartmentDirectUserCount: number
@@ -602,20 +602,23 @@ function buildDirectoryIntegrationTestWarnings(result: {
   rootDepartmentDirectUserHasMoreWithAccessLimit: boolean
 }): string[] {
   const warnings: string[] = []
+  const hasNoChildDepartments = result.departmentSampleCount === 0
+  const hasSuspiciouslySparseRootMembers =
+    result.rootDepartmentDirectUserCount <= 1 && !result.rootDepartmentDirectUserHasMore
 
-  if (result.departmentSampleCount === 0) {
+  if (hasNoChildDepartments) {
     warnings.push(`根部门 ${result.rootDepartmentId} 未返回任何子部门。`)
   }
 
-  if (result.rootDepartmentDirectUserCount <= 1 && !result.rootDepartmentDirectUserHasMore) {
+  if (hasNoChildDepartments && hasSuspiciouslySparseRootMembers) {
     warnings.push(
       `根部门 ${result.rootDepartmentId} 当前仅返回 ${result.rootDepartmentDirectUserCount} 个直属成员；如果钉钉企业通讯录里实际成员更多，通常是应用通讯录接口范围未覆盖，或根部门 ID 配置不正确。`,
     )
   }
 
   if (
-    result.rootDepartmentDirectUserCount <= 1
-    && !result.rootDepartmentDirectUserHasMore
+    hasNoChildDepartments
+    && hasSuspiciouslySparseRootMembers
     && result.rootDepartmentDirectUserCountWithAccessLimit === result.rootDepartmentDirectUserCount
     && result.rootDepartmentDirectUserHasMoreWithAccessLimit === result.rootDepartmentDirectUserHasMore
   ) {

--- a/packages/core-backend/tests/unit/directory-sync-warnings.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-warnings.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { buildDirectoryIntegrationTestWarnings } from '../../src/directory/directory-sync'
+
+describe('buildDirectoryIntegrationTestWarnings', () => {
+  it('keeps scope warnings when the root department returns no child departments', () => {
+    expect(
+      buildDirectoryIntegrationTestWarnings({
+        rootDepartmentId: '1',
+        departmentSampleCount: 0,
+        rootDepartmentDirectUserCount: 1,
+        rootDepartmentDirectUserHasMore: false,
+        rootDepartmentDirectUserCountWithAccessLimit: 1,
+        rootDepartmentDirectUserHasMoreWithAccessLimit: false,
+      }),
+    ).toEqual([
+      '根部门 1 未返回任何子部门。',
+      '根部门 1 当前仅返回 1 个直属成员；如果钉钉企业通讯录里实际成员更多，通常是应用通讯录接口范围未覆盖，或根部门 ID 配置不正确。',
+      '开启“包含访问受限成员”后返回结果没有变化，说明当前问题不是受限成员过滤导致的。',
+    ])
+  })
+
+  it('suppresses root-member warnings when child departments are present', () => {
+    expect(
+      buildDirectoryIntegrationTestWarnings({
+        rootDepartmentId: '1',
+        departmentSampleCount: 4,
+        rootDepartmentDirectUserCount: 1,
+        rootDepartmentDirectUserHasMore: false,
+        rootDepartmentDirectUserCountWithAccessLimit: 1,
+        rootDepartmentDirectUserHasMoreWithAccessLimit: false,
+      }),
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- suppress the sparse root-member warning when the root department already returns child departments
- add focused backend coverage for warning generation
- add a frontend regression test and a short design/validation note

## Why
The DingTalk diagnostics endpoint previously warned that the root department only returned one direct member even for healthy tenants where users mainly belong to child departments. That warning was misleading after the department parser hotfix.

## Validation
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-warnings.test.ts tests/unit/admin-directory-routes.test.ts`
- `pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts`

## Notes
- design and validation doc: `docs/development/dingtalk-directory-warning-suppression-20260411.md`
