### PR TITLE
fix(attendance): land #651 zero-state and viewport polish

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -148,6 +148,13 @@
                 : tr('No anomaly reminders in the current range.', '当前区间内没有异常提醒。')
             }}
           </p>
+          <p
+            v-if="selfServiceNeedsSetupHint"
+            class="attendance__field-hint attendance__field-hint--strong"
+            data-selfservice-setup-hint
+          >
+            {{ selfServiceSetupFollowupHint }}
+          </p>
           <ul class="attendance__selfservice-focus-list" data-selfservice-focus-list>
             <li v-for="item in selfServiceFocusItems" :key="item.key" class="attendance__selfservice-focus-item">
               <div class="attendance__selfservice-focus-copy">
@@ -5736,7 +5743,12 @@ const activeWorkbenchLatestPunchLabel = computed(() => {
 })
 
 const activeWorkbenchStatusDescription = computed(() =>
-  describeAttendanceStatus(activeWorkbenchRecord.value?.status)
+  selfServiceNeedsSetupHint.value
+    ? tr(
+      'No attendance data is available in this range yet.',
+      '当前区间内还没有考勤数据。',
+    )
+    : describeAttendanceStatus(activeWorkbenchRecord.value?.status)
 )
 
 const activeWorkbenchLateEarlyLabel = computed(() => {
@@ -5751,6 +5763,41 @@ const activeWorkbenchAttentionCount = computed(() => {
   if (!focusDate) return anomalies.value.length
   return anomalies.value.filter(item => item.workDate === focusDate).length
 })
+
+function attendanceSummaryHasSignal(value: AttendanceSummary | null): boolean {
+  if (!value) return false
+  return [
+    value.total_days,
+    value.total_minutes,
+    value.total_late_minutes ?? 0,
+    value.total_early_leave_minutes ?? 0,
+    value.normal_days,
+    value.late_days,
+    value.early_leave_days,
+    value.late_early_days,
+    value.partial_days,
+    value.absent_days,
+    value.adjusted_days,
+    value.off_days,
+    value.leave_minutes ?? 0,
+    value.overtime_minutes ?? 0,
+  ].some(item => Number(item) > 0)
+}
+
+const selfServiceNeedsSetupHint = computed(() => {
+  if (!summary.value) return false
+  if (records.value.length > 0 || requests.value.length > 0 || anomalies.value.length > 0) {
+    return false
+  }
+  return !attendanceSummaryHasSignal(summary.value)
+})
+
+const selfServiceSetupFollowupHint = computed(() =>
+  tr(
+    'If you recently joined or expected a schedule here, you may not be assigned to an attendance group yet. Ask an attendance admin to confirm your group and shift setup.',
+    '如果你是新入职员工，或原本应在这里看到班次/记录，可能还未被分配到考勤组。请联系考勤管理员确认你的分组和班次配置。',
+  )
+)
 
 function countRequestsByStatus(status: string): number {
   return requests.value.filter(item => item.status === status).length
@@ -5892,6 +5939,18 @@ const attendanceStatusGuideItems = computed<AttendanceSelfServiceStatusGuideItem
 ])
 
 const selfServiceFocusItems = computed<AttendanceSelfServiceFocusItem[]>(() => {
+  if (selfServiceNeedsSetupHint.value) {
+    return [
+      {
+        key: 'setup-guidance',
+        title: tr('Check attendance setup', '检查考勤配置'),
+        detail: selfServiceSetupFollowupHint.value,
+        action: null,
+        actionLabel: null,
+      },
+    ]
+  }
+
   const items: AttendanceSelfServiceFocusItem[] = []
   const focusRecord = activeWorkbenchRecord.value
   const attentionCount = activeWorkbenchAttentionCount.value
@@ -5953,6 +6012,15 @@ const selfServiceFocusItems = computed<AttendanceSelfServiceFocusItem[]>(() => {
 })
 
 const selfServicePrimaryAction = computed<AttendanceSelfServiceFocusItem>(() => {
+  if (selfServiceNeedsSetupHint.value) {
+    return {
+      key: 'setup-wait',
+      title: tr('Wait for attendance setup', '等待考勤配置'),
+      detail: selfServiceSetupFollowupHint.value,
+      action: null,
+      actionLabel: null,
+    }
+  }
   return selfServiceFocusItems.value.find(item => item.action && item.actionLabel) ?? {
     key: 'default-leave',
     title: tr('Start a new attendance request', '发起新的考勤申请'),
@@ -5966,6 +6034,9 @@ const selfServicePrimaryAction = computed<AttendanceSelfServiceFocusItem>(() => 
 })
 
 const selfServiceQuickActionHint = computed(() => {
+  if (selfServiceNeedsSetupHint.value) {
+    return selfServiceSetupFollowupHint.value
+  }
   if (activeWorkbenchAttentionCount.value > 0) {
     return tr(
       'Start with missing-punch handling to resolve the current anomaly reminder.',

--- a/apps/web/src/views/attendance/AttendanceExperienceView.vue
+++ b/apps/web/src/views/attendance/AttendanceExperienceView.vue
@@ -121,6 +121,28 @@ const desktopOnlyMessage = computed(() => {
   return t.value.adminDesktopHint
 })
 
+function matchesMediaQuery(query: string): boolean {
+  try {
+    return Boolean(window.matchMedia?.(query)?.matches)
+  } catch {
+    return false
+  }
+}
+
+function hasMobileRuntimeSignals(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return false
+
+  if (matchesMediaQuery('(pointer: coarse)')) return true
+
+  const touchPoints = Number(navigator.maxTouchPoints ?? 0)
+  if (touchPoints > 0) return true
+
+  const userAgent = String(navigator.userAgent || '')
+  if (/(android|iphone|ipad|ipod|mobile)/i.test(userAgent)) return true
+
+  return false
+}
+
 const activeView = computed(() => {
   switch (activeTab.value) {
     case 'overview':
@@ -161,26 +183,18 @@ const activeView = computed(() => {
 
 function updateMobileState(): void {
   if (typeof window === 'undefined') return
-  // Prefer media query (most stable) then fallback to viewport measurements.
-  // Some environments can report a scaled `innerWidth` even when the CSS viewport is narrow.
-  try {
-    if (window.matchMedia?.('(max-width: 899px)')?.matches) {
-      isMobile.value = true
-      return
-    }
-  } catch {
-    // ignore
-  }
+  const mediaQueryMatches = matchesMediaQuery('(max-width: 899px)')
 
   const docWidth = typeof document !== 'undefined'
     ? document.documentElement?.clientWidth
     : 0
   const viewportWidth = window.visualViewport?.width ?? 0
   const width = Math.max(viewportWidth || 0, docWidth || 0) || window.innerWidth
+  const narrowViewport = mediaQueryMatches || width < 900
 
-  // NOTE: `window.innerWidth` can be misleading on mobile due to viewport scaling.
-  // Prefer visualViewport / clientWidth for consistent gating.
-  isMobile.value = width < 900
+  // Narrow desktop/headless windows should still be usable.
+  // Only gate desktop-first tabs when the runtime also looks mobile/touch-first.
+  isMobile.value = narrowViewport && hasMobileRuntimeSignals()
 }
 
 function normalizeTab(value: unknown): AttendanceTab {

--- a/apps/web/tests/attendance-experience-entrypoints.spec.ts
+++ b/apps/web/tests/attendance-experience-entrypoints.spec.ts
@@ -89,6 +89,7 @@ async function flushUi(cycles = 6): Promise<void> {
 describe('Attendance experience entrypoints', () => {
   let app: App<Element> | null = null
   let container: HTMLDivElement | null = null
+  const originalMatchMedia = window.matchMedia
 
   beforeEach(() => {
     replaceSpy.mockClear()
@@ -102,6 +103,11 @@ describe('Attendance experience entrypoints', () => {
   afterEach(() => {
     if (app) app.unmount()
     if (container) container.remove()
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    })
     app = null
     container = null
   })
@@ -152,5 +158,31 @@ describe('Attendance experience entrypoints', () => {
     await flushUi(2)
 
     expect(replaceSpy).toHaveBeenCalledWith({ query: { tab: 'reports' } })
+  })
+
+  it('does not block admin entrypoints for narrow desktop-like viewports without mobile signals', async () => {
+    routeState.query = { tab: 'admin' }
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('max-width: 899px'),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+
+    app = createApp(AttendanceExperienceView)
+    app.mount(container!)
+    await flushUi()
+
+    expect(container!.querySelector('[data-view="admin"]')).toBeTruthy()
+    expect(container!.textContent).not.toContain('Desktop recommended')
   })
 })

--- a/apps/web/tests/attendance-experience-mobile-zh.spec.ts
+++ b/apps/web/tests/attendance-experience-mobile-zh.spec.ts
@@ -78,7 +78,7 @@ describe('AttendanceExperienceView mobile zh fallback', () => {
       configurable: true,
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
-        matches: query.includes('max-width: 899px'),
+        matches: query.includes('max-width: 899px') || query.includes('pointer: coarse'),
         media: query,
         onchange: null,
         addListener: vi.fn(),

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -191,6 +191,82 @@ function installOverviewMock(): void {
   })
 }
 
+function installZeroStateMock(): void {
+  vi.mocked(apiFetch).mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input : input.url
+
+    if (url.includes('/api/attendance/summary?')) {
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          total_days: 0,
+          total_minutes: 0,
+          total_late_minutes: 0,
+          total_early_leave_minutes: 0,
+          normal_days: 0,
+          late_days: 0,
+          early_leave_days: 0,
+          late_early_days: 0,
+          partial_days: 0,
+          absent_days: 0,
+          adjusted_days: 0,
+          off_days: 0,
+          leave_minutes: 0,
+          overtime_minutes: 0,
+        },
+      })
+    }
+    if (url.includes('/api/attendance/records?')) {
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          items: [],
+          total: 0,
+        },
+      })
+    }
+    if (url.includes('/api/attendance/requests?')) {
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          items: [],
+        },
+      })
+    }
+    if (url.includes('/api/attendance/anomalies?')) {
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          items: [],
+        },
+      })
+    }
+    if (url.includes('/api/attendance/reports/requests?')) {
+      return jsonResponse(200, { ok: true, data: { items: [] } })
+    }
+    if (url.includes('/api/attendance/holidays?')) {
+      return jsonResponse(200, { ok: true, data: { items: [] } })
+    }
+    if (url.includes('/api/attendance/settings')) {
+      return jsonResponse(200, { ok: true, data: {} })
+    }
+    if (url.includes('/api/attendance/rules/default')) {
+      return jsonResponse(200, { ok: true, data: {} })
+    }
+    if (url.includes('/api/attendance/rule-templates')) {
+      return jsonResponse(200, { ok: true, data: { system: [], library: [], versions: [] } })
+    }
+    if (url.includes('/api/attendance/leave-types')) {
+      return jsonResponse(200, { ok: true, data: { items: [] } })
+    }
+    if (url.includes('/api/attendance/overtime-rules')) {
+      return jsonResponse(200, { ok: true, data: { items: [] } })
+    }
+
+    return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+  })
+}
+
 describe('Attendance self-service dashboard', () => {
   let app: App<Element> | null = null
   let container: HTMLDivElement | null = null
@@ -288,6 +364,24 @@ describe('Attendance self-service dashboard', () => {
     await flushUi(3)
     expect(requestType?.value).toBe('missed_check_in')
     expect(workDate?.value).toBe('2026-04-15')
+  })
+
+  it('explains zero-data onboarding when no attendance records exist yet', async () => {
+    installZeroStateMock()
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const statusCard = container!.querySelector('[data-selfservice-card="status"]')?.textContent ?? ''
+    const setupHint = container!.querySelector('[data-selfservice-setup-hint]')?.textContent ?? ''
+    const focusList = container!.querySelector('[data-selfservice-focus-list]')?.textContent ?? ''
+    const actionsCard = container!.querySelector('[data-selfservice-card="actions"]')?.textContent ?? ''
+
+    expect(statusCard).toContain('No attendance data is available in this range yet.')
+    expect(setupHint).toContain('you may not be assigned to an attendance group yet')
+    expect(setupHint).toContain('confirm your group and shift setup')
+    expect(focusList).toContain('Check attendance setup')
+    expect(actionsCard).toContain('Wait for attendance setup')
   })
 
   it('surfaces punch-too-soon failures with status code, hint, and retry affordance', async () => {


### PR DESCRIPTION
## Summary
- add explicit attendance self-service zero-state setup guidance for users with no records, requests, anomalies, or summary signal
- relax attendance desktop-only gating so narrow desktop/headless viewports are not treated as mobile without touch/mobile runtime signals
- cover both fixes with focused web regression tests

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/attendance-selfservice-dashboard.spec.ts tests/attendance-experience-entrypoints.spec.ts tests/attendance-experience-mobile-zh.spec.ts
- pnpm --filter @metasheet/web build
