### PR TITLE
feat(multitable): add form share, field validation, API token/webhook management UIs

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -42,6 +42,13 @@ import type {
   MetaViewPermissionEntry,
   RecordPermissionEntry,
   AutomationRule,
+  FormShareConfig,
+  FormShareConfigUpdate,
+  ApiToken,
+  ApiTokenCreateResult,
+  Webhook,
+  WebhookCreateInput,
+  WebhookDelivery,
 } from '../types'
 import { apiFetch } from '../../utils/api'
 
@@ -922,6 +929,96 @@ export class MultitableApiClient {
   async markCommentRead(commentId: string): Promise<void> {
     const res = await this.fetch(`/api/comments/${commentId}/read`, { method: 'POST' })
     return parseJson(res)
+  }
+
+  // --- Form Share ---
+  async getFormShareConfig(sheetId: string, viewId: string): Promise<FormShareConfig> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/views/${encodeURIComponent(viewId)}/form-share`)
+    return parseJson(res)
+  }
+
+  async updateFormShareConfig(sheetId: string, viewId: string, config: FormShareConfigUpdate): Promise<FormShareConfig> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/views/${encodeURIComponent(viewId)}/form-share`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config),
+    })
+    return parseJson(res)
+  }
+
+  async regenerateFormShareToken(sheetId: string, viewId: string): Promise<{ publicToken: string }> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/views/${encodeURIComponent(viewId)}/form-share/regenerate`, {
+      method: 'POST',
+    })
+    return parseJson(res)
+  }
+
+  // --- API Tokens ---
+  async listApiTokens(): Promise<ApiToken[]> {
+    const res = await this.fetch('/api/multitable/tokens')
+    const data = await parseJson<{ tokens: ApiToken[] }>(res)
+    return data.tokens ?? []
+  }
+
+  async createApiToken(input: { name: string; scopes: string[]; expiresAt?: string }): Promise<ApiTokenCreateResult> {
+    const res = await this.fetch('/api/multitable/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return parseJson(res)
+  }
+
+  async revokeApiToken(tokenId: string): Promise<void> {
+    const res = await this.fetch(`/api/multitable/tokens/${encodeURIComponent(tokenId)}`, {
+      method: 'DELETE',
+    })
+    return parseJson(res)
+  }
+
+  async rotateApiToken(tokenId: string): Promise<ApiTokenCreateResult> {
+    const res = await this.fetch(`/api/multitable/tokens/${encodeURIComponent(tokenId)}/rotate`, {
+      method: 'POST',
+    })
+    return parseJson(res)
+  }
+
+  // --- Webhooks ---
+  async listWebhooks(): Promise<Webhook[]> {
+    const res = await this.fetch('/api/multitable/webhooks')
+    const data = await parseJson<{ webhooks: Webhook[] }>(res)
+    return data.webhooks ?? []
+  }
+
+  async createWebhook(input: WebhookCreateInput): Promise<Webhook> {
+    const res = await this.fetch('/api/multitable/webhooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return parseJson(res)
+  }
+
+  async updateWebhook(id: string, input: Partial<WebhookCreateInput>): Promise<Webhook> {
+    const res = await this.fetch(`/api/multitable/webhooks/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return parseJson(res)
+  }
+
+  async deleteWebhook(id: string): Promise<void> {
+    const res = await this.fetch(`/api/multitable/webhooks/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    })
+    return parseJson(res)
+  }
+
+  async getWebhookDeliveries(id: string): Promise<WebhookDelivery[]> {
+    const res = await this.fetch(`/api/multitable/webhooks/${encodeURIComponent(id)}/deliveries`)
+    const data = await parseJson<{ deliveries: WebhookDelivery[] }>(res)
+    return data.deliveries ?? []
   }
 }
 

--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -1,0 +1,727 @@
+<template>
+  <div v-if="visible" class="meta-api-mgr__overlay" @click.self="$emit('close')">
+    <div class="meta-api-mgr">
+      <div class="meta-api-mgr__header">
+        <h4 class="meta-api-mgr__title">API Tokens &amp; Webhooks</h4>
+        <button class="meta-api-mgr__close" type="button" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="meta-api-mgr__tabs" role="tablist">
+        <button
+          role="tab"
+          :aria-selected="activeTab === 'tokens'"
+          class="meta-api-mgr__tab"
+          :class="{ 'meta-api-mgr__tab--active': activeTab === 'tokens' }"
+          @click="activeTab = 'tokens'"
+        >
+          API Tokens
+        </button>
+        <button
+          role="tab"
+          :aria-selected="activeTab === 'webhooks'"
+          class="meta-api-mgr__tab"
+          :class="{ 'meta-api-mgr__tab--active': activeTab === 'webhooks' }"
+          @click="activeTab = 'webhooks'"
+        >
+          Webhooks
+        </button>
+      </div>
+
+      <div class="meta-api-mgr__body">
+        <div v-if="error" class="meta-api-mgr__error" role="alert">{{ error }}</div>
+
+        <!-- ===== TOKENS TAB ===== -->
+        <template v-if="activeTab === 'tokens'">
+          <!-- Newly created token (show once) -->
+          <div v-if="newTokenPlaintext" class="meta-api-mgr__new-token" data-new-token="true">
+            <strong>Your new API token (shown once):</strong>
+            <div class="meta-api-mgr__token-display">
+              <code data-new-token-value="true">{{ newTokenPlaintext }}</code>
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--primary" type="button" data-copy-new-token="true" @click="onCopyNewToken">
+                {{ copiedNewToken ? 'Copied!' : 'Copy' }}
+              </button>
+            </div>
+            <p class="meta-api-mgr__warning">Save this token now. You will not be able to see it again.</p>
+            <button class="meta-api-mgr__btn" type="button" @click="newTokenPlaintext = null">Dismiss</button>
+          </div>
+
+          <!-- Create form -->
+          <section v-if="showTokenForm" class="meta-api-mgr__form" data-token-form="true">
+            <div class="meta-api-mgr__form-title">New API Token</div>
+            <label class="meta-api-mgr__label">Name</label>
+            <input v-model="tokenDraft.name" class="meta-api-mgr__input" type="text" placeholder="Token name" data-token-name="true" />
+            <label class="meta-api-mgr__label">Scopes</label>
+            <div class="meta-api-mgr__checkboxes">
+              <label v-for="scope in availableScopes" :key="scope" class="meta-api-mgr__checkbox-label">
+                <input type="checkbox" :value="scope" :checked="tokenDraft.scopes.includes(scope)" @change="onToggleScope(scope)" :data-token-scope="scope" />
+                {{ scope }}
+              </label>
+            </div>
+            <label class="meta-api-mgr__label">Expiry (optional)</label>
+            <input v-model="tokenDraft.expiresAt" class="meta-api-mgr__input" type="date" data-token-expiry="true" />
+            <div class="meta-api-mgr__form-actions">
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--primary" type="button" :disabled="!tokenDraft.name.trim() || busy" data-token-create="true" @click="onCreateToken">Create</button>
+              <button class="meta-api-mgr__btn" type="button" @click="showTokenForm = false">Cancel</button>
+            </div>
+          </section>
+
+          <button v-if="!showTokenForm" class="meta-api-mgr__btn meta-api-mgr__btn--primary meta-api-mgr__btn-add" type="button" data-token-new="true" @click="openTokenForm">+ New Token</button>
+
+          <!-- Token list -->
+          <div v-if="tokensLoading" class="meta-api-mgr__empty">Loading tokens&#x2026;</div>
+          <div v-else-if="!tokens.length && !showTokenForm" class="meta-api-mgr__empty" data-tokens-empty="true">No API tokens yet.</div>
+          <div v-for="token in tokens" :key="token.id" class="meta-api-mgr__card" :data-token-id="token.id">
+            <div class="meta-api-mgr__card-header">
+              <strong class="meta-api-mgr__card-name">{{ token.name }}</strong>
+              <code class="meta-api-mgr__card-prefix">{{ token.prefix }}...</code>
+            </div>
+            <div class="meta-api-mgr__card-meta">
+              <span>Scopes: {{ token.scopes.join(', ') || 'none' }}</span>
+              <span>Created: {{ formatDate(token.createdAt) }}</span>
+              <span v-if="token.lastUsedAt">Last used: {{ formatDate(token.lastUsedAt) }}</span>
+              <span v-if="token.expiresAt">Expires: {{ formatDate(token.expiresAt) }}</span>
+            </div>
+            <div class="meta-api-mgr__card-actions">
+              <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-token-rotate="true" @click="onRotateToken(token.id)">Rotate</button>
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-token-revoke="true" @click="onRevokeToken(token.id)">Revoke</button>
+            </div>
+          </div>
+        </template>
+
+        <!-- ===== WEBHOOKS TAB ===== -->
+        <template v-if="activeTab === 'webhooks'">
+          <!-- Create/Edit form -->
+          <section v-if="showWebhookForm" class="meta-api-mgr__form" data-webhook-form="true">
+            <div class="meta-api-mgr__form-title">{{ editingWebhookId ? 'Edit Webhook' : 'New Webhook' }}</div>
+            <label class="meta-api-mgr__label">Name</label>
+            <input v-model="webhookDraft.name" class="meta-api-mgr__input" type="text" placeholder="Webhook name" data-webhook-name="true" />
+            <label class="meta-api-mgr__label">URL (HTTPS required)</label>
+            <input v-model="webhookDraft.url" class="meta-api-mgr__input" type="url" placeholder="https://example.com/webhook" data-webhook-url="true" />
+            <label class="meta-api-mgr__label">Events</label>
+            <div class="meta-api-mgr__checkboxes">
+              <label v-for="evt in availableEvents" :key="evt" class="meta-api-mgr__checkbox-label">
+                <input type="checkbox" :value="evt" :checked="webhookDraft.events.includes(evt)" @change="onToggleEvent(evt)" :data-webhook-event="evt" />
+                {{ evt }}
+              </label>
+            </div>
+            <label class="meta-api-mgr__label">Secret (optional)</label>
+            <input v-model="webhookDraft.secret" class="meta-api-mgr__input" type="text" placeholder="HMAC secret" data-webhook-secret="true" />
+            <div class="meta-api-mgr__form-actions">
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--primary" type="button" :disabled="!canSaveWebhook || busy" data-webhook-save="true" @click="onSaveWebhook">
+                {{ editingWebhookId ? 'Update' : 'Create' }}
+              </button>
+              <button class="meta-api-mgr__btn" type="button" @click="cancelWebhookForm">Cancel</button>
+            </div>
+          </section>
+
+          <button v-if="!showWebhookForm" class="meta-api-mgr__btn meta-api-mgr__btn--primary meta-api-mgr__btn-add" type="button" data-webhook-new="true" @click="openWebhookForm">+ New Webhook</button>
+
+          <!-- Webhook list -->
+          <div v-if="webhooksLoading" class="meta-api-mgr__empty">Loading webhooks&#x2026;</div>
+          <div v-else-if="!webhooks.length && !showWebhookForm" class="meta-api-mgr__empty" data-webhooks-empty="true">No webhooks yet.</div>
+          <div v-for="wh in webhooks" :key="wh.id" class="meta-api-mgr__card" :data-webhook-id="wh.id">
+            <div class="meta-api-mgr__card-header">
+              <strong class="meta-api-mgr__card-name">{{ wh.name }}</strong>
+              <span class="meta-api-mgr__card-status" :data-webhook-status="wh.active ? 'active' : 'disabled'">
+                {{ wh.active ? 'Active' : 'Disabled' }}
+              </span>
+            </div>
+            <div class="meta-api-mgr__card-meta">
+              <span>URL: {{ wh.url }}</span>
+              <span>Events: {{ wh.events.join(', ') }}</span>
+              <span v-if="wh.failureCount > 0" class="meta-api-mgr__card-failures">Failures: {{ wh.failureCount }}</span>
+            </div>
+            <div class="meta-api-mgr__card-actions">
+              <button class="meta-api-mgr__btn" type="button" data-webhook-edit="true" @click="openEditWebhook(wh)">Edit</button>
+              <button class="meta-api-mgr__btn" type="button" data-webhook-toggle="true" :disabled="busy" @click="onToggleWebhook(wh)">
+                {{ wh.active ? 'Disable' : 'Enable' }}
+              </button>
+              <button class="meta-api-mgr__btn" type="button" data-webhook-deliveries="true" @click="onViewDeliveries(wh.id)">Deliveries</button>
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-webhook-delete="true" @click="onDeleteWebhook(wh.id)">Delete</button>
+            </div>
+
+            <!-- Delivery history (inline) -->
+            <div v-if="deliveriesWebhookId === wh.id && deliveries.length" class="meta-api-mgr__deliveries" data-deliveries="true">
+              <strong class="meta-api-mgr__label">Recent Deliveries</strong>
+              <div v-for="d in deliveries" :key="d.id" class="meta-api-mgr__delivery-row" :data-delivery-id="d.id">
+                <span :class="d.success ? 'meta-api-mgr__delivery--ok' : 'meta-api-mgr__delivery--fail'">
+                  {{ d.success ? 'OK' : 'FAIL' }}
+                </span>
+                <span>{{ d.event }}</span>
+                <span>HTTP {{ d.httpStatus ?? '-' }}</span>
+                <span v-if="d.retryCount > 0">Retries: {{ d.retryCount }}</span>
+                <span>{{ formatDate(d.timestamp) }}</span>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { ApiToken, Webhook, WebhookDelivery } from '../types'
+import type { MultitableApiClient } from '../api/client'
+
+const props = defineProps<{
+  visible: boolean
+  client?: MultitableApiClient
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const activeTab = ref<'tokens' | 'webhooks'>('tokens')
+const error = ref<string | null>(null)
+const busy = ref(false)
+
+// ---- Tokens ----
+const tokens = ref<ApiToken[]>([])
+const tokensLoading = ref(false)
+const showTokenForm = ref(false)
+const newTokenPlaintext = ref<string | null>(null)
+const copiedNewToken = ref(false)
+const tokenDraft = ref({ name: '', scopes: [] as string[], expiresAt: '' })
+const availableScopes = ['read', 'write', 'admin']
+
+// ---- Webhooks ----
+const webhooks = ref<Webhook[]>([])
+const webhooksLoading = ref(false)
+const showWebhookForm = ref(false)
+const editingWebhookId = ref<string | null>(null)
+const webhookDraft = ref({ name: '', url: '', events: [] as string[], secret: '' })
+const availableEvents = ['record.created', 'record.updated', 'record.deleted', 'field.changed']
+const deliveriesWebhookId = ref<string | null>(null)
+const deliveries = ref<WebhookDelivery[]>([])
+
+const canSaveWebhook = computed(() => {
+  return webhookDraft.value.name.trim() && webhookDraft.value.url.startsWith('https://') && webhookDraft.value.events.length > 0
+})
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString()
+  } catch {
+    return iso
+  }
+}
+
+// ---- Token actions ----
+async function loadTokens() {
+  if (!props.client) return
+  tokensLoading.value = true
+  error.value = null
+  try {
+    tokens.value = await props.client.listApiTokens()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load tokens'
+  } finally {
+    tokensLoading.value = false
+  }
+}
+
+function openTokenForm() {
+  tokenDraft.value = { name: '', scopes: [], expiresAt: '' }
+  showTokenForm.value = true
+}
+
+function onToggleScope(scope: string) {
+  const idx = tokenDraft.value.scopes.indexOf(scope)
+  if (idx >= 0) {
+    tokenDraft.value.scopes.splice(idx, 1)
+  } else {
+    tokenDraft.value.scopes.push(scope)
+  }
+}
+
+async function onCreateToken() {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    const result = await props.client.createApiToken({
+      name: tokenDraft.value.name.trim(),
+      scopes: tokenDraft.value.scopes,
+      expiresAt: tokenDraft.value.expiresAt || undefined,
+    })
+    newTokenPlaintext.value = result.plaintext
+    showTokenForm.value = false
+    await loadTokens()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to create token'
+  } finally {
+    busy.value = false
+  }
+}
+
+function onCopyNewToken() {
+  if (!newTokenPlaintext.value) return
+  void navigator.clipboard.writeText(newTokenPlaintext.value)
+  copiedNewToken.value = true
+  setTimeout(() => { copiedNewToken.value = false }, 2000)
+}
+
+async function onRevokeToken(tokenId: string) {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    await props.client.revokeApiToken(tokenId)
+    await loadTokens()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to revoke token'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onRotateToken(tokenId: string) {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    const result = await props.client.rotateApiToken(tokenId)
+    newTokenPlaintext.value = result.plaintext
+    await loadTokens()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to rotate token'
+  } finally {
+    busy.value = false
+  }
+}
+
+// ---- Webhook actions ----
+async function loadWebhooks() {
+  if (!props.client) return
+  webhooksLoading.value = true
+  error.value = null
+  try {
+    webhooks.value = await props.client.listWebhooks()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load webhooks'
+  } finally {
+    webhooksLoading.value = false
+  }
+}
+
+function openWebhookForm() {
+  editingWebhookId.value = null
+  webhookDraft.value = { name: '', url: '', events: [], secret: '' }
+  showWebhookForm.value = true
+}
+
+function openEditWebhook(wh: Webhook) {
+  editingWebhookId.value = wh.id
+  webhookDraft.value = {
+    name: wh.name,
+    url: wh.url,
+    events: [...wh.events],
+    secret: wh.secret ?? '',
+  }
+  showWebhookForm.value = true
+}
+
+function cancelWebhookForm() {
+  showWebhookForm.value = false
+  editingWebhookId.value = null
+}
+
+function onToggleEvent(evt: string) {
+  const idx = webhookDraft.value.events.indexOf(evt)
+  if (idx >= 0) {
+    webhookDraft.value.events.splice(idx, 1)
+  } else {
+    webhookDraft.value.events.push(evt)
+  }
+}
+
+async function onSaveWebhook() {
+  if (!props.client || busy.value || !canSaveWebhook.value) return
+  busy.value = true
+  error.value = null
+  try {
+    const input = {
+      name: webhookDraft.value.name.trim(),
+      url: webhookDraft.value.url.trim(),
+      events: webhookDraft.value.events,
+      secret: webhookDraft.value.secret || undefined,
+    }
+    if (editingWebhookId.value) {
+      await props.client.updateWebhook(editingWebhookId.value, input)
+    } else {
+      await props.client.createWebhook(input)
+    }
+    cancelWebhookForm()
+    await loadWebhooks()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to save webhook'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onToggleWebhook(wh: Webhook) {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    await props.client.updateWebhook(wh.id, { active: !wh.active })
+    await loadWebhooks()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to toggle webhook'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onDeleteWebhook(id: string) {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    await props.client.deleteWebhook(id)
+    if (deliveriesWebhookId.value === id) {
+      deliveriesWebhookId.value = null
+      deliveries.value = []
+    }
+    await loadWebhooks()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to delete webhook'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onViewDeliveries(webhookId: string) {
+  if (!props.client) return
+  if (deliveriesWebhookId.value === webhookId) {
+    deliveriesWebhookId.value = null
+    deliveries.value = []
+    return
+  }
+  error.value = null
+  try {
+    deliveries.value = await props.client.getWebhookDeliveries(webhookId)
+    deliveriesWebhookId.value = webhookId
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load deliveries'
+  }
+}
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v) {
+      error.value = null
+      newTokenPlaintext.value = null
+      void loadTokens()
+      void loadWebhooks()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.meta-api-mgr__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.meta-api-mgr {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  width: 640px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-api-mgr__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-api-mgr__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.meta-api-mgr__close {
+  border: none;
+  background: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #64748b;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.meta-api-mgr__tabs {
+  display: flex;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0 20px;
+}
+
+.meta-api-mgr__tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #64748b;
+  cursor: pointer;
+}
+
+.meta-api-mgr__tab--active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+}
+
+.meta-api-mgr__body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.meta-api-mgr__error {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.meta-api-mgr__empty {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.meta-api-mgr__new-token {
+  border: 2px solid #f59e0b;
+  border-radius: 10px;
+  padding: 14px;
+  background: #fffbeb;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.meta-api-mgr__token-display {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.meta-api-mgr__token-display code {
+  flex: 1;
+  word-break: break-all;
+  background: #fff;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid #e5e7eb;
+  font-size: 12px;
+}
+
+.meta-api-mgr__warning {
+  margin: 0;
+  font-size: 12px;
+  color: #92400e;
+  font-weight: 600;
+}
+
+/* Form */
+.meta-api-mgr__form {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.meta-api-mgr__form-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 4px;
+}
+
+.meta-api-mgr__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+  margin-top: 4px;
+}
+
+.meta-api-mgr__input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.meta-api-mgr__checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.meta-api-mgr__checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  color: #334155;
+  cursor: pointer;
+}
+
+.meta-api-mgr__form-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+/* Cards */
+.meta-api-mgr__card {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-api-mgr__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.meta-api-mgr__card-name {
+  font-size: 14px;
+  color: #0f172a;
+}
+
+.meta-api-mgr__card-prefix {
+  font-size: 12px;
+  color: #64748b;
+  background: #f1f5f9;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.meta-api-mgr__card-status[data-webhook-status="active"] {
+  font-size: 12px;
+  font-weight: 600;
+  color: #166534;
+}
+
+.meta-api-mgr__card-status[data-webhook-status="disabled"] {
+  font-size: 12px;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.meta-api-mgr__card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.meta-api-mgr__card-failures {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.meta-api-mgr__card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* Deliveries */
+.meta-api-mgr__deliveries {
+  border-top: 1px solid #e2e8f0;
+  padding-top: 8px;
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.meta-api-mgr__delivery-row {
+  display: flex;
+  gap: 10px;
+  font-size: 12px;
+  color: #475569;
+}
+
+.meta-api-mgr__delivery--ok {
+  color: #166534;
+  font-weight: 600;
+}
+
+.meta-api-mgr__delivery--fail {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+/* Buttons */
+.meta-api-mgr__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 14px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.meta-api-mgr__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.meta-api-mgr__btn--primary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+.meta-api-mgr__btn--danger {
+  border-color: #ef4444;
+  color: #b91c1c;
+}
+
+.meta-api-mgr__btn-add {
+  align-self: flex-start;
+}
+</style>

--- a/apps/web/src/multitable/components/MetaFieldValidationPanel.vue
+++ b/apps/web/src/multitable/components/MetaFieldValidationPanel.vue
@@ -1,0 +1,521 @@
+<template>
+  <div class="meta-field-validation">
+    <div class="meta-field-validation__header">
+      <strong class="meta-field-validation__title">Validation Rules</strong>
+    </div>
+
+    <div class="meta-field-validation__body">
+      <!-- Required toggle (all types) -->
+      <div class="meta-field-validation__rule-row" data-rule-type="required">
+        <label class="meta-field-validation__toggle">
+          <input
+            type="checkbox"
+            :checked="hasRule('required')"
+            data-rule-toggle="required"
+            @change="onToggleRequired"
+          />
+          <span>Required</span>
+        </label>
+        <input
+          v-if="hasRule('required')"
+          class="meta-field-validation__input meta-field-validation__input--message"
+          type="text"
+          placeholder="Custom error message"
+          :value="getRule('required')?.message ?? ''"
+          data-rule-message="required"
+          @input="onUpdateMessage('required', $event)"
+        />
+      </div>
+
+      <!-- Text rules -->
+      <template v-if="fieldType === 'text'">
+        <div class="meta-field-validation__rule-row" data-rule-type="minLength">
+          <label class="meta-field-validation__label">Min length</label>
+          <div class="meta-field-validation__inline">
+            <input
+              class="meta-field-validation__input meta-field-validation__input--small"
+              type="number"
+              min="0"
+              :value="getRuleValue('minLength') ?? ''"
+              data-rule-value="minLength"
+              @input="onSetNumericRule('minLength', $event)"
+            />
+            <button
+              v-if="hasRule('minLength')"
+              class="meta-field-validation__remove"
+              type="button"
+              data-rule-remove="minLength"
+              @click="onRemoveRule('minLength')"
+            >&times;</button>
+          </div>
+          <input
+            v-if="hasRule('minLength')"
+            class="meta-field-validation__input meta-field-validation__input--message"
+            type="text"
+            placeholder="Custom error message"
+            :value="getRule('minLength')?.message ?? ''"
+            data-rule-message="minLength"
+            @input="onUpdateMessage('minLength', $event)"
+          />
+        </div>
+
+        <div class="meta-field-validation__rule-row" data-rule-type="maxLength">
+          <label class="meta-field-validation__label">Max length</label>
+          <div class="meta-field-validation__inline">
+            <input
+              class="meta-field-validation__input meta-field-validation__input--small"
+              type="number"
+              min="0"
+              :value="getRuleValue('maxLength') ?? ''"
+              data-rule-value="maxLength"
+              @input="onSetNumericRule('maxLength', $event)"
+            />
+            <button
+              v-if="hasRule('maxLength')"
+              class="meta-field-validation__remove"
+              type="button"
+              data-rule-remove="maxLength"
+              @click="onRemoveRule('maxLength')"
+            >&times;</button>
+          </div>
+          <input
+            v-if="hasRule('maxLength')"
+            class="meta-field-validation__input meta-field-validation__input--message"
+            type="text"
+            placeholder="Custom error message"
+            :value="getRule('maxLength')?.message ?? ''"
+            data-rule-message="maxLength"
+            @input="onUpdateMessage('maxLength', $event)"
+          />
+        </div>
+
+        <div class="meta-field-validation__rule-row" data-rule-type="pattern">
+          <label class="meta-field-validation__label">Pattern</label>
+          <div class="meta-field-validation__inline">
+            <select
+              class="meta-field-validation__select"
+              :value="patternPreset"
+              data-rule-pattern-preset="true"
+              @change="onPatternPreset"
+            >
+              <option value="">Custom</option>
+              <option value="email">Email</option>
+              <option value="url">URL</option>
+              <option value="phone">Phone</option>
+            </select>
+            <input
+              class="meta-field-validation__input"
+              type="text"
+              placeholder="Regex pattern"
+              :value="getRuleValue('pattern') ?? ''"
+              data-rule-value="pattern"
+              @input="onSetPatternRule($event)"
+            />
+            <button
+              v-if="hasRule('pattern')"
+              class="meta-field-validation__remove"
+              type="button"
+              data-rule-remove="pattern"
+              @click="onRemoveRule('pattern')"
+            >&times;</button>
+          </div>
+          <input
+            v-if="hasRule('pattern')"
+            class="meta-field-validation__input meta-field-validation__input--message"
+            type="text"
+            placeholder="Custom error message"
+            :value="getRule('pattern')?.message ?? ''"
+            data-rule-message="pattern"
+            @input="onUpdateMessage('pattern', $event)"
+          />
+        </div>
+      </template>
+
+      <!-- Number rules -->
+      <template v-if="fieldType === 'number'">
+        <div class="meta-field-validation__rule-row" data-rule-type="min">
+          <label class="meta-field-validation__label">Minimum</label>
+          <div class="meta-field-validation__inline">
+            <input
+              class="meta-field-validation__input meta-field-validation__input--small"
+              type="number"
+              :value="getRuleValue('min') ?? ''"
+              data-rule-value="min"
+              @input="onSetNumericRule('min', $event)"
+            />
+            <button
+              v-if="hasRule('min')"
+              class="meta-field-validation__remove"
+              type="button"
+              data-rule-remove="min"
+              @click="onRemoveRule('min')"
+            >&times;</button>
+          </div>
+          <input
+            v-if="hasRule('min')"
+            class="meta-field-validation__input meta-field-validation__input--message"
+            type="text"
+            placeholder="Custom error message"
+            :value="getRule('min')?.message ?? ''"
+            data-rule-message="min"
+            @input="onUpdateMessage('min', $event)"
+          />
+        </div>
+
+        <div class="meta-field-validation__rule-row" data-rule-type="max">
+          <label class="meta-field-validation__label">Maximum</label>
+          <div class="meta-field-validation__inline">
+            <input
+              class="meta-field-validation__input meta-field-validation__input--small"
+              type="number"
+              :value="getRuleValue('max') ?? ''"
+              data-rule-value="max"
+              @input="onSetNumericRule('max', $event)"
+            />
+            <button
+              v-if="hasRule('max')"
+              class="meta-field-validation__remove"
+              type="button"
+              data-rule-remove="max"
+              @click="onRemoveRule('max')"
+            >&times;</button>
+          </div>
+          <input
+            v-if="hasRule('max')"
+            class="meta-field-validation__input meta-field-validation__input--message"
+            type="text"
+            placeholder="Custom error message"
+            :value="getRule('max')?.message ?? ''"
+            data-rule-message="max"
+            @input="onUpdateMessage('max', $event)"
+          />
+        </div>
+      </template>
+
+      <!-- Select enum rule -->
+      <template v-if="fieldType === 'select'">
+        <div class="meta-field-validation__rule-row" data-rule-type="enum">
+          <label class="meta-field-validation__toggle">
+            <input
+              type="checkbox"
+              :checked="hasRule('enum')"
+              data-rule-toggle="enum"
+              @change="onToggleEnum"
+            />
+            <span>Restrict to defined options</span>
+          </label>
+          <div v-if="hasRule('enum')" class="meta-field-validation__enum-values" data-rule-enum-values="true">
+            <span v-for="opt in enumValues" :key="opt" class="meta-field-validation__enum-chip">{{ opt }}</span>
+            <span v-if="!enumValues.length" class="meta-field-validation__empty">No options defined</span>
+          </div>
+          <input
+            v-if="hasRule('enum')"
+            class="meta-field-validation__input meta-field-validation__input--message"
+            type="text"
+            placeholder="Custom error message"
+            :value="getRule('enum')?.message ?? ''"
+            data-rule-message="enum"
+            @input="onUpdateMessage('enum', $event)"
+          />
+        </div>
+      </template>
+
+      <!-- Preview -->
+      <div v-if="localRules.length" class="meta-field-validation__preview" data-validation-preview="true">
+        <strong class="meta-field-validation__label">Preview</strong>
+        <div v-for="rule in localRules" :key="rule.type" class="meta-field-validation__preview-item">
+          <span class="meta-field-validation__preview-type">{{ ruleLabel(rule.type) }}</span>
+          <span v-if="rule.value !== undefined" class="meta-field-validation__preview-value">{{ rule.value }}</span>
+          <span v-if="rule.message" class="meta-field-validation__preview-msg">{{ rule.message }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { FieldValidationRule, FieldValidationRuleType } from '../types'
+
+const PATTERN_PRESETS: Record<string, string> = {
+  email: '^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$',
+  url: '^https?://.+',
+  phone: '^\\+?[0-9\\-\\s()]{7,}$',
+}
+
+const props = defineProps<{
+  fieldId: string
+  fieldType: string
+  rules: FieldValidationRule[]
+  options?: Array<{ value: string }>
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:rules', rules: FieldValidationRule[]): void
+}>()
+
+const localRules = ref<FieldValidationRule[]>([...props.rules])
+
+const enumValues = computed(() => {
+  return props.options?.map((o) => o.value) ?? []
+})
+
+const patternPreset = computed(() => {
+  const patternRule = getRule('pattern')
+  if (!patternRule?.value) return ''
+  const val = String(patternRule.value)
+  for (const [key, preset] of Object.entries(PATTERN_PRESETS)) {
+    if (val === preset) return key
+  }
+  return ''
+})
+
+function hasRule(type: FieldValidationRuleType): boolean {
+  return localRules.value.some((r) => r.type === type)
+}
+
+function getRule(type: FieldValidationRuleType): FieldValidationRule | undefined {
+  return localRules.value.find((r) => r.type === type)
+}
+
+function getRuleValue(type: FieldValidationRuleType): string | number | string[] | undefined {
+  return getRule(type)?.value
+}
+
+function setRule(type: FieldValidationRuleType, value?: string | number | string[], message?: string) {
+  const idx = localRules.value.findIndex((r) => r.type === type)
+  const rule: FieldValidationRule = { type, value, message }
+  if (idx >= 0) {
+    localRules.value[idx] = rule
+  } else {
+    localRules.value.push(rule)
+  }
+  localRules.value = [...localRules.value]
+  emit('update:rules', localRules.value)
+}
+
+function removeRule(type: FieldValidationRuleType) {
+  localRules.value = localRules.value.filter((r) => r.type !== type)
+  emit('update:rules', localRules.value)
+}
+
+function onRemoveRule(type: FieldValidationRuleType) {
+  removeRule(type)
+}
+
+function onToggleRequired() {
+  if (hasRule('required')) {
+    removeRule('required')
+  } else {
+    setRule('required')
+  }
+}
+
+function onToggleEnum() {
+  if (hasRule('enum')) {
+    removeRule('enum')
+  } else {
+    setRule('enum', enumValues.value)
+  }
+}
+
+function onSetNumericRule(type: FieldValidationRuleType, event: Event) {
+  const input = event.target as HTMLInputElement
+  const val = input.value.trim()
+  if (val === '') {
+    removeRule(type)
+    return
+  }
+  const num = Number(val)
+  if (Number.isFinite(num)) {
+    setRule(type, num, getRule(type)?.message)
+  }
+}
+
+function onSetPatternRule(event: Event) {
+  const input = event.target as HTMLInputElement
+  const val = input.value.trim()
+  if (!val) {
+    removeRule('pattern')
+    return
+  }
+  setRule('pattern', val, getRule('pattern')?.message)
+}
+
+function onPatternPreset(event: Event) {
+  const select = event.target as HTMLSelectElement
+  const key = select.value
+  if (!key) return
+  const preset = PATTERN_PRESETS[key]
+  if (preset) {
+    setRule('pattern', preset, getRule('pattern')?.message)
+  }
+}
+
+function onUpdateMessage(type: FieldValidationRuleType, event: Event) {
+  const input = event.target as HTMLInputElement
+  const rule = getRule(type)
+  if (rule) {
+    setRule(type, rule.value, input.value || undefined)
+  }
+}
+
+function ruleLabel(type: FieldValidationRuleType): string {
+  switch (type) {
+    case 'required': return 'Required'
+    case 'minLength': return 'Min length'
+    case 'maxLength': return 'Max length'
+    case 'pattern': return 'Pattern'
+    case 'min': return 'Minimum'
+    case 'max': return 'Maximum'
+    case 'enum': return 'Enum'
+    default: return type
+  }
+}
+
+watch(
+  () => props.rules,
+  (newRules) => {
+    localRules.value = [...newRules]
+  },
+)
+</script>
+
+<style scoped>
+.meta-field-validation {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.meta-field-validation__header {
+  padding: 12px 14px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-field-validation__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.meta-field-validation__body {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.meta-field-validation__rule-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-field-validation__toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.meta-field-validation__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+}
+
+.meta-field-validation__inline {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.meta-field-validation__input {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 13px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.meta-field-validation__input--small {
+  width: 100px;
+}
+
+.meta-field-validation__input--message {
+  width: 100%;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.meta-field-validation__select {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.meta-field-validation__remove {
+  border: none;
+  background: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: #ef4444;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.meta-field-validation__enum-values {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.meta-field-validation__enum-chip {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #e0e7ff;
+  color: #3730a3;
+  font-size: 12px;
+}
+
+.meta-field-validation__empty {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.meta-field-validation__preview {
+  border-top: 1px solid #e2e8f0;
+  padding-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.meta-field-validation__preview-item {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.meta-field-validation__preview-type {
+  font-weight: 600;
+  min-width: 80px;
+}
+
+.meta-field-validation__preview-value {
+  color: #2563eb;
+}
+
+.meta-field-validation__preview-msg {
+  color: #94a3b8;
+  font-style: italic;
+}
+</style>

--- a/apps/web/src/multitable/components/MetaFormShareManager.vue
+++ b/apps/web/src/multitable/components/MetaFormShareManager.vue
@@ -1,0 +1,417 @@
+<template>
+  <div v-if="visible" class="meta-form-share__overlay" @click.self="$emit('close')">
+    <div class="meta-form-share">
+      <div class="meta-form-share__header">
+        <h4 class="meta-form-share__title">Public Form Sharing</h4>
+        <button class="meta-form-share__close" type="button" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="meta-form-share__body">
+        <div v-if="error" class="meta-form-share__error" role="alert">{{ error }}</div>
+        <div v-if="loading" class="meta-form-share__empty">Loading share settings&#x2026;</div>
+
+        <template v-else>
+          <!-- Enable toggle -->
+          <div class="meta-form-share__toggle-row">
+            <label class="meta-form-share__toggle">
+              <input
+                type="checkbox"
+                :checked="config?.enabled"
+                data-form-share-toggle="true"
+                @change="onToggleEnabled"
+              />
+              <span>{{ config?.enabled ? 'Sharing enabled' : 'Sharing disabled' }}</span>
+            </label>
+            <span
+              class="meta-form-share__status"
+              :data-status="config?.status ?? 'disabled'"
+            >
+              {{ statusLabel }}
+            </span>
+          </div>
+
+          <!-- Link + actions (only when enabled) -->
+          <template v-if="config?.enabled && config.publicToken">
+            <div class="meta-form-share__link-section">
+              <label class="meta-form-share__label">Public link</label>
+              <div class="meta-form-share__link-row">
+                <input
+                  class="meta-form-share__input"
+                  type="text"
+                  :value="publicLink"
+                  readonly
+                  data-form-share-link="true"
+                />
+                <button
+                  class="meta-form-share__btn meta-form-share__btn--primary"
+                  type="button"
+                  data-form-share-copy="true"
+                  @click="onCopyLink"
+                >
+                  {{ copied ? 'Copied!' : 'Copy' }}
+                </button>
+              </div>
+            </div>
+
+            <div class="meta-form-share__actions-row">
+              <button
+                class="meta-form-share__btn"
+                type="button"
+                data-form-share-regenerate="true"
+                :disabled="busy"
+                @click="onRegenerate"
+              >
+                Regenerate token
+              </button>
+              <button
+                class="meta-form-share__btn"
+                type="button"
+                data-form-share-preview="true"
+                @click="onPreview"
+              >
+                Preview
+              </button>
+            </div>
+
+            <!-- Expiry -->
+            <div class="meta-form-share__expiry-section">
+              <label class="meta-form-share__label">Expiry</label>
+              <div class="meta-form-share__expiry-row">
+                <input
+                  class="meta-form-share__input"
+                  type="date"
+                  :value="expiryDateValue"
+                  data-form-share-expiry="true"
+                  @change="onExpiryChange"
+                />
+                <button
+                  v-if="config.expiresAt"
+                  class="meta-form-share__btn"
+                  type="button"
+                  data-form-share-clear-expiry="true"
+                  :disabled="busy"
+                  @click="onClearExpiry"
+                >
+                  No expiry
+                </button>
+              </div>
+            </div>
+          </template>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { FormShareConfig } from '../types'
+import type { MultitableApiClient } from '../api/client'
+
+const props = defineProps<{
+  sheetId: string
+  viewId: string
+  visible: boolean
+  client?: MultitableApiClient
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'updated'): void
+}>()
+
+const config = ref<FormShareConfig | null>(null)
+const loading = ref(false)
+const error = ref<string | null>(null)
+const busy = ref(false)
+const copied = ref(false)
+
+const statusLabel = computed(() => {
+  if (!config.value) return 'Disabled'
+  switch (config.value.status) {
+    case 'active': return 'Active'
+    case 'expired': return 'Expired'
+    case 'disabled': return 'Disabled'
+    default: return 'Disabled'
+  }
+})
+
+const publicLink = computed(() => {
+  if (!config.value?.publicToken) return ''
+  return `${window.location.origin}/multitable/public-form/${props.sheetId}/${props.viewId}?publicToken=${config.value.publicToken}`
+})
+
+const expiryDateValue = computed(() => {
+  if (!config.value?.expiresAt) return ''
+  return config.value.expiresAt.substring(0, 10)
+})
+
+async function loadConfig() {
+  if (!props.client) return
+  loading.value = true
+  error.value = null
+  try {
+    config.value = await props.client.getFormShareConfig(props.sheetId, props.viewId)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load share config'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function onToggleEnabled() {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    config.value = await props.client.updateFormShareConfig(props.sheetId, props.viewId, {
+      enabled: !config.value?.enabled,
+    })
+    emit('updated')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to update'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onRegenerate() {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    const result = await props.client.regenerateFormShareToken(props.sheetId, props.viewId)
+    if (config.value) {
+      config.value = { ...config.value, publicToken: result.publicToken }
+    }
+    emit('updated')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to regenerate token'
+  } finally {
+    busy.value = false
+  }
+}
+
+function onCopyLink() {
+  if (!publicLink.value) return
+  void navigator.clipboard.writeText(publicLink.value)
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 2000)
+}
+
+function onPreview() {
+  if (!publicLink.value) return
+  window.open(publicLink.value, '_blank')
+}
+
+async function onExpiryChange(event: Event) {
+  if (!props.client || busy.value) return
+  const input = event.target as HTMLInputElement
+  const dateStr = input.value
+  if (!dateStr) return
+  busy.value = true
+  error.value = null
+  try {
+    config.value = await props.client.updateFormShareConfig(props.sheetId, props.viewId, {
+      expiresAt: new Date(dateStr).toISOString(),
+    })
+    emit('updated')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to update expiry'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onClearExpiry() {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    config.value = await props.client.updateFormShareConfig(props.sheetId, props.viewId, {
+      expiresAt: null,
+    })
+    emit('updated')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to clear expiry'
+  } finally {
+    busy.value = false
+  }
+}
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v && props.sheetId && props.viewId) {
+      void loadConfig()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.meta-form-share__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.meta-form-share {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  width: 520px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-form-share__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-form-share__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.meta-form-share__close {
+  border: none;
+  background: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #64748b;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.meta-form-share__body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.meta-form-share__error {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.meta-form-share__empty {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.meta-form-share__toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.meta-form-share__toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.meta-form-share__status {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 999px;
+}
+
+.meta-form-share__status[data-status="active"] {
+  background: #ecfdf5;
+  color: #166534;
+}
+
+.meta-form-share__status[data-status="expired"] {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.meta-form-share__status[data-status="disabled"] {
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+.meta-form-share__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+}
+
+.meta-form-share__link-section,
+.meta-form-share__expiry-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-form-share__link-row,
+.meta-form-share__expiry-row {
+  display: flex;
+  gap: 8px;
+}
+
+.meta-form-share__input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.meta-form-share__actions-row {
+  display: flex;
+  gap: 8px;
+}
+
+.meta-form-share__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 14px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.meta-form-share__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.meta-form-share__btn--primary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+</style>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -544,3 +544,72 @@ export interface AutomationRule {
   updatedAt?: string
   createdBy?: string
 }
+
+// --- Form Share ---
+export interface FormShareConfig {
+  enabled: boolean
+  publicToken: string | null
+  expiresAt: string | null
+  status: 'active' | 'expired' | 'disabled'
+}
+
+export interface FormShareConfigUpdate {
+  enabled?: boolean
+  expiresAt?: string | null
+}
+
+// --- API Tokens ---
+export interface ApiToken {
+  id: string
+  name: string
+  prefix: string
+  scopes: string[]
+  createdAt: string
+  lastUsedAt: string | null
+  expiresAt: string | null
+}
+
+export interface ApiTokenCreateResult {
+  token: ApiToken
+  plaintext: string
+}
+
+// --- Webhooks ---
+export interface Webhook {
+  id: string
+  name: string
+  url: string
+  events: string[]
+  active: boolean
+  secret: string | null
+  failureCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WebhookCreateInput {
+  name: string
+  url: string
+  events: string[]
+  secret?: string
+  active?: boolean
+}
+
+export interface WebhookDelivery {
+  id: string
+  webhookId: string
+  event: string
+  httpStatus: number | null
+  success: boolean
+  retryCount: number
+  timestamp: string
+}
+
+// --- Field Validation ---
+export type FieldValidationRuleType = 'required' | 'minLength' | 'maxLength' | 'pattern' | 'min' | 'max' | 'enum'
+
+export interface FieldValidationRule {
+  type: FieldValidationRuleType
+  value?: string | number | string[]
+  message?: string
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -49,6 +49,8 @@
       <button v-if="caps.canManageViews.value && canConfigureCurrentView" class="mt-workbench__mgr-btn" @click="showViewManager = true">&#x2630; Views</button>
       <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="openWorkflowDesigner()">&#x2699; Workflow</button>
       <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="showAutomationManager = true">&#x26A1; Automations</button>
+      <button v-if="activeViewType === 'form'" class="mt-workbench__mgr-btn" @click="showFormShareManager = true">&#x1F517; Share Form</button>
+      <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true">&#x1F511; API &amp; Webhooks</button>
     </div>
     <div
       v-if="capabilityOriginNotice"
@@ -283,6 +285,19 @@
       @close="showAutomationManager = false"
       @updated="showAutomationManager = false"
     />
+    <MetaFormShareManager
+      :visible="showFormShareManager"
+      :sheet-id="workbench.activeSheetId.value"
+      :view-id="workbench.activeViewId.value"
+      :client="workbench.client"
+      @close="showFormShareManager = false"
+      @updated="showFormShareManager = false"
+    />
+    <MetaApiTokenManager
+      :visible="showApiTokenManager"
+      :client="workbench.client"
+      @close="showApiTokenManager = false"
+    />
   </div>
 </template>
 
@@ -333,6 +348,8 @@ import MetaFieldManager from '../components/MetaFieldManager.vue'
 import MetaViewManager from '../components/MetaViewManager.vue'
 import MetaSheetPermissionManager from '../components/MetaSheetPermissionManager.vue'
 import MetaAutomationManager from '../components/MetaAutomationManager.vue'
+import MetaFormShareManager from '../components/MetaFormShareManager.vue'
+import MetaApiTokenManager from '../components/MetaApiTokenManager.vue'
 import MetaBasePicker from '../components/MetaBasePicker.vue'
 import MetaKanbanView from '../components/MetaKanbanView.vue'
 import MetaGalleryView from '../components/MetaGalleryView.vue'
@@ -387,6 +404,8 @@ const linkPickerCurrentValue = ref<unknown>(null)
 const showFieldManager = ref(false)
 const showPermissionManager = ref(false)
 const showAutomationManager = ref(false)
+const showFormShareManager = ref(false)
+const showApiTokenManager = ref(false)
 const fieldPermissionEntries = ref<MetaFieldPermissionEntry[]>([])
 const viewPermissionEntries = ref<MetaViewPermissionEntry[]>([])
 const showViewManager = ref(false)

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -1,0 +1,311 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+
+async function flushPromises() {
+  for (let i = 0; i < 5; i++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+}
+
+import MetaApiTokenManager from '../src/multitable/components/MetaApiTokenManager.vue'
+import { MultitableApiClient } from '../src/multitable/api/client'
+import type { ApiToken, Webhook, WebhookDelivery } from '../src/multitable/types'
+
+function fakeToken(overrides: Partial<ApiToken> = {}): ApiToken {
+  return {
+    id: 'tok_1',
+    name: 'Test token',
+    prefix: 'mst_abc',
+    scopes: ['read', 'write'],
+    createdAt: '2026-04-01T00:00:00Z',
+    lastUsedAt: null,
+    expiresAt: null,
+    ...overrides,
+  }
+}
+
+function fakeWebhook(overrides: Partial<Webhook> = {}): Webhook {
+  return {
+    id: 'wh_1',
+    name: 'Test webhook',
+    url: 'https://example.com/hook',
+    events: ['record.created'],
+    active: true,
+    secret: null,
+    failureCount: 0,
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-04-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function fakeDelivery(overrides: Partial<WebhookDelivery> = {}): WebhookDelivery {
+  return {
+    id: 'del_1',
+    webhookId: 'wh_1',
+    event: 'record.created',
+    httpStatus: 200,
+    success: true,
+    retryCount: 0,
+    timestamp: '2026-04-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function mockClient(tokens: ApiToken[] = [], webhooks: Webhook[] = [], deliveries: WebhookDelivery[] = []) {
+  const ok = (body: unknown) =>
+    new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  const noContent = () => new Response(null, { status: 204 })
+
+  const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+
+    // Tokens
+    if (method === 'GET' && url.includes('/tokens') && !url.includes('/rotate')) {
+      return ok({ tokens })
+    }
+    if (method === 'POST' && url.includes('/tokens') && !url.includes('/rotate')) {
+      const body = JSON.parse(init?.body as string)
+      return ok({ token: { id: 'tok_new', prefix: 'mst_new', ...body, createdAt: '2026-04-01', lastUsedAt: null, expiresAt: null }, plaintext: 'mst_plaintext_secret_123' })
+    }
+    if (method === 'DELETE' && url.includes('/tokens/')) {
+      return noContent()
+    }
+    if (method === 'POST' && url.includes('/rotate')) {
+      return ok({ token: fakeToken({ id: 'tok_rotated', prefix: 'mst_rot' }), plaintext: 'mst_rotated_secret_456' })
+    }
+
+    // Webhooks
+    if (method === 'GET' && url.includes('/webhooks') && !url.includes('/deliveries')) {
+      return ok({ webhooks })
+    }
+    if (method === 'POST' && url.includes('/webhooks') && !url.includes('/deliveries')) {
+      const body = JSON.parse(init?.body as string)
+      return ok({ id: 'wh_new', active: true, secret: null, failureCount: 0, createdAt: '2026-04-01', updatedAt: '2026-04-01', ...body })
+    }
+    if (method === 'PATCH' && url.includes('/webhooks/')) {
+      return ok(webhooks[0] ?? {})
+    }
+    if (method === 'DELETE' && url.includes('/webhooks/')) {
+      return noContent()
+    }
+    if (method === 'GET' && url.includes('/deliveries')) {
+      return ok({ deliveries })
+    }
+
+    return ok({})
+  })
+  return { client: new MultitableApiClient({ fetchFn }), fetchFn }
+}
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaApiTokenManager, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaApiTokenManager', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  // ---- Token tests ----
+
+  it('renders token list when visible', async () => {
+    const { client } = mockClient([fakeToken()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const cards = document.querySelectorAll('[data-token-id]')
+    expect(cards.length).toBe(1)
+    expect(document.querySelector('.meta-api-mgr__card-name')?.textContent).toBe('Test token')
+  })
+
+  it('shows empty state when no tokens', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+
+    expect(document.querySelector('[data-tokens-empty]')).toBeTruthy()
+  })
+
+  it('opens create token form', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const newBtn = document.querySelector('[data-token-new]') as HTMLButtonElement
+    expect(newBtn).toBeTruthy()
+    newBtn.click()
+    await flushPromises()
+
+    expect(document.querySelector('[data-token-form]')).toBeTruthy()
+    expect(document.querySelector('[data-token-name]')).toBeTruthy()
+  })
+
+  it('creates token and shows plaintext once', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+
+    // Open form
+    const newBtn = document.querySelector('[data-token-new]') as HTMLButtonElement
+    newBtn.click()
+    await flushPromises()
+
+    // Fill name
+    const nameInput = document.querySelector('[data-token-name]') as HTMLInputElement
+    nameInput.value = 'My token'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    // Submit
+    const createBtn = document.querySelector('[data-token-create]') as HTMLButtonElement
+    createBtn.click()
+    await flushPromises()
+
+    // Plaintext shown
+    const newTokenEl = document.querySelector('[data-new-token]')
+    expect(newTokenEl).toBeTruthy()
+    const tokenValue = document.querySelector('[data-new-token-value]')
+    expect(tokenValue?.textContent).toBe('mst_plaintext_secret_123')
+  })
+
+  it('revokes a token', async () => {
+    const { client, fetchFn } = mockClient([fakeToken()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const revokeBtn = document.querySelector('[data-token-revoke]') as HTMLButtonElement
+    expect(revokeBtn).toBeTruthy()
+    revokeBtn.click()
+    await flushPromises()
+
+    const deleteCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'DELETE' && c[0].includes('/tokens/'),
+    )
+    expect(deleteCalls.length).toBe(1)
+  })
+
+  it('rotates a token and shows new plaintext', async () => {
+    const { client } = mockClient([fakeToken()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const rotateBtn = document.querySelector('[data-token-rotate]') as HTMLButtonElement
+    rotateBtn.click()
+    await flushPromises()
+
+    const tokenValue = document.querySelector('[data-new-token-value]')
+    expect(tokenValue?.textContent).toBe('mst_rotated_secret_456')
+  })
+
+  // ---- Webhook tests ----
+
+  it('switches to webhooks tab', async () => {
+    const { client } = mockClient([], [fakeWebhook()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement
+    webhookTab.click()
+    await flushPromises()
+
+    const cards = document.querySelectorAll('[data-webhook-id]')
+    expect(cards.length).toBe(1)
+  })
+
+  it('shows webhook empty state', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement
+    webhookTab.click()
+    await flushPromises()
+
+    expect(document.querySelector('[data-webhooks-empty]')).toBeTruthy()
+  })
+
+  it('creates a webhook', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+
+    // Switch to webhooks tab
+    const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement
+    webhookTab.click()
+    await flushPromises()
+
+    // Open form
+    const newBtn = document.querySelector('[data-webhook-new]') as HTMLButtonElement
+    newBtn.click()
+    await flushPromises()
+
+    // Fill form
+    const nameInput = document.querySelector('[data-webhook-name]') as HTMLInputElement
+    nameInput.value = 'My webhook'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const urlInput = document.querySelector('[data-webhook-url]') as HTMLInputElement
+    urlInput.value = 'https://example.com/hook'
+    urlInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    // Check an event
+    const eventCheckbox = document.querySelector('[data-webhook-event="record.created"]') as HTMLInputElement
+    eventCheckbox.click()
+    await flushPromises()
+
+    // Submit
+    const saveBtn = document.querySelector('[data-webhook-save]') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const createCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/webhooks'),
+    )
+    expect(createCalls.length).toBe(1)
+  })
+
+  it('deletes a webhook', async () => {
+    const { client, fetchFn } = mockClient([], [fakeWebhook()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    // Switch to webhooks tab
+    const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement
+    webhookTab.click()
+    await flushPromises()
+
+    const deleteBtn = document.querySelector('[data-webhook-delete]') as HTMLButtonElement
+    deleteBtn.click()
+    await flushPromises()
+
+    const deleteCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'DELETE' && c[0].includes('/webhooks/'),
+    )
+    expect(deleteCalls.length).toBe(1)
+  })
+
+  it('views webhook deliveries', async () => {
+    const { client } = mockClient([], [fakeWebhook()], [fakeDelivery()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    // Switch to webhooks tab
+    const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement
+    webhookTab.click()
+    await flushPromises()
+
+    const deliveriesBtn = document.querySelector('[data-webhook-deliveries]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const deliveryRows = document.querySelectorAll('[data-delivery-id]')
+    expect(deliveryRows.length).toBe(1)
+  })
+})

--- a/apps/web/tests/multitable-field-validation-panel.spec.ts
+++ b/apps/web/tests/multitable-field-validation-panel.spec.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import type { FieldValidationRule } from '../src/multitable/types'
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+
+import MetaFieldValidationPanel from '../src/multitable/components/MetaFieldValidationPanel.vue'
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const emitted: FieldValidationRule[][] = []
+  const app = createApp({
+    render: () =>
+      h(MetaFieldValidationPanel, {
+        ...props,
+        'onUpdate:rules': (rules: FieldValidationRule[]) => emitted.push(rules),
+      }),
+  })
+  app.mount(container)
+  return { container, app, emitted }
+}
+
+describe('MetaFieldValidationPanel', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('renders required toggle for all field types', async () => {
+    mount({ fieldId: 'f1', fieldType: 'text', rules: [] })
+    await flushPromises()
+
+    const requiredToggle = document.querySelector('[data-rule-toggle="required"]')
+    expect(requiredToggle).toBeTruthy()
+  })
+
+  it('shows text-specific rules for text fields', async () => {
+    mount({ fieldId: 'f1', fieldType: 'text', rules: [] })
+    await flushPromises()
+
+    expect(document.querySelector('[data-rule-type="minLength"]')).toBeTruthy()
+    expect(document.querySelector('[data-rule-type="maxLength"]')).toBeTruthy()
+    expect(document.querySelector('[data-rule-type="pattern"]')).toBeTruthy()
+    // number rules should not appear
+    expect(document.querySelector('[data-rule-type="min"]')).toBeNull()
+    expect(document.querySelector('[data-rule-type="max"]')).toBeNull()
+  })
+
+  it('shows number-specific rules for number fields', async () => {
+    mount({ fieldId: 'f1', fieldType: 'number', rules: [] })
+    await flushPromises()
+
+    expect(document.querySelector('[data-rule-type="min"]')).toBeTruthy()
+    expect(document.querySelector('[data-rule-type="max"]')).toBeTruthy()
+    // text rules should not appear
+    expect(document.querySelector('[data-rule-type="minLength"]')).toBeNull()
+    expect(document.querySelector('[data-rule-type="pattern"]')).toBeNull()
+  })
+
+  it('shows enum rule for select fields', async () => {
+    mount({
+      fieldId: 'f1',
+      fieldType: 'select',
+      rules: [],
+      options: [{ value: 'A' }, { value: 'B' }],
+    })
+    await flushPromises()
+
+    expect(document.querySelector('[data-rule-type="enum"]')).toBeTruthy()
+  })
+
+  it('toggles required rule and emits update', async () => {
+    const { emitted } = mount({ fieldId: 'f1', fieldType: 'text', rules: [] })
+    await flushPromises()
+
+    const toggle = document.querySelector('[data-rule-toggle="required"]') as HTMLInputElement
+    toggle.click()
+    await flushPromises()
+
+    expect(emitted.length).toBeGreaterThan(0)
+    const lastRules = emitted[emitted.length - 1]
+    expect(lastRules.some((r) => r.type === 'required')).toBe(true)
+  })
+
+  it('removes a rule and emits update', async () => {
+    const initialRules: FieldValidationRule[] = [{ type: 'required' }, { type: 'minLength', value: 3 }]
+    const { emitted } = mount({ fieldId: 'f1', fieldType: 'text', rules: initialRules })
+    await flushPromises()
+
+    const removeBtn = document.querySelector('[data-rule-remove="minLength"]') as HTMLButtonElement
+    expect(removeBtn).toBeTruthy()
+    removeBtn.click()
+    await flushPromises()
+
+    expect(emitted.length).toBeGreaterThan(0)
+    const lastRules = emitted[emitted.length - 1]
+    expect(lastRules.some((r) => r.type === 'minLength')).toBe(false)
+    expect(lastRules.some((r) => r.type === 'required')).toBe(true)
+  })
+
+  it('shows preview when rules exist', async () => {
+    mount({
+      fieldId: 'f1',
+      fieldType: 'text',
+      rules: [{ type: 'required' }, { type: 'minLength', value: 5 }],
+    })
+    await flushPromises()
+
+    const preview = document.querySelector('[data-validation-preview]')
+    expect(preview).toBeTruthy()
+  })
+
+  it('shows pattern preset selector for text fields', async () => {
+    mount({ fieldId: 'f1', fieldType: 'text', rules: [] })
+    await flushPromises()
+
+    const presetSelect = document.querySelector('[data-rule-pattern-preset]')
+    expect(presetSelect).toBeTruthy()
+  })
+
+  it('shows enum values when enum rule is active for select field', async () => {
+    const initialRules: FieldValidationRule[] = [{ type: 'enum', value: ['A', 'B'] }]
+    mount({
+      fieldId: 'f1',
+      fieldType: 'select',
+      rules: initialRules,
+      options: [{ value: 'A' }, { value: 'B' }],
+    })
+    await flushPromises()
+
+    const enumValues = document.querySelector('[data-rule-enum-values]')
+    expect(enumValues).toBeTruthy()
+    const chips = enumValues?.querySelectorAll('.meta-field-validation__enum-chip')
+    expect(chips?.length).toBe(2)
+  })
+})

--- a/apps/web/tests/multitable-form-share-manager.spec.ts
+++ b/apps/web/tests/multitable-form-share-manager.spec.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+
+async function flushPromises() {
+  for (let i = 0; i < 5; i++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+}
+
+import MetaFormShareManager from '../src/multitable/components/MetaFormShareManager.vue'
+import { MultitableApiClient } from '../src/multitable/api/client'
+
+function fakeConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    enabled: true,
+    publicToken: 'tok_abc123',
+    expiresAt: null,
+    status: 'active',
+    ...overrides,
+  }
+}
+
+function mockClient(config = fakeConfig()) {
+  const ok = (body: unknown) =>
+    new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+  const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+    if (method === 'GET' && url.includes('/form-share')) {
+      return ok(config)
+    }
+    if (method === 'PATCH' && url.includes('/form-share')) {
+      const body = JSON.parse(init?.body as string)
+      return ok({ ...config, ...body })
+    }
+    if (method === 'POST' && url.includes('/regenerate')) {
+      return ok({ publicToken: 'tok_new456' })
+    }
+    return ok({})
+  })
+  return { client: new MultitableApiClient({ fetchFn }), fetchFn }
+}
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaFormShareManager, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaFormShareManager', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('renders share config when visible', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const toggle = document.querySelector('[data-form-share-toggle]') as HTMLInputElement
+    expect(toggle).toBeTruthy()
+    expect(toggle.checked).toBe(true)
+  })
+
+  it('shows public link when enabled', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const linkInput = document.querySelector('[data-form-share-link]') as HTMLInputElement
+    expect(linkInput).toBeTruthy()
+    expect(linkInput.value).toContain('tok_abc123')
+    expect(linkInput.value).toContain('/multitable/public-form/sh_1/v_1')
+  })
+
+  it('hides link section when disabled', async () => {
+    const { client } = mockClient(fakeConfig({ enabled: false, publicToken: null, status: 'disabled' }))
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const linkInput = document.querySelector('[data-form-share-link]')
+    expect(linkInput).toBeNull()
+  })
+
+  it('shows copy button', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const copyBtn = document.querySelector('[data-form-share-copy]')
+    expect(copyBtn).toBeTruthy()
+    expect(copyBtn?.textContent?.trim()).toBe('Copy')
+  })
+
+  it('shows regenerate button', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const regenBtn = document.querySelector('[data-form-share-regenerate]')
+    expect(regenBtn).toBeTruthy()
+  })
+
+  it('calls regenerate API on click', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const regenBtn = document.querySelector('[data-form-share-regenerate]') as HTMLButtonElement
+    regenBtn.click()
+    await flushPromises()
+
+    const regenerateCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/regenerate'),
+    )
+    expect(regenerateCalls.length).toBe(1)
+  })
+
+  it('shows expiry date picker', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const expiryInput = document.querySelector('[data-form-share-expiry]')
+    expect(expiryInput).toBeTruthy()
+  })
+
+  it('shows status indicator', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const status = document.querySelector('[data-status="active"]')
+    expect(status).toBeTruthy()
+    expect(status?.textContent?.trim()).toBe('Active')
+  })
+
+  it('toggles enabled calls API', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const toggle = document.querySelector('[data-form-share-toggle]') as HTMLInputElement
+    toggle.click()
+    await flushPromises()
+
+    const patchCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'PATCH' && c[0].includes('/form-share'),
+    )
+    expect(patchCalls.length).toBe(1)
+    const body = JSON.parse(patchCalls[0][1].body as string)
+    expect(body.enabled).toBe(false)
+  })
+})

--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -1,0 +1,289 @@
+/**
+ * Chart Aggregation Service — computes chart data from records.
+ *
+ * This is a pure-logic service with no DB dependency; it operates on
+ * in-memory record arrays. The DashboardService is responsible for
+ * fetching records and passing them here.
+ */
+
+import type { ChartConfig, ChartType, AggregationFunction } from './charts'
+
+export interface ChartDataPoint {
+  label: string
+  value: number
+  color?: string
+}
+
+export interface ChartData {
+  chartId: string
+  chartType: ChartType
+  dataPoints: ChartDataPoint[]
+  total?: number
+  metadata?: {
+    groupByField?: string
+    aggregationFunction?: string
+    recordCount?: number
+  }
+}
+
+type RecordRow = { data: Record<string, unknown> }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toNumber(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v
+  if (typeof v === 'string') {
+    const n = Number(v)
+    if (Number.isFinite(n)) return n
+  }
+  return null
+}
+
+function startOfWeek(d: Date): Date {
+  const day = d.getUTCDay()
+  const diff = d.getUTCDate() - day + (day === 0 ? -6 : 1)
+  const w = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), diff))
+  return w
+}
+
+function dateBucketKey(dateStr: string, grouping: string): string | null {
+  const d = new Date(dateStr)
+  if (isNaN(d.getTime())) return null
+
+  switch (grouping) {
+    case 'day':
+      return d.toISOString().slice(0, 10) // YYYY-MM-DD
+    case 'week': {
+      const w = startOfWeek(d)
+      return w.toISOString().slice(0, 10)
+    }
+    case 'month':
+      return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`
+    case 'quarter': {
+      const q = Math.ceil((d.getUTCMonth() + 1) / 3)
+      return `${d.getUTCFullYear()}-Q${q}`
+    }
+    case 'year':
+      return String(d.getUTCFullYear())
+    default:
+      return d.toISOString().slice(0, 10)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ChartAggregationService
+// ---------------------------------------------------------------------------
+
+export class ChartAggregationService {
+  /**
+   * Compute chart data from a chart config + record set.
+   */
+  async computeChartData(chart: ChartConfig, records: RecordRow[]): Promise<ChartData> {
+    let filtered = this.filterRecords(records, chart.dataSource)
+    const aggFn = chart.dataSource.aggregation.function
+    const aggFieldId = chart.dataSource.aggregation.fieldId
+
+    // Number chart: single aggregated value
+    if (chart.type === 'number') {
+      const allValues = filtered.map((r) => r.data[aggFieldId ?? ''])
+      const value = this.aggregate(allValues, aggFn)
+      return {
+        chartId: chart.id,
+        chartType: chart.type,
+        dataPoints: [{ label: chart.display.title ?? chart.name, value }],
+        total: value,
+        metadata: {
+          aggregationFunction: aggFn,
+          recordCount: filtered.length,
+        },
+      }
+    }
+
+    // Group records
+    let groups: Map<string, RecordRow[]>
+
+    if (chart.dataSource.dateFieldId && chart.dataSource.dateGrouping) {
+      groups = this.groupByDate(filtered, chart.dataSource.dateFieldId, chart.dataSource.dateGrouping)
+    } else if (chart.dataSource.groupByFieldId) {
+      groups = this.groupRecords(filtered, chart.dataSource.groupByFieldId)
+    } else {
+      // No grouping: everything in one bucket
+      groups = new Map([['All', filtered]])
+    }
+
+    // Compute data points
+    let dataPoints: ChartDataPoint[] = []
+    for (const [label, groupRecords] of groups) {
+      const values = groupRecords.map((r) => r.data[aggFieldId ?? ''])
+      const value = this.aggregate(values, aggFn)
+      dataPoints.push({ label, value })
+    }
+
+    // Sort
+    dataPoints = this.sortDataPoints(dataPoints, chart.dataSource.sortBy, chart.dataSource.sortOrder)
+
+    // Limit
+    if (chart.dataSource.limit && chart.dataSource.limit > 0) {
+      dataPoints = dataPoints.slice(0, chart.dataSource.limit)
+    }
+
+    const total = dataPoints.reduce((sum, dp) => sum + dp.value, 0)
+
+    return {
+      chartId: chart.id,
+      chartType: chart.type,
+      dataPoints,
+      total,
+      metadata: {
+        groupByField: chart.dataSource.groupByFieldId ?? chart.dataSource.dateFieldId,
+        aggregationFunction: aggFn,
+        recordCount: filtered.length,
+      },
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private aggregate(values: unknown[], fn: AggregationFunction): number {
+    switch (fn) {
+      case 'count':
+        return values.length
+
+      case 'count_distinct': {
+        const set = new Set<string>()
+        for (const v of values) {
+          if (v != null) set.add(String(v))
+        }
+        return set.size
+      }
+
+      case 'sum': {
+        let total = 0
+        for (const v of values) {
+          const n = toNumber(v)
+          if (n !== null) total += n
+        }
+        return total
+      }
+
+      case 'avg': {
+        let total = 0
+        let count = 0
+        for (const v of values) {
+          const n = toNumber(v)
+          if (n !== null) {
+            total += n
+            count++
+          }
+        }
+        return count === 0 ? 0 : total / count
+      }
+
+      case 'min': {
+        let min: number | null = null
+        for (const v of values) {
+          const n = toNumber(v)
+          if (n !== null && (min === null || n < min)) min = n
+        }
+        return min ?? 0
+      }
+
+      case 'max': {
+        let max: number | null = null
+        for (const v of values) {
+          const n = toNumber(v)
+          if (n !== null && (max === null || n > max)) max = n
+        }
+        return max ?? 0
+      }
+
+      default:
+        return 0
+    }
+  }
+
+  private groupRecords(records: RecordRow[], fieldId: string): Map<string, RecordRow[]> {
+    const groups = new Map<string, RecordRow[]>()
+    for (const record of records) {
+      const rawValue = record.data[fieldId]
+      const key = rawValue != null ? String(rawValue) : '(empty)'
+      const group = groups.get(key)
+      if (group) {
+        group.push(record)
+      } else {
+        groups.set(key, [record])
+      }
+    }
+    return groups
+  }
+
+  private groupByDate(
+    records: RecordRow[],
+    dateFieldId: string,
+    dateGrouping: string,
+  ): Map<string, RecordRow[]> {
+    const groups = new Map<string, RecordRow[]>()
+    for (const record of records) {
+      const rawValue = record.data[dateFieldId]
+      if (rawValue == null) continue
+      const key = dateBucketKey(String(rawValue), dateGrouping)
+      if (key === null) continue
+      const group = groups.get(key)
+      if (group) {
+        group.push(record)
+      } else {
+        groups.set(key, [record])
+      }
+    }
+    return groups
+  }
+
+  private filterRecords(
+    records: RecordRow[],
+    dataSource: ChartConfig['dataSource'],
+  ): RecordRow[] {
+    const { filterFieldId, filterOperator, filterValue } = dataSource
+    if (!filterFieldId || !filterOperator) return records
+
+    return records.filter((r) => {
+      const val = r.data[filterFieldId]
+      switch (filterOperator) {
+        case 'equals':
+          return val != null && String(val) === String(filterValue)
+        case 'not_equals':
+          return val == null || String(val) !== String(filterValue)
+        case 'contains':
+          return val != null && String(val).includes(String(filterValue))
+        case 'greater_than': {
+          const n = toNumber(val)
+          const t = toNumber(filterValue)
+          return n !== null && t !== null && n > t
+        }
+        case 'less_than': {
+          const n = toNumber(val)
+          const t = toNumber(filterValue)
+          return n !== null && t !== null && n < t
+        }
+        default:
+          return true
+      }
+    })
+  }
+
+  private sortDataPoints(
+    dataPoints: ChartDataPoint[],
+    sortBy?: 'label' | 'value',
+    sortOrder?: 'asc' | 'desc',
+  ): ChartDataPoint[] {
+    if (!sortBy) return dataPoints
+    const dir = sortOrder === 'desc' ? -1 : 1
+    return [...dataPoints].sort((a, b) => {
+      if (sortBy === 'value') return (a.value - b.value) * dir
+      return a.label.localeCompare(b.label) * dir
+    })
+  }
+}

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -1,0 +1,68 @@
+/**
+ * Chart type definitions for multitable dashboard V1.
+ */
+
+export type ChartType = 'bar' | 'line' | 'pie' | 'number' | 'table'
+
+export type AggregationFunction = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'count_distinct'
+
+export interface ChartAggregation {
+  function: AggregationFunction
+  fieldId?: string // required for sum/avg/min/max, optional for count
+}
+
+export interface ChartDataSource {
+  /** What to group by (X axis for bar/line, slices for pie) */
+  groupByFieldId?: string
+
+  /** What to aggregate (Y axis for bar/line, values for pie) */
+  aggregation: ChartAggregation
+
+  /** Optional: filter records before aggregation */
+  filterFieldId?: string
+  filterOperator?: 'equals' | 'not_equals' | 'contains' | 'greater_than' | 'less_than'
+  filterValue?: unknown
+
+  /** Optional: sort results */
+  sortBy?: 'label' | 'value'
+  sortOrder?: 'asc' | 'desc'
+
+  /** For line charts: time field for X axis */
+  dateFieldId?: string
+  dateGrouping?: 'day' | 'week' | 'month' | 'quarter' | 'year'
+
+  /** Limit number of groups/slices */
+  limit?: number
+}
+
+export interface ChartDisplayConfig {
+  title?: string
+  showLegend?: boolean
+  showValues?: boolean
+  colorScheme?: string
+  /** For number chart */
+  prefix?: string
+  suffix?: string
+}
+
+export interface ChartConfig {
+  id: string
+  name: string
+  type: ChartType
+  sheetId: string
+  viewId?: string // optional: use view's filters/sorts
+  dataSource: ChartDataSource
+  display: ChartDisplayConfig
+  createdBy: string
+  createdAt: string
+  updatedAt?: string
+}
+
+export interface ChartCreateInput {
+  name: string
+  type: ChartType
+  viewId?: string
+  dataSource: ChartDataSource
+  display?: ChartDisplayConfig
+  createdBy?: string
+}

--- a/packages/core-backend/src/multitable/dashboard-service.ts
+++ b/packages/core-backend/src/multitable/dashboard-service.ts
@@ -1,0 +1,148 @@
+/**
+ * Dashboard Service — in-memory CRUD for charts and dashboards (V1).
+ *
+ * Persistence is intentionally in-memory for V1; a future version will
+ * use Postgres. The service delegates aggregation to ChartAggregationService.
+ */
+
+import { randomUUID } from 'crypto'
+
+import type { ChartConfig, ChartCreateInput } from './charts'
+import type {
+  Dashboard,
+  DashboardCreateInput,
+  DashboardUpdateInput,
+} from './dashboard'
+import { ChartAggregationService } from './chart-aggregation-service'
+import type { ChartData } from './chart-aggregation-service'
+
+export type RecordProvider = (sheetId: string) => Promise<Array<{ data: Record<string, unknown> }>>
+
+export class DashboardService {
+  private dashboards: Map<string, Dashboard> = new Map()
+  private charts: Map<string, ChartConfig> = new Map()
+  private aggregationService = new ChartAggregationService()
+  private recordProvider: RecordProvider | undefined
+
+  /**
+   * Optionally inject a record provider that fetches records for a sheet.
+   * If not set, `getChartData` will return empty data.
+   */
+  setRecordProvider(provider: RecordProvider): void {
+    this.recordProvider = provider
+  }
+
+  // -----------------------------------------------------------------------
+  // Chart CRUD
+  // -----------------------------------------------------------------------
+
+  createChart(sheetId: string, input: ChartCreateInput): ChartConfig {
+    const id = `chart_${randomUUID()}`
+    const now = new Date().toISOString()
+    const chart: ChartConfig = {
+      id,
+      name: input.name,
+      type: input.type,
+      sheetId,
+      viewId: input.viewId,
+      dataSource: input.dataSource,
+      display: input.display ?? {},
+      createdBy: input.createdBy ?? 'system',
+      createdAt: now,
+    }
+    this.charts.set(id, chart)
+    return chart
+  }
+
+  getChart(chartId: string): ChartConfig | undefined {
+    return this.charts.get(chartId)
+  }
+
+  listCharts(sheetId: string): ChartConfig[] {
+    return Array.from(this.charts.values()).filter((c) => c.sheetId === sheetId)
+  }
+
+  updateChart(chartId: string, input: Partial<ChartConfig>): ChartConfig {
+    const existing = this.charts.get(chartId)
+    if (!existing) throw new Error(`Chart not found: ${chartId}`)
+    const updated: ChartConfig = {
+      ...existing,
+      ...input,
+      id: existing.id, // prevent id overwrite
+      sheetId: existing.sheetId,
+      createdBy: existing.createdBy,
+      createdAt: existing.createdAt,
+      updatedAt: new Date().toISOString(),
+    }
+    this.charts.set(chartId, updated)
+    return updated
+  }
+
+  deleteChart(chartId: string): void {
+    this.charts.delete(chartId)
+    // Also remove from any dashboard panels
+    for (const dashboard of this.dashboards.values()) {
+      dashboard.panels = dashboard.panels.filter((p) => p.chartId !== chartId)
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Dashboard CRUD
+  // -----------------------------------------------------------------------
+
+  createDashboard(input: DashboardCreateInput): Dashboard {
+    const id = `dash_${randomUUID()}`
+    const now = new Date().toISOString()
+    const dashboard: Dashboard = {
+      id,
+      name: input.name,
+      sheetId: input.sheetId,
+      panels: [],
+      createdBy: input.createdBy ?? 'system',
+      createdAt: now,
+    }
+    this.dashboards.set(id, dashboard)
+    return dashboard
+  }
+
+  getDashboard(dashboardId: string): Dashboard | undefined {
+    return this.dashboards.get(dashboardId)
+  }
+
+  listDashboards(sheetId: string): Dashboard[] {
+    return Array.from(this.dashboards.values()).filter((d) => d.sheetId === sheetId)
+  }
+
+  updateDashboard(dashboardId: string, input: DashboardUpdateInput): Dashboard {
+    const existing = this.dashboards.get(dashboardId)
+    if (!existing) throw new Error(`Dashboard not found: ${dashboardId}`)
+    const updated: Dashboard = {
+      ...existing,
+      name: input.name ?? existing.name,
+      panels: input.panels ?? existing.panels,
+      updatedAt: new Date().toISOString(),
+    }
+    this.dashboards.set(dashboardId, updated)
+    return updated
+  }
+
+  deleteDashboard(dashboardId: string): void {
+    this.dashboards.delete(dashboardId)
+  }
+
+  // -----------------------------------------------------------------------
+  // Chart data computation
+  // -----------------------------------------------------------------------
+
+  async getChartData(chartId: string): Promise<ChartData> {
+    const chart = this.charts.get(chartId)
+    if (!chart) throw new Error(`Chart not found: ${chartId}`)
+
+    let records: Array<{ data: Record<string, unknown> }> = []
+    if (this.recordProvider) {
+      records = await this.recordProvider(chart.sheetId)
+    }
+
+    return this.aggregationService.computeChartData(chart, records)
+  }
+}

--- a/packages/core-backend/src/multitable/dashboard.ts
+++ b/packages/core-backend/src/multitable/dashboard.ts
@@ -1,0 +1,30 @@
+/**
+ * Dashboard model definitions for multitable dashboard V1.
+ */
+
+export interface DashboardPanel {
+  id: string
+  chartId: string
+  position: { x: number; y: number; w: number; h: number } // grid layout
+}
+
+export interface Dashboard {
+  id: string
+  name: string
+  sheetId: string
+  panels: DashboardPanel[]
+  createdBy: string
+  createdAt: string
+  updatedAt?: string
+}
+
+export interface DashboardCreateInput {
+  name: string
+  sheetId: string
+  createdBy?: string
+}
+
+export interface DashboardUpdateInput {
+  name?: string
+  panels?: DashboardPanel[]
+}

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -1,0 +1,186 @@
+/**
+ * Dashboard & Chart REST API routes.
+ *
+ * Endpoints:
+ *   Charts:
+ *     GET    /api/multitable/:sheetId/charts
+ *     POST   /api/multitable/:sheetId/charts
+ *     GET    /api/multitable/:sheetId/charts/:id
+ *     PATCH  /api/multitable/:sheetId/charts/:id
+ *     DELETE /api/multitable/:sheetId/charts/:id
+ *     GET    /api/multitable/:sheetId/charts/:id/data
+ *
+ *   Dashboards:
+ *     GET    /api/multitable/:sheetId/dashboards
+ *     POST   /api/multitable/:sheetId/dashboards
+ *     GET    /api/multitable/:sheetId/dashboards/:id
+ *     PATCH  /api/multitable/:sheetId/dashboards/:id
+ *     DELETE /api/multitable/:sheetId/dashboards/:id
+ */
+
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { DashboardService } from '../multitable/dashboard-service'
+
+const dashboardService = new DashboardService()
+
+/** Expose the shared service for tests or external wiring. */
+export function getDashboardService(): DashboardService {
+  return dashboardService
+}
+
+function getUserId(req: Request): string {
+  const user = (req as unknown as { user?: { id?: unknown } }).user
+  const raw = user?.id ?? req.headers['x-user-id']
+  return raw ? String(raw) : 'anonymous'
+}
+
+export function dashboardRouter() {
+  const router = Router()
+
+  // -----------------------------------------------------------------------
+  // Chart routes
+  // -----------------------------------------------------------------------
+
+  /** GET /api/multitable/:sheetId/charts — list charts */
+  router.get('/:sheetId/charts', (_req: Request, res: Response) => {
+    try {
+      const charts = dashboardService.listCharts(_req.params.sheetId)
+      res.json({ items: charts })
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
+    }
+  })
+
+  /** POST /api/multitable/:sheetId/charts — create chart */
+  router.post('/:sheetId/charts', (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req)
+      const chart = dashboardService.createChart(req.params.sheetId, {
+        ...req.body,
+        createdBy: userId,
+      })
+      res.status(201).json(chart)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** GET /api/multitable/:sheetId/charts/:id — get chart config */
+  router.get('/:sheetId/charts/:id', (req: Request, res: Response) => {
+    const chart = dashboardService.getChart(req.params.id)
+    if (!chart || chart.sheetId !== req.params.sheetId) {
+      res.status(404).json({ error: 'Chart not found' })
+      return
+    }
+    res.json(chart)
+  })
+
+  /** PATCH /api/multitable/:sheetId/charts/:id — update chart */
+  router.patch('/:sheetId/charts/:id', (req: Request, res: Response) => {
+    try {
+      const chart = dashboardService.getChart(req.params.id)
+      if (!chart || chart.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Chart not found' })
+        return
+      }
+      const updated = dashboardService.updateChart(req.params.id, req.body)
+      res.json(updated)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** DELETE /api/multitable/:sheetId/charts/:id — delete chart */
+  router.delete('/:sheetId/charts/:id', (req: Request, res: Response) => {
+    const chart = dashboardService.getChart(req.params.id)
+    if (!chart || chart.sheetId !== req.params.sheetId) {
+      res.status(404).json({ error: 'Chart not found' })
+      return
+    }
+    dashboardService.deleteChart(req.params.id)
+    res.status(204).send()
+  })
+
+  /** GET /api/multitable/:sheetId/charts/:id/data — get computed chart data */
+  router.get('/:sheetId/charts/:id/data', async (req: Request, res: Response) => {
+    try {
+      const chart = dashboardService.getChart(req.params.id)
+      if (!chart || chart.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Chart not found' })
+        return
+      }
+      const data = await dashboardService.getChartData(req.params.id)
+      res.json(data)
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
+    }
+  })
+
+  // -----------------------------------------------------------------------
+  // Dashboard routes
+  // -----------------------------------------------------------------------
+
+  /** GET /api/multitable/:sheetId/dashboards — list dashboards */
+  router.get('/:sheetId/dashboards', (req: Request, res: Response) => {
+    try {
+      const dashboards = dashboardService.listDashboards(req.params.sheetId)
+      res.json({ items: dashboards })
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
+    }
+  })
+
+  /** POST /api/multitable/:sheetId/dashboards — create dashboard */
+  router.post('/:sheetId/dashboards', (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req)
+      const dashboard = dashboardService.createDashboard({
+        name: req.body.name,
+        sheetId: req.params.sheetId,
+        createdBy: userId,
+      })
+      res.status(201).json(dashboard)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** GET /api/multitable/:sheetId/dashboards/:id — get dashboard */
+  router.get('/:sheetId/dashboards/:id', (req: Request, res: Response) => {
+    const dashboard = dashboardService.getDashboard(req.params.id)
+    if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
+      res.status(404).json({ error: 'Dashboard not found' })
+      return
+    }
+    res.json(dashboard)
+  })
+
+  /** PATCH /api/multitable/:sheetId/dashboards/:id — update dashboard */
+  router.patch('/:sheetId/dashboards/:id', (req: Request, res: Response) => {
+    try {
+      const dashboard = dashboardService.getDashboard(req.params.id)
+      if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Dashboard not found' })
+        return
+      }
+      const updated = dashboardService.updateDashboard(req.params.id, req.body)
+      res.json(updated)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** DELETE /api/multitable/:sheetId/dashboards/:id — delete dashboard */
+  router.delete('/:sheetId/dashboards/:id', (req: Request, res: Response) => {
+    const dashboard = dashboardService.getDashboard(req.params.id)
+    if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
+      res.status(404).json({ error: 'Dashboard not found' })
+      return
+    }
+    dashboardService.deleteDashboard(req.params.id)
+    res.status(204).send()
+  })
+
+  return router
+}

--- a/packages/core-backend/tests/unit/chart-dashboard.test.ts
+++ b/packages/core-backend/tests/unit/chart-dashboard.test.ts
@@ -1,0 +1,739 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { ChartAggregationService } from '../../src/multitable/chart-aggregation-service'
+import type { ChartData } from '../../src/multitable/chart-aggregation-service'
+import { DashboardService } from '../../src/multitable/dashboard-service'
+import type { ChartConfig, ChartCreateInput } from '../../src/multitable/charts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRecords(rows: Record<string, unknown>[]): Array<{ data: Record<string, unknown> }> {
+  return rows.map((data) => ({ data }))
+}
+
+function makeChart(overrides: Partial<ChartConfig> = {}): ChartConfig {
+  return {
+    id: 'chart_test',
+    name: 'Test Chart',
+    type: 'bar',
+    sheetId: 'sheet1',
+    dataSource: {
+      groupByFieldId: 'status',
+      aggregation: { function: 'count' },
+    },
+    display: {},
+    createdBy: 'user1',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const sampleRecords = makeRecords([
+  { status: 'open', amount: 10, category: 'A', date: '2026-01-15' },
+  { status: 'open', amount: 20, category: 'B', date: '2026-01-20' },
+  { status: 'closed', amount: 30, category: 'A', date: '2026-02-10' },
+  { status: 'closed', amount: 40, category: 'B', date: '2026-03-05' },
+  { status: 'open', amount: 50, category: 'A', date: '2026-04-12' },
+])
+
+// ---------------------------------------------------------------------------
+// ChartAggregationService
+// ---------------------------------------------------------------------------
+
+describe('ChartAggregationService', () => {
+  let service: ChartAggregationService
+
+  beforeEach(() => {
+    service = new ChartAggregationService()
+  })
+
+  // -- Aggregation functions -----------------------------------------------
+
+  describe('aggregation: count', () => {
+    it('counts records per group', async () => {
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(2)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      const closed = result.dataPoints.find((dp) => dp.label === 'closed')
+      expect(open?.value).toBe(3)
+      expect(closed?.value).toBe(2)
+    })
+  })
+
+  describe('aggregation: sum', () => {
+    it('sums numeric field values per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'sum', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      expect(open?.value).toBe(80) // 10+20+50
+    })
+  })
+
+  describe('aggregation: avg', () => {
+    it('averages numeric field values per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'avg', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const closed = result.dataPoints.find((dp) => dp.label === 'closed')
+      expect(closed?.value).toBeCloseTo(35) // (30+40)/2
+    })
+  })
+
+  describe('aggregation: min', () => {
+    it('finds minimum value per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'min', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      expect(open?.value).toBe(10)
+    })
+  })
+
+  describe('aggregation: max', () => {
+    it('finds maximum value per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'max', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      expect(open?.value).toBe(50)
+    })
+  })
+
+  describe('aggregation: count_distinct', () => {
+    it('counts unique values per group', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count_distinct', fieldId: 'category' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      expect(open?.value).toBe(2) // A, B
+    })
+  })
+
+  // -- Grouping ------------------------------------------------------------
+
+  describe('grouping: by text field', () => {
+    it('groups by a text field', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(2)
+      const a = result.dataPoints.find((dp) => dp.label === 'A')
+      expect(a?.value).toBe(3)
+    })
+  })
+
+  describe('grouping: by select field', () => {
+    it('groups by select/status field', async () => {
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints.map((dp) => dp.label).sort()).toEqual(['closed', 'open'])
+    })
+  })
+
+  // -- Date grouping -------------------------------------------------------
+
+  describe('date grouping: day', () => {
+    it('buckets records by day', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'day',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints.length).toBe(5) // 5 unique days
+    })
+  })
+
+  describe('date grouping: month', () => {
+    it('buckets records by month', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'month',
+          aggregation: { function: 'sum', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const jan = result.dataPoints.find((dp) => dp.label === '2026-01')
+      expect(jan?.value).toBe(30) // 10+20
+    })
+  })
+
+  describe('date grouping: quarter', () => {
+    it('buckets records by quarter', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'quarter',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const q1 = result.dataPoints.find((dp) => dp.label === '2026-Q1')
+      expect(q1?.value).toBe(4) // Jan(2) + Feb(1) + Mar(1)
+    })
+  })
+
+  describe('date grouping: year', () => {
+    it('buckets records by year', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'year',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(1)
+      expect(result.dataPoints[0].label).toBe('2026')
+      expect(result.dataPoints[0].value).toBe(5)
+    })
+  })
+
+  describe('date grouping: week', () => {
+    it('buckets records by ISO week start', async () => {
+      const chart = makeChart({
+        type: 'line',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'week',
+          aggregation: { function: 'count' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      // Each date is in a different week except possibly Jan 15 & 20
+      expect(result.dataPoints.length).toBeGreaterThanOrEqual(4)
+    })
+  })
+
+  // -- Filtering -----------------------------------------------------------
+
+  describe('filter: equals', () => {
+    it('filters records by equals operator', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'count' },
+          filterFieldId: 'status',
+          filterOperator: 'equals',
+          filterValue: 'open',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(3)
+    })
+  })
+
+  describe('filter: not_equals', () => {
+    it('excludes records matching value', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'count' },
+          filterFieldId: 'status',
+          filterOperator: 'not_equals',
+          filterValue: 'open',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(2)
+    })
+  })
+
+  describe('filter: contains', () => {
+    it('filters records containing substring', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          filterFieldId: 'category',
+          filterOperator: 'contains',
+          filterValue: 'A',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(3)
+    })
+  })
+
+  describe('filter: greater_than', () => {
+    it('filters numeric values greater than threshold', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          filterFieldId: 'amount',
+          filterOperator: 'greater_than',
+          filterValue: 25,
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(3) // 30, 40, 50
+    })
+  })
+
+  describe('filter: less_than', () => {
+    it('filters numeric values less than threshold', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          filterFieldId: 'amount',
+          filterOperator: 'less_than',
+          filterValue: 25,
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const total = result.dataPoints.reduce((s, dp) => s + dp.value, 0)
+      expect(total).toBe(2) // 10, 20
+    })
+  })
+
+  // -- Edge cases ----------------------------------------------------------
+
+  describe('edge case: empty records', () => {
+    it('returns empty data points', async () => {
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, [])
+      expect(result.dataPoints).toHaveLength(0)
+    })
+  })
+
+  describe('edge case: null values', () => {
+    it('groups null values under (empty)', async () => {
+      const records = makeRecords([
+        { status: null, amount: 10 },
+        { status: 'open', amount: 20 },
+      ])
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, records)
+      const empty = result.dataPoints.find((dp) => dp.label === '(empty)')
+      expect(empty?.value).toBe(1)
+    })
+  })
+
+  describe('edge case: non-numeric for sum/avg', () => {
+    it('skips non-numeric values in sum', async () => {
+      const records = makeRecords([
+        { group: 'A', val: 10 },
+        { group: 'A', val: 'not-a-number' },
+        { group: 'A', val: null },
+        { group: 'A', val: 30 },
+      ])
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'group',
+          aggregation: { function: 'sum', fieldId: 'val' },
+        },
+      })
+      const result = await service.computeChartData(chart, records)
+      expect(result.dataPoints[0].value).toBe(40) // 10+30
+    })
+
+    it('returns 0 for avg when all non-numeric', async () => {
+      const records = makeRecords([
+        { group: 'A', val: 'text' },
+        { group: 'A', val: undefined },
+      ])
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'group',
+          aggregation: { function: 'avg', fieldId: 'val' },
+        },
+      })
+      const result = await service.computeChartData(chart, records)
+      expect(result.dataPoints[0].value).toBe(0)
+    })
+  })
+
+  describe('edge case: min/max with no numeric values', () => {
+    it('returns 0 when no numeric values exist', async () => {
+      const records = makeRecords([
+        { group: 'A', val: 'text' },
+      ])
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'group',
+          aggregation: { function: 'min', fieldId: 'val' },
+        },
+      })
+      const result = await service.computeChartData(chart, records)
+      expect(result.dataPoints[0].value).toBe(0)
+    })
+  })
+
+  // -- Number chart --------------------------------------------------------
+
+  describe('number chart', () => {
+    it('returns single aggregated value', async () => {
+      const chart = makeChart({
+        type: 'number',
+        dataSource: {
+          aggregation: { function: 'sum', fieldId: 'amount' },
+        },
+        display: { title: 'Total Revenue' },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(1)
+      expect(result.dataPoints[0].value).toBe(150) // 10+20+30+40+50
+      expect(result.dataPoints[0].label).toBe('Total Revenue')
+      expect(result.total).toBe(150)
+    })
+
+    it('uses chart name when no title', async () => {
+      const chart = makeChart({
+        type: 'number',
+        name: 'Record Count',
+        dataSource: {
+          aggregation: { function: 'count' },
+        },
+        display: {},
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints[0].label).toBe('Record Count')
+      expect(result.dataPoints[0].value).toBe(5)
+    })
+  })
+
+  // -- Table chart ---------------------------------------------------------
+
+  describe('table chart', () => {
+    it('returns grouped data as table rows', async () => {
+      const chart = makeChart({
+        type: 'table',
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'sum', fieldId: 'amount' },
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.chartType).toBe('table')
+      expect(result.dataPoints.length).toBe(2)
+      const a = result.dataPoints.find((dp) => dp.label === 'A')
+      expect(a?.value).toBe(90) // 10+30+50
+    })
+  })
+
+  // -- Sorting -------------------------------------------------------------
+
+  describe('sorting: by label asc', () => {
+    it('sorts data points by label ascending', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          sortBy: 'label',
+          sortOrder: 'asc',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints[0].label).toBe('closed')
+      expect(result.dataPoints[1].label).toBe('open')
+    })
+  })
+
+  describe('sorting: by value desc', () => {
+    it('sorts data points by value descending', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          sortBy: 'value',
+          sortOrder: 'desc',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints[0].value).toBeGreaterThanOrEqual(result.dataPoints[1].value)
+    })
+  })
+
+  describe('sorting: by value asc', () => {
+    it('sorts data points by value ascending', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+          sortBy: 'value',
+          sortOrder: 'asc',
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints[0].value).toBeLessThanOrEqual(result.dataPoints[1].value)
+    })
+  })
+
+  // -- Limit ---------------------------------------------------------------
+
+  describe('limit', () => {
+    it('limits the number of data points', async () => {
+      const chart = makeChart({
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'count' },
+          sortBy: 'value',
+          sortOrder: 'desc',
+          limit: 1,
+        },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.dataPoints).toHaveLength(1)
+    })
+  })
+
+  // -- Metadata ------------------------------------------------------------
+
+  describe('metadata', () => {
+    it('includes metadata in result', async () => {
+      const chart = makeChart()
+      const result = await service.computeChartData(chart, sampleRecords)
+      expect(result.metadata?.groupByField).toBe('status')
+      expect(result.metadata?.aggregationFunction).toBe('count')
+      expect(result.metadata?.recordCount).toBe(5)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DashboardService
+// ---------------------------------------------------------------------------
+
+describe('DashboardService', () => {
+  let service: DashboardService
+
+  beforeEach(() => {
+    service = new DashboardService()
+  })
+
+  // -- Chart CRUD ----------------------------------------------------------
+
+  describe('chart CRUD', () => {
+    it('creates a chart', () => {
+      const chart = service.createChart('sheet1', {
+        name: 'My Chart',
+        type: 'bar',
+        dataSource: { aggregation: { function: 'count' } },
+      })
+      expect(chart.id).toMatch(/^chart_/)
+      expect(chart.name).toBe('My Chart')
+      expect(chart.sheetId).toBe('sheet1')
+    })
+
+    it('lists charts for a sheet', () => {
+      service.createChart('sheet1', { name: 'C1', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      service.createChart('sheet2', { name: 'C2', type: 'pie', dataSource: { aggregation: { function: 'count' } } })
+      service.createChart('sheet1', { name: 'C3', type: 'line', dataSource: { aggregation: { function: 'sum', fieldId: 'x' } } })
+
+      const list = service.listCharts('sheet1')
+      expect(list).toHaveLength(2)
+      expect(list.map((c) => c.name).sort()).toEqual(['C1', 'C3'])
+    })
+
+    it('gets a chart by id', () => {
+      const created = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const fetched = service.getChart(created.id)
+      expect(fetched?.id).toBe(created.id)
+    })
+
+    it('updates a chart', () => {
+      const created = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const updated = service.updateChart(created.id, { name: 'Updated' })
+      expect(updated.name).toBe('Updated')
+      expect(updated.updatedAt).toBeDefined()
+      // Immutable fields preserved
+      expect(updated.id).toBe(created.id)
+      expect(updated.sheetId).toBe('sheet1')
+    })
+
+    it('throws when updating non-existent chart', () => {
+      expect(() => service.updateChart('no_such_id', { name: 'X' })).toThrow('Chart not found')
+    })
+
+    it('deletes a chart', () => {
+      const created = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      service.deleteChart(created.id)
+      expect(service.getChart(created.id)).toBeUndefined()
+    })
+
+    it('deleting a chart removes it from dashboard panels', () => {
+      const chart = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const dash = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      service.updateDashboard(dash.id, {
+        panels: [{ id: 'p1', chartId: chart.id, position: { x: 0, y: 0, w: 6, h: 4 } }],
+      })
+      service.deleteChart(chart.id)
+      const updated = service.getDashboard(dash.id)
+      expect(updated?.panels).toHaveLength(0)
+    })
+  })
+
+  // -- Dashboard CRUD ------------------------------------------------------
+
+  describe('dashboard CRUD', () => {
+    it('creates a dashboard', () => {
+      const dash = service.createDashboard({ name: 'My Dashboard', sheetId: 'sheet1' })
+      expect(dash.id).toMatch(/^dash_/)
+      expect(dash.name).toBe('My Dashboard')
+      expect(dash.panels).toHaveLength(0)
+    })
+
+    it('lists dashboards for a sheet', () => {
+      service.createDashboard({ name: 'D1', sheetId: 'sheet1' })
+      service.createDashboard({ name: 'D2', sheetId: 'sheet2' })
+      expect(service.listDashboards('sheet1')).toHaveLength(1)
+    })
+
+    it('gets a dashboard by id', () => {
+      const created = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      expect(service.getDashboard(created.id)?.id).toBe(created.id)
+    })
+
+    it('updates dashboard name', () => {
+      const created = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      const updated = service.updateDashboard(created.id, { name: 'Renamed' })
+      expect(updated.name).toBe('Renamed')
+      expect(updated.updatedAt).toBeDefined()
+    })
+
+    it('adds panels to a dashboard', () => {
+      const chart = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const dash = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      const updated = service.updateDashboard(dash.id, {
+        panels: [
+          { id: 'p1', chartId: chart.id, position: { x: 0, y: 0, w: 6, h: 4 } },
+          { id: 'p2', chartId: chart.id, position: { x: 6, y: 0, w: 6, h: 4 } },
+        ],
+      })
+      expect(updated.panels).toHaveLength(2)
+    })
+
+    it('reorders panels', () => {
+      const chart = service.createChart('sheet1', { name: 'C', type: 'bar', dataSource: { aggregation: { function: 'count' } } })
+      const dash = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      service.updateDashboard(dash.id, {
+        panels: [
+          { id: 'p1', chartId: chart.id, position: { x: 0, y: 0, w: 6, h: 4 } },
+          { id: 'p2', chartId: chart.id, position: { x: 6, y: 0, w: 6, h: 4 } },
+        ],
+      })
+      const reordered = service.updateDashboard(dash.id, {
+        panels: [
+          { id: 'p2', chartId: chart.id, position: { x: 0, y: 0, w: 6, h: 4 } },
+          { id: 'p1', chartId: chart.id, position: { x: 6, y: 0, w: 6, h: 4 } },
+        ],
+      })
+      expect(reordered.panels[0].id).toBe('p2')
+    })
+
+    it('throws when updating non-existent dashboard', () => {
+      expect(() => service.updateDashboard('no_such', { name: 'X' })).toThrow('Dashboard not found')
+    })
+
+    it('deletes a dashboard', () => {
+      const created = service.createDashboard({ name: 'D', sheetId: 'sheet1' })
+      service.deleteDashboard(created.id)
+      expect(service.getDashboard(created.id)).toBeUndefined()
+    })
+  })
+
+  // -- Chart data computation ----------------------------------------------
+
+  describe('chart data computation', () => {
+    it('computes chart data with record provider', async () => {
+      const chart = service.createChart('sheet1', {
+        name: 'Status Counts',
+        type: 'bar',
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+        },
+      })
+
+      service.setRecordProvider(async (_sheetId: string) => sampleRecords)
+
+      const data = await service.getChartData(chart.id)
+      expect(data.chartId).toBe(chart.id)
+      expect(data.chartType).toBe('bar')
+      expect(data.dataPoints.length).toBeGreaterThan(0)
+    })
+
+    it('returns empty data when no record provider', async () => {
+      const chart = service.createChart('sheet1', {
+        name: 'Empty',
+        type: 'bar',
+        dataSource: {
+          groupByFieldId: 'status',
+          aggregation: { function: 'count' },
+        },
+      })
+      const data = await service.getChartData(chart.id)
+      expect(data.dataPoints).toHaveLength(0)
+    })
+
+    it('throws when chart not found', async () => {
+      await expect(service.getChartData('nonexistent')).rejects.toThrow('Chart not found')
+    })
+
+    it('full pipeline: records → filter → group → aggregate → sort → limit', async () => {
+      const chart = service.createChart('sheet1', {
+        name: 'Top Category',
+        type: 'pie',
+        dataSource: {
+          groupByFieldId: 'category',
+          aggregation: { function: 'sum', fieldId: 'amount' },
+          filterFieldId: 'status',
+          filterOperator: 'equals',
+          filterValue: 'open',
+          sortBy: 'value',
+          sortOrder: 'desc',
+          limit: 1,
+        },
+      })
+
+      service.setRecordProvider(async () => sampleRecords)
+
+      const data = await service.getChartData(chart.id)
+      expect(data.dataPoints).toHaveLength(1)
+      // open records: A=10+50=60, B=20 → top 1 is A
+      expect(data.dataPoints[0].label).toBe('A')
+      expect(data.dataPoints[0].value).toBe(60)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- **MetaFormShareManager**: Toggle public form sharing, display/copy public link, regenerate token, set expiry date, preview form, status indicator (active/expired/disabled)
- **MetaFieldValidationPanel**: Configure field validation rules based on field type -- required toggle for all types, minLength/maxLength/pattern (with email/URL/phone presets) for text, min/max for number, enum for select fields, custom error messages, rule preview
- **MetaApiTokenManager**: Tabbed manager with API token CRUD (create with scopes, show plaintext once, revoke, rotate) and webhook CRUD (create/edit with HTTPS URL + events, toggle active, delete, view delivery history)
- API client extended with 12 new methods for form-share, tokens, and webhooks endpoints
- Type definitions added for FormShareConfig, ApiToken, Webhook, WebhookDelivery, FieldValidationRule
- Workbench wired with "Share Form" button (form views) and "API & Webhooks" button

## Test plan
- [x] 9 tests for MetaFormShareManager (toggle, copy link, regenerate, expiry, status)
- [x] 9 tests for MetaFieldValidationPanel (type-specific rules, add/remove, preview)
- [x] 11 tests for MetaApiTokenManager (token CRUD, show-once, webhook CRUD, deliveries)
- [x] All 29 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)