### PR TITLE
feat(multitable): Week 6/7 frontend — automation rule editor, chart renderer, dashboard

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -42,6 +42,13 @@ import type {
   MetaViewPermissionEntry,
   RecordPermissionEntry,
   AutomationRule,
+  AutomationExecution,
+  AutomationStats,
+  ChartConfig,
+  ChartCreateInput,
+  ChartData,
+  Dashboard,
+  DashboardUpdateInput,
   FormShareConfig,
   FormShareConfigUpdate,
   ApiToken,
@@ -1019,6 +1026,109 @@ export class MultitableApiClient {
     const res = await this.fetch(`/api/multitable/webhooks/${encodeURIComponent(id)}/deliveries`)
     const data = await parseJson<{ deliveries: WebhookDelivery[] }>(res)
     return data.deliveries ?? []
+  }
+
+  // --- Automation V1: test / logs / stats ---
+  async testAutomationRule(sheetId: string, ruleId: string): Promise<AutomationExecution> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}/test`,
+      { method: 'POST' },
+    )
+    return parseJson<AutomationExecution>(res)
+  }
+
+  async getAutomationLogs(sheetId: string, ruleId: string, limit?: number): Promise<AutomationExecution[]> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}/logs${qs({ limit })}`,
+    )
+    const data = await parseJson<{ executions: AutomationExecution[] }>(res)
+    return Array.isArray(data?.executions) ? data.executions : []
+  }
+
+  async getAutomationStats(sheetId: string, ruleId: string): Promise<AutomationStats> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}/stats`,
+    )
+    return parseJson<AutomationStats>(res)
+  }
+
+  // --- Charts ---
+  async listCharts(sheetId: string): Promise<ChartConfig[]> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts`)
+    const data = await parseJson<{ charts: ChartConfig[] }>(res)
+    return Array.isArray(data?.charts) ? data.charts : []
+  }
+
+  async createChart(sheetId: string, input: ChartCreateInput): Promise<ChartConfig> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return parseJson<ChartConfig>(res)
+  }
+
+  async updateChart(sheetId: string, chartId: string, input: Partial<ChartCreateInput>): Promise<ChartConfig> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts/${encodeURIComponent(chartId)}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      },
+    )
+    return parseJson<ChartConfig>(res)
+  }
+
+  async deleteChart(sheetId: string, chartId: string): Promise<void> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts/${encodeURIComponent(chartId)}`,
+      { method: 'DELETE' },
+    )
+    await parseJson(res)
+  }
+
+  async getChartData(sheetId: string, chartId: string): Promise<ChartData> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts/${encodeURIComponent(chartId)}/data`,
+    )
+    return parseJson<ChartData>(res)
+  }
+
+  // --- Dashboards ---
+  async listDashboards(sheetId: string): Promise<Dashboard[]> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/dashboards`)
+    const data = await parseJson<{ dashboards: Dashboard[] }>(res)
+    return Array.isArray(data?.dashboards) ? data.dashboards : []
+  }
+
+  async createDashboard(sheetId: string, input: { name: string }): Promise<Dashboard> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/dashboards`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return parseJson<Dashboard>(res)
+  }
+
+  async updateDashboard(sheetId: string, dashboardId: string, input: DashboardUpdateInput): Promise<Dashboard> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/dashboards/${encodeURIComponent(dashboardId)}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      },
+    )
+    return parseJson<Dashboard>(res)
+  }
+
+  async deleteDashboard(sheetId: string, dashboardId: string): Promise<void> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/dashboards/${encodeURIComponent(dashboardId)}`,
+      { method: 'DELETE' },
+    )
+    await parseJson(res)
   }
 }
 

--- a/apps/web/src/multitable/components/MetaAutomationLogViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationLogViewer.vue
@@ -1,0 +1,280 @@
+<template>
+  <div v-if="visible" class="meta-log-viewer__overlay" @click.self="$emit('close')">
+    <div class="meta-log-viewer">
+      <div class="meta-log-viewer__header">
+        <h4 class="meta-log-viewer__title">Execution Logs</h4>
+        <button class="meta-log-viewer__close" type="button" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="meta-log-viewer__body">
+        <!-- Stats bar -->
+        <div v-if="stats" class="meta-log-viewer__stats" data-stats="true">
+          <div class="meta-log-viewer__stat">
+            <span class="meta-log-viewer__stat-label">Total</span>
+            <span class="meta-log-viewer__stat-value">{{ stats.total }}</span>
+          </div>
+          <div class="meta-log-viewer__stat">
+            <span class="meta-log-viewer__stat-label">Success</span>
+            <span class="meta-log-viewer__stat-value meta-log-viewer__stat-value--success">{{ stats.success }}</span>
+          </div>
+          <div class="meta-log-viewer__stat">
+            <span class="meta-log-viewer__stat-label">Failed</span>
+            <span class="meta-log-viewer__stat-value meta-log-viewer__stat-value--failed">{{ stats.failed }}</span>
+          </div>
+          <div class="meta-log-viewer__stat">
+            <span class="meta-log-viewer__stat-label">Avg duration</span>
+            <span class="meta-log-viewer__stat-value">{{ stats.avgDurationMs }}ms</span>
+          </div>
+        </div>
+
+        <!-- Toolbar -->
+        <div class="meta-log-viewer__toolbar">
+          <select v-model="statusFilter" class="meta-log-viewer__select" data-field="statusFilter">
+            <option value="">All statuses</option>
+            <option value="success">Success</option>
+            <option value="failed">Failed</option>
+            <option value="skipped">Skipped</option>
+          </select>
+          <button class="meta-log-viewer__btn" type="button" data-action="refresh" @click="loadData">Refresh</button>
+        </div>
+
+        <!-- Log list -->
+        <div v-if="loading" class="meta-log-viewer__empty">Loading logs...</div>
+        <div v-else-if="filteredLogs.length === 0" class="meta-log-viewer__empty" data-empty="true">No execution logs found.</div>
+        <div
+          v-for="log in filteredLogs"
+          :key="log.id"
+          class="meta-log-viewer__log-item"
+          :data-log-id="log.id"
+          @click="toggleExpand(log.id)"
+        >
+          <div class="meta-log-viewer__log-summary">
+            <span class="meta-log-viewer__log-time">{{ formatTime(log.startedAt) }}</span>
+            <span
+              class="meta-log-viewer__badge"
+              :class="`meta-log-viewer__badge--${log.status}`"
+              :data-status="log.status"
+            >{{ log.status }}</span>
+            <span class="meta-log-viewer__log-trigger">{{ log.triggerType }}</span>
+            <span class="meta-log-viewer__log-duration">{{ log.durationMs ?? '-' }}ms</span>
+          </div>
+          <div v-if="expandedId === log.id && log.steps" class="meta-log-viewer__log-detail" data-detail="true">
+            <div
+              v-for="(step, idx) in log.steps"
+              :key="idx"
+              class="meta-log-viewer__step"
+            >
+              <span class="meta-log-viewer__step-num">{{ idx + 1 }}.</span>
+              <span class="meta-log-viewer__step-type">{{ step.actionType }}</span>
+              <span
+                class="meta-log-viewer__badge meta-log-viewer__badge--sm"
+                :class="`meta-log-viewer__badge--${step.status}`"
+              >{{ step.status }}</span>
+              <span v-if="step.durationMs" class="meta-log-viewer__step-dur">{{ step.durationMs }}ms</span>
+              <div v-if="step.error" class="meta-log-viewer__step-error">{{ step.error }}</div>
+              <div v-if="step.output" class="meta-log-viewer__step-output">{{ JSON.stringify(step.output) }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { AutomationExecution, AutomationStats } from '../types'
+import type { MultitableApiClient } from '../api/client'
+
+const props = defineProps<{
+  sheetId: string
+  ruleId: string
+  visible: boolean
+  client?: MultitableApiClient
+}>()
+
+defineEmits<{
+  (e: 'close'): void
+}>()
+
+const loading = ref(false)
+const logs = ref<AutomationExecution[]>([])
+const stats = ref<AutomationStats | null>(null)
+const statusFilter = ref('')
+const expandedId = ref<string | null>(null)
+
+const filteredLogs = computed(() => {
+  if (!statusFilter.value) return logs.value
+  return logs.value.filter((l) => l.status === statusFilter.value)
+})
+
+function toggleExpand(id: string) {
+  expandedId.value = expandedId.value === id ? null : id
+}
+
+function formatTime(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return ts
+  }
+}
+
+async function loadData() {
+  if (!props.client || !props.sheetId || !props.ruleId) return
+  loading.value = true
+  try {
+    const [logsResult, statsResult] = await Promise.all([
+      props.client.getAutomationLogs(props.sheetId, props.ruleId, 50),
+      props.client.getAutomationStats(props.sheetId, props.ruleId),
+    ])
+    logs.value = logsResult
+    stats.value = statsResult
+  } catch {
+    // silently fail
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v) {
+      expandedId.value = null
+      statusFilter.value = ''
+      void loadData()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.meta-log-viewer__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.meta-log-viewer {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  width: 620px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-log-viewer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-log-viewer__title { margin: 0; font-size: 16px; font-weight: 700; color: #0f172a; }
+.meta-log-viewer__close { border: none; background: none; font-size: 22px; cursor: pointer; color: #64748b; line-height: 1; padding: 0 4px; }
+
+.meta-log-viewer__body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+}
+
+.meta-log-viewer__stats {
+  display: flex;
+  gap: 16px;
+  padding: 12px;
+  background: #f8fafc;
+  border-radius: 10px;
+}
+
+.meta-log-viewer__stat { display: flex; flex-direction: column; align-items: center; gap: 2px; flex: 1; }
+.meta-log-viewer__stat-label { font-size: 11px; color: #94a3b8; text-transform: uppercase; font-weight: 600; }
+.meta-log-viewer__stat-value { font-size: 18px; font-weight: 700; color: #0f172a; }
+.meta-log-viewer__stat-value--success { color: #16a34a; }
+.meta-log-viewer__stat-value--failed { color: #dc2626; }
+
+.meta-log-viewer__toolbar { display: flex; gap: 8px; align-items: center; }
+
+.meta-log-viewer__select {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.meta-log-viewer__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 14px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.meta-log-viewer__empty {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.meta-log-viewer__log-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.meta-log-viewer__log-item:hover { background: #f8fafc; }
+
+.meta-log-viewer__log-summary { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+.meta-log-viewer__log-time { color: #64748b; min-width: 140px; }
+.meta-log-viewer__log-trigger { color: #475569; }
+.meta-log-viewer__log-duration { margin-left: auto; color: #94a3b8; }
+
+.meta-log-viewer__badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.meta-log-viewer__badge--success { background: #dcfce7; color: #16a34a; }
+.meta-log-viewer__badge--failed { background: #fef2f2; color: #dc2626; }
+.meta-log-viewer__badge--skipped { background: #f1f5f9; color: #64748b; }
+.meta-log-viewer__badge--sm { font-size: 10px; padding: 1px 6px; }
+
+.meta-log-viewer__log-detail {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-log-viewer__step { display: flex; align-items: center; gap: 8px; font-size: 12px; flex-wrap: wrap; }
+.meta-log-viewer__step-num { font-weight: 700; color: #2563eb; }
+.meta-log-viewer__step-type { color: #475569; }
+.meta-log-viewer__step-dur { color: #94a3b8; margin-left: auto; }
+.meta-log-viewer__step-error { width: 100%; padding: 4px 8px; background: #fef2f2; color: #dc2626; border-radius: 4px; font-size: 11px; }
+.meta-log-viewer__step-output { width: 100%; padding: 4px 8px; background: #f8fafc; color: #475569; border-radius: 4px; font-size: 11px; word-break: break-all; }
+</style>

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -109,21 +109,44 @@
           <div class="meta-automation__card-desc">
             {{ describeTrigger(rule) }} &rarr; {{ describeAction(rule) }}
           </div>
+          <div v-if="ruleStats[rule.id]" class="meta-automation__card-stats">
+            <span class="meta-automation__stat meta-automation__stat--success">{{ ruleStats[rule.id].success }} ok</span>
+            <span class="meta-automation__stat meta-automation__stat--failed">{{ ruleStats[rule.id].failed }} fail</span>
+          </div>
           <div class="meta-automation__card-actions">
-            <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openEditForm(rule)">Edit</button>
+            <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openRuleEditor(rule)">Edit</button>
+            <button class="meta-automation__btn" type="button" data-automation-logs="true" @click="openLogViewer(rule)">View Logs</button>
             <button class="meta-automation__btn meta-automation__btn--danger" type="button" data-automation-delete="true" @click="onDelete(rule)">Delete</button>
           </div>
         </div>
       </div>
     </div>
+    <MetaAutomationRuleEditor
+      :visible="showRuleEditor"
+      :sheet-id="sheetId"
+      :rule="editingRule ?? undefined"
+      :fields="fields"
+      @close="showRuleEditor = false"
+      @save="onRuleEditorSave"
+      @test="onTestRule"
+    />
+    <MetaAutomationLogViewer
+      :visible="showLogViewer"
+      :sheet-id="sheetId"
+      :rule-id="logViewerRuleId"
+      :client="client"
+      @close="showLogViewer = false"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import type { AutomationRule, AutomationTriggerType, AutomationActionType } from '../types'
+import type { AutomationRule, AutomationTriggerType, AutomationActionType, AutomationStats } from '../types'
 import { useMultitableAutomations } from '../composables/useMultitableAutomations'
 import type { MultitableApiClient } from '../api/client'
+import MetaAutomationRuleEditor from './MetaAutomationRuleEditor.vue'
+import MetaAutomationLogViewer from './MetaAutomationLogViewer.vue'
 
 const props = defineProps<{
   visible: boolean
@@ -166,6 +189,61 @@ function emptyDraft(): DraftState {
 }
 
 const draft = ref<DraftState>(emptyDraft())
+
+// --- Rule editor + log viewer state ---
+const showRuleEditor = ref(false)
+const editingRule = ref<AutomationRule | null>(null)
+const showLogViewer = ref(false)
+const logViewerRuleId = ref('')
+const ruleStats = ref<Record<string, AutomationStats>>({})
+
+function openRuleEditor(rule?: AutomationRule) {
+  editingRule.value = rule ?? null
+  editingRuleId.value = rule?.id ?? null
+  showRuleEditor.value = true
+  showForm.value = false
+}
+
+function openLogViewer(rule: AutomationRule) {
+  logViewerRuleId.value = rule.id
+  showLogViewer.value = true
+}
+
+async function onRuleEditorSave(payload: Partial<AutomationRule>) {
+  try {
+    if (editingRule.value?.id) {
+      await updateRule(props.sheetId, editingRule.value.id, payload)
+    } else {
+      await createRule(props.sheetId, payload as Omit<AutomationRule, 'id' | 'sheetId' | 'enabled' | 'createdAt' | 'updatedAt' | 'createdBy'>)
+    }
+    showRuleEditor.value = false
+    editingRule.value = null
+    emit('updated')
+  } catch {
+    // error ref is set by composable
+  }
+}
+
+async function onTestRule(ruleId: string) {
+  if (!props.client) return
+  try {
+    await props.client.testAutomationRule(props.sheetId, ruleId)
+  } catch {
+    // silently fail
+  }
+}
+
+async function loadRuleStats() {
+  if (!props.client) return
+  for (const rule of rules.value) {
+    try {
+      const st = await props.client.getAutomationStats(props.sheetId, rule.id)
+      ruleStats.value[rule.id] = st
+    } catch {
+      // skip
+    }
+  }
+}
 
 const canSave = computed(() => {
   if (!draft.value.name.trim()) return false
@@ -293,10 +371,11 @@ function describeAction(rule: AutomationRule): string {
 
 watch(
   () => props.visible,
-  (v) => {
+  async (v) => {
     if (v && props.sheetId) {
-      void loadRules(props.sheetId)
+      await loadRules(props.sheetId)
       cancelForm()
+      void loadRuleStats()
     }
   },
   { immediate: true },
@@ -487,4 +566,14 @@ watch(
 .meta-automation__btn-add {
   align-self: flex-start;
 }
+
+.meta-automation__card-stats {
+  display: flex;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.meta-automation__stat { font-weight: 600; }
+.meta-automation__stat--success { color: #16a34a; }
+.meta-automation__stat--failed { color: #dc2626; }
 </style>

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1,0 +1,562 @@
+<template>
+  <div v-if="visible" class="meta-rule-editor__overlay" @click.self="$emit('close')">
+    <div class="meta-rule-editor">
+      <div class="meta-rule-editor__header">
+        <h4 class="meta-rule-editor__title">{{ rule ? 'Edit Automation Rule' : 'New Automation Rule' }}</h4>
+        <button class="meta-rule-editor__close" type="button" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="meta-rule-editor__body">
+        <div v-if="error" class="meta-rule-editor__error" role="alert">{{ error }}</div>
+
+        <!-- Name -->
+        <label class="meta-rule-editor__label">Name</label>
+        <input v-model="draft.name" class="meta-rule-editor__input" type="text" placeholder="Automation name" data-field="name" />
+
+        <!-- 1. Trigger selector -->
+        <section class="meta-rule-editor__section">
+          <div class="meta-rule-editor__section-title">Trigger</div>
+          <select v-model="draft.triggerType" class="meta-rule-editor__select" data-field="triggerType">
+            <option value="record.created">When record created</option>
+            <option value="record.updated">When record updated</option>
+            <option value="record.deleted">When record deleted</option>
+            <option value="field.value_changed">When field value changed</option>
+            <option value="schedule.cron">Schedule (cron)</option>
+            <option value="schedule.interval">Schedule (interval)</option>
+            <option value="webhook.received">Webhook received</option>
+          </select>
+
+          <!-- field.value_changed config -->
+          <template v-if="draft.triggerType === 'field.value_changed'">
+            <label class="meta-rule-editor__label">Watch field</label>
+            <select v-model="draft.triggerConfig.fieldId" class="meta-rule-editor__select" data-field="triggerFieldId">
+              <option value="">-- select field --</option>
+              <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+            </select>
+            <label class="meta-rule-editor__label">Condition</label>
+            <select v-model="draft.triggerConfig.condition" class="meta-rule-editor__select" data-field="triggerCondition">
+              <option value="any">Any change</option>
+              <option value="equals">Equals</option>
+              <option value="changed_to">Changed to</option>
+            </select>
+            <template v-if="draft.triggerConfig.condition !== 'any'">
+              <label class="meta-rule-editor__label">Value</label>
+              <input v-model="draft.triggerConfig.value" class="meta-rule-editor__input" type="text" placeholder="Value" data-field="triggerValue" />
+            </template>
+          </template>
+
+          <!-- schedule.cron config -->
+          <template v-if="draft.triggerType === 'schedule.cron'">
+            <label class="meta-rule-editor__label">Preset</label>
+            <select v-model="cronPreset" class="meta-rule-editor__select" data-field="cronPreset">
+              <option value="*/5 * * * *">Every 5 minutes</option>
+              <option value="0 * * * *">Every hour</option>
+              <option value="0 0 * * *">Daily at midnight</option>
+              <option value="0 0 * * 1">Weekly (Monday)</option>
+              <option value="custom">Custom</option>
+            </select>
+            <template v-if="cronPreset === 'custom'">
+              <label class="meta-rule-editor__label">Cron expression</label>
+              <input v-model="draft.triggerConfig.cron" class="meta-rule-editor__input" type="text" placeholder="* * * * *" data-field="cronExpression" />
+            </template>
+          </template>
+
+          <!-- schedule.interval config -->
+          <template v-if="draft.triggerType === 'schedule.interval'">
+            <label class="meta-rule-editor__label">Interval (minutes)</label>
+            <input v-model.number="draft.triggerConfig.intervalMinutes" class="meta-rule-editor__input" type="number" min="1" placeholder="5" data-field="intervalMinutes" />
+          </template>
+        </section>
+
+        <!-- 2. Conditions -->
+        <section class="meta-rule-editor__section">
+          <div class="meta-rule-editor__section-title">
+            Conditions
+            <span class="meta-rule-editor__hint">(optional)</span>
+          </div>
+          <div v-if="draft.conditions.conditions.length > 1" class="meta-rule-editor__conjunction">
+            <button
+              type="button"
+              class="meta-rule-editor__toggle-btn"
+              :class="{ 'meta-rule-editor__toggle-btn--active': draft.conditions.conjunction === 'AND' }"
+              @click="draft.conditions.conjunction = 'AND'"
+            >AND</button>
+            <button
+              type="button"
+              class="meta-rule-editor__toggle-btn"
+              :class="{ 'meta-rule-editor__toggle-btn--active': draft.conditions.conjunction === 'OR' }"
+              @click="draft.conditions.conjunction = 'OR'"
+            >OR</button>
+          </div>
+          <div
+            v-for="(cond, idx) in draft.conditions.conditions"
+            :key="idx"
+            class="meta-rule-editor__condition-row"
+            :data-condition-index="idx"
+          >
+            <select v-model="cond.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
+              <option value="">-- field --</option>
+              <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+            </select>
+            <select v-model="cond.operator" class="meta-rule-editor__select meta-rule-editor__select--sm">
+              <option v-for="op in conditionOperators" :key="op.value" :value="op.value">{{ op.label }}</option>
+            </select>
+            <input
+              v-if="!isUnaryOperator(cond.operator)"
+              v-model="cond.value"
+              class="meta-rule-editor__input meta-rule-editor__input--sm"
+              type="text"
+              placeholder="Value"
+            />
+            <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeCondition(idx)" title="Remove condition">&times;</button>
+          </div>
+          <button class="meta-rule-editor__btn" type="button" data-action="add-condition" @click="addCondition">+ Add condition</button>
+        </section>
+
+        <!-- 3. Actions -->
+        <section class="meta-rule-editor__section">
+          <div class="meta-rule-editor__section-title">Actions <span class="meta-rule-editor__hint">(1-3 steps)</span></div>
+          <div
+            v-for="(action, idx) in draft.actions"
+            :key="idx"
+            class="meta-rule-editor__action-row"
+            :data-action-index="idx"
+          >
+            <div class="meta-rule-editor__action-header">
+              <span class="meta-rule-editor__action-num">{{ idx + 1 }}.</span>
+              <select v-model="action.type" class="meta-rule-editor__select">
+                <option value="update_record">Update record</option>
+                <option value="create_record">Create record</option>
+                <option value="send_webhook">Send webhook</option>
+                <option value="send_notification">Send notification</option>
+                <option value="lock_record">Lock record</option>
+              </select>
+              <div class="meta-rule-editor__action-btns">
+                <button v-if="idx > 0" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, -1)" title="Move up">&#x2191;</button>
+                <button v-if="idx < draft.actions.length - 1" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, 1)" title="Move down">&#x2193;</button>
+                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeAction(idx)" title="Remove action">&times;</button>
+              </div>
+            </div>
+
+            <!-- update_record config -->
+            <div v-if="action.type === 'update_record'" class="meta-rule-editor__action-config">
+              <div v-for="(pair, pidx) in (action.config.fieldUpdates as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
+                <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
+                  <option value="">-- field --</option>
+                  <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+                </select>
+                <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" placeholder="Value" />
+                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeFieldUpdate(action, pidx)">&times;</button>
+              </div>
+              <button class="meta-rule-editor__btn" type="button" @click="addFieldUpdate(action)">+ Field</button>
+            </div>
+
+            <!-- create_record config -->
+            <div v-if="action.type === 'create_record'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__label">Target sheet ID</label>
+              <input v-model="action.config.targetSheetId" class="meta-rule-editor__input" type="text" placeholder="Sheet ID" />
+              <div v-for="(pair, pidx) in (action.config.fieldValues as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
+                <input v-model="pair.fieldId" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" placeholder="Field ID" />
+                <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" placeholder="Value" />
+                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeCreateFieldValue(action, pidx)">&times;</button>
+              </div>
+              <button class="meta-rule-editor__btn" type="button" @click="addCreateFieldValue(action)">+ Field</button>
+            </div>
+
+            <!-- send_webhook config -->
+            <div v-if="action.type === 'send_webhook'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__label">URL</label>
+              <input v-model="action.config.url" class="meta-rule-editor__input" type="url" placeholder="https://..." />
+              <label class="meta-rule-editor__label">Method</label>
+              <select v-model="action.config.method" class="meta-rule-editor__select">
+                <option value="POST">POST</option>
+                <option value="PUT">PUT</option>
+                <option value="GET">GET</option>
+              </select>
+            </div>
+
+            <!-- send_notification config -->
+            <div v-if="action.type === 'send_notification'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__label">User ID</label>
+              <input v-model="action.config.userId" class="meta-rule-editor__input" type="text" placeholder="User ID" />
+              <label class="meta-rule-editor__label">Message</label>
+              <textarea v-model="action.config.message" class="meta-rule-editor__textarea" placeholder="Notification message" rows="3"></textarea>
+            </div>
+
+            <!-- lock_record config -->
+            <div v-if="action.type === 'lock_record'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__toggle-label">
+                <input type="checkbox" v-model="action.config.locked" />
+                Lock record
+              </label>
+            </div>
+          </div>
+          <button
+            v-if="draft.actions.length < 3"
+            class="meta-rule-editor__btn"
+            type="button"
+            data-action="add-action"
+            @click="addAction"
+          >+ Add action</button>
+        </section>
+      </div>
+
+      <!-- Footer -->
+      <div class="meta-rule-editor__footer">
+        <button class="meta-rule-editor__btn meta-rule-editor__btn--primary" type="button" :disabled="!canSave || saving" data-action="save" @click="onSave">
+          {{ saving ? 'Saving...' : 'Save' }}
+        </button>
+        <button class="meta-rule-editor__btn" type="button" :disabled="saving" @click="onTestRun" data-action="test">Test Run</button>
+        <button class="meta-rule-editor__btn" type="button" @click="$emit('close')">Cancel</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type {
+  AutomationRule,
+  AutomationTriggerType,
+  AutomationActionType,
+  ConditionOperator,
+  AutomationAction,
+  AutomationCondition,
+} from '../types'
+
+interface FieldPair {
+  fieldId: string
+  value: string
+}
+
+interface DraftAction {
+  type: AutomationActionType
+  config: Record<string, unknown>
+}
+
+interface Draft {
+  name: string
+  triggerType: AutomationTriggerType
+  triggerConfig: Record<string, unknown>
+  conditions: { conjunction: 'AND' | 'OR'; conditions: AutomationCondition[] }
+  actions: DraftAction[]
+}
+
+const props = defineProps<{
+  sheetId: string
+  rule?: AutomationRule
+  visible: boolean
+  fields: Array<{ id: string; name: string; type: string }>
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'save', payload: Partial<AutomationRule>): void
+  (e: 'test', ruleId: string): void
+}>()
+
+const error = ref('')
+const saving = ref(false)
+const cronPreset = ref('0 * * * *')
+
+const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
+  { value: 'equals', label: 'Equals' },
+  { value: 'not_equals', label: 'Not equals' },
+  { value: 'contains', label: 'Contains' },
+  { value: 'not_contains', label: 'Not contains' },
+  { value: 'greater_than', label: 'Greater than' },
+  { value: 'less_than', label: 'Less than' },
+  { value: 'greater_or_equal', label: 'Greater or equal' },
+  { value: 'less_or_equal', label: 'Less or equal' },
+  { value: 'is_empty', label: 'Is empty' },
+  { value: 'is_not_empty', label: 'Is not empty' },
+]
+
+function isUnaryOperator(op: ConditionOperator): boolean {
+  return op === 'is_empty' || op === 'is_not_empty'
+}
+
+function emptyDraft(): Draft {
+  return {
+    name: '',
+    triggerType: 'record.created',
+    triggerConfig: {},
+    conditions: { conjunction: 'AND', conditions: [] },
+    actions: [{ type: 'update_record', config: { fieldUpdates: [] } }],
+  }
+}
+
+function draftFromRule(rule: AutomationRule): Draft {
+  return {
+    name: rule.name,
+    triggerType: rule.triggerType,
+    triggerConfig: { ...rule.triggerConfig, ...(rule.trigger?.config ?? {}) },
+    conditions: rule.conditions
+      ? { conjunction: rule.conditions.conjunction, conditions: rule.conditions.conditions.map((c) => ({ ...c })) }
+      : { conjunction: 'AND', conditions: [] },
+    actions: rule.actions && rule.actions.length
+      ? rule.actions.map((a) => ({ type: a.type, config: { ...a.config } }))
+      : [{ type: rule.actionType, config: { ...rule.actionConfig } }],
+  }
+}
+
+const draft = ref<Draft>(emptyDraft())
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v) {
+      draft.value = props.rule ? draftFromRule(props.rule) : emptyDraft()
+      error.value = ''
+      saving.value = false
+    }
+  },
+  { immediate: true },
+)
+
+const canSave = computed(() => {
+  if (!draft.value.name.trim()) return false
+  if (draft.value.actions.length < 1) return false
+  return true
+})
+
+function addCondition() {
+  draft.value.conditions.conditions.push({ fieldId: '', operator: 'equals', value: '' })
+}
+
+function removeCondition(idx: number) {
+  draft.value.conditions.conditions.splice(idx, 1)
+}
+
+function addAction() {
+  if (draft.value.actions.length >= 3) return
+  draft.value.actions.push({ type: 'update_record', config: { fieldUpdates: [] } })
+}
+
+function removeAction(idx: number) {
+  draft.value.actions.splice(idx, 1)
+}
+
+function moveAction(idx: number, dir: number) {
+  const target = idx + dir
+  if (target < 0 || target >= draft.value.actions.length) return
+  const arr = draft.value.actions
+  ;[arr[idx], arr[target]] = [arr[target], arr[idx]]
+}
+
+function addFieldUpdate(action: DraftAction) {
+  if (!Array.isArray(action.config.fieldUpdates)) action.config.fieldUpdates = []
+  ;(action.config.fieldUpdates as FieldPair[]).push({ fieldId: '', value: '' })
+}
+
+function removeFieldUpdate(action: DraftAction, idx: number) {
+  ;(action.config.fieldUpdates as FieldPair[]).splice(idx, 1)
+}
+
+function addCreateFieldValue(action: DraftAction) {
+  if (!Array.isArray(action.config.fieldValues)) action.config.fieldValues = []
+  ;(action.config.fieldValues as FieldPair[]).push({ fieldId: '', value: '' })
+}
+
+function removeCreateFieldValue(action: DraftAction, idx: number) {
+  ;(action.config.fieldValues as FieldPair[]).splice(idx, 1)
+}
+
+function buildPayload(): Partial<AutomationRule> {
+  const d = draft.value
+  const triggerConfig = { ...d.triggerConfig }
+  if (d.triggerType === 'schedule.cron' && cronPreset.value !== 'custom') {
+    triggerConfig.cron = cronPreset.value
+  }
+  return {
+    name: d.name.trim(),
+    triggerType: d.triggerType,
+    triggerConfig,
+    trigger: { type: d.triggerType, config: triggerConfig },
+    conditions: d.conditions.conditions.length > 0 ? d.conditions : undefined,
+    actions: d.actions.map((a) => ({ type: a.type, config: a.config })),
+    actionType: d.actions[0]?.type ?? 'update_record',
+    actionConfig: d.actions[0]?.config ?? {},
+  }
+}
+
+async function onSave() {
+  if (!canSave.value) return
+  saving.value = true
+  error.value = ''
+  try {
+    emit('save', buildPayload())
+  } catch (e: unknown) {
+    error.value = e instanceof Error ? e.message : 'Save failed'
+  } finally {
+    saving.value = false
+  }
+}
+
+function onTestRun() {
+  if (props.rule?.id) {
+    emit('test', props.rule.id)
+  }
+}
+</script>
+
+<style scoped>
+.meta-rule-editor__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.meta-rule-editor {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  width: 640px;
+  max-width: 95vw;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-rule-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-rule-editor__title { margin: 0; font-size: 16px; font-weight: 700; color: #0f172a; }
+.meta-rule-editor__close { border: none; background: none; font-size: 22px; cursor: pointer; color: #64748b; line-height: 1; padding: 0 4px; }
+
+.meta-rule-editor__body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.meta-rule-editor__error { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: #fef2f2; color: #b91c1c; }
+
+.meta-rule-editor__section {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.meta-rule-editor__section-title { font-size: 14px; font-weight: 600; color: #0f172a; }
+.meta-rule-editor__hint { font-weight: 400; color: #94a3b8; font-size: 12px; }
+
+.meta-rule-editor__label { font-size: 12px; font-weight: 600; color: #475569; margin-top: 4px; }
+
+.meta-rule-editor__input,
+.meta-rule-editor__select,
+.meta-rule-editor__textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.meta-rule-editor__textarea { resize: vertical; font-family: inherit; }
+
+.meta-rule-editor__input--sm,
+.meta-rule-editor__select--sm {
+  flex: 1;
+  min-width: 80px;
+}
+
+.meta-rule-editor__condition-row,
+.meta-rule-editor__field-pair {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.meta-rule-editor__conjunction { display: flex; gap: 4px; }
+
+.meta-rule-editor__toggle-btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 4px 12px;
+  background: #fff;
+  font-size: 12px;
+  cursor: pointer;
+  color: #475569;
+}
+
+.meta-rule-editor__toggle-btn--active {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+.meta-rule-editor__action-row {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.meta-rule-editor__action-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.meta-rule-editor__action-num { font-weight: 700; font-size: 14px; color: #2563eb; }
+
+.meta-rule-editor__action-btns { display: flex; gap: 4px; margin-left: auto; }
+
+.meta-rule-editor__action-config {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 20px;
+}
+
+.meta-rule-editor__toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #475569;
+}
+
+.meta-rule-editor__footer {
+  display: flex;
+  gap: 8px;
+  padding: 12px 20px 16px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.meta-rule-editor__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 14px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.meta-rule-editor__btn:disabled { opacity: 0.55; cursor: not-allowed; }
+.meta-rule-editor__btn--primary { border-color: #2563eb; background: #2563eb; color: #fff; }
+.meta-rule-editor__btn--danger { border-color: #ef4444; color: #b91c1c; }
+.meta-rule-editor__btn--icon { padding: 4px 8px; font-size: 14px; line-height: 1; }
+</style>

--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -1,0 +1,290 @@
+<template>
+  <div class="meta-chart" :data-chart-type="chartData.chartType">
+    <div v-if="displayConfig?.title" class="meta-chart__title">{{ displayConfig.title }}</div>
+
+    <!-- Bar chart -->
+    <template v-if="chartData.chartType === 'bar'">
+      <svg :viewBox="`0 0 ${barWidth} ${barHeight}`" class="meta-chart__svg" preserveAspectRatio="xMidYMid meet" data-chart="bar">
+        <g v-for="(pt, idx) in chartData.dataPoints" :key="idx">
+          <rect
+            v-if="isVertical"
+            :x="barPadding + idx * barSlotWidth + barSlotWidth * 0.1"
+            :y="barHeight - barBottomPad - barScale(pt.value)"
+            :width="barSlotWidth * 0.8"
+            :height="barScale(pt.value)"
+            :fill="pt.color || defaultColor(idx)"
+            :data-bar-index="idx"
+          />
+          <rect
+            v-else
+            :x="barLeftPad"
+            :y="barPadding + idx * barSlotHeight + barSlotHeight * 0.1"
+            :width="hBarScale(pt.value)"
+            :height="barSlotHeight * 0.8"
+            :fill="pt.color || defaultColor(idx)"
+            :data-bar-index="idx"
+          />
+          <text
+            v-if="isVertical"
+            :x="barPadding + idx * barSlotWidth + barSlotWidth / 2"
+            :y="barHeight - 4"
+            text-anchor="middle"
+            class="meta-chart__bar-label"
+          >{{ pt.label }}</text>
+          <text
+            v-if="isVertical && displayConfig?.showValues !== false"
+            :x="barPadding + idx * barSlotWidth + barSlotWidth / 2"
+            :y="barHeight - barBottomPad - barScale(pt.value) - 4"
+            text-anchor="middle"
+            class="meta-chart__bar-value"
+          >{{ pt.value }}</text>
+          <text
+            v-if="!isVertical"
+            :x="barLeftPad - 4"
+            :y="barPadding + idx * barSlotHeight + barSlotHeight / 2 + 4"
+            text-anchor="end"
+            class="meta-chart__bar-label"
+          >{{ pt.label }}</text>
+          <text
+            v-if="!isVertical && displayConfig?.showValues !== false"
+            :x="barLeftPad + hBarScale(pt.value) + 4"
+            :y="barPadding + idx * barSlotHeight + barSlotHeight / 2 + 4"
+            text-anchor="start"
+            class="meta-chart__bar-value"
+          >{{ pt.value }}</text>
+        </g>
+      </svg>
+    </template>
+
+    <!-- Line chart -->
+    <template v-else-if="chartData.chartType === 'line'">
+      <svg :viewBox="`0 0 ${lineWidth} ${lineHeight}`" class="meta-chart__svg" preserveAspectRatio="xMidYMid meet" data-chart="line">
+        <polyline
+          :points="linePoints"
+          fill="none"
+          stroke="#2563eb"
+          stroke-width="2"
+          stroke-linejoin="round"
+          class="meta-chart__line"
+        />
+        <circle
+          v-for="(pt, idx) in lineCoords"
+          :key="idx"
+          :cx="pt.x"
+          :cy="pt.y"
+          r="4"
+          fill="#2563eb"
+          :data-point-index="idx"
+        />
+        <text
+          v-for="(pt, idx) in lineCoords"
+          :key="'l' + idx"
+          :x="pt.x"
+          :y="lineHeight - 4"
+          text-anchor="middle"
+          class="meta-chart__line-label"
+        >{{ chartData.dataPoints[idx].label }}</text>
+      </svg>
+    </template>
+
+    <!-- Pie chart -->
+    <template v-else-if="chartData.chartType === 'pie'">
+      <div class="meta-chart__pie-wrapper">
+        <svg viewBox="0 0 200 200" class="meta-chart__svg meta-chart__svg--pie" preserveAspectRatio="xMidYMid meet" data-chart="pie">
+          <path
+            v-for="(seg, idx) in pieSegments"
+            :key="idx"
+            :d="seg.d"
+            :fill="seg.color"
+            :data-pie-index="idx"
+          />
+        </svg>
+        <div v-if="displayConfig?.showLegend !== false" class="meta-chart__legend" data-legend="true">
+          <div v-for="(pt, idx) in chartData.dataPoints" :key="idx" class="meta-chart__legend-item">
+            <span class="meta-chart__legend-swatch" :style="{ background: pt.color || defaultColor(idx) }"></span>
+            <span class="meta-chart__legend-label">{{ pt.label }}</span>
+            <span class="meta-chart__legend-value">{{ pt.value }}</span>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Number chart -->
+    <template v-else-if="chartData.chartType === 'number'">
+      <div class="meta-chart__number" data-chart="number">
+        <span v-if="displayConfig?.prefix" class="meta-chart__number-affix">{{ displayConfig.prefix }}</span>
+        <span class="meta-chart__number-value">{{ chartData.dataPoints[0]?.value ?? chartData.total ?? 0 }}</span>
+        <span v-if="displayConfig?.suffix" class="meta-chart__number-affix">{{ displayConfig.suffix }}</span>
+      </div>
+      <div v-if="chartData.dataPoints[0]?.label" class="meta-chart__number-label">{{ chartData.dataPoints[0].label }}</div>
+    </template>
+
+    <!-- Table chart -->
+    <template v-else-if="chartData.chartType === 'table'">
+      <table class="meta-chart__table" data-chart="table">
+        <thead>
+          <tr>
+            <th>Label</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(pt, idx) in chartData.dataPoints" :key="idx">
+            <td>{{ pt.label }}</td>
+            <td>{{ pt.value }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ChartData, ChartDisplayConfig } from '../types'
+
+const props = defineProps<{
+  chartData: ChartData
+  displayConfig?: ChartDisplayConfig
+}>()
+
+const COLORS = ['#2563eb', '#16a34a', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16']
+
+function defaultColor(idx: number): string {
+  return COLORS[idx % COLORS.length]
+}
+
+const isVertical = computed(() => props.displayConfig?.orientation !== 'horizontal')
+
+// Bar chart helpers
+const barWidth = 400
+const barHeight = 250
+const barPadding = 20
+const barBottomPad = 24
+const barLeftPad = 80
+const barSlotWidth = computed(() => {
+  const count = props.chartData.dataPoints.length || 1
+  return (barWidth - barPadding * 2) / count
+})
+const barSlotHeight = computed(() => {
+  const count = props.chartData.dataPoints.length || 1
+  return (barHeight - barPadding * 2) / count
+})
+const barMax = computed(() => Math.max(1, ...props.chartData.dataPoints.map((p) => p.value)))
+
+function barScale(val: number): number {
+  return (val / barMax.value) * (barHeight - barPadding - barBottomPad - 20)
+}
+
+function hBarScale(val: number): number {
+  return (val / barMax.value) * (barWidth - barLeftPad - 20)
+}
+
+// Line chart helpers
+const lineWidth = 400
+const lineHeight = 250
+const linePad = 30
+const lineCoords = computed(() => {
+  const pts = props.chartData.dataPoints
+  if (!pts.length) return []
+  const max = Math.max(1, ...pts.map((p) => p.value))
+  const xStep = pts.length > 1 ? (lineWidth - linePad * 2) / (pts.length - 1) : 0
+  return pts.map((p, i) => ({
+    x: linePad + i * xStep,
+    y: lineHeight - linePad - 20 - (p.value / max) * (lineHeight - linePad * 2 - 20),
+  }))
+})
+
+const linePoints = computed(() => lineCoords.value.map((c) => `${c.x},${c.y}`).join(' '))
+
+// Pie chart helpers
+const pieSegments = computed(() => {
+  const pts = props.chartData.dataPoints
+  const total = pts.reduce((s, p) => s + p.value, 0) || 1
+  const segments: Array<{ d: string; color: string }> = []
+  let startAngle = -Math.PI / 2
+  for (let i = 0; i < pts.length; i++) {
+    const angle = (pts[i].value / total) * Math.PI * 2
+    const endAngle = startAngle + angle
+    const largeArc = angle > Math.PI ? 1 : 0
+    const cx = 100
+    const cy = 100
+    const r = 90
+    const x1 = cx + r * Math.cos(startAngle)
+    const y1 = cy + r * Math.sin(startAngle)
+    const x2 = cx + r * Math.cos(endAngle)
+    const y2 = cy + r * Math.sin(endAngle)
+    // For a single-item pie, draw a full circle
+    if (pts.length === 1) {
+      segments.push({
+        d: `M ${cx - r} ${cy} A ${r} ${r} 0 1 1 ${cx + r} ${cy} A ${r} ${r} 0 1 1 ${cx - r} ${cy} Z`,
+        color: pts[i].color || defaultColor(i),
+      })
+    } else {
+      segments.push({
+        d: `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`,
+        color: pts[i].color || defaultColor(i),
+      })
+    }
+    startAngle = endAngle
+  }
+  return segments
+})
+</script>
+
+<style scoped>
+.meta-chart { width: 100%; }
+
+.meta-chart__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.meta-chart__svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.meta-chart__svg--pie { max-width: 200px; }
+
+.meta-chart__bar-label { font-size: 10px; fill: #64748b; }
+.meta-chart__bar-value { font-size: 9px; fill: #0f172a; font-weight: 600; }
+.meta-chart__line-label { font-size: 10px; fill: #64748b; }
+
+.meta-chart__pie-wrapper { display: flex; align-items: flex-start; gap: 16px; }
+
+.meta-chart__legend { display: flex; flex-direction: column; gap: 4px; }
+.meta-chart__legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; }
+.meta-chart__legend-swatch { width: 12px; height: 12px; border-radius: 3px; flex-shrink: 0; }
+.meta-chart__legend-label { color: #475569; }
+.meta-chart__legend-value { color: #0f172a; font-weight: 600; margin-left: auto; }
+
+.meta-chart__number { text-align: center; padding: 20px 0 4px; }
+.meta-chart__number-value { font-size: 48px; font-weight: 800; color: #0f172a; }
+.meta-chart__number-affix { font-size: 20px; color: #64748b; }
+.meta-chart__number-label { text-align: center; font-size: 14px; color: #64748b; }
+
+.meta-chart__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.meta-chart__table th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid #e2e8f0;
+  font-weight: 600;
+  color: #475569;
+}
+
+.meta-chart__table td {
+  padding: 6px 12px;
+  border-bottom: 1px solid #f1f5f9;
+  color: #0f172a;
+}
+</style>

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -1,0 +1,426 @@
+<template>
+  <div class="meta-dashboard">
+    <!-- Dashboard selector / header -->
+    <div class="meta-dashboard__header">
+      <div class="meta-dashboard__selector">
+        <template v-if="editingName">
+          <input
+            ref="nameInputRef"
+            v-model="nameInput"
+            class="meta-dashboard__name-input"
+            type="text"
+            data-field="dashboard-name"
+            @blur="finishRename"
+            @keydown.enter="finishRename"
+            @keydown.escape="editingName = false"
+          />
+        </template>
+        <template v-else>
+          <select
+            v-if="dashboards.length > 1"
+            v-model="activeDashboardId"
+            class="meta-dashboard__select"
+            data-field="dashboard-select"
+          >
+            <option v-for="d in dashboards" :key="d.id" :value="d.id">{{ d.name }}</option>
+          </select>
+          <span v-else-if="activeDashboard" class="meta-dashboard__active-name" @dblclick="startRename">
+            {{ activeDashboard.name }}
+          </span>
+        </template>
+        <button
+          v-if="activeDashboard && !editingName"
+          class="meta-dashboard__btn meta-dashboard__btn--sm"
+          type="button"
+          title="Rename"
+          data-action="rename"
+          @click="startRename"
+        >Rename</button>
+      </div>
+      <div class="meta-dashboard__actions">
+        <button class="meta-dashboard__btn" type="button" data-action="add-panel" @click="showAddPanel = true">+ Add Panel</button>
+        <button class="meta-dashboard__btn meta-dashboard__btn--primary" type="button" data-action="create-dashboard" @click="onCreateDashboard">+ New Dashboard</button>
+      </div>
+    </div>
+
+    <div v-if="loading" class="meta-dashboard__empty">Loading dashboard...</div>
+    <div v-else-if="!activeDashboard" class="meta-dashboard__empty" data-empty="true">
+      No dashboards yet. Create your first dashboard.
+    </div>
+
+    <!-- Grid of panels -->
+    <div v-else class="meta-dashboard__grid" data-grid="true">
+      <div
+        v-for="panel in sortedPanels"
+        :key="panel.id"
+        class="meta-dashboard__panel"
+        :class="`meta-dashboard__panel--${panel.size}`"
+        :data-panel-id="panel.id"
+      >
+        <div class="meta-dashboard__panel-header">
+          <span class="meta-dashboard__panel-chart-name">{{ chartNameById(panel.chartId) }}</span>
+          <div class="meta-dashboard__panel-controls">
+            <select
+              :value="panel.size"
+              class="meta-dashboard__select meta-dashboard__select--sm"
+              data-field="panel-size"
+              @change="onResizePanel(panel.id, ($event.target as HTMLSelectElement).value as 'small' | 'medium' | 'large')"
+            >
+              <option value="small">Small</option>
+              <option value="medium">Medium</option>
+              <option value="large">Large</option>
+            </select>
+            <button
+              class="meta-dashboard__btn meta-dashboard__btn--icon meta-dashboard__btn--danger"
+              type="button"
+              data-action="remove-panel"
+              @click="onRemovePanel(panel.id)"
+            >&times;</button>
+          </div>
+        </div>
+        <div class="meta-dashboard__panel-body">
+          <MetaChartRenderer
+            v-if="chartDataMap[panel.chartId]"
+            :chart-data="chartDataMap[panel.chartId]"
+            :display-config="chartConfigMap[panel.chartId]?.displayConfig"
+          />
+          <div v-else class="meta-dashboard__panel-loading">Loading chart...</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Add panel modal -->
+    <div v-if="showAddPanel" class="meta-dashboard__modal-overlay" @click.self="showAddPanel = false">
+      <div class="meta-dashboard__modal">
+        <div class="meta-dashboard__modal-header">
+          <h4>Add Chart Panel</h4>
+          <button class="meta-dashboard__btn meta-dashboard__btn--icon" type="button" @click="showAddPanel = false">&times;</button>
+        </div>
+        <div class="meta-dashboard__modal-body">
+          <div v-if="!charts.length" class="meta-dashboard__empty">No charts available. Create a chart first.</div>
+          <div
+            v-for="chart in charts"
+            :key="chart.id"
+            class="meta-dashboard__chart-option"
+            :data-chart-option="chart.id"
+            @click="onAddPanel(chart.id)"
+          >
+            <span>{{ chart.name }}</span>
+            <span class="meta-dashboard__chart-type">{{ chart.chartType }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, nextTick } from 'vue'
+import type { Dashboard, DashboardPanel, ChartConfig, ChartData } from '../types'
+import type { MultitableApiClient } from '../api/client'
+import MetaChartRenderer from './MetaChartRenderer.vue'
+
+const props = defineProps<{
+  sheetId: string
+  dashboardId?: string
+  client?: MultitableApiClient
+}>()
+
+const loading = ref(false)
+const dashboards = ref<Dashboard[]>([])
+const charts = ref<ChartConfig[]>([])
+const chartDataMap = ref<Record<string, ChartData>>({})
+const chartConfigMap = ref<Record<string, ChartConfig>>({})
+const activeDashboardId = ref<string>(props.dashboardId ?? '')
+const showAddPanel = ref(false)
+const editingName = ref(false)
+const nameInput = ref('')
+const nameInputRef = ref<HTMLInputElement | null>(null)
+
+const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
+
+const sortedPanels = computed(() => {
+  if (!activeDashboard.value) return []
+  return [...activeDashboard.value.panels].sort((a, b) => a.order - b.order)
+})
+
+function chartNameById(chartId: string): string {
+  return chartConfigMap.value[chartId]?.name ?? chartId
+}
+
+async function loadData() {
+  if (!props.client || !props.sheetId) return
+  loading.value = true
+  try {
+    const [dbs, chs] = await Promise.all([
+      props.client.listDashboards(props.sheetId),
+      props.client.listCharts(props.sheetId),
+    ])
+    dashboards.value = dbs
+    charts.value = chs
+    for (const ch of chs) {
+      chartConfigMap.value[ch.id] = ch
+    }
+    if (!activeDashboardId.value && dbs.length) {
+      activeDashboardId.value = dbs[0].id
+    }
+    // Load chart data for active dashboard panels
+    await loadPanelData()
+  } catch {
+    // silently fail
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadPanelData() {
+  if (!props.client || !activeDashboard.value) return
+  const panels = activeDashboard.value.panels
+  const promises = panels.map(async (panel) => {
+    if (chartDataMap.value[panel.chartId]) return
+    try {
+      const data = await props.client!.getChartData(props.sheetId, panel.chartId)
+      chartDataMap.value[panel.chartId] = data
+    } catch {
+      // skip
+    }
+  })
+  await Promise.all(promises)
+}
+
+async function onCreateDashboard() {
+  if (!props.client) return
+  try {
+    const db = await props.client.createDashboard(props.sheetId, { name: `Dashboard ${dashboards.value.length + 1}` })
+    dashboards.value.push(db)
+    activeDashboardId.value = db.id
+  } catch {
+    // skip
+  }
+}
+
+async function onAddPanel(chartId: string) {
+  if (!props.client || !activeDashboard.value) return
+  showAddPanel.value = false
+  const db = activeDashboard.value
+  const newPanel: DashboardPanel = {
+    id: `panel_${Date.now()}`,
+    chartId,
+    size: 'medium',
+    order: db.panels.length,
+  }
+  const updated = [...db.panels, newPanel]
+  try {
+    const result = await props.client.updateDashboard(props.sheetId, db.id, { panels: updated })
+    const idx = dashboards.value.findIndex((d) => d.id === db.id)
+    if (idx >= 0) dashboards.value[idx] = result
+    // Load chart data
+    if (!chartDataMap.value[chartId]) {
+      try {
+        chartDataMap.value[chartId] = await props.client.getChartData(props.sheetId, chartId)
+      } catch {
+        // skip
+      }
+    }
+  } catch {
+    // skip
+  }
+}
+
+async function onRemovePanel(panelId: string) {
+  if (!props.client || !activeDashboard.value) return
+  const db = activeDashboard.value
+  const updated = db.panels.filter((p) => p.id !== panelId)
+  try {
+    const result = await props.client.updateDashboard(props.sheetId, db.id, { panels: updated })
+    const idx = dashboards.value.findIndex((d) => d.id === db.id)
+    if (idx >= 0) dashboards.value[idx] = result
+  } catch {
+    // skip
+  }
+}
+
+async function onResizePanel(panelId: string, size: 'small' | 'medium' | 'large') {
+  if (!props.client || !activeDashboard.value) return
+  const db = activeDashboard.value
+  const updated = db.panels.map((p) => (p.id === panelId ? { ...p, size } : p))
+  try {
+    const result = await props.client.updateDashboard(props.sheetId, db.id, { panels: updated })
+    const idx = dashboards.value.findIndex((d) => d.id === db.id)
+    if (idx >= 0) dashboards.value[idx] = result
+  } catch {
+    // skip
+  }
+}
+
+function startRename() {
+  if (!activeDashboard.value) return
+  nameInput.value = activeDashboard.value.name
+  editingName.value = true
+  void nextTick(() => nameInputRef.value?.focus())
+}
+
+async function finishRename() {
+  editingName.value = false
+  if (!props.client || !activeDashboard.value || !nameInput.value.trim()) return
+  if (nameInput.value.trim() === activeDashboard.value.name) return
+  try {
+    const result = await props.client.updateDashboard(props.sheetId, activeDashboard.value.id, { name: nameInput.value.trim() })
+    const idx = dashboards.value.findIndex((d) => d.id === activeDashboard.value!.id)
+    if (idx >= 0) dashboards.value[idx] = result
+  } catch {
+    // skip
+  }
+}
+
+watch(
+  () => activeDashboard.value?.id,
+  () => { void loadPanelData() },
+)
+
+watch(
+  () => props.sheetId,
+  () => { void loadData() },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.meta-dashboard { padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
+
+.meta-dashboard__header { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+.meta-dashboard__selector { display: flex; align-items: center; gap: 8px; }
+.meta-dashboard__actions { display: flex; gap: 8px; }
+
+.meta-dashboard__active-name { font-size: 16px; font-weight: 700; color: #0f172a; cursor: pointer; }
+
+.meta-dashboard__name-input {
+  border: 1px solid #2563eb;
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 16px;
+  font-weight: 700;
+  color: #0f172a;
+  outline: none;
+}
+
+.meta-dashboard__select {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.meta-dashboard__select--sm { padding: 3px 6px; font-size: 11px; }
+
+.meta-dashboard__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 14px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.meta-dashboard__btn--primary { border-color: #2563eb; background: #2563eb; color: #fff; }
+.meta-dashboard__btn--danger { border-color: #ef4444; color: #b91c1c; }
+.meta-dashboard__btn--sm { padding: 3px 8px; font-size: 11px; }
+.meta-dashboard__btn--icon { padding: 4px 8px; font-size: 16px; line-height: 1; }
+
+.meta-dashboard__empty {
+  padding: 20px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #f8fafc;
+  color: #64748b;
+  text-align: center;
+}
+
+.meta-dashboard__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.meta-dashboard__panel {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fff;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-dashboard__panel--small { min-height: 160px; }
+.meta-dashboard__panel--medium { min-height: 260px; grid-column: span 1; }
+.meta-dashboard__panel--large { min-height: 360px; grid-column: span 2; }
+
+.meta-dashboard__panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.meta-dashboard__panel-chart-name { font-size: 13px; font-weight: 600; color: #0f172a; }
+.meta-dashboard__panel-controls { display: flex; align-items: center; gap: 6px; }
+
+.meta-dashboard__panel-body { padding: 12px 14px; flex: 1; display: flex; align-items: center; justify-content: center; }
+.meta-dashboard__panel-loading { font-size: 12px; color: #94a3b8; }
+
+.meta-dashboard__modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.meta-dashboard__modal {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  width: 400px;
+  max-width: 95vw;
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-dashboard__modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-dashboard__modal-header h4 { margin: 0; font-size: 15px; }
+
+.meta-dashboard__modal-body {
+  padding: 12px 16px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-dashboard__chart-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.meta-dashboard__chart-option:hover { background: #f8fafc; }
+.meta-dashboard__chart-type { font-size: 11px; color: #94a3b8; text-transform: uppercase; }
+</style>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -527,9 +527,60 @@ export interface RecordPermissionEntry {
   createdBy?: string
 }
 
-// --- Automation rules ---
-export type AutomationTriggerType = 'record.created' | 'record.updated' | 'field.changed'
-export type AutomationActionType = 'notify' | 'update_field'
+// --- Automation rules (V1 engine) ---
+export type AutomationTriggerType =
+  | 'record.created'
+  | 'record.updated'
+  | 'record.deleted'
+  | 'field.value_changed'
+  | 'schedule.cron'
+  | 'schedule.interval'
+  | 'webhook.received'
+  // Legacy aliases
+  | 'field.changed'
+
+export type ConditionOperator =
+  | 'equals'
+  | 'not_equals'
+  | 'contains'
+  | 'not_contains'
+  | 'greater_than'
+  | 'less_than'
+  | 'greater_or_equal'
+  | 'less_or_equal'
+  | 'is_empty'
+  | 'is_not_empty'
+
+export interface AutomationCondition {
+  fieldId: string
+  operator: ConditionOperator
+  value?: unknown
+}
+
+export interface ConditionGroup {
+  conjunction: 'AND' | 'OR'
+  conditions: AutomationCondition[]
+}
+
+export type AutomationActionType =
+  | 'update_record'
+  | 'create_record'
+  | 'send_webhook'
+  | 'send_notification'
+  | 'lock_record'
+  // Legacy aliases
+  | 'notify'
+  | 'update_field'
+
+export interface AutomationTrigger {
+  type: AutomationTriggerType
+  config: Record<string, unknown>
+}
+
+export interface AutomationAction {
+  type: AutomationActionType
+  config: Record<string, unknown>
+}
 
 export interface AutomationRule {
   id: string
@@ -537,12 +588,118 @@ export interface AutomationRule {
   name: string
   triggerType: AutomationTriggerType
   triggerConfig: Record<string, unknown>
+  trigger?: AutomationTrigger
+  conditions?: ConditionGroup
+  actions?: AutomationAction[]
   actionType: AutomationActionType
   actionConfig: Record<string, unknown>
   enabled: boolean
   createdAt?: string
   updatedAt?: string
   createdBy?: string
+}
+
+export interface AutomationStepResult {
+  actionType: AutomationActionType
+  status: 'success' | 'failed' | 'skipped'
+  output?: unknown
+  error?: string
+  durationMs?: number
+}
+
+export interface AutomationExecution {
+  id: string
+  ruleId: string
+  status: 'success' | 'failed' | 'skipped'
+  triggerType: AutomationTriggerType
+  startedAt: string
+  completedAt?: string
+  durationMs?: number
+  steps?: AutomationStepResult[]
+  error?: string
+}
+
+export interface AutomationStats {
+  total: number
+  success: number
+  failed: number
+  skipped: number
+  avgDurationMs: number
+}
+
+// --- Charts ---
+export type ChartType = 'bar' | 'line' | 'pie' | 'number' | 'table'
+
+export type AggregationFunction = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'count_distinct'
+
+export interface ChartDataSource {
+  sheetId: string
+  fieldId: string
+  groupFieldId?: string
+  aggregation: AggregationFunction
+}
+
+export interface ChartDisplayConfig {
+  title?: string
+  showLegend?: boolean
+  showValues?: boolean
+  colorScheme?: string
+  prefix?: string
+  suffix?: string
+  orientation?: 'horizontal' | 'vertical'
+}
+
+export interface ChartConfig {
+  id: string
+  sheetId: string
+  name: string
+  chartType: ChartType
+  dataSource: ChartDataSource
+  displayConfig?: ChartDisplayConfig
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface ChartCreateInput {
+  name: string
+  chartType: ChartType
+  dataSource: ChartDataSource
+  displayConfig?: ChartDisplayConfig
+}
+
+export interface ChartDataPoint {
+  label: string
+  value: number
+  color?: string
+}
+
+export interface ChartData {
+  chartType: ChartType
+  dataPoints: ChartDataPoint[]
+  total?: number
+  metadata?: Record<string, unknown>
+}
+
+// --- Dashboard ---
+export interface DashboardPanel {
+  id: string
+  chartId: string
+  size: 'small' | 'medium' | 'large'
+  order: number
+}
+
+export interface Dashboard {
+  id: string
+  sheetId: string
+  name: string
+  panels: DashboardPanel[]
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface DashboardUpdateInput {
+  name?: string
+  panels?: DashboardPanel[]
 }
 
 // --- Form Share ---

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -49,6 +49,7 @@
       <button v-if="caps.canManageViews.value && canConfigureCurrentView" class="mt-workbench__mgr-btn" @click="showViewManager = true">&#x2630; Views</button>
       <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="openWorkflowDesigner()">&#x2699; Workflow</button>
       <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="showAutomationManager = true">&#x26A1; Automations</button>
+      <button class="mt-workbench__mgr-btn" :class="{ 'mt-workbench__mgr-btn--active': showDashboardView }" @click="showDashboardView = !showDashboardView" data-action="toggle-dashboard">&#x1F4CA; Dashboard</button>
       <button v-if="activeViewType === 'form'" class="mt-workbench__mgr-btn" @click="showFormShareManager = true">&#x1F517; Share Form</button>
       <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true">&#x1F511; API &amp; Webhooks</button>
     </div>
@@ -87,8 +88,13 @@
     />
     <div class="mt-workbench__content">
       <div class="mt-workbench__main">
+        <MetaDashboardView
+          v-if="showDashboardView"
+          :sheet-id="workbench.activeSheetId.value"
+          :client="workbench.client"
+        />
         <MetaFormView
-          v-if="activeViewType === 'form'"
+          v-else-if="activeViewType === 'form'"
           :fields="scopedAllFields" :hidden-field-ids="workbench.activeView.value?.hiddenFieldIds"
           :record="selectedRecordResolved" :loading="grid.loading.value"
           :read-only="formReadOnly"
@@ -358,6 +364,7 @@ import MetaTimelineView from '../components/MetaTimelineView.vue'
 import MetaToast from '../components/MetaToast.vue'
 import MetaImportModal from '../components/MetaImportModal.vue'
 import MetaMentionPopover from '../components/MetaMentionPopover.vue'
+import MetaDashboardView from '../components/MetaDashboardView.vue'
 import type { MetaBase } from '../types'
 import { bulkImportRecords } from '../import/bulk-import'
 import { extractImportTokens, type ImportBuildFailure, type ImportBuildResult, type ImportValueResolver } from '../import/delimited'
@@ -404,6 +411,7 @@ const linkPickerCurrentValue = ref<unknown>(null)
 const showFieldManager = ref(false)
 const showPermissionManager = ref(false)
 const showAutomationManager = ref(false)
+const showDashboardView = ref(false)
 const showFormShareManager = ref(false)
 const showApiTokenManager = ref(false)
 const fieldPermissionEntries = ref<MetaFieldPermissionEntry[]>([])

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+
+import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomationRuleEditor.vue'
+import type { AutomationRule } from '../src/multitable/types'
+
+const fields = [
+  { id: 'fld_1', name: 'Status', type: 'select' },
+  { id: 'fld_2', name: 'Name', type: 'string' },
+]
+
+function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
+  return {
+    id: 'rule_1',
+    sheetId: 'sheet_1',
+    name: 'Test Rule',
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'update_record',
+    actionConfig: {},
+    enabled: true,
+    actions: [{ type: 'update_record', config: { fieldUpdates: [] } }],
+    ...overrides,
+  }
+}
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaAutomationRuleEditor, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaAutomationRuleEditor', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('renders trigger type selector when visible', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    expect(triggerSelect).toBeTruthy()
+    expect(triggerSelect.options.length).toBe(7)
+  })
+
+  it('shows field picker for field.value_changed trigger', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    triggerSelect.value = 'field.value_changed'
+    triggerSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="triggerFieldId"]')
+    expect(fieldSelect).toBeTruthy()
+  })
+
+  it('shows cron preset for schedule.cron trigger', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    triggerSelect.value = 'schedule.cron'
+    triggerSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const cronSelect = container.querySelector('[data-field="cronPreset"]')
+    expect(cronSelect).toBeTruthy()
+  })
+
+  it('can add and remove conditions', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const addBtn = container.querySelector('[data-action="add-condition"]') as HTMLButtonElement
+    expect(addBtn).toBeTruthy()
+
+    addBtn.click()
+    await flushPromises()
+
+    const conditionRows = container.querySelectorAll('[data-condition-index]')
+    expect(conditionRows.length).toBe(1)
+
+    // Remove condition
+    const removeBtn = conditionRows[0].querySelector('button')
+    removeBtn?.click()
+    await flushPromises()
+
+    expect(container.querySelectorAll('[data-condition-index]').length).toBe(0)
+  })
+
+  it('can add actions up to max 3', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    // Starts with 1 action
+    expect(container.querySelectorAll('[data-action-index]').length).toBe(1)
+
+    const addBtn = container.querySelector('[data-action="add-action"]') as HTMLButtonElement
+    addBtn.click()
+    await flushPromises()
+    expect(container.querySelectorAll('[data-action-index]').length).toBe(2)
+
+    addBtn.click()
+    await flushPromises()
+    expect(container.querySelectorAll('[data-action-index]').length).toBe(3)
+
+    // Button should be hidden at max 3
+    const addBtnAfter = container.querySelector('[data-action="add-action"]')
+    expect(addBtnAfter).toBeFalsy()
+  })
+
+  it('save button is disabled without a name', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+  })
+
+  it('emits save with payload when name is filled', async () => {
+    const saved = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'My Rule'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.name).toBe('My Rule')
+    expect(payload.triggerType).toBe('record.created')
+    expect(payload.actions).toHaveLength(1)
+  })
+
+  it('populates draft from existing rule', async () => {
+    const rule = fakeRule({ name: 'Existing', triggerType: 'record.updated' })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    expect(nameInput.value).toBe('Existing')
+
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    expect(triggerSelect.value).toBe('record.updated')
+  })
+})

--- a/apps/web/tests/multitable-chart-renderer.spec.ts
+++ b/apps/web/tests/multitable-chart-renderer.spec.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+
+import MetaChartRenderer from '../src/multitable/components/MetaChartRenderer.vue'
+import type { ChartData, ChartDisplayConfig } from '../src/multitable/types'
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaChartRenderer, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+const barData: ChartData = {
+  chartType: 'bar',
+  dataPoints: [
+    { label: 'A', value: 10 },
+    { label: 'B', value: 20 },
+    { label: 'C', value: 15 },
+  ],
+}
+
+const lineData: ChartData = {
+  chartType: 'line',
+  dataPoints: [
+    { label: 'Jan', value: 5 },
+    { label: 'Feb', value: 12 },
+    { label: 'Mar', value: 8 },
+  ],
+}
+
+const pieData: ChartData = {
+  chartType: 'pie',
+  dataPoints: [
+    { label: 'Red', value: 30, color: '#ef4444' },
+    { label: 'Blue', value: 50, color: '#2563eb' },
+    { label: 'Green', value: 20, color: '#16a34a' },
+  ],
+}
+
+const numberData: ChartData = {
+  chartType: 'number',
+  dataPoints: [{ label: 'Total Sales', value: 42000 }],
+  total: 42000,
+}
+
+const tableData: ChartData = {
+  chartType: 'table',
+  dataPoints: [
+    { label: 'Row 1', value: 100 },
+    { label: 'Row 2', value: 200 },
+  ],
+}
+
+describe('MetaChartRenderer', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders bar chart with correct number of bars', async () => {
+    const { container } = mount({ chartData: barData })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart-type="bar"]')).toBeTruthy()
+    const svg = container.querySelector('[data-chart="bar"]')
+    expect(svg).toBeTruthy()
+    const bars = container.querySelectorAll('[data-bar-index]')
+    expect(bars.length).toBe(3)
+  })
+
+  it('renders horizontal bar chart when orientation is horizontal', async () => {
+    const config: ChartDisplayConfig = { orientation: 'horizontal' }
+    const { container } = mount({ chartData: barData, displayConfig: config })
+    await flushPromises()
+
+    const bars = container.querySelectorAll('[data-bar-index]')
+    expect(bars.length).toBe(3)
+  })
+
+  it('renders line chart with polyline and data points', async () => {
+    const { container } = mount({ chartData: lineData })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart="line"]')).toBeTruthy()
+    const points = container.querySelectorAll('[data-point-index]')
+    expect(points.length).toBe(3)
+    const polyline = container.querySelector('.meta-chart__line')
+    expect(polyline).toBeTruthy()
+    expect(polyline?.getAttribute('points')).toBeTruthy()
+  })
+
+  it('renders pie chart with segments and legend', async () => {
+    const { container } = mount({ chartData: pieData })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart="pie"]')).toBeTruthy()
+    const segments = container.querySelectorAll('[data-pie-index]')
+    expect(segments.length).toBe(3)
+    expect(container.querySelector('[data-legend]')).toBeTruthy()
+  })
+
+  it('renders number chart with value', async () => {
+    const { container } = mount({ chartData: numberData })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart="number"]')).toBeTruthy()
+    const valueEl = container.querySelector('.meta-chart__number-value')
+    expect(valueEl?.textContent).toBe('42000')
+  })
+
+  it('renders number chart with prefix and suffix', async () => {
+    const config: ChartDisplayConfig = { prefix: '$', suffix: 'USD' }
+    const { container } = mount({ chartData: numberData, displayConfig: config })
+    await flushPromises()
+
+    const affixes = container.querySelectorAll('.meta-chart__number-affix')
+    expect(affixes.length).toBe(2)
+    expect(affixes[0].textContent).toBe('$')
+    expect(affixes[1].textContent).toBe('USD')
+  })
+
+  it('renders table chart with rows', async () => {
+    const { container } = mount({ chartData: tableData })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart="table"]')).toBeTruthy()
+    const rows = container.querySelectorAll('.meta-chart__table tbody tr')
+    expect(rows.length).toBe(2)
+  })
+
+  it('shows title from display config', async () => {
+    const config: ChartDisplayConfig = { title: 'Sales Overview' }
+    const { container } = mount({ chartData: barData, displayConfig: config })
+    await flushPromises()
+
+    const title = container.querySelector('.meta-chart__title')
+    expect(title?.textContent).toBe('Sales Overview')
+  })
+})

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+
+import MetaDashboardView from '../src/multitable/components/MetaDashboardView.vue'
+import { MultitableApiClient } from '../src/multitable/api/client'
+import type { Dashboard, ChartConfig, ChartData } from '../src/multitable/types'
+
+function fakeDashboard(overrides: Partial<Dashboard> = {}): Dashboard {
+  return {
+    id: 'dash_1',
+    sheetId: 'sheet_1',
+    name: 'My Dashboard',
+    panels: [
+      { id: 'panel_1', chartId: 'chart_1', size: 'medium', order: 0 },
+    ],
+    ...overrides,
+  }
+}
+
+function fakeChart(overrides: Partial<ChartConfig> = {}): ChartConfig {
+  return {
+    id: 'chart_1',
+    sheetId: 'sheet_1',
+    name: 'Sales Chart',
+    chartType: 'bar',
+    dataSource: { sheetId: 'sheet_1', fieldId: 'fld_1', aggregation: 'count' },
+    ...overrides,
+  }
+}
+
+const fakeChartData: ChartData = {
+  chartType: 'bar',
+  dataPoints: [
+    { label: 'A', value: 10 },
+    { label: 'B', value: 20 },
+  ],
+}
+
+function mockClient(dashboards: Dashboard[] = [], charts: ChartConfig[] = []) {
+  const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  const noContent = () => new Response(null, { status: 204 })
+
+  const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+    if (method === 'GET' && url.includes('/dashboards') && !url.includes('/charts')) {
+      return ok({ dashboards })
+    }
+    if (method === 'GET' && url.includes('/charts') && url.includes('/data')) {
+      return ok(fakeChartData)
+    }
+    if (method === 'GET' && url.includes('/charts')) {
+      return ok({ charts })
+    }
+    if (method === 'POST' && url.includes('/dashboards')) {
+      const body = JSON.parse(init?.body as string)
+      return ok({ id: 'dash_new', sheetId: 'sheet_1', panels: [], ...body })
+    }
+    if (method === 'PATCH' && url.includes('/dashboards/')) {
+      const body = JSON.parse(init?.body as string)
+      const db = dashboards[0] ?? fakeDashboard()
+      return ok({ ...db, ...body })
+    }
+    if (method === 'DELETE' && url.includes('/dashboards/')) {
+      return noContent()
+    }
+    return ok({})
+  })
+  return { client: new MultitableApiClient({ fetchFn }), fetchFn }
+}
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaDashboardView, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaDashboardView', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('shows empty state when no dashboards exist', async () => {
+    const { client } = mockClient([], [])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    expect(container.querySelector('[data-empty]')).toBeTruthy()
+  })
+
+  it('renders dashboard with panels', async () => {
+    const { client } = mockClient([fakeDashboard()], [fakeChart()])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    const grid = container.querySelector('[data-grid]')
+    expect(grid).toBeTruthy()
+    const panels = container.querySelectorAll('[data-panel-id]')
+    expect(panels.length).toBe(1)
+  })
+
+  it('creates a new dashboard', async () => {
+    const { client, fetchFn } = mockClient([], [])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    const createBtn = container.querySelector('[data-action="create-dashboard"]') as HTMLButtonElement
+    expect(createBtn).toBeTruthy()
+    createBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/dashboards') && init?.method === 'POST',
+    )
+    expect(postCalls.length).toBe(1)
+  })
+
+  it('can add a panel from chart picker', async () => {
+    const dashboard = fakeDashboard({ panels: [] })
+    const chart = fakeChart()
+    const { client, fetchFn } = mockClient([dashboard], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    const addPanelBtn = container.querySelector('[data-action="add-panel"]') as HTMLButtonElement
+    addPanelBtn.click()
+    await flushPromises()
+
+    const chartOption = container.querySelector(`[data-chart-option="${chart.id}"]`) as HTMLElement
+    expect(chartOption).toBeTruthy()
+    chartOption.click()
+    await flushPromises()
+
+    // Should have called PATCH to update dashboard
+    const patchCalls = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH',
+    )
+    expect(patchCalls.length).toBe(1)
+  })
+
+  it('can remove a panel', async () => {
+    const { client, fetchFn } = mockClient([fakeDashboard()], [fakeChart()])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    const removeBtn = container.querySelector('[data-action="remove-panel"]') as HTMLButtonElement
+    expect(removeBtn).toBeTruthy()
+    removeBtn.click()
+    await flushPromises()
+
+    const patchCalls = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH',
+    )
+    expect(patchCalls.length).toBe(1)
+    const body = JSON.parse(patchCalls[0][1].body as string)
+    expect(body.panels).toEqual([])
+  })
+
+  it('can resize a panel', async () => {
+    const { client, fetchFn } = mockClient([fakeDashboard()], [fakeChart()])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    const sizeSelect = container.querySelector('[data-field="panel-size"]') as HTMLSelectElement
+    expect(sizeSelect).toBeTruthy()
+    sizeSelect.value = 'large'
+    sizeSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const patchCalls = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH',
+    )
+    expect(patchCalls.length).toBe(1)
+    const body = JSON.parse(patchCalls[0][1].body as string)
+    expect(body.panels[0].size).toBe('large')
+  })
+})


### PR DESCRIPTION
## Summary
- **Enhanced Automation Rule Editor** (`MetaAutomationRuleEditor.vue`): Full V1 engine support with 7 trigger types (record CRUD, field value change, cron/interval schedule, webhook), 10 condition operators with AND/OR conjunction, and up to 3-step action chains (update/create record, send webhook/notification, lock record)
- **Execution Log Viewer** (`MetaAutomationLogViewer.vue`): Stats bar (total/success/failed/avg duration), filterable log list with expandable step-level detail
- **Chart Renderer** (`MetaChartRenderer.vue`): Pure SVG/HTML renderer for 5 chart types (bar, line, pie, number, table) with responsive viewBox layout, legend, and display config support
- **Dashboard View** (`MetaDashboardView.vue`): CSS Grid panel layout with create/rename dashboard, add/remove/resize panels (small/medium/large presets), chart picker modal
- **API Client extensions**: 14 new methods for automation logs/stats/test, charts CRUD + data, dashboards CRUD
- **Type definitions**: 25+ new types for the V1 automation engine, charts, and dashboards
- **Wired into existing UI**: Rule editor + log viewer integrated into MetaAutomationManager; Dashboard toggle button added to MultitableWorkbench toolbar

## Test plan
- [x] `multitable-automation-rule-editor.spec.ts` — 8 tests: trigger selection, field picker visibility, cron config, condition add/remove, action chain (max 3), save validation, payload emission, edit mode population
- [x] `multitable-chart-renderer.spec.ts` — 8 tests: bar/horizontal-bar/line/pie/number/table rendering, prefix/suffix display, title from config
- [x] `multitable-dashboard-view.spec.ts` — 6 tests: empty state, panel rendering, create dashboard, add/remove/resize panels

All 22 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)