### PR TITLE
feat(multitable): add field type registry for plugin-extensible custom fields

### DIFF
--- a/packages/core-backend/src/core/plugin-service-factory.ts
+++ b/packages/core-backend/src/core/plugin-service-factory.ts
@@ -3,6 +3,7 @@
  * 负责创建和管理所有插件相关服务的实例
  */
 
+import { fieldTypeRegistry } from '../multitable/field-type-registry'
 import type { PluginServices } from '../types/plugin'
 import { Logger } from './logger'
 
@@ -215,7 +216,12 @@ export class PluginServiceFactory {
         },
         websocket: await this.createWebSocketService(),
         security: await this.createSecurityService(),
-        validation: await this.createValidationService()
+        validation: await this.createValidationService(),
+        fieldTypes: {
+          register(name, definition) {
+            fieldTypeRegistry.register(name, definition)
+          },
+        },
       }
 
       // 设置服务间的相互引用

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -1,3 +1,5 @@
+import { fieldTypeRegistry } from './field-type-registry'
+
 export type MultitableFieldType =
   | 'string'
   | 'number'
@@ -59,7 +61,7 @@ export function normalizeJsonArray(value: unknown): string[] {
   return []
 }
 
-export function mapFieldType(type: string): MultitableFieldType {
+export function mapFieldType(type: string): MultitableFieldType | string {
   const normalized = type.trim().toLowerCase()
   if (normalized === 'number') return 'number'
   if (normalized === 'boolean' || normalized === 'checkbox') return 'boolean'
@@ -70,6 +72,7 @@ export function mapFieldType(type: string): MultitableFieldType {
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
+  if (fieldTypeRegistry.has(normalized)) return normalized
   return 'string'
 }
 
@@ -117,7 +120,7 @@ function parseRollupAggregation(value: unknown): 'count' | 'sum' | 'avg' | 'min'
 }
 
 export function sanitizeFieldProperty(
-  type: MultitableFieldType,
+  type: MultitableFieldType | string,
   property: unknown,
 ): Record<string, unknown> {
   const obj = normalizeJson(property)
@@ -231,6 +234,11 @@ export function sanitizeFieldProperty(
     }
   }
 
+  const customDef = fieldTypeRegistry.get(type)
+  if (customDef) {
+    return customDef.sanitizeProperty(property)
+  }
+
   return obj
 }
 
@@ -242,7 +250,7 @@ export function serializeFieldRow(row: any): MultitableField {
   return {
     id: String(row.id),
     name: String(row.name),
-    type: mappedType,
+    type: mappedType as MultitableFieldType,
     ...(mappedType === 'select' ? { options: extractSelectOptions(property) } : {}),
     order: Number.isFinite(order) ? order : 0,
     property,

--- a/packages/core-backend/src/multitable/field-type-registry.ts
+++ b/packages/core-backend/src/multitable/field-type-registry.ts
@@ -1,0 +1,36 @@
+export interface FieldTypeDefinition {
+  name: string
+  validate: (value: unknown, fieldId: string) => unknown
+  sanitizeProperty: (property: unknown) => Record<string, unknown>
+  serialize?: (value: unknown) => unknown
+  deserialize?: (value: unknown) => unknown
+}
+
+export class FieldTypeRegistry {
+  private readonly definitions = new Map<string, FieldTypeDefinition>()
+
+  register(typeName: string, definition: FieldTypeDefinition): void {
+    if (!typeName || typeof typeName !== 'string') {
+      throw new Error('Field type name must be a non-empty string')
+    }
+    this.definitions.set(typeName, definition)
+  }
+
+  has(typeName: string): boolean {
+    return this.definitions.has(typeName)
+  }
+
+  get(typeName: string): FieldTypeDefinition | undefined {
+    return this.definitions.get(typeName)
+  }
+
+  unregister(typeName: string): void {
+    this.definitions.delete(typeName)
+  }
+
+  getRegisteredTypes(): string[] {
+    return Array.from(this.definitions.keys())
+  }
+}
+
+export const fieldTypeRegistry = new FieldTypeRegistry()

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 
+import { fieldTypeRegistry } from './field-type-registry'
 import { loadFieldsForSheet, loadSheetRow } from './loaders'
 
 export type MultitableRecordsQueryFn = (
@@ -216,8 +217,13 @@ function normalizeFieldValue(
       throw new MultitableRecordValidationError(
         `Field type is not supported by multitable.records.createRecord yet: ${field.id}`,
       )
-    default:
+    default: {
+      const customDef = fieldTypeRegistry.get(field.type)
+      if (customDef) {
+        return customDef.validate(value, field.id)
+      }
       return value
+    }
   }
 }
 

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -850,6 +850,16 @@ export interface PluginInstance {
  * 插件服务集合
  * 包含所有可用的插件运行时服务
  */
+export interface PluginFieldTypesService {
+  register(name: string, definition: {
+    name: string
+    validate: (value: unknown, fieldId: string) => unknown
+    sanitizeProperty: (property: unknown) => Record<string, unknown>
+    serialize?: (value: unknown) => unknown
+    deserialize?: (value: unknown) => unknown
+  }): void
+}
+
 export interface PluginServices {
   cache: CacheService        // Cache service instance
   queue: QueueService        // Queue service instance
@@ -861,6 +871,7 @@ export interface PluginServices {
   websocket: WebSocketService    // WebSocket service instance
   security: SecurityService     // Security service instance
   validation: ValidationService   // Validation service instance
+  fieldTypes: PluginFieldTypesService // Field type registry for custom fields
 }
 
 /**

--- a/packages/core-backend/tests/unit/multitable-field-type-registry.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-type-registry.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { FieldTypeRegistry } from '../../src/multitable/field-type-registry'
+import type { FieldTypeDefinition } from '../../src/multitable/field-type-registry'
+
+function makeDef(overrides: Partial<FieldTypeDefinition> = {}): FieldTypeDefinition {
+  return {
+    name: overrides.name ?? 'test-type',
+    validate: overrides.validate ?? ((v) => v),
+    sanitizeProperty: overrides.sanitizeProperty ?? ((p) => (typeof p === 'object' && p !== null ? p as Record<string, unknown> : {})),
+    ...(overrides.serialize ? { serialize: overrides.serialize } : {}),
+    ...(overrides.deserialize ? { deserialize: overrides.deserialize } : {}),
+  }
+}
+
+describe('FieldTypeRegistry', () => {
+  let registry: FieldTypeRegistry
+
+  beforeEach(() => {
+    registry = new FieldTypeRegistry()
+  })
+
+  it('register and get returns the definition', () => {
+    const def = makeDef({ name: 'currency' })
+    registry.register('currency', def)
+    expect(registry.get('currency')).toBe(def)
+  })
+
+  it('has returns true for registered types', () => {
+    registry.register('currency', makeDef({ name: 'currency' }))
+    expect(registry.has('currency')).toBe(true)
+  })
+
+  it('has returns false for unregistered types', () => {
+    expect(registry.has('nonexistent')).toBe(false)
+  })
+
+  it('get returns undefined for unregistered types', () => {
+    expect(registry.get('nonexistent')).toBeUndefined()
+  })
+
+  it('unregister removes the definition', () => {
+    registry.register('currency', makeDef({ name: 'currency' }))
+    registry.unregister('currency')
+    expect(registry.has('currency')).toBe(false)
+    expect(registry.get('currency')).toBeUndefined()
+  })
+
+  it('unregister on nonexistent type does not throw', () => {
+    expect(() => registry.unregister('nonexistent')).not.toThrow()
+  })
+
+  it('getRegisteredTypes lists all registered types', () => {
+    registry.register('currency', makeDef({ name: 'currency' }))
+    registry.register('rating', makeDef({ name: 'rating' }))
+    expect(registry.getRegisteredTypes().sort()).toEqual(['currency', 'rating'])
+  })
+
+  it('getRegisteredTypes returns empty array when nothing registered', () => {
+    expect(registry.getRegisteredTypes()).toEqual([])
+  })
+
+  it('register overwrites existing definition', () => {
+    const def1 = makeDef({ name: 'v1' })
+    const def2 = makeDef({ name: 'v2' })
+    registry.register('currency', def1)
+    registry.register('currency', def2)
+    expect(registry.get('currency')).toBe(def2)
+  })
+
+  it('register throws on empty name', () => {
+    expect(() => registry.register('', makeDef())).toThrow()
+  })
+
+  it('validate delegates correctly', () => {
+    const def = makeDef({
+      name: 'currency',
+      validate: (value, fieldId) => {
+        if (typeof value !== 'number') {
+          throw new Error(`Currency must be a number: ${fieldId}`)
+        }
+        return Math.round(value * 100) / 100
+      },
+    })
+    registry.register('currency', def)
+    const registered = registry.get('currency')!
+    expect(registered.validate(12.345, 'fld1')).toBe(12.35)
+    expect(() => registered.validate('abc', 'fld1')).toThrow('Currency must be a number: fld1')
+  })
+
+  it('sanitizeProperty delegates correctly', () => {
+    const def = makeDef({
+      name: 'currency',
+      sanitizeProperty: (property) => {
+        const obj = typeof property === 'object' && property !== null
+          ? property as Record<string, unknown>
+          : {}
+        return {
+          currencyCode: typeof obj.currencyCode === 'string' ? obj.currencyCode : 'USD',
+          precision: typeof obj.precision === 'number' ? obj.precision : 2,
+        }
+      },
+    })
+    registry.register('currency', def)
+    const registered = registry.get('currency')!
+    expect(registered.sanitizeProperty({ currencyCode: 'EUR' })).toEqual({
+      currencyCode: 'EUR',
+      precision: 2,
+    })
+    expect(registered.sanitizeProperty(null)).toEqual({
+      currencyCode: 'USD',
+      precision: 2,
+    })
+  })
+
+  it('serialize and deserialize are optional', () => {
+    const def = makeDef({ name: 'simple' })
+    registry.register('simple', def)
+    const registered = registry.get('simple')!
+    expect(registered.serialize).toBeUndefined()
+    expect(registered.deserialize).toBeUndefined()
+  })
+
+  it('serialize and deserialize delegate correctly when provided', () => {
+    const def = makeDef({
+      name: 'json-list',
+      serialize: (value) => JSON.stringify(value),
+      deserialize: (value) => typeof value === 'string' ? JSON.parse(value) : value,
+    })
+    registry.register('json-list', def)
+    const registered = registry.get('json-list')!
+    expect(registered.serialize!([1, 2, 3])).toBe('[1,2,3]')
+    expect(registered.deserialize!('[1,2,3]')).toEqual([1, 2, 3])
+  })
+})


### PR DESCRIPTION
## Summary
- New `FieldTypeRegistry` with register/get/has/unregister API
- Plugins can register custom field types via `services.fieldTypes.register()`
- Built-in types untouched — registry only used in default/fallback branches
- No migration needed (DB `type` column is already `text`)

## Multitable Enhancement (1/5): Custom Field Types

## Test plan
- [x] 14/14 unit tests pass
- [ ] `pnpm type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)