### PR TITLE
feat(approvals): consume pack1a return and mode ui

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -71,8 +71,8 @@ function mockTemplateDetail(id: string): ApprovalTemplateDetailDTO {
     approvalGraph: {
       nodes: [
         { key: 'start', type: 'start', name: '发起', config: {} },
-        { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeType: 'role', assigneeIds: ['role_manager'] } },
-        { key: 'approval_2', type: 'approval', name: '财务审批', config: { assigneeType: 'user', assigneeIds: ['user_finance'] } },
+        { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeType: 'role', assigneeIds: ['role_manager'], approvalMode: 'all', emptyAssigneePolicy: 'error' } },
+        { key: 'approval_2', type: 'approval', name: '财务审批', config: { assigneeType: 'user', assigneeIds: ['user_finance'], approvalMode: 'any', emptyAssigneePolicy: 'auto-approve' } },
         { key: 'end', type: 'end', name: '结束', config: {} },
       ],
       edges: [
@@ -149,8 +149,8 @@ function mockHistory(approvalId: string): UnifiedApprovalHistoryDTO[] {
       comment: null,
       fromStatus: null,
       toStatus: 'pending',
-      occurredAt: new Date(Date.now() - 86400000).toISOString(),
-      metadata: {},
+      occurredAt: new Date(Date.now() - 86400000 * 3).toISOString(),
+      metadata: { nodeKey: 'start' },
     },
     {
       id: 'hist_2',
@@ -159,9 +159,42 @@ function mockHistory(approvalId: string): UnifiedApprovalHistoryDTO[] {
       actorName: '李四',
       comment: '同意',
       fromStatus: 'pending',
+      toStatus: 'pending',
+      occurredAt: new Date(Date.now() - 86400000 * 2).toISOString(),
+      metadata: { nodeKey: 'approval_1', approvalMode: 'all', aggregateComplete: true },
+    },
+    {
+      id: 'hist_3',
+      action: 'approve',
+      actorId: null,
+      actorName: '系统',
+      comment: '无审批人，自动通过',
+      fromStatus: 'pending',
+      toStatus: 'pending',
+      occurredAt: new Date(Date.now() - 86400000).toISOString(),
+      metadata: { nodeKey: 'approval_2', autoApproved: true },
+    },
+    {
+      id: 'hist_4',
+      action: 'return',
+      actorId: 'user_3',
+      actorName: '王五',
+      comment: '金额有误，退回修改',
+      fromStatus: 'pending',
+      toStatus: 'pending',
+      occurredAt: new Date(Date.now() - 3600000).toISOString(),
+      metadata: { nodeKey: 'approval_3', targetNodeKey: 'approval_1' },
+    },
+    {
+      id: 'hist_5',
+      action: 'approve',
+      actorId: 'user_2',
+      actorName: '李四',
+      comment: '重新审批通过',
+      fromStatus: 'pending',
       toStatus: 'approved',
       occurredAt: new Date().toISOString(),
-      metadata: {},
+      metadata: { nodeKey: 'approval_1' },
     },
   ]
 }
@@ -288,6 +321,7 @@ export async function dispatchAction(
       reject: 'rejected',
       revoke: 'revoked',
       transfer: 'pending',
+      return: 'pending',
     }
     return { ...base, status: statusMap[req.action] ?? base.status }
   }

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -80,7 +80,7 @@
               v-for="item in store.history"
               :key="item.id"
               :type="timelineItemType(item.action, item.toStatus)"
-              :icon="timelineIcon(item.action)"
+              :icon="timelineIcon(item.action, item.metadata)"
               :hollow="item.toStatus === 'pending'"
               size="large"
               :timestamp="item.occurredAt ? formatDate(item.occurredAt) : '-'"
@@ -88,14 +88,31 @@
             >
               <div class="approval-detail__timeline-content">
                 <div class="approval-detail__timeline-header">
-                  <strong>{{ item.actorName ?? '系统' }}</strong>
-                  <el-tag :type="statusTagType(item.toStatus)" size="small">
-                    {{ actionLabel(item.action) }}
+                  <strong>{{ item.metadata?.autoApproved ? '系统自动审批' : (item.actorName ?? '系统') }}</strong>
+                  <el-tag :type="timelineActionTagType(item.action, item.metadata)" size="small">
+                    {{ actionLabel(item.action, item.metadata) }}
                   </el-tag>
                 </div>
                 <p v-if="item.comment" class="approval-detail__timeline-comment">
                   {{ item.comment }}
                 </p>
+                <div v-if="hasTimelineMetadata(item.metadata)" class="approval-detail__timeline-meta">
+                  <span v-if="item.metadata?.autoApproved" class="approval-detail__meta-badge approval-detail__meta-badge--auto">
+                    自动审批
+                  </span>
+                  <span v-if="item.metadata?.approvalMode" class="approval-detail__meta-badge">
+                    审批模式: {{ approvalModeLabel(item.metadata.approvalMode as string) }}
+                  </span>
+                  <span v-if="item.metadata?.aggregateComplete" class="approval-detail__meta-badge approval-detail__meta-badge--complete">
+                    会签完成
+                  </span>
+                  <span v-if="item.action === 'return' && item.metadata?.targetNodeKey" class="approval-detail__meta-badge approval-detail__meta-badge--return">
+                    退回至: {{ item.metadata.targetNodeKey }}
+                  </span>
+                  <span v-if="item.metadata?.nodeKey" class="approval-detail__meta-badge">
+                    节点: {{ item.metadata.nodeKey }}
+                  </span>
+                </div>
               </div>
             </el-timeline-item>
           </el-timeline>
@@ -125,6 +142,14 @@
             </el-button>
           </div>
           <div class="approval-detail__actions-secondary">
+            <el-button
+              v-if="canAct && returnableNodes.length > 0"
+              type="warning"
+              :loading="store.loading"
+              @click="openReturnDialog"
+            >
+              退回
+            </el-button>
             <el-button
               v-if="canAct"
               type="warning"
@@ -243,6 +268,40 @@
         </el-button>
       </template>
     </el-dialog>
+
+    <!-- Return dialog -->
+    <el-dialog
+      v-model="returnDialogVisible"
+      title="退回审批"
+      width="480px"
+    >
+      <el-form>
+        <el-form-item label="退回至节点">
+          <el-select v-model="returnTargetNodeKey" placeholder="选择退回目标节点" style="width: 100%">
+            <el-option
+              v-for="node in returnableNodes"
+              :key="node.key"
+              :label="node.label"
+              :value="node.key"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="退回说明">
+          <el-input
+            v-model="actionComment"
+            type="textarea"
+            :rows="2"
+            placeholder="请输入退回说明"
+          />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="returnDialogVisible = false">取消</el-button>
+        <el-button type="warning" :loading="store.loading" @click="submitReturn">
+          确认退回
+        </el-button>
+      </template>
+    </el-dialog>
   </section>
 </template>
 
@@ -278,9 +337,27 @@ const isRequester = computed(() => {
 const actionDialogVisible = ref(false)
 const transferDialogVisible = ref(false)
 const commentDialogVisible = ref(false)
+const returnDialogVisible = ref(false)
 const currentAction = ref<ApprovalActionType>('approve')
 const actionComment = ref('')
 const transferUserId = ref('')
+const returnTargetNodeKey = ref('')
+
+const returnableNodes = computed(() => {
+  if (!approval.value || approval.value.status !== 'pending') return []
+  const currentNodeKey = approval.value.currentNodeKey
+  const visited = new Set<string>()
+  for (const h of store.history) {
+    const nk = h.metadata?.nodeKey as string | undefined
+    if (nk && nk !== currentNodeKey && nk !== 'start' && nk !== 'end') {
+      visited.add(nk)
+    }
+  }
+  return Array.from(visited).map((key) => ({
+    key,
+    label: key,
+  }))
+})
 
 const actionDialogTitle = computed(() =>
   currentAction.value === 'approve' ? '审批通过' : '审批驳回',
@@ -311,7 +388,9 @@ function statusLabel(status: string) {
   return map[status] ?? status
 }
 
-function actionLabel(action: string) {
+function actionLabel(action: string, metadata?: Record<string, unknown>) {
+  if (action === 'approve' && metadata?.autoApproved) return '自动通过'
+  if (action === 'return') return '退回'
   const map: Record<string, string> = {
     created: '发起',
     approve: '通过',
@@ -319,11 +398,13 @@ function actionLabel(action: string) {
     transfer: '转交',
     revoke: '撤回',
     comment: '评论',
+    return: '退回',
   }
   return map[action] ?? action
 }
 
 function timelineItemType(action: string, toStatus: string): string {
+  if (action === 'return') return 'warning'
   if (action === 'approve') return 'success'
   if (action === 'reject') return 'danger'
   if (action === 'transfer') return 'warning'
@@ -332,7 +413,15 @@ function timelineItemType(action: string, toStatus: string): string {
   return 'info'
 }
 
-function timelineIcon(action: string) {
+function timelineActionTagType(action: string, metadata?: Record<string, unknown>): string {
+  if (action === 'approve' && metadata?.autoApproved) return 'info'
+  if (action === 'return') return 'warning'
+  return statusTagType(action === 'approve' ? 'approved' : action === 'reject' ? 'rejected' : 'pending')
+}
+
+function timelineIcon(action: string, metadata?: Record<string, unknown>) {
+  if (action === 'return') return RefreshLeft
+  if (action === 'approve' && metadata?.autoApproved) return Bell
   const map: Record<string, any> = {
     approve: Check,
     reject: Close,
@@ -342,6 +431,16 @@ function timelineIcon(action: string) {
     revoke: RefreshLeft,
   }
   return map[action] ?? undefined
+}
+
+function hasTimelineMetadata(metadata?: Record<string, unknown>): boolean {
+  if (!metadata) return false
+  return !!(metadata.autoApproved || metadata.approvalMode || metadata.aggregateComplete || metadata.nodeKey || metadata.targetNodeKey)
+}
+
+function approvalModeLabel(mode: string): string {
+  const map: Record<string, string> = { single: '单人', all: '会签', any: '或签' }
+  return map[mode] ?? mode
 }
 
 function formatDate(dateStr: string) {
@@ -379,6 +478,12 @@ function openTransferDialog() {
   transferUserId.value = ''
   actionComment.value = ''
   transferDialogVisible.value = true
+}
+
+function openReturnDialog() {
+  returnTargetNodeKey.value = ''
+  actionComment.value = ''
+  returnDialogVisible.value = true
 }
 
 function openCommentDialog() {
@@ -431,6 +536,23 @@ async function submitComment() {
     await store.loadHistory(id)
   } catch {
     ElMessage.error('评论提交失败，请重试')
+  }
+}
+
+async function submitReturn() {
+  if (!returnTargetNodeKey.value) return
+  const id = route.params.id as string
+  try {
+    await store.executeAction(id, {
+      action: 'return',
+      comment: actionComment.value || undefined,
+      targetNodeKey: returnTargetNodeKey.value,
+    })
+    ElMessage.success('已退回审批')
+    returnDialogVisible.value = false
+    await store.loadHistory(id)
+  } catch {
+    ElMessage.error('退回失败，请重试')
   }
 }
 
@@ -548,6 +670,37 @@ onMounted(async () => {
   margin: 4px 0 0;
   color: var(--el-text-color-regular, #606266);
   font-size: 13px;
+}
+
+.approval-detail__timeline-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.approval-detail__meta-badge {
+  display: inline-block;
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--el-fill-color-light, #f5f7fa);
+  color: var(--el-text-color-secondary, #909399);
+}
+
+.approval-detail__meta-badge--auto {
+  background: #e6f7ff;
+  color: #1890ff;
+}
+
+.approval-detail__meta-badge--complete {
+  background: #f6ffed;
+  color: #52c41a;
+}
+
+.approval-detail__meta-badge--return {
+  background: #fff7e6;
+  color: #fa8c16;
 }
 
 .approval-detail__actions {

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -107,7 +107,7 @@
                     会签完成
                   </span>
                   <span v-if="item.action === 'return' && item.metadata?.targetNodeKey" class="approval-detail__meta-badge approval-detail__meta-badge--return">
-                    退回至: {{ item.metadata.targetNodeKey }}
+                    退回至: {{ nodeLabel(item.metadata.targetNodeKey as string) }}
                   </span>
                   <span v-if="item.metadata?.nodeKey" class="approval-detail__meta-badge">
                     节点: {{ item.metadata.nodeKey }}
@@ -322,10 +322,12 @@ import {
 import type { ApprovalActionType } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
+import { useApprovalTemplateStore } from '../../approvals/templateStore'
 
 const route = useRoute()
 const router = useRouter()
 const store = useApprovalStore()
+const templateStore = useApprovalTemplateStore()
 const { canAct } = useApprovalPermissions()
 
 const approval = computed(() => store.activeApproval)
@@ -355,7 +357,7 @@ const returnableNodes = computed(() => {
   }
   return Array.from(visited).map((key) => ({
     key,
-    label: key,
+    label: nodeLabel(key),
   }))
 })
 
@@ -390,7 +392,6 @@ function statusLabel(status: string) {
 
 function actionLabel(action: string, metadata?: Record<string, unknown>) {
   if (action === 'approve' && metadata?.autoApproved) return '自动通过'
-  if (action === 'return') return '退回'
   const map: Record<string, string> = {
     created: '发起',
     approve: '通过',
@@ -441,6 +442,12 @@ function hasTimelineMetadata(metadata?: Record<string, unknown>): boolean {
 function approvalModeLabel(mode: string): string {
   const map: Record<string, string> = { single: '单人', all: '会签', any: '或签' }
   return map[mode] ?? mode
+}
+
+function nodeLabel(nodeKey: string): string {
+  if (!nodeKey) return '-'
+  const node = templateStore.activeTemplate?.approvalGraph.nodes.find((entry) => entry.key === nodeKey)
+  return node?.name?.trim() || nodeKey
 }
 
 function formatDate(dateStr: string) {
@@ -573,6 +580,9 @@ async function handleRevoke() {
 onMounted(async () => {
   const id = route.params.id as string
   await Promise.all([store.loadDetail(id), store.loadHistory(id)])
+  if (store.activeApproval?.templateId) {
+    await templateStore.loadTemplate(store.activeApproval.templateId).catch(() => undefined)
+  }
 })
 </script>
 

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -110,6 +110,21 @@
                     {{ (node.config as any).assigneeType === 'role' ? '角色' : '用户' }}:
                     {{ (node.config as any).assigneeIds?.join(', ') ?? '-' }}
                   </span>
+                  <el-tag
+                    v-if="node.type === 'approval' && (node.config as any).approvalMode"
+                    size="small"
+                    class="template-detail__node-mode"
+                  >
+                    {{ approvalModeLabel((node.config as any).approvalMode) }}
+                  </el-tag>
+                  <el-tag
+                    v-if="node.type === 'approval' && (node.config as any).emptyAssigneePolicy"
+                    size="small"
+                    :type="(node.config as any).emptyAssigneePolicy === 'auto-approve' ? 'success' : 'danger'"
+                    class="template-detail__node-policy"
+                  >
+                    {{ emptyAssigneePolicyLabel((node.config as any).emptyAssigneePolicy) }}
+                  </el-tag>
                 </div>
               </el-timeline-item>
             </el-timeline>
@@ -134,7 +149,7 @@ import {
   QuestionFilled,
   CircleCheckFilled,
 } from '@element-plus/icons-vue'
-import type { ApprovalNodeType, FormFieldType } from '../../types/approval'
+import type { ApprovalNodeType, FormFieldType, ApprovalMode, EmptyAssigneePolicy } from '../../types/approval'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
 
@@ -220,6 +235,16 @@ function nodeTagType(type: ApprovalNodeType): string {
     end: 'info',
   }
   return map[type] ?? ''
+}
+
+function approvalModeLabel(mode: ApprovalMode): string {
+  const map: Record<ApprovalMode, string> = { single: '单人审批', all: '会签', any: '或签' }
+  return map[mode] ?? mode
+}
+
+function emptyAssigneePolicyLabel(policy: EmptyAssigneePolicy): string {
+  const map: Record<EmptyAssigneePolicy, string> = { error: '无人时报错', 'auto-approve': '无人时自动通过' }
+  return map[policy] ?? policy
 }
 
 function formatDate(dateStr: string) {
@@ -324,6 +349,11 @@ onMounted(() => {
 .template-detail__node-assignee {
   font-size: 12px;
   color: var(--el-text-color-regular, #606266);
+}
+
+.template-detail__node-mode,
+.template-detail__node-policy {
+  margin-left: 4px;
 }
 
 @media (max-width: 768px) {

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -19,6 +19,9 @@ import {
   mockPublishedTemplate,
   mockDraftTemplate,
   mockHistoryItems,
+  mockAutoApproveHistory,
+  mockReturnHistory,
+  mockTemplateWithModes,
   mockPermissions,
   CURRENT_USER_ID,
 } from './helpers/approval-test-fixtures'
@@ -976,6 +979,154 @@ describe('Approval E2E Permissions', () => {
 
       const empty = container!.querySelector('[data-el-empty]')
       expect(empty?.textContent).toContain('未找到模板')
+    })
+  })
+
+  // =========================================================================
+  // 6. Return action affordance
+  // =========================================================================
+  describe('Return action affordance', () => {
+    it('shows return button when history has visited approval nodes', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_2' })
+      mockHistoryRef.value = mockReturnHistory()
+      await mountDetailView()
+
+      const buttons = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+      const labels = buttons.map((b) => b.textContent?.trim())
+      expect(labels).toContain('退回')
+    })
+
+    it('does not show return button when no returnable nodes exist', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
+      routeParams = { id: 'apv_pending_1' }
+      // currentNodeKey is approval_1 and history only has 'start' (excluded) and approval_1 (current, excluded)
+      mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_1' })
+      mockHistoryRef.value = [
+        {
+          id: 'hist_1', action: 'created', actorId: 'user_1', actorName: '张三',
+          comment: null, fromStatus: null, toStatus: 'pending',
+          occurredAt: '2026-04-09T08:00:00Z', metadata: { nodeKey: 'start' },
+        },
+      ]
+      await mountDetailView()
+
+      const buttons = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+      const labels = buttons.map((b) => b.textContent?.trim())
+      expect(labels).not.toContain('退回')
+    })
+
+    it('clicking return opens dialog and submits with targetNodeKey', async () => {
+      setMockPermissions(['approvals:read', 'approvals:act'])
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_2' })
+      mockHistoryRef.value = mockReturnHistory()
+      executeActionSpy.mockResolvedValue(mockPendingApproval())
+      await mountDetailView()
+
+      const returnBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '退回')
+      returnBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="退回审批"]')
+      expect(dialog).toBeTruthy()
+
+      // Select a target node
+      const select = dialog!.querySelector('[data-el-select]') as HTMLSelectElement
+      select.value = 'approval_1'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi()
+
+      const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('确认退回'))
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', expect.objectContaining({
+        action: 'return',
+        targetNodeKey: 'approval_1',
+      }))
+    })
+  })
+
+  // =========================================================================
+  // 7. Template approvalMode / emptyAssigneePolicy display
+  // =========================================================================
+  describe('Template approvalMode and emptyAssigneePolicy display', () => {
+    it('renders approvalMode tags on approval nodes', async () => {
+      setMockPermissions(['approval-templates:manage'])
+      routeParams = { id: 'tpl_modes' }
+      mockActiveTemplate.value = mockTemplateWithModes()
+      await mountTemplateDetailView()
+
+      const nodes = queryTemplateGraphNodes(container)
+      expect(nodes.length).toBe(4) // start + 2 approval + end
+
+      const textContent = container!.textContent ?? ''
+      expect(textContent).toContain('会签')
+      expect(textContent).toContain('或签')
+    })
+
+    it('renders emptyAssigneePolicy tags on approval nodes', async () => {
+      setMockPermissions(['approval-templates:manage'])
+      routeParams = { id: 'tpl_modes' }
+      mockActiveTemplate.value = mockTemplateWithModes()
+      await mountTemplateDetailView()
+
+      const textContent = container!.textContent ?? ''
+      expect(textContent).toContain('无人时报错')
+      expect(textContent).toContain('无人时自动通过')
+    })
+  })
+
+  // =========================================================================
+  // 8. Auto-approve timeline display
+  // =========================================================================
+  describe('Auto-approve timeline display', () => {
+    it('renders auto-approved history item with system label', async () => {
+      setMockPermissions(['approvals:read'])
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval()
+      mockHistoryRef.value = mockAutoApproveHistory()
+      await mountDetailView()
+
+      const items = queryHistoryItems(container)
+      expect(items.length).toBe(2)
+
+      const textContent = container!.textContent ?? ''
+      expect(textContent).toContain('系统自动审批')
+      expect(textContent).toContain('自动通过')
+      expect(textContent).toContain('自动审批')
+    })
+
+    it('renders return event in timeline with metadata', async () => {
+      setMockPermissions(['approvals:read'])
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_1' })
+      mockHistoryRef.value = mockReturnHistory()
+      await mountDetailView()
+
+      const items = queryHistoryItems(container)
+      expect(items.length).toBe(3)
+
+      const textContent = container!.textContent ?? ''
+      expect(textContent).toContain('退回')
+      expect(textContent).toContain('退回至: approval_1')
+      expect(textContent).toContain('金额有误，退回修改')
+    })
+
+    it('renders aggregateComplete and approvalMode metadata in timeline', async () => {
+      setMockPermissions(['approvals:read'])
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_2' })
+      mockHistoryRef.value = mockReturnHistory()
+      await mountDetailView()
+
+      const textContent = container!.textContent ?? ''
+      expect(textContent).toContain('会签完成')
+      expect(textContent).toContain('审批模式: 会签')
     })
   })
 })

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -991,6 +991,7 @@ describe('Approval E2E Permissions', () => {
       routeParams = { id: 'apv_pending_1' }
       mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_2' })
       mockHistoryRef.value = mockReturnHistory()
+      mockActiveTemplate.value = mockTemplateWithModes()
       await mountDetailView()
 
       const buttons = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
@@ -1022,6 +1023,7 @@ describe('Approval E2E Permissions', () => {
       routeParams = { id: 'apv_pending_1' }
       mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_2' })
       mockHistoryRef.value = mockReturnHistory()
+      mockActiveTemplate.value = mockTemplateWithModes()
       executeActionSpy.mockResolvedValue(mockPendingApproval())
       await mountDetailView()
 
@@ -1032,6 +1034,7 @@ describe('Approval E2E Permissions', () => {
 
       const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="退回审批"]')
       expect(dialog).toBeTruthy()
+      expect(dialog?.textContent).toContain('部门主管审批')
 
       // Select a target node
       const select = dialog!.querySelector('[data-el-select]') as HTMLSelectElement
@@ -1106,6 +1109,7 @@ describe('Approval E2E Permissions', () => {
       routeParams = { id: 'apv_pending_1' }
       mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_1' })
       mockHistoryRef.value = mockReturnHistory()
+      mockActiveTemplate.value = mockTemplateWithModes()
       await mountDetailView()
 
       const items = queryHistoryItems(container)
@@ -1113,7 +1117,7 @@ describe('Approval E2E Permissions', () => {
 
       const textContent = container!.textContent ?? ''
       expect(textContent).toContain('退回')
-      expect(textContent).toContain('退回至: approval_1')
+      expect(textContent).toContain('退回至: 部门主管审批')
       expect(textContent).toContain('金额有误，退回修改')
     })
 

--- a/apps/web/tests/helpers/approval-test-fixtures.ts
+++ b/apps/web/tests/helpers/approval-test-fixtures.ts
@@ -199,7 +199,7 @@ export function mockHistoryItems(): UnifiedApprovalHistoryDTO[] {
       fromStatus: null,
       toStatus: 'pending',
       occurredAt: YESTERDAY,
-      metadata: {},
+      metadata: { nodeKey: 'start' },
     },
     {
       id: 'hist_2',
@@ -210,9 +210,99 @@ export function mockHistoryItems(): UnifiedApprovalHistoryDTO[] {
       fromStatus: 'pending',
       toStatus: 'approved',
       occurredAt: NOW,
-      metadata: {},
+      metadata: { nodeKey: 'approval_1' },
     },
   ]
+}
+
+/** History with auto-approved event. */
+export function mockAutoApproveHistory(): UnifiedApprovalHistoryDTO[] {
+  return [
+    {
+      id: 'hist_auto_1',
+      action: 'created',
+      actorId: REQUESTER_USER_ID,
+      actorName: '张三',
+      comment: null,
+      fromStatus: null,
+      toStatus: 'pending',
+      occurredAt: YESTERDAY,
+      metadata: { nodeKey: 'start' },
+    },
+    {
+      id: 'hist_auto_2',
+      action: 'approve',
+      actorId: null,
+      actorName: '系统',
+      comment: '无审批人，自动通过',
+      fromStatus: 'pending',
+      toStatus: 'approved',
+      occurredAt: NOW,
+      metadata: { nodeKey: 'approval_1', autoApproved: true },
+    },
+  ]
+}
+
+/** History with return event and rich metadata. */
+export function mockReturnHistory(): UnifiedApprovalHistoryDTO[] {
+  return [
+    {
+      id: 'hist_ret_1',
+      action: 'created',
+      actorId: REQUESTER_USER_ID,
+      actorName: '张三',
+      comment: null,
+      fromStatus: null,
+      toStatus: 'pending',
+      occurredAt: YESTERDAY,
+      metadata: { nodeKey: 'start' },
+    },
+    {
+      id: 'hist_ret_2',
+      action: 'approve',
+      actorId: CURRENT_USER_ID,
+      actorName: '当前用户',
+      comment: '同意',
+      fromStatus: 'pending',
+      toStatus: 'pending',
+      occurredAt: YESTERDAY,
+      metadata: { nodeKey: 'approval_1', approvalMode: 'all', aggregateComplete: true },
+    },
+    {
+      id: 'hist_ret_3',
+      action: 'return',
+      actorId: 'user_3',
+      actorName: '王五',
+      comment: '金额有误，退回修改',
+      fromStatus: 'pending',
+      toStatus: 'pending',
+      occurredAt: NOW,
+      metadata: { nodeKey: 'approval_2', targetNodeKey: 'approval_1' },
+    },
+  ]
+}
+
+/** Template with approvalMode and emptyAssigneePolicy on approval nodes. */
+export function mockTemplateWithModes(overrides?: Partial<ApprovalTemplateDetailDTO>): ApprovalTemplateDetailDTO {
+  return {
+    ...mockPublishedTemplate(),
+    id: 'tpl_modes',
+    name: '含模式策略模板',
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeType: 'role', assigneeIds: ['role_manager'], approvalMode: 'all', emptyAssigneePolicy: 'error' } },
+        { key: 'approval_2', type: 'approval', name: '财务审批', config: { assigneeType: 'user', assigneeIds: ['user_finance'], approvalMode: 'any', emptyAssigneePolicy: 'auto-approve' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' },
+        { key: 'e2', source: 'approval_1', target: 'approval_2' },
+        { key: 'e3', source: 'approval_2', target: 'end' },
+      ],
+    },
+    ...overrides,
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n- consume Pack 1A return semantics in the approval detail view\n- surface approvalMode / emptyAssigneePolicy in template detail\n- extend fixtures and view tests for return and auto-approve history\n\n## Verification\n- pnpm --filter @metasheet/web exec vitest run tests/approval-e2e-permissions.spec.ts --reporter=dot\n- pnpm --filter @metasheet/web exec vue-tsc --noEmit