### PR TITLE
feat(multitable): add automation rule builder UI with trigger/action configuration

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -41,6 +41,7 @@ import type {
   MetaFieldPermissionEntry,
   MetaViewPermissionEntry,
   RecordPermissionEntry,
+  AutomationRule,
 } from '../types'
 import { apiFetch } from '../../utils/api'
 
@@ -713,6 +714,45 @@ export class MultitableApiClient {
   async deleteRecordPermission(sheetId: string, recordId: string, permissionId: string): Promise<void> {
     const res = await this.fetch(
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/permissions/${encodeURIComponent(permissionId)}`,
+      { method: 'DELETE' },
+    )
+    await parseJson(res)
+  }
+
+  // --- Automation rules ---
+  async listAutomationRules(sheetId: string): Promise<AutomationRule[]> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations`)
+    const data = await parseJson<{ rules: AutomationRule[] }>(res)
+    return Array.isArray(data?.rules) ? data.rules : []
+  }
+
+  async createAutomationRule(
+    sheetId: string,
+    rule: Omit<AutomationRule, 'id' | 'sheetId' | 'enabled' | 'createdAt' | 'updatedAt' | 'createdBy'>,
+  ): Promise<AutomationRule> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rule),
+    })
+    return parseJson<AutomationRule>(res)
+  }
+
+  async updateAutomationRule(sheetId: string, ruleId: string, updates: Partial<AutomationRule>): Promise<void> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      },
+    )
+    await parseJson(res)
+  }
+
+  async deleteAutomationRule(sheetId: string, ruleId: string): Promise<void> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}`,
       { method: 'DELETE' },
     )
     await parseJson(res)

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1,0 +1,490 @@
+<template>
+  <div v-if="visible" class="meta-automation__overlay" @click.self="$emit('close')">
+    <div class="meta-automation">
+      <div class="meta-automation__header">
+        <h4 class="meta-automation__title">Automations</h4>
+        <button class="meta-automation__close" type="button" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="meta-automation__body">
+        <div v-if="error" class="meta-automation__error" role="alert">{{ error }}</div>
+
+        <!-- Create / Edit form -->
+        <section v-if="showForm" class="meta-automation__form">
+          <div class="meta-automation__form-title">{{ editingRuleId ? 'Edit Automation' : 'New Automation' }}</div>
+
+          <label class="meta-automation__label">Name</label>
+          <input
+            v-model="draft.name"
+            class="meta-automation__input"
+            type="text"
+            placeholder="Automation name"
+            data-automation-field="name"
+          />
+
+          <label class="meta-automation__label">Trigger</label>
+          <select v-model="draft.triggerType" class="meta-automation__select" data-automation-field="triggerType">
+            <option value="record.created">When record created</option>
+            <option value="record.updated">When record updated</option>
+            <option value="field.changed">When field changes</option>
+          </select>
+
+          <template v-if="draft.triggerType === 'field.changed'">
+            <label class="meta-automation__label">Watch field</label>
+            <select v-model="draft.triggerFieldId" class="meta-automation__select" data-automation-field="triggerFieldId">
+              <option value="">-- select field --</option>
+              <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+            </select>
+          </template>
+
+          <label class="meta-automation__label">Action</label>
+          <select v-model="draft.actionType" class="meta-automation__select" data-automation-field="actionType">
+            <option value="notify">Send notification</option>
+            <option value="update_field">Update field value</option>
+          </select>
+
+          <template v-if="draft.actionType === 'notify'">
+            <label class="meta-automation__label">Message</label>
+            <input
+              v-model="draft.notifyMessage"
+              class="meta-automation__input"
+              type="text"
+              placeholder="Notification message"
+              data-automation-field="notifyMessage"
+            />
+          </template>
+
+          <template v-if="draft.actionType === 'update_field'">
+            <label class="meta-automation__label">Target field</label>
+            <select v-model="draft.targetFieldId" class="meta-automation__select" data-automation-field="targetFieldId">
+              <option value="">-- select field --</option>
+              <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+            </select>
+            <label class="meta-automation__label">Value</label>
+            <input
+              v-model="draft.targetValue"
+              class="meta-automation__input"
+              type="text"
+              placeholder="New value"
+              data-automation-field="targetValue"
+            />
+          </template>
+
+          <div class="meta-automation__form-actions">
+            <button class="meta-automation__btn meta-automation__btn--primary" type="button" :disabled="!canSave" @click="onSave">
+              {{ editingRuleId ? 'Update' : 'Create' }}
+            </button>
+            <button class="meta-automation__btn" type="button" @click="cancelForm">Cancel</button>
+          </div>
+        </section>
+
+        <!-- Add button -->
+        <button v-if="!showForm" class="meta-automation__btn meta-automation__btn--primary meta-automation__btn-add" type="button" @click="openCreateForm">
+          + New Automation
+        </button>
+
+        <!-- Rule list -->
+        <div v-if="loading" class="meta-automation__empty">Loading automations&#x2026;</div>
+        <div v-else-if="!rules.length && !showForm" class="meta-automation__empty" data-automation-empty="true">
+          No automations yet. Create your first automation rule.
+        </div>
+        <div
+          v-for="rule in rules"
+          :key="rule.id"
+          class="meta-automation__card"
+          :data-automation-rule="rule.id"
+        >
+          <div class="meta-automation__card-header">
+            <strong class="meta-automation__card-name">{{ rule.name }}</strong>
+            <label class="meta-automation__toggle">
+              <input
+                type="checkbox"
+                :checked="rule.enabled"
+                data-automation-toggle="true"
+                @change="onToggle(rule)"
+              />
+              <span>{{ rule.enabled ? 'Enabled' : 'Disabled' }}</span>
+            </label>
+          </div>
+          <div class="meta-automation__card-desc">
+            {{ describeTrigger(rule) }} &rarr; {{ describeAction(rule) }}
+          </div>
+          <div class="meta-automation__card-actions">
+            <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openEditForm(rule)">Edit</button>
+            <button class="meta-automation__btn meta-automation__btn--danger" type="button" data-automation-delete="true" @click="onDelete(rule)">Delete</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { AutomationRule, AutomationTriggerType, AutomationActionType } from '../types'
+import { useMultitableAutomations } from '../composables/useMultitableAutomations'
+import type { MultitableApiClient } from '../api/client'
+
+const props = defineProps<{
+  visible: boolean
+  sheetId: string
+  fields: Array<{ id: string; name: string; type: string }>
+  client?: MultitableApiClient
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'updated'): void
+}>()
+
+const { rules, loading, error, loadRules, createRule, updateRule, deleteRule, toggleRule } =
+  useMultitableAutomations(props.client)
+
+const showForm = ref(false)
+const editingRuleId = ref<string | null>(null)
+
+interface DraftState {
+  name: string
+  triggerType: AutomationTriggerType
+  triggerFieldId: string
+  actionType: AutomationActionType
+  notifyMessage: string
+  targetFieldId: string
+  targetValue: string
+}
+
+function emptyDraft(): DraftState {
+  return {
+    name: '',
+    triggerType: 'record.created',
+    triggerFieldId: '',
+    actionType: 'notify',
+    notifyMessage: '',
+    targetFieldId: '',
+    targetValue: '',
+  }
+}
+
+const draft = ref<DraftState>(emptyDraft())
+
+const canSave = computed(() => {
+  if (!draft.value.name.trim()) return false
+  if (draft.value.triggerType === 'field.changed' && !draft.value.triggerFieldId) return false
+  if (draft.value.actionType === 'notify' && !draft.value.notifyMessage.trim()) return false
+  if (draft.value.actionType === 'update_field' && (!draft.value.targetFieldId || !draft.value.targetValue.trim())) return false
+  return true
+})
+
+function openCreateForm() {
+  editingRuleId.value = null
+  draft.value = emptyDraft()
+  showForm.value = true
+}
+
+function openEditForm(rule: AutomationRule) {
+  editingRuleId.value = rule.id
+  draft.value = {
+    name: rule.name,
+    triggerType: rule.triggerType,
+    triggerFieldId: (rule.triggerConfig?.fieldId as string) ?? '',
+    actionType: rule.actionType,
+    notifyMessage: (rule.actionConfig?.message as string) ?? '',
+    targetFieldId: (rule.actionConfig?.fieldId as string) ?? '',
+    targetValue: (rule.actionConfig?.value as string) ?? '',
+  }
+  showForm.value = true
+}
+
+function cancelForm() {
+  showForm.value = false
+  editingRuleId.value = null
+  draft.value = emptyDraft()
+}
+
+function buildTriggerConfig(): Record<string, unknown> {
+  if (draft.value.triggerType === 'field.changed') {
+    return { fieldId: draft.value.triggerFieldId }
+  }
+  return {}
+}
+
+function buildActionConfig(): Record<string, unknown> {
+  if (draft.value.actionType === 'notify') {
+    return { message: draft.value.notifyMessage }
+  }
+  if (draft.value.actionType === 'update_field') {
+    return { fieldId: draft.value.targetFieldId, value: draft.value.targetValue }
+  }
+  return {}
+}
+
+async function onSave() {
+  if (!canSave.value) return
+  const payload = {
+    name: draft.value.name.trim(),
+    triggerType: draft.value.triggerType,
+    triggerConfig: buildTriggerConfig(),
+    actionType: draft.value.actionType,
+    actionConfig: buildActionConfig(),
+  }
+  try {
+    if (editingRuleId.value) {
+      await updateRule(props.sheetId, editingRuleId.value, payload)
+    } else {
+      await createRule(props.sheetId, payload)
+    }
+    cancelForm()
+    emit('updated')
+  } catch {
+    // error ref is set by composable
+  }
+}
+
+async function onToggle(rule: AutomationRule) {
+  try {
+    await toggleRule(props.sheetId, rule.id, !rule.enabled)
+    emit('updated')
+  } catch {
+    // error ref is set by composable
+  }
+}
+
+async function onDelete(rule: AutomationRule) {
+  try {
+    await deleteRule(props.sheetId, rule.id)
+    emit('updated')
+  } catch {
+    // error ref is set by composable
+  }
+}
+
+function fieldNameById(fieldId: string): string {
+  const field = props.fields.find((f) => f.id === fieldId)
+  return field?.name ?? fieldId
+}
+
+function describeTrigger(rule: AutomationRule): string {
+  switch (rule.triggerType) {
+    case 'record.created':
+      return 'When a record is created'
+    case 'record.updated':
+      return 'When a record is updated'
+    case 'field.changed': {
+      const fid = rule.triggerConfig?.fieldId as string | undefined
+      return fid ? `When "${fieldNameById(fid)}" changes` : 'When a field changes'
+    }
+    default:
+      return String(rule.triggerType)
+  }
+}
+
+function describeAction(rule: AutomationRule): string {
+  switch (rule.actionType) {
+    case 'notify':
+      return 'Send notification'
+    case 'update_field': {
+      const fid = rule.actionConfig?.fieldId as string | undefined
+      return fid ? `Update "${fieldNameById(fid)}"` : 'Update field value'
+    }
+    default:
+      return String(rule.actionType)
+  }
+}
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v && props.sheetId) {
+      void loadRules(props.sheetId)
+      cancelForm()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.meta-automation__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.meta-automation {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  width: 560px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-automation__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-automation__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.meta-automation__close {
+  border: none;
+  background: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #64748b;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.meta-automation__body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.meta-automation__error {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.meta-automation__empty {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+/* Form */
+.meta-automation__form {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.meta-automation__form-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 4px;
+}
+
+.meta-automation__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+  margin-top: 4px;
+}
+
+.meta-automation__input,
+.meta-automation__select {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.meta-automation__form-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+/* Cards */
+.meta-automation__card {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-automation__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.meta-automation__card-name {
+  font-size: 14px;
+  color: #0f172a;
+}
+
+.meta-automation__toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #64748b;
+  cursor: pointer;
+}
+
+.meta-automation__card-desc {
+  font-size: 13px;
+  color: #475569;
+}
+
+.meta-automation__card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* Buttons */
+.meta-automation__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 14px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.meta-automation__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.meta-automation__btn--primary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+.meta-automation__btn--danger {
+  border-color: #ef4444;
+  color: #b91c1c;
+}
+
+.meta-automation__btn-add {
+  align-self: flex-start;
+}
+</style>

--- a/apps/web/src/multitable/composables/useMultitableAutomations.ts
+++ b/apps/web/src/multitable/composables/useMultitableAutomations.ts
@@ -1,0 +1,67 @@
+import { ref } from 'vue'
+import type { AutomationRule } from '../types'
+import { MultitableApiClient, multitableClient } from '../api/client'
+
+export function useMultitableAutomations(client?: MultitableApiClient) {
+  const api = client ?? multitableClient
+  const rules = ref<AutomationRule[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function loadRules(sheetId: string): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      rules.value = await api.listAutomationRules(sheetId)
+    } catch (e: any) {
+      error.value = e.message ?? 'Failed to load automation rules'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createRule(
+    sheetId: string,
+    rule: Omit<AutomationRule, 'id' | 'sheetId' | 'enabled' | 'createdAt' | 'updatedAt' | 'createdBy'>,
+  ): Promise<void> {
+    error.value = null
+    try {
+      const created = await api.createAutomationRule(sheetId, rule)
+      rules.value = [created, ...rules.value]
+    } catch (e: any) {
+      error.value = e.message ?? 'Failed to create automation rule'
+      throw e
+    }
+  }
+
+  async function updateRule(sheetId: string, ruleId: string, updates: Partial<AutomationRule>): Promise<void> {
+    error.value = null
+    try {
+      await api.updateAutomationRule(sheetId, ruleId, updates)
+      const idx = rules.value.findIndex((r) => r.id === ruleId)
+      if (idx >= 0) {
+        rules.value[idx] = { ...rules.value[idx], ...updates }
+      }
+    } catch (e: any) {
+      error.value = e.message ?? 'Failed to update automation rule'
+      throw e
+    }
+  }
+
+  async function deleteRule(sheetId: string, ruleId: string): Promise<void> {
+    error.value = null
+    try {
+      await api.deleteAutomationRule(sheetId, ruleId)
+      rules.value = rules.value.filter((r) => r.id !== ruleId)
+    } catch (e: any) {
+      error.value = e.message ?? 'Failed to delete automation rule'
+      throw e
+    }
+  }
+
+  async function toggleRule(sheetId: string, ruleId: string, enabled: boolean): Promise<void> {
+    await updateRule(sheetId, ruleId, { enabled })
+  }
+
+  return { rules, loading, error, loadRules, createRule, updateRule, deleteRule, toggleRule }
+}

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -525,3 +525,21 @@ export interface RecordPermissionEntry {
   createdAt?: string
   createdBy?: string
 }
+
+// --- Automation rules ---
+export type AutomationTriggerType = 'record.created' | 'record.updated' | 'field.changed'
+export type AutomationActionType = 'notify' | 'update_field'
+
+export interface AutomationRule {
+  id: string
+  sheetId: string
+  name: string
+  triggerType: AutomationTriggerType
+  triggerConfig: Record<string, unknown>
+  actionType: AutomationActionType
+  actionConfig: Record<string, unknown>
+  enabled: boolean
+  createdAt?: string
+  updatedAt?: string
+  createdBy?: string
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -39,6 +39,7 @@
       <button v-if="caps.canManageSheetAccess.value" class="mt-workbench__mgr-btn" @click="showPermissionManager = true; void loadPermissionEntries()">&#x1F512; Access</button>
       <button v-if="caps.canManageViews.value && canConfigureCurrentView" class="mt-workbench__mgr-btn" @click="showViewManager = true">&#x2630; Views</button>
       <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="openWorkflowDesigner()">&#x2699; Workflow</button>
+      <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="showAutomationManager = true">&#x26A1; Automations</button>
     </div>
     <div
       v-if="capabilityOriginNotice"
@@ -265,6 +266,14 @@
       @update-field-permission="onFieldPermissionUpdated"
       @update-view-permission="onViewPermissionUpdated"
     />
+    <MetaAutomationManager
+      :visible="showAutomationManager"
+      :sheet-id="workbench.activeSheetId.value"
+      :fields="grid.fields.value"
+      :client="workbench.client"
+      @close="showAutomationManager = false"
+      @updated="showAutomationManager = false"
+    />
   </div>
 </template>
 
@@ -314,6 +323,7 @@ import MetaLinkPicker from '../components/MetaLinkPicker.vue'
 import MetaFieldManager from '../components/MetaFieldManager.vue'
 import MetaViewManager from '../components/MetaViewManager.vue'
 import MetaSheetPermissionManager from '../components/MetaSheetPermissionManager.vue'
+import MetaAutomationManager from '../components/MetaAutomationManager.vue'
 import MetaBasePicker from '../components/MetaBasePicker.vue'
 import MetaKanbanView from '../components/MetaKanbanView.vue'
 import MetaGalleryView from '../components/MetaGalleryView.vue'
@@ -367,6 +377,7 @@ const linkPickerRecordId = ref<string | null>(null)
 const linkPickerCurrentValue = ref<unknown>(null)
 const showFieldManager = ref(false)
 const showPermissionManager = ref(false)
+const showAutomationManager = ref(false)
 const fieldPermissionEntries = ref<MetaFieldPermissionEntry[]>([])
 const viewPermissionEntries = ref<MetaViewPermissionEntry[]>([])
 const showViewManager = ref(false)

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+import MetaAutomationManager from '../src/multitable/components/MetaAutomationManager.vue'
+import { MultitableApiClient } from '../src/multitable/api/client'
+import type { AutomationRule } from '../src/multitable/types'
+
+function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
+  return {
+    id: 'rule_1',
+    sheetId: 'sheet_1',
+    name: 'Notify on create',
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'notify',
+    actionConfig: { message: 'New record!' },
+    enabled: true,
+    ...overrides,
+  }
+}
+
+function mockClient(rules: AutomationRule[] = []) {
+  const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  const noContent = () => new Response(null, { status: 204 })
+
+  const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+    if (method === 'GET' && url.includes('/automations')) {
+      return ok({ rules })
+    }
+    if (method === 'POST' && url.includes('/automations')) {
+      const body = JSON.parse(init?.body as string)
+      return ok({ id: 'rule_new', sheetId: 'sheet_1', enabled: true, ...body })
+    }
+    if (method === 'PATCH' && url.includes('/automations/')) {
+      return noContent()
+    }
+    if (method === 'DELETE' && url.includes('/automations/')) {
+      return noContent()
+    }
+    return ok({})
+  })
+  return { client: new MultitableApiClient({ fetchFn }), fetchFn }
+}
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaAutomationManager, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+const fields = [
+  { id: 'fld_1', name: 'Status', type: 'select' },
+  { id: 'fld_2', name: 'Name', type: 'string' },
+]
+
+describe('MetaAutomationManager', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('renders rule list when visible', async () => {
+    const { client } = mockClient([fakeRule()])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    await flushPromises()
+
+    const cards = container.querySelectorAll('[data-automation-rule]')
+    expect(cards.length).toBe(1)
+    expect(container.querySelector('.meta-automation__card-name')?.textContent).toBe('Notify on create')
+  })
+
+  it('shows empty state when no rules', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    await flushPromises()
+
+    const el = container.querySelector('[data-automation-empty]')
+    expect(el).not.toBeNull()
+    expect(el!.textContent).toContain('No automations yet')
+  })
+
+  it('creates rule via form', async () => {
+    const { client, fetchFn } = mockClient([])
+    const updatedSpy = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client, onUpdated: updatedSpy })
+    await flushPromises()
+
+    // Open form
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    // Fill name
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'My Rule'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    // Fill message for notify action
+    const msgInput = container.querySelector('[data-automation-field="notifyMessage"]') as HTMLInputElement
+    msgInput.value = 'Hello!'
+    msgInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    // Save
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.name).toBe('My Rule')
+    expect(body.triggerType).toBe('record.created')
+    expect(body.actionType).toBe('notify')
+    expect(body.actionConfig.message).toBe('Hello!')
+  })
+
+  it('toggles rule enabled/disabled', async () => {
+    const { client, fetchFn } = mockClient([fakeRule()])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    await flushPromises()
+
+    const toggle = container.querySelector('[data-automation-toggle]') as HTMLInputElement
+    expect(toggle.checked).toBe(true)
+    toggle.click()
+    await flushPromises()
+
+    const patchCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'PATCH')
+    expect(patchCalls.length).toBe(1)
+    const body = JSON.parse(patchCalls[0][1]?.body as string)
+    expect(body.enabled).toBe(false)
+  })
+
+  it('deletes rule', async () => {
+    const { client, fetchFn } = mockClient([fakeRule()])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    await flushPromises()
+
+    const deleteBtn = container.querySelector('[data-automation-delete]') as HTMLButtonElement
+    deleteBtn.click()
+    await flushPromises()
+
+    const deleteCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'DELETE')
+    expect(deleteCalls.length).toBe(1)
+    expect(container.querySelectorAll('[data-automation-rule]').length).toBe(0)
+  })
+
+  it('shows field picker for field.changed trigger', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    await flushPromises()
+
+    // Open form
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    // No field picker by default
+    expect(container.querySelector('[data-automation-field="triggerFieldId"]')).toBeNull()
+
+    // Change trigger type to field.changed
+    const triggerSelect = container.querySelector('[data-automation-field="triggerType"]') as HTMLSelectElement
+    triggerSelect.value = 'field.changed'
+    triggerSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const fieldPicker = container.querySelector('[data-automation-field="triggerFieldId"]') as HTMLSelectElement
+    expect(fieldPicker).not.toBeNull()
+    // Should have option for each field plus the placeholder
+    expect(fieldPicker.options.length).toBe(fields.length + 1)
+  })
+
+  it('shows appropriate action config for each action type', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    await flushPromises()
+
+    // Open form
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    // Default action is notify — should show message input
+    expect(container.querySelector('[data-automation-field="notifyMessage"]')).not.toBeNull()
+    expect(container.querySelector('[data-automation-field="targetFieldId"]')).toBeNull()
+
+    // Switch to update_field
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'update_field'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(container.querySelector('[data-automation-field="notifyMessage"]')).toBeNull()
+    expect(container.querySelector('[data-automation-field="targetFieldId"]')).not.toBeNull()
+    expect(container.querySelector('[data-automation-field="targetValue"]')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- New `MetaAutomationManager.vue` modal with rule cards, create/edit form
- Conditional trigger config (field picker for field.changed)
- Conditional action config (message for notify, target field + value for update_field)
- Enable/disable toggle per rule
- New `useMultitableAutomations` composable (CRUD + toggle)
- API client: automation CRUD methods
- Wired into `MultitableWorkbench` toolbar (admin-gated "Automations" button)

## Frontend for backend PR #851

## Test plan
- [x] 7/7 unit tests pass
- [ ] Visual verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)