### PR TITLE
feat(multitable): chart/dashboard V1 contracts + runtime

### DIFF
--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -1,0 +1,289 @@
+/**
+ * Chart Aggregation Service — computes chart data from records.
+ *
+ * This is a pure-logic service with no DB dependency; it operates on
+ * in-memory record arrays. The DashboardService is responsible for
+ * fetching records and passing them here.
+ */
+
+import type { ChartConfig, ChartType, AggregationFunction } from './charts'
+
+export interface ChartDataPoint {
+  label: string
+  value: number
+  color?: string
+}
+
+export interface ChartData {
+  chartId: string
+  chartType: ChartType
+  dataPoints: ChartDataPoint[]
+  total?: number
+  metadata?: {
+    groupByField?: string
+    aggregationFunction?: string
+    recordCount?: number
+  }
+}
+
+type RecordRow = { data: Record<string, unknown> }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toNumber(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v
+  if (typeof v === 'string') {
+    const n = Number(v)
+    if (Number.isFinite(n)) return n
+  }
+  return null
+}
+
+function startOfWeek(d: Date): Date {
+  const day = d.getUTCDay()
+  const diff = d.getUTCDate() - day + (day === 0 ? -6 : 1)
+  const w = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), diff))
+  return w
+}
+
+function dateBucketKey(dateStr: string, grouping: string): string | null {
+  const d = new Date(dateStr)
+  if (isNaN(d.getTime())) return null
+
+  switch (grouping) {
+    case 'day':
+      return d.toISOString().slice(0, 10) // YYYY-MM-DD
+    case 'week': {
+      const w = startOfWeek(d)
+      return w.toISOString().slice(0, 10)
+    }
+    case 'month':
+      return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`
+    case 'quarter': {
+      const q = Math.ceil((d.getUTCMonth() + 1) / 3)
+      return `${d.getUTCFullYear()}-Q${q}`
+    }
+    case 'year':
+      return String(d.getUTCFullYear())
+    default:
+      return d.toISOString().slice(0, 10)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ChartAggregationService
+// ---------------------------------------------------------------------------
+
+export class ChartAggregationService {
+  /**
+   * Compute chart data from a chart config + record set.
+   */
+  async computeChartData(chart: ChartConfig, records: RecordRow[]): Promise<ChartData> {
+    let filtered = this.filterRecords(records, chart.dataSource)
+    const aggFn = chart.dataSource.aggregation.function
+    const aggFieldId = chart.dataSource.aggregation.fieldId
+
+    // Number chart: single aggregated value
+    if (chart.type === 'number') {
+      const allValues = filtered.map((r) => r.data[aggFieldId ?? ''])
+      const value = this.aggregate(allValues, aggFn)
+      return {
+        chartId: chart.id,
+        chartType: chart.type,
+        dataPoints: [{ label: chart.display.title ?? chart.name, value }],
+        total: value,
+        metadata: {
+          aggregationFunction: aggFn,
+          recordCount: filtered.length,
+        },
+      }
+    }
+
+    // Group records
+    let groups: Map<string, RecordRow[]>
+
+    if (chart.dataSource.dateFieldId && chart.dataSource.dateGrouping) {
+      groups = this.groupByDate(filtered, chart.dataSource.dateFieldId, chart.dataSource.dateGrouping)
+    } else if (chart.dataSource.groupByFieldId) {
+      groups = this.groupRecords(filtered, chart.dataSource.groupByFieldId)
+    } else {
+      // No grouping: everything in one bucket
+      groups = new Map([['All', filtered]])
+    }
+
+    // Compute data points
+    let dataPoints: ChartDataPoint[] = []
+    for (const [label, groupRecords] of groups) {
+      const values = groupRecords.map((r) => r.data[aggFieldId ?? ''])
+      const value = this.aggregate(values, aggFn)
+      dataPoints.push({ label, value })
+    }
+
+    // Sort
+    dataPoints = this.sortDataPoints(dataPoints, chart.dataSource.sortBy, chart.dataSource.sortOrder)
+
+    // Limit
+    if (chart.dataSource.limit && chart.dataSource.limit > 0) {
+      dataPoints = dataPoints.slice(0, chart.dataSource.limit)
+    }
+
+    const total = dataPoints.reduce((sum, dp) => sum + dp.value, 0)
+
+    return {
+      chartId: chart.id,
+      chartType: chart.type,
+      dataPoints,
+      total,
+      metadata: {
+        groupByField: chart.dataSource.groupByFieldId ?? chart.dataSource.dateFieldId,
+        aggregationFunction: aggFn,
+        recordCount: filtered.length,
+      },
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private aggregate(values: unknown[], fn: AggregationFunction): number {
+    switch (fn) {
+      case 'count':
+        return values.length
+
+      case 'count_distinct': {
+        const set = new Set<string>()
+        for (const v of values) {
+          if (v != null) set.add(String(v))
+        }
+        return set.size
+      }
+
+      case 'sum': {
+        let total = 0
+        for (const v of values) {
+          const n = toNumber(v)
+          if (n !== null) total += n
+        }
+        return total
+      }
+
+      case 'avg': {
+        let total = 0
+        let count = 0
+        for (const v of values) {
+          const n = toNumber(v)
+          if (n !== null) {
+            total += n
+            count++
+          }
+        }
+        return count === 0 ? 0 : total / count
+      }
+
+      case 'min': {
+        let min: number | null = null
+        for (const v of values) {
+          const n = toNumber(v)
+          if (n !== null && (min === null || n < min)) min = n
+        }
+        return min ?? 0
+      }
+
+      case 'max': {
+        let max: number | null = null
+        for (const v of values) {
+          const n = toNumber(v)
+          if (n !== null && (max === null || n > max)) max = n
+        }
+        return max ?? 0
+      }
+
+      default:
+        return 0
+    }
+  }
+
+  private groupRecords(records: RecordRow[], fieldId: string): Map<string, RecordRow[]> {
+    const groups = new Map<string, RecordRow[]>()
+    for (const record of records) {
+      const rawValue = record.data[fieldId]
+      const key = rawValue != null ? String(rawValue) : '(empty)'
+      const group = groups.get(key)
+      if (group) {
+        group.push(record)
+      } else {
+        groups.set(key, [record])
+      }
+    }
+    return groups
+  }
+
+  private groupByDate(
+    records: RecordRow[],
+    dateFieldId: string,
+    dateGrouping: string,
+  ): Map<string, RecordRow[]> {
+    const groups = new Map<string, RecordRow[]>()
+    for (const record of records) {
+      const rawValue = record.data[dateFieldId]
+      if (rawValue == null) continue
+      const key = dateBucketKey(String(rawValue), dateGrouping)
+      if (key === null) continue
+      const group = groups.get(key)
+      if (group) {
+        group.push(record)
+      } else {
+        groups.set(key, [record])
+      }
+    }
+    return groups
+  }
+
+  private filterRecords(
+    records: RecordRow[],
+    dataSource: ChartConfig['dataSource'],
+  ): RecordRow[] {
+    const { filterFieldId, filterOperator, filterValue } = dataSource
+    if (!filterFieldId || !filterOperator) return records
+
+    return records.filter((r) => {
+      const val = r.data[filterFieldId]
+      switch (filterOperator) {
+        case 'equals':
+          return val != null && String(val) === String(filterValue)
+        case 'not_equals':
+          return val == null || String(val) !== String(filterValue)
+        case 'contains':
+          return val != null && String(val).includes(String(filterValue))
+        case 'greater_than': {
+          const n = toNumber(val)
+          const t = toNumber(filterValue)
+          return n !== null && t !== null && n > t
+        }
+        case 'less_than': {
+          const n = toNumber(val)
+          const t = toNumber(filterValue)
+          return n !== null && t !== null && n < t
+        }
+        default:
+          return true
+      }
+    })
+  }
+
+  private sortDataPoints(
+    dataPoints: ChartDataPoint[],
+    sortBy?: 'label' | 'value',
+    sortOrder?: 'asc' | 'desc',
+  ): ChartDataPoint[] {
+    if (!sortBy) return dataPoints
+    const dir = sortOrder === 'desc' ? -1 : 1
+    return [...dataPoints].sort((a, b) => {
+      if (sortBy === 'value') return (a.value - b.value) * dir
+      return a.label.localeCompare(b.label) * dir
+    })
+  }
+}

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -1,0 +1,68 @@
+/**
+ * Chart type definitions for multitable dashboard V1.
+ */
+
+export type ChartType = 'bar' | 'line' | 'pie' | 'number' | 'table'
+
+export type AggregationFunction = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'count_distinct'
+
+export interface ChartAggregation {
+  function: AggregationFunction
+  fieldId?: string // required for sum/avg/min/max, optional for count
+}
+
+export interface ChartDataSource {
+  /** What to group by (X axis for bar/line, slices for pie) */
+  groupByFieldId?: string
+
+  /** What to aggregate (Y axis for bar/line, values for pie) */
+  aggregation: ChartAggregation
+
+  /** Optional: filter records before aggregation */
+  filterFieldId?: string
+  filterOperator?: 'equals' | 'not_equals' | 'contains' | 'greater_than' | 'less_than'
+  filterValue?: unknown
+
+  /** Optional: sort results */
+  sortBy?: 'label' | 'value'
+  sortOrder?: 'asc' | 'desc'
+
+  /** For line charts: time field for X axis */
+  dateFieldId?: string
+  dateGrouping?: 'day' | 'week' | 'month' | 'quarter' | 'year'
+
+  /** Limit number of groups/slices */
+  limit?: number
+}
+
+export interface ChartDisplayConfig {
+  title?: string
+  showLegend?: boolean
+  showValues?: boolean
+  colorScheme?: string
+  /** For number chart */
+  prefix?: string
+  suffix?: string
+}
+
+export interface ChartConfig {
+  id: string
+  name: string
+  type: ChartType
+  sheetId: string
+  viewId?: string // optional: use view's filters/sorts
+  dataSource: ChartDataSource
+  display: ChartDisplayConfig
+  createdBy: string
+  createdAt: string
+  updatedAt?: string
+}
+
+export interface ChartCreateInput {
+  name: string
+  type: ChartType
+  viewId?: string
+  dataSource: ChartDataSource
+  display?: ChartDisplayConfig
+  createdBy?: string
+}

--- a/packages/core-backend/src/multitable/dashboard-service.ts
+++ b/packages/core-backend/src/multitable/dashboard-service.ts
@@ -1,0 +1,148 @@
+/**
+ * Dashboard Service — in-memory CRUD for charts and dashboards (V1).
+ *
+ * Persistence is intentionally in-memory for V1; a future version will
+ * use Postgres. The service delegates aggregation to ChartAggregationService.
+ */
+
+import { randomUUID } from 'crypto'
+
+import type { ChartConfig, ChartCreateInput } from './charts'
+import type {
+  Dashboard,
+  DashboardCreateInput,
+  DashboardUpdateInput,
+} from './dashboard'
+import { ChartAggregationService } from './chart-aggregation-service'
+import type { ChartData } from './chart-aggregation-service'
+
+export type RecordProvider = (sheetId: string) => Promise<Array<{ data: Record<string, unknown> }>>
+
+export class DashboardService {
+  private dashboards: Map<string, Dashboard> = new Map()
+  private charts: Map<string, ChartConfig> = new Map()
+  private aggregationService = new ChartAggregationService()
+  private recordProvider: RecordProvider | undefined
+
+  /**
+   * Optionally inject a record provider that fetches records for a sheet.
+   * If not set, `getChartData` will return empty data.
+   */
+  setRecordProvider(provider: RecordProvider): void {
+    this.recordProvider = provider
+  }
+
+  // -----------------------------------------------------------------------
+  // Chart CRUD
+  // -----------------------------------------------------------------------
+
+  createChart(sheetId: string, input: ChartCreateInput): ChartConfig {
+    const id = `chart_${randomUUID()}`
+    const now = new Date().toISOString()
+    const chart: ChartConfig = {
+      id,
+      name: input.name,
+      type: input.type,
+      sheetId,
+      viewId: input.viewId,
+      dataSource: input.dataSource,
+      display: input.display ?? {},
+      createdBy: input.createdBy ?? 'system',
+      createdAt: now,
+    }
+    this.charts.set(id, chart)
+    return chart
+  }
+
+  getChart(chartId: string): ChartConfig | undefined {
+    return this.charts.get(chartId)
+  }
+
+  listCharts(sheetId: string): ChartConfig[] {
+    return Array.from(this.charts.values()).filter((c) => c.sheetId === sheetId)
+  }
+
+  updateChart(chartId: string, input: Partial<ChartConfig>): ChartConfig {
+    const existing = this.charts.get(chartId)
+    if (!existing) throw new Error(`Chart not found: ${chartId}`)
+    const updated: ChartConfig = {
+      ...existing,
+      ...input,
+      id: existing.id, // prevent id overwrite
+      sheetId: existing.sheetId,
+      createdBy: existing.createdBy,
+      createdAt: existing.createdAt,
+      updatedAt: new Date().toISOString(),
+    }
+    this.charts.set(chartId, updated)
+    return updated
+  }
+
+  deleteChart(chartId: string): void {
+    this.charts.delete(chartId)
+    // Also remove from any dashboard panels
+    for (const dashboard of this.dashboards.values()) {
+      dashboard.panels = dashboard.panels.filter((p) => p.chartId !== chartId)
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Dashboard CRUD
+  // -----------------------------------------------------------------------
+
+  createDashboard(input: DashboardCreateInput): Dashboard {
+    const id = `dash_${randomUUID()}`
+    const now = new Date().toISOString()
+    const dashboard: Dashboard = {
+      id,
+      name: input.name,
+      sheetId: input.sheetId,
+      panels: [],
+      createdBy: input.createdBy ?? 'system',
+      createdAt: now,
+    }
+    this.dashboards.set(id, dashboard)
+    return dashboard
+  }
+
+  getDashboard(dashboardId: string): Dashboard | undefined {
+    return this.dashboards.get(dashboardId)
+  }
+
+  listDashboards(sheetId: string): Dashboard[] {
+    return Array.from(this.dashboards.values()).filter((d) => d.sheetId === sheetId)
+  }
+
+  updateDashboard(dashboardId: string, input: DashboardUpdateInput): Dashboard {
+    const existing = this.dashboards.get(dashboardId)
+    if (!existing) throw new Error(`Dashboard not found: ${dashboardId}`)
+    const updated: Dashboard = {
+      ...existing,
+      name: input.name ?? existing.name,
+      panels: input.panels ?? existing.panels,
+      updatedAt: new Date().toISOString(),
+    }
+    this.dashboards.set(dashboardId, updated)
+    return updated
+  }
+
+  deleteDashboard(dashboardId: string): void {
+    this.dashboards.delete(dashboardId)
+  }
+
+  // -----------------------------------------------------------------------
+  // Chart data computation
+  // -----------------------------------------------------------------------
+
+  async getChartData(chartId: string): Promise<ChartData> {
+    const chart = this.charts.get(chartId)
+    if (!chart) throw new Error(`Chart not found: ${chartId}`)
+
+    let records: Array<{ data: Record<string, unknown> }> = []
+    if (this.recordProvider) {
+      records = await this.recordProvider(chart.sheetId)
+    }
+
+    return this.aggregationService.computeChartData(chart, records)
+  }
+}

--- a/packages/core-backend/src/multitable/dashboard.ts
+++ b/packages/core-backend/src/multitable/dashboard.ts
@@ -1,0 +1,30 @@
+/**
+ * Dashboard model definitions for multitable dashboard V1.
+ */
+
+export interface DashboardPanel {
+  id: string
+  chartId: string
+  position: { x: number; y: number; w: number; h: number } // grid layout
+}
+
+export interface Dashboard {
+  id: string
+  name: string
+  sheetId: string
+  panels: DashboardPanel[]
+  createdBy: string
+  createdAt: string
+  updatedAt?: string
+}
+
+export interface DashboardCreateInput {
+  name: string
+  sheetId: string
+  createdBy?: string
+}
+
+export interface DashboardUpdateInput {
+  name?: string
+  panels?: DashboardPanel[]
+}

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -1,0 +1,186 @@
+/**
+ * Dashboard & Chart REST API routes.
+ *
+ * Endpoints:
+ *   Charts:
+ *     GET    /api/multitable/:sheetId/charts
+ *     POST   /api/multitable/:sheetId/charts
+ *     GET    /api/multitable/:sheetId/charts/:id
+ *     PATCH  /api/multitable/:sheetId/charts/:id
+ *     DELETE /api/multitable/:sheetId/charts/:id
+ *     GET    /api/multitable/:sheetId/charts/:id/data
+ *
+ *   Dashboards:
+ *     GET    /api/multitable/:sheetId/dashboards
+ *     POST   /api/multitable/:sheetId/dashboards
+ *     GET    /api/multitable/:sheetId/dashboards/:id
+ *     PATCH  /api/multitable/:sheetId/dashboards/:id
+ *     DELETE /api/multitable/:sheetId/dashboards/:id
+ */
+
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { DashboardService } from '../multitable/dashboard-service'
+
+const dashboardService = new DashboardService()
+
+/** Expose the shared service for tests or external wiring. */
+export function getDashboardService(): DashboardService {
+  return dashboardService
+}
+
+function getUserId(req: Request): string {
+  const user = (req as unknown as { user?: { id?: unknown } }).user
+  const raw = user?.id ?? req.headers['x-user-id']
+  return raw ? String(raw) : 'anonymous'
+}
+
+export function dashboardRouter() {
+  const router = Router()
+
+  // -----------------------------------------------------------------------
+  // Chart routes
+  // -----------------------------------------------------------------------
+
+  /** GET /api/multitable/:sheetId/charts — list charts */
+  router.get('/:sheetId/charts', (_req: Request, res: Response) => {
+    try {
+      const charts = dashboardService.listCharts(_req.params.sheetId)
+      res.json({ items: charts })
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
+    }
+  })
+
+  /** POST /api/multitable/:sheetId/charts — create chart */
+  router.post('/:sheetId/charts', (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req)
+      const chart = dashboardService.createChart(req.params.sheetId, {
+        ...req.body,
+        createdBy: userId,
+      })
+      res.status(201).json(chart)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** GET /api/multitable/:sheetId/charts/:id — get chart config */
+  router.get('/:sheetId/charts/:id', (req: Request, res: Response) => {
+    const chart = dashboardService.getChart(req.params.id)
+    if (!chart || chart.sheetId !== req.params.sheetId) {
+      res.status(404).json({ error: 'Chart not found' })
+      return
+    }
+    res.json(chart)
+  })
+
+  /** PATCH /api/multitable/:sheetId/charts/:id — update chart */
+  router.patch('/:sheetId/charts/:id', (req: Request, res: Response) => {
+    try {
+      const chart = dashboardService.getChart(req.params.id)
+      if (!chart || chart.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Chart not found' })
+        return
+      }
+      const updated = dashboardService.updateChart(req.params.id, req.body)
+      res.json(updated)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** DELETE /api/multitable/:sheetId/charts/:id — delete chart */
+  router.delete('/:sheetId/charts/:id', (req: Request, res: Response) => {
+    const chart = dashboardService.getChart(req.params.id)
+    if (!chart || chart.sheetId !== req.params.sheetId) {
+      res.status(404).json({ error: 'Chart not found' })
+      return
+    }
+    dashboardService.deleteChart(req.params.id)
+    res.status(204).send()
+  })
+
+  /** GET /api/multitable/:sheetId/charts/:id/data — get computed chart data */
+  router.get('/:sheetId/charts/:id/data', async (req: Request, res: Response) => {
+    try {
+      const chart = dashboardService.getChart(req.params.id)
+      if (!chart || chart.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Chart not found' })
+        return
+      }
+      const data = await dashboardService.getChartData(req.params.id)
+      res.json(data)
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
+    }
+  })
+
+  // -----------------------------------------------------------------------
+  // Dashboard routes
+  // -----------------------------------------------------------------------
+
+  /** GET /api/multitable/:sheetId/dashboards — list dashboards */
+  router.get('/:sheetId/dashboards', (req: Request, res: Response) => {
+    try {
+      const dashboards = dashboardService.listDashboards(req.params.sheetId)
+      res.json({ items: dashboards })
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
+    }
+  })
+
+  /** POST /api/multitable/:sheetId/dashboards — create dashboard */
+  router.post('/:sheetId/dashboards', (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req)
+      const dashboard = dashboardService.createDashboard({
+        name: req.body.name,
+        sheetId: req.params.sheetId,
+        createdBy: userId,
+      })
+      res.status(201).json(dashboard)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** GET /api/multitable/:sheetId/dashboards/:id — get dashboard */
+  router.get('/:sheetId/dashboards/:id', (req: Request, res: Response) => {
+    const dashboard = dashboardService.getDashboard(req.params.id)
+    if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
+      res.status(404).json({ error: 'Dashboard not found' })
+      return
+    }
+    res.json(dashboard)
+  })
+
+  /** PATCH /api/multitable/:sheetId/dashboards/:id — update dashboard */
+  router.patch('/:sheetId/dashboards/:id', (req: Request, res: Response) => {
+    try {
+      const dashboard = dashboardService.getDashboard(req.params.id)
+      if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Dashboard not found' })
+        return
+      }
+      const updated = dashboardService.updateDashboard(req.params.id, req.body)
+      res.json(updated)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** DELETE /api/multitable/:sheetId/dashboards/:id — delete dashboard */
+  router.delete('/:sheetId/dashboards/:id', (req: Request, res: Response) => {
+    const dashboard = dashboardService.getDashboard(req.params.id)
+    if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
+      res.status(404).json({ error: 'Dashboard not found' })
+      return
+    }
+    dashboardService.deleteDashboard(req.params.id)
+    res.status(204).send()
+  })
+
+  return router
+}

--- a/packages/core-backend/tests/unit/chart-dashboard.test.ts
+++ b/packages/core-backend/tests/unit/chart-dashboard.test.ts
@@ -1,0 +1,739 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { ChartAggregationService } from '../../src/multitable/chart-aggregation-service'
+import type { ChartData } from '../../src/multitable/chart-aggregation-service'
+import { DashboardService } from '../../src/multitable/dashboard-service'
+import type { ChartConfig, ChartCreateInput } from '../../src/multitable/charts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRecords(rows: Record<string, unknown>[]): Array<{ data: Record<string, unknown> }> {
+  return rows.map((data) => ({ data }))
+}
+
+function makeChart(overrides: Partial<ChartConfig> = {}): ChartConfig {
+  return {
+    id: 'chart_test',
+    name: 'Test Chart',
+    type: 'bar',
+    sheetId: 'sheet1',
+    dataSource: {
+      groupByFieldId: 'status',
+      aggregation: { function: 'count' },
+    },
+    display: {},
+    createdBy: 'user1',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const sampleRecords = makeRecords([
+  { status: 'open', amount: 10, category: 'A', date: '2026-01-15' },
+  { status: 'open', amount: 20, category: 'B', date: '2026-01-20' },
+  { status: 'closed', amount: 30, category: 'A', date: '2026-02-10' },
+  { status: 'closed', amount: 40, category: 'B', date: '2026-03-05' },
+  { status: 'open', amount: 50, category: 'A', date: '2026-04-12' },
+])
+
+// ---------------------------------------------------------------------------
+// ChartAggregationService
+// ---------------------------------------------------------------------------
+
+describe('ChartAggregationService', () => {
+  let service: ChartAggregationService
+
+  beforeEach(() => {
+    service = new ChartAggregationService()
+  })
+
+  // -- Aggregation functions -----------------------------------------------
+
+  describe('aggregation: count', () => {
+    it('counts records per group', async () => {
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(2)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      const closed = result.dataPoints.find((dp) => dp.label === 'closed')
+      expect(open?.value).toBe(3)
+      expect(closed?.value).toBe(2)
+    })
+  })
+
+  describe('aggregation: sum', () => {
+    it('sums numeric field values per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'sum', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      expect(open?.value).toBe(80) // 10+20+50
+    })
+  })
+
+  describe('aggregation: avg', () => {
+    it('averages numeric field values per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'avg', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const closed = result.dataPoints.find((dp) => dp.label === 'closed')
+      expect(closed?.value).toBeCloseTo(35) // (30+40)/2
+    })
+  })
+
+  describe('aggregation: min', () => {
+    it('finds minimum value per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'min', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      expect(open?.value).toBe(10)
+    })
+  })
+
+  describe('aggregation: max', () => {
+    it('finds maximum value per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'max', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      expect(open?.value).toBe(50)
+    })
+  })
+
+  describe('aggregation: count_distinct', () => {
+    it('counts unique values per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count_distinct', fieldId: 'category' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      expect(open?.value).toBe(2) // A, B
+    })
+  })
+
+  // -- Grouping ------------------------------------------------------------
+
+  describe('grouping: by text field', () => {
+    it('groups by a text field', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(2)
+      const a = result.dataPoints.find((dp) => dp.label === 'A')
+      expect(a?.value).toBe(3)
+    })
+  })
+
+  describe('grouping: by select field', () => {
+    it('groups by select/status field', async () => {
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints.map((dp) => dp.label).sort()).toEqual(['closed', 'open'])
+    })
+  })
+
+  // -- Date grouping -------------------------------------------------------
+
+  describe('date grouping: day', () => {
+    it('buckets records by day', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'day',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints.length).toBe(5) // 5 unique days
+    })
+  })
+
+  describe('date grouping: month', () => {
+    it('buckets records by month', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'month',
+          aggregation: { function: 'sum', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const jan = result.dataPoints.find((dp) => dp.label === '2026-01')
+      expect(jan?.value).toBe(30) // 10+20
+    })
+  })
+
+  describe('date grouping: quarter', () => {
+    it('buckets records by quarter', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'quarter',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const q1 = result.dataPoints.find((dp) => dp.label === '2026-Q1')
+      expect(q1?.value).toBe(4) // Jan(2) + Feb(1) + Mar(1)
+    })
+  })
+
+  describe('date grouping: year', () => {
+    it('buckets records by year', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'year',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(1)
+      expect(result.dataPoints[0].label).toBe('2026')
+      expect(result.dataPoints[0].value).toBe(5)
+    })
+  })
+
+  describe('date grouping: week', () => {
+    it('buckets records by ISO week start', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'week',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      // Each date is in a different week except possibly Jan 15 & 20
+      expect(result.dataPoints.length).toBeGreaterThanOrEqual(4)
+    })
+  })
+
+  // -- Filtering -----------------------------------------------------------
+
+  describe('filter: equals', () => {
+    it('filters records by equals operator', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'count' },
+          filterFieldId: 'status',
+          filterOperator: 'equals',
+          filterValue: 'open',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(3)
+    })
+  })
+
+  describe('filter: not_equals', () => {
+    it('excludes records matching value', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'count' },
+          filterFieldId: 'status',
+          filterOperator: 'not_equals',
+          filterValue: 'open',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(2)
+    })
+  })
+
+  describe('filter: contains', () => {
+    it('filters records containing substring', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          filterFieldId: 'category',
+          filterOperator: 'contains',
+          filterValue: 'A',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(3)
+    })
+  })
+
+  describe('filter: greater_than', () => {
+    it('filters numeric values greater than threshold', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          filterFieldId: 'amount',
+          filterOperator: 'greater_than',
+          filterValue: 25,
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(3) // 30, 40, 50
+    })
+  })
+
+  describe('filter: less_than', () => {
+    it('filters numeric values less than threshold', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          filterFieldId: 'amount',
+          filterOperator: 'less_than',
+          filterValue: 25,
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(2) // 10, 20
+    })
+  })
+
+  // -- Edge cases ----------------------------------------------------------
+
+  describe('edge case: empty records', () => {
+    it('returns empty data points', async () => {
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, [])
+      expect(result.dataPoints).toHaveLength(0)
+    })
+  })
+
+  describe('edge case: null values', () => {
+    it('groups null values under (empty)', async () => {
+      const records = makeRecords([
+        { status: null, amount: 10 },
+        { status: 'open', amount: 20 },
+      ])
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, records)
+      const empty = result.dataPoints.find((dp) => dp.label === '(empty)')
+      expect(empty?.value).toBe(1)
+    })
+  })
+
+  describe('edge case: non-numeric for sum/avg', () => {
+    it('skips non-numeric values in sum', async () => {
+      const records = makeRecords([
+        { group: 'A', val: 10 },
+        { group: 'A', val: 'not-a-number' },
+        { group: 'A', val: null },
+        { group: 'A', val: 30 },
+      ])
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'group',
+          aggregation: { function: 'sum', fieldId: 'val' },
+        },
+      })
+      const result = await service.computeChartData(chart, records)
+      expect(result.dataPoints[0].value).toBe(40) // 10+30
+    })
+
+    it('returns 0 for avg when all non-numeric', async () => {
+      const records = makeRecords([
+        { group: 'A', val: 'text' },
+        { group: 'A', val: undefined },
+      ])
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'group',
+          aggregation: { function: 'avg', fieldId: 'val' },
+        },
+      })
+      const result = await service.computeChartData(chart, records)
+      expect(result.dataPoints[0].value).toBe(0)
+    })
+  })
+
+  describe('edge case: min/max with no numeric values', () => {
+    it('returns 0 when no numeric values exist', async () => {
+      const records = makeRecords([
+        { group: 'A', val: 'text' },
+      ])
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'group',
+          aggregation: { function: 'min', fieldId: 'val' },
+        },
+      })
+      const result = await service.computeChartData(chart, records)
+      expect(result.dataPoints[0].value).toBe(0)
+    })
+  })
+
+  // -- Number chart --------------------------------------------------------
+
+  describe('number chart', () => {
+    it('returns single aggregated value', async () => {
+      const chart = makeChart({
+        type: 'number',
+        dataSource: {
+          aggregation: { function: 'sum', fieldId: 'amount' },
+        },
+        display: { title: 'Total Revenue' },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(1)
+      expect(result.dataPoints[0].value).toBe(150) // 10+20+30+40+50
+      expect(result.dataPoints[0].label).toBe('Total Revenue')
+      expect(result.total).toBe(150)
+    })
+
+    it('uses chart name when no title', async () => {
+      const chart = makeChart({
+        type: 'number',
+        name: 'Record Count',
+        dataSource: {
+          aggregation: { function: 'count' },
+        },
+        display: {},
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints[0].label).toBe('Record Count')
+      expect(result.dataPoints[0].value).toBe(5)
+    })
+  })
+
+  // -- Table chart ---------------------------------------------------------
+
+  describe('table chart', () => {
+    it('returns grouped data as table rows', async () => {
+      const chart = makeChart({
+        type: 'table',
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'sum', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.chartType).toBe('table')
+      expect(result.dataPoints.length).toBe(2)
+      const a = result.dataPoints.find((dp) => dp.label === 'A')
+      expect(a?.value).toBe(90) // 10+30+50
+    })
+  })
+
+  // -- Sorting -------------------------------------------------------------
+
+  describe('sorting: by label asc', () => {
+    it('sorts data points by label ascending', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          sortBy: 'label',
+          sortOrder: 'asc',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints[0].label).toBe('closed')
+      expect(result.dataPoints[1].label).toBe('open')
+    })
+  })
+
+  describe('sorting: by value desc', () => {
+    it('sorts data points by value descending', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          sortBy: 'value',
+          sortOrder: 'desc',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints[0].value).toBeGreaterThanOrEqual(result.dataPoints[1].value)
+    })
+  })
+
+  describe('sorting: by value asc', () => {
+    it('sorts data points by value ascending', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          sortBy: 'value',
+          sortOrder: 'asc',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints[0].value).toBeLessThanOrEqual(result.dataPoints[1].value)
+    })
+  })
+
+  // -- Limit ---------------------------------------------------------------
+
+  describe('limit', () => {
+    it('limits the number of data points', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'count' },
+          sortBy: 'value',
+          sortOrder: 'desc',
+          limit: 1,
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(1)
+    })
+  })
+
+  // -- Metadata ------------------------------------------------------------
+
+  describe('metadata', () => {
+    it('includes metadata in result', async () => {
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.metadata?.groupByField).toBe('status')
+      expect(result.metadata?.aggregationFunction).toBe('count')
+      expect(result.metadata?.recordCount).toBe(5)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DashboardService
+// ---------------------------------------------------------------------------
+
+describe('DashboardService', () => {
+  let service: DashboardService
+
+  beforeEach(() => {
+    service = new DashboardService()
+  })
+
+  // -- Chart CRUD ----------------------------------------------------------
+
+  describe('chart CRUD', () => {
+    it('creates a chart', () => {
+      const chart = service.createChart('sheet1', {
+        name: 'My Chart',
+        type: 'bar',
+        dataSource: { aggregation: { function: 'count' } },
+      })
+      expect(chart.id).toMatch(/^chart_/)
+      expect(chart.name).toBe('My Chart')
+      expect(chart.sheetId).toBe('sheet1')
+    })
+
+    it('lists charts for a sheet', () => {
+      service.createChart('sheet1', { name: 'C1', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      service.createChart('sheet2', { name: 'C2', type: 'pie', dataSource: { aggregation: { function: 'count' } } })
+      service.createChart('sheet1', { name: 'C3', type: 'line', dataSource: { aggregation: { function: 'sum', fieldId: 'x' } } })
+
+      const list = service.listCharts('sheet1')
+      expect(list).toHaveLength(2)
+      expect(list.map((c) => c.name).sort()).toEqual(['C1', 'C3'])
+    })
+
+    it('gets a chart by id', () => {
+      const created = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const fetched = service.getChart(created.id)
+      expect(fetched?.id).toBe(created.id)
+    })
+
+    it('updates a chart', () => {
+      const created = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const updated = service.updateChart(created.id, { name: 'Updated' })
+      expect(updated.name).toBe('Updated')
+      expect(updated.updatedAt).toBeDefined()
+      // Immutable fields preserved
+      expect(updated.id).toBe(created.id)
+      expect(updated.sheetId).toBe('sheet1')
+    })
+
+    it('throws when updating non-existent chart', () => {
+      expect(() => service.updateChart('no_such_id', { name: 'X' })).toThrow('Chart not found')
+    })
+
+    it('deletes a chart', () => {
+      const created = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      service.deleteChart(created.id)
+      expect(service.getChart(created.id)).toBeUndefined()
+    })
+
+    it('deleting a chart removes it from dashboard panels', () => {
+      const chart = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const dash = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      service.updateDashboard(dash.id, {
+        panels: [{ id: 'p1', chartId: chart.id, position: { x: 0, y: 0, w: 6, h: 4 } }],
+      })
+      service.deleteChart(chart.id)
+      const updated = service.getDashboard(dash.id)
+      expect(updated?.panels).toHaveLength(0)
+    })
+  })
+
+  // -- Dashboard CRUD ------------------------------------------------------
+
+  describe('dashboard CRUD', () => {
+    it('creates a dashboard', () => {
+      const dash = service.createDashboard({ name: 'My Dashboard', sheetId: 'sheet1' })
+      expect(dash.id).toMatch(/^dash_/)
+      expect(dash.name).toBe('My Dashboard')
+      expect(dash.panels).toHaveLength(0)
+    })
+
+    it('lists dashboards for a sheet', () => {
+      service.createDashboard({ name: 'D1', sheetId: 'sheet1' })
+      service.createDashboard({ name: 'D2', sheetId: 'sheet2' })
+      expect(service.listDashboards('sheet1')).toHaveLength(1)
+    })
+
+    it('gets a dashboard by id', () => {
+      const created = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      expect(service.getDashboard(created.id)?.id).toBe(created.id)
+    })
+
+    it('updates dashboard name', () => {
+      const created = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      const updated = service.updateDashboard(created.id, { name: 'Renamed' })
+      expect(updated.name).toBe('Renamed')
+      expect(updated.updatedAt).toBeDefined()
+    })
+
+    it('adds panels to a dashboard', () => {
+      const chart = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const dash = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      const updated = service.updateDashboard(dash.id, {
+        panels: [
+          { id: 'p1', chartId: chart.id, position: { x: 0, y: 0, w: 6, h: 4 } },
+          { id: 'p2', chartId: chart.id, position: { x: 6, y: 0, w: 6, h: 4 } },
+        ],
+      })
+      expect(updated.panels).toHaveLength(2)
+    })
+
+    it('reorders panels', () => {
+      const chart = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const dash = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      service.updateDashboard(dash.id, {
+        panels: [
+          { id: 'p1', chartId: chart.id, position: { x: 0, y: 0, w: 6, h: 4 } },
+          { id: 'p2', chartId: chart.id, position: { x: 6, y: 0, w: 6, h: 4 } },
+        ],
+      })
+      const reordered = service.updateDashboard(dash.id, {
+        panels: [
+          { id: 'p2', chartId: chart.id, position: { x: 0, y: 0, w: 6, h: 4 } },
+          { id: 'p1', chartId: chart.id, position: { x: 6, y: 0, w: 6, h: 4 } },
+        ],
+      })
+      expect(reordered.panels[0].id).toBe('p2')
+    })
+
+    it('throws when updating non-existent dashboard', () => {
+      expect(() => service.updateDashboard('no_such', { name: 'X' })).toThrow('Dashboard not found')
+    })
+
+    it('deletes a dashboard', () => {
+      const created = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      service.deleteDashboard(created.id)
+      expect(service.getDashboard(created.id)).toBeUndefined()
+    })
+  })
+
+  // -- Chart data computation ----------------------------------------------
+
+  describe('chart data computation', () => {
+    it('computes chart data with record provider', async () => {
+      const chart = service.createChart('sheet1', {
+        name: 'Status Counts',
+        type: 'bar',
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+        },
+      })
+
+      service.setRecordProvider(async (_sheetId: string) => sampleRecords)
+
+      const data = await service.getChartData(chart.id)
+      expect(data.chartId).toBe(chart.id)
+      expect(data.chartType).toBe('bar')
+      expect(data.dataPoints.length).toBeGreaterThan(0)
+    })
+
+    it('returns empty data when no record provider', async () => {
+      const chart = service.createChart('sheet1', {
+        name: 'Empty',
+        type: 'bar',
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+        },
+      })
+      const data = await service.getChartData(chart.id)
+      expect(data.dataPoints).toHaveLength(0)
+    })
+
+    it('throws when chart not found', async () => {
+      await expect(service.getChartData('nonexistent')).rejects.toThrow('Chart not found')
+    })
+
+    it('full pipeline: records → filter → group → aggregate → sort → limit', async () => {
+      const chart = service.createChart('sheet1', {
+        name: 'Top Category',
+        type: 'pie',
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'sum', fieldId: 'amount' },
+          filterFieldId: 'status',
+          filterOperator: 'equals',
+          filterValue: 'open',
+          sortBy: 'value',
+          sortOrder: 'desc',
+          limit: 1,
+        },
+      })
+
+      service.setRecordProvider(async () => sampleRecords)
+
+      const data = await service.getChartData(chart.id)
+      expect(data.dataPoints).toHaveLength(1)
+      // open records: A=10+50=60, B=20 → top 1 is A
+      expect(data.dataPoints[0].label).toBe('A')
+      expect(data.dataPoints[0].value).toBe(60)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add chart type definitions (bar/line/pie/number/table) with data source, aggregation, and display config
- Add dashboard model with grid-based panel layout (DashboardPanel with x/y/w/h positioning)
- Implement ChartAggregationService with all aggregation functions (count, sum, avg, min, max, count_distinct), field/date grouping (day/week/month/quarter/year), record filtering (equals/not_equals/contains/greater_than/less_than), sorting, and limit
- Implement DashboardService with in-memory CRUD for charts and dashboards, plus chart data computation pipeline
- Add REST routes at `/api/multitable/:sheetId/charts` and `/api/multitable/:sheetId/dashboards`
- 50 unit tests covering aggregation, grouping, date bucketing, filtering, edge cases (null/non-numeric/empty), chart CRUD, dashboard CRUD, and full pipeline

## Test plan
- [x] `npx vitest run tests/unit/chart-dashboard.test.ts` — 50/50 passing
- [ ] Manual smoke test: create chart via POST, verify GET /data returns correct aggregation
- [ ] Verify dashboard panel CRUD + chart deletion cascades panel removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)