### PR TITLE
feat(approvals): implement pack1a runtime actions

### DIFF
--- a/docs/development/approval-pack1a-runtime-development-and-verification-20260413.md
+++ b/docs/development/approval-pack1a-runtime-development-and-verification-20260413.md
@@ -1,0 +1,162 @@
+# Approval Pack1A Runtime Development And Verification
+
+> 日期: `2026-04-13`
+> 分支: `codex/approval-pack1a-runtime-20260413`
+> 基线: `origin/codex/approval-pack1a-contracts-20260413` @ `4279061ed`
+> 实现提交: `199bb14aa feat(approvals): implement pack1a runtime actions`
+
+## 1. 目标
+
+本次实现只覆盖审批 `Wave 2 / Pack 1A runtime` 的后端执行语义，不扩展到 true parallel/join，也不改 `PLM`、`考勤` 的兼容边界。
+
+本次需要兑现的能力：
+
+- `approvalMode: single | all | any`
+- `return + targetNodeKey`
+- `emptyAssigneePolicy: error | auto-approve`
+- 对应的历史、assignment、状态推进与单元回归
+
+## 2. 实现范围
+
+### 2.1 Runtime executor
+
+文件：
+
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+
+本次新增：
+
+- `ApprovalGraphAutoApprovalEvent`
+- `ApprovalGraphResolution.autoApprovalEvents`
+- `getApprovalMode(nodeKey)`
+- `resolveReturnToNode(targetNodeKey)`
+- `listVisitedApprovalNodeKeysUntil(currentNodeKey)`
+
+语义变化：
+
+- 审批节点默认仍按 `single` 处理，保持旧行为兼容。
+- 当审批节点 `assigneeIds=[]` 且 `emptyAssigneePolicy='auto-approve'` 时：
+  - executor 直接跳过当前审批节点
+  - 继续解析后续节点
+  - 产出系统自动通过事件，交给 service 写入历史
+- 当审批节点 `assigneeIds=[]` 且策略不是 `auto-approve` 时：
+  - executor 明确抛错，不再静默生成空 assignment
+- `return` 的合法目标通过当前运行路径计算，不允许退回到当前节点本身，也不允许跳到未走过的审批节点
+
+### 2.2 Product service
+
+文件：
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+
+本次落地：
+
+- 创建实例时写入 `autoApprovalEvents`
+- `transfer` 改为只关闭当前 actor 在当前节点命中的 assignment，不再粗暴关闭整节点全部活跃 assignment
+- `return` 由占位报错改为真实语义：
+  - 校验 `targetNodeKey`
+  - 校验目标必须是当前路径上已走过的审批节点
+  - 关闭当前活跃 assignment
+  - 回到目标节点并重建目标节点 assignment
+  - 写 `return` 历史
+- `all` 模式改为聚合审批：
+  - 当前 actor 审批后，仅关闭自己的 assignment
+  - 若同节点仍有其他活跃 assignment，则实例保持 `pending`
+  - 写 `approve` 历史并标 `aggregateComplete=false`
+  - 只有最后一个审批人处理后，流程才真正推进
+- `single/any` 继续走“当前节点完成即推进”的路径
+- 自动通过节点现在会统一写入系统 `approve` 历史，metadata 带：
+  - `autoApproved: true`
+  - `reason: 'empty-assignee'`
+  - `approvalMode`
+
+## 3. 变更文件
+
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/tests/unit/approval-graph-executor.test.ts`
+- `packages/core-backend/tests/unit/approval-product-service.test.ts`
+
+## 4. 验证覆盖
+
+### 4.1 新增或补强的场景
+
+`approval-graph-executor.test.ts`：
+
+- date-only 条件比较仍然正确
+- 空审批人 + `auto-approve` 会自动跳过节点并产出系统自动通过事件
+- `listVisitedApprovalNodeKeysUntil()` 能按当前活跃路径给出合法 return 候选链
+
+`approval-product-service.test.ts`：
+
+- `return` 拒绝非法目标节点
+- `return` 成功退回到已走过节点并重建 assignment
+- `all` 模式下第一位审批人处理后实例仍保持 `pending`
+- 既有 `revoke` policy / revoke window 约束不回归
+
+### 4.2 实际执行的验证命令
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-graph-executor.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-template-routes.test.ts \
+  tests/unit/approvals-routes.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+
+git diff --check
+```
+
+### 4.3 验证结果
+
+- `approval-graph-executor.test.ts`: `7/7 PASS`
+- `approval-product-service.test.ts`: `5/5 PASS`
+- `approval-template-routes.test.ts`: `4/4 PASS`
+- `approvals-routes.test.ts`: `12/12 PASS`
+- `tsc --noEmit`: `PASS`
+- `git diff --check`: `PASS`
+
+合计本轮直接回归：
+
+- `4` 个测试文件
+- `28` 个测试用例
+
+## 5. 兼容与边界说明
+
+本次明确保持不变的边界：
+
+- 不引入 true parallel / join
+- 不修改 `PLM` bridge 旧动作模型
+- 不把 `考勤` 与 `PLM` 拉入统一 Inbox
+- 不新增前端 runtime 交互改动
+
+本次对旧行为的兼容判断：
+
+- 旧模板未声明 `approvalMode` 时，仍按 `single` 执行
+- 旧模板未声明 `emptyAssigneePolicy` 时，仍按保守语义处理，不自动通过
+- 旧 `approve / reject / revoke / comment` 路径仍保留
+
+## 6. 残余事项
+
+Pack 1A runtime 完成后，后续仍需单独收口以下事项：
+
+- 将当前 runtime 分支发布为 stacked PR，base 指向 `codex/approval-pack1a-contracts-20260413`
+- 补前端对 `return / all / any / auto-approve` 的消费与 UI 表达
+- 补更高层集成验证，覆盖“建模板 -> 发布 -> 发起 -> all/return/auto-approve”完整链路
+- 评审是否开启 `Pack 1B true parallel / join`
+
+## 7. 当前结论
+
+截至本文件落地时，`Pack 1A runtime` 的核心后端执行语义已经可以单独审阅：
+
+- 契约面与 runtime 面已对齐
+- 旧 `return not implemented` 占位已经移除
+- `all` 模式不再错误地提前推进流程
+- 空审批人节点不再靠隐式空 assignment 漏过执行
+
+结论：本轮代码已达到可开 stacked PR、可继续前端并行消费、可进入下一轮集成验证的状态。

--- a/docs/development/approval-pack1a-runtime-development-and-verification-20260413.md
+++ b/docs/development/approval-pack1a-runtime-development-and-verification-20260413.md
@@ -160,3 +160,24 @@ Pack 1A runtime 完成后，后续仍需单独收口以下事项：
 - 空审批人节点不再靠隐式空 assignment 漏过执行
 
 结论：本轮代码已达到可开 stacked PR、可继续前端并行消费、可进入下一轮集成验证的状态。
+
+## 8. 并行审阅结论
+
+本轮同时调用本机 `Claude Code CLI` 对当前 runtime 分支相对
+`origin/codex/approval-pack1a-contracts-20260413` 的改动做了独立审阅。
+
+审阅结论：
+
+- `No blocker`
+- `single / any / all` 语义与 Pack 1A 契约一致
+- `return + targetNodeKey` 的路径校验正确
+- `emptyAssigneePolicy=auto-approve` 的跳过与审计记录正确
+
+Claude 额外建议后续补的测试：
+
+- `any` 模式显式回归
+- `all` 模式最后一位审批人完成后真正推进的场景
+- `emptyAssigneePolicy` 缺失时的负面用例
+- 更高层幂等/重复 approve 行为验证
+
+这些建议已记录为下一轮测试补强项，不构成当前合入 blocker。

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -1,5 +1,6 @@
 import type {
   ApprovalEdge,
+  ApprovalMode,
   ApprovalNode,
   ApprovalNodeConfig,
   ConditionBranch,
@@ -22,6 +23,13 @@ export interface ApprovalCcEvent {
   targetId: string
 }
 
+export interface ApprovalGraphAutoApprovalEvent {
+  nodeKey: string
+  sourceStep: number
+  approvalMode: ApprovalMode
+  reason: 'empty-assignee'
+}
+
 export interface ApprovalGraphResolution {
   status: 'pending' | 'approved'
   currentNodeKey: string | null
@@ -29,6 +37,7 @@ export interface ApprovalGraphResolution {
   totalSteps: number
   assignments: ApprovalGraphAssignment[]
   ccEvents: ApprovalCcEvent[]
+  autoApprovalEvents: ApprovalGraphAutoApprovalEvent[]
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -83,6 +92,10 @@ function isEmptyValue(value: unknown): boolean {
     || value === undefined
     || value === ''
     || (Array.isArray(value) && value.length === 0)
+}
+
+function normalizeApprovalMode(value: unknown): ApprovalMode {
+  return value === 'all' || value === 'any' || value === 'single' ? value : 'single'
 }
 
 function evaluateRule(rule: ConditionRule, formData: Record<string, unknown>): boolean {
@@ -312,9 +325,74 @@ export class ApprovalGraphExecutor {
         totalSteps: this.totalSteps,
         assignments: [],
         ccEvents: [],
+        autoApprovalEvents: [],
       }
     }
     return this.resolveFromNode(next)
+  }
+
+  getApprovalMode(nodeKey: string): ApprovalMode {
+    return normalizeApprovalMode(this.getApprovalNodeConfig(nodeKey).approvalMode)
+  }
+
+  resolveReturnToNode(targetNodeKey: string): ApprovalGraphResolution {
+    this.getApprovalNodeConfig(targetNodeKey)
+    return this.resolveFromNode(targetNodeKey)
+  }
+
+  listVisitedApprovalNodeKeysUntil(currentNodeKey: string): string[] {
+    this.getApprovalNodeConfig(currentNodeKey)
+
+    const start = this.runtimeGraph.nodes.find((node) => node.type === 'start')
+    if (!start) {
+      throw new Error('Runtime graph must contain a start node')
+    }
+
+    const visited = new Set<string>()
+    const approvalTrail: string[] = []
+    let nextNodeKey: string | null = start.key
+
+    while (nextNodeKey) {
+      if (visited.has(nextNodeKey)) {
+        throw new Error(`Runtime graph contains a cycle near ${nextNodeKey}`)
+      }
+      visited.add(nextNodeKey)
+
+      const node = this.nodeMap.get(nextNodeKey)
+      if (!node) {
+        throw new Error(`Runtime graph references unknown node ${nextNodeKey}`)
+      }
+
+      if (node.type === 'start') {
+        nextNodeKey = this.firstTargetForNode(node.key)
+        continue
+      }
+
+      if (node.type === 'condition') {
+        nextNodeKey = this.resolveConditionTarget(node)
+        continue
+      }
+
+      if (node.type === 'cc') {
+        nextNodeKey = this.firstTargetForNode(node.key)
+        continue
+      }
+
+      if (node.type === 'approval') {
+        approvalTrail.push(node.key)
+        if (node.key === currentNodeKey) {
+          return approvalTrail
+        }
+        nextNodeKey = this.firstTargetForNode(node.key)
+        continue
+      }
+
+      if (node.type === 'end') {
+        break
+      }
+    }
+
+    throw new Error(`Approval node ${currentNodeKey} is not reachable from runtime start`)
   }
 
   buildTransferAssignments(currentNodeKey: string, targetUserId: string): ApprovalGraphAssignment[] {
@@ -329,6 +407,7 @@ export class ApprovalGraphExecutor {
 
   private resolveFromNode(nodeKey: string): ApprovalGraphResolution {
     const ccEvents: ApprovalCcEvent[] = []
+    const autoApprovalEvents: ApprovalGraphAutoApprovalEvent[] = []
     let currentKey: string | null = nodeKey
 
     while (currentKey) {
@@ -371,6 +450,20 @@ export class ApprovalGraphExecutor {
           throw new Error(`Approval node ${node.key} has invalid config`)
         }
         const sourceStep = this.stepIndexForNode(node.key)
+        const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode)
+        if (approvalConfig.assigneeIds.length === 0) {
+          if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
+            autoApprovalEvents.push({
+              nodeKey: node.key,
+              sourceStep,
+              approvalMode,
+              reason: 'empty-assignee',
+            })
+            currentKey = this.firstTargetForNode(node.key)
+            continue
+          }
+          throw new Error(`Approval node ${node.key} has no assignees`)
+        }
         return {
           status: 'pending',
           currentNodeKey: node.key,
@@ -383,6 +476,7 @@ export class ApprovalGraphExecutor {
             sourceStep,
           })),
           ccEvents,
+          autoApprovalEvents,
         }
       }
 
@@ -394,6 +488,7 @@ export class ApprovalGraphExecutor {
           totalSteps: this.totalSteps,
           assignments: [],
           ccEvents,
+          autoApprovalEvents,
         }
       }
 
@@ -407,6 +502,7 @@ export class ApprovalGraphExecutor {
       totalSteps: this.totalSteps,
       assignments: [],
       ccEvents,
+      autoApprovalEvents,
     }
   }
 
@@ -448,5 +544,17 @@ export class ApprovalGraphExecutor {
   private stepIndexForNode(nodeKey: string): number {
     const index = this.approvalNodeOrder.indexOf(nodeKey)
     return index >= 0 ? index + 1 : 0
+  }
+
+  private getApprovalNodeConfig(nodeKey: string): ApprovalNodeConfig {
+    const node = this.nodeMap.get(nodeKey)
+    if (!node || node.type !== 'approval') {
+      throw new Error(`Approval node ${nodeKey} is not registered in the runtime graph`)
+    }
+    const approvalConfig = isApprovalNodeConfig(node.config) ? node.config : null
+    if (!approvalConfig) {
+      throw new Error(`Approval node ${node.key} has invalid config`)
+    }
+    return approvalConfig
   }
 }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -16,7 +16,11 @@ import type {
   RuntimePolicy,
   UpdateApprovalTemplateRequest,
 } from '../types/approval-product'
-import { ApprovalGraphExecutor, validateApprovalFormData } from './ApprovalGraphExecutor'
+import {
+  ApprovalGraphExecutor,
+  type ApprovalGraphAutoApprovalEvent,
+  validateApprovalFormData,
+} from './ApprovalGraphExecutor'
 import type {
   ApprovalAssignmentDTO,
   ApprovalAssignmentRow,
@@ -960,6 +964,7 @@ export class ApprovalProductService {
       )
 
       await this.insertAssignments(client, instanceId, initial.assignments)
+      await this.insertAutoApprovalEvents(client, instanceId, 0, initial.status, initial.autoApprovalEvents)
       await this.insertCcEvents(client, instanceId, 0, initial.status, initial.ccEvents)
       await this.insertApprovalRecord(client, instanceId, {
         action: 'created',
@@ -1029,25 +1034,22 @@ export class ApprovalProductService {
         [id],
       )
 
-      if (request.action === 'return') {
-        if (!request.targetNodeKey?.trim()) {
-          throw new ServiceError('targetNodeKey is required for return', 400, 'VALIDATION_ERROR')
-        }
-        throw new ServiceError('Return action is not implemented yet', 409, 'APPROVAL_ACTION_NOT_SUPPORTED')
-      }
-
+      const runtimeGraph = asRuntimeGraph(runtime.runtime_graph)
+      const executor = new ApprovalGraphExecutor(runtimeGraph, toNullableRecord(instance.form_snapshot) || {})
+      const currentNodeKey = instance.current_node_key
       const actorRoles = actor.roles || []
-      const actorCanAct = assignments.rows.some((assignment) => assignmentMatchesActor(assignment, actor.userId, actorRoles))
       const actorName = actor.userName || actor.userId
+      const currentNodeAssignments = currentNodeKey
+        ? assignments.rows.filter((assignment) => assignment.node_key === currentNodeKey)
+        : []
+      const actorAssignments = currentNodeAssignments.filter((assignment) =>
+        assignmentMatchesActor(assignment, actor.userId, actorRoles))
+      const actorCanAct = actorAssignments.length > 0
+      const nextVersion = instance.version + 1
 
       if (request.action !== 'revoke' && !actorCanAct) {
         throw new ServiceError('Approval assignment not found for actor', 403, 'APPROVAL_ASSIGNMENT_REQUIRED')
       }
-
-      const runtimeGraph = asRuntimeGraph(runtime.runtime_graph)
-      const executor = new ApprovalGraphExecutor(runtimeGraph, toNullableRecord(instance.form_snapshot) || {})
-      const currentNodeKey = instance.current_node_key
-      const nextVersion = instance.version + 1
 
       if (request.action === 'comment') {
         await this.insertApprovalRecord(client, id, {
@@ -1072,10 +1074,7 @@ export class ApprovalProductService {
         if (!currentNodeKey) {
           throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
         }
-        await client.query(
-          `UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND is_active = TRUE`,
-          [id],
-        )
+        await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
         await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, request.targetUserId))
         await this.insertApprovalRecord(client, id, {
           action: 'transfer',
@@ -1163,12 +1162,68 @@ export class ApprovalProductService {
         throw new ServiceError('Rejection comment is required', 400, APPROVAL_ERROR_CODES.REJECT_COMMENT_REQUIRED)
       }
 
-      await client.query(
-        `UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND is_active = TRUE`,
-        [id],
-      )
+      if (!currentNodeKey) {
+        throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
+      }
+
+      if (request.action === 'return') {
+        const targetNodeKey = request.targetNodeKey?.trim()
+        if (!targetNodeKey) {
+          throw new ServiceError('targetNodeKey is required for return', 400, 'VALIDATION_ERROR')
+        }
+        const visitedApprovalNodes = executor.listVisitedApprovalNodeKeysUntil(currentNodeKey)
+        if (!visitedApprovalNodes.slice(0, -1).includes(targetNodeKey)) {
+          throw new ServiceError(
+            'Return target must be a previously visited approval node',
+            409,
+            'APPROVAL_RETURN_TARGET_INVALID',
+          )
+        }
+
+        await this.deactivateAllActiveAssignments(client, id)
+        const resolution = executor.resolveReturnToNode(targetNodeKey)
+        await client.query(
+          `UPDATE approval_instances
+           SET status = $2,
+               version = $3,
+               current_node_key = $4,
+               current_step = $5,
+               total_steps = $6,
+               updated_at = now()
+           WHERE id = $1`,
+          [
+            id,
+            resolution.status,
+            nextVersion,
+            resolution.currentNodeKey,
+            resolution.currentStep ?? instance.total_steps,
+            resolution.totalSteps,
+          ],
+        )
+        await this.insertAssignments(client, id, resolution.assignments)
+        await this.insertApprovalRecord(client, id, {
+          action: 'return',
+          actorId: actor.userId,
+          actorName,
+          comment: request.comment || null,
+          fromStatus: instance.status,
+          toStatus: resolution.status,
+          fromVersion: instance.version,
+          toVersion: nextVersion,
+          metadata: {
+            nodeKey: currentNodeKey,
+            targetNodeKey,
+            nextNodeKey: resolution.currentNodeKey,
+          },
+        }, actor)
+        await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
+        await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
+        await client.query('COMMIT')
+        return (await this.getApproval(id))!
+      }
 
       if (request.action === 'reject') {
+        await this.deactivateAllActiveAssignments(client, id)
         await client.query(
           `UPDATE approval_instances
            SET status = 'rejected',
@@ -1194,8 +1249,40 @@ export class ApprovalProductService {
         return (await this.getApproval(id))!
       }
 
-      if (!currentNodeKey) {
-        throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
+      const approvalMode = executor.getApprovalMode(currentNodeKey)
+      if (approvalMode === 'all') {
+        await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
+        const remainingAssignments = currentNodeAssignments.length - actorAssignments.length
+        if (remainingAssignments > 0) {
+          await client.query(
+            `UPDATE approval_instances
+             SET version = $2,
+                 updated_at = now()
+             WHERE id = $1`,
+            [id, nextVersion],
+          )
+          await this.insertApprovalRecord(client, id, {
+            action: 'approve',
+            actorId: actor.userId,
+            actorName,
+            comment: request.comment || null,
+            fromStatus: instance.status,
+            toStatus: instance.status,
+            fromVersion: instance.version,
+            toVersion: nextVersion,
+            metadata: {
+              nodeKey: currentNodeKey,
+              nextNodeKey: currentNodeKey,
+              approvalMode,
+              aggregateComplete: false,
+              remainingAssignments,
+            },
+          }, actor)
+          await client.query('COMMIT')
+          return (await this.getApproval(id))!
+        }
+      } else {
+        await this.deactivateAllActiveAssignments(client, id)
       }
 
       const resolution = executor.resolveAfterApprove(currentNodeKey)
@@ -1227,8 +1314,14 @@ export class ApprovalProductService {
         toStatus: resolution.status,
         fromVersion: instance.version,
         toVersion: nextVersion,
-        metadata: { nodeKey: currentNodeKey, nextNodeKey: resolution.currentNodeKey },
+        metadata: {
+          nodeKey: currentNodeKey,
+          nextNodeKey: resolution.currentNodeKey,
+          approvalMode,
+          aggregateComplete: true,
+        },
       }, actor)
+      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
       await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
 
       await client.query('COMMIT')
@@ -1351,6 +1444,37 @@ export class ApprovalProductService {
     }
   }
 
+  private async deactivateAllActiveAssignments(
+    client: { query: typeof pool.query },
+    instanceId: string,
+  ): Promise<void> {
+    await client.query(
+      `UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND is_active = TRUE`,
+      [instanceId],
+    )
+  }
+
+  private async deactivateActorAssignmentsAtNode(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    nodeKey: string,
+    actorId: string,
+    actorRoles: string[],
+  ): Promise<void> {
+    await client.query(
+      `UPDATE approval_assignments
+       SET is_active = FALSE, updated_at = now()
+       WHERE instance_id = $1
+         AND node_key = $2
+         AND is_active = TRUE
+         AND (
+           (assignment_type = 'user' AND assignee_id = $3)
+           OR (assignment_type = 'role' AND assignee_id = ANY($4::text[]))
+         )`,
+      [instanceId, nodeKey, actorId, actorRoles],
+    )
+  }
+
   private async insertAssignments(
     client: { query: typeof pool.query },
     instanceId: string,
@@ -1369,6 +1493,34 @@ export class ApprovalProductService {
           assignment.nodeKey,
         ],
       )
+    }
+  }
+
+  private async insertAutoApprovalEvents(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    version: number,
+    status: string,
+    autoApprovalEvents: ApprovalGraphAutoApprovalEvent[],
+  ): Promise<void> {
+    for (const event of autoApprovalEvents) {
+      await this.insertApprovalRecord(client, instanceId, {
+        action: 'approve',
+        actorId: 'system',
+        actorName: 'System',
+        comment: null,
+        fromStatus: status,
+        toStatus: status,
+        fromVersion: version,
+        toVersion: version,
+        metadata: {
+          nodeKey: event.nodeKey,
+          sourceStep: event.sourceStep,
+          approvalMode: event.approvalMode,
+          autoApproved: true,
+          reason: event.reason,
+        },
+      })
     }
   }
 

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -133,6 +133,99 @@ describe('ApprovalGraphExecutor', () => {
       },
     ])
   })
+
+  it('auto-approves empty approval nodes when the node policy allows it', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'review-gap',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: [],
+            approvalMode: 'all',
+            emptyAssigneePolicy: 'auto-approve',
+          },
+        },
+        { key: 'final-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-9'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-gap', source: 'start', target: 'review-gap' },
+        { key: 'edge-gap-final', source: 'review-gap', target: 'final-review' },
+        { key: 'edge-final-end', source: 'final-review', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+      },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const initial = executor.resolveInitialState()
+
+    expect(initial.currentNodeKey).toBe('final-review')
+    expect(initial.currentStep).toBe(2)
+    expect(initial.assignments).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'user-9',
+        nodeKey: 'final-review',
+        sourceStep: 2,
+      },
+    ])
+    expect(initial.autoApprovalEvents).toEqual([
+      {
+        nodeKey: 'review-gap',
+        sourceStep: 1,
+        approvalMode: 'all',
+        reason: 'empty-assignee',
+      },
+    ])
+  })
+
+  it('lists the visited approval nodes for return validation on the active path', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [
+              {
+                edgeKey: 'edge-fast',
+                rules: [{ fieldId: 'amount', operator: 'lte', value: 1000 }],
+              },
+            ],
+            defaultEdgeKey: 'edge-slow',
+          },
+        },
+        { key: 'manager-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-1'] } },
+        { key: 'director-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-2'] } },
+        { key: 'finance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-3'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-fast', source: 'route', target: 'manager-review' },
+        { key: 'edge-slow', source: 'route', target: 'director-review' },
+        { key: 'edge-manager-finance', source: 'manager-review', target: 'finance-review' },
+        { key: 'edge-director-finance', source: 'director-review', target: 'finance-review' },
+        { key: 'edge-finance-end', source: 'finance-review', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+      },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, { amount: 2000 })
+
+    expect(executor.listVisitedApprovalNodeKeysUntil('finance-review')).toEqual([
+      'director-review',
+      'finance-review',
+    ])
+  })
 })
 
 describe('validateApprovalFormData', () => {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -37,6 +37,65 @@ function buildRuntimeGraph(policyOverrides?: Record<string, unknown>) {
   }
 }
 
+function buildInstanceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'apr-1',
+    status: 'pending',
+    version: 2,
+    source_system: 'platform',
+    external_approval_id: null,
+    workflow_key: 'approval-product-template',
+    business_key: 'travel-request',
+    title: 'Travel Request',
+    requester_snapshot: { id: 'user-1', name: 'Owner One' },
+    subject_snapshot: {},
+    policy_snapshot: { allowRevoke: true },
+    metadata: {},
+    current_step: 1,
+    total_steps: 1,
+    source_updated_at: null,
+    last_synced_at: null,
+    sync_status: 'ok',
+    sync_error: null,
+    template_id: 'tpl-1',
+    template_version_id: 'ver-1',
+    published_definition_id: 'pub-1',
+    request_no: 'AP-100001',
+    form_snapshot: {},
+    current_node_key: 'approval_1',
+    created_at: new Date('2026-04-11T00:00:00.000Z'),
+    updated_at: new Date('2026-04-11T00:05:00.000Z'),
+    ...overrides,
+  }
+}
+
+function buildApprovalDto(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'apr-1',
+    sourceSystem: 'platform',
+    externalApprovalId: null,
+    workflowKey: 'approval-product-template',
+    businessKey: 'travel-request',
+    title: 'Travel Request',
+    status: 'pending',
+    requester: { id: 'user-1', name: 'Owner One' },
+    subject: {},
+    policy: { allowRevoke: true },
+    currentStep: 1,
+    totalSteps: 1,
+    templateId: 'tpl-1',
+    templateVersionId: 'ver-1',
+    publishedDefinitionId: 'pub-1',
+    requestNo: 'AP-100001',
+    formSnapshot: {},
+    currentNodeKey: 'approval_1',
+    assignments: [],
+    createdAt: '2026-04-11T00:00:00.000Z',
+    updatedAt: '2026-04-11T00:05:00.000Z',
+    ...overrides,
+  }
+}
+
 describe('ApprovalProductService', () => {
   beforeEach(() => {
     pgState.pool.connect.mockReset()
@@ -194,8 +253,21 @@ describe('ApprovalProductService', () => {
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
 
-  it('rejects return actions until pack 1A runtime semantics are implemented', async () => {
-    const runtimeGraph = buildRuntimeGraph()
+  it('rejects return targets that are not previously visited approval nodes', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'approval_2', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-2'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-1-approval-2', source: 'approval_1', target: 'approval_2' },
+        { key: 'edge-approval-2-end', source: 'approval_2', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
 
     pgState.client.query.mockImplementation(async (sql: string) => {
       const statement = normalize(sql)
@@ -204,34 +276,12 @@ describe('ApprovalProductService', () => {
       }
       if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
         return {
-          rows: [{
-            id: 'apr-1',
-            status: 'pending',
+          rows: [buildInstanceRow({
             version: 4,
-            source_system: 'platform',
-            external_approval_id: null,
-            workflow_key: 'approval-product-template',
-            business_key: 'travel-request',
-            title: 'Travel Request',
-            requester_snapshot: { id: 'user-1', name: 'Owner One' },
-            subject_snapshot: {},
-            policy_snapshot: { allowRevoke: true },
-            metadata: {},
-            current_step: 1,
-            total_steps: 1,
-            source_updated_at: null,
-            last_synced_at: null,
-            sync_status: 'ok',
-            sync_error: null,
-            template_id: 'tpl-1',
-            template_version_id: 'ver-1',
-            published_definition_id: 'pub-1',
-            request_no: 'AP-100001',
-            form_snapshot: {},
-            current_node_key: 'approval_1',
-            created_at: new Date('2026-04-11T00:00:00.000Z'),
-            updated_at: new Date('2026-04-11T00:05:00.000Z'),
-          }],
+            current_step: 2,
+            total_steps: 2,
+            current_node_key: 'approval_2',
+          })],
           rowCount: 1,
         }
       }
@@ -249,7 +299,21 @@ describe('ApprovalProductService', () => {
         }
       }
       if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
-        return { rows: [], rowCount: 0 }
+        return {
+          rows: [{
+            id: 'asg-approval-2',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'manager-2',
+            source_step: 2,
+            node_key: 'approval_2',
+            is_active: true,
+            metadata: {},
+            created_at: new Date('2026-04-11T00:00:00.000Z'),
+            updated_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
       }
       throw new Error(`Unhandled query: ${statement}`)
     })
@@ -259,14 +323,276 @@ describe('ApprovalProductService', () => {
 
     await expect(service.dispatchAction(
       'apr-1',
-      { action: 'return', targetNodeKey: 'approval_1' },
-      { userId: 'user-1' },
+      { action: 'return', targetNodeKey: 'approval_2' },
+      { userId: 'manager-2' },
     )).rejects.toMatchObject({
-      message: 'Return action is not implemented yet',
+      message: 'Return target must be a previously visited approval node',
       statusCode: 409,
-      code: 'APPROVAL_ACTION_NOT_SUPPORTED',
+      code: 'APPROVAL_RETURN_TARGET_INVALID',
     })
 
+    expect(pgState.client.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns an approval to a previously visited node and reassigns that node', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'approval_2', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-2'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-1-approval-2', source: 'approval_1', target: 'approval_2' },
+        { key: 'edge-approval-2-end', source: 'approval_2', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            version: 4,
+            current_step: 2,
+            total_steps: 2,
+            current_node_key: 'approval_2',
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-approval-2',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'manager-2',
+            source_step: 2,
+            node_key: 'approval_2',
+            is_active: true,
+            metadata: {},
+            created_at: new Date('2026-04-11T00:00:00.000Z'),
+            updated_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+    vi.spyOn(service, 'getApproval').mockResolvedValue(
+      buildApprovalDto({
+        currentStep: 1,
+        totalSteps: 2,
+        currentNodeKey: 'approval_1',
+        assignments: [{
+          id: 'asg-returned',
+          type: 'user',
+          assigneeId: 'manager-1',
+          sourceStep: 1,
+          nodeKey: 'approval_1',
+          isActive: true,
+          metadata: {},
+        }],
+      }),
+    )
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'return', targetNodeKey: 'approval_1', comment: 'needs rework' },
+      { userId: 'manager-2' },
+    )
+
+    expect(result.currentNodeKey).toBe('approval_1')
+    expect(result.assignments).toEqual([
+      {
+        id: 'asg-returned',
+        type: 'user',
+        assigneeId: 'manager-1',
+        sourceStep: 1,
+        nodeKey: 'approval_1',
+        isActive: true,
+        metadata: {},
+      },
+    ])
+
+    const recordCall = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records'))
+    expect(recordCall).toBeDefined()
+    expect(JSON.parse(String(recordCall?.[1]?.[9]))).toMatchObject({
+      nodeKey: 'approval_2',
+      targetNodeKey: 'approval_1',
+      nextNodeKey: 'approval_1',
+    })
+    expect(pgState.client.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps all-mode approvals pending until every assignee has acted', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: ['manager-1', 'manager-2'],
+            approvalMode: 'all',
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-1-end', source: 'approval_1', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            version: 4,
+            current_step: 1,
+            total_steps: 1,
+            current_node_key: 'approval_1',
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [
+            {
+              id: 'asg-manager-1',
+              instance_id: 'apr-1',
+              assignment_type: 'user',
+              assignee_id: 'manager-1',
+              source_step: 1,
+              node_key: 'approval_1',
+              is_active: true,
+              metadata: {},
+              created_at: new Date('2026-04-11T00:00:00.000Z'),
+              updated_at: new Date('2026-04-11T00:00:00.000Z'),
+            },
+            {
+              id: 'asg-manager-2',
+              instance_id: 'apr-1',
+              assignment_type: 'user',
+              assignee_id: 'manager-2',
+              source_step: 1,
+              node_key: 'approval_1',
+              is_active: true,
+              metadata: {},
+              created_at: new Date('2026-04-11T00:00:00.000Z'),
+              updated_at: new Date('2026-04-11T00:00:00.000Z'),
+            },
+          ],
+          rowCount: 2,
+        }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        expect(params).toEqual(['apr-1', 'approval_1', 'manager-1', []])
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET version = $2')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+    vi.spyOn(service, 'getApproval').mockResolvedValue(
+      buildApprovalDto({
+        currentNodeKey: 'approval_1',
+        assignments: [{
+          id: 'asg-manager-2',
+          type: 'user',
+          assigneeId: 'manager-2',
+          sourceStep: 1,
+          nodeKey: 'approval_1',
+          isActive: true,
+          metadata: {},
+        }],
+      }),
+    )
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'approve', comment: 'approved by first signer' },
+      { userId: 'manager-1' },
+    )
+
+    expect(result.status).toBe('pending')
+    expect(result.currentNodeKey).toBe('approval_1')
+    expect(pgState.client.query.mock.calls.some(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))).toBe(false)
+
+    const recordCall = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records'))
+    expect(recordCall).toBeDefined()
+    expect(JSON.parse(String(recordCall?.[1]?.[9]))).toMatchObject({
+      nodeKey: 'approval_1',
+      nextNodeKey: 'approval_1',
+      approvalMode: 'all',
+      aggregateComplete: false,
+      remainingAssignments: 1,
+    })
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- implement Pack 1A runtime semantics for platform approvals
- add real `return + targetNodeKey` handling
- add `all` aggregation behavior and `emptyAssigneePolicy=auto-approve` execution
- add development and verification notes for this slice

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-template-routes.test.ts tests/unit/approvals-routes.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `git diff --check`
