### PR TITLE
feat(approvals): freeze pack1a action and node contracts

### DIFF
--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -9,7 +9,9 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment'
+export type ApprovalMode = 'single' | 'all' | 'any'
+export type EmptyAssigneePolicy = 'error' | 'auto-approve'
+export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
 export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
 export type FormFieldType =
@@ -33,6 +35,8 @@ export interface ApprovalNode {
 export interface ApprovalNodeConfig {
   assigneeType: ApprovalAssigneeType
   assigneeIds: string[]
+  approvalMode?: ApprovalMode
+  emptyAssigneePolicy?: EmptyAssigneePolicy
 }
 
 export interface ConditionNodeConfig {
@@ -170,6 +174,7 @@ export interface ApprovalActionRequest {
   action: ApprovalActionType
   comment?: string
   targetUserId?: string
+  targetNodeKey?: string
 }
 
 export interface ApprovalTemplateListItemDTO {

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -528,17 +528,18 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       }
 
       const action = req.body?.action
-      if (!['approve', 'reject', 'transfer', 'revoke', 'comment'].includes(String(action))) {
+      if (!['approve', 'reject', 'transfer', 'revoke', 'comment', 'return'].includes(String(action))) {
         return res.status(400).json({
           error: {
             code: 'VALIDATION_ERROR',
-            message: 'action must be approve, reject, transfer, revoke, or comment',
+            message: 'action must be approve, reject, transfer, revoke, comment, or return',
           },
         })
       }
 
       const comment = typeof req.body?.comment === 'string' ? req.body.comment : undefined
       const targetUserId = typeof req.body?.targetUserId === 'string' ? req.body.targetUserId.trim() : undefined
+      const targetNodeKey = typeof req.body?.targetNodeKey === 'string' ? req.body.targetNodeKey.trim() : undefined
       const actor = {
         userId,
         userName: resolveApprovalActorName(req, userId),
@@ -590,6 +591,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
               action,
               comment,
               targetUserId,
+              targetNodeKey,
             },
             actor,
           )

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1,12 +1,15 @@
 import crypto from 'crypto'
 import { pool } from '../db/pg'
 import type {
+  ApprovalActionRequest,
   ApprovalTemplateDetailDTO,
   ApprovalTemplateListItemDTO,
   ApprovalTemplateVersionDetailDTO,
   ApprovalGraph,
+  ApprovalMode,
   CreateApprovalRequest,
   CreateApprovalTemplateRequest,
+  EmptyAssigneePolicy,
   FormSchema,
   PublishApprovalTemplateRequest,
   RuntimeGraph,
@@ -15,7 +18,6 @@ import type {
 } from '../types/approval-product'
 import { ApprovalGraphExecutor, validateApprovalFormData } from './ApprovalGraphExecutor'
 import type {
-  ApprovalActionRequest,
   ApprovalAssignmentDTO,
   ApprovalAssignmentRow,
   ApprovalInstanceRow,
@@ -143,6 +145,8 @@ const FORM_FIELD_TYPES = new Set([
 
 const APPROVAL_NODE_TYPES = new Set(['start', 'approval', 'cc', 'condition', 'end'])
 const CONDITION_OPERATORS = new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'isEmpty'])
+const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any'])
+const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve'])
 
 function toNullableRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -156,6 +160,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0
+}
+
+function normalizeApprovalMode(value: unknown, context: ValidationContext, path: string): ApprovalMode | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || !APPROVAL_MODES.has(value as ApprovalMode)) {
+    failValidation(context, `${path} must be single, all, or any`)
+  }
+  return value as ApprovalMode
+}
+
+function normalizeEmptyAssigneePolicy(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): EmptyAssigneePolicy | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || !EMPTY_ASSIGNEE_POLICIES.has(value as EmptyAssigneePolicy)) {
+    failValidation(context, `${path} must be error or auto-approve`)
+  }
+  return value as EmptyAssigneePolicy
 }
 
 function failValidation(context: ValidationContext, message: string): never {
@@ -285,9 +309,23 @@ function normalizeApprovalGraph(value: unknown, context: ValidationContext): App
           || node.config.assigneeIds.some((entry) => !isNonEmptyString(entry))) {
           failValidation(context, `approvalGraph.nodes[${index}].config must define assigneeType and assigneeIds`)
         }
-        normalizedNode.config = {
-          assigneeType: node.config.assigneeType,
-          assigneeIds: node.config.assigneeIds.map((entry) => entry.trim()),
+        {
+          const approvalMode = normalizeApprovalMode(
+            node.config.approvalMode,
+            context,
+            `approvalGraph.nodes[${index}].config.approvalMode`,
+          )
+          const emptyAssigneePolicy = normalizeEmptyAssigneePolicy(
+            node.config.emptyAssigneePolicy,
+            context,
+            `approvalGraph.nodes[${index}].config.emptyAssigneePolicy`,
+          )
+          normalizedNode.config = {
+            assigneeType: node.config.assigneeType,
+            assigneeIds: node.config.assigneeIds.map((entry) => entry.trim()),
+            ...(approvalMode ? { approvalMode } : {}),
+            ...(emptyAssigneePolicy ? { emptyAssigneePolicy } : {}),
+          }
         }
         break
       case 'cc':
@@ -990,6 +1028,13 @@ export class ApprovalProductService {
         `SELECT * FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY created_at ASC`,
         [id],
       )
+
+      if (request.action === 'return') {
+        if (!request.targetNodeKey?.trim()) {
+          throw new ServiceError('targetNodeKey is required for return', 400, 'VALIDATION_ERROR')
+        }
+        throw new ServiceError('Return action is not implemented yet', 409, 'APPROVAL_ACTION_NOT_SUPPORTED')
+      }
 
       const actorRoles = actor.roles || []
       const actorCanAct = assignments.rows.some((assignment) => assignmentMatchesActor(assignment, actor.userId, actorRoles))

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -9,7 +9,9 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment'
+export type ApprovalMode = 'single' | 'all' | 'any'
+export type EmptyAssigneePolicy = 'error' | 'auto-approve'
+export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
 export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
 export type FormFieldType =
@@ -33,6 +35,8 @@ export interface ApprovalNode {
 export interface ApprovalNodeConfig {
   assigneeType: ApprovalAssigneeType
   assigneeIds: string[]
+  approvalMode?: ApprovalMode
+  emptyAssigneePolicy?: EmptyAssigneePolicy
 }
 
 export interface ConditionNodeConfig {
@@ -170,6 +174,7 @@ export interface ApprovalActionRequest {
   action: ApprovalActionType
   comment?: string
   targetUserId?: string
+  targetNodeKey?: string
 }
 
 export interface ApprovalTemplateListItemDTO {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -193,4 +193,80 @@ describe('ApprovalProductService', () => {
 
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
+
+  it('rejects return actions until pack 1A runtime semantics are implemented', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'apr-1',
+            status: 'pending',
+            version: 4,
+            source_system: 'platform',
+            external_approval_id: null,
+            workflow_key: 'approval-product-template',
+            business_key: 'travel-request',
+            title: 'Travel Request',
+            requester_snapshot: { id: 'user-1', name: 'Owner One' },
+            subject_snapshot: {},
+            policy_snapshot: { allowRevoke: true },
+            metadata: {},
+            current_step: 1,
+            total_steps: 1,
+            source_updated_at: null,
+            last_synced_at: null,
+            sync_status: 'ok',
+            sync_error: null,
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            published_definition_id: 'pub-1',
+            request_no: 'AP-100001',
+            form_snapshot: {},
+            current_node_key: 'approval_1',
+            created_at: new Date('2026-04-11T00:00:00.000Z'),
+            updated_at: new Date('2026-04-11T00:05:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return { rows: [], rowCount: 0 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await expect(service.dispatchAction(
+      'apr-1',
+      { action: 'return', targetNodeKey: 'approval_1' },
+      { userId: 'user-1' },
+    )).rejects.toMatchObject({
+      message: 'Return action is not implemented yet',
+      statusCode: 409,
+      code: 'APPROVAL_ACTION_NOT_SUPPORTED',
+    })
+
+    expect(pgState.client.release).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/core-backend/tests/unit/approval-template-routes.test.ts
+++ b/packages/core-backend/tests/unit/approval-template-routes.test.ts
@@ -335,7 +335,16 @@ describe('approval template routes', () => {
         approvalGraph: {
           nodes: [
             { key: 'start', type: 'start', config: {} },
-            { key: 'approve_1', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['finance'] } },
+            {
+              key: 'approve_1',
+              type: 'approval',
+              config: {
+                assigneeType: 'role',
+                assigneeIds: ['finance'],
+                approvalMode: 'all',
+                emptyAssigneePolicy: 'auto-approve',
+              },
+            },
             { key: 'end', type: 'end', config: {} },
           ],
           edges: [
@@ -350,6 +359,12 @@ describe('approval template routes', () => {
     expect(response.body.status).toBe('draft')
     expect(response.body.latestVersionId).toMatch(/^ver-/)
     expect(response.body.formSchema.fields).toHaveLength(1)
+    expect(response.body.approvalGraph.nodes[1].config).toEqual({
+      assigneeType: 'role',
+      assigneeIds: ['finance'],
+      approvalMode: 'all',
+      emptyAssigneePolicy: 'auto-approve',
+    })
   })
 
   it('patches template metadata and creates a new draft version when graph changes', async () => {
@@ -386,7 +401,28 @@ describe('approval template routes', () => {
 
   it('publishes latest template version and injects runtime policy', async () => {
     const template = routeState.createTemplateFixture()
-    const version = routeState.createVersionFixture(template.id)
+    const version = routeState.createVersionFixture(template.id, {
+      approval_graph: {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          {
+            key: 'approve_1',
+            type: 'approval',
+            config: {
+              assigneeType: 'role',
+              assigneeIds: ['manager'],
+              approvalMode: 'any',
+              emptyAssigneePolicy: 'error',
+            },
+          },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approve_1' },
+          { key: 'e2', source: 'approve_1', target: 'end' },
+        ],
+      },
+    })
     template.latest_version_id = version.id
 
     const app = createApp()
@@ -405,6 +441,12 @@ describe('approval template routes', () => {
     expect(response.body.runtimeGraph.policy).toEqual({
       allowRevoke: true,
       revokeBeforeNodeKeys: ['approve_1'],
+    })
+    expect(response.body.runtimeGraph.nodes[1].config).toEqual({
+      assigneeType: 'role',
+      assigneeIds: ['manager'],
+      approvalMode: 'any',
+      emptyAssigneePolicy: 'error',
     })
     expect(routeState.state.templates.get(template.id)?.active_version_id).toBe(version.id)
   })

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2236,6 +2236,25 @@ components:
           type: array
           items:
             type: string
+        approvalMode:
+          type: string
+          enum:
+            - single
+            - all
+            - any
+          description: |
+            Approval aggregation mode for a single approval node. `single`
+            preserves the Wave 1 behavior, `all` represents countersign, and
+            `any` represents any-sign.
+        emptyAssigneePolicy:
+          type: string
+          enum:
+            - error
+            - auto-approve
+          description: |
+            Behavior when the approval node resolves to zero assignees. `error`
+            blocks runtime execution, `auto-approve` allows the node to advance
+            automatically.
       required:
         - assigneeType
         - assigneeIds
@@ -2606,9 +2625,12 @@ components:
             - transfer
             - revoke
             - comment
+            - return
         comment:
           type: string
         targetUserId:
+          type: string
+        targetNodeKey:
           type: string
       required:
         - action
@@ -3350,19 +3372,15 @@ paths:
       tags:
         - Approvals
       summary: Execute an approval action
-      description: >
-        Unified action dispatch endpoint. Supported actions: approve, reject,
-
-        transfer (requires targetUserId), revoke (subject to RuntimePolicy), and
-
-        comment (does not change status). Concurrent writes are serialized with
-        a
-
-        database row lock. This endpoint does not accept a client version field.
-
-        409 responses indicate a conflicting current state after serialization,
-
-        such as an invalid status transition or a closed revoke window.
+      description: |
+        Unified action dispatch endpoint. Accepted actions: approve, reject,
+        transfer (requires targetUserId), revoke (subject to RuntimePolicy),
+        comment (does not change status), and return (requires targetNodeKey).
+        Concurrent writes are serialized with a database row lock. This endpoint
+        does not accept a client version field. 409 responses indicate a
+        conflicting current state after serialization, such as an invalid status
+        transition or a closed revoke window. The Wave 2 Pack 1A executor
+        follow-up will activate return semantics for template-runtime approvals.
       security:
         - bearerAuth: []
       parameters:
@@ -3524,9 +3542,9 @@ paths:
         - Approvals (Legacy)
       deprecated: true
       summary: Return instance with optimistic locking
-      description: >
+      description: |
         Deprecated. Use POST /api/approvals/{id}/actions with
-        {"action":"reject"} instead.
+        {"action":"return","targetNodeKey":"..."} instead.
       security:
         - bearerAuth: []
       parameters:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3249,6 +3249,23 @@
             "items": {
               "type": "string"
             }
+          },
+          "approvalMode": {
+            "type": "string",
+            "enum": [
+              "single",
+              "all",
+              "any"
+            ],
+            "description": "Approval aggregation mode for a single approval node. `single`\npreserves the Wave 1 behavior, `all` represents countersign, and\n`any` represents any-sign.\n"
+          },
+          "emptyAssigneePolicy": {
+            "type": "string",
+            "enum": [
+              "error",
+              "auto-approve"
+            ],
+            "description": "Behavior when the approval node resolves to zero assignees. `error`\nblocks runtime execution, `auto-approve` allows the node to advance\nautomatically.\n"
           }
         },
         "required": [
@@ -3781,13 +3798,17 @@
               "reject",
               "transfer",
               "revoke",
-              "comment"
+              "comment",
+              "return"
             ]
           },
           "comment": {
             "type": "string"
           },
           "targetUserId": {
+            "type": "string"
+          },
+          "targetNodeKey": {
             "type": "string"
           }
         },
@@ -4922,7 +4943,7 @@
           "Approvals"
         ],
         "summary": "Execute an approval action",
-        "description": "Unified action dispatch endpoint. Supported actions: approve, reject,\ntransfer (requires targetUserId), revoke (subject to RuntimePolicy), and\ncomment (does not change status). Concurrent writes are serialized with a\ndatabase row lock. This endpoint does not accept a client version field.\n409 responses indicate a conflicting current state after serialization,\nsuch as an invalid status transition or a closed revoke window.\n",
+        "description": "Unified action dispatch endpoint. Accepted actions: approve, reject,\ntransfer (requires targetUserId), revoke (subject to RuntimePolicy),\ncomment (does not change status), and return (requires targetNodeKey).\nConcurrent writes are serialized with a database row lock. This endpoint\ndoes not accept a client version field. 409 responses indicate a\nconflicting current state after serialization, such as an invalid status\ntransition or a closed revoke window. The Wave 2 Pack 1A executor\nfollow-up will activate return semantics for template-runtime approvals.\n",
         "security": [
           {
             "bearerAuth": []
@@ -5173,7 +5194,7 @@
         ],
         "deprecated": true,
         "summary": "Return instance with optimistic locking",
-        "description": "Deprecated. Use POST /api/approvals/{id}/actions with {\"action\":\"reject\"} instead.\n",
+        "description": "Deprecated. Use POST /api/approvals/{id}/actions with\n{\"action\":\"return\",\"targetNodeKey\":\"...\"} instead.\n",
         "security": [
           {
             "bearerAuth": []

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2236,6 +2236,25 @@ components:
           type: array
           items:
             type: string
+        approvalMode:
+          type: string
+          enum:
+            - single
+            - all
+            - any
+          description: |
+            Approval aggregation mode for a single approval node. `single`
+            preserves the Wave 1 behavior, `all` represents countersign, and
+            `any` represents any-sign.
+        emptyAssigneePolicy:
+          type: string
+          enum:
+            - error
+            - auto-approve
+          description: |
+            Behavior when the approval node resolves to zero assignees. `error`
+            blocks runtime execution, `auto-approve` allows the node to advance
+            automatically.
       required:
         - assigneeType
         - assigneeIds
@@ -2606,9 +2625,12 @@ components:
             - transfer
             - revoke
             - comment
+            - return
         comment:
           type: string
         targetUserId:
+          type: string
+        targetNodeKey:
           type: string
       required:
         - action
@@ -3350,19 +3372,15 @@ paths:
       tags:
         - Approvals
       summary: Execute an approval action
-      description: >
-        Unified action dispatch endpoint. Supported actions: approve, reject,
-
-        transfer (requires targetUserId), revoke (subject to RuntimePolicy), and
-
-        comment (does not change status). Concurrent writes are serialized with
-        a
-
-        database row lock. This endpoint does not accept a client version field.
-
-        409 responses indicate a conflicting current state after serialization,
-
-        such as an invalid status transition or a closed revoke window.
+      description: |
+        Unified action dispatch endpoint. Accepted actions: approve, reject,
+        transfer (requires targetUserId), revoke (subject to RuntimePolicy),
+        comment (does not change status), and return (requires targetNodeKey).
+        Concurrent writes are serialized with a database row lock. This endpoint
+        does not accept a client version field. 409 responses indicate a
+        conflicting current state after serialization, such as an invalid status
+        transition or a closed revoke window. The Wave 2 Pack 1A executor
+        follow-up will activate return semantics for template-runtime approvals.
       security:
         - bearerAuth: []
       parameters:
@@ -3524,9 +3542,9 @@ paths:
         - Approvals (Legacy)
       deprecated: true
       summary: Return instance with optimistic locking
-      description: >
+      description: |
         Deprecated. Use POST /api/approvals/{id}/actions with
-        {"action":"reject"} instead.
+        {"action":"return","targetNodeKey":"..."} instead.
       security:
         - bearerAuth: []
       parameters:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2155,6 +2155,20 @@ components:
           type: array
           items:
             type: string
+        approvalMode:
+          type: string
+          enum: [single, all, any]
+          description: |
+            Approval aggregation mode for a single approval node. `single`
+            preserves the Wave 1 behavior, `all` represents countersign, and
+            `any` represents any-sign.
+        emptyAssigneePolicy:
+          type: string
+          enum: [error, auto-approve]
+          description: |
+            Behavior when the approval node resolves to zero assignees. `error`
+            blocks runtime execution, `auto-approve` allows the node to advance
+            automatically.
       required: [assigneeType, assigneeIds]
     ApprovalConditionRule:
       type: object
@@ -2456,10 +2470,12 @@ components:
       properties:
         action:
           type: string
-          enum: [approve, reject, transfer, revoke, comment]
+          enum: [approve, reject, transfer, revoke, comment, return]
         comment:
           type: string
         targetUserId:
+          type: string
+        targetNodeKey:
           type: string
       required: [action]
     ApprovalTemplateListItem:

--- a/packages/openapi/src/paths/approvals.yml
+++ b/packages/openapi/src/paths/approvals.yml
@@ -162,12 +162,14 @@ paths:
       tags: [Approvals]
       summary: Execute an approval action
       description: |
-        Unified action dispatch endpoint. Supported actions: approve, reject,
-        transfer (requires targetUserId), revoke (subject to RuntimePolicy), and
-        comment (does not change status). Concurrent writes are serialized with a
-        database row lock. This endpoint does not accept a client version field.
-        409 responses indicate a conflicting current state after serialization,
-        such as an invalid status transition or a closed revoke window.
+        Unified action dispatch endpoint. Accepted actions: approve, reject,
+        transfer (requires targetUserId), revoke (subject to RuntimePolicy),
+        comment (does not change status), and return (requires targetNodeKey).
+        Concurrent writes are serialized with a database row lock. This endpoint
+        does not accept a client version field. 409 responses indicate a
+        conflicting current state after serialization, such as an invalid status
+        transition or a closed revoke window. The Wave 2 Pack 1A executor
+        follow-up will activate return semantics for template-runtime approvals.
       security:
         - bearerAuth: []
       parameters:
@@ -304,7 +306,8 @@ paths:
       deprecated: true
       summary: Return instance with optimistic locking
       description: |
-        Deprecated. Use POST /api/approvals/{id}/actions with {"action":"reject"} instead.
+        Deprecated. Use POST /api/approvals/{id}/actions with
+        {"action":"return","targetNodeKey":"..."} instead.
       security:
         - bearerAuth: []
       parameters:


### PR DESCRIPTION
## Summary
- freeze Wave 2 Pack 1A approval-node and action contracts
- add `approvalMode` and `emptyAssigneePolicy` to approval-node config
- extend product approval actions with `return` and `targetNodeKey`
- preserve the new approval-node config fields through template graph normalization and published runtime graph generation
- keep `return` explicitly rejected at runtime for now so this PR does not silently misroute actions before executor semantics land

## Included
- backend product types and frontend approval types updated
- approvals OpenAPI source and generated dist updated
- template graph normalization updated to accept and retain the new config fields
- product action dispatcher guarded to reject `return` with a clear not-supported error until Pack 1A runtime implementation follows
- unit tests for config retention and `return` safety guard

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-product-service.test.ts tests/unit/approval-template-routes.test.ts tests/unit/approval-graph-executor.test.ts tests/unit/approvals-routes.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm exec tsx packages/openapi/tools/build.ts`
- `git diff --check`
