### PR TITLE
docs(approvals): refresh wave2 status recheck

### DIFF
--- a/docs/development/approval-pack1a-followup-development-and-verification-20260413.md
+++ b/docs/development/approval-pack1a-followup-development-and-verification-20260413.md
@@ -104,9 +104,44 @@ Local environment note:
 
 ## Known Limits
 
-- return target labels still render `nodeKey`; they do not yet map back to template node names
+- return target labels now resolve to template node names when the template graph is available; they fall back to `nodeKey` only when node metadata cannot be resolved
 - the frontend return candidate list is history-driven, not graph-aware
 - backend lifecycle verification has passed locally, but it still benefits from one CI run against a fuller migrated schema
+
+## Current Recheck - 2026-04-21
+
+Rechecked against `origin/main` @ `923b43ebd` while updating PR `#837`.
+
+Current state:
+
+- `ApprovalDetailView` still exposes the return action and submits `targetNodeKey`.
+- `ApprovalDetailView` timeline still renders `approvalMode`, `aggregateComplete`, auto-approve, and return metadata.
+- `TemplateDetailView` still renders `approvalMode` and `emptyAssigneePolicy` tags.
+- `ApprovalNewView` remains a request-submission form and does not author runtime policy fields.
+- `approvalMode=all` is a same-node assignee aggregation, not a parallel branch/join model.
+- `approvalMode=any` is typed and accepted, but runtime behavior currently follows the same path as `single`.
+
+Recheck verification:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-graph-executor.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  tests/unit/approval-template-routes.test.ts \
+  tests/unit/approval-rbac-boundary.test.ts \
+  --reporter=verbose
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/approval-center.spec.ts \
+  tests/approval-e2e-lifecycle.spec.ts \
+  tests/approval-e2e-permissions.spec.ts \
+  --watch=false
+```
+
+Observed result:
+
+- Backend targeted tests: `36 passed`
+- Frontend targeted tests: `85 passed`
 
 ## Recommended Next Verification
 

--- a/docs/development/approval-wave1-blocker-recheck-and-wave2-pack1-plan-20260413.md
+++ b/docs/development/approval-wave1-blocker-recheck-and-wave2-pack1-plan-20260413.md
@@ -1,307 +1,176 @@
-# 审批 Wave 1 Blocker 复核与 Wave 2 包 1 执行计划
+# 审批 Wave 2 当前状态复核与收口建议
 
-> 日期: `2026-04-13`
-> 基线: `origin/main` @ `713d77898`
+> 日期: `2026-04-21`
+> 当前基线: `origin/main` @ `923b43ebd`
 > 工作分支: `codex/approval-wave2-20260413`
-> 方法: 旧验收文档复核 + 当前主干代码审阅 + Git 历史核对 + 本机最小回归尝试
+> 方法: `#837` 旧文档复核 + 当前代码审阅 + targeted tests + 只读 explorer 后端复核
 
 ---
 
-## 1. 复核结论
+## 1. 结论
 
-截至 `2026-04-13`，平台原生审批 `Wave 1` 仍然没有发现新的代码级 blocker，可以进入 `Wave 2` 设计与实现准备。
+`#837` 的原始结论已经部分过时。当前审批系统不是停留在 2026-04-13 的“准备启动 Wave 2 包 1A”状态，而是已经合入了一部分 Wave 2 节点级能力：
 
-这次复核后的结论分成两类：
+- `approvalMode: 'single' | 'all' | 'any'` 类型已存在。
+- `emptyAssigneePolicy: 'error' | 'auto-approve'` 类型与运行时已存在。
+- `return` action 与 `targetNodeKey` 已存在。
+- 模板详情和审批详情 UI 已能展示一部分新能力。
 
-- 产品 / 代码层面：`无新增 blocker`
-- 环境 / 工作站层面：`有阻塞，但不属于审批产品 blocker`
+但当前实现仍然不是 true parallel / join DAG：
 
----
+- 图执行仍是单路径推进。
+- `condition` 只选择一条分支继续。
+- `approval` 完成后只沿一个 next edge 继续。
+- `cc` 只产生事件，不创建活跃分支。
+- `all` 是“同一审批节点内多审批人聚合”，不是并行分支合流。
 
-## 2. 本次复核输入
+因此，下一步不应再按“从零开始做 Wave 2 包 1A”推进，而应改成：
 
-本次结论基于以下输入：
-
-- 文档:
-  - `docs/development/approval-mvp-wave1-execution-runbook-20260411.md`
-  - `docs/development/approval-mvp-wave1-verification-report-20260411.md`
-  - `docs/development/approval-mvp-wave2-scope-breakdown-20260411.md`
-- 当前主干代码:
-  - `packages/core-backend/src/services/ApprovalProductService.ts`
-  - `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
-  - `packages/core-backend/src/types/approval-product.ts`
-  - `apps/web/src/types/approval.ts`
-- Git 历史核对:
-  - `9092bc1e8 feat(approvals): freeze platform approval v1 contracts`
-  - `68d0f988b feat(approvals): add template runtime executor`
-  - `0958370a2 feat(approvals): add template crud skeleton`
-  - `47303f4bf fix(approvals): harden runtime validation and revoke flow`
-  - `70e6bb381 docs(approvals): add wave1 runbook and wave2 scope`
-  - `03f8ff1c6 docs(approvals): align wave1 acceptance with row-lock runtime`
-
-未发现 `03f8ff1c6` 之后还有新的提交继续修改上述审批核心文件，因此当前 `origin/main` 上的审批实现语义与 `2026-04-11` 收口时保持一致。
+1. 收口并补强当前已落地的节点级能力。
+2. 明确 `any` 语义当前与 `single` 等价，决定是否需要真正做“任一多人审批”。
+3. 将 true parallel / join 继续保留为单独设计包，不混入当前节点级收口。
 
 ---
 
-## 3. Wave 1 真 blocker 复核
+## 2. 当前已验证能力
 
-### 3.1 仍成立的结论
+### 2.1 类型与契约
 
-`docs/development/approval-mvp-wave1-verification-report-20260411.md` 中的 6 个 `BLOCKED` 项，复核后仍然是环境验证项，不是代码级 blocker：
+后端和前端类型均已包含：
 
-| ID | 类别 | 结论 |
-|----|------|------|
-| BL1 | 模板权限 | 仍需真实账号验证 `approval-templates:manage` |
-| BL2 | 发起权限 | 仍需真实账号验证 `approvals:write` |
-| BL3 | 权限矩阵 | 仍需真实环境验证“无权限返回 403” |
-| BL4 | 权限矩阵 | 仍需真实环境验证“只读可看不可操作” |
-| BL5 | 兼容性 | 仍需真实环境验证 PLM 旧链路兼容 |
-| BL6 | 兼容性 | 仍需真实环境验证考勤旧链路兼容 |
+- `ApprovalMode = 'single' | 'all' | 'any'`
+- `EmptyAssigneePolicy = 'error' | 'auto-approve'`
+- `ApprovalActionType` 包含 `return`
+- `ApprovalActionRequest.targetNodeKey`
 
-这些项的状态没有变化，依旧需要真实部署环境、真实用户或 JWT 来关闭。
+涉及文件：
 
-### 3.2 本次代码复核未发现的新 blocker
+- `packages/core-backend/src/types/approval-product.ts`
+- `apps/web/src/types/approval.ts`
 
-本次对当前主干代码的复核结论：
+### 2.2 后端运行时
 
-- 审批节点类型仍只有 `start / approval / cc / condition / end`
-- 审批动作仍只有 `approve / reject / transfer / revoke / comment`
-- `ApprovalProductService.dispatchAction()` 仍使用 `SELECT ... FOR UPDATE` 行锁串行化，而不是客户端版本号 optimistic locking
-- `ApprovalGraphExecutor` 仍是线性推进 + 条件分支模型，不支持 true parallel / join
-- 表单校验仍覆盖 `required / 基础类型 / options / min/max / pattern`
-- `revoke` 策略检查与 `cc` 历史落库逻辑仍存在
+当前后端支持的真实语义：
 
-结论：当前主干与 Wave 1 交付边界一致，没有出现“Wave 1 已被后续提交打穿”的迹象。
+- `single`: 当前审批人通过后，当前节点完成并推进到下一节点。
+- `all`: 同一审批节点下所有活跃 assignee 都处理后才推进；未全部完成时实例保持 pending。
+- `any`: 当前代码没有独立分支，实际走与 `single` 相同的推进路径。
+- `emptyAssigneePolicy=auto-approve`: 空审批人节点会自动通过并继续向后解析。
+- `emptyAssigneePolicy=error`: 默认失败路径，空审批人节点会报错。
+- `return`: 仅 template-runtime approvals 支持，且 `targetNodeKey` 必须是当前路径上先前访问过的 approval 节点。
 
----
+涉及文件：
 
-## 4. 新电脑环境复核结果
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/src/routes/approvals.ts`
 
-本次尝试在新电脑上复跑审批相关最小验证，结果是“工作站依赖未装全”，不是审批代码回归。
+### 2.3 前端展示与动作
 
-### 4.1 已确认
+当前前端已覆盖的消费面：
 
-- `pnpm` 未安装到本机 PATH
-- 可以通过 `npx pnpm@10` 临时执行
-- 当前根仓库 `node_modules` 不完整
+- 模板详情页展示 `approvalMode` 标签。
+- 模板详情页展示 `emptyAssigneePolicy` 标签。
+- 审批详情页展示 `approvalMode` / `aggregateComplete` 等 timeline metadata。
+- 审批详情页展示 `return` 事件 metadata。
+- 审批详情页在存在可退回节点时提供 `return` 操作入口，并提交 `targetNodeKey`。
 
-### 4.2 实际复跑结果
+涉及文件：
 
-尝试执行：
-
-```bash
-npx --yes pnpm@10 --filter @metasheet/core-backend exec vitest run \
-  tests/unit/approval-graph-executor.test.ts \
-  tests/unit/approval-product-service.test.ts \
-  tests/unit/approval-template-routes.test.ts --reporter=dot
-
-npx --yes pnpm@10 --filter @metasheet/core-backend exec tsc --noEmit --pretty false
-```
-
-得到的失败均为工作站依赖缺失，例如：
-
-- `Failed to load url uuid`
-- `Cannot find module 'pg'`
-- `Cannot find module 'express'`
-- `Cannot find module 'kysely'`
-
-### 4.3 结论
-
-这说明当前新电脑不具备完整的本地验证环境，不能把这类失败误判成审批产品 blocker。
-
-建议把这件事单列为工作站准备项：
-
-1. 安装 `pnpm`
-2. 在仓库根目录补齐 workspace 依赖
-3. 再复跑审批相关最小套件
-
-在此之前，`Wave 2` 可以继续做契约与切片设计，但不应声称“本机已经完成重新验收”。
+- `apps/web/src/views/approval/TemplateDetailView.vue`
+- `apps/web/src/views/approval/ApprovalDetailView.vue`
 
 ---
 
-## 5. Wave 2 包 1 的正确切法
+## 3. 仍未支持或仍需收口的点
 
-`docs/development/approval-mvp-wave2-scope-breakdown-20260411.md` 把 `并行分支 / 会签 / 或签 / return 到指定节点 / 空审批人自动通过` 放在同一个工作包里，这个方向对，但如果一次性全上，会把执行器从“线性 + 条件分支”直接抬到“部分 DAG + 聚合状态机”，风险过高。
+### 3.1 不支持 true parallel / join
 
-这次复核后的建议是：
+当前执行器仍是单活跃节点模型。`current_node_key/current_step/total_steps` 也仍然偏向单路径表达，不适合表示多个同时活跃分支。
 
-- `Wave 2 包 1` 先做“审批节点能力扩展”
-- `true parallel / join` 单独拆成 `Wave 2 包 1B`
+不要把当前 `all` 称为“并行审批”。它只是单节点多审批人聚合。
 
-也就是说，先做能在当前图模型上增量落地的能力，不在第一刀里强行引入 DAG 级复杂度。
+### 3.2 `any` 语义需明确
 
----
+当前 `any` 在类型和配置校验层存在，但运行时没有独立逻辑；实际效果与 `single` 一致。
 
-## 6. 建议执行范围
+如果产品定义中 `any` 只是“多人中任一人处理即可”，当前行为基本可接受，但需要补文档和显式测试。如果产品定义要求更复杂的候选组/多 assignment 剩余清理语义，则需要单独补实现和回归。
 
-### 6.1 Wave 2 包 1A: 审批节点能力扩展
+### 3.3 `return` 范围需明确
 
-这是建议立即启动的包。
+当前 `return` 不是通用 legacy approval action。它依赖 template runtime graph，只能退回当前路径上已访问过的 approval 节点。
 
-目标能力：
+这条限制应该写进 API 文档和前端提示，避免用户以为可以任意退回任意节点。
 
-- 会签: 同一审批节点支持 `all`
-- 或签: 同一审批节点支持 `any`
-- `return` 到指定已走过节点
-- 审批人为空自动通过
+### 3.4 UI authoring 仍需确认
 
-建议的最小契约扩展：
-
-- `approval` 节点配置新增 `approvalMode: 'single' | 'all' | 'any'`
-- `approval` 节点配置新增空审批人策略
-  - 推荐命名: `emptyAssigneePolicy: 'error' | 'auto-approve'`
-  - 默认值保持保守，建议为 `error`
-- `ApprovalActionRequest` 新增 `return`
-- `return` 请求体新增 `targetNodeKey`
-- 历史时间线增加多审批人聚合结果表达
-
-保持不变的点：
-
-- 图拓扑仍是 `start / approval / cc / condition / end`
-- 不新增并行分支节点
-- 不新增 join 节点
-- 不改 PLM / 考勤接入边界
-
-### 6.2 Wave 2 包 1B: 真并行与聚合节点
-
-这一包建议后置，不和 `1A` 同时开。
-
-原因：
-
-- 当前 `ApprovalGraphExecutor.resolveAfterApprove()` 是单路径推进
-- 当前实例态只有 `current_node_key/current_step/total_steps`，不适合表达多活跃节点
-- 真并行意味着需要 join 条件、分支完成度、实例聚合状态，已经不是“给 approval 节点多加几个字段”能解决的事
-
-因此 `1B` 至少要单独评审：
-
-- 图模型是否允许多活跃节点
-- 实例表是否需要新的运行时状态字段
-- 历史与 assignment 如何表达 branch / join
-
-在这些问题没定稿前，不建议把 true parallel 放进 `1A`。
+当前前端已能展示 `approvalMode`、`emptyAssigneePolicy`，也能在审批详情页执行 `return`。但模板设计/编辑侧是否完整支持创建这些配置，需要另行做 UI round-trip 验证。
 
 ---
 
-## 7. Wave 2 包 1A 的实现切片
+## 4. Wave 1 blocker 复核
 
-### 切片 1: 契约冻结
+原 Wave 1 报告里的真实环境项仍然不能通过本地单测完全替代：
 
-由主线 owner 负责。
+| ID | 类别 | 当前状态 |
+| --- | --- | --- |
+| BL1 | 模板权限 | 本地 RBAC route tests 已覆盖 401/403/200 关键路径；真实账号仍需 staging 验证 |
+| BL2 | 发起权限 | 本地 RBAC route tests 已覆盖只读不可写；真实账号仍需 staging 验证 |
+| BL3 | 权限矩阵 | 本地 permission matrix integration 已覆盖；真实账号仍需 staging 验证 |
+| BL4 | 只读行为 | 本地后端边界已覆盖；真实 UI 点击仍需 staging 验证 |
+| BL5 | PLM 旧链路兼容 | 本次未复跑真实 PLM 联动 |
+| BL6 | 考勤旧链路兼容 | 本次未复跑真实考勤联动 |
 
-内容：
-
-- `approval-product.ts` 类型扩展
-- `apps/web/src/types/approval.ts` 同步
-- OpenAPI 契约同步
-- `return` 语义与错误码固定
-- `all / any / single` 的历史表达和响应字段固定
-
-验收标准：
-
-- 后端类型、前端类型、OpenAPI 三者一致
-- 对旧模板完全向后兼容
-
-### 切片 2: Executor / Service
-
-由主线 owner 负责。
-
-内容：
-
-- `ApprovalGraphExecutor` 支持 `single / all / any`
-- `ApprovalProductService.dispatchAction()` 支持 `return`
-- 同节点聚合审批结果写入 `approval_records`
-- 空审批人策略在运行时兑现
-
-关键约束：
-
-- 默认行为必须继续兼容当前 `single`
-- 不允许把现有 `approve/reject/transfer/revoke/comment` 语义打坏
-
-### 切片 3: 后端测试
-
-由主线 owner 负责。
-
-至少补齐：
-
-- `single` 回归不变
-- `all` 要求所有审批人处理后才推进
-- `any` 任意一人通过即可推进
-- `return` 只能退回到合法已走过审批节点
-- `emptyAssigneePolicy=auto-approve` 能自动推进
-- 历史时间线能表达聚合节点结果
-
-### 切片 4: 前端消费与 UI 标注
-
-可以并行给 Claude，但前提是切片 1 已冻结。
-
-内容：
-
-- 审批详情页展示 `会签 / 或签 / 单审` 标签
-- 动作区支持 `return`
-- 多审批人节点的状态文案、空状态、错误态
-- 模板设计页 / 模板详情页展示新配置
-
-### 切片 5: 文档与验收
-
-可以并行给 Claude。
-
-内容：
-
-- API 指南补 `return / all / any / empty-assignee`
-- Wave 2 包 1A 验收条目
-- 与飞书审批差距表更新
+与 2026-04-13 文档不同的是：本地依赖环境已可运行审批 targeted tests，不再是“pnpm / uuid / pg / express / kysely 缺失”的工作站阻塞。
 
 ---
 
-## 8. 我与 Claude 的推荐分工
+## 5. 推荐下一步
 
-### 我负责
+### 5.1 立即做: Wave 2 节点能力收口
 
-- 契约冻结
-- `ApprovalGraphExecutor` 语义
-- `ApprovalProductService` 动作推进
-- 后端测试
-- 兼容边界与 PR 收口
+建议开一个新的实现包，目标不是大改 DAG，而是把当前已存在的节点能力补齐到可发布状态：
 
-### Claude 负责
+- 给 `any` 补显式运行时测试，确认它与 `single` 的产品语义是否一致。
+- 给 `all` 补“最后一个审批人处理后推进”的显式测试。
+- 给 `return` 补更多非法目标测试，包括非 approval 节点、未访问节点、当前节点自身。
+- 给 `emptyAssigneePolicy=error` 补显式失败测试。
+- 补 API 文档，明确 `return` 和 `all/any/single` 的边界。
+- 补模板配置 UI round-trip 验证，确认能创建并保存新配置。
 
-- 契约冻结后的前端 UI 消费
-- 文档与差距表更新
-- 只读 / 展示类测试
-- Wave 2 包 1A 的前端产品壳演进
+### 5.2 暂缓做: true parallel / join
 
-### 当前不建议交给 Claude 的部分
+true parallel / join 需要单独设计，不建议混入当前包：
 
-- executor 运行时语义
-- 多审批人聚合状态
-- `return` 的服务端边界
-- 任何需要改运行时表语义的后端逻辑
+- 多活跃节点状态模型。
+- join 完成条件。
+- assignment 与 history 的 branch metadata。
+- return/revoke 在多分支上的语义。
 
-原因很直接：这些部分一旦做错，不是 UI 小修，而是审批状态机出错。
+在这些契约没冻结前，不应直接改 `ApprovalGraphExecutor` 成 DAG 聚合状态机。
 
 ---
 
-## 9. 下一步顺序
+## 6. 本轮验证摘要
 
-建议按下面顺序推进：
+本轮在 rebase 到 `origin/main` @ `923b43ebd` 后执行了 targeted tests：
 
-1. 先把新电脑的依赖环境补齐，恢复最小本地验证能力
-2. 开 `Wave 2 包 1A` 契约冻结 PR
-3. 契约冻结后，Claude 开始前端消费与文档并行块
-4. 主线同时做 executor / service / tests
-5. `1A` 稳定后，再评审是否开启 `1B true parallel`
+- 后端审批 targeted tests: `36/36 passed`
+- 前端审批 targeted tests: `85/85 passed`
+- `git diff --check`: passed
+
+完整命令和输出摘要见：
+
+- `docs/development/approval-wave2-current-state-verification-20260421.md`
 
 ---
 
-## 10. 最终判断
+## 7. 合并建议
 
-当前最稳妥的判断是：
+`#837` 现在应作为“当前审批 Wave 2 状态复核与下一步收口建议”文档合入，而不是作为旧版“准备启动 1A”的计划合入。
 
-- `Wave 1` 没有新增代码 blocker
-- 当前真正阻塞的是:
-  - 真实环境的 6 个验收项未关闭
-  - 新电脑本地依赖未装全
-- `Wave 2` 不应该直接上“大并行 DAG”
-- 应先启动 `Wave 2 包 1A: 会签 / 或签 / return / 空审批人自动通过`
+合入后，建议新开实际实现 PR：
 
-这是当前最小、最稳、能继续并行开发的切法。
+- `Wave 2 node capability hardening`
+- 范围只包含 `single/all/any/return/emptyAssigneePolicy` 的测试、文档和小修
+- 不包含 true parallel / join

--- a/docs/development/approval-wave1-blocker-recheck-and-wave2-pack1-plan-20260413.md
+++ b/docs/development/approval-wave1-blocker-recheck-and-wave2-pack1-plan-20260413.md
@@ -1,0 +1,307 @@
+# 审批 Wave 1 Blocker 复核与 Wave 2 包 1 执行计划
+
+> 日期: `2026-04-13`
+> 基线: `origin/main` @ `713d77898`
+> 工作分支: `codex/approval-wave2-20260413`
+> 方法: 旧验收文档复核 + 当前主干代码审阅 + Git 历史核对 + 本机最小回归尝试
+
+---
+
+## 1. 复核结论
+
+截至 `2026-04-13`，平台原生审批 `Wave 1` 仍然没有发现新的代码级 blocker，可以进入 `Wave 2` 设计与实现准备。
+
+这次复核后的结论分成两类：
+
+- 产品 / 代码层面：`无新增 blocker`
+- 环境 / 工作站层面：`有阻塞，但不属于审批产品 blocker`
+
+---
+
+## 2. 本次复核输入
+
+本次结论基于以下输入：
+
+- 文档:
+  - `docs/development/approval-mvp-wave1-execution-runbook-20260411.md`
+  - `docs/development/approval-mvp-wave1-verification-report-20260411.md`
+  - `docs/development/approval-mvp-wave2-scope-breakdown-20260411.md`
+- 当前主干代码:
+  - `packages/core-backend/src/services/ApprovalProductService.ts`
+  - `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+  - `packages/core-backend/src/types/approval-product.ts`
+  - `apps/web/src/types/approval.ts`
+- Git 历史核对:
+  - `9092bc1e8 feat(approvals): freeze platform approval v1 contracts`
+  - `68d0f988b feat(approvals): add template runtime executor`
+  - `0958370a2 feat(approvals): add template crud skeleton`
+  - `47303f4bf fix(approvals): harden runtime validation and revoke flow`
+  - `70e6bb381 docs(approvals): add wave1 runbook and wave2 scope`
+  - `03f8ff1c6 docs(approvals): align wave1 acceptance with row-lock runtime`
+
+未发现 `03f8ff1c6` 之后还有新的提交继续修改上述审批核心文件，因此当前 `origin/main` 上的审批实现语义与 `2026-04-11` 收口时保持一致。
+
+---
+
+## 3. Wave 1 真 blocker 复核
+
+### 3.1 仍成立的结论
+
+`docs/development/approval-mvp-wave1-verification-report-20260411.md` 中的 6 个 `BLOCKED` 项，复核后仍然是环境验证项，不是代码级 blocker：
+
+| ID | 类别 | 结论 |
+|----|------|------|
+| BL1 | 模板权限 | 仍需真实账号验证 `approval-templates:manage` |
+| BL2 | 发起权限 | 仍需真实账号验证 `approvals:write` |
+| BL3 | 权限矩阵 | 仍需真实环境验证“无权限返回 403” |
+| BL4 | 权限矩阵 | 仍需真实环境验证“只读可看不可操作” |
+| BL5 | 兼容性 | 仍需真实环境验证 PLM 旧链路兼容 |
+| BL6 | 兼容性 | 仍需真实环境验证考勤旧链路兼容 |
+
+这些项的状态没有变化，依旧需要真实部署环境、真实用户或 JWT 来关闭。
+
+### 3.2 本次代码复核未发现的新 blocker
+
+本次对当前主干代码的复核结论：
+
+- 审批节点类型仍只有 `start / approval / cc / condition / end`
+- 审批动作仍只有 `approve / reject / transfer / revoke / comment`
+- `ApprovalProductService.dispatchAction()` 仍使用 `SELECT ... FOR UPDATE` 行锁串行化，而不是客户端版本号 optimistic locking
+- `ApprovalGraphExecutor` 仍是线性推进 + 条件分支模型，不支持 true parallel / join
+- 表单校验仍覆盖 `required / 基础类型 / options / min/max / pattern`
+- `revoke` 策略检查与 `cc` 历史落库逻辑仍存在
+
+结论：当前主干与 Wave 1 交付边界一致，没有出现“Wave 1 已被后续提交打穿”的迹象。
+
+---
+
+## 4. 新电脑环境复核结果
+
+本次尝试在新电脑上复跑审批相关最小验证，结果是“工作站依赖未装全”，不是审批代码回归。
+
+### 4.1 已确认
+
+- `pnpm` 未安装到本机 PATH
+- 可以通过 `npx pnpm@10` 临时执行
+- 当前根仓库 `node_modules` 不完整
+
+### 4.2 实际复跑结果
+
+尝试执行：
+
+```bash
+npx --yes pnpm@10 --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-graph-executor.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  tests/unit/approval-template-routes.test.ts --reporter=dot
+
+npx --yes pnpm@10 --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+得到的失败均为工作站依赖缺失，例如：
+
+- `Failed to load url uuid`
+- `Cannot find module 'pg'`
+- `Cannot find module 'express'`
+- `Cannot find module 'kysely'`
+
+### 4.3 结论
+
+这说明当前新电脑不具备完整的本地验证环境，不能把这类失败误判成审批产品 blocker。
+
+建议把这件事单列为工作站准备项：
+
+1. 安装 `pnpm`
+2. 在仓库根目录补齐 workspace 依赖
+3. 再复跑审批相关最小套件
+
+在此之前，`Wave 2` 可以继续做契约与切片设计，但不应声称“本机已经完成重新验收”。
+
+---
+
+## 5. Wave 2 包 1 的正确切法
+
+`docs/development/approval-mvp-wave2-scope-breakdown-20260411.md` 把 `并行分支 / 会签 / 或签 / return 到指定节点 / 空审批人自动通过` 放在同一个工作包里，这个方向对，但如果一次性全上，会把执行器从“线性 + 条件分支”直接抬到“部分 DAG + 聚合状态机”，风险过高。
+
+这次复核后的建议是：
+
+- `Wave 2 包 1` 先做“审批节点能力扩展”
+- `true parallel / join` 单独拆成 `Wave 2 包 1B`
+
+也就是说，先做能在当前图模型上增量落地的能力，不在第一刀里强行引入 DAG 级复杂度。
+
+---
+
+## 6. 建议执行范围
+
+### 6.1 Wave 2 包 1A: 审批节点能力扩展
+
+这是建议立即启动的包。
+
+目标能力：
+
+- 会签: 同一审批节点支持 `all`
+- 或签: 同一审批节点支持 `any`
+- `return` 到指定已走过节点
+- 审批人为空自动通过
+
+建议的最小契约扩展：
+
+- `approval` 节点配置新增 `approvalMode: 'single' | 'all' | 'any'`
+- `approval` 节点配置新增空审批人策略
+  - 推荐命名: `emptyAssigneePolicy: 'error' | 'auto-approve'`
+  - 默认值保持保守，建议为 `error`
+- `ApprovalActionRequest` 新增 `return`
+- `return` 请求体新增 `targetNodeKey`
+- 历史时间线增加多审批人聚合结果表达
+
+保持不变的点：
+
+- 图拓扑仍是 `start / approval / cc / condition / end`
+- 不新增并行分支节点
+- 不新增 join 节点
+- 不改 PLM / 考勤接入边界
+
+### 6.2 Wave 2 包 1B: 真并行与聚合节点
+
+这一包建议后置，不和 `1A` 同时开。
+
+原因：
+
+- 当前 `ApprovalGraphExecutor.resolveAfterApprove()` 是单路径推进
+- 当前实例态只有 `current_node_key/current_step/total_steps`，不适合表达多活跃节点
+- 真并行意味着需要 join 条件、分支完成度、实例聚合状态，已经不是“给 approval 节点多加几个字段”能解决的事
+
+因此 `1B` 至少要单独评审：
+
+- 图模型是否允许多活跃节点
+- 实例表是否需要新的运行时状态字段
+- 历史与 assignment 如何表达 branch / join
+
+在这些问题没定稿前，不建议把 true parallel 放进 `1A`。
+
+---
+
+## 7. Wave 2 包 1A 的实现切片
+
+### 切片 1: 契约冻结
+
+由主线 owner 负责。
+
+内容：
+
+- `approval-product.ts` 类型扩展
+- `apps/web/src/types/approval.ts` 同步
+- OpenAPI 契约同步
+- `return` 语义与错误码固定
+- `all / any / single` 的历史表达和响应字段固定
+
+验收标准：
+
+- 后端类型、前端类型、OpenAPI 三者一致
+- 对旧模板完全向后兼容
+
+### 切片 2: Executor / Service
+
+由主线 owner 负责。
+
+内容：
+
+- `ApprovalGraphExecutor` 支持 `single / all / any`
+- `ApprovalProductService.dispatchAction()` 支持 `return`
+- 同节点聚合审批结果写入 `approval_records`
+- 空审批人策略在运行时兑现
+
+关键约束：
+
+- 默认行为必须继续兼容当前 `single`
+- 不允许把现有 `approve/reject/transfer/revoke/comment` 语义打坏
+
+### 切片 3: 后端测试
+
+由主线 owner 负责。
+
+至少补齐：
+
+- `single` 回归不变
+- `all` 要求所有审批人处理后才推进
+- `any` 任意一人通过即可推进
+- `return` 只能退回到合法已走过审批节点
+- `emptyAssigneePolicy=auto-approve` 能自动推进
+- 历史时间线能表达聚合节点结果
+
+### 切片 4: 前端消费与 UI 标注
+
+可以并行给 Claude，但前提是切片 1 已冻结。
+
+内容：
+
+- 审批详情页展示 `会签 / 或签 / 单审` 标签
+- 动作区支持 `return`
+- 多审批人节点的状态文案、空状态、错误态
+- 模板设计页 / 模板详情页展示新配置
+
+### 切片 5: 文档与验收
+
+可以并行给 Claude。
+
+内容：
+
+- API 指南补 `return / all / any / empty-assignee`
+- Wave 2 包 1A 验收条目
+- 与飞书审批差距表更新
+
+---
+
+## 8. 我与 Claude 的推荐分工
+
+### 我负责
+
+- 契约冻结
+- `ApprovalGraphExecutor` 语义
+- `ApprovalProductService` 动作推进
+- 后端测试
+- 兼容边界与 PR 收口
+
+### Claude 负责
+
+- 契约冻结后的前端 UI 消费
+- 文档与差距表更新
+- 只读 / 展示类测试
+- Wave 2 包 1A 的前端产品壳演进
+
+### 当前不建议交给 Claude 的部分
+
+- executor 运行时语义
+- 多审批人聚合状态
+- `return` 的服务端边界
+- 任何需要改运行时表语义的后端逻辑
+
+原因很直接：这些部分一旦做错，不是 UI 小修，而是审批状态机出错。
+
+---
+
+## 9. 下一步顺序
+
+建议按下面顺序推进：
+
+1. 先把新电脑的依赖环境补齐，恢复最小本地验证能力
+2. 开 `Wave 2 包 1A` 契约冻结 PR
+3. 契约冻结后，Claude 开始前端消费与文档并行块
+4. 主线同时做 executor / service / tests
+5. `1A` 稳定后，再评审是否开启 `1B true parallel`
+
+---
+
+## 10. 最终判断
+
+当前最稳妥的判断是：
+
+- `Wave 1` 没有新增代码 blocker
+- 当前真正阻塞的是:
+  - 真实环境的 6 个验收项未关闭
+  - 新电脑本地依赖未装全
+- `Wave 2` 不应该直接上“大并行 DAG”
+- 应先启动 `Wave 2 包 1A: 会签 / 或签 / return / 空审批人自动通过`
+
+这是当前最小、最稳、能继续并行开发的切法。

--- a/docs/development/approval-wave2-current-state-verification-20260421.md
+++ b/docs/development/approval-wave2-current-state-verification-20260421.md
@@ -1,0 +1,129 @@
+# 审批 Wave 2 当前状态验证记录 2026-04-21
+
+## 环境
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/approval-wave2-20260413`
+- Branch: `codex/approval-wave2-20260413`
+- Rebased base: `origin/main` @ `923b43ebd`
+- PR: `#837`
+
+## 代码复核范围
+
+后端：
+
+- `packages/core-backend/src/types/approval-product.ts`
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/src/routes/approvals.ts`
+
+前端：
+
+- `apps/web/src/types/approval.ts`
+- `apps/web/src/views/approval/ApprovalDetailView.vue`
+- `apps/web/src/views/approval/TemplateDetailView.vue`
+- `apps/web/src/approvals/*`
+
+## 命令与结果
+
+### Worktree dependencies
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+结果：通过。
+
+备注：
+
+- 首次补充 typecheck 时，隔离 worktree 缺少 `yjs` / `y-protocols` / `lib0` 依赖解析，导致前后端 typecheck 失败。
+- 执行 `pnpm install --frozen-lockfile` 后依赖解析恢复。
+- `pnpm install` 造成 `plugins/*/node_modules` 和 `tools/cli/node_modules` 的本地链接噪声；这些文件未纳入提交。
+
+### 后端审批 targeted tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-graph-executor.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  tests/unit/approval-template-routes.test.ts \
+  tests/unit/approval-rbac-boundary.test.ts \
+  --reporter=verbose
+```
+
+结果：
+
+```text
+Test Files  4 passed (4)
+Tests       36 passed (36)
+```
+
+覆盖点：
+
+- `ApprovalGraphExecutor` 初始节点解析、条件节点、空审批人 auto-approve、return visited-node 列表。
+- `ApprovalProductService` revoke 策略、return 合法性、return 重新分配、all-mode 未全部处理时保持 pending。
+- approval template routes 创建、更新、发布、列表和版本详情。
+- approval RBAC 401/403/200 权限边界。
+
+### 前端审批 targeted tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/approval-center.spec.ts \
+  tests/approval-e2e-lifecycle.spec.ts \
+  tests/approval-e2e-permissions.spec.ts \
+  --watch=false
+```
+
+结果：
+
+```text
+Test Files  3 passed (3)
+Tests       85 passed (85)
+```
+
+备注：
+
+- 测试期间 jsdom 输出既有 `el-icon` component resolution warning。
+- 该 warning 没有导致测试失败。
+
+覆盖点：
+
+- Approval center 基础渲染和加载。
+- 发起、详情、历史、模板中心、模板详情等前端生命周期。
+- 权限态、return 按钮、return target 提交、approvalMode / emptyAssigneePolicy 展示、timeline metadata 展示。
+
+### Diff 检查
+
+```bash
+git diff --check
+```
+
+结果：通过。
+
+### Typecheck
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+结果：通过。
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+结果：通过。
+
+## 当前结论
+
+- 本地依赖环境已可运行审批 targeted tests，不再复现 2026-04-13 文档里的 dependency-missing 阻塞。
+- 当前实现已经具备部分 Wave 2 节点级能力。
+- 当前实现仍不是 true parallel / join DAG。
+- #837 应更新为当前状态复核文档后再合入。
+
+## 未验证项
+
+- 未连接真实 staging 用户关闭 Wave 1 的 6 个真实环境验收项。
+- 未做 PLM / 考勤真实链路联动。
+- 未跑全仓 `pnpm test`。
+- 未验证模板配置 UI 是否能完整 author `approvalMode` / `emptyAssigneePolicy` 并 round-trip 保存。


### PR DESCRIPTION
## Summary
- rebases #837 onto current main and replaces the stale 2026-04-13 plan with a current Wave 2 status recheck
- documents that node-level capabilities are partly implemented: approvalMode, emptyAssigneePolicy, and return targetNodeKey
- clarifies remaining boundaries: no true parallel/join DAG, any currently follows single, return is template-runtime and visited-node constrained
- adds a dedicated verification MD and updates the Pack1A follow-up known limits

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts tests/unit/approval-template-routes.test.ts tests/unit/approval-rbac-boundary.test.ts --reporter=verbose
- pnpm --filter @metasheet/web exec vitest run tests/approval-center.spec.ts tests/approval-e2e-lifecycle.spec.ts tests/approval-e2e-permissions.spec.ts --watch=false
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- git diff --check

## Notes
- local worktree has pnpm-generated node_modules link noise under plugins/* and tools/cli; not committed
- real staging RBAC/PLM/attendance checks still need valid remote credentials