### PR TITLE
feat(dingtalk): add directory review ops stack

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -147,6 +147,395 @@
         <section v-if="selectedIntegration" class="directory-admin__section">
           <div class="directory-admin__section-head">
             <div>
+              <h3>待处理队列</h3>
+              <p class="directory-admin__hint">展示待绑定、目录停用待停权、缺少钉钉身份标识的成员。</p>
+              <p class="directory-admin__hint">
+                待绑定中：可推荐 {{ pendingBindingCounts.recommended }} · 需人工 {{ pendingBindingCounts.manual }}
+              </p>
+              <p v-if="pendingBindingCounts.manual > 0" class="directory-admin__hint">
+                人工处理中：无精确匹配 {{ pendingBindingManualReasonCounts.no_exact_match }} ·
+                冲突待复核 {{ pendingBindingManualReasonCounts.conflict }}
+              </p>
+              <p v-if="reviewTotal > 0" class="directory-admin__hint">
+                当前已加载 {{ reviewItems.length }} / {{ reviewTotal }} 项，筛选统计基于已加载数据。
+              </p>
+            </div>
+            <div class="directory-admin__actions">
+              <button
+                v-for="option in reviewFilterOptions"
+                :key="option.value"
+                class="directory-admin__button directory-admin__button--secondary"
+                :class="{ 'directory-admin__button--active': reviewFilter === option.value }"
+                type="button"
+                :disabled="loadingReviewItems"
+                @click="void updateReviewFilter(option.value)"
+              >
+                {{ option.label }}{{ reviewCounts[option.value] > 0 ? ` (${reviewCounts[option.value]})` : '' }}
+              </button>
+              <button
+                v-for="option in pendingBindingViewOptions"
+                :key="option.value"
+                class="directory-admin__button directory-admin__button--secondary"
+                :class="{ 'directory-admin__button--active': pendingBindingView === option.value }"
+                type="button"
+                :disabled="loadingReviewItems || reviewCounts.pending_binding === 0"
+                @click="updatePendingBindingView(option.value)"
+              >
+                {{ option.label }}{{ pendingBindingCounts[option.value] > 0 ? ` (${pendingBindingCounts[option.value]})` : '' }}
+              </button>
+              <button
+                v-for="option in pendingBindingManualReasonOptions"
+                v-if="showPendingBindingManualReasonFilters"
+                :key="option.value"
+                class="directory-admin__button directory-admin__button--secondary"
+                :class="{ 'directory-admin__button--active': pendingBindingManualReason === option.value }"
+                type="button"
+                :disabled="loadingReviewItems || pendingBindingCounts.manual === 0"
+                @click="updatePendingBindingManualReason(option.value)"
+              >
+                {{ option.label }}{{ pendingBindingManualReasonCounts[option.value] > 0 ? ` (${pendingBindingManualReasonCounts[option.value]})` : '' }}
+              </button>
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="loadingReviewItems"
+                @click="void loadReviewItems(selectedIntegration.id)"
+              >
+                {{ loadingReviewItems ? '刷新中...' : '刷新队列' }}
+              </button>
+            </div>
+          </div>
+          <article v-if="reviewBatchProgress" class="directory-admin__progress-card">
+            <div class="directory-admin__alert-head">
+              <div>
+                <strong>处理进度</strong>
+                <p class="directory-admin__hint">{{ reviewBatchProgress.message }}</p>
+              </div>
+              <div class="directory-admin__chips">
+                <span class="directory-admin__chip">{{ readReviewBatchProgressKindLabel(reviewBatchProgress.kind) }}</span>
+                <span class="directory-admin__chip" :class="readReviewBatchProgressPhaseClass(reviewBatchProgress.phase)">
+                  {{ readReviewBatchProgressPhaseLabel(reviewBatchProgress.phase) }}
+                </span>
+                <span class="directory-admin__chip">进度 {{ reviewBatchProgress.applied }} / {{ reviewBatchProgress.total }}</span>
+              </div>
+            </div>
+            <div v-if="!reviewBatchProcessing" class="directory-admin__actions">
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                @click="clearReviewBatchProgress()"
+              >
+                清除进度
+              </button>
+            </div>
+          </article>
+          <div class="directory-admin__actions" v-if="filteredReviewItems.length > 0">
+            <button
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              :disabled="selectableVisibleReviewIds.length === 0"
+              @click="selectVisibleReviewItems()"
+            >
+              {{ `选择当前筛选 (${selectableVisibleReviewIds.length})` }}
+            </button>
+            <button
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              :disabled="selectableVisibleRecommendedReviewIds.length === 0"
+              @click="selectVisibleRecommendedReviewItems()"
+            >
+              {{ `选择可推荐 (${selectableVisibleRecommendedReviewIds.length})` }}
+            </button>
+            <button
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              :disabled="Object.keys(selectedReviewIds).length === 0"
+              @click="clearReviewSelection()"
+            >
+              清空选择
+            </button>
+            <button
+              class="directory-admin__button"
+              type="button"
+              :disabled="reviewBatchProcessing || selectedRecommendedReviewBindEntries.length === 0"
+              @click="void batchConfirmRecommendedReviewItems()"
+            >
+              {{ reviewBatchProcessing ? '处理中...' : `批量确认推荐 (${selectedRecommendedReviewBindEntries.length})` }}
+            </button>
+            <button
+              class="directory-admin__button"
+              type="button"
+              :disabled="reviewBatchProcessing || selectedReviewBindEntries.length === 0"
+              @click="void batchBindReviewItems()"
+            >
+              {{ reviewBatchProcessing ? '处理中...' : `批量绑定 (${selectedReviewBindEntries.length})` }}
+            </button>
+            <label class="directory-admin__toggle directory-admin__toggle--compact">
+              <input v-model="reviewDisableDingTalkGrant" type="checkbox" />
+              <span>停权时同时关闭钉钉登录</span>
+            </label>
+            <button
+              class="directory-admin__button"
+              type="button"
+              :disabled="reviewBatchProcessing || selectedReviewBatchIds.length === 0"
+              @click="void batchUnbindReviewItems()"
+            >
+              {{ reviewBatchProcessing ? '处理中...' : `批量停权处理 (${selectedReviewBatchIds.length})` }}
+            </button>
+          </div>
+          <div v-if="loadingReviewItems" class="directory-admin__empty">待处理队列加载中...</div>
+          <div v-else-if="filteredReviewItems.length === 0" class="directory-admin__empty">
+            {{ hasMoreReviewItems ? '当前筛选在已加载数据中暂无结果，可继续加载更多。' : '暂无待处理项' }}
+          </div>
+          <article v-for="item in filteredReviewItems" :key="`${item.kind}-${item.account.id}`" class="directory-admin__review-item">
+            <div class="directory-admin__review-head">
+              <div class="directory-admin__review-title">
+                <label v-if="item.actionable.canBatchUnbind || item.kind === 'pending_binding'" class="directory-admin__review-select">
+                  <input
+                    type="checkbox"
+                    :checked="Boolean(selectedReviewIds[item.account.id])"
+                    @change="onReviewSelectionChange(item.account.id, $event)"
+                  />
+                </label>
+                <div>
+                  <strong>{{ item.account.name }}</strong>
+                  <p class="directory-admin__hint">{{ item.reason }}</p>
+                </div>
+              </div>
+              <div class="directory-admin__chips">
+                <span class="directory-admin__chip" :class="readReviewKindClass(item.kind)">{{ readReviewKindLabel(item.kind) }}</span>
+                <span class="directory-admin__chip" :class="{ 'directory-admin__badge--inactive': !item.account.isActive }">
+                  {{ item.account.isActive ? '目录启用' : '目录停用' }}
+                </span>
+              </div>
+            </div>
+            <p class="directory-admin__hint">
+              本地用户：{{ item.account.localUser ? (item.account.localUser.email || item.account.localUser.id) : '未绑定' }} ·
+              外部用户：{{ item.account.externalUserId }} ·
+              部门：{{ item.account.departmentPaths.join('，') || '未分配部门' }}
+            </p>
+            <p v-if="item.kind === 'pending_binding' && item.recommendationStatus" class="directory-admin__hint">
+              推荐判断：{{ item.recommendationStatus.message }}
+            </p>
+            <div class="directory-admin__chips">
+              <span v-if="item.flags.missingUnionId" class="directory-admin__chip directory-admin__chip--warning">缺 unionId</span>
+              <span v-if="item.flags.missingOpenId" class="directory-admin__chip directory-admin__chip--warning">缺 openId</span>
+              <span class="directory-admin__chip">{{ item.account.linkStatus }}</span>
+              <span v-if="item.account.matchStrategy" class="directory-admin__chip">策略 {{ item.account.matchStrategy }}</span>
+            </div>
+            <div v-if="item.kind === 'pending_binding'" class="directory-admin__form-grid directory-admin__form-grid--account">
+              <label class="directory-admin__field">
+                <span>绑定到本地用户 ID / 邮箱</span>
+                <input
+                  :value="readBindingDraft(item.account)"
+                  class="directory-admin__input"
+                  type="text"
+                  placeholder="例如 user-123 或 alpha@example.com"
+                  @input="onBindingDraftInput(item.account.id, $event)"
+                  @focus="clearBindingSearch(item.account.id)"
+                />
+              </label>
+              <label class="directory-admin__toggle directory-admin__toggle--compact">
+                <input
+                  :checked="readGrantToggle(item.account.id)"
+                  type="checkbox"
+                  @change="onGrantToggleChange(item.account.id, $event)"
+                />
+                <span>绑定后同时开通钉钉登录</span>
+              </label>
+            </div>
+            <div v-if="item.kind === 'pending_binding' && item.recommendations.length > 0" class="directory-admin__search-results">
+              <button
+                v-for="recommendation in item.recommendations"
+                :key="`${item.account.id}-${recommendation.localUser.id}`"
+                class="directory-admin__search-result"
+                type="button"
+                @click="applyRecommendedLocalUser(item.account.id, recommendation)"
+              >
+                <strong>{{ recommendation.localUser.name || recommendation.localUser.email || recommendation.localUser.id }}</strong>
+                <span>{{ recommendation.localUser.email || recommendation.localUser.id }}</span>
+                <small>{{ readRecommendationReasonLabel(recommendation.reasons) }}</small>
+              </button>
+            </div>
+            <div v-if="item.kind === 'pending_binding' && readBindingSearchResults(item.account.id).length > 0" class="directory-admin__search-results">
+              <button
+                v-for="user in readBindingSearchResults(item.account.id)"
+                :key="user.id"
+                class="directory-admin__search-result"
+                type="button"
+                @click="chooseLocalUser(item.account.id, user)"
+              >
+                <strong>{{ user.name || user.email }}</strong>
+                <span>{{ user.email }}</span>
+                <small>{{ user.id }} · {{ user.role }} · {{ user.is_active ? 'active' : 'inactive' }}</small>
+              </button>
+            </div>
+            <p v-if="item.kind === 'pending_binding' && readBindingSearchError(item.account.id)" class="directory-admin__status directory-admin__status--error">
+              {{ readBindingSearchError(item.account.id) }}
+            </p>
+            <div class="directory-admin__actions">
+              <button
+                v-if="item.kind === 'pending_binding'"
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="readBindingDraft(item.account).trim().length === 0 || readBindingSearchLoading(item.account.id)"
+                @click="void searchLocalUsers(item.account.id)"
+              >
+                {{ readBindingSearchLoading(item.account.id) ? '搜索中...' : '搜索本地用户' }}
+              </button>
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                @click="focusReviewAccount(item)"
+              >
+                定位到成员
+              </button>
+              <button
+                v-if="item.kind === 'pending_binding'"
+                class="directory-admin__button"
+                type="button"
+                :disabled="reviewProcessingAccountId === item.account.id || !item.actionable.canConfirmRecommendation"
+                @click="void confirmRecommendedReviewBinding(item)"
+              >
+                {{ reviewProcessingAccountId === item.account.id ? '处理中...' : '确认推荐' }}
+              </button>
+              <button
+                v-if="item.kind === 'pending_binding'"
+                class="directory-admin__button"
+                type="button"
+                :disabled="reviewProcessingAccountId === item.account.id || readBindingDraft(item.account).trim().length === 0"
+                @click="void handleReviewBind(item)"
+              >
+                {{ reviewProcessingAccountId === item.account.id ? '处理中...' : '快速绑定' }}
+              </button>
+              <button
+                v-if="item.actionable.canBatchUnbind"
+                class="directory-admin__button"
+                type="button"
+                :disabled="reviewProcessingAccountId === item.account.id"
+                @click="void handleReviewUnbind(item)"
+              >
+                {{ reviewProcessingAccountId === item.account.id ? '处理中...' : '停权处理' }}
+              </button>
+            </div>
+          </article>
+          <div v-if="!loadingReviewItems && hasMoreReviewItems" class="directory-admin__actions">
+            <button
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              :disabled="loadingMoreReviewItems"
+              @click="void loadMoreReviewItems()"
+            >
+              {{ loadingMoreReviewItems ? '加载中...' : `加载更多 (${Math.min(reviewPageSize, reviewTotal - reviewItems.length)})` }}
+            </button>
+          </div>
+        </section>
+
+        <section v-if="selectedIntegration" class="directory-admin__section">
+          <div class="directory-admin__section-head">
+            <div>
+              <h3>自动同步观测</h3>
+              <p class="directory-admin__hint">展示 cron 配置、预计下次运行、最近自动触发和观测状态。</p>
+            </div>
+            <button
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              :disabled="loadingSchedule"
+              @click="void loadScheduleSnapshot(selectedIntegration.id)"
+            >
+              {{ loadingSchedule ? '刷新中...' : '刷新观测' }}
+            </button>
+          </div>
+          <div v-if="loadingSchedule" class="directory-admin__empty">自动同步观测加载中...</div>
+          <div v-else-if="!scheduleSnapshot" class="directory-admin__empty">暂无自动同步观测</div>
+          <article v-else class="directory-admin__schedule-card">
+            <div class="directory-admin__chips">
+              <span class="directory-admin__chip" :class="readObservationStatusClass(scheduleSnapshot.observationStatus)">
+                {{ readObservationStatusLabel(scheduleSnapshot.observationStatus) }}
+              </span>
+              <span class="directory-admin__chip" :class="{ 'directory-admin__chip--warning': !scheduleSnapshot.syncEnabled }">
+                {{ scheduleSnapshot.syncEnabled ? '自动同步已启用' : '仅手动同步' }}
+              </span>
+              <span class="directory-admin__chip" :class="{ 'directory-admin__chip--warning': !scheduleSnapshot.cronValid }">
+                {{ scheduleSnapshot.scheduleCron || '未配置 cron' }}
+              </span>
+              <span class="directory-admin__chip">下次执行 {{ formatDateTime(scheduleSnapshot.nextExpectedRunAt) }}</span>
+              <span class="directory-admin__chip">触发源 {{ readTriggerSourceLabel(scheduleSnapshot.lastRun?.triggerSource) }}</span>
+            </div>
+            <p class="directory-admin__hint">{{ scheduleSnapshot.observationMessage }}</p>
+            <p class="directory-admin__hint">
+              最近自动运行：{{ formatDateTime(scheduleSnapshot.lastAutomaticRun?.startedAt ?? null) }} ·
+              最近手动运行：{{ formatDateTime(scheduleSnapshot.lastManualRun?.startedAt ?? null) }} ·
+              最近运行：{{ formatDateTime(scheduleSnapshot.lastRun?.startedAt ?? null) }}
+            </p>
+          </article>
+        </section>
+
+        <section v-if="selectedIntegration" class="directory-admin__section">
+          <div class="directory-admin__section-head">
+            <div>
+              <h3>最近告警</h3>
+              <p class="directory-admin__hint">展示目录同步告警，并支持确认处理。</p>
+            </div>
+            <div class="directory-admin__actions">
+              <button
+                v-for="option in alertFilterOptions"
+                :key="option.value"
+                class="directory-admin__button directory-admin__button--secondary"
+                :class="{ 'directory-admin__button--active': alertFilter === option.value }"
+                type="button"
+                :disabled="loadingAlerts"
+                @click="void updateAlertFilter(option.value)"
+              >
+                {{ option.label }}{{ alertCounts[option.value] > 0 ? ` (${alertCounts[option.value]})` : '' }}
+              </button>
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="loadingAlerts"
+                @click="void loadAlerts(selectedIntegration.id)"
+              >
+                {{ loadingAlerts ? '刷新中...' : '刷新告警' }}
+              </button>
+            </div>
+          </div>
+          <div v-if="loadingAlerts" class="directory-admin__empty">最近告警加载中...</div>
+          <div v-else-if="filteredAlerts.length === 0" class="directory-admin__empty">暂无告警</div>
+          <article v-for="alert in filteredAlerts" :key="alert.id" class="directory-admin__alert">
+            <div class="directory-admin__alert-head">
+              <div>
+                <strong>{{ readAlertLevelLabel(alert.level) }}</strong>
+                <p class="directory-admin__hint">{{ alert.code }} · {{ formatDateTime(alert.createdAt) }}</p>
+              </div>
+              <div class="directory-admin__chips">
+                <span class="directory-admin__chip" :class="readAlertLevelClass(alert.level)">
+                  {{ readAlertLevelLabel(alert.level) }}
+                </span>
+                <span class="directory-admin__chip" :class="{ 'directory-admin__chip--success': Boolean(alert.acknowledgedAt) }">
+                  {{ alert.acknowledgedAt ? '已确认' : '待确认' }}
+                </span>
+              </div>
+            </div>
+            <p>{{ alert.message }}</p>
+            <p v-if="alert.acknowledgedAt" class="directory-admin__hint">
+              确认时间：{{ formatDateTime(alert.acknowledgedAt) }}{{ alert.acknowledgedBy ? ` · ${alert.acknowledgedBy}` : '' }}
+            </p>
+            <div class="directory-admin__actions">
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="acknowledgingAlertId === alert.id || Boolean(alert.acknowledgedAt)"
+                @click="void acknowledgeAlert(alert)"
+              >
+                {{ acknowledgingAlertId === alert.id ? '确认中...' : alert.acknowledgedAt ? '已确认' : '确认告警' }}
+              </button>
+            </div>
+          </article>
+        </section>
+
+        <section v-if="selectedIntegration" class="directory-admin__section">
+          <div class="directory-admin__section-head">
+            <div>
               <h3>成员账号</h3>
               <p class="directory-admin__hint">展示同步后的钉钉成员、钉钉 ID 与本地绑定状态；支持按本地用户 ID 或邮箱手工绑定，并按页管理大规模组织。</p>
             </div>
@@ -394,6 +783,104 @@ type DirectoryRun = {
   errorMessage: string | null
 }
 
+type DirectoryObservationStatus =
+  | 'disabled'
+  | 'missing_cron'
+  | 'invalid_cron'
+  | 'awaiting_first_run'
+  | 'scheduler_observed'
+
+type DirectoryScheduleRun = {
+  id: string
+  status: string
+  startedAt: string
+  finishedAt: string | null
+  stats: Record<string, unknown>
+  errorMessage: string | null
+  triggeredBy: string | null
+  triggerSource: string
+  createdAt: string
+  updatedAt: string
+}
+
+type DirectoryScheduleSnapshot = {
+  integrationId: string
+  syncEnabled: boolean
+  scheduleCron: string | null
+  cronValid: boolean
+  nextExpectedRunAt: string | null
+  lastRun: DirectoryScheduleRun | null
+  lastManualRun: DirectoryScheduleRun | null
+  lastAutomaticRun: DirectoryScheduleRun | null
+  observationStatus: DirectoryObservationStatus
+  observationMessage: string
+}
+
+type DirectoryAlertFilter = 'all' | 'pending' | 'acknowledged'
+
+type DirectorySyncAlert = {
+  id: string
+  integrationId: string
+  runId: string | null
+  level: 'info' | 'warning' | 'error'
+  code: string
+  message: string
+  details: Record<string, unknown> | null
+  createdAt: string
+  acknowledgedAt: string | null
+  acknowledgedBy: string | null
+}
+
+type DirectoryReviewItemFilter = 'all' | 'pending_binding' | 'inactive_linked' | 'missing_identifier'
+
+type DirectoryReviewItem = {
+  kind: DirectoryReviewItemFilter
+  reason: string
+  account: DirectoryAccount
+  recommendations: DirectoryBindingRecommendation[]
+  recommendationStatus: DirectoryBindingRecommendationStatus | null
+  flags: {
+    missingUnionId: boolean
+    missingOpenId: boolean
+  }
+  actionable: {
+    canBatchUnbind: boolean
+    canConfirmRecommendation: boolean
+  }
+}
+
+type DirectoryBindingRecommendationReason = 'pending_link' | 'email' | 'mobile'
+type DirectoryBindingRecommendationStatusCode =
+  | 'recommended'
+  | 'no_exact_match'
+  | 'ambiguous_exact_match'
+  | 'pending_link_conflict'
+  | 'linked_user_conflict'
+  | 'external_identity_conflict'
+
+type PendingBindingView = 'all' | 'recommended' | 'manual'
+type PendingBindingManualReasonFilter = 'all' | 'no_exact_match' | 'conflict'
+type ReviewBatchProgressKind = 'bind' | 'recommend' | 'unbind'
+type ReviewBatchProgressPhase = 'submitting' | 'refreshing' | 'completed' | 'failed'
+
+type ReviewBatchProgress = {
+  kind: ReviewBatchProgressKind
+  phase: ReviewBatchProgressPhase
+  total: number
+  applied: number
+  message: string
+}
+
+type DirectoryBindingRecommendation = {
+  localUser: LocalUserOption
+  reasons: DirectoryBindingRecommendationReason[]
+}
+
+type DirectoryBindingRecommendationStatus = {
+  code: DirectoryBindingRecommendationStatusCode
+  message: string
+}
+
 type DirectoryAccount = {
   id: string
   integrationId: string
@@ -464,6 +951,9 @@ type DirectoryDraft = {
 const integrations = ref<DirectoryIntegration[]>([])
 const runs = ref<DirectoryRun[]>([])
 const accounts = ref<DirectoryAccount[]>([])
+const scheduleSnapshot = ref<DirectoryScheduleSnapshot | null>(null)
+const alerts = ref<DirectorySyncAlert[]>([])
+const reviewItems = ref<DirectoryReviewItem[]>([])
 const accountPageSizeOptions = [25, 50, 100]
 const accountPage = ref(1)
 const accountPageSize = ref(25)
@@ -471,19 +961,58 @@ const accountTotal = ref(0)
 const selectedIntegrationId = ref('')
 const loading = ref(false)
 const loadingRuns = ref(false)
+const loadingSchedule = ref(false)
+const loadingAlerts = ref(false)
+const loadingReviewItems = ref(false)
+const loadingMoreReviewItems = ref(false)
 const loadingAccounts = ref(false)
 const busy = ref(false)
 const bindingAccountId = ref('')
 const unbindingAccountId = ref('')
+const acknowledgingAlertId = ref('')
+const reviewProcessingAccountId = ref('')
+const reviewBatchProcessing = ref(false)
+const reviewBatchProgress = ref<ReviewBatchProgress | null>(null)
 const status = ref('')
 const statusTone = ref<'info' | 'error'>('info')
 const testResult = ref<TestResult | null>(null)
 const accountQuery = ref('')
+const alertFilter = ref<DirectoryAlertFilter>('all')
+const reviewFilter = ref<DirectoryReviewItemFilter>('all')
+const pendingBindingView = ref<PendingBindingView>('recommended')
+const pendingBindingViewTouched = ref(false)
+const pendingBindingManualReason = ref<PendingBindingManualReasonFilter>('all')
 const bindingDrafts = reactive<Record<string, string>>({})
 const userSearchResults = reactive<Record<string, LocalUserOption[]>>({})
 const userSearchLoading = reactive<Record<string, boolean>>({})
 const userSearchError = reactive<Record<string, string>>({})
 const grantToggles = reactive<Record<string, boolean>>({})
+const selectedReviewIds = reactive<Record<string, boolean>>({})
+const reviewDisableDingTalkGrant = ref(true)
+const reviewPageSize = 100
+const reviewPage = ref(1)
+const reviewTotal = ref(0)
+const alertFilterOptions = [
+  { value: 'all' as const, label: '全部' },
+  { value: 'pending' as const, label: '待确认' },
+  { value: 'acknowledged' as const, label: '已确认' },
+]
+const reviewFilterOptions = [
+  { value: 'all' as const, label: '全部待处理' },
+  { value: 'pending_binding' as const, label: '待绑定' },
+  { value: 'inactive_linked' as const, label: '停用待停权' },
+  { value: 'missing_identifier' as const, label: '缺身份标识' },
+]
+const pendingBindingViewOptions = [
+  { value: 'all' as const, label: '全部待绑定' },
+  { value: 'recommended' as const, label: '可推荐处理' },
+  { value: 'manual' as const, label: '需人工处理' },
+]
+const pendingBindingManualReasonOptions = [
+  { value: 'all' as const, label: '全部人工' },
+  { value: 'no_exact_match' as const, label: '无精确匹配' },
+  { value: 'conflict' as const, label: '冲突待复核' },
+]
 
 const draft = reactive<DirectoryDraft>({
   name: '',
@@ -513,6 +1042,99 @@ const accountRangeEnd = computed(() => (
     ? 0
     : Math.min(accountPage.value * accountPageSize.value, accountTotal.value)
 ))
+const alertCounts = computed<Record<DirectoryAlertFilter, number>>(() => ({
+  all: alerts.value.length,
+  pending: alerts.value.filter((item) => !item.acknowledgedAt).length,
+  acknowledged: alerts.value.filter((item) => Boolean(item.acknowledgedAt)).length,
+}))
+const filteredAlerts = computed(() => {
+  if (alertFilter.value === 'pending') return alerts.value.filter((item) => !item.acknowledgedAt)
+  if (alertFilter.value === 'acknowledged') return alerts.value.filter((item) => Boolean(item.acknowledgedAt))
+  return alerts.value
+})
+const reviewCounts = computed<Record<DirectoryReviewItemFilter, number>>(() => ({
+  all: reviewItems.value.length,
+  pending_binding: reviewItems.value.filter((item) => item.kind === 'pending_binding').length,
+  inactive_linked: reviewItems.value.filter((item) => item.kind === 'inactive_linked').length,
+  missing_identifier: reviewItems.value.filter((item) => item.kind === 'missing_identifier').length,
+}))
+const pendingBindingCounts = computed<Record<PendingBindingView, number>>(() => ({
+  all: reviewItems.value.filter((item) => item.kind === 'pending_binding').length,
+  recommended: reviewItems.value.filter((item) => item.kind === 'pending_binding' && item.actionable.canConfirmRecommendation).length,
+  manual: reviewItems.value.filter((item) => item.kind === 'pending_binding' && !item.actionable.canConfirmRecommendation).length,
+}))
+const pendingBindingManualReasonCounts = computed<Record<PendingBindingManualReasonFilter, number>>(() => {
+  const manualItems = reviewItems.value.filter((item) => item.kind === 'pending_binding' && !item.actionable.canConfirmRecommendation)
+  return {
+    all: manualItems.length,
+    no_exact_match: manualItems.filter((item) => readPendingBindingManualReasonCode(item) === 'no_exact_match').length,
+    conflict: manualItems.filter((item) => readPendingBindingManualReasonCode(item) === 'conflict').length,
+  }
+})
+const showPendingBindingManualReasonFilters = computed(() => (
+  pendingBindingView.value === 'manual'
+  && pendingBindingCounts.value.manual > 0
+  && (reviewFilter.value === 'all' || reviewFilter.value === 'pending_binding')
+))
+const hasMoreReviewItems = computed(() => reviewItems.value.length < reviewTotal.value)
+const filteredReviewItems = computed(() => {
+  if (reviewFilter.value === 'all') {
+    if (pendingBindingView.value === 'all') return reviewItems.value
+    return reviewItems.value.filter((item) => (
+      item.kind === 'pending_binding'
+      && matchesPendingBindingView(item)
+    ))
+  }
+  if (reviewFilter.value !== 'pending_binding') {
+    return reviewItems.value.filter((item) => item.kind === reviewFilter.value)
+  }
+  if (pendingBindingView.value === 'all') {
+    return reviewItems.value.filter((item) => item.kind === 'pending_binding')
+  }
+  return reviewItems.value.filter((item) => (
+    item.kind === 'pending_binding'
+    && matchesPendingBindingView(item)
+  ))
+})
+const selectableVisibleReviewIds = computed(() => (
+  filteredReviewItems.value
+    .filter((item) => item.kind === 'pending_binding' || item.actionable.canBatchUnbind)
+    .map((item) => item.account.id)
+))
+const selectableVisibleRecommendedReviewIds = computed(() => (
+  filteredReviewItems.value
+    .filter((item) => item.kind === 'pending_binding' && item.actionable.canConfirmRecommendation)
+    .map((item) => item.account.id)
+))
+const selectedRecommendedReviewBindEntries = computed(() => (
+  filteredReviewItems.value
+    .filter((item) => (
+      item.kind === 'pending_binding'
+      && selectedReviewIds[item.account.id]
+      && item.actionable.canConfirmRecommendation
+      && item.recommendations.length > 0
+    ))
+    .map((item) => ({
+      accountId: item.account.id,
+      localUserRef: item.recommendations[0].localUser.id,
+      enableDingTalkGrant: readGrantToggle(item.account.id),
+    }))
+))
+const selectedReviewBindEntries = computed(() => (
+  filteredReviewItems.value
+    .filter((item) => item.kind === 'pending_binding' && selectedReviewIds[item.account.id])
+    .map((item) => ({
+      accountId: item.account.id,
+      localUserRef: readBindingDraft(item.account).trim(),
+      enableDingTalkGrant: readGrantToggle(item.account.id),
+    }))
+    .filter((item) => item.localUserRef.length > 0)
+))
+const selectedReviewBatchIds = computed(() => (
+  filteredReviewItems.value
+    .filter((item) => item.actionable.canBatchUnbind && selectedReviewIds[item.account.id])
+    .map((item) => item.account.id)
+))
 
 const canSave = computed(() =>
   draft.name.trim().length > 0 &&
@@ -531,15 +1153,28 @@ function resetDraft() {
   testResult.value = null
   runs.value = []
   accounts.value = []
+  reviewBatchProgress.value = null
+  scheduleSnapshot.value = null
+  alerts.value = []
+  reviewItems.value = []
+  reviewPage.value = 1
+  reviewTotal.value = 0
   accountPage.value = 1
   accountPageSize.value = accountPageSizeOptions[0]
   accountTotal.value = 0
   accountQuery.value = ''
+  alertFilter.value = 'all'
+  reviewFilter.value = 'all'
+  pendingBindingView.value = 'recommended'
+  pendingBindingViewTouched.value = false
+  pendingBindingManualReason.value = 'all'
+  reviewDisableDingTalkGrant.value = true
   for (const key of Object.keys(bindingDrafts)) delete bindingDrafts[key]
   for (const key of Object.keys(userSearchResults)) delete userSearchResults[key]
   for (const key of Object.keys(userSearchLoading)) delete userSearchLoading[key]
   for (const key of Object.keys(userSearchError)) delete userSearchError[key]
   for (const key of Object.keys(grantToggles)) delete grantToggles[key]
+  for (const key of Object.keys(selectedReviewIds)) delete selectedReviewIds[key]
   draft.name = ''
   draft.corpId = ''
   draft.appKey = ''
@@ -572,11 +1207,23 @@ function selectIntegration(integrationId: string) {
   testResult.value = null
   accountPage.value = 1
   accountTotal.value = 0
+  reviewBatchProgress.value = null
+  alertFilter.value = 'all'
+  reviewFilter.value = 'all'
+  pendingBindingView.value = 'recommended'
+  pendingBindingViewTouched.value = false
+  pendingBindingManualReason.value = 'all'
+  reviewPage.value = 1
+  reviewTotal.value = 0
+  for (const key of Object.keys(selectedReviewIds)) delete selectedReviewIds[key]
   const integration = integrations.value.find((item) => item.id === integrationId)
   if (!integration) return
   applyIntegrationToDraft(integration)
   void Promise.all([
     loadRuns(integrationId),
+    loadScheduleSnapshot(integrationId),
+    loadAlerts(integrationId),
+    loadReviewItems(integrationId),
     loadAccounts(integrationId),
   ])
 }
@@ -687,6 +1334,19 @@ function chooseLocalUser(accountId: string, user: LocalUserOption) {
   setBindingSearchState(accountId, { results: [] })
 }
 
+function applyRecommendedLocalUser(accountId: string, recommendation: DirectoryBindingRecommendation) {
+  updateBindingDraft(accountId, recommendation.localUser.email || recommendation.localUser.id)
+  clearBindingSearch(accountId)
+}
+
+function readRecommendationReasonLabel(reasons: DirectoryBindingRecommendationReason[]): string {
+  return reasons.map((reason) => {
+    if (reason === 'pending_link') return '已存在待确认匹配'
+    if (reason === 'email') return '邮箱精确匹配'
+    return '手机号精确匹配'
+  }).join(' · ')
+}
+
 function readGrantToggle(accountId: string): boolean {
   return grantToggles[accountId] ?? true
 }
@@ -779,6 +1439,9 @@ async function syncIntegration() {
     await Promise.all([
       loadIntegrations(),
       loadRuns(selectedIntegration.value.id),
+      loadScheduleSnapshot(selectedIntegration.value.id),
+      loadAlerts(selectedIntegration.value.id),
+      loadReviewItems(selectedIntegration.value.id),
       loadAccounts(selectedIntegration.value.id),
     ])
   } catch (error) {
@@ -862,6 +1525,233 @@ async function loadRuns(integrationId: string) {
   }
 }
 
+async function loadScheduleSnapshot(integrationId: string) {
+  loadingSchedule.value = true
+  try {
+    const response = await apiFetch(`/api/admin/directory/integrations/${integrationId}/schedule`)
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '加载自动同步观测失败'))
+    scheduleSnapshot.value = body?.data?.snapshot ?? null
+  } catch (error) {
+    scheduleSnapshot.value = null
+    setStatus(error instanceof Error ? error.message : '加载自动同步观测失败', 'error')
+  } finally {
+    loadingSchedule.value = false
+  }
+}
+
+async function loadAlerts(integrationId: string) {
+  loadingAlerts.value = true
+  try {
+    const params = new URLSearchParams({ page: '1', pageSize: '20', filter: 'all' })
+    const response = await apiFetch(`/api/admin/directory/integrations/${integrationId}/alerts?${params.toString()}`)
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '加载最近告警失败'))
+    alerts.value = Array.isArray(body?.data?.items) ? body.data.items : []
+  } catch (error) {
+    alerts.value = []
+    setStatus(error instanceof Error ? error.message : '加载最近告警失败', 'error')
+  } finally {
+    loadingAlerts.value = false
+  }
+}
+
+function normalizeReviewItems(items: unknown[]): DirectoryReviewItem[] {
+  return items.map((item) => ({
+    ...item,
+    recommendations: Array.isArray(item?.recommendations) ? item.recommendations : [],
+    recommendationStatus: item?.recommendationStatus && typeof item.recommendationStatus === 'object'
+      ? {
+        code: typeof item.recommendationStatus.code === 'string' ? item.recommendationStatus.code : 'no_exact_match',
+        message: typeof item.recommendationStatus.message === 'string'
+          ? item.recommendationStatus.message
+          : '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+      }
+      : null,
+    actionable: {
+      canBatchUnbind: item?.actionable?.canBatchUnbind === true,
+      canConfirmRecommendation: item?.actionable?.canConfirmRecommendation === true,
+    },
+  }))
+}
+
+function mergeReviewItems(existingItems: DirectoryReviewItem[], incomingItems: DirectoryReviewItem[]): DirectoryReviewItem[] {
+  if (existingItems.length === 0) return incomingItems
+  const merged = [...existingItems]
+  const indexByAccountId = new Map(existingItems.map((item, index) => [item.account.id, index]))
+  for (const item of incomingItems) {
+    const existingIndex = indexByAccountId.get(item.account.id)
+    if (typeof existingIndex === 'number') {
+      merged[existingIndex] = item
+      continue
+    }
+    indexByAccountId.set(item.account.id, merged.length)
+    merged.push(item)
+  }
+  return merged
+}
+
+async function loadReviewItems(integrationId: string, options: { append?: boolean } = {}) {
+  const append = options.append === true
+  if (append) loadingMoreReviewItems.value = true
+  else loadingReviewItems.value = true
+  try {
+    const nextPage = append ? reviewPage.value + 1 : 1
+    const response = await apiFetch(`/api/admin/directory/integrations/${integrationId}/review-items?page=${nextPage}&pageSize=${reviewPageSize}&filter=all`)
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '加载待处理队列失败'))
+    const items = Array.isArray(body?.data?.items) ? body.data.items : []
+    const total = typeof body?.data?.total === 'number'
+      ? body.data.total
+      : Number(body?.data?.total ?? items.length)
+    const normalizedTotal = Number.isFinite(total) && total >= 0 ? total : items.length
+    const normalizedItems = normalizeReviewItems(items)
+    reviewItems.value = append
+      ? mergeReviewItems(reviewItems.value, normalizedItems)
+      : normalizedItems
+    reviewTotal.value = normalizedTotal
+    if (!append) reviewPage.value = 1
+    else if (normalizedItems.length > 0) reviewPage.value = nextPage
+    const validIds = new Set(reviewItems.value.map((item) => item.account.id))
+    for (const key of Object.keys(selectedReviewIds)) {
+      if (!validIds.has(key)) delete selectedReviewIds[key]
+    }
+    syncPendingBindingQueueDefaults()
+  } catch (error) {
+    if (!append) {
+      reviewItems.value = []
+      reviewPage.value = 1
+      reviewTotal.value = 0
+      for (const key of Object.keys(selectedReviewIds)) delete selectedReviewIds[key]
+    }
+    setStatus(error instanceof Error ? error.message : '加载待处理队列失败', 'error')
+  } finally {
+    if (append) loadingMoreReviewItems.value = false
+    else loadingReviewItems.value = false
+  }
+}
+
+async function updateAlertFilter(value: DirectoryAlertFilter) {
+  alertFilter.value = value
+}
+
+async function updateReviewFilter(value: DirectoryReviewItemFilter) {
+  reviewFilter.value = value
+}
+
+function updatePendingBindingView(value: PendingBindingView) {
+  pendingBindingView.value = value
+  pendingBindingViewTouched.value = true
+  if (value !== 'manual') pendingBindingManualReason.value = 'all'
+}
+
+function updatePendingBindingManualReason(value: PendingBindingManualReasonFilter) {
+  pendingBindingManualReason.value = value
+}
+
+function syncPendingBindingQueueDefaults() {
+  if (reviewCounts.value.pending_binding === 0) {
+    pendingBindingView.value = 'all'
+    pendingBindingViewTouched.value = false
+    pendingBindingManualReason.value = 'all'
+    clearReviewSelection()
+    return
+  }
+
+  const recommendedAvailable = pendingBindingCounts.value.recommended > 0
+  const manualAvailable = pendingBindingCounts.value.manual > 0
+
+  const currentViewInvalid = (
+    (pendingBindingView.value === 'recommended' && !recommendedAvailable)
+    || (pendingBindingView.value === 'manual' && !manualAvailable)
+  )
+
+  if (!pendingBindingViewTouched.value || currentViewInvalid) {
+    if (recommendedAvailable) pendingBindingView.value = 'recommended'
+    else if (manualAvailable) pendingBindingView.value = 'manual'
+    else pendingBindingView.value = 'all'
+    pendingBindingViewTouched.value = false
+  }
+
+  if (!manualAvailable || pendingBindingView.value !== 'manual') {
+    pendingBindingManualReason.value = 'all'
+  } else if (
+    pendingBindingManualReason.value !== 'all'
+    && pendingBindingManualReasonCounts.value[pendingBindingManualReason.value] === 0
+  ) {
+    pendingBindingManualReason.value = 'all'
+  }
+
+  const hasSelection = Object.keys(selectedReviewIds).length > 0
+  if (!hasSelection && pendingBindingView.value === 'recommended' && selectableVisibleRecommendedReviewIds.value.length > 0) {
+    selectVisibleRecommendedReviewItems()
+  }
+}
+
+async function loadMoreReviewItems() {
+  if (!selectedIntegration.value || !hasMoreReviewItems.value || loadingMoreReviewItems.value) return
+  await loadReviewItems(selectedIntegration.value.id, { append: true })
+}
+
+function clearReviewBatchProgress() {
+  reviewBatchProgress.value = null
+}
+
+function readReviewBatchProgressKindLabel(kind: ReviewBatchProgressKind): string {
+  if (kind === 'recommend') return '推荐绑定确认'
+  if (kind === 'unbind') return '批量停权处理'
+  return '批量绑定'
+}
+
+function readReviewBatchProgressPhaseLabel(phase: ReviewBatchProgressPhase): string {
+  if (phase === 'submitting') return '提交中'
+  if (phase === 'refreshing') return '刷新中'
+  if (phase === 'completed') return '已完成'
+  return '失败'
+}
+
+function readReviewBatchProgressPhaseClass(phase: ReviewBatchProgressPhase): string {
+  if (phase === 'completed') return 'directory-admin__chip--success'
+  if (phase === 'failed') return 'directory-admin__chip--danger'
+  return 'directory-admin__chip--warning'
+}
+
+function setReviewBatchProgress(progress: ReviewBatchProgress) {
+  reviewBatchProgress.value = progress
+}
+
+function readPendingBindingManualReasonCode(item: DirectoryReviewItem): PendingBindingManualReasonFilter {
+  if (item.kind !== 'pending_binding' || item.actionable.canConfirmRecommendation) return 'all'
+  const code = item.recommendationStatus?.code ?? 'no_exact_match'
+  return code === 'no_exact_match' ? 'no_exact_match' : 'conflict'
+}
+
+function matchesPendingBindingView(item: DirectoryReviewItem): boolean {
+  if (pendingBindingView.value === 'all') return true
+  if (pendingBindingView.value === 'recommended') return item.actionable.canConfirmRecommendation
+  if (item.actionable.canConfirmRecommendation) return false
+  if (pendingBindingManualReason.value === 'all') return true
+  return readPendingBindingManualReasonCode(item) === pendingBindingManualReason.value
+}
+
+async function acknowledgeAlert(alert: DirectorySyncAlert) {
+  if (!selectedIntegration.value || alert.acknowledgedAt) return
+  acknowledgingAlertId.value = alert.id
+  try {
+    const response = await apiFetch(`/api/admin/directory/alerts/${alert.id}/ack`, {
+      method: 'POST',
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '确认告警失败'))
+    await loadAlerts(selectedIntegration.value.id)
+    setStatus('目录告警已确认')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '确认告警失败', 'error')
+  } finally {
+    acknowledgingAlertId.value = ''
+  }
+}
+
 async function bindAccount(account: DirectoryAccount) {
   bindingAccountId.value = account.id
   try {
@@ -884,6 +1774,7 @@ async function bindAccount(account: DirectoryAccount) {
     setStatus(`目录成员 ${account.name} 已绑定到本地用户`)
     if (selectedIntegration.value) {
       await loadIntegrations()
+      await loadReviewItems(selectedIntegration.value.id)
       await loadAccounts(selectedIntegration.value.id)
     }
   } catch (error) {
@@ -893,11 +1784,17 @@ async function bindAccount(account: DirectoryAccount) {
   }
 }
 
-async function unbindAccount(account: DirectoryAccount) {
+async function unbindAccount(account: DirectoryAccount, options: {
+  disableDingTalkGrant?: boolean
+  successMessage?: string
+} = {}) {
   unbindingAccountId.value = account.id
   try {
     const response = await apiFetch(`/api/admin/directory/accounts/${account.id}/unbind`, {
       method: 'POST',
+      body: JSON.stringify({
+        disableDingTalkGrant: options.disableDingTalkGrant === true,
+      }),
     })
     const body = await readJson(response)
     if (!response.ok) throw new Error(readApiError(body, '解除绑定失败'))
@@ -915,15 +1812,244 @@ async function unbindAccount(account: DirectoryAccount) {
     })
     delete bindingDrafts[account.id]
     clearBindingSearch(account.id)
-    setStatus(`目录成员 ${account.name} 已解除绑定`)
+    setStatus(options.successMessage ?? `目录成员 ${account.name} 已解除绑定`)
     if (selectedIntegration.value) {
       await loadIntegrations()
+      await loadReviewItems(selectedIntegration.value.id)
       await loadAccounts(selectedIntegration.value.id)
     }
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '解除绑定失败', 'error')
   } finally {
     unbindingAccountId.value = ''
+  }
+}
+
+function updateReviewSelection(accountId: string, checked: boolean) {
+  if (checked) selectedReviewIds[accountId] = true
+  else delete selectedReviewIds[accountId]
+}
+
+function clearReviewSelection() {
+  for (const key of Object.keys(selectedReviewIds)) delete selectedReviewIds[key]
+}
+
+function selectVisibleReviewItems() {
+  clearReviewSelection()
+  for (const accountId of selectableVisibleReviewIds.value) {
+    selectedReviewIds[accountId] = true
+  }
+}
+
+function selectVisibleRecommendedReviewItems() {
+  clearReviewSelection()
+  for (const accountId of selectableVisibleRecommendedReviewIds.value) {
+    selectedReviewIds[accountId] = true
+  }
+}
+
+function onReviewSelectionChange(accountId: string, event: Event) {
+  const target = event.target
+  updateReviewSelection(accountId, target instanceof HTMLInputElement ? target.checked : false)
+}
+
+function focusReviewAccount(item: DirectoryReviewItem) {
+  accountQuery.value = item.account.externalUserId
+  if (selectedIntegration.value) {
+    accountPage.value = 1
+    void loadAccounts(selectedIntegration.value.id)
+  }
+}
+
+async function handleReviewUnbind(item: DirectoryReviewItem) {
+  reviewProcessingAccountId.value = item.account.id
+  try {
+    await unbindAccount(item.account, {
+      disableDingTalkGrant: reviewDisableDingTalkGrant.value,
+      successMessage: `待处理成员 ${item.account.name} 已完成停权处理`,
+    })
+  } finally {
+    reviewProcessingAccountId.value = ''
+  }
+}
+
+async function submitReviewBindings(bindings: Array<{
+  accountId: string
+  localUserRef: string
+  enableDingTalkGrant: boolean
+}>, successMessage: string, failureMessage: string, progressKind?: ReviewBatchProgressKind) {
+  if (!selectedIntegration.value || bindings.length === 0) return
+  reviewBatchProcessing.value = true
+  let appliedCount = 0
+  try {
+    if (progressKind) {
+      setReviewBatchProgress({
+        kind: progressKind,
+        phase: 'submitting',
+        total: bindings.length,
+        applied: 0,
+        message: `正在提交${readReviewBatchProgressKindLabel(progressKind)}请求...`,
+      })
+    }
+    const response = await apiFetch('/api/admin/directory/accounts/batch-bind', {
+      method: 'POST',
+      body: JSON.stringify({ bindings }),
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, failureMessage))
+    const processedItems = Array.isArray(body?.data?.items) ? body.data.items : []
+    appliedCount = processedItems.length > 0 ? processedItems.length : bindings.length
+    if (progressKind) {
+      setReviewBatchProgress({
+        kind: progressKind,
+        phase: 'refreshing',
+        total: bindings.length,
+        applied: appliedCount,
+        message: `已提交 ${appliedCount} / ${bindings.length}，正在刷新目录成员与待处理队列...`,
+      })
+    }
+    for (const key of Object.keys(selectedReviewIds)) delete selectedReviewIds[key]
+    setStatus(successMessage)
+    await Promise.all([
+      loadIntegrations(),
+      loadReviewItems(selectedIntegration.value.id),
+      loadAccounts(selectedIntegration.value.id),
+    ])
+    if (progressKind) {
+      setReviewBatchProgress({
+        kind: progressKind,
+        phase: 'completed',
+        total: bindings.length,
+        applied: appliedCount,
+        message: successMessage,
+      })
+    }
+  } catch (error) {
+    if (progressKind) {
+      setReviewBatchProgress({
+        kind: progressKind,
+        phase: 'failed',
+        total: bindings.length,
+        applied: appliedCount,
+        message: error instanceof Error ? error.message : failureMessage,
+      })
+    }
+    setStatus(error instanceof Error ? error.message : failureMessage, 'error')
+  } finally {
+    reviewBatchProcessing.value = false
+  }
+}
+
+async function handleReviewBind(item: DirectoryReviewItem) {
+  reviewProcessingAccountId.value = item.account.id
+  try {
+    await submitReviewBindings([{
+      accountId: item.account.id,
+      localUserRef: readBindingDraft(item.account).trim(),
+      enableDingTalkGrant: readGrantToggle(item.account.id),
+    }], `待处理成员 ${item.account.name} 已完成快速绑定`, '快速绑定失败')
+  } finally {
+    reviewProcessingAccountId.value = ''
+  }
+}
+
+async function batchBindReviewItems() {
+  await submitReviewBindings(
+    selectedReviewBindEntries.value.map((item) => ({
+      accountId: item.accountId,
+      localUserRef: item.localUserRef,
+      enableDingTalkGrant: item.enableDingTalkGrant,
+    })),
+    `已完成 ${selectedReviewBindEntries.value.length} 个目录成员的批量绑定`,
+    '批量绑定失败',
+    'bind',
+  )
+}
+
+async function confirmRecommendedReviewBinding(item: DirectoryReviewItem) {
+  if (item.recommendations.length === 0) return
+  reviewProcessingAccountId.value = item.account.id
+  try {
+    const recommendation = item.recommendations[0]
+    await submitReviewBindings([{
+      accountId: item.account.id,
+      localUserRef: recommendation.localUser.id,
+      enableDingTalkGrant: readGrantToggle(item.account.id),
+    }], `待处理成员 ${item.account.name} 已确认推荐绑定`, '确认推荐绑定失败')
+  } finally {
+    reviewProcessingAccountId.value = ''
+  }
+}
+
+async function batchConfirmRecommendedReviewItems() {
+  await submitReviewBindings(
+    selectedRecommendedReviewBindEntries.value.map((item) => ({
+      accountId: item.accountId,
+      localUserRef: item.localUserRef,
+      enableDingTalkGrant: item.enableDingTalkGrant,
+    })),
+    `已完成 ${selectedRecommendedReviewBindEntries.value.length} 个目录成员的推荐绑定确认`,
+    '批量确认推荐绑定失败',
+    'recommend',
+  )
+}
+
+async function batchUnbindReviewItems() {
+  if (!selectedIntegration.value || selectedReviewBatchIds.value.length === 0) return
+  reviewBatchProcessing.value = true
+  let appliedCount = 0
+  try {
+    const batchIds = [...selectedReviewBatchIds.value]
+    setReviewBatchProgress({
+      kind: 'unbind',
+      phase: 'submitting',
+      total: batchIds.length,
+      applied: 0,
+      message: '正在提交批量停权处理请求...',
+    })
+    const response = await apiFetch('/api/admin/directory/accounts/batch-unbind', {
+      method: 'POST',
+      body: JSON.stringify({
+        accountIds: batchIds,
+        disableDingTalkGrant: reviewDisableDingTalkGrant.value,
+      }),
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '批量停权处理失败'))
+    const processedItems = Array.isArray(body?.data?.items) ? body.data.items : []
+    appliedCount = processedItems.length > 0 ? processedItems.length : batchIds.length
+    setReviewBatchProgress({
+      kind: 'unbind',
+      phase: 'refreshing',
+      total: batchIds.length,
+      applied: appliedCount,
+      message: `已提交 ${appliedCount} / ${batchIds.length}，正在刷新目录成员与待处理队列...`,
+    })
+    for (const key of Object.keys(selectedReviewIds)) delete selectedReviewIds[key]
+    setStatus(`已完成 ${batchIds.length} 个目录成员的批量停权处理`)
+    await Promise.all([
+      loadIntegrations(),
+      loadReviewItems(selectedIntegration.value.id),
+      loadAccounts(selectedIntegration.value.id),
+    ])
+    setReviewBatchProgress({
+      kind: 'unbind',
+      phase: 'completed',
+      total: batchIds.length,
+      applied: appliedCount,
+      message: `已完成 ${batchIds.length} 个目录成员的批量停权处理`,
+    })
+  } catch (error) {
+    setReviewBatchProgress({
+      kind: 'unbind',
+      phase: 'failed',
+      total: selectedReviewBatchIds.value.length,
+      applied: appliedCount,
+      message: error instanceof Error ? error.message : '批量停权处理失败',
+    })
+    setStatus(error instanceof Error ? error.message : '批量停权处理失败', 'error')
+  } finally {
+    reviewBatchProcessing.value = false
   }
 }
 
@@ -938,6 +2064,55 @@ function formatDateTime(value: string | null): string {
     hour: '2-digit',
     minute: '2-digit',
   })
+}
+
+function readObservationStatusLabel(status: DirectoryObservationStatus | null | undefined): string {
+  if (status === 'scheduler_observed') return '已观察到自动触发'
+  if (status === 'awaiting_first_run') return '等待首次自动触发'
+  if (status === 'missing_cron') return '缺少 cron'
+  if (status === 'invalid_cron') return 'cron 无效'
+  if (status === 'disabled') return '自动同步未启用'
+  return '状态未知'
+}
+
+function readObservationStatusClass(status: DirectoryObservationStatus | null | undefined): string {
+  if (status === 'scheduler_observed') return 'directory-admin__chip--success'
+  if (status === 'awaiting_first_run' || status === 'missing_cron' || status === 'disabled') return 'directory-admin__chip--warning'
+  if (status === 'invalid_cron') return 'directory-admin__chip--danger'
+  return ''
+}
+
+function readTriggerSourceLabel(triggerSource: string | null | undefined): string {
+  if (!triggerSource) return '未记录'
+  if (triggerSource === 'scheduler') return '自动调度'
+  if (triggerSource === 'manual') return '手动触发'
+  return triggerSource
+}
+
+function readAlertLevelLabel(level: DirectorySyncAlert['level']): string {
+  if (level === 'info') return '信息'
+  if (level === 'warning') return '警告'
+  return '错误'
+}
+
+function readAlertLevelClass(level: DirectorySyncAlert['level']): string {
+  if (level === 'info') return 'directory-admin__chip--success'
+  if (level === 'warning') return 'directory-admin__chip--warning'
+  return 'directory-admin__chip--danger'
+}
+
+function readReviewKindLabel(kind: DirectoryReviewItem['kind']): string {
+  if (kind === 'pending_binding') return '待绑定'
+  if (kind === 'inactive_linked') return '停用待停权'
+  if (kind === 'missing_identifier') return '缺身份标识'
+  return '待处理'
+}
+
+function readReviewKindClass(kind: DirectoryReviewItem['kind']): string {
+  if (kind === 'pending_binding') return 'directory-admin__chip--warning'
+  if (kind === 'inactive_linked') return 'directory-admin__chip--danger'
+  if (kind === 'missing_identifier') return 'directory-admin__chip--warning'
+  return ''
 }
 
 function readNumericStat(stats: Record<string, unknown>, key: string): number {
@@ -1085,6 +2260,12 @@ onMounted(() => {
   color: #1d4ed8;
 }
 
+.directory-admin__button--active {
+  border-color: #1d4ed8;
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
 .directory-admin__section {
   display: flex;
   flex-direction: column;
@@ -1107,6 +2288,21 @@ onMounted(() => {
   background: #e2e8f0;
   color: #0f172a;
   font-size: 13px;
+}
+
+.directory-admin__chip--success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.directory-admin__chip--warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.directory-admin__chip--danger {
+  background: #fee2e2;
+  color: #991b1b;
 }
 
 .directory-admin__badge--inactive {
@@ -1138,6 +2334,43 @@ onMounted(() => {
   border-radius: 14px;
   padding: 14px;
   background: #f8fafc;
+}
+
+.directory-admin__schedule-card,
+.directory-admin__alert,
+.directory-admin__review-item,
+.directory-admin__progress-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 14px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.directory-admin__alert-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.directory-admin__review-head,
+.directory-admin__review-title,
+.directory-admin__review-select {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.directory-admin__review-head {
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.directory-admin__review-title {
+  align-items: flex-start;
 }
 
 .directory-admin__account {

--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -1560,22 +1560,32 @@ async function loadAlerts(integrationId: string) {
 }
 
 function normalizeReviewItems(items: unknown[]): DirectoryReviewItem[] {
-  return items.map((item) => ({
-    ...item,
-    recommendations: Array.isArray(item?.recommendations) ? item.recommendations : [],
-    recommendationStatus: item?.recommendationStatus && typeof item.recommendationStatus === 'object'
-      ? {
-        code: typeof item.recommendationStatus.code === 'string' ? item.recommendationStatus.code : 'no_exact_match',
-        message: typeof item.recommendationStatus.message === 'string'
-          ? item.recommendationStatus.message
-          : '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
-      }
-      : null,
-    actionable: {
-      canBatchUnbind: item?.actionable?.canBatchUnbind === true,
-      canConfirmRecommendation: item?.actionable?.canConfirmRecommendation === true,
-    },
-  }))
+  return items.map((item) => {
+    const raw = item && typeof item === 'object' ? item as Record<string, unknown> : {}
+    const recommendationStatusRaw = raw.recommendationStatus && typeof raw.recommendationStatus === 'object'
+      ? raw.recommendationStatus as Record<string, unknown>
+      : null
+    const actionableRaw = raw.actionable && typeof raw.actionable === 'object'
+      ? raw.actionable as Record<string, unknown>
+      : null
+
+    return {
+      ...raw,
+      recommendations: Array.isArray(raw.recommendations) ? raw.recommendations as DirectoryBindingRecommendation[] : [],
+      recommendationStatus: recommendationStatusRaw
+        ? {
+          code: typeof recommendationStatusRaw.code === 'string' ? recommendationStatusRaw.code as DirectoryBindingRecommendationStatusCode : 'no_exact_match',
+          message: typeof recommendationStatusRaw.message === 'string'
+            ? recommendationStatusRaw.message
+            : '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+        }
+        : null,
+      actionable: {
+        canBatchUnbind: actionableRaw?.canBatchUnbind === true,
+        canConfirmRecommendation: actionableRaw?.canConfirmRecommendation === true,
+      },
+    } as DirectoryReviewItem
+  })
 }
 
 function mergeReviewItems(existingItems: DirectoryReviewItem[], incomingItems: DirectoryReviewItem[]): DirectoryReviewItem[] {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -92,6 +92,76 @@ function createAccountListPayload(items: Record<string, unknown>[], overrides: R
   }
 }
 
+function createScheduleSnapshotPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    data: {
+      snapshot: {
+        integrationId: 'dir-1',
+        syncEnabled: true,
+        scheduleCron: '*/15 * * * *',
+        cronValid: true,
+        nextExpectedRunAt: '2026-04-08T01:15:00.000Z',
+        lastRun: {
+          id: 'run-1',
+          status: 'completed',
+          startedAt: '2026-04-08T01:00:00.000Z',
+          finishedAt: '2026-04-08T01:05:00.000Z',
+          stats: {},
+          errorMessage: null,
+          triggeredBy: 'admin-1',
+          triggerSource: 'manual',
+          createdAt: '2026-04-08T01:00:00.000Z',
+          updatedAt: '2026-04-08T01:05:00.000Z',
+        },
+        lastManualRun: {
+          id: 'run-1',
+          status: 'completed',
+          startedAt: '2026-04-08T01:00:00.000Z',
+          finishedAt: '2026-04-08T01:05:00.000Z',
+          stats: {},
+          errorMessage: null,
+          triggeredBy: 'admin-1',
+          triggerSource: 'manual',
+          createdAt: '2026-04-08T01:00:00.000Z',
+          updatedAt: '2026-04-08T01:05:00.000Z',
+        },
+        lastAutomaticRun: null,
+        observationStatus: 'awaiting_first_run',
+        observationMessage: '已配置 cron，等待首次自动触发或尚未观察到调度执行。',
+        ...overrides,
+      },
+    },
+  }
+}
+
+function createAlertListPayload(items: Record<string, unknown>[]) {
+  return {
+    ok: true,
+    data: {
+      items,
+      total: items.length,
+      page: 1,
+      pageSize: 20,
+      filter: 'all',
+    },
+  }
+}
+
+function createReviewItemsPayload(items: Record<string, unknown>[], overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    data: {
+      items,
+      total: items.length,
+      page: 1,
+      pageSize: 100,
+      filter: 'all',
+      ...overrides,
+    },
+  }
+}
+
 function createTestResultPayload(overrides: Record<string, unknown> = {}) {
   return {
     ok: true,
@@ -173,6 +243,42 @@ describe('DirectoryManagementView', () => {
         },
       }))
       .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([
+          {
+            id: 'alert-1',
+            integrationId: 'dir-1',
+            runId: 'run-1',
+            level: 'warning',
+            code: 'root_department_sparse',
+            message: '根部门直属成员过少',
+            details: {},
+            createdAt: '2026-04-08T01:06:00.000Z',
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount(),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: true,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([createAccount()], { total: 60 }),
       ))
 
@@ -186,10 +292,16 @@ describe('DirectoryManagementView', () => {
 
     expect(apiFetchMock).toHaveBeenNthCalledWith(1, '/api/admin/directory/integrations')
     expect(apiFetchMock).toHaveBeenNthCalledWith(2, '/api/admin/directory/integrations/dir-1/runs?page=1&pageSize=10')
-    expect(apiFetchMock).toHaveBeenNthCalledWith(3, '/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=25')
+    expect(apiFetchMock).toHaveBeenNthCalledWith(3, '/api/admin/directory/integrations/dir-1/schedule')
+    expect(apiFetchMock).toHaveBeenNthCalledWith(4, '/api/admin/directory/integrations/dir-1/alerts?page=1&pageSize=20&filter=all')
+    expect(apiFetchMock).toHaveBeenNthCalledWith(5, '/api/admin/directory/integrations/dir-1/review-items?page=1&pageSize=100&filter=all')
+    expect(apiFetchMock).toHaveBeenNthCalledWith(6, '/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=25')
     expect(container?.textContent).toContain('DingTalk CN')
     expect(container?.textContent).toContain('账号 98')
     expect(container?.textContent).toContain('completed')
+    expect(container?.textContent).toContain('待处理队列')
+    expect(container?.textContent).toContain('自动同步观测')
+    expect(container?.textContent).toContain('最近告警')
     expect(container?.textContent).toContain('Union ID')
     expect(container?.textContent).toContain('0447654442691174')
     expect(container?.textContent).toContain('第 1 / 3 页')
@@ -207,6 +319,37 @@ describe('DirectoryManagementView', () => {
         ok: true,
         data: { items: [] },
       }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'inactive_linked',
+            reason: '目录成员已停用，但仍绑定本地用户，需要停权处理。',
+            account: createAccount({
+              isActive: false,
+              linkStatus: 'linked',
+              matchStrategy: 'external_identity',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+              },
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: true,
+            },
+          },
+        ]),
+      ))
       .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([createAccount()], { total: 98 }),
       ))
@@ -254,6 +397,56 @@ describe('DirectoryManagementView', () => {
         },
       }))
       .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload({
+          nextExpectedRunAt: '2026-04-08T02:15:00.000Z',
+          lastRun: {
+            id: 'run-2',
+            status: 'completed',
+            startedAt: '2026-04-08T02:00:00.000Z',
+            finishedAt: '2026-04-08T02:05:00.000Z',
+            stats: {},
+            errorMessage: null,
+            triggeredBy: 'system:directory-sync-scheduler',
+            triggerSource: 'scheduler',
+            createdAt: '2026-04-08T02:00:00.000Z',
+            updatedAt: '2026-04-08T02:05:00.000Z',
+          },
+          lastAutomaticRun: {
+            id: 'run-2',
+            status: 'completed',
+            startedAt: '2026-04-08T02:00:00.000Z',
+            finishedAt: '2026-04-08T02:05:00.000Z',
+            stats: {},
+            errorMessage: null,
+            triggeredBy: 'system:directory-sync-scheduler',
+            triggerSource: 'scheduler',
+            createdAt: '2026-04-08T02:00:00.000Z',
+            updatedAt: '2026-04-08T02:05:00.000Z',
+          },
+          observationStatus: 'scheduler_observed',
+          observationMessage: '已观察到调度器触发的自动同步。',
+        }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([
+          {
+            id: 'alert-1',
+            integrationId: 'dir-1',
+            runId: 'run-2',
+            level: 'warning',
+            code: 'root_department_sparse',
+            message: '根部门直属成员过少',
+            details: {},
+            createdAt: '2026-04-08T02:06:00.000Z',
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([
           createAccount({
             matchStrategy: 'external_identity',
@@ -281,6 +474,9 @@ describe('DirectoryManagementView', () => {
       '/api/admin/directory/integrations/dir-1/sync',
       expect.objectContaining({ method: 'POST' }),
     )
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/schedule')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/alerts?page=1&pageSize=20&filter=all')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/review-items?page=1&pageSize=100&filter=all')
     expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=25')
     expect(container?.textContent).toContain('目录同步已完成')
     expect(container?.textContent).toContain('账号 99')
@@ -298,6 +494,15 @@ describe('DirectoryManagementView', () => {
         ok: true,
         data: { items: [] },
       }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
       .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([createAccount()], { total: 60 }),
       ))
@@ -330,7 +535,7 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('次页成员')
   })
 
-  it('binds a directory account to a local user reference', async () => {
+  it('quick-binds a pending review item via batch-bind', async () => {
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
@@ -342,6 +547,29 @@ describe('DirectoryManagementView', () => {
         ok: true,
         data: { items: [] },
       }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount(),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: true,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
       .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([createAccount()]),
       ))
@@ -362,15 +590,13 @@ describe('DirectoryManagementView', () => {
       .mockResolvedValueOnce(createJsonResponse({
         ok: true,
         data: {
-          account: createAccount({
-            linkStatus: 'linked',
-            matchStrategy: 'manual_admin',
-            localUser: {
-              id: 'user-1',
-              email: 'alpha@example.com',
-              name: 'Alpha',
+          items: [
+            {
+              accountId: 'account-1',
+              localUserRef: 'alpha@example.com',
+              enableDingTalkGrant: true,
             },
-          }),
+          ],
         },
       }))
       .mockResolvedValueOnce(createJsonResponse({
@@ -387,6 +613,9 @@ describe('DirectoryManagementView', () => {
           })],
         },
       }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
       .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([
           createAccount({
@@ -429,23 +658,2126 @@ describe('DirectoryManagementView', () => {
     searchResult?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flushUi(2)
 
-    const bindButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('绑定用户'))
+    const bindButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('快速绑定'))
     expect(bindButton).toBeTruthy()
     bindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flushUi(8)
 
     expect(apiFetchMock).toHaveBeenCalledWith(
-      '/api/admin/directory/accounts/account-1/bind',
+      '/api/admin/directory/accounts/batch-bind',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
-          localUserRef: 'alpha@example.com',
-          enableDingTalkGrant: true,
+          bindings: [
+            {
+              accountId: 'account-1',
+              localUserRef: 'alpha@example.com',
+              enableDingTalkGrant: true,
+            },
+          ],
         }),
       }),
     )
-    expect(container?.textContent).toContain('已绑定到本地用户')
+    expect(container?.textContent).toContain('已完成快速绑定')
     expect(container?.textContent).toContain('alpha@example.com')
+  })
+
+  it('confirms a recommended pending binding', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              linkStatus: 'pending',
+              matchStrategy: 'email',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+              },
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['pending_link', 'email'],
+            }],
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'account-1',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+              },
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('邮箱精确匹配')
+
+    const confirmButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('确认推荐'))
+    expect(confirmButton).toBeTruthy()
+    confirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          bindings: [
+            {
+              accountId: 'account-1',
+              localUserRef: 'user-1',
+              enableDingTalkGrant: true,
+            },
+          ],
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('已确认推荐绑定')
+  })
+
+  it('batch-binds selected pending review items', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-1',
+              name: '成员一',
+              externalUserId: '0447654442691174',
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: true,
+            },
+            actionable: {
+              canBatchUnbind: false,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-2',
+              name: '成员二',
+              externalUserId: '0447654442691175',
+            }),
+            flags: {
+              missingUnionId: true,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-1',
+            name: '成员一',
+          }),
+          createAccount({
+            id: 'account-2',
+            name: '成员二',
+          }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              accountId: 'account-1',
+              localUserRef: 'alpha@example.com',
+              enableDingTalkGrant: true,
+            },
+            {
+              accountId: 'account-2',
+              localUserRef: 'beta@example.com',
+              enableDingTalkGrant: true,
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-1',
+            name: '成员一',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+          createAccount({
+            id: 'account-2',
+            name: '成员二',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-2',
+              email: 'beta@example.com',
+              name: 'Beta',
+            },
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const pendingInputs = Array.from(container!.querySelectorAll('.directory-admin__review-item input[placeholder="例如 user-123 或 alpha@example.com"]')) as HTMLInputElement[]
+    expect(pendingInputs).toHaveLength(2)
+    pendingInputs[0].value = 'alpha@example.com'
+    pendingInputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+    pendingInputs[1].value = 'beta@example.com'
+    pendingInputs[1].dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    const reviewCheckboxes = Array.from(container!.querySelectorAll('.directory-admin__review-item .directory-admin__review-select input[type="checkbox"]')) as HTMLInputElement[]
+    reviewCheckboxes[0].checked = true
+    reviewCheckboxes[0].dispatchEvent(new Event('change', { bubbles: true }))
+    reviewCheckboxes[1].checked = true
+    reviewCheckboxes[1].dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const batchButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('批量绑定'))
+    expect(batchButton).toBeTruthy()
+    batchButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          bindings: [
+            {
+              accountId: 'account-1',
+              localUserRef: 'alpha@example.com',
+              enableDingTalkGrant: true,
+            },
+            {
+              accountId: 'account-2',
+              localUserRef: 'beta@example.com',
+              enableDingTalkGrant: true,
+            },
+          ],
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('已完成 2 个目录成员的批量绑定')
+    expect(container?.textContent).toContain('暂无待处理项')
+  })
+
+  it('batch-confirms recommended pending bindings', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-1',
+              name: '成员一',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-2',
+              name: '成员二',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-2',
+                email: 'beta@example.com',
+                name: 'Beta',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['mobile'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-1',
+            name: '成员一',
+          }),
+          createAccount({
+            id: 'account-2',
+            name: '成员二',
+            externalUserId: '0447654442691175',
+          }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'account-1',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+              },
+            },
+            {
+              id: 'account-2',
+              localUser: {
+                id: 'user-2',
+                email: 'beta@example.com',
+              },
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-1',
+            name: '成员一',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+          createAccount({
+            id: 'account-2',
+            name: '成员二',
+            externalUserId: '0447654442691175',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-2',
+              email: 'beta@example.com',
+              name: 'Beta',
+            },
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const reviewCheckboxes = Array.from(container!.querySelectorAll('.directory-admin__review-item .directory-admin__review-select input[type="checkbox"]')) as HTMLInputElement[]
+    expect(reviewCheckboxes).toHaveLength(2)
+
+    reviewCheckboxes[0].checked = true
+    reviewCheckboxes[0].dispatchEvent(new Event('change', { bubbles: true }))
+    reviewCheckboxes[1].checked = true
+    reviewCheckboxes[1].dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const batchConfirmButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('批量确认推荐'))
+    expect(batchConfirmButton).toBeTruthy()
+    batchConfirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          bindings: [
+            {
+              accountId: 'account-1',
+              localUserRef: 'user-1',
+              enableDingTalkGrant: true,
+            },
+            {
+              accountId: 'account-2',
+              localUserRef: 'user-2',
+              enableDingTalkGrant: true,
+            },
+          ],
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('已完成 2 个目录成员的推荐绑定确认')
+    expect(container?.textContent).toContain('处理进度')
+    expect(container?.textContent).toContain('推荐绑定确认')
+    expect(container?.textContent).toContain('已完成')
+    expect(container?.textContent).toContain('进度 2 / 2')
+  })
+
+  it('shows visible progress while batch-confirming recommended pending bindings', async () => {
+    let resolveBatchBindResponse: ((value: unknown) => void) | null = null
+
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-progress',
+              name: '进度成员',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-progress',
+                email: 'progress@example.com',
+                name: 'Progress',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-progress',
+            name: '进度成员',
+          }),
+        ]),
+      ))
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveBatchBindResponse = resolve
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-progress',
+            name: '进度成员',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-progress',
+              email: 'progress@example.com',
+              name: 'Progress',
+            },
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const batchConfirmButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('批量确认推荐 (1)'))
+    expect(batchConfirmButton).toBeTruthy()
+    batchConfirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    expect(container?.textContent).toContain('处理进度')
+    expect(container?.textContent).toContain('推荐绑定确认')
+    expect(container?.textContent).toContain('提交中')
+    expect(container?.textContent).toContain('进度 0 / 1')
+
+    resolveBatchBindResponse?.(createJsonResponse({
+      ok: true,
+      data: {
+        items: [
+          {
+            id: 'account-progress',
+            localUser: {
+              id: 'user-progress',
+              email: 'progress@example.com',
+            },
+          },
+        ],
+      },
+    }))
+    await flushUi(8)
+
+    expect(container?.textContent).toContain('已完成 1 个目录成员的推荐绑定确认')
+    expect(container?.textContent).toContain('已完成')
+    expect(container?.textContent).toContain('进度 1 / 1')
+  })
+
+  it('filters review queue by recommendation readiness and selects visible recommended items', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-recommended',
+              name: '可推荐成员',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-manual',
+              name: '人工成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+          {
+            kind: 'inactive_linked',
+            reason: '目录成员已停用，但仍绑定本地用户，需要停权处理。',
+            account: createAccount({
+              id: 'account-inactive',
+              name: '停用成员',
+              isActive: false,
+              linkStatus: 'linked',
+              matchStrategy: 'external_identity',
+              localUser: {
+                id: 'user-9',
+                email: 'inactive@example.com',
+                name: 'Inactive',
+              },
+            }),
+            recommendations: [],
+            recommendationStatus: null,
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: true,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-recommended',
+            name: '可推荐成员',
+          }),
+          createAccount({
+            id: 'account-manual',
+            name: '人工成员',
+            externalUserId: '0447654442691175',
+          }),
+          createAccount({
+            id: 'account-inactive',
+            name: '停用成员',
+            isActive: false,
+          }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'account-recommended',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+              },
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-manual',
+              name: '人工成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+          {
+            kind: 'inactive_linked',
+            reason: '目录成员已停用，但仍绑定本地用户，需要停权处理。',
+            account: createAccount({
+              id: 'account-inactive',
+              name: '停用成员',
+              isActive: false,
+              linkStatus: 'linked',
+              matchStrategy: 'external_identity',
+              localUser: {
+                id: 'user-9',
+                email: 'inactive@example.com',
+                name: 'Inactive',
+              },
+            }),
+            recommendations: [],
+            recommendationStatus: null,
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: true,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-recommended',
+            name: '可推荐成员',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+          createAccount({
+            id: 'account-manual',
+            name: '人工成员',
+            externalUserId: '0447654442691175',
+          }),
+          createAccount({
+            id: 'account-inactive',
+            name: '停用成员',
+            isActive: false,
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('待绑定中：可推荐 1 · 需人工 1')
+
+    const reviewCardsAfterDefaultLoad = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCardsAfterDefaultLoad.join(' ')).toContain('可推荐成员')
+    expect(reviewCardsAfterDefaultLoad.join(' ')).toContain('已命中唯一精确候选，可直接确认推荐绑定。')
+    expect(reviewCardsAfterDefaultLoad.join(' ')).not.toContain('人工成员')
+    expect(reviewCardsAfterDefaultLoad.join(' ')).not.toContain('停用成员')
+
+    const initialBatchConfirmButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('批量确认推荐 (1)'))
+    expect(initialBatchConfirmButton).toBeTruthy()
+
+    const clearSelectionButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('清空选择'))
+    expect(clearSelectionButton).toBeTruthy()
+    clearSelectionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    expect(container?.textContent).toContain('批量确认推荐 (0)')
+
+    const selectRecommendedButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('选择可推荐 (1)'))
+    expect(selectRecommendedButton).toBeTruthy()
+    selectRecommendedButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    expect(container?.textContent).toContain('批量确认推荐 (1)')
+
+    const batchConfirmButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('批量确认推荐 (1)'))
+    expect(batchConfirmButton).toBeTruthy()
+    batchConfirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          bindings: [
+            {
+              accountId: 'account-recommended',
+              localUserRef: 'user-1',
+              enableDingTalkGrant: true,
+            },
+          ],
+        }),
+      }),
+    )
+
+    const manualFilter = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('需人工处理 (1)'))
+    expect(manualFilter).toBeTruthy()
+    manualFilter?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    const reviewCardsAfterManualFilter = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCardsAfterManualFilter.join(' ')).toContain('人工成员')
+    expect(reviewCardsAfterManualFilter.join(' ')).toContain('未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。')
+    expect(reviewCardsAfterManualFilter.join(' ')).not.toContain('可推荐成员')
+  })
+
+  it('loads additional review queue pages and resets to the first page on refresh', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-page-1-recommended',
+              name: '第一页推荐成员',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-page-1-manual',
+              name: '第一页人工成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ], { total: 3, page: 1, pageSize: 100 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-page-1-recommended',
+            name: '第一页推荐成员',
+          }),
+          createAccount({
+            id: 'account-page-1-manual',
+            name: '第一页人工成员',
+            externalUserId: '0447654442691175',
+          }),
+        ], { total: 3 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-page-2-recommended',
+              name: '第二页推荐成员',
+              externalUserId: '0447654442691176',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-2',
+                email: 'beta@example.com',
+                name: 'Beta',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['mobile'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ], { total: 3, page: 2, pageSize: 100 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-page-1-recommended',
+              name: '第一页推荐成员',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-page-1-manual',
+              name: '第一页人工成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ], { total: 3, page: 1, pageSize: 100 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('当前已加载 2 / 3 项')
+    expect(container?.textContent).toContain('加载更多 (1)')
+
+    let reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('第一页推荐成员')
+    expect(reviewCards.join(' ')).not.toContain('第一页人工成员')
+
+    const loadMoreButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('加载更多 (1)'))
+    expect(loadMoreButton).toBeTruthy()
+    loadMoreButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/review-items?page=2&pageSize=100&filter=all')
+    expect(container?.textContent).toContain('当前已加载 3 / 3 项')
+
+    reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('第二页推荐成员')
+
+    const refreshQueueButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('刷新队列'))
+    expect(refreshQueueButton).toBeTruthy()
+    refreshQueueButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenLastCalledWith('/api/admin/directory/integrations/dir-1/review-items?page=1&pageSize=100&filter=all')
+    expect(container?.textContent).toContain('当前已加载 2 / 3 项')
+
+    reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('第一页推荐成员')
+    expect(reviewCards.join(' ')).not.toContain('第二页推荐成员')
+  })
+
+  it('filters manual review items by recommendationStatus reason', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-no-match',
+              name: '无精确匹配成员',
+              externalUserId: '0447654442691174',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-ambiguous',
+              name: '精确匹配冲突成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'ambiguous_exact_match',
+              message: '命中多个精确候选，请人工确认绑定目标。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-no-match',
+            name: '无精确匹配成员',
+            externalUserId: '0447654442691174',
+          }),
+          createAccount({
+            id: 'account-ambiguous',
+            name: '精确匹配冲突成员',
+            externalUserId: '0447654442691175',
+          }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-no-match',
+              name: '无精确匹配成员',
+              externalUserId: '0447654442691174',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-ambiguous',
+              name: '精确匹配冲突成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'ambiguous_exact_match',
+              message: '命中多个精确候选，请人工确认绑定目标。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-no-match',
+            name: '无精确匹配成员',
+            externalUserId: '0447654442691174',
+          }),
+          createAccount({
+            id: 'account-ambiguous',
+            name: '精确匹配冲突成员',
+            externalUserId: '0447654442691175',
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('待绑定中：可推荐 0 · 需人工 2')
+    expect(container?.textContent).toContain('全部人工')
+    expect(container?.textContent).toContain('无精确匹配')
+    expect(container?.textContent).toContain('冲突待复核')
+
+    const noExactMatchFilter = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('无精确匹配'))
+    expect(noExactMatchFilter).toBeTruthy()
+    noExactMatchFilter?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    let reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('无精确匹配成员')
+    expect(reviewCards.join(' ')).not.toContain('精确匹配冲突成员')
+
+    const conflictFilter = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('冲突待复核'))
+    expect(conflictFilter).toBeTruthy()
+    conflictFilter?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('精确匹配冲突成员')
+    expect(reviewCards.join(' ')).not.toContain('无精确匹配成员')
+
+    const allManualFilter = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('全部人工'))
+    expect(allManualFilter).toBeTruthy()
+    allManualFilter?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('无精确匹配成员')
+    expect(reviewCards.join(' ')).toContain('精确匹配冲突成员')
+  })
+
+  it('loads more review items and refreshes back to the first page', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-page-1-a',
+              name: '第一页成员一',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-page-1-b',
+              name: '第一页成员二',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-2',
+                email: 'beta@example.com',
+                name: 'Beta',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['mobile'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ], { total: 3, page: 1, pageSize: 100 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-page-2',
+              name: '第二页成员',
+              externalUserId: '0447654442691176',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-3',
+                email: 'gamma@example.com',
+                name: 'Gamma',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ], { total: 3, page: 2, pageSize: 100 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-page-1-a',
+              name: '第一页成员一',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-page-1-b',
+              name: '第一页成员二',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-2',
+                email: 'beta@example.com',
+                name: 'Beta',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['mobile'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ], { total: 2, page: 1, pageSize: 100 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('当前已加载 2 / 3 项')
+    expect(container?.textContent).toContain('第一页成员一')
+    expect(container?.textContent).toContain('第一页成员二')
+    expect(container?.textContent).not.toContain('第二页成员')
+
+    const loadMoreButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('加载更多 (1)'))
+    expect(loadMoreButton).toBeTruthy()
+    loadMoreButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(4)
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/review-items?page=2&pageSize=100&filter=all')
+    expect(container?.textContent).toContain('当前已加载 3 / 3 项')
+    expect(container?.textContent).toContain('第二页成员')
+    expect(container?.textContent).not.toContain('加载更多 (1)')
+
+    const refreshQueueButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('刷新队列'))
+    expect(refreshQueueButton).toBeTruthy()
+    refreshQueueButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(4)
+
+    expect(container?.textContent).toContain('当前已加载 2 / 2 项')
+    expect(container?.textContent).not.toContain('第二页成员')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/review-items?page=1&pageSize=100&filter=all')
+  })
+
+  it('keeps the manual review view on queue refresh after the user explicitly switches to it', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-recommended',
+              name: '可推荐成员',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-manual',
+              name: '人工成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-recommended',
+            name: '可推荐成员',
+          }),
+          createAccount({
+            id: 'account-manual',
+            name: '人工成员',
+            externalUserId: '0447654442691175',
+          }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-recommended',
+              name: '可推荐成员',
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['email'],
+            }],
+            recommendationStatus: {
+              code: 'recommended',
+              message: '已命中唯一精确候选，可直接确认推荐绑定。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-manual',
+              name: '人工成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('批量确认推荐 (1)')
+
+    const manualFilter = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('需人工处理 (1)'))
+    expect(manualFilter).toBeTruthy()
+    manualFilter?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    const reviewCardsAfterManualFilter = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCardsAfterManualFilter.join(' ')).toContain('人工成员')
+    expect(reviewCardsAfterManualFilter.join(' ')).not.toContain('可推荐成员')
+
+    const refreshQueueButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('刷新队列'))
+    expect(refreshQueueButton).toBeTruthy()
+    refreshQueueButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(4)
+
+    const reviewCardsAfterRefresh = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCardsAfterRefresh.join(' ')).toContain('人工成员')
+    expect(reviewCardsAfterRefresh.join(' ')).not.toContain('可推荐成员')
+    expect(container?.textContent).toContain('批量确认推荐 (0)')
+  })
+
+  it('filters manual review items by recommendation reason and falls back when the chosen reason disappears', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-no-match',
+              name: '无匹配成员',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '待确认绑定与候选用户不一致，需要人工复核。',
+            account: createAccount({
+              id: 'account-conflict',
+              name: '冲突成员',
+              externalUserId: '0447654442691175',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'pending_link_conflict',
+              message: '现有待确认匹配与精确候选不一致，请人工复核。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-no-match',
+            name: '无匹配成员',
+          }),
+          createAccount({
+            id: 'account-conflict',
+            name: '冲突成员',
+            externalUserId: '0447654442691175',
+          }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-no-match',
+              name: '无匹配成员',
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('待绑定中：可推荐 0 · 需人工 2')
+    expect(container?.textContent).toContain('人工处理中：无精确匹配 1 · 冲突待复核 1')
+
+    const allManualButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('全部人工 (2)'))
+    const noMatchButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('无精确匹配 (1)'))
+    const conflictButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('冲突待复核 (1)'))
+    expect(allManualButton).toBeTruthy()
+    expect(noMatchButton).toBeTruthy()
+    expect(conflictButton).toBeTruthy()
+
+    noMatchButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    let reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('无匹配成员')
+    expect(reviewCards.join(' ')).toContain('未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。')
+    expect(reviewCards.join(' ')).not.toContain('冲突成员')
+
+    conflictButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('冲突成员')
+    expect(reviewCards.join(' ')).toContain('现有待确认匹配与精确候选不一致，请人工复核。')
+    expect(reviewCards.join(' ')).not.toContain('无匹配成员')
+
+    const refreshQueueButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('刷新队列'))
+    expect(refreshQueueButton).toBeTruthy()
+    refreshQueueButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(4)
+
+    reviewCards = Array.from(container!.querySelectorAll('.directory-admin__review-item'))
+      .map((item) => item.textContent ?? '')
+    expect(reviewCards.join(' ')).toContain('无匹配成员')
+    expect(reviewCards.join(' ')).not.toContain('冲突成员')
+    expect(container?.textContent).toContain('人工处理中：无精确匹配 1 · 冲突待复核 0')
+  })
+
+  it('batch-binds pending review items', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-1',
+              name: '周华',
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-2',
+              externalUserId: '0447654442691175',
+              name: '次页成员',
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({ id: 'account-1' }),
+          createAccount({ id: 'account-2', externalUserId: '0447654442691175', name: '次页成员' }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+              role: 'user',
+              is_active: true,
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'user-2',
+              email: 'beta@example.com',
+              name: 'Beta',
+              role: 'user',
+              is_active: true,
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'account-1',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+              },
+            },
+            {
+              id: 'account-2',
+              localUser: {
+                id: 'user-2',
+                email: 'beta@example.com',
+              },
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({
+            stats: {
+              departmentCount: 12,
+              accountCount: 98,
+              pendingLinkCount: 2,
+              linkedCount: 90,
+              lastRunStatus: 'completed',
+            },
+          })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-1',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+          createAccount({
+            id: 'account-2',
+            externalUserId: '0447654442691175',
+            name: '次页成员',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-2',
+              email: 'beta@example.com',
+              name: 'Beta',
+            },
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const reviewCheckboxes = Array.from(container!.querySelectorAll('.directory-admin__review-item .directory-admin__review-select input[type="checkbox"]')) as HTMLInputElement[]
+    expect(reviewCheckboxes).toHaveLength(2)
+
+    const searchButtons = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).filter((button) => button.textContent?.includes('搜索本地用户'))
+    expect(searchButtons).toHaveLength(2)
+
+    const reviewInputs = Array.from(container!.querySelectorAll('.directory-admin__review-item input[placeholder=\"例如 user-123 或 alpha@example.com\"]')) as HTMLInputElement[]
+    reviewInputs[0].value = 'alpha@example.com'
+    reviewInputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+    reviewInputs[1].value = 'beta@example.com'
+    reviewInputs[1].dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    searchButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(3)
+    searchButtons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(3)
+
+    const reviewSearchResults = Array.from(container!.querySelectorAll('.directory-admin__review-item .directory-admin__search-result'))
+    expect(reviewSearchResults.length).toBeGreaterThanOrEqual(2)
+    reviewSearchResults[0].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+    reviewSearchResults[1].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    reviewCheckboxes[0].checked = true
+    reviewCheckboxes[0].dispatchEvent(new Event('change', { bubbles: true }))
+    reviewCheckboxes[1].checked = true
+    reviewCheckboxes[1].dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const batchBindButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('批量绑定'))
+    expect(batchBindButton).toBeTruthy()
+    batchBindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          bindings: [
+            {
+              accountId: 'account-1',
+              localUserRef: 'alpha@example.com',
+              enableDingTalkGrant: true,
+            },
+            {
+              accountId: 'account-2',
+              localUserRef: 'beta@example.com',
+              enableDingTalkGrant: true,
+            },
+          ],
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('批量绑定')
+    expect(container?.textContent).toContain('处理进度')
+    expect(container?.textContent).toContain('批量绑定')
+    expect(container?.textContent).toContain('已完成')
+    expect(container?.textContent).toContain('进度 2 / 2')
+    expect(container?.textContent).toContain('暂无待处理项')
   })
 
   it('tests a saved integration with diagnostics and reuses the saved secret on the backend', async () => {
@@ -460,6 +2792,15 @@ describe('DirectoryManagementView', () => {
         ok: true,
         data: { items: [] },
       }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
       .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([createAccount()]),
       ))
@@ -518,6 +2859,36 @@ describe('DirectoryManagementView', () => {
         data: { items: [] },
       }))
       .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'inactive_linked',
+            reason: '目录成员已停用，但仍绑定本地用户，需要停权处理。',
+            account: createAccount({
+              linkStatus: 'linked',
+              matchStrategy: 'manual_admin',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+              },
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([createAccount({
           linkStatus: 'linked',
           matchStrategy: 'manual_admin',
@@ -544,6 +2915,26 @@ describe('DirectoryManagementView', () => {
           items: [createIntegration()],
         },
       }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              linkStatus: 'unmatched',
+              matchStrategy: 'manual_unbound',
+              localUser: null,
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+            },
+          },
+        ]),
+      ))
       .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([createAccount({
           linkStatus: 'unmatched',
@@ -572,6 +2963,285 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('已解除绑定')
   })
 
+  it('batch unbinds inactive linked review items', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'inactive_linked',
+            reason: '目录成员已停用，但仍绑定本地用户，需要停权处理。',
+            account: createAccount({
+              id: 'account-1',
+              isActive: false,
+              linkStatus: 'linked',
+              matchStrategy: 'external_identity',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+              },
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: true,
+            },
+          },
+          {
+            kind: 'inactive_linked',
+            reason: '目录成员已停用，但仍绑定本地用户，需要停权处理。',
+            account: createAccount({
+              id: 'account-2',
+              externalUserId: '0447654442691175',
+              name: '次页成员',
+              isActive: false,
+              linkStatus: 'linked',
+              matchStrategy: 'external_identity',
+              localUser: {
+                id: 'user-2',
+                email: 'beta@example.com',
+                name: 'Beta',
+              },
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-1',
+            isActive: false,
+            linkStatus: 'linked',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+          createAccount({
+            id: 'account-2',
+            externalUserId: '0447654442691175',
+            name: '次页成员',
+            isActive: false,
+            linkStatus: 'linked',
+            localUser: {
+              id: 'user-2',
+              email: 'beta@example.com',
+              name: 'Beta',
+            },
+          }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            { id: 'account-1' },
+            { id: 'account-2' },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({
+            stats: {
+              departmentCount: 12,
+              accountCount: 98,
+              pendingLinkCount: 6,
+              linkedCount: 86,
+              lastRunStatus: 'completed',
+            },
+          })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-1',
+            isActive: false,
+            linkStatus: 'unmatched',
+            matchStrategy: 'manual_unbound',
+            localUser: null,
+          }),
+          createAccount({
+            id: 'account-2',
+            externalUserId: '0447654442691175',
+            name: '次页成员',
+            isActive: false,
+            linkStatus: 'unmatched',
+            matchStrategy: 'manual_unbound',
+            localUser: null,
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const checkboxes = Array.from(container!.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[]
+    const reviewCheckboxes = checkboxes.filter((input) => input.closest('.directory-admin__review-item'))
+    expect(reviewCheckboxes).toHaveLength(2)
+    reviewCheckboxes[0].checked = true
+    reviewCheckboxes[0].dispatchEvent(new Event('change', { bubbles: true }))
+    reviewCheckboxes[1].checked = true
+    reviewCheckboxes[1].dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const batchButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('批量停权处理'))
+    expect(batchButton).toBeTruthy()
+    batchButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-unbind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          accountIds: ['account-1', 'account-2'],
+          disableDingTalkGrant: true,
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('批量停权处理')
+    expect(container?.textContent).toContain('处理进度')
+    expect(container?.textContent).toContain('已完成')
+    expect(container?.textContent).toContain('进度 2 / 2')
+    expect(container?.textContent).toContain('暂无待处理项')
+  })
+
+  it('acknowledges a pending directory alert and refreshes the alert list', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([
+          {
+            id: 'alert-1',
+            integrationId: 'dir-1',
+            runId: 'run-1',
+            level: 'warning',
+            code: 'root_department_sparse',
+            message: '根部门直属成员过少',
+            details: {},
+            createdAt: '2026-04-08T01:06:00.000Z',
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount(),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: true,
+            },
+            actionable: {
+              canBatchUnbind: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          alert: {
+            id: 'alert-1',
+            acknowledgedAt: '2026-04-08T01:10:00.000Z',
+            acknowledgedBy: 'admin-1',
+          },
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([
+          {
+            id: 'alert-1',
+            integrationId: 'dir-1',
+            runId: 'run-1',
+            level: 'warning',
+            code: 'root_department_sparse',
+            message: '根部门直属成员过少',
+            details: {},
+            createdAt: '2026-04-08T01:06:00.000Z',
+            acknowledgedAt: '2026-04-08T01:10:00.000Z',
+            acknowledgedBy: 'admin-1',
+          },
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const ackButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('确认告警'))
+    expect(ackButton).toBeTruthy()
+    ackButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(6)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/alerts/alert-1/ack',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/alerts?page=1&pageSize=20&filter=all')
+    expect(container?.textContent).toContain('目录告警已确认')
+    expect(container?.textContent).toContain('已确认')
+  })
+
   it('does not show the sparse root-member warning when child departments are present', async () => {
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({
@@ -584,6 +3254,15 @@ describe('DirectoryManagementView', () => {
         ok: true,
         data: { items: [] },
       }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
       .mockResolvedValueOnce(createJsonResponse(
         createAccountListPayload([createAccount()]),
       ))

--- a/docs/development/dingtalk-directory-batch-bind-20260414.md
+++ b/docs/development/dingtalk-directory-batch-bind-20260414.md
@@ -1,0 +1,98 @@
+# DingTalk Directory Batch Bind - 2026-04-14
+
+## Scope
+
+This round extends the directory review queue from read-only review into bind execution:
+
+- backend `batch-bind` route for directory accounts
+- frontend quick bind and batch bind in review queue
+- targeted backend/frontend test coverage
+
+## Backend Changes
+
+Updated [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:1):
+
+- added `DirectoryAccountBatchBindEntry`
+- added `batchBindDirectoryAccounts(...)`
+- batch bind reuses `bindDirectoryAccount(...)`, so the same identity conflict checks, DingTalk identifier requirements, and grant behavior apply
+
+Updated [packages/core-backend/src/routes/admin-directory.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/routes/admin-directory.ts:1):
+
+- added `POST /api/admin/directory/accounts/batch-bind`
+- route accepts `bindings: [{ accountId, localUserRef, enableDingTalkGrant }]`
+- each successful bind writes the same audit pattern as the single-account bind path
+
+## Frontend Changes
+
+Updated [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:150):
+
+- `待处理队列` now supports inline bind for `pending_binding` items
+- each pending item can:
+  - input local user id/email
+  - search local users
+  - choose a result
+  - toggle `绑定后同时开通钉钉登录`
+  - execute `快速绑定`
+- added batch action:
+  - select multiple `pending_binding` review items
+  - submit `批量绑定`
+- existing queue refresh chain stays consistent:
+  - integration selection
+  - manual sync
+  - single bind/unbind
+  - batch bind/unbind
+
+## Tests
+
+Updated:
+
+- [packages/core-backend/tests/unit/admin-directory-routes.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/admin-directory-routes.test.ts:1)
+- [packages/core-backend/tests/unit/directory-sync-bind-account.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts:1)
+- [apps/web/tests/directoryManagementView.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/apps/web/tests/directoryManagementView.spec.ts:1)
+
+Covered behaviors:
+
+- backend `POST /accounts/batch-bind`
+- frontend review queue initial load still includes review items
+- frontend batch bind for pending review items
+- existing batch unbind / observability flows remain green
+
+## Verification
+
+Passed:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-scheduler.test.ts
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Still failing outside this DingTalk change set:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Current unrelated failures include:
+
+- `src/db/types.ts`
+- `src/middleware/api-token-auth.ts`
+- `src/multitable/api-token-service.ts`
+- `src/multitable/automation-log-service.ts`
+- `src/multitable/automation-service.ts`
+- `src/multitable/dashboard-service.ts`
+- `src/multitable/webhook-service.ts`
+- `src/routes/comments.ts`
+- `src/routes/dashboard.ts`
+- `src/routes/univer-meta.ts`
+
+## Claude CLI Note
+
+Claude Code CLI is available in this environment (`2.1.107`).
+
+A read-only check confirmed the new admin routes are present:
+
+- `POST /accounts/batch-bind`
+- `GET /integrations/:integrationId/review-items`
+
+Implementation and verification still rely on local code and local tests as the source of truth.

--- a/docs/development/dingtalk-directory-batch-progress-20260415.md
+++ b/docs/development/dingtalk-directory-batch-progress-20260415.md
@@ -1,0 +1,100 @@
+# DingTalk Directory Batch Progress
+
+## Goal
+
+继续把目录 review queue 做成真实可运营的管理员工作台。
+
+在已有的批量绑定、推荐确认、批量停权处理里，管理员之前只能看到按钮上的 `处理中...` 和最终一条成功提示；中间没有任何可见的处理状态，也不知道当前目标项数和系统处于哪个阶段。
+
+本轮目标：
+
+- 给 review queue 的批量动作增加可见的处理进度。
+- 在不改后端接口的前提下，明确展示：
+  - 当前动作类型
+  - 当前阶段
+  - 当前进度 `X / Y`
+- 继续兼容现有批量绑定、推荐确认、批量停权处理。
+
+## Implementation
+
+### Frontend
+
+- 在 `apps/web/src/views/DirectoryManagementView.vue` 增加 `ReviewBatchProgress` 状态：
+  - `kind`
+  - `phase`
+  - `total`
+  - `applied`
+  - `message`
+- 在待处理队列顶部新增“处理进度”卡片，展示：
+  - 动作类型：
+    - `批量绑定`
+    - `推荐绑定确认`
+    - `批量停权处理`
+  - 阶段：
+    - `提交中`
+    - `刷新中`
+    - `已完成`
+    - `失败`
+  - 进度：
+    - `进度 X / Y`
+- `submitReviewBindings(...)` 现在支持可选的 `progressKind`：
+  - 发请求前进入 `submitting`
+  - 后端返回成功后进入 `refreshing`
+  - 本地刷新 integrations / review-items / accounts 完成后进入 `completed`
+  - 任一阶段出错则进入 `failed`
+- `batchUnbindReviewItems()` 也接上同一套进度卡逻辑。
+- 进度卡在切换集成或重置页面时会清空；处理结束后管理员也可以手动 `清除进度`。
+
+说明：
+
+- 本轮没有变更后端 API。
+- 进度里的 `applied` 直接复用后端批量接口返回的 `items.length`；若后端未显式返回，则回退到本次提交目标数。
+
+## Tests
+
+前端测试更新在：
+
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+覆盖点：
+
+- `batch-confirms recommended pending bindings`
+  - 继续覆盖推荐批量确认成功
+  - 额外断言最终进度卡为 `推荐绑定确认 / 已完成 / 2 / 2`
+- `shows visible progress while batch-confirming recommended pending bindings`
+  - 覆盖请求未返回时的 `提交中 / 0 / 1`
+  - 覆盖请求完成后的 `已完成 / 1 / 1`
+- `batch-binds pending review items`
+  - 额外断言最终进度卡为 `批量绑定 / 已完成 / 2 / 2`
+- `batch unbinds inactive linked review items`
+  - 额外断言最终进度卡为 `批量停权处理 / 已完成 / 2 / 2`
+
+## Verification
+
+通过：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+## Environment Note
+
+这轮验证前，当前工作区的 `pnpm` 依赖链接里存在断到旧临时目录的坏链，导致：
+
+- `apps/web/node_modules/vitest`
+- `apps/web/node_modules/vue-tsc`
+- 以及部分根级依赖入口
+
+无法正常执行。为完成验证，我先执行了：
+
+```bash
+CI=true pnpm install --frozen-lockfile
+```
+
+它只重建本地依赖链接，没有改锁文件或仓库源码。
+
+## Notes
+
+- 本轮并行开发里使用了 worker 辅助补测试。
+- 也调用了 `Claude Code CLI` 做只读辅助检查；最终实现与结论仍以本地代码和本地测试结果为准。

--- a/docs/development/dingtalk-directory-manual-review-filters-20260415.md
+++ b/docs/development/dingtalk-directory-manual-review-filters-20260415.md
@@ -1,0 +1,71 @@
+# DingTalk Directory Manual Review Filters
+
+## Goal
+
+继续把目录 review queue 做成真正可运营的管理员工作台。
+
+在“推荐优先默认流”之后，管理员仍然需要面对一批 `pending_binding` 的人工处理项；如果这些项只按列表平铺展示，管理员还是需要逐条阅读“推荐判断”文案，效率不高。
+
+本轮目标：
+
+- 把 `需人工处理` 再按原因拆成可直接点击的子视图。
+- 优先把最常见、最有运营价值的两类拆出来：
+  - `无精确匹配`
+  - `冲突待复核`
+- 保持现有后端推荐规则不变，不扩展 review item API。
+
+## Implementation
+
+### Frontend
+
+- 在 `apps/web/src/views/DirectoryManagementView.vue` 为 `pending_binding` 的人工处理项新增 `PendingBindingManualReasonFilter`：
+  - `all`
+  - `no_exact_match`
+  - `conflict`
+- 继续沿用后端已有的 `recommendationStatus.code` 做前端归类：
+  - `no_exact_match` 归到“无精确匹配”
+  - 其余人工状态：
+    - `ambiguous_exact_match`
+    - `pending_link_conflict`
+    - `linked_user_conflict`
+    - `external_identity_conflict`
+    统一归到“冲突待复核”
+- 在待处理队列头部增加人工项概览：
+  - `人工处理中：无精确匹配 X · 冲突待复核 Y`
+- 当管理员切到 `需人工处理` 时，展示新的原因筛选按钮：
+  - `全部人工`
+  - `无精确匹配`
+  - `冲突待复核`
+- 刷新队列时，如果当前人工原因筛选已无命中项，会自动回退到 `全部人工`，避免管理员停留在空视图。
+
+说明：
+
+- 这轮没有改后端推荐判定。
+- 前端只是把已存在的 `recommendationStatus.code` 做成更可操作的运营分组。
+
+## Tests
+
+前端测试更新在：
+
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+覆盖点：
+
+- 切到 `需人工处理` 后会显示人工原因统计与筛选按钮。
+- `无精确匹配` 子视图只展示没有唯一精确候选的目录成员。
+- `冲突待复核` 子视图只展示存在精确匹配冲突或待确认绑定冲突的目录成员。
+- 当某个人工原因在刷新后已无可处理项时，页面会安全回退到 `全部人工`。
+
+## Verification
+
+通过：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+`Claude Code CLI`：
+
+- 已调用只读检查当前 review queue 实现；
+- 这轮最终结论仍以本地代码和本地测试结果为准。

--- a/docs/development/dingtalk-directory-observability-and-alerts-20260414.md
+++ b/docs/development/dingtalk-directory-observability-and-alerts-20260414.md
@@ -1,0 +1,109 @@
+# DingTalk Directory Observability And Alerts - 2026-04-14
+
+## Scope
+
+This round closes the DingTalk directory observability path end-to-end:
+
+- backend scheduler-aware directory sync snapshot
+- backend alert list and alert acknowledgement routes
+- backend route wiring for schedule refresh on integration create/update
+- frontend directory page cards for schedule observability and recent alerts
+- targeted tests and type checks
+
+## Backend Changes
+
+### Directory Sync Service
+
+Updated [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:1):
+
+- added `DirectorySyncAlertSummary`, `DirectorySyncScheduleSnapshot`, and related types
+- added `listDirectorySyncAlerts(...)`
+- added `acknowledgeDirectorySyncAlert(...)`
+- added `getDirectorySyncScheduleSnapshot(...)`
+- extended `syncDirectoryIntegration(...)` to accept `triggerSource`, so scheduler-triggered sync runs persist `trigger_source = 'scheduler'`
+- extended `unbindDirectoryAccount(...)` to accept `disableDingTalkGrant`
+
+### Admin Routes
+
+Updated [packages/core-backend/src/routes/admin-directory.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/routes/admin-directory.ts:1):
+
+- create/update integration now refresh scheduler state
+- added `GET /api/admin/directory/integrations/:integrationId/schedule`
+- added `GET /api/admin/directory/integrations/:integrationId/alerts`
+- added `POST /api/admin/directory/alerts/:alertId/ack`
+- admin unbind now accepts `disableDingTalkGrant`
+
+### Runtime Wiring
+
+Updated [packages/core-backend/src/index.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/index.ts:1):
+
+- start directory sync scheduler during backend startup
+- stop directory sync scheduler during shutdown
+
+Scheduler implementation is in [packages/core-backend/src/directory/directory-sync-scheduler.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync-scheduler.ts:1).
+
+## Frontend Changes
+
+Updated [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:1):
+
+- added `自动同步观测` card
+- loads `/api/admin/directory/integrations/:integrationId/schedule`
+- shows cron, next expected run, last run, last manual run, last automatic run, trigger source, and observation state
+- added `最近告警` panel
+- loads `/api/admin/directory/integrations/:integrationId/alerts`
+- supports `全部 / 待确认 / 已确认` local filtering
+- supports alert acknowledgement through `/api/admin/directory/alerts/:alertId/ack`
+- refreshing integration selection and manual sync now also refresh schedule snapshot and alerts
+
+## Tests
+
+Updated:
+
+- [packages/core-backend/tests/unit/admin-directory-routes.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/admin-directory-routes.test.ts:1)
+- [packages/core-backend/tests/unit/directory-sync-scheduler.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts:1)
+- [apps/web/tests/directoryManagementView.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/apps/web/tests/directoryManagementView.spec.ts:1)
+
+Covered behaviors:
+
+- scheduler refresh on integration create/update
+- schedule snapshot route
+- alert list route
+- alert acknowledgement route
+- scheduler-triggered sync handler
+- frontend initial load for runs + schedule + alerts + accounts
+- frontend manual sync refresh chain
+- frontend alert acknowledgement refresh
+
+## Verification
+
+Passed:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-scheduler.test.ts
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+`core-backend` type check still fails, but the remaining errors are pre-existing and outside this DingTalk change set:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Current unrelated failures include:
+
+- `src/db/types.ts`
+- `src/middleware/api-token-auth.ts`
+- `src/multitable/api-token-service.ts`
+- `src/multitable/automation-log-service.ts`
+- `src/multitable/automation-service.ts`
+- `src/multitable/dashboard-service.ts`
+- `src/multitable/webhook-service.ts`
+- `src/routes/comments.ts`
+- `src/routes/dashboard.ts`
+- `src/routes/univer-meta.ts`
+
+## Notes
+
+- Claude Code CLI is available in this environment; verified with `claude --version` returning `2.1.107 (Claude Code)`.
+- Local tests and local type checks remain the source of truth for this round.

--- a/docs/development/dingtalk-directory-observability-frontend-20260414.md
+++ b/docs/development/dingtalk-directory-observability-frontend-20260414.md
@@ -1,0 +1,30 @@
+# DingTalk Directory Observability Frontend 2026-04-14
+
+## Scope
+
+This round closes the admin directory page observability surface on the frontend only.
+
+## Changes
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+  - Added the automatic sync observability card.
+  - Loads `/api/admin/directory/integrations/:integrationId/schedule` alongside the existing integration, run, and account data.
+  - Renders cron state, next expected run, last run timestamps, trigger source, and observation status.
+  - Added the recent alerts panel.
+  - Loads `/api/admin/directory/integrations/:integrationId/alerts` and supports filtering and acknowledging alerts through `/api/admin/directory/alerts/:alertId/ack`.
+- `apps/web/tests/directoryManagementView.spec.ts`
+  - Updated the mount and sync flows to include the new schedule and alerts requests.
+  - Added coverage for the observability card rendering.
+  - Added coverage for acknowledging a pending alert and refreshing the alert list.
+
+## Verification
+
+- `pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts`
+  - Passed: 8 tests.
+- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
+  - Passed.
+
+## Notes
+
+- This change is intentionally scoped to the frontend files listed in the task.
+- The backend endpoints are consumed as already available by the current workspace.

--- a/docs/development/dingtalk-directory-ops-node20-typecheck-development-20260415.md
+++ b/docs/development/dingtalk-directory-ops-node20-typecheck-development-20260415.md
@@ -1,0 +1,36 @@
+# DingTalk Directory Ops Node20 Typecheck Development - 2026-04-15
+
+## Scope
+
+This follow-up fixes the remaining `Plugin System Tests / test (20.x)` failure on [#876](https://github.com/zensgit/metasheet2/pull/876).
+
+The failing path was not backend logic. It was frontend type-checking in:
+
+- [apps/web/src/views/DirectoryManagementView.vue](/tmp/metasheet2-dingtalk-directory-ops/apps/web/src/views/DirectoryManagementView.vue:1562)
+
+## Root Cause
+
+`normalizeReviewItems()` spread `unknown` values directly and then accessed nested properties like:
+
+- `item.recommendations`
+- `item.recommendationStatus`
+- `item.actionable`
+
+GitHub Actions on Node 20 runs `vue-tsc -b`, which rejected that code with:
+
+- `TS2698: Spread types may only be created from object types`
+- `TS2339` on the nested review-item properties
+
+## Fix
+
+`normalizeReviewItems()` now narrows each incoming item first:
+
+- coerces the unknown item into `Record<string, unknown>` only after an object check
+- narrows `recommendationStatus` and `actionable` separately
+- keeps the existing runtime behavior for recommendation arrays and actionable flags
+
+This is a type-safety fix only. It does not change queue behavior.
+
+## Claude Code CLI
+
+`Claude Code CLI` remains callable in this environment and was re-checked during the PR follow-up phase.

--- a/docs/development/dingtalk-directory-ops-node20-typecheck-verification-20260415.md
+++ b/docs/development/dingtalk-directory-ops-node20-typecheck-verification-20260415.md
@@ -1,0 +1,28 @@
+# DingTalk Directory Ops Node20 Typecheck Verification - 2026-04-15
+
+## Passed
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+- passed
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts --reporter=dot
+```
+
+Result:
+
+- frontend test files: `1`
+- frontend tests: `20/20`
+
+## CI Failure Addressed
+
+This verification directly targets the previous GitHub Actions failure from:
+
+- `Plugin System Tests / test (20.x)`
+
+The failing `DirectoryManagementView.vue` type-check path is now locally green.

--- a/docs/development/dingtalk-directory-ops-stack-development-20260415.md
+++ b/docs/development/dingtalk-directory-ops-stack-development-20260415.md
@@ -1,0 +1,68 @@
+# DingTalk Directory Ops Stack Development - 2026-04-15
+
+## Scope
+
+This branch packages the next DingTalk directory admin slice into one isolated worktree branch:
+
+- manual review queue operations
+- recommended binding guidance and reason filtering
+- batch bind / batch unbind execution
+- visible batch progress in the admin page
+- backend auto-sync scheduler wiring
+- schedule observability in the directory UI
+
+It intentionally excludes unrelated dirty files from the main worktree such as plugin `node_modules`, API token migrations, and session center tests.
+
+## Backend
+
+Updated:
+
+- [packages/core-backend/src/directory/directory-sync.ts](/tmp/metasheet2-dingtalk-directory-ops/packages/core-backend/src/directory/directory-sync.ts:1)
+- [packages/core-backend/src/routes/admin-directory.ts](/tmp/metasheet2-dingtalk-directory-ops/packages/core-backend/src/routes/admin-directory.ts:1)
+- [packages/core-backend/src/index.ts](/tmp/metasheet2-dingtalk-directory-ops/packages/core-backend/src/index.ts:1)
+- [packages/core-backend/src/directory/directory-sync-scheduler.ts](/tmp/metasheet2-dingtalk-directory-ops/packages/core-backend/src/directory/directory-sync-scheduler.ts:1)
+
+Key additions:
+
+- review item loading with pagination and operator-facing filters
+- recommendation metadata for pending bindings
+- batch bind and batch unbind execution paths
+- scheduler registration for active DingTalk directory integrations
+- schedule snapshot endpoint for admin observability
+
+## Frontend
+
+Updated:
+
+- [apps/web/src/views/DirectoryManagementView.vue](/tmp/metasheet2-dingtalk-directory-ops/apps/web/src/views/DirectoryManagementView.vue:1)
+- [apps/web/tests/directoryManagementView.spec.ts](/tmp/metasheet2-dingtalk-directory-ops/apps/web/tests/directoryManagementView.spec.ts:1)
+
+Key additions:
+
+- manual review queue actions
+- recommendation-based filtering and defaults
+- batch progress card for queue actions
+- schedule observability card for the selected integration
+
+## Supporting Docs
+
+This branch also brings over the focused notes already written for the same feature line:
+
+- `dingtalk-directory-review-queue-20260414.md`
+- `dingtalk-directory-batch-bind-20260414.md`
+- `dingtalk-directory-batch-progress-20260415.md`
+- `dingtalk-directory-manual-review-filters-20260415.md`
+- `dingtalk-directory-recommended-bindings-20260415.md`
+- `dingtalk-directory-recommendation-defaults-20260415.md`
+- `dingtalk-directory-recommendation-explainability-20260415.md`
+- `dingtalk-directory-recommendation-ops-20260415.md`
+- `dingtalk-directory-review-pagination-20260415.md`
+- `dingtalk-directory-scheduler-development-20260414.md`
+- `dingtalk-directory-schedule-observability-frontend-20260414.md`
+- `dingtalk-directory-observability-and-alerts-20260414.md`
+- `dingtalk-directory-observability-frontend-20260414.md`
+
+## Notes
+
+- `Claude Code CLI` is callable in this environment and was re-checked before packaging the branch.
+- A narrow `claude -p` review prompt did not return in time, so branch readiness is based on local test evidence rather than CLI review output.

--- a/docs/development/dingtalk-directory-ops-stack-verification-20260415.md
+++ b/docs/development/dingtalk-directory-ops-stack-verification-20260415.md
@@ -1,0 +1,57 @@
+# DingTalk Directory Ops Stack Verification - 2026-04-15
+
+## Passed
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-review-items.test.ts tests/unit/directory-sync-scheduler.test.ts --reporter=dot
+```
+
+Result:
+
+- test files: `4`
+- tests: `27/27`
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts --reporter=dot
+```
+
+Result:
+
+- test files: `1`
+- tests: `20/20`
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+- passed
+
+## Claude Code CLI
+
+Re-checked in the isolated worktree:
+
+```bash
+claude auth status
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+Observed result:
+
+- authenticated successfully
+- `claude -p` returned `CLAUDE_CLI_OK`
+
+## Not Included
+
+The following noisy or unrelated paths from the main worktree were intentionally excluded from this branch:
+
+- plugin and tool `node_modules` changes
+- `.claude/`
+- `apps/web/tests/sessionCenterView.spec.ts`
+- API token / automation migration drafts
+
+## Residual Risk
+
+- No backend `tsc --noEmit` run was added for this branch because the repository still carries unrelated type failures outside this DingTalk directory slice.
+- The isolated worktree temporarily uses `node_modules` symlinks from the main repo only to execute tests; those links are not committed.

--- a/docs/development/dingtalk-directory-recommendation-defaults-20260415.md
+++ b/docs/development/dingtalk-directory-recommendation-defaults-20260415.md
@@ -1,0 +1,65 @@
+# DingTalk Directory Recommendation Defaults
+
+## Goal
+
+继续把目录 review queue 做成“推荐优先”的管理员操作面。
+
+本轮目标：
+
+- 当 `pending_binding` 队列里存在可直接确认的推荐项时，默认进入“可推荐处理”视图。
+- 在推荐视图下，首次加载自动选中当前可见的推荐项，减少管理员重复勾选。
+- 管理员一旦显式切到“需人工处理”，刷新队列时要保留这个选择，不能被默认逻辑覆盖。
+- 前端不再根据 `recommendations.length` 自己推导“是否可确认推荐”，只信任后端返回的 `actionable.canConfirmRecommendation`。
+
+## Implementation
+
+### Frontend
+
+- 在 `apps/web/src/views/DirectoryManagementView.vue` 将 `pendingBindingView` 默认值调整为 `recommended`。
+- 增加 `pendingBindingViewTouched`，用于区分“系统默认选择”与“管理员手动切换”。
+- 调整 `syncPendingBindingQueueDefaults()`：
+  - 无待绑定项时回退到 `all`，并清空选中项。
+  - 有推荐项时默认进入 `recommended`。
+  - 无推荐项但仍有待绑定项时回退到 `manual`。
+  - 已显式切到 `manual` 的情况下，刷新队列时保持 `manual`，除非当前视图已失效。
+  - 仅在推荐视图且当前没有任何选择时，自动选中当前可见推荐项。
+- 调整 review item payload 归一化逻辑：
+  - `canConfirmRecommendation` 只接受后端显式返回的 `true`。
+  - 不再使用 `recommendations.length > 0` 做前端推导。
+- 加固 `selectedRecommendedReviewBindEntries`，只处理同时满足“已选中 + 后端允许确认推荐 + recommendation 非空”的条目，避免空数组访问。
+
+### Tests
+
+更新前端测试 `apps/web/tests/directoryManagementView.spec.ts`：
+
+- `filters review queue by recommendation readiness and selects visible recommended items`
+  - 覆盖默认进入推荐视图。
+  - 覆盖首次加载自动选中推荐项。
+  - 覆盖 `可推荐处理 / 需人工处理` 切换。
+- `keeps the manual review view on queue refresh after the user explicitly switches to it`
+  - 覆盖管理员显式切到人工视图后，刷新队列仍保持人工视图。
+- `batch-confirms recommended pending bindings`
+  - 按新语义补齐推荐 fixture 的 `actionable.canConfirmRecommendation`，保证批量确认测试与后端契约一致。
+
+## Verification
+
+通过：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+`Claude Code CLI` 只读核对结论：
+
+- 推荐默认流仍是前端行为，没有扩展后端接口。
+- 页面已只依赖 `actionable.canConfirmRecommendation`，不再从 `recommendations` 长度推导。
+
+## Notes
+
+本轮没有变更后端推荐规则：
+
+- 仍然只使用唯一精确邮箱/手机号匹配。
+- 仍然要求后端显式判定该项是否允许“确认推荐”。
+
+这样可以避免前端和后端在推荐资格上的语义漂移。

--- a/docs/development/dingtalk-directory-recommendation-explainability-20260415.md
+++ b/docs/development/dingtalk-directory-recommendation-explainability-20260415.md
@@ -1,0 +1,90 @@
+# DingTalk Directory Recommendation Explainability
+
+## Goal
+
+继续把目录 review queue 做成可运营、可解释的管理员工作台。
+
+本轮目标：
+
+- 不只告诉管理员哪些 `pending_binding` 可以推荐确认。
+- 还要明确告诉管理员为什么某个成员没有进入推荐流。
+- 保持现有推荐规则不变，不引入模糊匹配。
+
+## Implementation
+
+### Backend
+
+- 在 [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:355) 为 `DirectoryReviewItemSummary` 增加 `recommendationStatus`。
+- 在 [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:625) 增加 `buildRecommendationStatus(...)`，统一生成可解释状态和文案。
+- 在 [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:801) 到 [directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:862) 的推荐判定里，为以下情况返回明确状态：
+  - `recommended`
+  - `no_exact_match`
+  - `ambiguous_exact_match`
+  - `pending_link_conflict`
+  - `linked_user_conflict`
+  - `external_identity_conflict`
+
+说明：
+
+- 推荐规则本身没有变化，仍然只用唯一精确邮箱/手机号匹配。
+- 这轮增加的是“解释层”，不是新的匹配算法。
+
+### Frontend
+
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:272) 为 `pending_binding` 增加“推荐判断”文案展示：
+  - `推荐判断：{{ item.recommendationStatus.message }}`
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:786) 补齐 `recommendationStatus` 前端类型。
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:1466) 对 review item 的 API payload 做前端归一化，避免缺字段时页面报错。
+
+现在管理员可以直接看到：
+
+- `已命中唯一精确候选，可直接确认推荐绑定。`
+- `未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。`
+- `现有待确认匹配与精确候选不一致，请人工复核。`
+
+## Tests
+
+新增/更新：
+
+- 后端：
+  - [packages/core-backend/tests/unit/directory-sync-review-items.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-review-items.test.ts:183)
+  - [packages/core-backend/tests/unit/directory-sync-review-items.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-review-items.test.ts:233)
+- 前端：
+  - [apps/web/tests/directoryManagementView.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/apps/web/tests/directoryManagementView.spec.ts:1167)
+
+覆盖内容：
+
+- 推荐项会返回 `recommended` 状态。
+- 无唯一精确候选时会返回 `no_exact_match`。
+- 待确认绑定与精确候选不一致时会返回 `pending_link_conflict`。
+- 页面在 `可推荐处理 / 需人工处理` 视图下都能展示对应的解释文案。
+
+## Verification
+
+通过：
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-review-items.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-scheduler.test.ts
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+`Claude Code CLI` 只读核对通过：
+
+- `pending_binding` review item 已附带 `recommendationStatus`
+- `DirectoryManagementView.vue` 已展示“推荐判断”文案
+
+未通过但与本轮无关：
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+当前仍是仓库既有问题，集中在：
+
+- `src/db/types.ts`
+- `src/middleware/api-token-auth.ts`
+- 若干 `src/multitable/*`
+- `src/routes/comments.ts`
+- `src/routes/dashboard.ts`
+- `src/routes/univer-meta.ts`

--- a/docs/development/dingtalk-directory-recommendation-ops-20260415.md
+++ b/docs/development/dingtalk-directory-recommendation-ops-20260415.md
@@ -1,0 +1,97 @@
+# DingTalk Directory Recommendation Operations
+
+## Goal
+
+继续把目录 review queue 从“有推荐能力”推进到“推荐优先运营”。
+
+本轮目标：
+
+- 明确展示 `pending_binding` 中可推荐处理和需人工处理的数量。
+- 让管理员可以按推荐就绪度筛选 review queue。
+- 给管理员一键选择当前筛选结果和一键选择可推荐项，减少手工勾选。
+- 保持现有批量确认推荐、手工绑定、停权处理路径不变。
+
+## Implementation
+
+### Backend
+
+- 在 [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:343) 为 `DirectoryReviewItemSummary.actionable` 增加 `canConfirmRecommendation`。
+- 在 [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:525) 让 `pending_binding` 且存在推荐候选的项显式标记为可确认推荐。
+
+这样前端不需要自己重复推断推荐可用性，review item payload 自带运营信号。
+
+### Frontend
+
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:153) 增加待绑定运营摘要：
+  - `可推荐`
+  - `需人工`
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:169) 增加 `全部待绑定 / 可推荐处理 / 需人工处理` 视图切换。
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:194) 和 [DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:202) 增加：
+  - `选择当前筛选`
+  - `选择可推荐`
+  - `清空选择`
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:967) 增加推荐/人工计数。
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:972) 调整 `filteredReviewItems`，让 `pending_binding` 可以按推荐就绪度切分。
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:1581) 和 [DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:1588) 增加批量选择工具函数。
+
+## Behavior
+
+现在管理员可以：
+
+- 先看 `待绑定中：可推荐 X · 需人工 Y`
+- 切换到 `可推荐处理`
+- 一键 `选择可推荐`
+- 直接执行 `批量确认推荐`
+
+如果需要手工处理，也可以切到 `需人工处理`，再继续使用现有搜索本地用户和批量绑定流程。
+
+## Tests
+
+新增/更新：
+
+- 后端：
+  - [packages/core-backend/tests/unit/directory-sync-review-items.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-review-items.test.ts:21)
+  - [packages/core-backend/tests/unit/directory-sync-review-items.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-review-items.test.ts:103)
+- 前端：
+  - [apps/web/tests/directoryManagementView.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/apps/web/tests/directoryManagementView.spec.ts:1167)
+
+前端新增用例覆盖：
+
+- 推荐/人工计数展示
+- `可推荐处理` 视图切换
+- `选择可推荐`
+- `批量确认推荐`
+- `需人工处理` 视图切换
+
+## Verification
+
+通过：
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-review-items.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-scheduler.test.ts
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+`Claude Code CLI` 只读核对通过：
+
+- 已确认页面存在：
+  - 待绑定中可推荐/需人工计数
+  - `选择当前筛选`
+  - `选择可推荐`
+  - `可推荐处理 / 需人工处理` 筛选
+
+未通过但与本轮无关：
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+当前仍是仓库既有问题，集中在：
+
+- `src/db/types.ts`
+- `src/middleware/api-token-auth.ts`
+- 若干 `src/multitable/*`
+- `src/routes/comments.ts`
+- `src/routes/dashboard.ts`
+- `src/routes/univer-meta.ts`

--- a/docs/development/dingtalk-directory-recommended-bindings-20260415.md
+++ b/docs/development/dingtalk-directory-recommended-bindings-20260415.md
@@ -1,0 +1,87 @@
+# DingTalk Directory Recommended Bindings Development
+
+## Goal
+
+继续把 `pending_binding` review queue 从“人工输入绑定”推进到“安全推荐候选人 + 一键确认推荐 + 批量确认推荐”。
+
+本轮约束：
+
+- 只做精确匹配推荐，不引入姓名或模糊匹配。
+- 只在唯一候选且无已知冲突时给推荐。
+- 复用现有 `/api/admin/directory/accounts/batch-bind`，不新增绑定提交接口。
+
+## Implementation
+
+### Backend
+
+- 在 [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:319) 新增 `DirectoryBindingRecommendation` 和 `DirectoryBindingRecommendationReason`。
+- 在 [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:615) 增加 `loadDirectoryReviewRecommendations(...)`。
+- 在 [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:1785) 的 `listDirectoryReviewItems(...)` 中为 `pending_binding` 生成推荐候选，并把结果附带到 `recommendations` 字段。
+
+推荐规则：
+
+- 仅使用精确邮箱匹配、精确手机号匹配。
+- 若同一目录成员落到多个不同本地用户，则不推荐。
+- 若候选用户已 linked 到别的 DingTalk 目录账号，则不推荐。
+- 若候选用户已有不匹配当前目录成员的 DingTalk 外部身份，则不推荐。
+- 若已有 `pending` 链接且与唯一精确候选一致，则在推荐原因中带上 `pending_link`。
+
+### Frontend
+
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:179) 增加顶部“批量确认推荐”入口。
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:267) 为每条 `pending_binding` 展示推荐候选卡片和推荐原因。
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:312) 增加单条“确认推荐”。
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:1135) 增加推荐采用与文案映射逻辑。
+- 在 [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:1563) 增加单条/批量推荐确认提交流程。
+
+交互结果：
+
+- 管理员可直接看到“邮箱精确匹配 / 手机号精确匹配 / 已存在待确认匹配”。
+- 可单条确认推荐绑定。
+- 可多选后批量确认推荐绑定。
+- 原有手工输入、本地搜索、快速绑定仍保留，继续作为兜底路径。
+
+## Tests
+
+新增/更新测试：
+
+- 后端推荐逻辑：
+  - [packages/core-backend/tests/unit/directory-sync-review-items.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-review-items.test.ts:21)
+  - [packages/core-backend/tests/unit/directory-sync-review-items.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-review-items.test.ts:100)
+- 前端目录页推荐确认：
+  - [apps/web/tests/directoryManagementView.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/apps/web/tests/directoryManagementView.spec.ts:682)
+  - [apps/web/tests/directoryManagementView.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/apps/web/tests/directoryManagementView.spec.ts:978)
+
+## Verification
+
+通过：
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-review-items.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-scheduler.test.ts
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+`Claude Code CLI` 只读交叉检查：
+
+- 命令通过 `python3 + claude -p` 非交互执行。
+- CLI 确认：
+  - `DirectoryManagementView.vue` 已包含“推荐候选 / 确认推荐 / 批量确认推荐”。
+  - `directory-sync.ts` 的 review items 已包含 `recommendations` 字段。
+
+未通过但与本轮无关：
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+现有报错仍集中在既有文件：
+
+- `src/db/types.ts`
+- `src/middleware/api-token-auth.ts`
+- 若干 `src/multitable/*`
+- `src/routes/comments.ts`
+- `src/routes/dashboard.ts`
+- `src/routes/univer-meta.ts`
+
+本轮未引入新的 `directory-sync.ts` 或 `DirectoryManagementView.vue` 全量类型错误。

--- a/docs/development/dingtalk-directory-review-pagination-20260415.md
+++ b/docs/development/dingtalk-directory-review-pagination-20260415.md
@@ -1,0 +1,67 @@
+# DingTalk Directory Review Pagination
+
+## Goal
+
+继续把目录 review queue 做成可用于更大规模成员治理的工作台。
+
+当前后端 `review-items` 已经支持分页和 `total`，但前端一直固定请求第一页 `page=1&pageSize=100`。当待处理项超过 100 条时，管理员只能看到第一页，而且页面没有任何“队列被截断”的提示。
+
+本轮目标：
+
+- 把 review queue 从“固定第一页”改成“已加载 / 总数 + 加载更多”。
+- 保持现有筛选、推荐默认流、人工原因分组不变。
+- 刷新队列时回到第一页，避免把旧的追加页残留在刷新结果里。
+
+## Implementation
+
+### Frontend
+
+- 在 `apps/web/src/views/DirectoryManagementView.vue` 增加 review queue 分页状态：
+  - `reviewPage`
+  - `reviewTotal`
+  - `reviewPageSize`
+  - `loadingMoreReviewItems`
+- `loadReviewItems(...)` 现在支持两种模式：
+  - 默认刷新：请求第一页并替换当前队列
+  - `append: true`：请求下一页并把结果追加到当前队列
+- 页面头部新增加载进度提示：
+  - `当前已加载 X / Y 项，筛选统计基于已加载数据。`
+- 页面底部新增：
+  - `加载更多 (N)` 按钮
+- 如果当前筛选在已加载数据中暂无结果，但后面还有未加载页，空状态改成：
+  - `当前筛选在已加载数据中暂无结果，可继续加载更多。`
+- 分页追加失败时不会清空已加载队列，只提示错误；完整刷新失败时仍按原逻辑清空并报错。
+
+### Backend
+
+- 本轮没有改后端接口。
+- 继续复用已有：
+  - `GET /api/admin/directory/integrations/:integrationId/review-items`
+  - 返回的 `items / total / page / pageSize`
+
+## Tests
+
+前端测试更新在：
+
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+覆盖点：
+
+- 初次加载 `page=1` 时显示 `当前已加载 X / Y`。
+- 当 `total > 当前已加载数` 时显示 `加载更多`。
+- 点击 `加载更多` 后请求 `page=2`，并把第二页条目追加到 review queue。
+- 点击 `刷新队列` 后重新请求 `page=1`，并回到第一页结果。
+
+## Verification
+
+通过：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+## Notes
+
+- 本轮并行开发里使用了 worker 辅助补测试。
+- 也调用了 `Claude Code CLI` 做只读辅助检查；最终实现与结论仍以本地代码和本地测试结果为准。

--- a/docs/development/dingtalk-directory-review-queue-20260414.md
+++ b/docs/development/dingtalk-directory-review-queue-20260414.md
@@ -1,0 +1,114 @@
+# DingTalk Directory Review Queue - 2026-04-14
+
+## Scope
+
+This round extends DingTalk directory governance from observability into operator workflow:
+
+- backend review queue snapshot for directory governance
+- backend batch unbind for inactive-linked directory members
+- frontend review queue section in directory management
+- targeted route/service/frontend tests
+
+## Backend Changes
+
+### Directory Sync Service
+
+Updated [packages/core-backend/src/directory/directory-sync.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync.ts:1):
+
+- added `DirectoryReviewItemSummary` and `DirectoryReviewItemFilter`
+- added `listDirectoryReviewItems(...)`
+- added `batchUnbindDirectoryAccounts(...)`
+- review queue currently covers:
+  - `pending_binding`
+  - `inactive_linked`
+  - `missing_identifier`
+- `unbindDirectoryAccount(...)` already supports `disableDingTalkGrant`, and batch unbind reuses that path
+
+### Admin Routes
+
+Updated [packages/core-backend/src/routes/admin-directory.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/routes/admin-directory.ts:1):
+
+- added `GET /api/admin/directory/integrations/:integrationId/review-items`
+- added `POST /api/admin/directory/accounts/batch-unbind`
+- batch route writes audit logs for each processed directory account
+
+### Existing Runtime Context
+
+This builds on the directory scheduler + observability work already wired through:
+
+- [packages/core-backend/src/directory/directory-sync-scheduler.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/directory/directory-sync-scheduler.ts:1)
+- [packages/core-backend/src/index.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/src/index.ts:97)
+
+## Frontend Changes
+
+Updated [apps/web/src/views/DirectoryManagementView.vue](/Users/chouhua/Downloads/Github/metasheet2/apps/web/src/views/DirectoryManagementView.vue:1):
+
+- added a `待处理队列` section above the member account list
+- queue displays:
+  - pending binding members
+  - inactive linked members
+  - missing DingTalk identifier members
+- added local tabs for:
+  - `全部待处理`
+  - `待绑定`
+  - `停用待停权`
+  - `缺身份标识`
+- added queue actions:
+  - `定位到成员`
+  - single `停权处理`
+  - batch `批量停权处理`
+  - optional `停权时同时关闭钉钉登录`
+- integration selection, manual sync, bind, and unbind now all refresh review queue state
+
+## Tests
+
+Updated:
+
+- [packages/core-backend/tests/unit/admin-directory-routes.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/admin-directory-routes.test.ts:1)
+- [packages/core-backend/tests/unit/directory-sync-bind-account.test.ts](/Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts:1)
+- [apps/web/tests/directoryManagementView.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/apps/web/tests/directoryManagementView.spec.ts:1)
+
+Covered behaviors:
+
+- review-items route
+- batch unbind route
+- unbind with `disableDingTalkGrant`
+- frontend initial load now includes review queue
+- frontend manual sync refresh chain now includes review queue
+- frontend batch review queue unbind
+
+## Verification
+
+Passed:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-scheduler.test.ts
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Still failing outside this DingTalk review-queue change set:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Current unrelated failures include:
+
+- `src/db/types.ts`
+- `src/middleware/api-token-auth.ts`
+- `src/multitable/api-token-service.ts`
+- `src/multitable/automation-log-service.ts`
+- `src/multitable/automation-service.ts`
+- `src/multitable/dashboard-service.ts`
+- `src/multitable/webhook-service.ts`
+- `src/routes/comments.ts`
+- `src/routes/dashboard.ts`
+- `src/routes/univer-meta.ts`
+
+## Notes
+
+- Claude Code CLI is available in this environment (`2.1.107`), but non-interactive `claude -p` remained unstable during this round, so implementation and verification relied on local code plus local tests.
+- Review queue and alerts stay separate by design:
+  - alerts are runtime/sync observability
+  - review queue is member-governance workflow

--- a/docs/development/dingtalk-directory-schedule-observability-frontend-20260414.md
+++ b/docs/development/dingtalk-directory-schedule-observability-frontend-20260414.md
@@ -1,0 +1,101 @@
+# DingTalk Directory Schedule Observability Frontend Development And Verification
+
+## Scope
+
+This round connects the directory admin page to the new backend schedule snapshot.
+
+- Consume `GET /api/admin/directory/integrations/:integrationId/schedule`
+- Render an auto-sync observation card in the directory integration detail page
+- Refresh schedule observation when:
+  - an integration is selected
+  - a manual sync finishes
+  - an admin explicitly clicks the refresh button
+- Cover the new flow with frontend tests
+
+## Files Changed
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+## Implementation Notes
+
+### New UI block
+
+The page now renders an `自动同步观测` section for the selected integration.
+
+The card shows:
+
+- whether auto-sync is enabled
+- schedule observation status
+- whether the cron expression is valid
+- configured `scheduleCron`
+- timezone
+- next expected run
+- latest observed trigger source
+- latest automatic run
+- latest manual run
+- backend note text
+
+### Observation state mapping
+
+The frontend now maps backend statuses to operator-facing labels:
+
+- `disabled` -> `未启用自动同步`
+- `missing_cron` -> `缺少 Cron`
+- `invalid_cron` -> `Cron 无效`
+- `configured_no_runs` -> `已配置待观察`
+- `manual_only` -> `仅观察到手动执行`
+- `auto_observed` -> `已观察到自动执行`
+
+It also maps them to chip colors:
+
+- success: `auto_observed`
+- warning: `disabled`, `configured_no_runs`, `manual_only`
+- danger: invalid or missing cron
+
+### Data flow
+
+- `selectIntegration()` now loads:
+  - runs
+  - schedule snapshot
+  - accounts
+- `syncIntegration()` now refreshes:
+  - integrations
+  - runs
+  - schedule snapshot
+  - accounts
+
+## Verification
+
+### Passed
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+- `directoryManagementView.spec.ts`: 8 tests passed
+- `vue-tsc --noEmit`: passed
+
+### Test coverage added/updated
+
+- initial mount now requests `/schedule`
+- schedule observation renders on the page
+- manual sync refreshes `/schedule`
+- missing-cron state renders operator-facing guidance
+- invalid cron state renders operator-facing warning text
+
+## Claude Code CLI
+
+- Claude Code CLI is available in this environment
+- It may be used as a read-only helper, but local implementation and local test results remain the source of truth for this round
+
+## Next Step
+
+The next useful step is to continue the same operator workflow and add:
+
+- directory sync alerts panel
+- alert acknowledgement actions
+- a tighter relationship between schedule observation and sync warning triage

--- a/docs/development/dingtalk-directory-scheduler-development-20260414.md
+++ b/docs/development/dingtalk-directory-scheduler-development-20260414.md
@@ -1,0 +1,148 @@
+# DingTalk Directory Scheduler Development And Verification
+
+## Scope
+
+This change closes the backend loop for DingTalk directory auto-sync scheduling.
+
+- Adds a runtime scheduler for active DingTalk directory integrations with `syncEnabled=true` and a non-empty `scheduleCron`
+- Registers scheduler jobs during backend startup and tears them down during shutdown
+- Propagates scheduled runs with `trigger_source = 'scheduler'`
+- Exposes a schedule observation snapshot at `GET /api/admin/directory/integrations/:integrationId/schedule`
+- Extends admin unbind to optionally disable the user's DingTalk login grant at the same time
+
+## Files Changed
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+- `packages/core-backend/src/directory/directory-sync-scheduler.ts`
+- `packages/core-backend/src/routes/admin-directory.ts`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/tests/unit/admin-directory-routes.test.ts`
+- `packages/core-backend/tests/unit/directory-sync-scheduler.test.ts`
+
+## Implementation Notes
+
+### Runtime scheduler
+
+- New module: `directory-sync-scheduler.ts`
+- Job name format: `directory-sync:<integrationId>`
+- Scheduling conditions:
+  - provider is DingTalk
+  - integration `status === 'active'`
+  - `sync_enabled === true`
+  - `schedule_cron` is non-empty
+- Scheduler timezone is fixed to `UTC`
+- Scheduled job handler calls:
+
+```ts
+syncDirectoryIntegration(integrationId, 'system:directory-sync-scheduler', 'scheduler')
+```
+
+### Startup / shutdown wiring
+
+- `MetaSheetServer.start()` now initializes the directory sync scheduler in degraded mode
+- `MetaSheetServer.stop()` now stops the directory sync scheduler as part of shutdown tasks
+- Create/update integration routes refresh the schedule registration after persistence
+
+### Schedule observation snapshot
+
+`GET /api/admin/directory/integrations/:integrationId/schedule`
+
+Returns:
+
+- `syncEnabled`
+- `scheduleCron`
+- `cronValid`
+- `nextExpectedRunAt`
+- `latestRunAt`
+- `latestRunTriggerSource`
+- `latestManualRunAt`
+- `latestAutoRunAt`
+- `observationStatus`
+- `note`
+
+Observation statuses currently include:
+
+- `disabled`
+- `missing_cron`
+- `invalid_cron`
+- `configured_no_runs`
+- `manual_only`
+- `auto_observed`
+
+### Admin unbind extension
+
+`POST /api/admin/directory/accounts/:accountId/unbind`
+
+Request body now supports:
+
+```json
+{
+  "disableDingTalkGrant": true
+}
+```
+
+When enabled, the route keeps the directory unbind behavior and also upserts the DingTalk auth grant to `enabled = false` for the previously linked local user.
+
+## Verification
+
+### Passed
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts \
+  tests/unit/directory-sync-scheduler.test.ts
+```
+
+Result:
+
+- 3 test files passed
+- 19 tests passed
+
+### TypeScript check
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result:
+
+- Still fails, but the failures are pre-existing and outside this change
+- No remaining TypeScript error points to:
+  - `directory-sync.ts`
+  - `directory-sync-scheduler.ts`
+  - `admin-directory.ts`
+  - `index.ts`
+
+Current unrelated failing areas include:
+
+- `src/middleware/api-token-auth.ts`
+- `src/multitable/api-token-service.ts`
+- `src/multitable/automation-service.ts`
+- `src/multitable/webhook-event-bridge.ts`
+- `src/multitable/webhook-service.ts`
+- `src/routes/api-tokens.ts`
+- `src/routes/comments.ts`
+- `src/routes/dashboard.ts`
+- `src/routes/univer-meta.ts`
+
+## Claude Code CLI Cross-check
+
+- Claude Code CLI is available in this environment (`2.1.107`)
+- A read-only follow-up prompt was attempted during this round, but the CLI returned a usage-limit message
+- Local code changes and local test results remain the source of truth
+
+## Current Limitations
+
+- Scheduler is in-process and per-node; there is no leader election or distributed locking
+- Cron parsing and next-run projection use `UTC`
+- The new schedule snapshot route is backend-only for now; the current directory admin page has not yet been upgraded to consume it in this worktree
+- Automatic scheduling depends on backend process uptime; missed runs are not backfilled yet
+
+## Recommended Next Step
+
+- Upgrade `apps/web/src/views/DirectoryManagementView.vue` to consume `/schedule` and render:
+  - schedule health
+  - next expected run
+  - last manual vs last auto run
+  - invalid/missing cron warnings

--- a/packages/core-backend/src/directory/directory-sync-scheduler.ts
+++ b/packages/core-backend/src/directory/directory-sync-scheduler.ts
@@ -1,0 +1,139 @@
+import { Logger } from '../core/logger'
+import { query } from '../db/pg'
+import { SchedulerServiceImpl } from '../services/SchedulerService'
+import { syncDirectoryIntegration } from './directory-sync'
+
+type DirectoryScheduleRow = {
+  id: string
+  name: string
+  status: string
+  sync_enabled: boolean
+  schedule_cron: string | null
+}
+
+type DirectorySyncSchedulerLike = Pick<SchedulerServiceImpl, 'schedule' | 'reschedule' | 'unschedule' | 'getJob' | 'destroy'>
+
+const logger = new Logger('DirectorySyncScheduler')
+const SYSTEM_TRIGGERED_BY = 'system:directory-sync-scheduler'
+const JOB_PREFIX = 'directory-sync'
+
+let scheduler: DirectorySyncSchedulerLike | null = null
+let started = false
+
+function buildJobName(integrationId: string): string {
+  return `${JOB_PREFIX}:${integrationId}`
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function shouldSchedule(row: DirectoryScheduleRow | null): row is DirectoryScheduleRow {
+  if (!row) return false
+  return row.status === 'active' && row.sync_enabled === true && normalizeText(row.schedule_cron).length > 0
+}
+
+async function listScheduleRows(): Promise<DirectoryScheduleRow[]> {
+  const result = await query<DirectoryScheduleRow>(
+    `SELECT id, name, status, sync_enabled, schedule_cron
+     FROM directory_integrations
+     WHERE provider = 'dingtalk'`,
+  )
+  return result.rows
+}
+
+async function getScheduleRow(integrationId: string): Promise<DirectoryScheduleRow | null> {
+  const result = await query<DirectoryScheduleRow>(
+    `SELECT id, name, status, sync_enabled, schedule_cron
+     FROM directory_integrations
+     WHERE id = $1 AND provider = 'dingtalk'`,
+    [integrationId],
+  )
+  return result.rows[0] ?? null
+}
+
+async function runScheduledSync(integrationId: string): Promise<void> {
+  await syncDirectoryIntegration(integrationId, SYSTEM_TRIGGERED_BY, 'scheduler')
+}
+
+async function applySchedule(row: DirectoryScheduleRow | null): Promise<void> {
+  if (!scheduler) return
+
+  const jobName = buildJobName(normalizeText(row?.id))
+  const existingJob = jobName ? await scheduler.getJob(jobName) : null
+
+  if (!shouldSchedule(row)) {
+    if (existingJob && jobName) {
+      await scheduler.unschedule(jobName)
+      logger.info(`Unscheduled directory sync job: ${jobName}`)
+    }
+    return
+  }
+
+  const cronExpression = normalizeText(row.schedule_cron)
+  try {
+    if (existingJob) {
+      await scheduler.reschedule(jobName, cronExpression)
+      logger.info(`Rescheduled directory sync job: ${jobName} (${cronExpression})`)
+    } else {
+      await scheduler.schedule(jobName, cronExpression, async () => {
+        await runScheduledSync(row.id)
+      }, {
+        timezone: 'UTC',
+      })
+      logger.info(`Scheduled directory sync job: ${jobName} (${cronExpression})`)
+    }
+  } catch (error) {
+    logger.warn(`Failed to apply directory sync schedule for ${row.id}: ${error instanceof Error ? error.message : String(error)}`)
+    if (existingJob) {
+      await scheduler.unschedule(jobName)
+    }
+  }
+}
+
+export async function startDirectorySyncScheduler(
+  options: { scheduler?: DirectorySyncSchedulerLike } = {},
+): Promise<void> {
+  if (started) return
+
+  scheduler = options.scheduler ?? new SchedulerServiceImpl()
+  started = true
+
+  try {
+    const rows = await listScheduleRows()
+    await Promise.all(rows.map((row) => applySchedule(row)))
+    logger.info(`Directory sync scheduler started with ${rows.length} integration(s) loaded`)
+  } catch (error) {
+    logger.warn(`Directory sync scheduler bootstrap failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+export async function refreshDirectoryIntegrationSchedule(integrationId: string): Promise<void> {
+  if (!started || !scheduler) return
+
+  const normalizedIntegrationId = normalizeText(integrationId)
+  if (!normalizedIntegrationId) return
+
+  try {
+    const row = await getScheduleRow(normalizedIntegrationId)
+    await applySchedule(row)
+  } catch (error) {
+    logger.warn(`Failed to refresh directory sync schedule for ${normalizedIntegrationId}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+export async function stopDirectorySyncScheduler(): Promise<void> {
+  if (!scheduler) return
+
+  try {
+    scheduler.destroy()
+  } finally {
+    scheduler = null
+    started = false
+  }
+}
+
+export function resetDirectorySyncSchedulerForTests(): void {
+  scheduler = null
+  started = false
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -10,6 +10,7 @@ import {
 } from '../integrations/dingtalk/client'
 import { assertDingTalkCorpAllowed } from '../integrations/dingtalk/runtime-policy'
 import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../security/encrypted-secrets'
+import { SimpleCronExpression } from '../services/SchedulerService'
 
 const logger = new Logger('DirectorySync')
 const DEFAULT_ORG_ID = 'default'
@@ -60,6 +61,21 @@ type DirectoryRunRow = {
   error_message: string | null
   triggered_by: string | null
   trigger_source: string
+  created_at: string
+  updated_at: string
+}
+
+type DirectorySyncAlertRow = {
+  id: string
+  integration_id: string
+  run_id: string | null
+  level: string
+  code: string
+  message: string
+  details: JsonRecord | string | null
+  sent_to_webhook: boolean
+  acknowledged_at: string | null
+  acknowledged_by: string | null
   created_at: string
   updated_at: string
 }
@@ -126,12 +142,41 @@ type DirectoryIntegrationAccountRow = {
   department_paths: string[] | null
 }
 
+type DirectoryReviewItemRow = DirectoryIntegrationAccountRow & {
+  review_kind: string
+  review_reason: string
+  missing_union_id: boolean
+  missing_open_id: boolean
+}
+
 type DirectoryBindingUserRow = {
   id: string
   email: string
   name: string | null
   role: string
   is_active: boolean
+}
+
+type DirectoryBindingCandidateRow = DirectoryBindingUserRow & {
+  mobile: string | null
+}
+
+type DirectoryLinkedAccountByUserRow = {
+  local_user_id: string
+  directory_account_id: string
+}
+
+type DirectoryIdentityByUserRow = {
+  local_user_id: string
+  external_key: string
+  provider_union_id: string | null
+  provider_open_id: string | null
+  corp_id: string | null
+}
+
+type DirectoryReviewRecommendationResult = {
+  recommendations: DirectoryBindingRecommendation[]
+  status: DirectoryBindingRecommendationStatus
 }
 
 type DirectoryBindingTargetAccountRow = {
@@ -237,6 +282,87 @@ export type DirectorySyncRunSummary = {
   updatedAt: string
 }
 
+export type DirectorySyncAlertFilter = 'all' | 'pending' | 'acknowledged'
+
+export type DirectorySyncAlertSummary = {
+  id: string
+  integrationId: string
+  runId: string | null
+  level: string
+  code: string
+  message: string
+  details: JsonRecord
+  sentToWebhook: boolean
+  acknowledgedAt: string | null
+  acknowledgedBy: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type DirectorySyncObservationStatus =
+  | 'disabled'
+  | 'missing_cron'
+  | 'invalid_cron'
+  | 'awaiting_first_run'
+  | 'scheduler_observed'
+
+export type DirectorySyncScheduleSnapshot = {
+  integrationId: string
+  syncEnabled: boolean
+  scheduleCron: string | null
+  cronValid: boolean
+  nextExpectedRunAt: string | null
+  lastRun: DirectorySyncRunSummary | null
+  lastManualRun: DirectorySyncRunSummary | null
+  lastAutomaticRun: DirectorySyncRunSummary | null
+  observationStatus: DirectorySyncObservationStatus
+  observationMessage: string
+}
+
+export type DirectoryReviewItemFilter = 'all' | 'pending_binding' | 'inactive_linked' | 'missing_identifier'
+
+export type DirectoryBindingRecommendationReason = 'pending_link' | 'email' | 'mobile'
+
+export type DirectoryBindingRecommendationStatusCode =
+  | 'recommended'
+  | 'no_exact_match'
+  | 'ambiguous_exact_match'
+  | 'pending_link_conflict'
+  | 'linked_user_conflict'
+  | 'external_identity_conflict'
+
+export type DirectoryBindingRecommendation = {
+  localUser: {
+    id: string
+    email: string
+    name: string | null
+    role: string
+    isActive: boolean
+  }
+  reasons: DirectoryBindingRecommendationReason[]
+}
+
+export type DirectoryBindingRecommendationStatus = {
+  code: DirectoryBindingRecommendationStatusCode
+  message: string
+}
+
+export type DirectoryReviewItemSummary = {
+  kind: DirectoryReviewItemFilter
+  reason: string
+  account: DirectoryIntegrationAccountSummary
+  recommendations: DirectoryBindingRecommendation[]
+  recommendationStatus: DirectoryBindingRecommendationStatus | null
+  flags: {
+    missingUnionId: boolean
+    missingOpenId: boolean
+  }
+  actionable: {
+    canBatchUnbind: boolean
+    canConfirmRecommendation: boolean
+  }
+}
+
 export type DirectoryIntegrationAccountSummary = {
   id: string
   integrationId: string
@@ -270,8 +396,15 @@ export type DirectoryAccountBindInput = {
   enableDingTalkGrant?: boolean
 }
 
+export type DirectoryAccountBatchBindEntry = {
+  accountId: string
+  localUserRef: string
+  enableDingTalkGrant?: boolean
+}
+
 export type DirectoryAccountUnbindInput = {
   adminUserId: string
+  disableDingTalkGrant?: boolean
 }
 
 export type DirectoryAccountMutationResult = {
@@ -372,6 +505,54 @@ function summarizeRun(row: DirectoryRunRow): DirectorySyncRunSummary {
   }
 }
 
+function summarizeAlert(row: DirectorySyncAlertRow): DirectorySyncAlertSummary {
+  return {
+    id: row.id,
+    integrationId: row.integration_id,
+    runId: row.run_id,
+    level: row.level,
+    code: row.code,
+    message: row.message,
+    details: parseJsonRecord(row.details),
+    sentToWebhook: Boolean(row.sent_to_webhook),
+    acknowledgedAt: row.acknowledged_at,
+    acknowledgedBy: row.acknowledged_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function summarizeReviewItem(
+  row: DirectoryReviewItemRow,
+  recommendation: DirectoryReviewRecommendationResult | null = null,
+): DirectoryReviewItemSummary {
+  const kind = row.review_kind === 'inactive_linked' || row.review_kind === 'missing_identifier'
+    ? row.review_kind
+    : 'pending_binding'
+  const recommendations = recommendation?.recommendations ?? []
+
+  return {
+    kind,
+    reason: row.review_reason,
+    account: summarizeDirectoryAccount(row),
+    recommendations,
+    recommendationStatus: kind === 'pending_binding'
+      ? recommendation?.status ?? {
+        code: 'no_exact_match',
+        message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+      }
+      : null,
+    flags: {
+      missingUnionId: Boolean(row.missing_union_id),
+      missingOpenId: Boolean(row.missing_open_id),
+    },
+    actionable: {
+      canBatchUnbind: kind === 'inactive_linked' && Boolean(row.local_user_id),
+      canConfirmRecommendation: kind === 'pending_binding' && recommendations.length > 0,
+    },
+  }
+}
+
 function summarizeDirectoryAccount(row: DirectoryIntegrationAccountRow): DirectoryIntegrationAccountSummary {
   return {
     id: row.directory_account_id,
@@ -425,6 +606,264 @@ function buildDingTalkIdentityExternalKey(corpId: string | null | undefined, ope
   }
 
   return normalizedUnionId || normalizedOpenId
+}
+
+function buildRecommendationScore(reasons: DirectoryBindingRecommendationReason[]): number {
+  let score = 0
+  if (reasons.includes('pending_link')) score += 100
+  if (reasons.includes('email')) score += 10
+  if (reasons.includes('mobile')) score += 5
+  return score
+}
+
+function sortRecommendationReasons(reasons: Iterable<DirectoryBindingRecommendationReason>): DirectoryBindingRecommendationReason[] {
+  const order: DirectoryBindingRecommendationReason[] = ['pending_link', 'email', 'mobile']
+  const values = new Set(reasons)
+  return order.filter((item) => values.has(item))
+}
+
+function buildRecommendationStatus(
+  code: DirectoryBindingRecommendationStatusCode,
+): DirectoryBindingRecommendationStatus {
+  if (code === 'recommended') {
+    return {
+      code,
+      message: '已命中唯一精确候选，可直接确认推荐绑定。',
+    }
+  }
+  if (code === 'ambiguous_exact_match') {
+    return {
+      code,
+      message: '邮箱或手机号命中多个本地用户，需人工确认。',
+    }
+  }
+  if (code === 'pending_link_conflict') {
+    return {
+      code,
+      message: '现有待确认匹配与精确候选不一致，请人工复核。',
+    }
+  }
+  if (code === 'linked_user_conflict') {
+    return {
+      code,
+      message: '候选本地用户已链接其他钉钉目录成员，请人工处理。',
+    }
+  }
+  if (code === 'external_identity_conflict') {
+    return {
+      code,
+      message: '候选本地用户已绑定其他钉钉身份，请人工处理。',
+    }
+  }
+  return {
+    code,
+    message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+  }
+}
+
+function doesExternalIdentityMatchAccount(
+  identity: DirectoryIdentityByUserRow,
+  account: Pick<DirectoryReviewItemRow, 'corp_id' | 'external_key' | 'open_id' | 'union_id'>,
+): boolean {
+  const externalKey = buildDingTalkIdentityExternalKey(account.corp_id, account.open_id, account.union_id)
+  if (externalKey && identity.external_key === externalKey) return true
+
+  const scopedOpenKey = buildScopedIdentityKey(account.corp_id, account.open_id)
+  const identityOpenKey = buildScopedIdentityKey(identity.corp_id, identity.provider_open_id)
+  if (scopedOpenKey && identityOpenKey && scopedOpenKey === identityOpenKey) return true
+
+  const scopedUnionKey = buildScopedIdentityKey(account.corp_id, account.union_id)
+  const identityUnionKey = buildScopedIdentityKey(identity.corp_id, identity.provider_union_id)
+  if (scopedUnionKey && identityUnionKey && scopedUnionKey === identityUnionKey) return true
+
+  return normalizeText(identity.external_key) !== '' && identity.external_key === normalizeText(account.external_key)
+}
+
+async function loadDirectoryReviewRecommendations(
+  rows: DirectoryReviewItemRow[],
+): Promise<Map<string, DirectoryReviewRecommendationResult>> {
+  const pendingRows = rows.filter((row) => row.review_kind === 'pending_binding')
+  const emails = Array.from(new Set(
+    pendingRows
+      .map((row) => normalizeText(row.account_email).toLowerCase())
+      .filter(Boolean),
+  ))
+  const mobiles = Array.from(new Set(
+    pendingRows
+      .map((row) => normalizeText(row.account_mobile))
+      .filter(Boolean),
+  ))
+
+  if (pendingRows.length === 0) {
+    return new Map()
+  }
+
+  const candidateUsersResult = emails.length > 0 || mobiles.length > 0
+    ? await query<DirectoryBindingCandidateRow>(
+      `SELECT id,
+              email,
+              name,
+              COALESCE(role, 'user') AS role,
+              COALESCE(is_active, TRUE) AS is_active,
+              mobile
+       FROM users
+       WHERE COALESCE(is_active, TRUE) = TRUE
+         AND (
+           LOWER(email) = ANY($1::text[])
+           OR mobile = ANY($2::text[])
+         )`,
+      [emails, mobiles],
+    )
+    : { rows: [] }
+
+  const usersByEmail = new Map<string, DirectoryBindingCandidateRow[]>()
+  const usersByMobile = new Map<string, DirectoryBindingCandidateRow[]>()
+  const userDetailsById = new Map<string, DirectoryBindingCandidateRow>()
+
+  for (const user of candidateUsersResult.rows) {
+    userDetailsById.set(user.id, user)
+
+    const normalizedEmail = normalizeText(user.email).toLowerCase()
+    if (normalizedEmail) {
+      const items = usersByEmail.get(normalizedEmail) ?? []
+      items.push(user)
+      usersByEmail.set(normalizedEmail, items)
+    }
+
+    const normalizedMobile = normalizeText(user.mobile)
+    if (normalizedMobile) {
+      const items = usersByMobile.get(normalizedMobile) ?? []
+      items.push(user)
+      usersByMobile.set(normalizedMobile, items)
+    }
+  }
+
+  const candidateUserIds = Array.from(new Set(candidateUsersResult.rows.map((user) => user.id)))
+  const [linkedAccountsResult, identitiesResult] = candidateUserIds.length > 0
+    ? await Promise.all([
+      query<DirectoryLinkedAccountByUserRow>(
+        `SELECT l.local_user_id, l.directory_account_id
+         FROM directory_account_links l
+         JOIN directory_accounts a ON a.id = l.directory_account_id
+         WHERE a.provider = $1
+           AND l.link_status = 'linked'
+           AND l.local_user_id = ANY($2::text[])`,
+        [DEFAULT_PROVIDER, candidateUserIds],
+      ),
+      query<DirectoryIdentityByUserRow>(
+        `SELECT local_user_id, external_key, provider_union_id, provider_open_id, corp_id
+         FROM user_external_identities
+         WHERE provider = $1
+           AND local_user_id = ANY($2::text[])`,
+        [DEFAULT_PROVIDER, candidateUserIds],
+      ),
+    ])
+    : [{ rows: [] }, { rows: [] }]
+
+  const linkedAccountsByUser = new Map<string, Set<string>>()
+  for (const row of linkedAccountsResult.rows) {
+    const accountIds = linkedAccountsByUser.get(row.local_user_id) ?? new Set<string>()
+    accountIds.add(row.directory_account_id)
+    linkedAccountsByUser.set(row.local_user_id, accountIds)
+  }
+
+  const identitiesByUser = new Map<string, DirectoryIdentityByUserRow>()
+  for (const row of identitiesResult.rows) {
+    identitiesByUser.set(row.local_user_id, row)
+  }
+
+  const summaries = new Map<string, DirectoryReviewRecommendationResult>()
+  for (const row of pendingRows) {
+    const matches = new Map<string, Set<DirectoryBindingRecommendationReason>>()
+    const normalizedEmail = normalizeText(row.account_email).toLowerCase()
+    const normalizedMobile = normalizeText(row.account_mobile)
+    const emailMatches = normalizedEmail ? (usersByEmail.get(normalizedEmail) ?? []) : []
+    const mobileMatches = normalizedMobile ? (usersByMobile.get(normalizedMobile) ?? []) : []
+    const hasAmbiguousEmail = emailMatches.length > 1
+    const hasAmbiguousMobile = mobileMatches.length > 1
+
+    if (emailMatches.length === 1) {
+      matches.set(emailMatches[0].id, new Set<DirectoryBindingRecommendationReason>(['email']))
+    }
+    if (mobileMatches.length === 1) {
+      const reasons = matches.get(mobileMatches[0].id) ?? new Set<DirectoryBindingRecommendationReason>()
+      reasons.add('mobile')
+      matches.set(mobileMatches[0].id, reasons)
+    }
+
+    const pendingLocalUserId = normalizeText(row.local_user_id)
+    if (pendingLocalUserId) {
+      if (matches.size === 1 && matches.has(pendingLocalUserId)) {
+        matches.get(pendingLocalUserId)?.add('pending_link')
+      } else if (matches.size > 0) {
+        summaries.set(row.directory_account_id, {
+          recommendations: [],
+          status: buildRecommendationStatus('pending_link_conflict'),
+        })
+        continue
+      }
+    }
+
+    if (hasAmbiguousEmail || hasAmbiguousMobile || matches.size > 1) {
+      summaries.set(row.directory_account_id, {
+        recommendations: [],
+        status: buildRecommendationStatus('ambiguous_exact_match'),
+      })
+      continue
+    }
+
+    if (matches.size !== 1) {
+      summaries.set(row.directory_account_id, {
+        recommendations: [],
+        status: buildRecommendationStatus('no_exact_match'),
+      })
+      continue
+    }
+
+    const [candidateUserId, reasons] = Array.from(matches.entries())[0]
+    const user = userDetailsById.get(candidateUserId)
+    if (!user?.is_active) {
+      summaries.set(row.directory_account_id, {
+        recommendations: [],
+        status: buildRecommendationStatus('no_exact_match'),
+      })
+      continue
+    }
+
+    const linkedAccounts = linkedAccountsByUser.get(candidateUserId)
+    if (linkedAccounts && Array.from(linkedAccounts).some((accountId) => accountId !== row.directory_account_id)) {
+      summaries.set(row.directory_account_id, {
+        recommendations: [],
+        status: buildRecommendationStatus('linked_user_conflict'),
+      })
+      continue
+    }
+
+    const externalIdentity = identitiesByUser.get(candidateUserId)
+    if (externalIdentity && !doesExternalIdentityMatchAccount(externalIdentity, row)) {
+      summaries.set(row.directory_account_id, {
+        recommendations: [],
+        status: buildRecommendationStatus('external_identity_conflict'),
+      })
+      continue
+    }
+
+    summaries.set(row.directory_account_id, {
+      recommendations: [{
+        localUser: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+          isActive: user.is_active,
+        },
+        reasons: sortRecommendationReasons(reasons),
+      }].sort((left, right) => buildRecommendationScore(right.reasons) - buildRecommendationScore(left.reasons)),
+      status: buildRecommendationStatus('recommended'),
+    })
+  }
+
+  return summaries
 }
 
 function normalizeIntegrationInput(
@@ -918,6 +1357,7 @@ async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
 export async function syncDirectoryIntegration(
   integrationId: string,
   triggeredBy: string,
+  triggerSource: 'manual' | 'scheduler' = 'manual',
 ): Promise<{ integration: DirectoryIntegrationSummary; run: DirectorySyncRunSummary }> {
   const integration = await getIntegrationRow(integrationId)
   if (!integration) throw new Error('Directory integration not found')
@@ -927,9 +1367,9 @@ export async function syncDirectoryIntegration(
     `INSERT INTO directory_sync_runs (
        integration_id, status, started_at, stats, meta, triggered_by, trigger_source, created_at, updated_at
      )
-     VALUES ($1, 'running', NOW(), '{}'::jsonb, '{}'::jsonb, $2, 'manual', NOW(), NOW())
+     VALUES ($1, 'running', NOW(), '{}'::jsonb, '{}'::jsonb, $2, $3, NOW(), NOW())
      RETURNING id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at`,
-    [integrationId, triggeredBy],
+    [integrationId, triggeredBy, triggerSource],
   )
   const runId = runResult.rows[0].id
 
@@ -1230,6 +1670,345 @@ export async function listDirectorySyncRuns(
     items: rowsResult.rows.map(summarizeRun),
     total: Number(totalResult.rows[0]?.total ?? 0),
   }
+}
+
+export async function listDirectorySyncAlerts(
+  integrationId: string,
+  pagination: { limit: number; offset: number },
+  filter: DirectorySyncAlertFilter = 'all',
+): Promise<{ items: DirectorySyncAlertSummary[]; total: number }> {
+  const normalizedIntegrationId = normalizeText(integrationId)
+  if (!normalizedIntegrationId) throw new Error('integrationId is required')
+
+  const normalizedFilter: DirectorySyncAlertFilter = filter === 'pending' || filter === 'acknowledged' ? filter : 'all'
+  const where: string[] = ['integration_id = $1']
+  if (normalizedFilter === 'pending') where.push('acknowledged_at IS NULL')
+  if (normalizedFilter === 'acknowledged') where.push('acknowledged_at IS NOT NULL')
+
+  const whereSql = where.join(' AND ')
+  const [countResult, rowsResult] = await Promise.all([
+    query<{ total: number }>(
+      `SELECT COUNT(*)::int AS total
+       FROM directory_sync_alerts
+       WHERE ${whereSql}`,
+      [normalizedIntegrationId],
+    ),
+    query<DirectorySyncAlertRow>(
+      `SELECT
+          id,
+          integration_id,
+          run_id,
+          level,
+          code,
+          message,
+          details,
+          sent_to_webhook,
+          acknowledged_at,
+          acknowledged_by,
+          created_at,
+          updated_at
+       FROM directory_sync_alerts
+       WHERE ${whereSql}
+       ORDER BY created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [normalizedIntegrationId, pagination.limit, pagination.offset],
+    ),
+  ])
+
+  return {
+    items: rowsResult.rows.map(summarizeAlert),
+    total: Number(countResult.rows[0]?.total ?? 0),
+  }
+}
+
+export async function acknowledgeDirectorySyncAlert(
+  alertId: string,
+  acknowledgedBy: string,
+): Promise<DirectorySyncAlertSummary | null> {
+  const normalizedAlertId = normalizeText(alertId)
+  const normalizedAcknowledgedBy = normalizeText(acknowledgedBy)
+  if (!normalizedAlertId) throw new Error('alertId is required')
+  if (!normalizedAcknowledgedBy) throw new Error('acknowledgedBy is required')
+
+  const result = await query<DirectorySyncAlertRow>(
+    `UPDATE directory_sync_alerts
+     SET acknowledged_at = COALESCE(acknowledged_at, NOW()),
+         acknowledged_by = COALESCE(acknowledged_by, $2),
+         updated_at = NOW()
+     WHERE id = $1
+     RETURNING
+       id,
+       integration_id,
+       run_id,
+       level,
+       code,
+       message,
+       details,
+       sent_to_webhook,
+       acknowledged_at,
+       acknowledged_by,
+       created_at,
+       updated_at`,
+    [normalizedAlertId, normalizedAcknowledgedBy],
+  )
+
+  const row = result.rows[0]
+  return row ? summarizeAlert(row) : null
+}
+
+function readScheduleObservation(
+  integration: DirectoryIntegrationRow,
+  lastAutomaticRun: DirectoryRunRow | null,
+): Pick<DirectorySyncScheduleSnapshot, 'cronValid' | 'nextExpectedRunAt' | 'observationStatus' | 'observationMessage'> {
+  if (!integration.sync_enabled) {
+    return {
+      cronValid: normalizeText(integration.schedule_cron).length > 0,
+      nextExpectedRunAt: null,
+      observationStatus: 'disabled',
+      observationMessage: '自动同步未启用。',
+    }
+  }
+
+  const cronExpression = normalizeText(integration.schedule_cron)
+  if (!cronExpression) {
+    return {
+      cronValid: false,
+      nextExpectedRunAt: null,
+      observationStatus: 'missing_cron',
+      observationMessage: '已启用自动同步，但尚未配置 cron 表达式。',
+    }
+  }
+
+  try {
+    const parser = new SimpleCronExpression(cronExpression, 'UTC')
+    const nextRun = parser.next()
+    if (lastAutomaticRun) {
+      return {
+        cronValid: true,
+        nextExpectedRunAt: nextRun?.toISOString() ?? null,
+        observationStatus: 'scheduler_observed',
+        observationMessage: '已观察到调度器触发的自动同步。',
+      }
+    }
+
+    return {
+      cronValid: true,
+      nextExpectedRunAt: nextRun?.toISOString() ?? null,
+      observationStatus: 'awaiting_first_run',
+      observationMessage: '已配置 cron，等待首次自动触发或尚未观察到调度执行。',
+    }
+  } catch {
+    return {
+      cronValid: false,
+      nextExpectedRunAt: null,
+      observationStatus: 'invalid_cron',
+      observationMessage: 'cron 表达式无效，当前无法推算下次自动同步时间。',
+    }
+  }
+}
+
+export async function getDirectorySyncScheduleSnapshot(
+  integrationId: string,
+): Promise<DirectorySyncScheduleSnapshot | null> {
+  const normalizedIntegrationId = normalizeText(integrationId)
+  if (!normalizedIntegrationId) throw new Error('integrationId is required')
+
+  const integration = await getIntegrationRow(normalizedIntegrationId)
+  if (!integration) return null
+
+  const [lastRunResult, lastManualRunResult, lastAutomaticRunResult] = await Promise.all([
+    query<DirectoryRunRow>(
+      `SELECT id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at
+       FROM directory_sync_runs
+       WHERE integration_id = $1
+       ORDER BY started_at DESC
+       LIMIT 1`,
+      [normalizedIntegrationId],
+    ),
+    query<DirectoryRunRow>(
+      `SELECT id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at
+       FROM directory_sync_runs
+       WHERE integration_id = $1 AND trigger_source = 'manual'
+       ORDER BY started_at DESC
+       LIMIT 1`,
+      [normalizedIntegrationId],
+    ),
+    query<DirectoryRunRow>(
+      `SELECT id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at
+       FROM directory_sync_runs
+       WHERE integration_id = $1 AND trigger_source = 'scheduler'
+       ORDER BY started_at DESC
+       LIMIT 1`,
+      [normalizedIntegrationId],
+    ),
+  ])
+
+  const lastRun = lastRunResult.rows[0] ?? null
+  const lastManualRun = lastManualRunResult.rows[0] ?? null
+  const lastAutomaticRun = lastAutomaticRunResult.rows[0] ?? null
+  const observation = readScheduleObservation(integration, lastAutomaticRun)
+
+  return {
+    integrationId: normalizedIntegrationId,
+    syncEnabled: Boolean(integration.sync_enabled),
+    scheduleCron: integration.schedule_cron,
+    cronValid: observation.cronValid,
+    nextExpectedRunAt: observation.nextExpectedRunAt,
+    lastRun: lastRun ? summarizeRun(lastRun) : null,
+    lastManualRun: lastManualRun ? summarizeRun(lastManualRun) : null,
+    lastAutomaticRun: lastAutomaticRun ? summarizeRun(lastAutomaticRun) : null,
+    observationStatus: observation.observationStatus,
+    observationMessage: observation.observationMessage,
+  }
+}
+
+function buildReviewFilterSql(filter: DirectoryReviewItemFilter): string {
+  if (filter === 'inactive_linked') {
+    return '(a.is_active = FALSE AND l.local_user_id IS NOT NULL)'
+  }
+  if (filter === 'missing_identifier') {
+    return "(COALESCE(a.union_id, '') = '' AND COALESCE(a.open_id, '') = '')"
+  }
+  if (filter === 'pending_binding') {
+    return "(l.local_user_id IS NULL OR COALESCE(l.link_status, 'pending') <> 'linked')"
+  }
+  return `(
+    (COALESCE(a.union_id, '') = '' AND COALESCE(a.open_id, '') = '')
+    OR (a.is_active = FALSE AND l.local_user_id IS NOT NULL)
+    OR (l.local_user_id IS NULL OR COALESCE(l.link_status, 'pending') <> 'linked')
+  )`
+}
+
+export async function listDirectoryReviewItems(
+  integrationId: string,
+  pagination: { limit: number; offset: number },
+  filter: DirectoryReviewItemFilter = 'all',
+): Promise<{ items: DirectoryReviewItemSummary[]; total: number }> {
+  const normalizedIntegrationId = normalizeText(integrationId)
+  if (!normalizedIntegrationId) throw new Error('integrationId is required')
+
+  const normalizedFilter: DirectoryReviewItemFilter = filter === 'pending_binding' || filter === 'inactive_linked' || filter === 'missing_identifier'
+    ? filter
+    : 'all'
+  const filterSql = buildReviewFilterSql(normalizedFilter)
+
+  const [countResult, rowsResult] = await Promise.all([
+    query<{ total: number }>(
+      `SELECT COUNT(*)::int AS total
+       FROM directory_accounts a
+       LEFT JOIN directory_account_links l ON l.directory_account_id = a.id
+       WHERE a.integration_id = $1 AND ${filterSql}`,
+      [normalizedIntegrationId],
+    ),
+    query<DirectoryReviewItemRow>(
+      `SELECT
+          a.integration_id,
+          a.provider,
+          a.corp_id,
+          a.id AS directory_account_id,
+          a.external_user_id,
+          a.union_id,
+          a.open_id,
+          a.external_key,
+          a.name AS account_name,
+          a.email AS account_email,
+          a.mobile AS account_mobile,
+          a.is_active AS account_is_active,
+          a.updated_at AS account_updated_at,
+          l.link_status,
+          l.match_strategy,
+          l.reviewed_by,
+          l.review_note,
+          l.updated_at AS link_updated_at,
+          u.id AS local_user_id,
+          u.email AS local_user_email,
+          u.name AS local_user_name,
+          COALESCE(array_remove(array_agg(DISTINCT d.full_path), NULL), ARRAY[]::text[]) AS department_paths,
+          CASE
+            WHEN COALESCE(a.union_id, '') = '' AND COALESCE(a.open_id, '') = '' THEN 'missing_identifier'
+            WHEN a.is_active = FALSE AND l.local_user_id IS NOT NULL THEN 'inactive_linked'
+            ELSE 'pending_binding'
+          END AS review_kind,
+          CASE
+            WHEN COALESCE(a.union_id, '') = '' AND COALESCE(a.open_id, '') = '' THEN '目录成员缺少 unionId/openId，无法用于钉钉登录绑定。'
+            WHEN a.is_active = FALSE AND l.local_user_id IS NOT NULL THEN '目录成员已停用，但仍绑定本地用户，需要停权处理。'
+            WHEN l.local_user_id IS NULL THEN '目录成员尚未绑定本地用户。'
+            ELSE '目录成员当前不是已确认绑定状态，建议复核。'
+          END AS review_reason,
+          (COALESCE(a.union_id, '') = '') AS missing_union_id,
+          (COALESCE(a.open_id, '') = '') AS missing_open_id
+       FROM directory_accounts a
+       LEFT JOIN directory_account_links l ON l.directory_account_id = a.id
+       LEFT JOIN users u ON u.id = l.local_user_id
+       LEFT JOIN directory_account_departments ad ON ad.directory_account_id = a.id
+       LEFT JOIN directory_departments d ON d.id = ad.directory_department_id
+       WHERE a.integration_id = $1 AND ${filterSql}
+       GROUP BY
+         a.integration_id, a.provider, a.corp_id, a.id, a.external_user_id, a.union_id, a.open_id, a.external_key,
+         a.name, a.email, a.mobile, a.is_active, a.updated_at,
+         l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
+         u.id, u.email, u.name
+       ORDER BY
+         CASE
+           WHEN COALESCE(a.union_id, '') = '' AND COALESCE(a.open_id, '') = '' THEN 0
+           WHEN a.is_active = FALSE AND l.local_user_id IS NOT NULL THEN 1
+           ELSE 2
+         END,
+         a.name ASC,
+         a.external_user_id ASC
+       LIMIT $2 OFFSET $3`,
+      [normalizedIntegrationId, pagination.limit, pagination.offset],
+    ),
+  ])
+
+  const recommendationsByAccount = await loadDirectoryReviewRecommendations(rowsResult.rows)
+
+  return {
+    items: rowsResult.rows.map((row) => summarizeReviewItem(
+      row,
+      recommendationsByAccount.get(row.directory_account_id) ?? null,
+    )),
+    total: Number(countResult.rows[0]?.total ?? 0),
+  }
+}
+
+export async function batchUnbindDirectoryAccounts(
+  directoryAccountIds: string[],
+  input: DirectoryAccountUnbindInput,
+): Promise<DirectoryAccountMutationResult[]> {
+  const normalizedIds = Array.from(new Set(directoryAccountIds.map((item) => normalizeText(item)).filter(Boolean)))
+  if (normalizedIds.length === 0) throw new Error('accountIds are required')
+
+  const results: DirectoryAccountMutationResult[] = []
+  for (const directoryAccountId of normalizedIds) {
+    results.push(await unbindDirectoryAccount(directoryAccountId, input))
+  }
+  return results
+}
+
+export async function batchBindDirectoryAccounts(
+  entries: DirectoryAccountBatchBindEntry[],
+  input: { adminUserId: string },
+): Promise<DirectoryAccountMutationResult[]> {
+  const normalizedEntries = entries
+    .map((entry) => ({
+      accountId: normalizeText(entry.accountId),
+      localUserRef: normalizeText(entry.localUserRef),
+      enableDingTalkGrant: entry.enableDingTalkGrant !== false,
+    }))
+    .filter((entry) => entry.accountId.length > 0 && entry.localUserRef.length > 0)
+
+  if (normalizedEntries.length === 0) throw new Error('bindings are required')
+
+  const results: DirectoryAccountMutationResult[] = []
+  for (const entry of normalizedEntries) {
+    results.push(await bindDirectoryAccount(entry.accountId, {
+      localUserRef: entry.localUserRef,
+      adminUserId: input.adminUserId,
+      enableDingTalkGrant: entry.enableDingTalkGrant,
+    }))
+  }
+  return results
 }
 
 async function getDirectoryAccountSummary(accountId: string): Promise<DirectoryIntegrationAccountSummary | null> {
@@ -1588,6 +2367,7 @@ export async function unbindDirectoryAccount(
 ): Promise<DirectoryAccountMutationResult> {
   const normalizedAccountId = normalizeText(directoryAccountId)
   const normalizedAdminUserId = normalizeText(input.adminUserId)
+  const disableDingTalkGrant = input.disableDingTalkGrant === true
 
   if (!normalizedAccountId) throw new Error('directoryAccountId is required')
   if (!normalizedAdminUserId) throw new Error('adminUserId is required')
@@ -1631,6 +2411,16 @@ export async function unbindDirectoryAccount(
           `DELETE FROM user_external_identities
            WHERE ${deleteIdentityClauses.join(' AND ')}`,
           deleteIdentityParams,
+        )
+      }
+
+      if (disableDingTalkGrant) {
+        await client.query(
+          `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+           VALUES ($1, $2, FALSE, $3, NOW(), NOW())
+           ON CONFLICT (provider, local_user_id)
+           DO UPDATE SET enabled = FALSE, granted_by = EXCLUDED.granted_by, updated_at = NOW()`,
+          [account.provider, previousLinkedUser.local_user_id, normalizedAdminUserId],
         )
       }
     }

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -94,6 +94,7 @@ import { viewsRouter } from './routes/views'
 import { initAdminRoutes } from './routes/admin-routes'
 import { adminUsersRouter } from './routes/admin-users'
 import { adminDirectoryRouter } from './routes/admin-directory'
+import { startDirectorySyncScheduler, stopDirectorySyncScheduler } from './directory/directory-sync-scheduler'
 import { canaryRoutes } from './routes/canary-routes'
 import { CanaryRouter } from './canary/CanaryRouter'
 import { createCanaryInterceptor } from './canary/CanaryInterceptor'
@@ -1537,6 +1538,15 @@ export class MetaSheetServer {
       })())
     }
 
+    shutdownTasks.push((async () => {
+      try {
+        await stopDirectorySyncScheduler()
+        this.logger.info('Directory sync scheduler stopped')
+      } catch (err) {
+        this.logger.warn(`Directory sync scheduler shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })())
+
     // 4. Destroy API Gateway resources
     // shutdownTasks.push((async () => {
     //   try {
@@ -1612,6 +1622,13 @@ export class MetaSheetServer {
       this.logger.info('AutomationService initialized')
     } catch (e) {
       this.logger.error('AutomationService initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    try {
+      await startDirectorySyncScheduler()
+      this.logger.info('Directory sync scheduler initialized')
+    } catch (e) {
+      this.logger.error('Directory sync scheduler initialization failed; continuing in degraded mode', e as Error)
     }
 
     // 加载插件并启动 HTTP 服务

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -1,19 +1,26 @@
 import type { Request, Response } from 'express'
 import { Router } from 'express'
 import { auditLog } from '../audit/audit'
-import { isAdmin as isRbacAdmin } from '../rbac/service'
-import { jsonError, jsonOk, parsePagination } from '../util/response'
 import {
+  acknowledgeDirectorySyncAlert,
+  batchBindDirectoryAccounts,
+  batchUnbindDirectoryAccounts,
   bindDirectoryAccount,
   createDirectoryIntegration,
+  getDirectorySyncScheduleSnapshot,
   listDirectoryIntegrationAccounts,
   listDirectoryIntegrations,
+  listDirectoryReviewItems,
+  listDirectorySyncAlerts,
   listDirectorySyncRuns,
   syncDirectoryIntegration,
   testDirectoryIntegration,
   unbindDirectoryAccount,
   updateDirectoryIntegration,
 } from '../directory/directory-sync'
+import { refreshDirectoryIntegrationSchedule } from '../directory/directory-sync-scheduler'
+import { isAdmin as isRbacAdmin } from '../rbac/service'
+import { jsonError, jsonOk, parsePagination } from '../util/response'
 
 function readErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error && error.message.trim().length > 0) return error.message
@@ -72,6 +79,7 @@ export function adminDirectoryRouter(): Router {
 
     try {
       const integration = await createDirectoryIntegration(req.body as Record<string, unknown> as never)
+      await refreshDirectoryIntegrationSchedule(integration.id)
       jsonOk(res, { integration })
     } catch (error) {
       jsonError(res, 400, 'DIRECTORY_CREATE_FAILED', readErrorMessage(error, 'Failed to create directory integration'))
@@ -88,6 +96,7 @@ export function adminDirectoryRouter(): Router {
         jsonError(res, 404, 'DIRECTORY_NOT_FOUND', 'Directory integration not found')
         return
       }
+      await refreshDirectoryIntegrationSchedule(integration.id)
       jsonOk(res, { integration })
     } catch (error) {
       jsonError(res, 400, 'DIRECTORY_UPDATE_FAILED', readErrorMessage(error, 'Failed to update directory integration'))
@@ -138,6 +147,85 @@ export function adminDirectoryRouter(): Router {
       })
     } catch (error) {
       jsonError(res, 500, 'DIRECTORY_RUNS_FAILED', readErrorMessage(error, 'Failed to load sync runs'))
+    }
+  })
+
+  router.get('/integrations/:integrationId/schedule', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const snapshot = await getDirectorySyncScheduleSnapshot(req.params.integrationId)
+      if (!snapshot) {
+        jsonError(res, 404, 'DIRECTORY_NOT_FOUND', 'Directory integration not found')
+        return
+      }
+      jsonOk(res, { snapshot })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory schedule')
+      jsonError(res, /required/i.test(message) ? 400 : 500, 'DIRECTORY_SCHEDULE_FAILED', message)
+    }
+  })
+
+  router.get('/integrations/:integrationId/alerts', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const { page, pageSize, offset } = parsePagination(req.query as Record<string, unknown>, {
+        defaultPage: 1,
+        defaultPageSize: 20,
+        maxPageSize: 100,
+      })
+      const filter = typeof req.query.filter === 'string' ? req.query.filter : 'all'
+      const result = await listDirectorySyncAlerts(
+        req.params.integrationId,
+        { limit: pageSize, offset },
+        filter === 'pending' || filter === 'acknowledged' ? filter : 'all',
+      )
+      jsonOk(res, {
+        items: result.items,
+        total: result.total,
+        page,
+        pageSize,
+        filter: filter === 'pending' || filter === 'acknowledged' ? filter : 'all',
+      })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory alerts')
+      jsonError(res, /required/i.test(message) ? 400 : 500, 'DIRECTORY_ALERTS_FAILED', message)
+    }
+  })
+
+  router.get('/integrations/:integrationId/review-items', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const { page, pageSize, offset } = parsePagination(req.query as Record<string, unknown>, {
+        defaultPage: 1,
+        defaultPageSize: 100,
+        maxPageSize: 200,
+      })
+      const filter = typeof req.query.filter === 'string' ? req.query.filter : 'all'
+      const result = await listDirectoryReviewItems(
+        req.params.integrationId,
+        { limit: pageSize, offset },
+        filter === 'pending_binding' || filter === 'inactive_linked' || filter === 'missing_identifier'
+          ? filter
+          : 'all',
+      )
+      jsonOk(res, {
+        items: result.items,
+        total: result.total,
+        page,
+        pageSize,
+        filter: filter === 'pending_binding' || filter === 'inactive_linked' || filter === 'missing_identifier'
+          ? filter
+          : 'all',
+      })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory review items')
+      jsonError(res, /required/i.test(message) ? 400 : 500, 'DIRECTORY_REVIEW_ITEMS_FAILED', message)
     }
   })
 
@@ -214,13 +302,64 @@ export function adminDirectoryRouter(): Router {
     }
   })
 
+  router.post('/accounts/batch-bind', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const rawBindings = Array.isArray(req.body?.bindings) ? req.body.bindings : []
+      const bindings = rawBindings
+        .map((entry) => (entry && typeof entry === 'object' ? entry as Record<string, unknown> : null))
+        .filter((entry): entry is Record<string, unknown> => entry !== null)
+        .map((entry) => ({
+          accountId: typeof entry.accountId === 'string' ? entry.accountId : '',
+          localUserRef: typeof entry.localUserRef === 'string' ? entry.localUserRef : '',
+          enableDingTalkGrant: typeof entry.enableDingTalkGrant === 'boolean' ? entry.enableDingTalkGrant : true,
+        }))
+
+      const results = await batchBindDirectoryAccounts(bindings, { adminUserId })
+      await Promise.all(results.map((result) => auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'bind',
+        resourceType: 'directory-account-link',
+        resourceId: result.account.id,
+        meta: {
+          adminUserId,
+          directoryAccountId: result.account.id,
+          integrationId: result.account.integrationId,
+          previousLocalUserId: result.previousLocalUser?.id ?? null,
+          previousLocalUserEmail: result.previousLocalUser?.email ?? null,
+          localUserId: result.account.localUser?.id ?? null,
+          localUserEmail: result.account.localUser?.email ?? null,
+          externalUserId: result.account.externalUserId,
+          corpId: result.account.corpId,
+          batch: true,
+        },
+      })))
+      jsonOk(res, { items: results.map((result) => result.account) })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to batch bind directory accounts')
+      const statusCode = /not found/i.test(message)
+        ? 404
+        : /already bound|already linked/i.test(message)
+          ? 409
+          : /required|cannot be pre-bound/i.test(message)
+            ? 400
+            : 500
+      jsonError(res, statusCode, 'DIRECTORY_BATCH_BIND_FAILED', message)
+    }
+  })
+
   router.post('/accounts/:accountId/unbind', async (req: Request, res: Response) => {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
 
     try {
+      const disableDingTalkGrant = req.body?.disableDingTalkGrant === true
       const result = await unbindDirectoryAccount(req.params.accountId, {
         adminUserId,
+        disableDingTalkGrant,
       })
       await auditLog({
         actorId: adminUserId,
@@ -236,6 +375,7 @@ export function adminDirectoryRouter(): Router {
           corpId: result.account.corpId,
           previousLocalUserId: result.previousLocalUser?.id ?? null,
           previousLocalUserEmail: result.previousLocalUser?.email ?? null,
+          disableDingTalkGrant,
         },
       })
       jsonOk(res, { account: result.account })
@@ -247,6 +387,79 @@ export function adminDirectoryRouter(): Router {
           ? 400
           : 500
       jsonError(res, statusCode, 'DIRECTORY_UNBIND_FAILED', message)
+    }
+  })
+
+  router.post('/accounts/batch-unbind', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const rawAccountIds = Array.isArray(req.body?.accountIds) ? req.body.accountIds : []
+      const accountIds = rawAccountIds.filter((value): value is string => typeof value === 'string')
+      const disableDingTalkGrant = req.body?.disableDingTalkGrant === true
+      const results = await batchUnbindDirectoryAccounts(accountIds, {
+        adminUserId,
+        disableDingTalkGrant,
+      })
+      await Promise.all(results.map((result) => auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'unbind',
+        resourceType: 'directory-account-link',
+        resourceId: result.account.id,
+        meta: {
+          adminUserId,
+          directoryAccountId: result.account.id,
+          integrationId: result.account.integrationId,
+          externalUserId: result.account.externalUserId,
+          corpId: result.account.corpId,
+          previousLocalUserId: result.previousLocalUser?.id ?? null,
+          previousLocalUserEmail: result.previousLocalUser?.email ?? null,
+          disableDingTalkGrant,
+          batch: true,
+        },
+      })))
+      jsonOk(res, { items: results.map((result) => result.account) })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to batch unbind directory accounts')
+      const statusCode = /not found/i.test(message)
+        ? 404
+        : /required/i.test(message)
+          ? 400
+          : 500
+      jsonError(res, statusCode, 'DIRECTORY_BATCH_UNBIND_FAILED', message)
+    }
+  })
+
+  router.post('/alerts/:alertId/ack', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const alert = await acknowledgeDirectorySyncAlert(req.params.alertId, adminUserId)
+      if (!alert) {
+        jsonError(res, 404, 'DIRECTORY_ALERT_NOT_FOUND', 'Directory alert not found')
+        return
+      }
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'ack',
+        resourceType: 'directory-sync-alert',
+        resourceId: alert.id,
+        meta: {
+          adminUserId,
+          integrationId: alert.integrationId,
+          runId: alert.runId,
+          level: alert.level,
+          code: alert.code,
+        },
+      })
+      jsonOk(res, { alert })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to acknowledge directory alert')
+      jsonError(res, /required/i.test(message) ? 400 : 500, 'DIRECTORY_ALERT_ACK_FAILED', message)
     }
   })
 

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -10,15 +10,25 @@ const auditMocks = vi.hoisted(() => ({
 }))
 
 const directoryMocks = vi.hoisted(() => ({
-  listDirectoryIntegrations: vi.fn(),
-  createDirectoryIntegration: vi.fn(),
-  updateDirectoryIntegration: vi.fn(),
-  testDirectoryIntegration: vi.fn(),
-  syncDirectoryIntegration: vi.fn(),
-  listDirectorySyncRuns: vi.fn(),
-  listDirectoryIntegrationAccounts: vi.fn(),
+  acknowledgeDirectorySyncAlert: vi.fn(),
+  batchBindDirectoryAccounts: vi.fn(),
+  batchUnbindDirectoryAccounts: vi.fn(),
   bindDirectoryAccount: vi.fn(),
+  createDirectoryIntegration: vi.fn(),
+  getDirectorySyncScheduleSnapshot: vi.fn(),
+  listDirectoryIntegrationAccounts: vi.fn(),
+  listDirectoryIntegrations: vi.fn(),
+  listDirectoryReviewItems: vi.fn(),
+  listDirectorySyncAlerts: vi.fn(),
+  listDirectorySyncRuns: vi.fn(),
+  syncDirectoryIntegration: vi.fn(),
+  testDirectoryIntegration: vi.fn(),
   unbindDirectoryAccount: vi.fn(),
+  updateDirectoryIntegration: vi.fn(),
+}))
+
+const schedulerMocks = vi.hoisted(() => ({
+  refreshDirectoryIntegrationSchedule: vi.fn(),
 }))
 
 vi.mock('../../src/rbac/service', () => ({
@@ -30,15 +40,25 @@ vi.mock('../../src/audit/audit', () => ({
 }))
 
 vi.mock('../../src/directory/directory-sync', () => ({
-  listDirectoryIntegrations: directoryMocks.listDirectoryIntegrations,
-  createDirectoryIntegration: directoryMocks.createDirectoryIntegration,
-  updateDirectoryIntegration: directoryMocks.updateDirectoryIntegration,
-  testDirectoryIntegration: directoryMocks.testDirectoryIntegration,
-  syncDirectoryIntegration: directoryMocks.syncDirectoryIntegration,
-  listDirectorySyncRuns: directoryMocks.listDirectorySyncRuns,
-  listDirectoryIntegrationAccounts: directoryMocks.listDirectoryIntegrationAccounts,
+  acknowledgeDirectorySyncAlert: directoryMocks.acknowledgeDirectorySyncAlert,
+  batchBindDirectoryAccounts: directoryMocks.batchBindDirectoryAccounts,
+  batchUnbindDirectoryAccounts: directoryMocks.batchUnbindDirectoryAccounts,
   bindDirectoryAccount: directoryMocks.bindDirectoryAccount,
+  createDirectoryIntegration: directoryMocks.createDirectoryIntegration,
+  getDirectorySyncScheduleSnapshot: directoryMocks.getDirectorySyncScheduleSnapshot,
+  listDirectoryIntegrationAccounts: directoryMocks.listDirectoryIntegrationAccounts,
+  listDirectoryIntegrations: directoryMocks.listDirectoryIntegrations,
+  listDirectoryReviewItems: directoryMocks.listDirectoryReviewItems,
+  listDirectorySyncAlerts: directoryMocks.listDirectorySyncAlerts,
+  listDirectorySyncRuns: directoryMocks.listDirectorySyncRuns,
+  syncDirectoryIntegration: directoryMocks.syncDirectoryIntegration,
+  testDirectoryIntegration: directoryMocks.testDirectoryIntegration,
   unbindDirectoryAccount: directoryMocks.unbindDirectoryAccount,
+  updateDirectoryIntegration: directoryMocks.updateDirectoryIntegration,
+}))
+
+vi.mock('../../src/directory/directory-sync-scheduler', () => ({
+  refreshDirectoryIntegrationSchedule: schedulerMocks.refreshDirectoryIntegrationSchedule,
 }))
 
 import { adminDirectoryRouter } from '../../src/routes/admin-directory'
@@ -114,15 +134,22 @@ describe('adminDirectoryRouter', () => {
   beforeEach(() => {
     rbacMocks.isRbacAdmin.mockReset()
     auditMocks.auditLog.mockReset()
-    directoryMocks.listDirectoryIntegrations.mockReset()
-    directoryMocks.createDirectoryIntegration.mockReset()
-    directoryMocks.updateDirectoryIntegration.mockReset()
-    directoryMocks.testDirectoryIntegration.mockReset()
-    directoryMocks.syncDirectoryIntegration.mockReset()
-    directoryMocks.listDirectorySyncRuns.mockReset()
-    directoryMocks.listDirectoryIntegrationAccounts.mockReset()
+    directoryMocks.acknowledgeDirectorySyncAlert.mockReset()
+    directoryMocks.batchBindDirectoryAccounts.mockReset()
+    directoryMocks.batchUnbindDirectoryAccounts.mockReset()
     directoryMocks.bindDirectoryAccount.mockReset()
+    directoryMocks.createDirectoryIntegration.mockReset()
+    directoryMocks.getDirectorySyncScheduleSnapshot.mockReset()
+    directoryMocks.listDirectoryIntegrationAccounts.mockReset()
+    directoryMocks.listDirectoryIntegrations.mockReset()
+    directoryMocks.listDirectoryReviewItems.mockReset()
+    directoryMocks.listDirectorySyncAlerts.mockReset()
+    directoryMocks.listDirectorySyncRuns.mockReset()
+    directoryMocks.syncDirectoryIntegration.mockReset()
+    directoryMocks.testDirectoryIntegration.mockReset()
     directoryMocks.unbindDirectoryAccount.mockReset()
+    directoryMocks.updateDirectoryIntegration.mockReset()
+    schedulerMocks.refreshDirectoryIntegrationSchedule.mockReset()
   })
 
   it('rejects unauthenticated requests', async () => {
@@ -137,25 +164,60 @@ describe('adminDirectoryRouter', () => {
   })
 
   it('lists integrations for admin users', async () => {
-    directoryMocks.listDirectoryIntegrations.mockResolvedValue([
-      { id: 'dir-1', name: 'DingTalk CN' },
-    ])
+    directoryMocks.listDirectoryIntegrations.mockResolvedValue([{ id: 'dir-1', name: 'DingTalk CN' }])
 
     const response = await invokeRoute('get', '/integrations', {
-      user: {
-        id: 'admin-1',
-        role: 'admin',
-      },
+      user: { id: 'admin-1', role: 'admin' },
     })
 
     expect(response.statusCode).toBe(200)
     expect(directoryMocks.listDirectoryIntegrations).toHaveBeenCalledTimes(1)
     expect(response.body).toMatchObject({
       ok: true,
-      data: {
-        items: [{ id: 'dir-1', name: 'DingTalk CN' }],
-      },
+      data: { items: [{ id: 'dir-1', name: 'DingTalk CN' }] },
     })
+  })
+
+  it('refreshes scheduler state after creating an integration', async () => {
+    directoryMocks.createDirectoryIntegration.mockResolvedValue({ id: 'dir-1', name: 'DingTalk CN' })
+
+    const payload = {
+      name: 'DingTalk CN',
+      corpId: 'dingcorp',
+      appKey: 'ding-app-key',
+      appSecret: 'secret',
+      syncEnabled: true,
+      scheduleCron: '*/15 * * * *',
+    }
+
+    const response = await invokeRoute('post', '/integrations', {
+      body: payload,
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.createDirectoryIntegration).toHaveBeenCalledWith(payload)
+    expect(schedulerMocks.refreshDirectoryIntegrationSchedule).toHaveBeenCalledWith('dir-1')
+  })
+
+  it('refreshes scheduler state after updating an integration', async () => {
+    directoryMocks.updateDirectoryIntegration.mockResolvedValue({ id: 'dir-1', name: 'DingTalk CN' })
+
+    const payload = {
+      name: 'DingTalk CN',
+      scheduleCron: '*/10 * * * *',
+      syncEnabled: true,
+    }
+
+    const response = await invokeRoute('put', '/integrations/:integrationId', {
+      params: { integrationId: 'dir-1' },
+      body: payload,
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.updateDirectoryIntegration).toHaveBeenCalledWith('dir-1', payload)
+    expect(schedulerMocks.refreshDirectoryIntegrationSchedule).toHaveBeenCalledWith('dir-1')
   })
 
   it('delegates sync to the directory service and returns its payload', async () => {
@@ -166,10 +228,7 @@ describe('adminDirectoryRouter', () => {
 
     const response = await invokeRoute('post', '/integrations/:integrationId/sync', {
       params: { integrationId: 'dir-1' },
-      user: {
-        id: 'admin-1',
-        role: 'admin',
-      },
+      user: { id: 'admin-1', role: 'admin' },
     })
 
     expect(response.statusCode).toBe(200)
@@ -219,10 +278,7 @@ describe('adminDirectoryRouter', () => {
 
     const response = await invokeRoute('post', '/integrations/test', {
       body: payload,
-      user: {
-        id: 'admin-1',
-        role: 'admin',
-      },
+      user: { id: 'admin-1', role: 'admin' },
     })
 
     expect(response.statusCode).toBe(200)
@@ -248,15 +304,131 @@ describe('adminDirectoryRouter', () => {
     const response = await invokeRoute('get', '/integrations/:integrationId/runs', {
       params: { integrationId: 'dir-1' },
       query: { page: '1', pageSize: '10' },
-      user: {
-        id: 'user-2',
-        role: 'user',
-      },
+      user: { id: 'user-2', role: 'user' },
     })
 
     expect(response.statusCode).toBe(200)
     expect(rbacMocks.isRbacAdmin).toHaveBeenCalledWith('user-2')
     expect(directoryMocks.listDirectorySyncRuns).toHaveBeenCalledWith('dir-1', { limit: 10, offset: 0 })
+  })
+
+  it('returns the directory sync schedule snapshot', async () => {
+    directoryMocks.getDirectorySyncScheduleSnapshot.mockResolvedValue({
+      integrationId: 'dir-1',
+      syncEnabled: true,
+      scheduleCron: '*/15 * * * *',
+      cronValid: true,
+      nextExpectedRunAt: '2026-04-14T01:15:00.000Z',
+      lastRun: null,
+      lastManualRun: null,
+      lastAutomaticRun: null,
+      observationStatus: 'awaiting_first_run',
+      observationMessage: '已配置 cron，等待首次自动触发或尚未观察到调度执行。',
+    })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/schedule', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.getDirectorySyncScheduleSnapshot).toHaveBeenCalledWith('dir-1')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        snapshot: {
+          integrationId: 'dir-1',
+          observationStatus: 'awaiting_first_run',
+        },
+      },
+    })
+  })
+
+  it('lists directory sync alerts for an integration', async () => {
+    directoryMocks.listDirectorySyncAlerts.mockResolvedValue({
+      items: [
+        {
+          id: 'alert-1',
+          integrationId: 'dir-1',
+          runId: 'run-1',
+          level: 'warning',
+          code: 'root_department_sparse',
+          message: '根部门直属成员过少',
+          details: {},
+          sentToWebhook: false,
+          acknowledgedAt: null,
+          acknowledgedBy: null,
+          createdAt: '2026-04-14T01:00:00.000Z',
+          updatedAt: '2026-04-14T01:00:00.000Z',
+        },
+      ],
+      total: 1,
+    })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/alerts', {
+      params: { integrationId: 'dir-1' },
+      query: { page: '1', pageSize: '20', filter: 'pending' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.listDirectorySyncAlerts).toHaveBeenCalledWith('dir-1', { limit: 20, offset: 0 }, 'pending')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        filter: 'pending',
+        total: 1,
+      },
+    })
+  })
+
+  it('lists directory review items for an integration', async () => {
+    directoryMocks.listDirectoryReviewItems.mockResolvedValue({
+      items: [
+        {
+          kind: 'inactive_linked',
+          reason: '目录成员已停用，但仍绑定本地用户，需要停权处理。',
+          account: {
+            id: 'account-1',
+            integrationId: 'dir-1',
+            externalUserId: '0447654442691174',
+            name: '周华',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+            },
+          },
+          flags: {
+            missingUnionId: false,
+            missingOpenId: false,
+          },
+          actionable: {
+            canBatchUnbind: true,
+          },
+        },
+      ],
+      total: 1,
+    })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/review-items', {
+      params: { integrationId: 'dir-1' },
+      query: { page: '1', pageSize: '100', filter: 'inactive_linked' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.listDirectoryReviewItems).toHaveBeenCalledWith(
+      'dir-1',
+      { limit: 100, offset: 0 },
+      'inactive_linked',
+    )
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        filter: 'inactive_linked',
+        total: 1,
+      },
+    })
   })
 
   it('lists directory accounts for an integration', async () => {
@@ -268,10 +440,7 @@ describe('adminDirectoryRouter', () => {
     const response = await invokeRoute('get', '/integrations/:integrationId/accounts', {
       params: { integrationId: 'dir-1' },
       query: { page: '1', pageSize: '50', q: '0447' },
-      user: {
-        id: 'admin-1',
-        role: 'admin',
-      },
+      user: { id: 'admin-1', role: 'admin' },
     })
 
     expect(response.statusCode).toBe(200)
@@ -306,10 +475,7 @@ describe('adminDirectoryRouter', () => {
         localUserRef: 'alpha@example.com',
         enableDingTalkGrant: true,
       },
-      user: {
-        id: 'admin-1',
-        role: 'admin',
-      },
+      user: { id: 'admin-1', role: 'admin' },
     })
 
     expect(response.statusCode).toBe(200)
@@ -334,6 +500,81 @@ describe('adminDirectoryRouter', () => {
     }))
   })
 
+  it('batch binds directory accounts', async () => {
+    directoryMocks.batchBindDirectoryAccounts.mockResolvedValue([
+      {
+        account: {
+          id: 'account-1',
+          integrationId: 'dir-1',
+          corpId: 'dingcorp',
+          externalUserId: '0447654442691174',
+          localUser: {
+            id: 'user-1',
+            email: 'alpha@example.com',
+          },
+        },
+        previousLocalUser: null,
+      },
+      {
+        account: {
+          id: 'account-2',
+          integrationId: 'dir-1',
+          corpId: 'dingcorp',
+          externalUserId: '0447654442691175',
+          localUser: {
+            id: 'user-2',
+            email: 'beta@example.com',
+          },
+        },
+        previousLocalUser: null,
+      },
+    ])
+
+    const response = await invokeRoute('post', '/accounts/batch-bind', {
+      body: {
+        bindings: [
+          {
+            accountId: 'account-1',
+            localUserRef: 'alpha@example.com',
+            enableDingTalkGrant: true,
+          },
+          {
+            accountId: 'account-2',
+            localUserRef: 'beta@example.com',
+            enableDingTalkGrant: false,
+          },
+        ],
+      },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.batchBindDirectoryAccounts).toHaveBeenCalledWith([
+      {
+        accountId: 'account-1',
+        localUserRef: 'alpha@example.com',
+        enableDingTalkGrant: true,
+      },
+      {
+        accountId: 'account-2',
+        localUserRef: 'beta@example.com',
+        enableDingTalkGrant: false,
+      },
+    ], {
+      adminUserId: 'admin-1',
+    })
+    expect(auditMocks.auditLog).toHaveBeenCalledTimes(2)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        items: [
+          { id: 'account-1' },
+          { id: 'account-2' },
+        ],
+      },
+    })
+  })
+
   it('unbinds a directory account', async () => {
     directoryMocks.unbindDirectoryAccount.mockResolvedValue({
       account: {
@@ -352,29 +593,112 @@ describe('adminDirectoryRouter', () => {
 
     const response = await invokeRoute('post', '/accounts/:accountId/unbind', {
       params: { accountId: 'account-1' },
-      user: {
-        id: 'admin-1',
-        role: 'admin',
-      },
+      body: { disableDingTalkGrant: true },
+      user: { id: 'admin-1', role: 'admin' },
     })
 
     expect(response.statusCode).toBe(200)
     expect(directoryMocks.unbindDirectoryAccount).toHaveBeenCalledWith('account-1', {
       adminUserId: 'admin-1',
+      disableDingTalkGrant: true,
     })
     expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
       action: 'unbind',
       resourceType: 'directory-account-link',
       resourceId: 'account-1',
+      meta: expect.objectContaining({
+        disableDingTalkGrant: true,
+      }),
     }))
-    expect(response.body).toMatchObject({
-      ok: true,
-      data: {
+  })
+
+  it('batch unbinds directory accounts', async () => {
+    directoryMocks.batchUnbindDirectoryAccounts.mockResolvedValue([
+      {
         account: {
           id: 'account-1',
           externalUserId: '0447654442691174',
+          integrationId: 'dir-1',
+          corpId: 'dingcorp',
+          localUser: null,
+        },
+        previousLocalUser: {
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
         },
       },
+      {
+        account: {
+          id: 'account-2',
+          externalUserId: '0447654442691175',
+          integrationId: 'dir-1',
+          corpId: 'dingcorp',
+          localUser: null,
+        },
+        previousLocalUser: {
+          id: 'user-2',
+          email: 'beta@example.com',
+          name: 'Beta',
+        },
+      },
+    ])
+
+    const response = await invokeRoute('post', '/accounts/batch-unbind', {
+      body: {
+        accountIds: ['account-1', 'account-2'],
+        disableDingTalkGrant: true,
+      },
+      user: { id: 'admin-1', role: 'admin' },
     })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.batchUnbindDirectoryAccounts).toHaveBeenCalledWith(
+      ['account-1', 'account-2'],
+      {
+        adminUserId: 'admin-1',
+        disableDingTalkGrant: true,
+      },
+    )
+    expect(auditMocks.auditLog).toHaveBeenCalledTimes(2)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        items: [
+          { id: 'account-1' },
+          { id: 'account-2' },
+        ],
+      },
+    })
+  })
+
+  it('acknowledges a directory sync alert', async () => {
+    directoryMocks.acknowledgeDirectorySyncAlert.mockResolvedValue({
+      id: 'alert-1',
+      integrationId: 'dir-1',
+      runId: 'run-1',
+      level: 'warning',
+      code: 'root_department_sparse',
+      message: '根部门直属成员过少',
+      details: {},
+      sentToWebhook: false,
+      acknowledgedAt: '2026-04-14T01:10:00.000Z',
+      acknowledgedBy: 'admin-1',
+      createdAt: '2026-04-14T01:00:00.000Z',
+      updatedAt: '2026-04-14T01:10:00.000Z',
+    })
+
+    const response = await invokeRoute('post', '/alerts/:alertId/ack', {
+      params: { alertId: 'alert-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.acknowledgeDirectorySyncAlert).toHaveBeenCalledWith('alert-1', 'admin-1')
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'ack',
+      resourceType: 'directory-sync-alert',
+      resourceId: 'alert-1',
+    }))
   })
 })

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -243,4 +243,73 @@ describe('bindDirectoryAccount', () => {
       },
     })
   })
+
+  it('can disable the DingTalk grant while unbinding', async () => {
+    const clientQuery = vi.fn()
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: '周华',
+          email: null,
+          mobile: '13758875801',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: 'user-1',
+          local_user_email: 'alpha@example.com',
+          local_user_name: 'Alpha',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '周华',
+          account_email: null,
+          account_mobile: '13758875801',
+          account_is_active: true,
+          account_updated_at: '2026-04-11T08:01:00.000Z',
+          link_status: 'unmatched',
+          match_strategy: 'manual_unbound',
+          reviewed_by: null,
+          review_note: null,
+          link_updated_at: '2026-04-11T08:01:00.000Z',
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+
+    clientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    await unbindDirectoryAccount('account-1', {
+      adminUserId: 'admin-1',
+      disableDingTalkGrant: true,
+    })
+
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_external_auth_grants'),
+      ['dingtalk', 'user-1', 'admin-1'],
+    )
+  })
 })

--- a/packages/core-backend/tests/unit/directory-sync-review-items.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-review-items.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+}))
+
+import { listDirectoryReviewItems } from '../../src/directory/directory-sync'
+
+describe('listDirectoryReviewItems', () => {
+  beforeEach(() => {
+    pgMocks.query.mockReset()
+    pgMocks.transaction.mockReset()
+  })
+
+  it('returns a safe recommendation for uniquely matched pending bindings', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{ total: 1 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '周华',
+          account_email: 'alpha@example.com',
+          account_mobile: '13758875801',
+          account_is_active: true,
+          account_updated_at: '2026-04-15T08:00:00.000Z',
+          link_status: 'pending',
+          match_strategy: 'email',
+          reviewed_by: null,
+          review_note: null,
+          link_updated_at: '2026-04-15T08:00:00.000Z',
+          local_user_id: 'user-1',
+          local_user_email: 'alpha@example.com',
+          local_user_name: 'Alpha',
+          department_paths: ['DingTalk CN'],
+          review_kind: 'pending_binding',
+          review_reason: '目录成员当前不是已确认绑定状态，建议复核。',
+          missing_union_id: false,
+          missing_open_id: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+          mobile: '13758875801',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: 'user-1',
+          external_key: 'dingcorp:open-1',
+          provider_union_id: 'union-1',
+          provider_open_id: 'open-1',
+          corp_id: 'dingcorp',
+        }],
+      })
+
+    const result = await listDirectoryReviewItems('dir-1', { limit: 100, offset: 0 }, 'pending_binding')
+
+    expect(result.total).toBe(1)
+    expect(result.items[0]).toMatchObject({
+      kind: 'pending_binding',
+      account: {
+        id: 'account-1',
+      },
+      recommendationStatus: {
+        code: 'recommended',
+        message: '已命中唯一精确候选，可直接确认推荐绑定。',
+      },
+      actionable: {
+        canConfirmRecommendation: true,
+      },
+      recommendations: [{
+        localUser: {
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          isActive: true,
+        },
+        reasons: ['pending_link', 'email', 'mobile'],
+      }],
+    })
+  })
+
+  it('suppresses ambiguous or conflicting recommendations', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{ total: 1 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '周华',
+          account_email: null,
+          account_mobile: '13758875801',
+          account_is_active: true,
+          account_updated_at: '2026-04-15T08:00:00.000Z',
+          link_status: 'unmatched',
+          match_strategy: 'none',
+          reviewed_by: null,
+          review_note: null,
+          link_updated_at: '2026-04-15T08:00:00.000Z',
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+          department_paths: ['DingTalk CN'],
+          review_kind: 'pending_binding',
+          review_reason: '目录成员尚未绑定本地用户。',
+          missing_union_id: false,
+          missing_open_id: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'user-1',
+            email: 'alpha@example.com',
+            name: 'Alpha',
+            role: 'user',
+            is_active: true,
+            mobile: '13758875801',
+          },
+          {
+            id: 'user-2',
+            email: 'beta@example.com',
+            name: 'Beta',
+            role: 'user',
+            is_active: true,
+            mobile: '13758875801',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [],
+      })
+      .mockResolvedValueOnce({
+        rows: [],
+      })
+
+    const result = await listDirectoryReviewItems('dir-1', { limit: 100, offset: 0 }, 'pending_binding')
+
+    expect(result.items[0]).toMatchObject({
+      recommendationStatus: {
+        code: 'ambiguous_exact_match',
+        message: '邮箱或手机号命中多个本地用户，需人工确认。',
+      },
+      actionable: {
+        canConfirmRecommendation: false,
+      },
+    })
+    expect(result.items[0]?.recommendations).toEqual([])
+  })
+
+  it('returns a manual-required status when no exact candidate exists', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{ total: 1 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '周华',
+          account_email: null,
+          account_mobile: null,
+          account_is_active: true,
+          account_updated_at: '2026-04-15T08:00:00.000Z',
+          link_status: 'unmatched',
+          match_strategy: 'none',
+          reviewed_by: null,
+          review_note: null,
+          link_updated_at: '2026-04-15T08:00:00.000Z',
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+          department_paths: ['DingTalk CN'],
+          review_kind: 'pending_binding',
+          review_reason: '目录成员尚未绑定本地用户。',
+          missing_union_id: false,
+          missing_open_id: false,
+        }],
+      })
+
+    const result = await listDirectoryReviewItems('dir-1', { limit: 100, offset: 0 }, 'pending_binding')
+
+    expect(result.items[0]).toMatchObject({
+      recommendationStatus: {
+        code: 'no_exact_match',
+        message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+      },
+      actionable: {
+        canConfirmRecommendation: false,
+      },
+    })
+    expect(result.items[0]?.recommendations).toEqual([])
+  })
+
+  it('returns a conflict status when pending binding disagrees with the exact candidate', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{ total: 1 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '周华',
+          account_email: 'alpha@example.com',
+          account_mobile: null,
+          account_is_active: true,
+          account_updated_at: '2026-04-15T08:00:00.000Z',
+          link_status: 'pending',
+          match_strategy: 'email',
+          reviewed_by: null,
+          review_note: null,
+          link_updated_at: '2026-04-15T08:00:00.000Z',
+          local_user_id: 'user-pending',
+          local_user_email: 'pending@example.com',
+          local_user_name: 'Pending',
+          department_paths: ['DingTalk CN'],
+          review_kind: 'pending_binding',
+          review_reason: '目录成员当前不是已确认绑定状态，建议复核。',
+          missing_union_id: false,
+          missing_open_id: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+          mobile: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [],
+      })
+      .mockResolvedValueOnce({
+        rows: [],
+      })
+
+    const result = await listDirectoryReviewItems('dir-1', { limit: 100, offset: 0 }, 'pending_binding')
+
+    expect(result.items[0]).toMatchObject({
+      recommendationStatus: {
+        code: 'pending_link_conflict',
+        message: '现有待确认匹配与精确候选不一致，请人工复核。',
+      },
+      actionable: {
+        canConfirmRecommendation: false,
+      },
+    })
+    expect(result.items[0]?.recommendations).toEqual([])
+  })
+})

--- a/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}))
+
+const directoryMocks = vi.hoisted(() => ({
+  syncDirectoryIntegration: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+}))
+
+vi.mock('../../src/directory/directory-sync', () => ({
+  syncDirectoryIntegration: directoryMocks.syncDirectoryIntegration,
+}))
+
+import {
+  refreshDirectoryIntegrationSchedule,
+  resetDirectorySyncSchedulerForTests,
+  startDirectorySyncScheduler,
+} from '../../src/directory/directory-sync-scheduler'
+
+function createSchedulerMock() {
+  return {
+    schedule: vi.fn(),
+    reschedule: vi.fn(),
+    unschedule: vi.fn(),
+    getJob: vi.fn(),
+    destroy: vi.fn(),
+  }
+}
+
+describe('directory-sync-scheduler', () => {
+  beforeEach(() => {
+    pgMocks.query.mockReset()
+    directoryMocks.syncDirectoryIntegration.mockReset()
+    resetDirectorySyncSchedulerForTests()
+  })
+
+  it('registers a job for active sync-enabled integrations with a cron schedule and forwards the handler to directory sync', async () => {
+    const scheduler = createSchedulerMock()
+    scheduler.getJob.mockResolvedValue(null)
+
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'dir-1',
+          name: 'DingTalk CN',
+          status: 'active',
+          sync_enabled: true,
+          schedule_cron: '*/5 * * * *',
+        },
+        {
+          id: 'dir-2',
+          name: 'Inactive',
+          status: 'inactive',
+          sync_enabled: true,
+          schedule_cron: '*/5 * * * *',
+        },
+        {
+          id: 'dir-3',
+          name: 'Disabled',
+          status: 'active',
+          sync_enabled: false,
+          schedule_cron: '*/5 * * * *',
+        },
+        {
+          id: 'dir-4',
+          name: 'Blank cron',
+          status: 'active',
+          sync_enabled: true,
+          schedule_cron: '   ',
+        },
+      ],
+    })
+
+    await startDirectorySyncScheduler({ scheduler: scheduler as never })
+
+    expect(pgMocks.query).toHaveBeenCalledWith(
+      expect.stringContaining("FROM directory_integrations"),
+    )
+    expect(scheduler.schedule).toHaveBeenCalledTimes(1)
+    expect(scheduler.schedule).toHaveBeenCalledWith(
+      'directory-sync:dir-1',
+      '*/5 * * * *',
+      expect.any(Function),
+      {
+        timezone: 'UTC',
+      },
+    )
+    expect(scheduler.reschedule).not.toHaveBeenCalled()
+    expect(scheduler.unschedule).not.toHaveBeenCalled()
+
+    const scheduleHandler = scheduler.schedule.mock.calls[0][2] as () => Promise<void>
+    await scheduleHandler()
+
+    expect(directoryMocks.syncDirectoryIntegration).toHaveBeenCalledWith(
+      'dir-1',
+      'system:directory-sync-scheduler',
+      'scheduler',
+    )
+  })
+
+  it.each([
+    {
+      label: 'disabled integration',
+      row: {
+        id: 'dir-disabled',
+        name: 'Disabled',
+        status: 'active',
+        sync_enabled: false,
+        schedule_cron: '*/10 * * * *',
+      },
+    },
+    {
+      label: 'blank cron',
+      row: {
+        id: 'dir-blank-cron',
+        name: 'Blank cron',
+        status: 'active',
+        sync_enabled: true,
+        schedule_cron: '   ',
+      },
+    },
+  ])('cancels an existing job for a $label during schedule refresh', async ({ row }) => {
+    const scheduler = createSchedulerMock()
+    scheduler.getJob.mockResolvedValue({ name: `directory-sync:${row.id}` })
+
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [row] })
+
+    await startDirectorySyncScheduler({ scheduler: scheduler as never })
+    await refreshDirectoryIntegrationSchedule(row.id)
+
+    expect(scheduler.unschedule).toHaveBeenCalledWith(`directory-sync:${row.id}`)
+    expect(scheduler.schedule).not.toHaveBeenCalled()
+    expect(scheduler.reschedule).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What Changed

This PR packages the next DingTalk directory admin slice into one branch:

- manual review queue operations
- recommendation-based bind guidance and reason filters
- batch bind / batch unbind actions
- visible batch progress in the directory UI
- backend directory sync scheduler wiring
- schedule observability for selected integrations

Primary touched files:

- `apps/web/src/views/DirectoryManagementView.vue`
- `apps/web/tests/directoryManagementView.spec.ts`
- `packages/core-backend/src/directory/directory-sync.ts`
- `packages/core-backend/src/directory/directory-sync-scheduler.ts`
- `packages/core-backend/src/routes/admin-directory.ts`
- `packages/core-backend/src/index.ts`
- `packages/core-backend/tests/unit/admin-directory-routes.test.ts`
- `packages/core-backend/tests/unit/directory-sync-bind-account.test.ts`
- `packages/core-backend/tests/unit/directory-sync-review-items.test.ts`
- `packages/core-backend/tests/unit/directory-sync-scheduler.test.ts`

Supporting docs are included under `docs/development/dingtalk-directory-*`.

## Why

The existing DingTalk directory flow already supported sync and single-account binding, but the operator path was still too shallow:

- review items were not rich enough for real manual operations
- batch actions lacked visible operator feedback
- auto-sync scheduling had no runtime registration and no admin-facing observation path

This PR closes that gap and turns the directory page into a more usable admin workflow.

## Verification

Passed:

```bash
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-review-items.test.ts tests/unit/directory-sync-scheduler.test.ts --reporter=dot
pnpm --filter @metasheet/web exec vitest run --api.port 0 tests/directoryManagementView.spec.ts --reporter=dot
pnpm --filter @metasheet/web exec vue-tsc --noEmit
```

Summary:

- backend unit tests: `27/27`
- frontend tests: `20/20`
- frontend type-check: passed

Detailed notes:

- `docs/development/dingtalk-directory-ops-stack-development-20260415.md`
- `docs/development/dingtalk-directory-ops-stack-verification-20260415.md`

## Notes

- This branch intentionally excludes unrelated dirty files from the local main worktree such as plugin `node_modules`, `.claude/`, session-center tests, and migration drafts.
- `Claude Code CLI` is callable in this environment and was re-checked during packaging. A narrow review prompt did not return in time, so branch readiness is based on local verification evidence.
