### PR TITLE
feat(multitable): API token + webhook V1 contracts & runtime

### DIFF
--- a/packages/core-backend/src/middleware/api-token-auth.ts
+++ b/packages/core-backend/src/middleware/api-token-auth.ts
@@ -1,0 +1,100 @@
+/**
+ * API Token Authentication Middleware
+ * Validates Bearer tokens with the `mst_` prefix and attaches scopes to the request.
+ */
+
+import type { Request, Response, NextFunction } from 'express'
+import { apiTokenService } from '../multitable/api-token-service'
+import type { ApiTokenScope } from '../multitable/api-tokens'
+
+// Extend Express Request with api token context
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      apiTokenScopes?: ApiTokenScope[]
+      apiTokenUserId?: string
+    }
+  }
+}
+
+const TOKEN_PREFIX = 'mst_'
+
+/**
+ * Middleware that checks for `Authorization: Bearer mst_...` headers.
+ *
+ * - If the header is absent or does not start with `mst_`, the middleware
+ *   passes through (allowing normal session auth to take over).
+ * - If the header IS an API token, it is validated:
+ *   - Invalid / revoked / expired tokens receive a 401.
+ *   - Valid tokens have their scopes attached to `req.apiTokenScopes`.
+ */
+export function apiTokenAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const authHeader = req.headers.authorization
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    next()
+    return
+  }
+
+  const token = authHeader.slice('Bearer '.length).trim()
+
+  // Only intercept mst_ tokens; let JWT tokens pass through
+  if (!token.startsWith(TOKEN_PREFIX)) {
+    next()
+    return
+  }
+
+  const result = apiTokenService.validateToken(token)
+
+  if (!result.valid) {
+    res.status(401).json({
+      ok: false,
+      error: { code: 'INVALID_API_TOKEN', message: result.reason },
+    })
+    return
+  }
+
+  // Attach scopes and synthetic user context
+  req.apiTokenScopes = result.token.scopes
+  req.apiTokenUserId = result.token.createdBy
+
+  // Set a minimal user object so downstream route guards work
+  ;(req as Record<string, unknown>).user = {
+    id: result.token.createdBy,
+    apiToken: true,
+  }
+
+  next()
+}
+
+/**
+ * Route-level guard that requires a specific scope on the API token.
+ * If the request was not authenticated via API token, it passes through
+ * (assuming normal session auth is in effect).
+ */
+export function requireScope(scope: ApiTokenScope) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // Not an API-token request — let other auth handle it
+    if (!req.apiTokenScopes) {
+      next()
+      return
+    }
+
+    if (!req.apiTokenScopes.includes(scope)) {
+      res.status(403).json({
+        ok: false,
+        error: {
+          code: 'INSUFFICIENT_SCOPE',
+          message: `Required scope: ${scope}`,
+        },
+      })
+      return
+    }
+
+    next()
+  }
+}

--- a/packages/core-backend/src/multitable/api-token-service.ts
+++ b/packages/core-backend/src/multitable/api-token-service.ts
@@ -1,0 +1,184 @@
+/**
+ * API Token Service
+ * In-memory token management for multitable open API access.
+ * V1: in-memory store — tokens are lost on restart.
+ */
+
+import { createHash, randomBytes } from 'crypto'
+import { Logger } from '../core/logger'
+import type {
+  ApiToken,
+  ApiTokenCreateInput,
+  ApiTokenCreateResult,
+  ApiTokenScope,
+} from './api-tokens'
+
+const logger = new Logger('ApiTokenService')
+
+const TOKEN_PREFIX = 'mst_'
+
+function generateTokenId(): string {
+  return randomBytes(16).toString('hex')
+}
+
+function generatePlainTextToken(): string {
+  return TOKEN_PREFIX + randomBytes(16).toString('hex')
+}
+
+function hashToken(plainText: string): string {
+  return createHash('sha256').update(plainText).digest('hex')
+}
+
+export class ApiTokenService {
+  /** tokenId -> ApiToken */
+  private tokens = new Map<string, ApiToken>()
+  /** tokenHash -> tokenId (reverse index for validation) */
+  private hashIndex = new Map<string, string>()
+
+  /**
+   * Create a new API token. The plain-text token is returned only once.
+   */
+  createToken(userId: string, input: ApiTokenCreateInput): ApiTokenCreateResult {
+    if (!input.name || input.name.trim().length === 0) {
+      throw new Error('Token name is required')
+    }
+    if (!input.scopes || input.scopes.length === 0) {
+      throw new Error('At least one scope is required')
+    }
+
+    const plainTextToken = generatePlainTextToken()
+    const tokenHashValue = hashToken(plainTextToken)
+    const tokenPrefix = plainTextToken.slice(0, 8)
+    const id = generateTokenId()
+    const now = new Date().toISOString()
+
+    const token: ApiToken = {
+      id,
+      name: input.name.trim(),
+      tokenHash: tokenHashValue,
+      tokenPrefix,
+      scopes: [...input.scopes],
+      createdBy: userId,
+      createdAt: now,
+      expiresAt: input.expiresAt,
+      revoked: false,
+    }
+
+    this.tokens.set(id, token)
+    this.hashIndex.set(tokenHashValue, id)
+
+    logger.info(`API token created: ${tokenPrefix}... by user ${userId}`)
+
+    return { token, plainTextToken }
+  }
+
+  /**
+   * List all tokens belonging to a user. Token hashes are redacted.
+   */
+  listTokens(userId: string): Omit<ApiToken, 'tokenHash'>[] {
+    const result: Omit<ApiToken, 'tokenHash'>[] = []
+    for (const token of this.tokens.values()) {
+      if (token.createdBy === userId) {
+        const { tokenHash: _hash, ...rest } = token
+        result.push(rest)
+      }
+    }
+    return result
+  }
+
+  /**
+   * Soft-revoke a token. Only the token owner can revoke.
+   */
+  revokeToken(tokenId: string, userId: string): void {
+    const token = this.tokens.get(tokenId)
+    if (!token) {
+      throw new Error('Token not found')
+    }
+    if (token.createdBy !== userId) {
+      throw new Error('Not authorized to revoke this token')
+    }
+    if (token.revoked) {
+      return // already revoked, idempotent
+    }
+
+    token.revoked = true
+    token.revokedAt = new Date().toISOString()
+
+    logger.info(`API token revoked: ${token.tokenPrefix}... by user ${userId}`)
+  }
+
+  /**
+   * Validate a plain-text token. Returns the token with its scopes if valid.
+   */
+  validateToken(
+    plainTextToken: string,
+  ): { valid: true; token: ApiToken } | { valid: false; reason: string } {
+    if (!plainTextToken || !plainTextToken.startsWith(TOKEN_PREFIX)) {
+      return { valid: false, reason: 'Invalid token format' }
+    }
+
+    const tokenHashValue = hashToken(plainTextToken)
+    const tokenId = this.hashIndex.get(tokenHashValue)
+    if (!tokenId) {
+      return { valid: false, reason: 'Token not found' }
+    }
+
+    const token = this.tokens.get(tokenId)
+    if (!token) {
+      return { valid: false, reason: 'Token not found' }
+    }
+
+    if (token.revoked) {
+      return { valid: false, reason: 'Token has been revoked' }
+    }
+
+    if (token.expiresAt && new Date(token.expiresAt) < new Date()) {
+      return { valid: false, reason: 'Token has expired' }
+    }
+
+    // Update last used timestamp
+    token.lastUsedAt = new Date().toISOString()
+
+    return { valid: true, token }
+  }
+
+  /**
+   * Rotate a token: revoke the old one and create a new one with the same scopes.
+   */
+  rotateToken(tokenId: string, userId: string): ApiTokenCreateResult {
+    const token = this.tokens.get(tokenId)
+    if (!token) {
+      throw new Error('Token not found')
+    }
+    if (token.createdBy !== userId) {
+      throw new Error('Not authorized to rotate this token')
+    }
+
+    // Revoke old token
+    this.revokeToken(tokenId, userId)
+
+    // Create new token with same name and scopes
+    return this.createToken(userId, {
+      name: token.name,
+      scopes: token.scopes,
+      expiresAt: token.expiresAt,
+    })
+  }
+
+  /**
+   * Check if a token has the required scope.
+   */
+  static hasScope(token: ApiToken, requiredScope: ApiTokenScope): boolean {
+    return token.scopes.includes(requiredScope)
+  }
+
+  /**
+   * Get a token by ID (for internal use).
+   */
+  getTokenById(tokenId: string): ApiToken | undefined {
+    return this.tokens.get(tokenId)
+  }
+}
+
+/** Singleton instance for V1 in-memory usage */
+export const apiTokenService = new ApiTokenService()

--- a/packages/core-backend/src/multitable/api-tokens.ts
+++ b/packages/core-backend/src/multitable/api-tokens.ts
@@ -1,0 +1,46 @@
+/**
+ * API Token Types
+ * Type definitions for the multitable open API token system.
+ */
+
+export interface ApiToken {
+  id: string
+  name: string
+  tokenHash: string        // SHA-256 hash, never store plaintext
+  tokenPrefix: string      // first 8 chars for display: "mst_abc1..."
+  scopes: ApiTokenScope[]
+  createdBy: string        // userId
+  createdAt: string
+  lastUsedAt?: string
+  expiresAt?: string       // optional expiry
+  revoked: boolean
+  revokedAt?: string
+}
+
+export type ApiTokenScope =
+  | 'records:read'
+  | 'records:write'
+  | 'fields:read'
+  | 'comments:read'
+  | 'comments:write'
+  | 'webhooks:manage'
+
+export const ALL_API_TOKEN_SCOPES: ApiTokenScope[] = [
+  'records:read',
+  'records:write',
+  'fields:read',
+  'comments:read',
+  'comments:write',
+  'webhooks:manage',
+]
+
+export interface ApiTokenCreateInput {
+  name: string
+  scopes: ApiTokenScope[]
+  expiresAt?: string
+}
+
+export interface ApiTokenCreateResult {
+  token: ApiToken
+  plainTextToken: string   // only returned once at creation
+}

--- a/packages/core-backend/src/multitable/webhook-event-bridge.ts
+++ b/packages/core-backend/src/multitable/webhook-event-bridge.ts
@@ -1,0 +1,45 @@
+/**
+ * Webhook Event Bridge
+ * Wires internal EventBus events to the WebhookService delivery pipeline.
+ *
+ * This module subscribes to multitable EventBus topics and forwards them
+ * as webhook deliveries, keeping the publish sites untouched.
+ */
+
+import { eventBus } from '../core/EventBusService'
+import { Logger } from '../core/logger'
+import { webhookService } from './webhook-service'
+import type { WebhookEventType } from './webhooks'
+
+const logger = new Logger('WebhookEventBridge')
+
+/**
+ * Map internal event names (as published on the EventBus) to webhook event types.
+ */
+const EVENT_MAP: Record<string, WebhookEventType> = {
+  'multitable.record.created': 'record.created',
+  'multitable.record.updated': 'record.updated',
+  'multitable.record.deleted': 'record.deleted',
+  'multitable.comment.created': 'comment.created',
+}
+
+let initialized = false
+
+/**
+ * Call once at application startup to bridge EventBus -> WebhookService.
+ */
+export function initWebhookEventBridge(): void {
+  if (initialized) return
+  initialized = true
+
+  for (const [busEvent, webhookEvent] of Object.entries(EVENT_MAP)) {
+    eventBus.on(busEvent, (payload: unknown) => {
+      webhookService.deliverEvent(webhookEvent, payload).catch((err) => {
+        logger.error(
+          `Failed to deliver webhook for ${webhookEvent}: ${err instanceof Error ? err.message : String(err)}`,
+        )
+      })
+    })
+    logger.info(`Bridged EventBus "${busEvent}" -> Webhook "${webhookEvent}"`)
+  }
+}

--- a/packages/core-backend/src/multitable/webhook-service.ts
+++ b/packages/core-backend/src/multitable/webhook-service.ts
@@ -1,0 +1,334 @@
+/**
+ * Webhook Service
+ * In-memory webhook management and delivery for multitable open API.
+ * V1: in-memory store and delivery queue — state is lost on restart.
+ */
+
+import { createHmac, randomBytes } from 'crypto'
+import { Logger } from '../core/logger'
+import type {
+  Webhook,
+  WebhookCreateInput,
+  WebhookDelivery,
+  WebhookEventType,
+  WebhookUpdateInput,
+} from './webhooks'
+import { ALL_WEBHOOK_EVENT_TYPES } from './webhooks'
+
+const logger = new Logger('WebhookService')
+
+const DELIVERY_TIMEOUT_MS = 5_000
+const MAX_CONSECUTIVE_FAILURES = 10
+const BASE_RETRY_DELAY_MS = 1_000
+
+function generateId(): string {
+  return randomBytes(16).toString('hex')
+}
+
+export class WebhookService {
+  private webhooks = new Map<string, Webhook>()
+  private deliveries: WebhookDelivery[] = []
+  /** Pluggable fetch for testing */
+  private fetchFn: typeof fetch
+
+  constructor(fetchFn?: typeof fetch) {
+    this.fetchFn = fetchFn ?? globalThis.fetch
+  }
+
+  // ─── CRUD ────────────────────────────────────────────────────────────
+
+  createWebhook(userId: string, input: WebhookCreateInput): Webhook {
+    if (!input.name || input.name.trim().length === 0) {
+      throw new Error('Webhook name is required')
+    }
+    if (!input.url || input.url.trim().length === 0) {
+      throw new Error('Webhook URL is required')
+    }
+    try {
+      const parsed = new URL(input.url)
+      if (
+        process.env.NODE_ENV === 'production' &&
+        parsed.protocol !== 'https:'
+      ) {
+        throw new Error('Webhook URL must use HTTPS in production')
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('HTTPS')) throw err
+      throw new Error('Webhook URL is not a valid URL')
+    }
+    if (!input.events || input.events.length === 0) {
+      throw new Error('At least one event type is required')
+    }
+    for (const evt of input.events) {
+      if (!ALL_WEBHOOK_EVENT_TYPES.includes(evt)) {
+        throw new Error(`Unknown event type: ${evt}`)
+      }
+    }
+
+    const id = generateId()
+    const now = new Date().toISOString()
+
+    const webhook: Webhook = {
+      id,
+      name: input.name.trim(),
+      url: input.url.trim(),
+      secret: input.secret,
+      events: [...input.events],
+      active: true,
+      createdBy: userId,
+      createdAt: now,
+      failureCount: 0,
+      maxRetries: 3,
+    }
+
+    this.webhooks.set(id, webhook)
+    logger.info(`Webhook created: ${id} by user ${userId}`)
+    return webhook
+  }
+
+  listWebhooks(userId: string): Webhook[] {
+    const result: Webhook[] = []
+    for (const wh of this.webhooks.values()) {
+      if (wh.createdBy === userId) {
+        result.push(wh)
+      }
+    }
+    return result
+  }
+
+  updateWebhook(
+    webhookId: string,
+    userId: string,
+    input: WebhookUpdateInput,
+  ): Webhook {
+    const wh = this.webhooks.get(webhookId)
+    if (!wh) throw new Error('Webhook not found')
+    if (wh.createdBy !== userId) throw new Error('Not authorized')
+
+    if (input.name !== undefined) wh.name = input.name.trim()
+    if (input.url !== undefined) {
+      try {
+        new URL(input.url)
+      } catch {
+        throw new Error('Webhook URL is not a valid URL')
+      }
+      wh.url = input.url.trim()
+    }
+    if (input.secret !== undefined) wh.secret = input.secret
+    if (input.events !== undefined) wh.events = [...input.events]
+    if (input.active !== undefined) wh.active = input.active
+    wh.updatedAt = new Date().toISOString()
+
+    return wh
+  }
+
+  deleteWebhook(webhookId: string, userId: string): void {
+    const wh = this.webhooks.get(webhookId)
+    if (!wh) throw new Error('Webhook not found')
+    if (wh.createdBy !== userId) throw new Error('Not authorized')
+    this.webhooks.delete(webhookId)
+    logger.info(`Webhook deleted: ${webhookId} by user ${userId}`)
+  }
+
+  getWebhookById(webhookId: string): Webhook | undefined {
+    return this.webhooks.get(webhookId)
+  }
+
+  // ─── Delivery ────────────────────────────────────────────────────────
+
+  /**
+   * Queue deliveries for all active webhooks subscribed to the given event type.
+   */
+  async deliverEvent(
+    event: WebhookEventType,
+    payload: unknown,
+  ): Promise<WebhookDelivery[]> {
+    const matching: Webhook[] = []
+    for (const wh of this.webhooks.values()) {
+      if (wh.active && wh.events.includes(event)) {
+        matching.push(wh)
+      }
+    }
+
+    const deliveries: WebhookDelivery[] = []
+    for (const wh of matching) {
+      const delivery = this.createDeliveryRecord(wh.id, event, payload)
+      deliveries.push(delivery)
+      // Fire-and-forget — do not await per delivery to avoid blocking the caller
+      this.executeDelivery(delivery).catch((err) => {
+        logger.error(
+          `Delivery ${delivery.id} failed: ${err instanceof Error ? err.message : String(err)}`,
+        )
+      })
+    }
+
+    return deliveries
+  }
+
+  /**
+   * Execute a single webhook delivery attempt.
+   */
+  async executeDelivery(delivery: WebhookDelivery): Promise<void> {
+    const wh = this.webhooks.get(delivery.webhookId)
+    if (!wh) {
+      delivery.status = 'failed'
+      return
+    }
+
+    const bodyStr = JSON.stringify(delivery.payload)
+    const timestamp = new Date().toISOString()
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-Webhook-Id': wh.id,
+      'X-Webhook-Event': delivery.event,
+      'X-Webhook-Timestamp': timestamp,
+    }
+
+    if (wh.secret) {
+      headers['X-Webhook-Signature'] = WebhookService.signPayload(
+        bodyStr,
+        wh.secret,
+      )
+    }
+
+    delivery.attemptCount += 1
+
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS)
+
+      const response = await this.fetchFn(wh.url, {
+        method: 'POST',
+        headers,
+        body: bodyStr,
+        signal: controller.signal,
+      })
+
+      clearTimeout(timer)
+
+      delivery.httpStatus = response.status
+      try {
+        delivery.responseBody = await response.text()
+      } catch {
+        // ignore body read errors
+      }
+
+      if (response.ok) {
+        delivery.status = 'success'
+        delivery.deliveredAt = new Date().toISOString()
+        wh.lastDeliveredAt = delivery.deliveredAt
+        wh.failureCount = 0
+      } else {
+        this.handleDeliveryFailure(delivery, wh)
+      }
+    } catch (err) {
+      logger.error(
+        `Webhook delivery error for ${wh.id}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+      this.handleDeliveryFailure(delivery, wh)
+    }
+  }
+
+  /**
+   * Retry all failed deliveries that are due for retry.
+   */
+  async retryFailedDeliveries(): Promise<number> {
+    const now = Date.now()
+    let retried = 0
+
+    for (const delivery of this.deliveries) {
+      if (delivery.status !== 'pending') continue
+      if (!delivery.nextRetryAt) continue
+      if (new Date(delivery.nextRetryAt).getTime() > now) continue
+
+      const wh = this.webhooks.get(delivery.webhookId)
+      if (!wh || !wh.active) {
+        delivery.status = 'failed'
+        continue
+      }
+
+      if (delivery.attemptCount >= wh.maxRetries) {
+        delivery.status = 'failed'
+        continue
+      }
+
+      await this.executeDelivery(delivery)
+      retried++
+    }
+
+    return retried
+  }
+
+  /**
+   * List recent deliveries for a webhook.
+   */
+  listDeliveries(
+    webhookId: string,
+    limit = 50,
+  ): WebhookDelivery[] {
+    return this.deliveries
+      .filter((d) => d.webhookId === webhookId)
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      )
+      .slice(0, limit)
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────
+
+  private createDeliveryRecord(
+    webhookId: string,
+    event: WebhookEventType,
+    payload: unknown,
+  ): WebhookDelivery {
+    const delivery: WebhookDelivery = {
+      id: generateId(),
+      webhookId,
+      event,
+      payload,
+      status: 'pending',
+      attemptCount: 0,
+      createdAt: new Date().toISOString(),
+    }
+    this.deliveries.push(delivery)
+    return delivery
+  }
+
+  private handleDeliveryFailure(
+    delivery: WebhookDelivery,
+    wh: Webhook,
+  ): void {
+    wh.failureCount += 1
+
+    if (wh.failureCount >= MAX_CONSECUTIVE_FAILURES) {
+      wh.active = false
+      delivery.status = 'failed'
+      logger.warn(
+        `Webhook ${wh.id} auto-disabled after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`,
+      )
+      return
+    }
+
+    if (delivery.attemptCount >= wh.maxRetries) {
+      delivery.status = 'failed'
+      return
+    }
+
+    // Exponential backoff
+    const delay = BASE_RETRY_DELAY_MS * Math.pow(2, delivery.attemptCount - 1)
+    delivery.nextRetryAt = new Date(Date.now() + delay).toISOString()
+    delivery.status = 'pending'
+  }
+
+  /**
+   * Compute HMAC-SHA256 signature for webhook payload.
+   */
+  static signPayload(body: string, secret: string): string {
+    return createHmac('sha256', secret).update(body).digest('hex')
+  }
+}
+
+/** Singleton instance for V1 in-memory usage */
+export const webhookService = new WebhookService()

--- a/packages/core-backend/src/multitable/webhooks.ts
+++ b/packages/core-backend/src/multitable/webhooks.ts
@@ -1,0 +1,61 @@
+/**
+ * Webhook Types
+ * Type definitions for the multitable webhook delivery system.
+ */
+
+export interface Webhook {
+  id: string
+  name: string
+  url: string              // delivery target URL
+  secret?: string          // HMAC signing secret
+  events: WebhookEventType[]
+  active: boolean
+  createdBy: string
+  createdAt: string
+  updatedAt?: string
+  lastDeliveredAt?: string
+  failureCount: number     // consecutive failures
+  maxRetries: number       // default 3
+}
+
+export type WebhookEventType =
+  | 'record.created'
+  | 'record.updated'
+  | 'record.deleted'
+  | 'comment.created'
+
+export const ALL_WEBHOOK_EVENT_TYPES: WebhookEventType[] = [
+  'record.created',
+  'record.updated',
+  'record.deleted',
+  'comment.created',
+]
+
+export interface WebhookDelivery {
+  id: string
+  webhookId: string
+  event: WebhookEventType
+  payload: unknown
+  status: 'pending' | 'success' | 'failed'
+  httpStatus?: number
+  responseBody?: string
+  attemptCount: number
+  createdAt: string
+  deliveredAt?: string
+  nextRetryAt?: string
+}
+
+export interface WebhookCreateInput {
+  name: string
+  url: string
+  secret?: string
+  events: WebhookEventType[]
+}
+
+export interface WebhookUpdateInput {
+  name?: string
+  url?: string
+  secret?: string
+  events?: WebhookEventType[]
+  active?: boolean
+}

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -1,0 +1,268 @@
+/**
+ * API Token & Webhook REST Routes
+ * Provides CRUD endpoints for managing API tokens and webhooks.
+ */
+
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { z } from 'zod'
+import { Logger } from '../core/logger'
+import { authenticate } from '../middleware/auth'
+import { apiTokenService } from '../multitable/api-token-service'
+import { webhookService } from '../multitable/webhook-service'
+import { ALL_API_TOKEN_SCOPES } from '../multitable/api-tokens'
+import { ALL_WEBHOOK_EVENT_TYPES } from '../multitable/webhooks'
+
+const logger = new Logger('ApiTokenRoutes')
+
+// ─── Zod schemas ───────────────────────────────────────────────────────
+
+const CreateTokenSchema = z.object({
+  name: z.string().min(1).max(100),
+  scopes: z.array(z.enum(ALL_API_TOKEN_SCOPES as [string, ...string[]])).min(1),
+  expiresAt: z.string().datetime().optional(),
+})
+
+const CreateWebhookSchema = z.object({
+  name: z.string().min(1).max(100),
+  url: z.string().url(),
+  secret: z.string().optional(),
+  events: z
+    .array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]]))
+    .min(1),
+})
+
+const UpdateWebhookSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  url: z.string().url().optional(),
+  secret: z.string().optional(),
+  events: z
+    .array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]]))
+    .min(1)
+    .optional(),
+  active: z.boolean().optional(),
+})
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+function getUserId(req: Request): string {
+  const user = req.user as Record<string, unknown> | undefined
+  const id = user?.id ?? user?.userId ?? user?.sub
+  return typeof id === 'string' ? id.trim() : ''
+}
+
+function zodError(res: Response, err: z.ZodError): void {
+  res.status(400).json({
+    ok: false,
+    error: { code: 'VALIDATION_ERROR', details: err.errors },
+  })
+}
+
+// ─── Router factory ────────────────────────────────────────────────────
+
+export function apiTokensRouter(): Router {
+  const router = Router()
+
+  // All routes require authentication
+  router.use(
+    ['/api/multitable/api-tokens', '/api/multitable/webhooks'],
+    authenticate,
+  )
+
+  // ── Token routes ──────────────────────────────────────────────────
+
+  // GET /api/multitable/api-tokens — list user's tokens
+  router.get('/api/multitable/api-tokens', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    const tokens = apiTokenService.listTokens(userId)
+    res.json({ ok: true, data: tokens })
+  })
+
+  // POST /api/multitable/api-tokens — create token
+  router.post('/api/multitable/api-tokens', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      const input = CreateTokenSchema.parse(req.body)
+      const result = apiTokenService.createToken(userId, {
+        name: input.name,
+        scopes: input.scopes as import('../multitable/api-tokens').ApiTokenScope[],
+        expiresAt: input.expiresAt,
+      })
+      res.status(201).json({ ok: true, data: result })
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        zodError(res, err)
+        return
+      }
+      logger.error('Failed to create token', err instanceof Error ? err : undefined)
+      res.status(500).json({
+        ok: false,
+        error: { code: 'CREATE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
+      })
+    }
+  })
+
+  // DELETE /api/multitable/api-tokens/:id — revoke token
+  router.delete('/api/multitable/api-tokens/:id', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      apiTokenService.revokeToken(req.params.id, userId)
+      res.json({ ok: true })
+    } catch (err) {
+      logger.error('Failed to revoke token', err instanceof Error ? err : undefined)
+      const status = (err instanceof Error && err.message === 'Token not found') ? 404 : 500
+      res.status(status).json({
+        ok: false,
+        error: { code: 'REVOKE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
+      })
+    }
+  })
+
+  // POST /api/multitable/api-tokens/:id/rotate — rotate token
+  router.post('/api/multitable/api-tokens/:id/rotate', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      const result = apiTokenService.rotateToken(req.params.id, userId)
+      res.json({ ok: true, data: result })
+    } catch (err) {
+      logger.error('Failed to rotate token', err instanceof Error ? err : undefined)
+      const status = (err instanceof Error && err.message === 'Token not found') ? 404 : 500
+      res.status(status).json({
+        ok: false,
+        error: { code: 'ROTATE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
+      })
+    }
+  })
+
+  // ── Webhook routes ────────────────────────────────────────────────
+
+  // GET /api/multitable/webhooks — list webhooks
+  router.get('/api/multitable/webhooks', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    const webhooks = webhookService.listWebhooks(userId)
+    res.json({ ok: true, data: webhooks })
+  })
+
+  // POST /api/multitable/webhooks — create webhook
+  router.post('/api/multitable/webhooks', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      const input = CreateWebhookSchema.parse(req.body)
+      const webhook = webhookService.createWebhook(userId, {
+        name: input.name,
+        url: input.url,
+        secret: input.secret,
+        events: input.events as import('../multitable/webhooks').WebhookEventType[],
+      })
+      res.status(201).json({ ok: true, data: webhook })
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        zodError(res, err)
+        return
+      }
+      logger.error('Failed to create webhook', err instanceof Error ? err : undefined)
+      res.status(400).json({
+        ok: false,
+        error: { code: 'CREATE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
+      })
+    }
+  })
+
+  // PATCH /api/multitable/webhooks/:id — update webhook
+  router.patch('/api/multitable/webhooks/:id', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      const input = UpdateWebhookSchema.parse(req.body)
+      const webhook = webhookService.updateWebhook(req.params.id, userId, {
+        name: input.name,
+        url: input.url,
+        secret: input.secret,
+        events: input.events as import('../multitable/webhooks').WebhookEventType[] | undefined,
+        active: input.active,
+      })
+      res.json({ ok: true, data: webhook })
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        zodError(res, err)
+        return
+      }
+      logger.error('Failed to update webhook', err instanceof Error ? err : undefined)
+      const status = (err instanceof Error && err.message === 'Webhook not found') ? 404 : 500
+      res.status(status).json({
+        ok: false,
+        error: { code: 'UPDATE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
+      })
+    }
+  })
+
+  // DELETE /api/multitable/webhooks/:id — delete webhook
+  router.delete('/api/multitable/webhooks/:id', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      webhookService.deleteWebhook(req.params.id, userId)
+      res.json({ ok: true })
+    } catch (err) {
+      logger.error('Failed to delete webhook', err instanceof Error ? err : undefined)
+      const status = (err instanceof Error && err.message === 'Webhook not found') ? 404 : 500
+      res.status(status).json({
+        ok: false,
+        error: { code: 'DELETE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
+      })
+    }
+  })
+
+  // GET /api/multitable/webhooks/:id/deliveries — list recent deliveries
+  router.get('/api/multitable/webhooks/:id/deliveries', (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    const wh = webhookService.getWebhookById(req.params.id)
+    if (!wh) {
+      res.status(404).json({ ok: false, error: { code: 'NOT_FOUND' } })
+      return
+    }
+    if (wh.createdBy !== userId) {
+      res.status(403).json({ ok: false, error: { code: 'FORBIDDEN' } })
+      return
+    }
+    const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
+    const deliveries = webhookService.listDeliveries(req.params.id, limit)
+    res.json({ ok: true, data: deliveries })
+  })
+
+  return router
+}

--- a/packages/core-backend/tests/unit/api-token-webhook.test.ts
+++ b/packages/core-backend/tests/unit/api-token-webhook.test.ts
@@ -1,0 +1,578 @@
+/**
+ * API Token & Webhook V1 — Unit Tests
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { createHash, createHmac } from 'crypto'
+import { ApiTokenService } from '../../src/multitable/api-token-service'
+import { WebhookService } from '../../src/multitable/webhook-service'
+import type { ApiTokenScope } from '../../src/multitable/api-tokens'
+import type { WebhookEventType } from '../../src/multitable/webhooks'
+
+// ═══════════════════════════════════════════════════════════════════════
+//  API Token Service
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('ApiTokenService', () => {
+  let svc: ApiTokenService
+
+  beforeEach(() => {
+    svc = new ApiTokenService()
+  })
+
+  // ── Creation ──────────────────────────────────────────────────────
+
+  test('createToken returns a plaintext token starting with mst_', () => {
+    const result = svc.createToken('user1', {
+      name: 'Test Token',
+      scopes: ['records:read'],
+    })
+    expect(result.plainTextToken).toMatch(/^mst_[0-9a-f]{32}$/)
+  })
+
+  test('createToken returns the plaintext only once (not stored)', () => {
+    const result = svc.createToken('user1', {
+      name: 'Once',
+      scopes: ['records:read'],
+    })
+    const listed = svc.listTokens('user1')
+    // Listed tokens must NOT contain the hash
+    for (const t of listed) {
+      expect((t as Record<string, unknown>).tokenHash).toBeUndefined()
+    }
+    // But the creation result has the hash inside the token object (internal)
+    expect(result.token.tokenHash).toBeDefined()
+  })
+
+  test('createToken stores SHA-256 hash of the token', () => {
+    const result = svc.createToken('user1', {
+      name: 'Hash check',
+      scopes: ['records:read'],
+    })
+    const expectedHash = createHash('sha256')
+      .update(result.plainTextToken)
+      .digest('hex')
+    expect(result.token.tokenHash).toBe(expectedHash)
+  })
+
+  test('createToken stores the first 8 chars as tokenPrefix', () => {
+    const result = svc.createToken('user1', {
+      name: 'Prefix',
+      scopes: ['records:read'],
+    })
+    expect(result.token.tokenPrefix).toBe(result.plainTextToken.slice(0, 8))
+  })
+
+  test('createToken rejects empty name', () => {
+    expect(() =>
+      svc.createToken('user1', { name: '', scopes: ['records:read'] }),
+    ).toThrow('Token name is required')
+  })
+
+  test('createToken rejects empty scopes', () => {
+    expect(() =>
+      svc.createToken('user1', { name: 'No scopes', scopes: [] }),
+    ).toThrow('At least one scope is required')
+  })
+
+  // ── Validation ────────────────────────────────────────────────────
+
+  test('validateToken succeeds for a valid token', () => {
+    const { plainTextToken } = svc.createToken('user1', {
+      name: 'Valid',
+      scopes: ['records:read'],
+    })
+    const result = svc.validateToken(plainTextToken)
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.token.scopes).toContain('records:read')
+    }
+  })
+
+  test('validateToken fails for unknown token', () => {
+    const result = svc.validateToken('mst_0000000000000000000000000000dead')
+    expect(result.valid).toBe(false)
+  })
+
+  test('validateToken fails for non-mst_ prefix', () => {
+    const result = svc.validateToken('bearer_abc123')
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toMatch(/format/)
+    }
+  })
+
+  test('validateToken updates lastUsedAt on success', () => {
+    const { plainTextToken, token } = svc.createToken('user1', {
+      name: 'Used',
+      scopes: ['records:read'],
+    })
+    expect(token.lastUsedAt).toBeUndefined()
+    svc.validateToken(plainTextToken)
+    const stored = svc.getTokenById(token.id)
+    expect(stored?.lastUsedAt).toBeDefined()
+  })
+
+  // ── Revocation ────────────────────────────────────────────────────
+
+  test('revoked token fails validation', () => {
+    const { plainTextToken, token } = svc.createToken('user1', {
+      name: 'Revoke me',
+      scopes: ['records:read'],
+    })
+    svc.revokeToken(token.id, 'user1')
+    const result = svc.validateToken(plainTextToken)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toMatch(/revoked/)
+    }
+  })
+
+  test('revokeToken sets revokedAt timestamp', () => {
+    const { token } = svc.createToken('user1', {
+      name: 'Ts',
+      scopes: ['records:read'],
+    })
+    svc.revokeToken(token.id, 'user1')
+    const stored = svc.getTokenById(token.id)
+    expect(stored?.revoked).toBe(true)
+    expect(stored?.revokedAt).toBeDefined()
+  })
+
+  test('revokeToken throws if user is not the owner', () => {
+    const { token } = svc.createToken('user1', {
+      name: 'Protected',
+      scopes: ['records:read'],
+    })
+    expect(() => svc.revokeToken(token.id, 'user2')).toThrow('Not authorized')
+  })
+
+  test('revokeToken is idempotent', () => {
+    const { token } = svc.createToken('user1', {
+      name: 'Idem',
+      scopes: ['records:read'],
+    })
+    svc.revokeToken(token.id, 'user1')
+    expect(() => svc.revokeToken(token.id, 'user1')).not.toThrow()
+  })
+
+  // ── Expiry ────────────────────────────────────────────────────────
+
+  test('expired token fails validation', () => {
+    const past = new Date(Date.now() - 60_000).toISOString()
+    const { plainTextToken } = svc.createToken('user1', {
+      name: 'Expired',
+      scopes: ['records:read'],
+      expiresAt: past,
+    })
+    const result = svc.validateToken(plainTextToken)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toMatch(/expired/)
+    }
+  })
+
+  test('non-expired token passes validation', () => {
+    const future = new Date(Date.now() + 3_600_000).toISOString()
+    const { plainTextToken } = svc.createToken('user1', {
+      name: 'Future',
+      scopes: ['records:read'],
+      expiresAt: future,
+    })
+    const result = svc.validateToken(plainTextToken)
+    expect(result.valid).toBe(true)
+  })
+
+  // ── Scope checking ────────────────────────────────────────────────
+
+  test('hasScope returns true when scope is present', () => {
+    const { token } = svc.createToken('user1', {
+      name: 'Scoped',
+      scopes: ['records:read', 'records:write'],
+    })
+    expect(ApiTokenService.hasScope(token, 'records:read')).toBe(true)
+    expect(ApiTokenService.hasScope(token, 'records:write')).toBe(true)
+  })
+
+  test('hasScope returns false when scope is missing', () => {
+    const { token } = svc.createToken('user1', {
+      name: 'Limited',
+      scopes: ['records:read'],
+    })
+    expect(ApiTokenService.hasScope(token, 'webhooks:manage')).toBe(false)
+  })
+
+  // ── Rotation ──────────────────────────────────────────────────────
+
+  test('rotateToken revokes old and creates new with same scopes', () => {
+    const { plainTextToken: old, token: oldToken } = svc.createToken('user1', {
+      name: 'Rotate me',
+      scopes: ['records:read', 'comments:read'],
+    })
+    const { plainTextToken: newPt, token: newToken } = svc.rotateToken(
+      oldToken.id,
+      'user1',
+    )
+
+    // Old token revoked
+    expect(svc.validateToken(old).valid).toBe(false)
+    // New token valid
+    expect(svc.validateToken(newPt).valid).toBe(true)
+    // Same scopes
+    expect(newToken.scopes).toEqual(
+      expect.arrayContaining(['records:read', 'comments:read']),
+    )
+    // Different IDs
+    expect(newToken.id).not.toBe(oldToken.id)
+  })
+
+  // ── Listing ───────────────────────────────────────────────────────
+
+  test('listTokens returns only tokens for the given user', () => {
+    svc.createToken('user1', { name: 'A', scopes: ['records:read'] })
+    svc.createToken('user2', { name: 'B', scopes: ['records:read'] })
+    svc.createToken('user1', { name: 'C', scopes: ['records:write'] })
+
+    const list = svc.listTokens('user1')
+    expect(list).toHaveLength(2)
+    expect(list.every((t) => (t as Record<string, unknown>).createdBy === 'user1')).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Webhook Service
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('WebhookService', () => {
+  let svc: WebhookService
+
+  // Default mock fetch that returns 200
+  const okFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => 'ok',
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    svc = new WebhookService(okFetch as unknown as typeof fetch)
+  })
+
+  // ── CRUD ──────────────────────────────────────────────────────────
+
+  test('createWebhook validates URL', () => {
+    expect(() =>
+      svc.createWebhook('u1', {
+        name: 'Bad',
+        url: 'not-a-url',
+        events: ['record.created'],
+      }),
+    ).toThrow('not a valid URL')
+  })
+
+  test('createWebhook rejects empty name', () => {
+    expect(() =>
+      svc.createWebhook('u1', {
+        name: '',
+        url: 'https://example.com/hook',
+        events: ['record.created'],
+      }),
+    ).toThrow('name is required')
+  })
+
+  test('createWebhook rejects empty events', () => {
+    expect(() =>
+      svc.createWebhook('u1', {
+        name: 'No events',
+        url: 'https://example.com/hook',
+        events: [],
+      }),
+    ).toThrow('At least one event')
+  })
+
+  test('createWebhook rejects unknown event type', () => {
+    expect(() =>
+      svc.createWebhook('u1', {
+        name: 'Bad event',
+        url: 'https://example.com/hook',
+        events: ['unknown.event' as WebhookEventType],
+      }),
+    ).toThrow('Unknown event type')
+  })
+
+  test('createWebhook stores webhook and listWebhooks returns it', () => {
+    const wh = svc.createWebhook('u1', {
+      name: 'My Hook',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+    expect(wh.id).toBeDefined()
+    expect(wh.active).toBe(true)
+    expect(wh.failureCount).toBe(0)
+
+    const list = svc.listWebhooks('u1')
+    expect(list).toHaveLength(1)
+    expect(list[0].id).toBe(wh.id)
+  })
+
+  test('deleteWebhook removes webhook', () => {
+    const wh = svc.createWebhook('u1', {
+      name: 'Del',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+    svc.deleteWebhook(wh.id, 'u1')
+    expect(svc.listWebhooks('u1')).toHaveLength(0)
+  })
+
+  test('deleteWebhook throws for wrong user', () => {
+    const wh = svc.createWebhook('u1', {
+      name: 'Owned',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+    expect(() => svc.deleteWebhook(wh.id, 'u2')).toThrow('Not authorized')
+  })
+
+  test('updateWebhook modifies fields', () => {
+    const wh = svc.createWebhook('u1', {
+      name: 'Update me',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+    const updated = svc.updateWebhook(wh.id, 'u1', {
+      name: 'Updated',
+      active: false,
+    })
+    expect(updated.name).toBe('Updated')
+    expect(updated.active).toBe(false)
+    expect(updated.updatedAt).toBeDefined()
+  })
+
+  // ── HMAC Signature ────────────────────────────────────────────────
+
+  test('signPayload produces correct HMAC-SHA256', () => {
+    const body = '{"hello":"world"}'
+    const secret = 'test-secret'
+    const expected = createHmac('sha256', secret).update(body).digest('hex')
+    expect(WebhookService.signPayload(body, secret)).toBe(expected)
+  })
+
+  test('delivery includes signature header when secret is set', async () => {
+    const wh = svc.createWebhook('u1', {
+      name: 'Signed',
+      url: 'https://example.com/hook',
+      secret: 'my-secret',
+      events: ['record.created'],
+    })
+
+    await svc.deliverEvent('record.created', { test: true })
+
+    expect(okFetch).toHaveBeenCalledTimes(1)
+    const callArgs = okFetch.mock.calls[0]
+    const headers = callArgs[1].headers as Record<string, string>
+    expect(headers['X-Webhook-Signature']).toBeDefined()
+    expect(headers['X-Webhook-Id']).toBe(wh.id)
+    expect(headers['X-Webhook-Event']).toBe('record.created')
+    expect(headers['X-Webhook-Timestamp']).toBeDefined()
+  })
+
+  test('delivery does not include signature when no secret', async () => {
+    svc.createWebhook('u1', {
+      name: 'Unsigned',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+
+    await svc.deliverEvent('record.created', { test: true })
+
+    // Wait for fire-and-forget delivery
+    await new Promise((r) => setTimeout(r, 50))
+
+    const callArgs = okFetch.mock.calls[0]
+    const headers = callArgs[1].headers as Record<string, string>
+    expect(headers['X-Webhook-Signature']).toBeUndefined()
+  })
+
+  // ── Delivery logic ────────────────────────────────────────────────
+
+  test('deliverEvent only triggers webhooks subscribed to the event', async () => {
+    svc.createWebhook('u1', {
+      name: 'Records only',
+      url: 'https://example.com/a',
+      events: ['record.created'],
+    })
+    svc.createWebhook('u1', {
+      name: 'Comments only',
+      url: 'https://example.com/b',
+      events: ['comment.created'],
+    })
+
+    await svc.deliverEvent('record.created', {})
+    // Wait for fire-and-forget
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(okFetch).toHaveBeenCalledTimes(1)
+    expect(okFetch.mock.calls[0][0]).toBe('https://example.com/a')
+  })
+
+  test('inactive webhook is not triggered', async () => {
+    const wh = svc.createWebhook('u1', {
+      name: 'Inactive',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+    svc.updateWebhook(wh.id, 'u1', { active: false })
+
+    await svc.deliverEvent('record.created', {})
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(okFetch).not.toHaveBeenCalled()
+  })
+
+  // ── Failure tracking ──────────────────────────────────────────────
+
+  test('failed delivery increments failure count', async () => {
+    const failFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    })
+    const failSvc = new WebhookService(failFetch as unknown as typeof fetch)
+
+    const wh = failSvc.createWebhook('u1', {
+      name: 'Fail',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+
+    await failSvc.deliverEvent('record.created', {})
+    await new Promise((r) => setTimeout(r, 50))
+
+    const stored = failSvc.getWebhookById(wh.id)
+    expect(stored?.failureCount).toBeGreaterThan(0)
+  })
+
+  test('webhook is auto-disabled after 10 consecutive failures', async () => {
+    const failFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'error',
+    })
+    const failSvc = new WebhookService(failFetch as unknown as typeof fetch)
+
+    const wh = failSvc.createWebhook('u1', {
+      name: 'Will disable',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+
+    // Simulate 10 consecutive failures
+    for (let i = 0; i < 10; i++) {
+      await failSvc.deliverEvent('record.created', { attempt: i })
+      await new Promise((r) => setTimeout(r, 20))
+    }
+
+    const stored = failSvc.getWebhookById(wh.id)
+    expect(stored?.active).toBe(false)
+    expect(stored?.failureCount).toBeGreaterThanOrEqual(10)
+  })
+
+  test('successful delivery resets failure count', async () => {
+    // First fail, then succeed
+    let callCount = 0
+    const mixFetch = vi.fn().mockImplementation(async () => {
+      callCount++
+      if (callCount <= 1) {
+        return { ok: false, status: 500, text: async () => 'err' }
+      }
+      return { ok: true, status: 200, text: async () => 'ok' }
+    })
+    const mixSvc = new WebhookService(mixFetch as unknown as typeof fetch)
+
+    const wh = mixSvc.createWebhook('u1', {
+      name: 'Mix',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+
+    // First delivery fails
+    await mixSvc.deliverEvent('record.created', {})
+    await new Promise((r) => setTimeout(r, 50))
+    expect(mixSvc.getWebhookById(wh.id)?.failureCount).toBeGreaterThan(0)
+
+    // Second delivery succeeds
+    await mixSvc.deliverEvent('record.created', {})
+    await new Promise((r) => setTimeout(r, 50))
+    expect(mixSvc.getWebhookById(wh.id)?.failureCount).toBe(0)
+  })
+
+  // ── Delivery list ─────────────────────────────────────────────────
+
+  test('listDeliveries returns deliveries for the given webhook', async () => {
+    const wh = svc.createWebhook('u1', {
+      name: 'Deliveries',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+
+    await svc.deliverEvent('record.created', { a: 1 })
+    await svc.deliverEvent('record.created', { a: 2 })
+    await new Promise((r) => setTimeout(r, 50))
+
+    const deliveries = svc.listDeliveries(wh.id)
+    expect(deliveries.length).toBe(2)
+  })
+
+  // ── Retry logic ───────────────────────────────────────────────────
+
+  test('retryFailedDeliveries retries pending deliveries past nextRetryAt', async () => {
+    const failOnceFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 502, text: async () => 'bad' })
+      .mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' })
+
+    const retrySvc = new WebhookService(failOnceFetch as unknown as typeof fetch)
+    retrySvc.createWebhook('u1', {
+      name: 'Retry',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+
+    const deliveries = await retrySvc.deliverEvent('record.created', { x: 1 })
+    // Wait for first (failing) delivery
+    await new Promise((r) => setTimeout(r, 100))
+
+    // The delivery should be pending with a nextRetryAt
+    expect(deliveries[0].status).toBe('pending')
+
+    // Force nextRetryAt to be in the past for test
+    deliveries[0].nextRetryAt = new Date(Date.now() - 1000).toISOString()
+
+    const retried = await retrySvc.retryFailedDeliveries()
+    expect(retried).toBe(1)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+//  HMAC Signature (standalone)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('WebhookService.signPayload', () => {
+  test('returns hex-encoded HMAC-SHA256', () => {
+    const sig = WebhookService.signPayload('test-body', 'secret')
+    // Must be 64-char hex string (256 bits)
+    expect(sig).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  test('different secrets produce different signatures', () => {
+    const a = WebhookService.signPayload('same-body', 'secret-a')
+    const b = WebhookService.signPayload('same-body', 'secret-b')
+    expect(a).not.toBe(b)
+  })
+
+  test('different bodies produce different signatures', () => {
+    const a = WebhookService.signPayload('body-a', 'same-secret')
+    const b = WebhookService.signPayload('body-b', 'same-secret')
+    expect(a).not.toBe(b)
+  })
+})


### PR DESCRIPTION
## Summary
- **API Token system**: types, in-memory service (create/list/revoke/validate/rotate), SHA-256 hashing, `mst_` prefixed tokens
- **Webhook system**: types, in-memory service (CRUD, HMAC-SHA256 signing, delivery queue with retry & exponential backoff, auto-disable after 10 consecutive failures)
- **EventBus bridge**: wires `multitable.record.created/updated/deleted` and `multitable.comment.created` to webhook delivery without modifying existing publish sites
- **Auth middleware**: `apiTokenAuth` middleware for `Bearer mst_...` tokens with scope checking
- **REST routes**: full CRUD for tokens (`/api/multitable/api-tokens`) and webhooks (`/api/multitable/webhooks`) including delivery history
- **41 unit tests** covering token lifecycle, hash verification, revocation, expiry, scope checking, webhook CRUD, HMAC signature, delivery logic, failure tracking, auto-disable, and retry

## Test plan
- [x] `vitest run tests/unit/api-token-webhook.test.ts` — 41/41 passing
- [ ] Manual smoke test: create token, use Bearer header, verify 401 for revoked/expired
- [ ] Manual smoke test: create webhook, trigger record event, verify delivery + HMAC signature
- [ ] Verify webhook auto-disable after 10 consecutive failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)