### PR TITLE
feat(dingtalk): add focused account review flow

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -130,7 +130,7 @@
           </button>
         </footer>
 
-        <section v-if="selectedIntegration" class="directory-admin__section">
+        <section v-if="selectedIntegration" ref="accountsSectionRef" class="directory-admin__section">
           <h3>当前概览</h3>
           <div class="directory-admin__chips">
             <span class="directory-admin__chip">部门 {{ selectedIntegration.stats.departmentCount }}</span>
@@ -559,9 +559,41 @@
             </div>
           </div>
 
+          <article v-if="focusedAccountId" class="directory-admin__focus-card">
+            <div>
+              <strong>{{ focusedVisibleAccount ? `当前定位成员：${focusedVisibleAccount.name}` : `当前定位成员：${focusedAccountId}` }}</strong>
+              <p class="directory-admin__hint">
+                {{
+                  focusedVisibleAccount
+                    ? '已在当前成员结果中高亮显示，可直接继续绑定、解绑或复核。'
+                    : '当前定位成员不在本页结果中；如果你已切换筛选或分页，可清除定位后继续操作。'
+                }}
+              </p>
+            </div>
+            <div class="directory-admin__focus-actions">
+              <button
+                v-if="focusedVisibleAccount && focusedVisibleAccountBindDraft.length > 0"
+                class="directory-admin__button"
+                type="button"
+                :disabled="bindingAccountId === focusedVisibleAccount.id"
+                @click="void bindAccount(focusedVisibleAccount)"
+              >
+                {{ focusedVisibleAccountBindLabel }}
+              </button>
+              <button class="directory-admin__button directory-admin__button--secondary" type="button" @click="clearFocusedAccount()">
+                清除定位
+              </button>
+            </div>
+          </article>
+
           <div v-if="loadingAccounts" class="directory-admin__empty">成员加载中...</div>
           <div v-else-if="accounts.length === 0" class="directory-admin__empty">暂无同步成员</div>
-          <article v-for="account in accounts" :key="account.id" class="directory-admin__account">
+          <article
+            v-for="account in accounts"
+            :key="account.id"
+            class="directory-admin__account"
+            :class="{ 'directory-admin__account--focused': focusedAccountId === account.id }"
+          >
             <div class="directory-admin__account-head">
               <div>
                 <strong>{{ account.name }}</strong>
@@ -570,6 +602,7 @@
                 </p>
               </div>
               <div class="directory-admin__chips">
+                <span v-if="focusedAccountId === account.id" class="directory-admin__chip directory-admin__chip--success">已定位</span>
                 <span class="directory-admin__chip">{{ account.linkStatus }}</span>
                 <span v-if="account.matchStrategy" class="directory-admin__chip">策略 {{ account.matchStrategy }}</span>
                 <span class="directory-admin__chip" :class="{ 'directory-admin__badge--inactive': !account.isActive }">
@@ -744,7 +777,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, nextTick, onMounted, reactive, ref } from 'vue'
 import { apiFetch } from '../utils/api'
 
 type DirectoryIntegration = {
@@ -957,10 +990,13 @@ const accounts = ref<DirectoryAccount[]>([])
 const scheduleSnapshot = ref<DirectoryScheduleSnapshot | null>(null)
 const alerts = ref<DirectorySyncAlert[]>([])
 const reviewItems = ref<DirectoryReviewItem[]>([])
+const accountsSectionRef = ref<HTMLElement | null>(null)
 const accountPageSizeOptions = [25, 50, 100]
 const accountPage = ref(1)
 const accountPageSize = ref(25)
 const accountTotal = ref(0)
+const focusedAccountId = ref('')
+const pendingFocusedAccountScroll = ref(false)
 const selectedIntegrationId = ref('')
 const loading = ref(false)
 const loadingRuns = ref(false)
@@ -1079,6 +1115,18 @@ const showPendingBindingManualReasonFilters = computed(() => (
   && pendingBindingCounts.value.manual > 0
   && (reviewFilter.value === 'all' || reviewFilter.value === 'pending_binding')
 ))
+const focusedVisibleAccount = computed(() => (
+  accounts.value.find((account) => account.id === focusedAccountId.value) ?? null
+))
+const focusedVisibleAccountBindDraft = computed(() => {
+  if (!focusedVisibleAccount.value) return ''
+  return readBindingDraft(focusedVisibleAccount.value).trim()
+})
+const focusedVisibleAccountBindLabel = computed(() => {
+  if (!focusedVisibleAccount.value) return '绑定当前成员'
+  if (bindingAccountId.value === focusedVisibleAccount.value.id) return '绑定中...'
+  return focusedVisibleAccount.value.localUser ? '更新当前绑定' : '绑定当前成员'
+})
 const hasMoreReviewItems = computed(() => reviewItems.value.length < reviewTotal.value)
 const filteredReviewItems = computed(() => {
   if (reviewFilter.value === 'all') {
@@ -1208,6 +1256,7 @@ function applyIntegrationToDraft(integration: DirectoryIntegration) {
 function selectIntegration(integrationId: string) {
   selectedIntegrationId.value = integrationId
   testResult.value = null
+  clearFocusedAccount()
   accountPage.value = 1
   accountTotal.value = 0
   reviewBatchProgress.value = null
@@ -1273,6 +1322,11 @@ function readBindingDraftByAccountId(accountId: string): string {
   const account = accounts.value.find((item) => item.id === accountId)
   if (!account) return bindingDrafts[accountId] ?? ''
   return readBindingDraft(account)
+}
+
+function clearFocusedAccount() {
+  focusedAccountId.value = ''
+  pendingFocusedAccountScroll.value = false
 }
 
 function updateBindingDraft(accountId: string, value: string) {
@@ -1456,6 +1510,7 @@ async function syncIntegration() {
 
 async function searchAccounts() {
   if (!selectedIntegration.value) return
+  clearFocusedAccount()
   accountPage.value = 1
   await loadAccounts(selectedIntegration.value.id)
 }
@@ -1464,6 +1519,7 @@ async function changeAccountPage(nextPage: number) {
   if (!selectedIntegration.value) return
   const normalizedPage = Math.max(1, Math.min(nextPage, accountPageCount.value))
   if (normalizedPage === accountPage.value) return
+  clearFocusedAccount()
   accountPage.value = normalizedPage
   await loadAccounts(selectedIntegration.value.id)
 }
@@ -1473,9 +1529,23 @@ async function updateAccountPageSize(event: Event) {
   const target = event.target
   const nextPageSize = Number(target instanceof HTMLSelectElement ? target.value : accountPageSize.value)
   if (!Number.isFinite(nextPageSize) || nextPageSize <= 0 || nextPageSize === accountPageSize.value) return
+  clearFocusedAccount()
   accountPageSize.value = nextPageSize
   accountPage.value = 1
   await loadAccounts(selectedIntegration.value.id)
+}
+
+async function scrollFocusedAccountIntoView() {
+  await nextTick()
+  const section = accountsSectionRef.value
+  const focusedAccountElement = section?.querySelector('.directory-admin__account--focused')
+  if (focusedAccountElement instanceof HTMLElement) {
+    focusedAccountElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    return
+  }
+  if (section instanceof HTMLElement) {
+    section.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
 }
 
 async function loadAccounts(integrationId: string) {
@@ -1504,9 +1574,14 @@ async function loadAccounts(integrationId: string) {
     }
     accountTotal.value = normalizedTotal
     accounts.value = items
+    if (pendingFocusedAccountScroll.value) {
+      pendingFocusedAccountScroll.value = false
+      await scrollFocusedAccountIntoView()
+    }
   } catch (error) {
     accounts.value = []
     accountTotal.value = 0
+    pendingFocusedAccountScroll.value = false
     setStatus(error instanceof Error ? error.message : '加载目录成员失败', 'error')
   } finally {
     loadingAccounts.value = false
@@ -1867,6 +1942,8 @@ function onReviewSelectionChange(accountId: string, event: Event) {
 }
 
 function focusReviewAccount(item: DirectoryReviewItem) {
+  focusedAccountId.value = item.account.id
+  pendingFocusedAccountScroll.value = true
   accountQuery.value = item.account.externalUserId
   if (selectedIntegration.value) {
     accountPage.value = 1
@@ -2345,6 +2422,24 @@ onMounted(() => {
   color: #64748b;
 }
 
+.directory-admin__focus-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid #99f6e4;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #f0fdfa 0%, #ecfeff 100%);
+}
+
+.directory-admin__focus-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
 .directory-admin__run {
   border: 1px solid #e2e8f0;
   border-radius: 14px;
@@ -2397,6 +2492,11 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.directory-admin__account--focused {
+  border-color: #0f766e;
+  box-shadow: 0 0 0 2px rgba(20, 184, 166, 0.16);
 }
 
 .directory-admin__account-head {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -200,9 +200,16 @@ function createTestResultPayload(overrides: Record<string, unknown> = {}) {
 describe('DirectoryManagementView', () => {
   let app: App<Element> | null = null
   let container: HTMLDivElement | null = null
+  const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+  let scrollIntoViewMock = vi.fn()
 
   beforeEach(() => {
     apiFetchMock.mockReset()
+    scrollIntoViewMock = vi.fn()
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoViewMock,
+    })
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -210,6 +217,10 @@ describe('DirectoryManagementView', () => {
   afterEach(() => {
     if (app) app.unmount()
     if (container) container.remove()
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: originalScrollIntoView,
+    })
     app = null
     container = null
   })
@@ -679,6 +690,166 @@ describe('DirectoryManagementView', () => {
       }),
     )
     expect(container?.textContent).toContain('已完成快速绑定')
+    expect(container?.textContent).toContain('alpha@example.com')
+  })
+
+  it('focuses a reviewed account and quick-binds it from the accounts banner', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-focus',
+              name: '定位成员',
+              externalUserId: '0447654442691199',
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-other',
+            name: '其他成员',
+            externalUserId: '0447654442691188',
+          }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+          }),
+        ], { total: 1 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({
+            stats: {
+              departmentCount: 12,
+              accountCount: 98,
+              pendingLinkCount: 3,
+              linkedCount: 89,
+              lastRunStatus: 'completed',
+            },
+          })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const reviewBindInput = container!.querySelector('.directory-admin__review-item input[placeholder="例如 user-123 或 alpha@example.com"]') as HTMLInputElement | null
+    expect(reviewBindInput).toBeTruthy()
+    reviewBindInput!.value = 'alpha@example.com'
+    reviewBindInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    const focusButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('定位到成员'))
+    expect(focusButton).toBeTruthy()
+    focusButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=25&q=0447654442691199')
+    expect(scrollIntoViewMock).toHaveBeenCalledWith(expect.objectContaining({
+      behavior: 'smooth',
+      block: 'start',
+    }))
+    const focusCard = container!.querySelector('.directory-admin__focus-card')
+    expect(focusCard?.textContent).toContain('当前定位成员：定位成员')
+    expect(focusCard?.textContent).toContain('已在当前成员结果中高亮显示，可直接继续绑定、解绑或复核。')
+    const focusedAccount = container!.querySelector('.directory-admin__account--focused')
+    expect(focusedAccount?.textContent).toContain('定位成员')
+    expect(focusedAccount?.textContent).toContain('已定位')
+    const focusedAccountBindInput = focusedAccount?.querySelector('input[placeholder="例如 user-123 或 alpha@example.com"]') as HTMLInputElement | null
+    expect(focusedAccountBindInput?.value).toBe('alpha@example.com')
+
+    const quickBindButton = Array.from(focusCard?.querySelectorAll('button') ?? []).find((button) => button.textContent?.includes('绑定当前成员'))
+    expect(quickBindButton).toBeTruthy()
+    quickBindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/account-focus/bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          localUserRef: 'alpha@example.com',
+          enableDingTalkGrant: true,
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('目录成员 定位成员 已绑定到本地用户')
     expect(container?.textContent).toContain('alpha@example.com')
   })
 

--- a/docs/development/dingtalk-directory-focus-account-development-20260415.md
+++ b/docs/development/dingtalk-directory-focus-account-development-20260415.md
@@ -1,0 +1,69 @@
+# DingTalk Directory Focus Account Development
+
+日期：2026-04-15
+
+## 目标
+
+把 `DirectoryManagementView` 里的待处理复核项和成员账号列表串起来，补一个更短的人工处理路径：
+
+- 从 review item 直接“定位到成员”
+- 自动带着钉钉用户 ID 刷新账号列表
+- 在成员区域高亮目标账号
+- 复用已有绑定草稿，直接从聚焦卡片执行快捷绑定
+
+## 本次改动
+
+### 前端视图
+
+文件：
+- `apps/web/src/views/DirectoryManagementView.vue`
+
+新增能力：
+- 成员区 section 增加 `accountsSectionRef`
+- 引入 `focusedAccountId` 和 `pendingFocusedAccountScroll`
+- review item 点击“定位到成员”后：
+  - 把 `accountQuery` 预填为 `externalUserId`
+  - 重载成员列表
+  - 成功后滚动到高亮成员
+- 成员区顶部新增 focus card：
+  - 显示当前定位成员
+  - 若目标成员仍在当前结果页，允许直接“绑定当前成员”
+  - 提供“清除定位”
+- 账号卡片增加 `directory-admin__account--focused` 高亮态
+- 切换 integration、搜索、分页、调整 page size 时清掉旧的 focus 状态，避免错误残留
+
+### 测试
+
+文件：
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+新增内容：
+- mock `HTMLElement.prototype.scrollIntoView`
+- 新增回归用例：
+  - 从 review item 定位成员
+  - 断言账号列表按钉钉用户 ID 重载
+  - 断言滚动、高亮、focus card 文案
+  - 断言可直接从 focus card 触发绑定并刷新结果
+
+## 范围控制
+
+这次只收一个前端 follow-up slice：
+
+- 不改后端 API
+- 不改目录 review/batch bind 语义
+- 不把主工作区里其他 `directory` 脏改动混进来
+
+## 对 Claude 反馈的核对
+
+本次顺手核对了 Claude 提到的 3 个修复点，结论如下：
+
+- `packages/core-backend/src/routes/dashboard.ts`
+  当前 `main` 已是 `async` 路由并包含对应 `await`
+- `packages/core-backend/src/routes/automation.ts`
+  当前 `main` 已对 `getByRule()` / `getStats()` 使用 `await`
+- migration 时间戳冲突
+  当前 `main` 已去重为：
+  - `zzzz20260414100001_create_automation_executions_and_dashboard_charts.ts`
+  - `zzzz20260414100002_create_multitable_api_tokens_and_webhooks.ts`
+
+因此这些问题不需要在本 follow-up 分支里重复修复。

--- a/docs/development/dingtalk-directory-focus-account-verification-20260415.md
+++ b/docs/development/dingtalk-directory-focus-account-verification-20260415.md
@@ -1,0 +1,53 @@
+# DingTalk Directory Focus Account Verification
+
+日期：2026-04-15
+
+## 代码验证
+
+### 前端类型检查
+
+命令：
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+结果：
+- 通过
+
+### 前端定向测试
+
+命令：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/directoryManagementView.spec.ts --reporter=dot
+```
+
+结果：
+- `1` 个文件通过
+- `21/21` 用例通过
+
+## 运行环境说明
+
+这次在独立 worktree `/tmp/metasheet2-dingtalk-directory-focus` 中执行。
+
+为了让 isolated worktree 复用已有依赖，补了两个本地 symlink：
+
+- `/tmp/metasheet2-dingtalk-directory-focus/node_modules`
+- `/tmp/metasheet2-dingtalk-directory-focus/apps/web/node_modules`
+
+它们只用于本地验证，不会进入 git。
+
+## Claude Code CLI
+
+本轮重新检查：
+
+```bash
+claude auth status
+```
+
+结果：
+- 已登录
+- 当前可调用
+
+但本次主交付没有依赖 Claude CLI 执行代码修改，仍以本地测试结果为准。

--- a/docs/development/dingtalk-directory-focus-mainline-resync-development-20260415.md
+++ b/docs/development/dingtalk-directory-focus-mainline-resync-development-20260415.md
@@ -1,0 +1,71 @@
+# DingTalk Directory Focus Mainline Resync
+
+日期：2026-04-15
+
+## 背景
+
+PR `#877` 原先已经通过本分支自己的前端验证，但在 GitHub 上进入了 `BEHIND` 状态。  
+本轮需要把它重新同步到最新 `main`，避免 auto-merge 因 base 漂移而卡住。
+
+## 本轮动作
+
+### 1. 合并最新 main
+
+在隔离 worktree `/tmp/metasheet2-dingtalk-directory-focus` 中执行：
+
+```bash
+git fetch origin --prune
+git merge origin/main
+```
+
+结果：
+
+- 无冲突合并
+- 生成 merge commit：
+  - `1e315d047`
+
+### 2. 同步进入的上游内容
+
+这次 mainline 同步把两类重要上游内容带了进来：
+
+- Claude 所说的 `Phase 1 closure` 文档：
+  - `docs/development/phase1-closure-verification-20260415.md`
+- automation persistence 相关后端主线改动：
+  - `packages/core-backend/src/multitable/automation-service.ts`
+  - `packages/core-backend/src/routes/univer-meta.ts`
+  - `packages/core-backend/src/db/migrations/zzzz20260414100000_extend_automation_rules.ts`
+
+这意味着 `#877` 现在不再建立在旧 main 上，而是明确叠在更新后的 Phase 1 主线上。
+
+### 3. 只回归本切片
+
+本轮没有扩大验证范围，只重跑这条切片自己的前端回归：
+
+- `DirectoryManagementView` 行为
+- 类型检查
+
+因为 `#877` 本身只修改：
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+## Claude Code CLI
+
+在当前 worktree 里执行：
+
+```bash
+claude auth status
+claude -p "Review the current dingtalk directory focus follow-up branch after merging origin/main. Reply with exactly NO_BLOCKERS or one short blocker sentence."
+```
+
+结果：
+
+- CLI 已登录
+- review 返回 `NO_BLOCKERS`
+
+## 结论
+
+这次 resync 后，`#877` 的问题不再是代码落后，而只剩标准的：
+
+- checks 重新跑完
+- reviewer approval

--- a/docs/development/dingtalk-directory-focus-mainline-resync-verification-20260415.md
+++ b/docs/development/dingtalk-directory-focus-mainline-resync-verification-20260415.md
@@ -1,0 +1,63 @@
+# DingTalk Directory Focus Mainline Resync Verification
+
+日期：2026-04-15
+
+## Git 状态
+
+当前 worktree：
+
+- branch: `codex/dingtalk-directory-focus-followup-20260415`
+- merge commit: `1e315d047`
+
+## 本轮验证
+
+### TypeScript
+
+命令：
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+结果：
+
+- 通过
+
+### Vitest
+
+命令：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/directoryManagementView.spec.ts --reporter=dot
+```
+
+结果：
+
+- `1` 个文件通过
+- `21/21` 用例通过
+
+### Claude Code CLI
+
+命令：
+
+```bash
+claude -p "Review the current dingtalk directory focus follow-up branch after merging origin/main. Reply with exactly NO_BLOCKERS or one short blocker sentence."
+```
+
+结果：
+
+- 返回两行，结尾为 `NO_BLOCKERS`
+- 结论上没有新增 merge blocker
+
+## 影响评估
+
+本轮同步没有改动 `#877` 的功能边界，只是：
+
+- 把分支追平到最新 `main`
+- 重新证明 focused-account review flow 仍然成立
+
+## 待办
+
+- push 最新 merge commit 和这对 sync 文档
+- 等 GitHub checks 重新跑完
+- reviewer approval 后由 auto-merge 收口

--- a/docs/development/dingtalk-directory-focus-mainline-sync-development-20260415.md
+++ b/docs/development/dingtalk-directory-focus-mainline-sync-development-20260415.md
@@ -1,0 +1,40 @@
+# DingTalk Directory Focus Mainline Sync Development
+
+日期：2026-04-15
+
+## 背景
+
+`#877` 在代码和 CI 都已通过后，GitHub 状态变为 `BEHIND`。这说明 PR 分支落后于最新 `main`，需要先把 `origin/main` 合入，再继续保留 `auto-merge` / reviewer gate 流程。
+
+## 本轮处理
+
+- 在 isolated worktree `/tmp/metasheet2-dingtalk-directory-focus` 中执行
+- `git fetch origin`
+- 确认 `origin/main` 从 `b939fc34e` 前进到 `1fba9933c`
+- 将最新 `origin/main` 合入 `codex/dingtalk-directory-focus-followup-20260415`
+
+## 合入结果
+
+本轮是 clean merge，没有碰到 `DirectoryManagementView` 或测试文件冲突。
+
+来自 `main` 的新增提交主要落在：
+- `packages/core-backend/src/db/redis.ts`
+- `packages/core-backend/src/middleware/rate-limiter.ts`
+- `packages/core-backend/tests/unit/rate-limiter.test.ts`
+
+这些都不属于本 PR 的功能面，因此本轮只需要重跑本切片自己的前端验证即可。
+
+## Claude Code CLI
+
+本轮重新核对：
+
+```bash
+claude auth status
+claude -p "Review the current branch diff against main for PR readiness. Reply with exactly NO_BLOCKERS or one short blocker sentence."
+```
+
+结果：
+- 已登录
+- 窄范围 review 返回 `NO_BLOCKERS`
+
+本轮仍然没有让 Claude CLI 直接改代码，只用它做窄范围复核。

--- a/docs/development/dingtalk-directory-focus-mainline-sync-verification-20260415.md
+++ b/docs/development/dingtalk-directory-focus-mainline-sync-verification-20260415.md
@@ -1,0 +1,50 @@
+# DingTalk Directory Focus Mainline Sync Verification
+
+日期：2026-04-15
+
+## 分支同步
+
+命令：
+
+```bash
+git fetch origin
+git merge --no-edit origin/main
+```
+
+结果：
+- 合并成功
+- 无冲突
+
+## 同步后验证
+
+### 前端类型检查
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+结果：
+- 通过
+
+### 定向视图回归
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/directoryManagementView.spec.ts --reporter=dot
+```
+
+结果：
+- `1` 个文件通过
+- `21/21` 用例通过
+
+## GitHub 状态
+
+同步前：
+- `#877` `mergeStateStatus=BEHIND`
+
+同步后预期：
+- 推送新 head 后，GitHub 重新计算 merge state
+- 仍只应剩 reviewer gate，而不是代码/CI gate
+
+## 本地说明
+
+worktree 中仍保留未跟踪的 `node_modules` symlink，仅用于本地测试，不会进入 git。

--- a/docs/development/dingtalk-directory-focus-post-automation-sync-development-20260415.md
+++ b/docs/development/dingtalk-directory-focus-post-automation-sync-development-20260415.md
@@ -1,0 +1,75 @@
+# DingTalk Directory Focus Post-Automation Sync
+
+日期：2026-04-15
+
+## 背景
+
+PR `#877` 上一轮失败的 `Plugin System Tests` 不是这条前端切片自己的问题，而是它同步到 `main` 后继承了 `#879` 留下的 automation 单测债。
+
+随后 follow-up PR `#880`：
+
+- `fix(multitable): sync automation scheduler on CRUD`
+
+已经在 `2026-04-15` 合入 `main`。  
+因此本轮需要把 `#877` 再追一次最新 `main`，验证这条 focused-account follow-up 在吃进 `#880` 后仍然成立。
+
+## 本轮动作
+
+### 1. 把 #877 再同步到最新 main
+
+在 isolated worktree `/tmp/metasheet2-dingtalk-directory-focus` 中执行：
+
+```bash
+git fetch origin --prune
+git merge origin/main
+```
+
+结果：
+
+- 无冲突
+- 新的上游内容包含：
+  - `#880` 的 automation scheduler sync 修复
+  - `#880` 的 4 份开发/验证文档
+
+### 2. 只验证这条切片自己的边界
+
+因为 `#877` 只修改：
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+所以本轮继续只跑：
+
+- 前端类型检查
+- `directoryManagementView` 定向 Vitest
+
+不把 automation follow-up 的后端验证重新塞进这条 PR。
+
+## 对 Claude 反馈的判断
+
+Claude 的 `Phase 1 全部完成` 总结里，和本轮最相关的地方是：
+
+- `#879` 不能按“完全收口”理解
+- 必须把 `#880` 当成必要修复补丁看
+
+这也解释了为什么上一轮 `#877` 的 CI 会在 `Plugin System Tests` 上失败。
+
+## Claude Code CLI
+
+本轮确认：
+
+```bash
+claude auth status
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+CLI 处于已登录、可调用状态。  
+但更长的 branch review prompt 返回不稳定，所以本轮最终仍以本地测试和 GitHub checks 为准。
+
+## 当前结论
+
+`#877` 现在重新建立在包含 `#880` 的 `main` 之上。  
+这轮同步后的预期是：
+
+- 不再重复继承 `multitable-automation-service` 那 9 个失败
+- PR 回到正常的 checks + reviewer gate

--- a/docs/development/dingtalk-directory-focus-post-automation-sync-verification-20260415.md
+++ b/docs/development/dingtalk-directory-focus-post-automation-sync-verification-20260415.md
@@ -1,0 +1,73 @@
+# DingTalk Directory Focus Post-Automation Sync Verification
+
+日期：2026-04-15
+
+## Git 状态
+
+当前 worktree：
+
+- branch: `codex/dingtalk-directory-focus-followup-20260415`
+- base: `main`
+
+本轮已在本地合入包含 `#880` 的最新 `origin/main`。
+
+## 本轮验证
+
+### TypeScript
+
+命令：
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+结果：
+
+- 通过
+
+### Vitest
+
+命令：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/directoryManagementView.spec.ts --reporter=dot
+```
+
+结果：
+
+- `1` 个文件通过
+- `21/21` 用例通过
+
+## GitHub 关联结论
+
+已确认：
+
+- `#880` 已合并
+- merge commit: `3b7310d7f3c7f0001eb4c70bf29e3462590f27e0`
+
+因此，`#877` 下一轮 CI 如果仍失败，就不该再是上一轮那个 inherited automation debt。
+
+## Claude Code CLI
+
+已确认：
+
+```bash
+claude auth status
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+结果：
+
+- CLI 已登录
+- smoke 调用成功
+
+说明：
+
+- 更长的 review prompt 返回不够稳定
+- 本轮不把交付建立在 CLI 长输出之上
+
+## 待办
+
+- push 当前 merge commit 和这两份 sync 文档
+- 等 GitHub 对 `#877` 重新跑 checks
+- checks 全绿后，由 auto-merge 或 admin merge 收口


### PR DESCRIPTION
## What Changed
- add a focused account banner to  so review items can jump directly into the accounts section
- highlight the focused account, preserve the existing bind draft, and allow quick bind from the focus card
- add a targeted regression spec for review-item focus, scroll, highlight, and quick bind behavior
- record the slice in development and verification docs

## Why
This keeps the next DingTalk directory follow-up small and reviewable. It improves the manual review path without reopening backend API or batch-bind semantics.

## Verification
- 
- 
 RUN  v1.6.1 /private/tmp/metasheet2-dingtalk-directory-focus/apps/web

 ✓ tests/directoryManagementView.spec.ts  (21 tests) 211ms

 Test Files  1 passed (1)
      Tests  21 passed (21)
   Start at  11:11:54
   Duration  671ms (transform 165ms, setup 0ms, collect 192ms, tests 211ms, environment 149ms, prepare 25ms)

## Notes
- verified Claude's earlier async/await and migration-timestamp feedback against current ; those fixes are already present and are not duplicated in this PR.