### PR TITLE
feat(multitable): add automation triggers with notify and update_field actions

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260413120000_create_automation_rules.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260413120000_create_automation_rules.ts
@@ -1,0 +1,73 @@
+/**
+ * Migration: Create automation_rules table
+ *
+ * Purpose: Sheet-level automation rules that trigger actions when records change
+ * Tables: automation_rules
+ * Breaking: No
+ */
+
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const tableExists = await checkTableExists(db, 'automation_rules')
+
+  if (tableExists) {
+    console.log('[Migration] Table automation_rules already exists, skipping creation')
+    return
+  }
+
+  console.log('[Migration] Creating table: automation_rules')
+
+  await db.schema
+    .createTable('automation_rules')
+    .ifNotExists()
+    .addColumn('id', 'text', (col) => col.primaryKey())
+    .addColumn('sheet_id', 'text', (col) => col.notNull())
+    .addColumn('name', 'text')
+    .addColumn('trigger_type', 'text', (col) => col.notNull())
+    .addColumn('trigger_config', 'jsonb', (col) => col.defaultTo(sql`'{}'::jsonb`))
+    .addColumn('action_type', 'text', (col) => col.notNull())
+    .addColumn('action_config', 'jsonb', (col) => col.defaultTo(sql`'{}'::jsonb`))
+    .addColumn('enabled', 'boolean', (col) => col.defaultTo(true))
+    .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`NOW()`))
+    .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`NOW()`))
+    .addColumn('created_by', 'text')
+    .execute()
+
+  // Add CHECK constraints via raw SQL
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN ('record.created', 'record.updated', 'field.changed'))
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN ('notify', 'update_field'))
+  `.execute(db)
+
+  console.log('[Migration] Creating indexes...')
+
+  await db.schema
+    .createIndex('idx_automation_rules_sheet_enabled')
+    .ifNotExists()
+    .on('automation_rules')
+    .columns(['sheet_id', 'enabled'])
+    .execute()
+
+  console.log('[Migration] Migration completed successfully')
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  console.log('[Migration] Rolling back: dropping automation_rules')
+
+  await db.schema
+    .dropTable('automation_rules')
+    .ifExists()
+    .execute()
+
+  console.log('[Migration] Rollback completed successfully')
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -67,6 +67,7 @@ import { getPoolStats } from './db/pg'
 import { isDatabaseSchemaError } from './utils/database-errors'
 import { startOperationAuditRetention } from './audit/operation-audit-retention'
 import { startMultitableAttachmentCleanup } from './multitable/attachment-orphan-retention'
+import { AutomationService } from './multitable/automation-service'
 import { tenantContext } from './db/sharding/tenant-context'
 import { attendanceAuditMiddleware, attendanceSecurityMiddleware } from './middleware/attendance-production'
 import { approvalsRouter } from './routes/approvals'
@@ -154,6 +155,7 @@ export class MetaSheetServer {
   private observabilityEnabled = false
   private stopOperationAuditRetention?: () => void
   private stopMultitableAttachmentCleanup?: () => void
+  private automationService?: AutomationService
   private afterSalesApprovalBridgeService: AfterSalesApprovalBridgeService
   // Optional bypass/degraded-mode flags for local debug
   private disableWorkflow = process.env.DISABLE_WORKFLOW === 'true'
@@ -1378,6 +1380,13 @@ export class MetaSheetServer {
     }))
     shutdownTasks.push(Promise.resolve().then(() => {
       try {
+        this.automationService?.shutdown()
+      } catch (err) {
+        this.logger.warn(`AutomationService shutdown error: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }))
+    shutdownTasks.push(Promise.resolve().then(() => {
+      try {
         this.stopMultitableAttachmentCleanup?.()
       } catch (err) {
         this.logger.warn(`Multitable attachment cleanup stop error: ${err instanceof Error ? err.message : String(err)}`)
@@ -1514,6 +1523,16 @@ export class MetaSheetServer {
         // 降级容错：记录错误但继续启动，使 Redis / metrics 在缺表或总线故障时仍可观测
         this.logger.error('EventBusService initialization failed; continuing in degraded mode', e as Error)
       }
+    }
+
+    // Initialize AutomationService
+    try {
+      const pool = poolManager.get()
+      this.automationService = new AutomationService(eventBus, pool.query.bind(pool))
+      this.automationService.init()
+      this.logger.info('AutomationService initialized')
+    } catch (e) {
+      this.logger.error('AutomationService initialization failed; continuing in degraded mode', e as Error)
     }
 
     // 加载插件并启动 HTTP 服务

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1,0 +1,195 @@
+import type { EventBus } from '../integration/events/event-bus'
+import { patchRecord, type MultitableRecordsQueryFn } from './records'
+import { Logger } from '../core/logger'
+
+const logger = new Logger('AutomationService')
+
+const MAX_AUTOMATION_DEPTH = 3
+
+const VALID_TRIGGER_TYPES = new Set([
+  'record.created',
+  'record.updated',
+  'field.changed',
+])
+
+const TRIGGER_TYPE_BY_EVENT: Record<string, string> = {
+  'multitable.record.created': 'record.created',
+  'multitable.record.updated': 'record.updated',
+}
+
+export type AutomationRule = {
+  id: string
+  sheet_id: string
+  name: string | null
+  trigger_type: string
+  trigger_config: Record<string, unknown>
+  action_type: string
+  action_config: Record<string, unknown>
+  enabled: boolean
+  created_at: string
+  updated_at: string
+  created_by: string | null
+}
+
+export type AutomationQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export type AutomationEventPayload = {
+  sheetId: string
+  recordId: string
+  data?: Record<string, unknown>
+  changes?: Record<string, unknown>
+  actorId?: string | null
+  _automationDepth?: number
+}
+
+export class AutomationService {
+  private eventBus: EventBus
+  private query: AutomationQueryFn
+  private subscriptionIds: string[] = []
+
+  constructor(eventBus: EventBus, query: AutomationQueryFn) {
+    this.eventBus = eventBus
+    this.query = query
+  }
+
+  init(): void {
+    const events = [
+      'multitable.record.created',
+      'multitable.record.updated',
+    ]
+
+    for (const eventType of events) {
+      const id = this.eventBus.subscribe<AutomationEventPayload>(
+        eventType,
+        (payload) => {
+          this.handleEvent(eventType, payload).catch((err) => {
+            logger.error(`Automation handler error for ${eventType}`, err instanceof Error ? err : undefined)
+          })
+        },
+      )
+      this.subscriptionIds.push(id)
+    }
+
+    logger.info('AutomationService initialized')
+  }
+
+  shutdown(): void {
+    for (const id of this.subscriptionIds) {
+      this.eventBus.unsubscribe(id)
+    }
+    this.subscriptionIds = []
+    logger.info('AutomationService shut down')
+  }
+
+  async handleEvent(eventType: string, payload: AutomationEventPayload): Promise<void> {
+    const depth = typeof payload._automationDepth === 'number' ? payload._automationDepth : 0
+    if (depth >= MAX_AUTOMATION_DEPTH) {
+      logger.warn(`Automation recursion guard triggered (depth=${depth}) for ${eventType} on sheet ${payload.sheetId}`)
+      return
+    }
+
+    const { sheetId, recordId } = payload
+    if (!sheetId || !recordId) return
+
+    const rules = await this.loadEnabledRules(sheetId)
+    if (rules.length === 0) return
+
+    const triggerType = TRIGGER_TYPE_BY_EVENT[eventType]
+    if (!triggerType) return
+
+    for (const rule of rules) {
+      if (!this.matchesTrigger(rule, triggerType, payload)) continue
+
+      try {
+        await this.executeAction(rule, payload, depth)
+      } catch (err) {
+        logger.error(
+          `Automation rule ${rule.id} action failed`,
+          err instanceof Error ? err : undefined,
+        )
+      }
+    }
+  }
+
+  private matchesTrigger(
+    rule: AutomationRule,
+    triggerType: string,
+    payload: AutomationEventPayload,
+  ): boolean {
+    if (rule.trigger_type === 'field.changed') {
+      // field.changed triggers on record.updated events only
+      if (triggerType !== 'record.updated') return false
+      const fieldId = typeof rule.trigger_config?.fieldId === 'string'
+        ? rule.trigger_config.fieldId
+        : null
+      if (!fieldId) return false
+      const changes = payload.changes ?? payload.data ?? {}
+      return fieldId in changes
+    }
+
+    return rule.trigger_type === triggerType
+  }
+
+  private async executeAction(
+    rule: AutomationRule,
+    payload: AutomationEventPayload,
+    depth: number,
+  ): Promise<void> {
+    switch (rule.action_type) {
+      case 'notify': {
+        this.eventBus.emit('automation.notify', {
+          ruleId: rule.id,
+          sheetId: payload.sheetId,
+          recordId: payload.recordId,
+          actorId: payload.actorId,
+          ...rule.action_config,
+          _automationDepth: depth + 1,
+        })
+        break
+      }
+      case 'update_field': {
+        const targetFieldId = typeof rule.action_config?.fieldId === 'string'
+          ? rule.action_config.fieldId
+          : null
+        const value = rule.action_config?.value
+        if (!targetFieldId) {
+          logger.warn(`Automation rule ${rule.id}: update_field action missing fieldId`)
+          return
+        }
+
+        await patchRecord({
+          query: this.query,
+          sheetId: payload.sheetId,
+          recordId: payload.recordId,
+          changes: { [targetFieldId]: value },
+        })
+
+        // Emit follow-up event with incremented depth for chaining
+        this.eventBus.emit('multitable.record.updated', {
+          sheetId: payload.sheetId,
+          recordId: payload.recordId,
+          changes: { [targetFieldId]: value },
+          actorId: payload.actorId,
+          _automationDepth: depth + 1,
+        })
+        break
+      }
+      default:
+        logger.warn(`Automation rule ${rule.id}: unknown action_type '${rule.action_type}'`)
+    }
+  }
+
+  async loadEnabledRules(sheetId: string): Promise<AutomationRule[]> {
+    const result = await this.query(
+      `SELECT id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_at, updated_at, created_by
+       FROM automation_rules
+       WHERE sheet_id = $1 AND enabled = true
+       ORDER BY created_at ASC`,
+      [sheetId],
+    )
+    return result.rows as AutomationRule[]
+  }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6116,6 +6116,12 @@ export function univerMetaRouter(): Router {
           patch,
         }],
       })
+      eventBus.emit('multitable.record.created', {
+        sheetId,
+        recordId,
+        data: patch,
+        actorId: getRequestActorId(req),
+      })
       return res.json({ ok: true, data: { record: { id: recordId, version, data: patch } } })
     } catch (err) {
       if (err instanceof ValidationError) {
@@ -6193,6 +6199,11 @@ export function univerMetaRouter(): Router {
           kind: 'record-deleted',
           recordId,
           recordIds: [recordId],
+        })
+        eventBus.emit('multitable.record.deleted', {
+          sheetId: deletedSheetId,
+          recordId,
+          actorId: getRequestActorId(req),
         })
       }
 
@@ -6615,6 +6626,17 @@ export function univerMetaRouter(): Router {
             ),
           })),
         })
+        for (const update of updates) {
+          const changes = Object.fromEntries(
+            (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
+          )
+          eventBus.emit('multitable.record.updated', {
+            sheetId,
+            recordId: update.recordId,
+            changes,
+            actorId: getRequestActorId(req),
+          })
+        }
       }
 
       return res.json({
@@ -6651,6 +6673,186 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] patch failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to patch meta records' } })
+    }
+  })
+
+  // ── Automation rule CRUD ──────────────────────────────────────────────
+
+  router.get('/sheets/:sheetId/automations', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId : ''
+    if (!sheetId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageAutomation) return sendForbidden(res)
+
+      const result = await pool.query(
+        `SELECT id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_at, updated_at, created_by
+         FROM automation_rules
+         WHERE sheet_id = $1
+         ORDER BY created_at ASC`,
+        [sheetId],
+      )
+      return res.json({ ok: true, data: { rules: result.rows } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list automation rules failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list automation rules' } })
+    }
+  })
+
+  router.post('/sheets/:sheetId/automations', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId : ''
+    if (!sheetId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const access = await resolveRequestAccess(req)
+      if (!access.userId) return res.status(401).json({ error: 'Authentication required' })
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageAutomation) return sendForbidden(res)
+
+      const body = req.body as Record<string, unknown> | undefined
+      const name = typeof body?.name === 'string' ? body.name : null
+      const triggerType = typeof body?.triggerType === 'string' ? body.triggerType : ''
+      const triggerConfig = (body?.triggerConfig && typeof body.triggerConfig === 'object') ? body.triggerConfig : {}
+      const actionType = typeof body?.actionType === 'string' ? body.actionType : ''
+      const actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig : {}
+      const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
+
+      const validTriggers = new Set(['record.created', 'record.updated', 'field.changed'])
+      const validActions = new Set(['notify', 'update_field'])
+      if (!validTriggers.has(triggerType)) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid trigger_type: ${triggerType}` } })
+      }
+      if (!validActions.has(actionType)) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid action_type: ${actionType}` } })
+      }
+
+      const ruleId = `atr_${randomUUID()}`
+      await pool.query(
+        `INSERT INTO automation_rules (id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_by)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, $8, $9)`,
+        [ruleId, sheetId, name, triggerType, JSON.stringify(triggerConfig), actionType, JSON.stringify(actionConfig), enabled, access.userId],
+      )
+
+      return res.json({
+        ok: true,
+        data: {
+          rule: { id: ruleId, sheetId, name, triggerType, triggerConfig, actionType, actionConfig, enabled },
+        },
+      })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] create automation rule failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create automation rule' } })
+    }
+  })
+
+  router.patch('/sheets/:sheetId/automations/:ruleId', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId : ''
+    const ruleId = typeof req.params.ruleId === 'string' ? req.params.ruleId : ''
+    if (!sheetId || !ruleId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and ruleId are required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageAutomation) return sendForbidden(res)
+
+      const body = req.body as Record<string, unknown> | undefined
+      const sets: string[] = []
+      const params: unknown[] = []
+      let paramIdx = 1
+
+      if (typeof body?.name === 'string') {
+        sets.push(`name = $${paramIdx++}`)
+        params.push(body.name)
+      }
+      if (typeof body?.triggerType === 'string') {
+        const validTriggers = new Set(['record.created', 'record.updated', 'field.changed'])
+        if (!validTriggers.has(body.triggerType)) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid trigger_type: ${body.triggerType}` } })
+        }
+        sets.push(`trigger_type = $${paramIdx++}`)
+        params.push(body.triggerType)
+      }
+      if (body?.triggerConfig && typeof body.triggerConfig === 'object') {
+        sets.push(`trigger_config = $${paramIdx++}::jsonb`)
+        params.push(JSON.stringify(body.triggerConfig))
+      }
+      if (typeof body?.actionType === 'string') {
+        const validActions = new Set(['notify', 'update_field'])
+        if (!validActions.has(body.actionType)) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid action_type: ${body.actionType}` } })
+        }
+        sets.push(`action_type = $${paramIdx++}`)
+        params.push(body.actionType)
+      }
+      if (body?.actionConfig && typeof body.actionConfig === 'object') {
+        sets.push(`action_config = $${paramIdx++}::jsonb`)
+        params.push(JSON.stringify(body.actionConfig))
+      }
+      if (typeof body?.enabled === 'boolean') {
+        sets.push(`enabled = $${paramIdx++}`)
+        params.push(body.enabled)
+      }
+
+      if (sets.length === 0) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'No fields to update' } })
+      }
+
+      sets.push(`updated_at = NOW()`)
+      params.push(ruleId, sheetId)
+      const result = await pool.query(
+        `UPDATE automation_rules SET ${sets.join(', ')} WHERE id = $${paramIdx++} AND sheet_id = $${paramIdx++} RETURNING *`,
+        params,
+      )
+
+      if ((result.rowCount ?? 0) === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
+      }
+
+      return res.json({ ok: true, data: { rule: result.rows[0] } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] update automation rule failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update automation rule' } })
+    }
+  })
+
+  router.delete('/sheets/:sheetId/automations/:ruleId', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId : ''
+    const ruleId = typeof req.params.ruleId === 'string' ? req.params.ruleId : ''
+    if (!sheetId || !ruleId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and ruleId are required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageAutomation) return sendForbidden(res)
+
+      const result = await pool.query(
+        'DELETE FROM automation_rules WHERE id = $1 AND sheet_id = $2',
+        [ruleId, sheetId],
+      )
+
+      if ((result.rowCount ?? 0) === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
+      }
+
+      return res.json({ ok: true, data: { deleted: ruleId } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] delete automation rule failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete automation rule' } })
     }
   })
 

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/multitable/records', () => ({
+  patchRecord: vi.fn(async () => ({
+    id: 'rec1',
+    sheetId: 'sheet1',
+    version: 2,
+    data: {},
+  })),
+}))
+
+import { patchRecord } from '../../src/multitable/records'
+import { AutomationService, type AutomationRule, type AutomationEventPayload, type AutomationQueryFn } from '../../src/multitable/automation-service'
+import { EventBus } from '../../src/integration/events/event-bus'
+
+function createMockRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
+  return {
+    id: 'atr_test1',
+    sheet_id: 'sheet1',
+    name: 'Test Rule',
+    trigger_type: 'record.created',
+    trigger_config: {},
+    action_type: 'notify',
+    action_config: { channel: 'general' },
+    enabled: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    created_by: 'user1',
+    ...overrides,
+  }
+}
+
+function createMockQuery(rules: AutomationRule[]): AutomationQueryFn {
+  return vi.fn(async (_sql: string, _params?: unknown[]) => ({
+    rows: rules,
+    rowCount: rules.length,
+  }))
+}
+
+describe('AutomationService', () => {
+  let bus: EventBus
+  let service: AutomationService
+
+  beforeEach(() => {
+    bus = new EventBus()
+  })
+
+  describe('rule matching', () => {
+    it('matches record.created trigger on multitable.record.created event', async () => {
+      const rule = createMockRule({ trigger_type: 'record.created', action_type: 'notify' })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.created', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        data: { field1: 'value1' },
+        actorId: 'user1',
+      })
+
+      expect(emitSpy).toHaveBeenCalledWith('automation.notify', expect.objectContaining({
+        ruleId: 'atr_test1',
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        channel: 'general',
+      }))
+    })
+
+    it('matches record.updated trigger on multitable.record.updated event', async () => {
+      const rule = createMockRule({ trigger_type: 'record.updated', action_type: 'notify' })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.updated', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        changes: { field1: 'new_value' },
+        actorId: 'user1',
+      })
+
+      expect(emitSpy).toHaveBeenCalledWith('automation.notify', expect.objectContaining({
+        ruleId: 'atr_test1',
+        sheetId: 'sheet1',
+      }))
+    })
+
+    it('matches field.changed trigger when specific field is in changes', async () => {
+      const rule = createMockRule({
+        trigger_type: 'field.changed',
+        trigger_config: { fieldId: 'status_field' },
+        action_type: 'notify',
+      })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.updated', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        changes: { status_field: 'done' },
+        actorId: 'user1',
+      })
+
+      expect(emitSpy).toHaveBeenCalledWith('automation.notify', expect.objectContaining({
+        ruleId: 'atr_test1',
+      }))
+    })
+
+    it('does not match field.changed trigger when field is not in changes', async () => {
+      const rule = createMockRule({
+        trigger_type: 'field.changed',
+        trigger_config: { fieldId: 'status_field' },
+        action_type: 'notify',
+      })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.updated', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        changes: { other_field: 'value' },
+        actorId: 'user1',
+      })
+
+      expect(emitSpy).not.toHaveBeenCalledWith('automation.notify', expect.anything())
+    })
+
+    it('does not match field.changed trigger on record.created events', async () => {
+      const rule = createMockRule({
+        trigger_type: 'field.changed',
+        trigger_config: { fieldId: 'status_field' },
+        action_type: 'notify',
+      })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.created', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        data: { status_field: 'new' },
+        actorId: 'user1',
+      })
+
+      expect(emitSpy).not.toHaveBeenCalledWith('automation.notify', expect.anything())
+    })
+  })
+
+  describe('notify action', () => {
+    it('emits automation.notify event with action_config merged', async () => {
+      const rule = createMockRule({
+        action_type: 'notify',
+        action_config: { channel: '#alerts', message: 'Record changed' },
+      })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.created', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        data: {},
+        actorId: 'user1',
+      })
+
+      expect(emitSpy).toHaveBeenCalledWith('automation.notify', expect.objectContaining({
+        ruleId: 'atr_test1',
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        actorId: 'user1',
+        channel: '#alerts',
+        message: 'Record changed',
+        _automationDepth: 1,
+      }))
+    })
+  })
+
+  describe('update_field action', () => {
+    it('calls patchRecord and emits follow-up event', async () => {
+      const rule = createMockRule({
+        action_type: 'update_field',
+        action_config: { fieldId: 'target_field', value: 'auto_value' },
+      })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.created', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        data: {},
+        actorId: 'user1',
+      })
+
+      // Should have called patchRecord with the correct args
+      expect(patchRecord).toHaveBeenCalledWith({
+        query,
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        changes: { target_field: 'auto_value' },
+      })
+
+      // Should emit follow-up update event with incremented depth
+      expect(emitSpy).toHaveBeenCalledWith('multitable.record.updated', expect.objectContaining({
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        changes: { target_field: 'auto_value' },
+        _automationDepth: 1,
+      }))
+    })
+  })
+
+  describe('recursion guard', () => {
+    it('blocks execution at depth >= 3', async () => {
+      const rule = createMockRule({ action_type: 'notify' })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.created', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        data: {},
+        actorId: 'user1',
+        _automationDepth: 3,
+      })
+
+      expect(emitSpy).not.toHaveBeenCalled()
+      // Query should not even be called for rule loading
+      expect(query).not.toHaveBeenCalled()
+    })
+
+    it('allows execution at depth < 3', async () => {
+      const rule = createMockRule({ action_type: 'notify' })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.created', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        data: {},
+        actorId: 'user1',
+        _automationDepth: 2,
+      })
+
+      expect(emitSpy).toHaveBeenCalledWith('automation.notify', expect.objectContaining({
+        _automationDepth: 3,
+      }))
+    })
+  })
+
+  describe('disabled rules', () => {
+    it('skips disabled rules (query returns only enabled)', async () => {
+      // The query only returns enabled rules, so we simulate empty result
+      const query = createMockQuery([])
+      service = new AutomationService(bus, query)
+
+      const emitSpy = vi.spyOn(bus, 'emit')
+
+      await service.handleEvent('multitable.record.created', {
+        sheetId: 'sheet1',
+        recordId: 'rec1',
+        data: {},
+        actorId: 'user1',
+      })
+
+      expect(emitSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('init / shutdown', () => {
+    it('subscribes to events on init and unsubscribes on shutdown', () => {
+      const query = createMockQuery([])
+      service = new AutomationService(bus, query)
+
+      const subscribeSpy = vi.spyOn(bus, 'subscribe')
+      const unsubscribeSpy = vi.spyOn(bus, 'unsubscribe')
+
+      service.init()
+      expect(subscribeSpy).toHaveBeenCalledTimes(2)
+      expect(subscribeSpy).toHaveBeenCalledWith(
+        'multitable.record.created',
+        expect.any(Function),
+      )
+      expect(subscribeSpy).toHaveBeenCalledWith(
+        'multitable.record.updated',
+        expect.any(Function),
+      )
+
+      service.shutdown()
+      expect(unsubscribeSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- New `automation_rules` table with trigger/action configuration
- `AutomationService` listens to EventBus for record mutations
- Trigger types: record.created, record.updated, field.changed
- Action types: notify (emit event), update_field (patch record)
- Recursion guard (depth < 3) prevents infinite loops
- CRUD endpoints for rule management

## Multitable Enhancement (5/5): Automation Triggers

## Test plan
- [x] 11/11 unit tests pass
- [ ] `pnpm type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)