### PR TITLE
docs: add dingtalk identity stack handoff

### DIFF
--- a/docs/development/dingtalk-identity-merge-checklist-development-20260414.md
+++ b/docs/development/dingtalk-identity-merge-checklist-development-20260414.md
@@ -1,0 +1,46 @@
+# DingTalk Identity Merge Checklist
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## PR Order
+
+1. runtime
+   - <https://github.com/zensgit/metasheet2/pull/new/codex/dingtalk-identity-runtime-20260414>
+2. frontend
+   - <https://github.com/zensgit/metasheet2/pull/new/codex/dingtalk-identity-frontend-20260414>
+3. integration/docs
+   - <https://github.com/zensgit/metasheet2/pull/new/codex/dingtalk-identity-integration-20260414>
+
+## Runtime PR Checklist
+
+- confirm branch head is `80864ac61`
+- confirm changed scope is backend/runtime only
+- confirm `GET /api/auth/dingtalk/launch?probe=1` returns structured runtime status
+- confirm `/api/admin/users/:userId/dingtalk-access` contains `server`
+- confirm launch/callback success path is unchanged
+- attach verification commands from:
+  - `dingtalk-runtime-status-verification-20260414.md`
+
+## Frontend PR Checklist
+
+- confirm branch head is `7060a2f30`
+- confirm base branch is runtime PR or `main` after runtime merge
+- confirm login page hides DingTalk entry when `available !== true`
+- confirm login page shows an unavailable reason hint
+- confirm user management page shows server runtime status, corpId, and allowlist
+- attach verification commands from:
+  - `dingtalk-runtime-status-frontend-verification-20260414.md`
+
+## Integration / Docs PR Checklist
+
+- confirm stack verification doc is present
+- confirm stack handoff docs are present
+- confirm PR draft docs are present
+- confirm PR package docs are present
+- keep this PR docs-only
+
+## Reviewer Notes
+
+- main worktree currently contains unrelated local DingTalk/admin changes and should not be used as evidence for these isolated lanes
+- runtime lane should merge first because frontend consumes the new backend `server` payload

--- a/docs/development/dingtalk-identity-merge-checklist-verification-20260414.md
+++ b/docs/development/dingtalk-identity-merge-checklist-verification-20260414.md
@@ -1,0 +1,72 @@
+# DingTalk Identity Merge Checklist Verification
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Reviewed Inputs
+
+- `dingtalk-runtime-status-verification-20260414.md`
+- `dingtalk-runtime-status-frontend-verification-20260414.md`
+- `dingtalk-identity-stack-verification-20260414.md`
+- `dingtalk-identity-stack-handoff-development-20260414.md`
+- `dingtalk-identity-stack-handoff-verification-20260414.md`
+- `dingtalk-identity-pr-drafts-development-20260414.md`
+- `dingtalk-identity-pr-drafts-verification-20260414.md`
+- `dingtalk-identity-pr-package-development-20260414.md`
+- `dingtalk-identity-pr-package-verification-20260414.md`
+
+## Confirmed Branch Heads
+
+- runtime: `80864ac61`
+- frontend: `7060a2f30`
+- integration/docs current head before this doc: `bbfcdaa0e`
+
+## Confirmed Verification Baseline
+
+### Runtime
+
+- `73/73`
+- backend `tsc` passed
+
+### Frontend
+
+- `5/5`
+- frontend `tsc` passed
+
+## Claude Code CLI Status
+
+Checked in this turn:
+
+- `claude auth status` succeeded
+- `claude -p "Return exactly: CLAUDE_CLI_OK"` succeeded
+
+Conclusion:
+
+- Claude Code CLI is callable right now
+- suitable use remains: isolated worktree, narrow backend/docs/integration tasks
+- avoid relying on it for long mixed-scope editing runs when deterministic delivery matters
+
+## Post-Merge Smoke Recommendation
+
+After runtime + frontend merge to `main`, run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/dingtalk-oauth-login-gates.test.ts \
+  --reporter=dot
+```
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  --watch=false --reporter=dot
+```
+
+Then manually verify:
+
+1. login page with `probe=1` available state
+2. login page with allowlist-blocked state
+3. user management DingTalk panel shows server status, corpId, allowlist, grant, identity

--- a/docs/development/dingtalk-identity-pr-drafts-development-20260414.md
+++ b/docs/development/dingtalk-identity-pr-drafts-development-20260414.md
@@ -1,0 +1,108 @@
+# DingTalk Identity PR Drafts
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Runtime PR
+
+Base:
+
+- `main`
+
+Title:
+
+```text
+feat(dingtalk): add runtime status probes
+```
+
+Body:
+
+```md
+## What Changed
+
+- added a shared DingTalk runtime status helper
+- enriched `GET /api/auth/dingtalk/launch?probe=1`
+- enriched `/api/admin/users/:userId/dingtalk-access` with a `server` runtime-status block
+
+## Why
+
+The login page and admin pages need one stable backend view of DingTalk availability, corp allowlist policy, and auth-mode flags without reopening the callback flow.
+
+## Verification
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/admin-users-routes.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts --reporter=dot`
+- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
+
+## Notes
+
+- launch and callback success behavior are unchanged
+- change is backend/runtime only
+```
+
+## Frontend PR
+
+Base:
+
+- `codex/dingtalk-identity-runtime-20260414`
+  or `main` after runtime merges
+
+Title:
+
+```text
+feat(dingtalk): surface runtime status in frontend
+```
+
+Body:
+
+```md
+## What Changed
+
+- login page now consumes the structured DingTalk probe payload
+- user management page now shows server runtime status, corpId, and allowlist context
+
+## Why
+
+Frontend should distinguish server unavailability from per-user grant and identity state instead of treating DingTalk availability as a simple boolean.
+
+## Verification
+
+- `pnpm --filter @metasheet/web exec vitest run tests/LoginView.spec.ts tests/userManagementView.spec.ts --watch=false --reporter=dot`
+- `pnpm --filter @metasheet/web exec tsc --noEmit --pretty false`
+
+## Notes
+
+- no callback flow semantics changed
+- change is limited to frontend consumption of the backend runtime-status block
+```
+
+## Integration / Docs PR
+
+Base:
+
+- `main`
+
+Title:
+
+```text
+docs: add dingtalk identity stack handoff
+```
+
+Body:
+
+```md
+## What Changed
+
+- added combined DingTalk identity verification summary
+- added merge order recommendation
+- added PR handoff and merge checklist notes
+
+## Why
+
+The DingTalk identity work was intentionally split across runtime, frontend, and integration lanes. This PR keeps the handoff material explicit and reviewable.
+
+## Verification
+
+- verified referenced runtime lane commit and docs
+- verified referenced frontend lane commit and docs
+- confirmed merge order and worktree isolation notes
+```

--- a/docs/development/dingtalk-identity-pr-drafts-verification-20260414.md
+++ b/docs/development/dingtalk-identity-pr-drafts-verification-20260414.md
@@ -1,0 +1,47 @@
+# DingTalk Identity PR Drafts Verification
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Runtime PR Review Checklist
+
+- confirm branch head is `80864ac61`
+- confirm backend docs exist:
+  - `dingtalk-runtime-status-development-20260414.md`
+  - `dingtalk-runtime-status-verification-20260414.md`
+- confirm runtime verification already passed:
+  - `73/73`
+  - backend `tsc`
+
+## Frontend PR Review Checklist
+
+- confirm branch head is `7060a2f30`
+- confirm frontend docs exist:
+  - `dingtalk-runtime-status-frontend-development-20260414.md`
+  - `dingtalk-runtime-status-frontend-verification-20260414.md`
+- confirm frontend verification already passed:
+  - `5/5`
+  - frontend `tsc`
+
+## Integration / Docs PR Review Checklist
+
+- confirm stack summary exists:
+  - `dingtalk-identity-stack-verification-20260414.md`
+- confirm handoff docs exist:
+  - `dingtalk-identity-stack-handoff-development-20260414.md`
+  - `dingtalk-identity-stack-handoff-verification-20260414.md`
+- confirm this PR-draft document pair exists
+
+## Merge Sequence
+
+1. merge runtime PR
+2. merge frontend PR
+3. merge integration/docs PR
+
+## Claude Code CLI Note
+
+Claude Code CLI is callable locally and authenticated. In this round:
+
+- simple `claude -p` invocations were verified
+- long doc-generation tasks were unreliable
+- final PR draft docs were completed manually after verification

--- a/docs/development/dingtalk-identity-pr-final-copy-development-20260414.md
+++ b/docs/development/dingtalk-identity-pr-final-copy-development-20260414.md
@@ -1,0 +1,119 @@
+# DingTalk Identity PR Final Copy
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Runtime PR
+
+Branch:
+
+- `codex/dingtalk-identity-runtime-20260414`
+
+Base:
+
+- `main`
+
+Title:
+
+```text
+feat(dingtalk): add runtime status probes
+```
+
+```md
+## What Changed
+
+- added a shared DingTalk runtime status helper in backend auth/runtime code
+- enriched `GET /api/auth/dingtalk/launch?probe=1` to return structured runtime status
+- enriched `/api/admin/users/:userId/dingtalk-access` with a `server` runtime-status block
+
+## Why
+
+Login and admin pages need one stable backend view of DingTalk availability, allowlist policy, and auth-mode flags without reopening the callback flow.
+
+## Verification
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/admin-users-routes.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts --reporter=dot`
+- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
+
+## Notes
+
+- launch and callback success behavior remain unchanged
+- backend/runtime only
+```
+
+## Frontend PR
+
+Branch:
+
+- `codex/dingtalk-identity-frontend-20260414`
+
+Base:
+
+- `codex/dingtalk-identity-runtime-20260414`
+  or `main` after the runtime PR merges
+
+Title:
+
+```text
+feat(dingtalk): surface runtime status in frontend
+```
+
+```md
+## What Changed
+
+- login page now consumes the structured DingTalk probe payload
+- user management page now surfaces backend runtime status, corpId, and allowlist context
+
+## Why
+
+Frontend should distinguish server unavailability from per-user grant and identity state instead of treating DingTalk availability as a simple boolean.
+
+## Verification
+
+- `pnpm --filter @metasheet/web exec vitest run tests/LoginView.spec.ts tests/userManagementView.spec.ts --watch=false --reporter=dot`
+- `pnpm --filter @metasheet/web exec tsc --noEmit --pretty false`
+
+## Notes
+
+- frontend consumption only
+- no callback-flow protocol changes
+```
+
+## Integration PR
+
+Branch:
+
+- `codex/dingtalk-identity-integration-20260414`
+
+Base:
+
+- `main`
+
+Title:
+
+```text
+docs: add dingtalk identity stack handoff
+```
+
+```md
+## What Changed
+
+- added combined DingTalk identity verification summary
+- added handoff and merge-order notes
+- added GitHub-ready PR drafts, PR package copy, and merge checklists
+
+## Why
+
+The DingTalk identity work was intentionally split across runtime, frontend, and integration lanes. This PR keeps the handoff material explicit and reviewable.
+
+## Verification
+
+- verified referenced runtime lane commit and docs
+- verified referenced frontend lane commit and docs
+- confirmed merge order and worktree isolation notes
+
+## Notes
+
+- docs-only
+- merge after runtime + frontend
+```

--- a/docs/development/dingtalk-identity-pr-final-copy-verification-20260414.md
+++ b/docs/development/dingtalk-identity-pr-final-copy-verification-20260414.md
@@ -1,0 +1,46 @@
+# DingTalk Identity PR Final Copy Verification
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Verified Inputs
+
+- `dingtalk-runtime-status-development-20260414.md`
+- `dingtalk-runtime-status-verification-20260414.md`
+- `dingtalk-runtime-status-frontend-development-20260414.md`
+- `dingtalk-runtime-status-frontend-verification-20260414.md`
+- `dingtalk-identity-pr-package-development-20260414.md`
+
+## Verified Branches
+
+- runtime head: `80864ac61`
+- frontend head: `7060a2f30`
+- integration head before this doc: `302a4b60f`
+
+## Verified Command Baseline
+
+### Runtime
+
+- `73/73`
+- backend `tsc` passed
+
+### Frontend
+
+- `5/5`
+- frontend `tsc` passed
+
+## Claude Code CLI Status In This Turn
+
+Checked:
+
+- `claude auth status` passed
+- `claude -p "Return exactly: CLAUDE_CLI_OK"` passed
+
+Observed behavior:
+
+- CLI is callable and authenticated
+- long single-file doc generation remained slower than manual fallback
+
+## Conclusion
+
+The PR final copy in the paired development doc is consistent with the verified runtime/frontend docs and ready to paste into GitHub PR descriptions.

--- a/docs/development/dingtalk-identity-pr-package-development-20260414.md
+++ b/docs/development/dingtalk-identity-pr-package-development-20260414.md
@@ -1,0 +1,142 @@
+# DingTalk Identity PR Package
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Purpose
+
+Package the DingTalk identity work into three reviewable PRs with copy-ready GitHub content.
+
+## PR 1
+
+Branch:
+
+- `codex/dingtalk-identity-runtime-20260414`
+
+Base:
+
+- `main`
+
+Title:
+
+```text
+feat(dingtalk): add runtime status probes
+```
+
+Short body:
+
+```md
+## What Changed
+
+- added a shared DingTalk runtime status helper in backend auth/runtime code
+- enriched `GET /api/auth/dingtalk/launch?probe=1` to return structured runtime status
+- enriched `/api/admin/users/:userId/dingtalk-access` with a shared `server` runtime-status block
+
+## Why
+
+Login and admin pages need one stable backend view of DingTalk availability, allowlist policy, and auth-mode flags without reopening the callback flow.
+
+## Verification
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/admin-users-routes.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts --reporter=dot`
+- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
+
+## Notes
+
+- normal launch/callback success behavior is unchanged
+- backend/runtime only
+```
+
+## PR 2
+
+Branch:
+
+- `codex/dingtalk-identity-frontend-20260414`
+
+Base:
+
+- `codex/dingtalk-identity-runtime-20260414`
+  or `main` after PR 1 merges
+
+Title:
+
+```text
+feat(dingtalk): surface runtime status in frontend
+```
+
+Short body:
+
+```md
+## What Changed
+
+- login page now consumes the structured DingTalk probe payload
+- user management page now surfaces backend runtime status, corpId, and allowlist context
+
+## Why
+
+Frontend should distinguish server unavailability from per-user grant and identity state instead of treating DingTalk availability as a simple boolean.
+
+## Verification
+
+- `pnpm --filter @metasheet/web exec vitest run tests/LoginView.spec.ts tests/userManagementView.spec.ts --watch=false --reporter=dot`
+- `pnpm --filter @metasheet/web exec tsc --noEmit --pretty false`
+
+## Notes
+
+- frontend consumption only
+- no callback-flow protocol changes
+```
+
+## PR 3
+
+Branch:
+
+- `codex/dingtalk-identity-integration-20260414`
+
+Base:
+
+- `main`
+
+Title:
+
+```text
+docs: add dingtalk identity stack handoff
+```
+
+Short body:
+
+```md
+## What Changed
+
+- added combined DingTalk identity verification summary
+- added handoff and merge-order notes
+- added GitHub-ready PR drafts and review checklists
+
+## Why
+
+The DingTalk identity work was intentionally split across runtime, frontend, and integration lanes. This PR keeps the handoff material explicit and reviewable.
+
+## Verification
+
+- verified referenced runtime lane commit and docs
+- verified referenced frontend lane commit and docs
+- confirmed merge order and worktree isolation notes
+```
+
+## Recommended Merge Order
+
+1. PR 1 runtime
+2. PR 2 frontend
+3. PR 3 integration/docs
+
+## Supporting Docs
+
+- `dingtalk-runtime-status-development-20260414.md`
+- `dingtalk-runtime-status-verification-20260414.md`
+- `dingtalk-runtime-status-frontend-development-20260414.md`
+- `dingtalk-runtime-status-frontend-verification-20260414.md`
+- `dingtalk-identity-stack-verification-20260414.md`
+- `dingtalk-identity-stack-handoff-development-20260414.md`
+- `dingtalk-identity-stack-handoff-verification-20260414.md`
+- `dingtalk-identity-pr-drafts-development-20260414.md`
+- `dingtalk-identity-pr-drafts-verification-20260414.md`

--- a/docs/development/dingtalk-identity-pr-package-verification-20260414.md
+++ b/docs/development/dingtalk-identity-pr-package-verification-20260414.md
@@ -1,0 +1,85 @@
+# DingTalk Identity PR Package Verification
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Verified Branch Heads
+
+- runtime: `80864ac61`
+- frontend: `7060a2f30`
+- integration/docs (before this package doc): `d5e6fc3c7`
+
+## Verified Supporting Docs
+
+- runtime docs present
+- frontend docs present
+- stack verification doc present
+- handoff docs present
+- PR draft docs present
+
+## Verified Runtime Lane Results
+
+Source:
+
+- `dingtalk-runtime-status-verification-20260414.md`
+
+Recorded passed commands:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/dingtalk-oauth-login-gates.test.ts \
+  --reporter=dot
+```
+
+Result: `73/73`
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: passed
+
+## Verified Frontend Lane Results
+
+Source:
+
+- `dingtalk-runtime-status-frontend-verification-20260414.md`
+
+Recorded passed commands:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  --watch=false --reporter=dot
+```
+
+Result: `5/5`
+
+```bash
+pnpm --filter @metasheet/web exec tsc --noEmit --pretty false
+```
+
+Result: passed
+
+## Claude Code CLI Status
+
+Current local status:
+
+- binary is present
+- authenticated session is present
+- `claude auth status` succeeds
+
+Current limitation observed in this turn:
+
+- non-interactive `claude -p` is currently rate-limited for the logged-in account
+- returned message: `You've hit your limit · resets 6pm (Asia/Shanghai)`
+
+## Conclusion
+
+The PR package is ready to use. The reliable path for this round is:
+
+1. keep CLI usage to short, isolated tasks when quota is available
+2. keep final merge/handoff documents manual when CLI quota is exhausted

--- a/docs/development/dingtalk-identity-review-runbook-development-20260414.md
+++ b/docs/development/dingtalk-identity-review-runbook-development-20260414.md
@@ -1,0 +1,98 @@
+# DingTalk Identity Review Runbook
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Purpose
+
+Provide one compact review/merge runbook for the three DingTalk identity lanes.
+
+## PR Links
+
+### Runtime
+
+- Branch: `codex/dingtalk-identity-runtime-20260414`
+- PR: <https://github.com/zensgit/metasheet2/pull/new/codex/dingtalk-identity-runtime-20260414>
+- Head: `80864ac61`
+
+### Frontend
+
+- Branch: `codex/dingtalk-identity-frontend-20260414`
+- PR: <https://github.com/zensgit/metasheet2/pull/new/codex/dingtalk-identity-frontend-20260414>
+- Head: `7060a2f30`
+
+### Integration / Docs
+
+- Branch: `codex/dingtalk-identity-integration-20260414`
+- PR: <https://github.com/zensgit/metasheet2/pull/new/codex/dingtalk-identity-integration-20260414>
+- Current docs head: `3d4d68cda` before this runbook
+
+## Merge Order
+
+1. runtime
+2. frontend
+3. integration/docs
+
+## Review Focus
+
+### Runtime review
+
+- `GET /api/auth/dingtalk/launch?probe=1` now returns structured runtime status
+- `/api/admin/users/:userId/dingtalk-access` now includes `server`
+- launch/callback success semantics remain unchanged
+
+### Frontend review
+
+- login page only shows DingTalk entry when runtime probe reports `available === true`
+- login page shows a reason hint for unavailable probe states
+- user management page shows server runtime status, corpId, and allowlist context
+
+### Integration/docs review
+
+- stack verification exists
+- handoff docs exist
+- PR draft/package/final-copy docs exist
+- merge checklist exists
+
+## Post-Merge Smoke
+
+After runtime + frontend merge to `main`, run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/dingtalk-oauth-login-gates.test.ts \
+  --reporter=dot
+```
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  --watch=false --reporter=dot
+```
+
+Manual checks:
+
+1. login page when DingTalk probe is available
+2. login page when allowlist blocks DingTalk
+3. admin user page shows server status, corpId, allowlist, grant, identity
+
+## Supporting Docs
+
+- `dingtalk-runtime-status-development-20260414.md`
+- `dingtalk-runtime-status-verification-20260414.md`
+- `dingtalk-runtime-status-frontend-development-20260414.md`
+- `dingtalk-runtime-status-frontend-verification-20260414.md`
+- `dingtalk-identity-stack-verification-20260414.md`
+- `dingtalk-identity-stack-handoff-development-20260414.md`
+- `dingtalk-identity-stack-handoff-verification-20260414.md`
+- `dingtalk-identity-pr-drafts-development-20260414.md`
+- `dingtalk-identity-pr-drafts-verification-20260414.md`
+- `dingtalk-identity-pr-package-development-20260414.md`
+- `dingtalk-identity-pr-package-verification-20260414.md`
+- `dingtalk-identity-pr-final-copy-development-20260414.md`
+- `dingtalk-identity-pr-final-copy-verification-20260414.md`
+- `dingtalk-identity-merge-checklist-development-20260414.md`
+- `dingtalk-identity-merge-checklist-verification-20260414.md`

--- a/docs/development/dingtalk-identity-review-runbook-verification-20260414.md
+++ b/docs/development/dingtalk-identity-review-runbook-verification-20260414.md
@@ -1,0 +1,40 @@
+# DingTalk Identity Review Runbook Verification
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Verified Branch Heads
+
+- runtime: `80864ac61`
+- frontend: `7060a2f30`
+- integration/docs before this runbook pair: `3d4d68cda`
+
+## Verified Existing Baseline
+
+### Runtime
+
+- `73/73`
+- backend `tsc` passed
+
+### Frontend
+
+- `5/5`
+- frontend `tsc` passed
+
+## Verified PR Links
+
+- runtime PR URL format present and branch exists
+- frontend PR URL format present and branch exists
+- integration/docs PR URL format present and branch exists
+
+## Claude Code CLI Status
+
+Checked in this turn:
+
+- `claude -p "Return exactly: CLAUDE_CLI_OK"` returned `CLAUDE_CLI_OK`
+
+Conclusion:
+
+- Claude Code CLI is callable right now
+- it remains suitable for isolated narrow tasks
+- final runbook docs in this turn were still completed manually for deterministic delivery

--- a/docs/development/dingtalk-identity-stack-handoff-development-20260414.md
+++ b/docs/development/dingtalk-identity-stack-handoff-development-20260414.md
@@ -1,0 +1,86 @@
+# DingTalk Identity Stack Handoff Development
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Goal
+
+Prepare the DingTalk identity work for merge as three isolated lanes:
+
+1. backend/runtime
+2. frontend consumption
+3. integration/docs handoff
+
+## Lanes
+
+### Runtime
+
+- Branch: `codex/dingtalk-identity-runtime-20260414`
+- Commit: `80864ac61`
+- Scope:
+  - shared DingTalk runtime status helper
+  - richer `/api/auth/dingtalk/launch?probe=1`
+  - richer `/api/admin/users/:userId/dingtalk-access`
+
+### Frontend
+
+- Branch: `codex/dingtalk-identity-frontend-20260414`
+- Commit: `7060a2f30`
+- Scope:
+  - login page consumes structured probe payload
+  - admin user management page displays backend runtime status
+
+### Integration / Docs
+
+- Branch: `codex/dingtalk-identity-integration-20260414`
+- Commit introducing stack summary: `c4769d58b`
+- Scope:
+  - combined verification summary
+  - merge order recommendation
+  - handoff/checklist docs
+
+## Recommended Merge Order
+
+1. `codex/dingtalk-identity-runtime-20260414`
+2. `codex/dingtalk-identity-frontend-20260414`
+3. `codex/dingtalk-identity-integration-20260414`
+
+Reason:
+
+- frontend lane consumes the new backend `server` runtime-status block
+- integration lane is documentation-only and should reflect the final merged order
+
+## PR Checklist
+
+### Runtime PR
+
+- confirm probe payload shape is documented
+- confirm launch/callback success path behavior is unchanged
+- confirm admin DingTalk access response stays backward-compatible
+
+### Frontend PR
+
+- confirm login page hides the DingTalk button when `available !== true`
+- confirm login page shows a stable reason hint for unavailable probe states
+- confirm user management page surfaces server runtime status, corpId, and allowlist context
+
+### Integration / Docs PR
+
+- include links to runtime/frontend verification docs
+- include merge order
+- include explicit note that main worktree had unrelated DingTalk/admin changes and they were not touched
+
+## Claude Code CLI Use
+
+Claude Code CLI is available locally and authenticated.
+
+Recommended use:
+
+- isolated worktree only
+- docs, backend, contract, or verification lanes
+- narrow prompts with one output file or one bounded backend task
+
+Avoid:
+
+- long mixed frontend/backend editing tasks
+- concurrent edits against the same working tree as Codex

--- a/docs/development/dingtalk-identity-stack-handoff-verification-20260414.md
+++ b/docs/development/dingtalk-identity-stack-handoff-verification-20260414.md
@@ -1,0 +1,91 @@
+# DingTalk Identity Stack Handoff Verification
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Source Verification Docs
+
+- `dingtalk-runtime-status-verification-20260414.md`
+- `dingtalk-runtime-status-frontend-verification-20260414.md`
+- `dingtalk-identity-stack-verification-20260414.md`
+
+## Verified Lanes
+
+### Runtime lane
+
+- Branch: `codex/dingtalk-identity-runtime-20260414`
+- Commit: `80864ac61`
+
+Commands already passed:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/dingtalk-oauth-login-gates.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+- `3` files
+- `73` tests
+- all passed
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: passed
+
+### Frontend lane
+
+- Branch: `codex/dingtalk-identity-frontend-20260414`
+- Commit: `7060a2f30`
+
+Commands already passed:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  --watch=false --reporter=dot
+```
+
+Result:
+
+- `2` files
+- `5` tests
+- all passed
+
+```bash
+pnpm --filter @metasheet/web exec tsc --noEmit --pretty false
+```
+
+Result: passed
+
+## Worktree Hygiene Notes
+
+- runtime and frontend lanes each used isolated worktrees
+- temporary `node_modules` symlinks in those worktrees were not committed
+- main worktree still contains unrelated local DingTalk/admin changes and they remain untouched
+
+## Merge Readiness
+
+Current recommendation:
+
+- runtime lane is ready to review first
+- frontend lane is ready to review after runtime
+- integration/docs lane is optional but useful for final handoff context
+
+## Claude Code CLI Verification
+
+Claude Code CLI was verified as callable locally:
+
+- binary present
+- authenticated session present
+- non-interactive `claude -p` works
+
+Operational note:
+
+- in this round, long doc-generation prompts were unreliable, so final integration handoff docs were completed manually after verification

--- a/docs/development/dingtalk-identity-stack-verification-20260414.md
+++ b/docs/development/dingtalk-identity-stack-verification-20260414.md
@@ -1,0 +1,92 @@
+# DingTalk Identity Stack Verification
+
+Date: 2026-04-14
+Branch: `codex/dingtalk-identity-integration-20260414`
+
+## Scope
+
+This document summarizes the two isolated DingTalk identity lanes completed on top of `main`.
+
+### Runtime lane
+
+- Branch: `codex/dingtalk-identity-runtime-20260414`
+- Commit: `80864ac61`
+- Title: `feat(dingtalk): add runtime status probes`
+
+Delivered:
+
+- shared backend/runtime status helper for DingTalk auth
+- richer `GET /api/auth/dingtalk/launch?probe=1` payload
+- admin DingTalk access snapshot includes server runtime status
+
+### Frontend lane
+
+- Branch: `codex/dingtalk-identity-frontend-20260414`
+- Commit: `7060a2f30`
+- Title: `feat(dingtalk): surface runtime status in frontend`
+
+Delivered:
+
+- login page consumes structured DingTalk probe status
+- user management page displays server runtime status, corpId, and allowlist context
+
+## Verification
+
+### Backend/runtime lane
+
+Source: `dingtalk-runtime-status-verification-20260414.md`
+
+Commands already passed:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/dingtalk-oauth-login-gates.test.ts \
+  --reporter=dot
+```
+
+Result: `73/73`
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: passed
+
+### Frontend lane
+
+Source: `dingtalk-runtime-status-frontend-verification-20260414.md`
+
+Commands already passed:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  --watch=false --reporter=dot
+```
+
+Result: `5/5`
+
+```bash
+pnpm --filter @metasheet/web exec tsc --noEmit --pretty false
+```
+
+Result: passed
+
+## Merge Order Recommendation
+
+1. Merge `codex/dingtalk-identity-runtime-20260414`
+2. Merge `codex/dingtalk-identity-frontend-20260414`
+3. Keep this integration/doc branch optional unless a combined handoff doc is needed in `main`
+
+Reason:
+
+- frontend lane consumes the backend `server` runtime-status block
+- runtime lane is additive and should land first to avoid frontend drift
+
+## Notes
+
+- Main worktree currently contains unrelated local DingTalk/admin changes; they were intentionally not touched by these isolated lanes.
+- Claude Code CLI is available locally and usable for isolated read-only or narrow backend/docs tasks, but in this round it did not produce a completed integration doc, so this summary was finalized manually.

--- a/docs/development/dingtalk-integration-mainline-sync-development-20260415.md
+++ b/docs/development/dingtalk-integration-mainline-sync-development-20260415.md
@@ -1,0 +1,10 @@
+## Summary
+
+- Synced `codex/dingtalk-identity-integration-20260414` with `origin/main` in an isolated detached worktree.
+- The merge completed cleanly with no manual conflict resolution.
+- This branch remains docs/integration focused; the sync is intended to clear the stale `BEHIND` state on PR `#872`.
+
+## Notes
+
+- The resulting merge commit brings the docs branch up to date with the already-merged DingTalk admin and multitable mainline work.
+- No additional branch-specific code edits were required beyond the clean merge.

--- a/docs/development/dingtalk-integration-mainline-sync-verification-20260415.md
+++ b/docs/development/dingtalk-integration-mainline-sync-verification-20260415.md
@@ -1,0 +1,11 @@
+## Verification
+
+### Passed
+
+- `git merge origin/main` completed cleanly in the isolated worktree.
+- `git status --short --branch` returned a clean worktree after the merge commit.
+
+## Scope
+
+- No branch-local code changes were introduced in this sync.
+- Follow-up verification for PR `#872` is expected to come from the rerun GitHub checks after the branch is pushed.


### PR DESCRIPTION
## What Changed

- added combined DingTalk identity verification summary
- added handoff and merge-order notes
- added GitHub-ready PR drafts, PR package copy, merge checklists, and review runbook docs

## Why

The DingTalk identity work was intentionally split across runtime, frontend, and integration lanes. This PR keeps the handoff material explicit and reviewable.

## Verification

- verified referenced runtime lane commit and docs
- verified referenced frontend lane commit and docs
- confirmed merge order and worktree isolation notes

## Notes

- docs-only
- merge after runtime + frontend
