### PR TITLE
feat(middleware): upgrade rate limiter with Redis support

### DIFF
--- a/packages/core-backend/src/db/redis.ts
+++ b/packages/core-backend/src/db/redis.ts
@@ -1,0 +1,61 @@
+/**
+ * Redis client singleton (ioredis).
+ *
+ * Usage:
+ *   import { getRedisClient } from '../db/redis'
+ *   const redis = await getRedisClient()
+ *
+ * Configuration:
+ *   REDIS_URL  — full connection string (default: redis://localhost:6379)
+ *
+ * The client is lazily created on first call and reused thereafter.
+ * Returns `null` if the REDIS_URL is empty or connection fails, so
+ * callers can gracefully fall back to in-memory alternatives.
+ */
+
+import Redis from 'ioredis'
+
+let client: Redis | null = null
+let connectionAttempted = false
+
+export async function getRedisClient(): Promise<Redis | null> {
+  if (client) return client
+  if (connectionAttempted) return null // already failed once
+
+  const url = process.env.REDIS_URL
+  if (!url) return null
+
+  connectionAttempted = true
+  try {
+    const redis = new Redis(url, {
+      maxRetriesPerRequest: 1,
+      lazyConnect: true,
+      enableReadyCheck: true,
+    })
+
+    redis.on('error', (err) => {
+      console.error('[redis] connection error:', err.message)
+    })
+
+    await redis.connect()
+    client = redis
+    return client
+  } catch (err) {
+    console.warn(
+      '[redis] failed to connect:',
+      err instanceof Error ? err.message : err,
+    )
+    return null
+  }
+}
+
+/**
+ * Disconnect and clear the singleton (useful in tests / graceful shutdown).
+ */
+export async function closeRedisClient(): Promise<void> {
+  if (client) {
+    await client.quit()
+    client = null
+  }
+  connectionAttempted = false
+}

--- a/packages/core-backend/src/middleware/rate-limiter.ts
+++ b/packages/core-backend/src/middleware/rate-limiter.ts
@@ -1,11 +1,132 @@
 /**
- * Generic in-memory sliding-window rate limiter middleware.
+ * Generic sliding-window rate limiter middleware with pluggable store.
  *
- * V1 uses a Map-based store (no Redis dependency).
- * Suitable for single-process deployments; swap store for Redis in V2.
+ * V1 used an in-memory Map.
+ * V2 adds a RateLimitStore interface with Redis and Memory implementations.
+ * If a Redis store is provided but becomes unavailable, the middleware
+ * falls back to the in-memory store automatically.
  */
 
 import type { Request, Response, NextFunction } from 'express'
+
+// ---------------------------------------------------------------------------
+// Store interface
+// ---------------------------------------------------------------------------
+
+export interface RateLimitStore {
+  /**
+   * Increment the counter for `key` within the given window.
+   * Returns the current count and remaining TTL in milliseconds.
+   * Implementations must create the key with the given windowMs if it
+   * does not already exist.
+   */
+  increment(key: string, windowMs: number): Promise<{ count: number; ttlMs: number }>
+
+  /**
+   * Optional cleanup hook (e.g. clear timers).
+   */
+  destroy?(): void
+}
+
+// ---------------------------------------------------------------------------
+// In-memory store (default / fallback)
+// ---------------------------------------------------------------------------
+
+interface MemoryEntry {
+  count: number
+  /** epoch-ms when the window expires */
+  expiresAt: number
+}
+
+export class MemoryRateLimitStore implements RateLimitStore {
+  private store = new Map<string, MemoryEntry>()
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null
+
+  constructor(cleanupIntervalMs?: number) {
+    if (cleanupIntervalMs && cleanupIntervalMs > 0) {
+      this.cleanupTimer = setInterval(() => {
+        const now = Date.now()
+        for (const [key, entry] of this.store.entries()) {
+          if (now >= entry.expiresAt) {
+            this.store.delete(key)
+          }
+        }
+      }, cleanupIntervalMs)
+      if (this.cleanupTimer && typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
+        this.cleanupTimer.unref()
+      }
+    }
+  }
+
+  async increment(key: string, windowMs: number): Promise<{ count: number; ttlMs: number }> {
+    const now = Date.now()
+    let entry = this.store.get(key)
+
+    if (!entry || now >= entry.expiresAt) {
+      entry = { count: 0, expiresAt: now + windowMs }
+      this.store.set(key, entry)
+    }
+
+    entry.count += 1
+    const ttlMs = Math.max(0, entry.expiresAt - now)
+    return { count: entry.count, ttlMs }
+  }
+
+  /** Expose the internal map for testing purposes */
+  get _map(): Map<string, MemoryEntry> {
+    return this.store
+  }
+
+  destroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer)
+      this.cleanupTimer = null
+    }
+    this.store.clear()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Redis store (ioredis compatible)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal ioredis-compatible interface so callers can pass any Redis client
+ * that supports incr + expire + ttl.
+ */
+export interface RedisClient {
+  incr(key: string): Promise<number>
+  expire(key: string, seconds: number): Promise<number | boolean>
+  pttl(key: string): Promise<number>
+}
+
+export class RedisRateLimitStore implements RateLimitStore {
+  private redis: RedisClient
+
+  constructor(redis: RedisClient) {
+    this.redis = redis
+  }
+
+  async increment(key: string, windowMs: number): Promise<{ count: number; ttlMs: number }> {
+    const count = await this.redis.incr(key)
+
+    // If this is the first increment (count === 1), set the expiry.
+    if (count === 1) {
+      const ttlSeconds = Math.max(1, Math.ceil(windowMs / 1000))
+      await this.redis.expire(key, ttlSeconds)
+    }
+
+    const pttl = await this.redis.pttl(key)
+    // pttl returns -1 if no expiry, -2 if key doesn't exist
+    const ttlMs = pttl > 0 ? pttl : windowMs
+
+    return { count, ttlMs }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
 
 export interface RateLimiterOptions {
   /** Time window in milliseconds */
@@ -14,12 +135,14 @@ export interface RateLimiterOptions {
   maxRequests: number
   /** Prefix used to namespace keys (e.g. 'public-form-submit') */
   keyPrefix: string
+  /** Optional Redis client — enables distributed rate limiting.
+   *  If omitted or if Redis operations fail, falls back to in-memory store. */
+  redis?: RedisClient
 }
 
-interface WindowEntry {
-  /** Timestamps (ms) of requests within the current window */
-  timestamps: number[]
-}
+// ---------------------------------------------------------------------------
+// Middleware factory
+// ---------------------------------------------------------------------------
 
 /**
  * Create a rate limiter middleware with the given options.
@@ -28,67 +151,64 @@ interface WindowEntry {
  * - Anonymous requests: keyed by `req.ip`
  * - Authenticated requests: keyed by `(req as any).userId`
  *
- * On-access cleanup: expired entries are pruned every time a key is accessed
- * and a periodic sweep runs every `windowMs` to remove stale entries.
+ * When a Redis client is provided, it is used as the primary store.
+ * If any Redis operation throws, the middleware logs a warning and
+ * transparently falls back to the in-memory store for that request.
  */
 export function createRateLimiter(options: RateLimiterOptions) {
-  const { windowMs, maxRequests, keyPrefix } = options
-  const store = new Map<string, WindowEntry>()
+  const { windowMs, maxRequests, keyPrefix, redis } = options
 
-  // Periodic cleanup of stale entries
-  const cleanupInterval = setInterval(() => {
-    const now = Date.now()
-    for (const [key, entry] of store.entries()) {
-      entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs)
-      if (entry.timestamps.length === 0) {
-        store.delete(key)
-      }
-    }
-  }, windowMs)
+  const memoryStore = new MemoryRateLimitStore(windowMs)
+  const redisStore = redis ? new RedisRateLimitStore(redis) : null
 
-  // Allow the timer to not block Node process exit
-  if (cleanupInterval && typeof cleanupInterval === 'object' && 'unref' in cleanupInterval) {
-    cleanupInterval.unref()
-  }
+  let redisFallbackWarned = false
 
   function middleware(req: Request, res: Response, next: NextFunction): void {
     const userId = (req as any).userId as string | undefined
     const rawKey = userId || req.ip || 'unknown'
-    const key = `${keyPrefix}:${rawKey}`
+    const key = `ratelimit:${keyPrefix}:${rawKey}`
 
-    const now = Date.now()
-    let entry = store.get(key)
-    if (!entry) {
-      entry = { timestamps: [] }
-      store.set(key, entry)
+    const handleResult = (result: { count: number; ttlMs: number }) => {
+      if (result.count > maxRequests) {
+        const retryAfterSeconds = Math.ceil(result.ttlMs / 1000)
+        res.set('Retry-After', String(retryAfterSeconds))
+        res.status(429).json({
+          ok: false,
+          error: {
+            code: 'RATE_LIMITED',
+            message: 'Too many requests. Please try again later.',
+            retryAfter: retryAfterSeconds,
+          },
+        })
+        return
+      }
+
+      next()
     }
 
-    // Prune timestamps outside the current window
-    entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs)
+    const primaryStore = redisStore || memoryStore
 
-    if (entry.timestamps.length >= maxRequests) {
-      const oldestInWindow = entry.timestamps[0]
-      const retryAfterMs = windowMs - (now - oldestInWindow)
-      const retryAfterSeconds = Math.ceil(retryAfterMs / 1000)
-      res.set('Retry-After', String(retryAfterSeconds))
-      res.status(429).json({
-        ok: false,
-        error: {
-          code: 'RATE_LIMITED',
-          message: 'Too many requests. Please try again later.',
-          retryAfter: retryAfterSeconds,
-        },
+    // Synchronous wrapper that handles the async store call
+    primaryStore.increment(key, windowMs).then(handleResult).catch((err) => {
+      // Redis failed — fall back to memory store
+      if (!redisFallbackWarned) {
+        console.warn(
+          `[rate-limiter] Redis unavailable for prefix "${keyPrefix}", falling back to in-memory store:`,
+          err instanceof Error ? err.message : err,
+        )
+        redisFallbackWarned = true
+      }
+      memoryStore.increment(key, windowMs).then(handleResult).catch(() => {
+        // Memory store should never fail, but just in case, let the request through
+        next()
       })
-      return
-    }
-
-    entry.timestamps.push(now)
-    next()
+    })
   }
 
   // Expose internals for testing
-  middleware._store = store
-  middleware._cleanup = () => clearInterval(cleanupInterval)
+  middleware._memoryStore = memoryStore
+  middleware._redisStore = redisStore
+  middleware._cleanup = () => memoryStore.destroy()
 
   return middleware
 }

--- a/packages/core-backend/tests/unit/rate-limiter.test.ts
+++ b/packages/core-backend/tests/unit/rate-limiter.test.ts
@@ -1,6 +1,12 @@
 import type { Request, Response, NextFunction } from 'express'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createRateLimiter, conditionalPublicRateLimiter } from '../../src/middleware/rate-limiter'
+import {
+  createRateLimiter,
+  conditionalPublicRateLimiter,
+  MemoryRateLimitStore,
+  RedisRateLimitStore,
+} from '../../src/middleware/rate-limiter'
+import type { RedisClient } from '../../src/middleware/rate-limiter'
 
 function createMockRequest(overrides: Partial<Request> = {}): Request {
   return {
@@ -32,44 +38,147 @@ function createMockResponse(): Response & { _status: number; _body: unknown; _he
   return res
 }
 
+// ---------------------------------------------------------------------------
+// Helper: run async middleware as a promise
+// ---------------------------------------------------------------------------
+function runMiddleware(
+  mw: (req: Request, res: Response, next: NextFunction) => void,
+  req: Request,
+  res: Response,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    mw(req, res, ((err?: unknown) => {
+      if (err) reject(err)
+      else resolve()
+    }) as NextFunction)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// MemoryRateLimitStore unit tests
+// ---------------------------------------------------------------------------
+
+describe('MemoryRateLimitStore', () => {
+  it('increments count within the same window', async () => {
+    const store = new MemoryRateLimitStore()
+    const r1 = await store.increment('k', 60_000)
+    expect(r1.count).toBe(1)
+    const r2 = await store.increment('k', 60_000)
+    expect(r2.count).toBe(2)
+    store.destroy()
+  })
+
+  it('resets count after window expires', async () => {
+    const originalNow = Date.now
+    let now = 1_000_000
+    Date.now = () => now
+
+    const store = new MemoryRateLimitStore()
+    await store.increment('k', 5_000)
+    await store.increment('k', 5_000)
+    expect((await store.increment('k', 5_000)).count).toBe(3)
+
+    // Advance past window
+    now += 6_000
+    const r = await store.increment('k', 5_000)
+    expect(r.count).toBe(1) // reset
+    store.destroy()
+    Date.now = originalNow
+  })
+
+  it('destroy clears internal state', async () => {
+    const store = new MemoryRateLimitStore(1000)
+    await store.increment('k', 60_000)
+    expect(store._map.size).toBe(1)
+    store.destroy()
+    expect(store._map.size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RedisRateLimitStore unit tests (mocked Redis)
+// ---------------------------------------------------------------------------
+
+describe('RedisRateLimitStore', () => {
+  function createMockRedis(): RedisClient & { _counters: Map<string, number> } {
+    const counters = new Map<string, number>()
+    const ttls = new Map<string, number>()
+    return {
+      _counters: counters,
+      async incr(key: string) {
+        const val = (counters.get(key) || 0) + 1
+        counters.set(key, val)
+        return val
+      },
+      async expire(key: string, seconds: number) {
+        ttls.set(key, seconds * 1000)
+        return 1
+      },
+      async pttl(key: string) {
+        return ttls.get(key) ?? -1
+      },
+    }
+  }
+
+  it('increments via Redis INCR and sets expiry on first call', async () => {
+    const redis = createMockRedis()
+    const store = new RedisRateLimitStore(redis)
+    const r1 = await store.increment('ratelimit:test:1.1.1.1', 60_000)
+    expect(r1.count).toBe(1)
+    expect(r1.ttlMs).toBe(60_000)
+
+    const r2 = await store.increment('ratelimit:test:1.1.1.1', 60_000)
+    expect(r2.count).toBe(2)
+  })
+
+  it('does not reset expiry on subsequent increments', async () => {
+    const redis = createMockRedis()
+    const expireSpy = vi.spyOn(redis, 'expire')
+    const store = new RedisRateLimitStore(redis)
+
+    await store.increment('k', 30_000)
+    expect(expireSpy).toHaveBeenCalledTimes(1)
+
+    await store.increment('k', 30_000)
+    // expire should NOT be called again (count > 1)
+    expect(expireSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createRateLimiter middleware tests (memory-backed, same as V1)
+// ---------------------------------------------------------------------------
+
 describe('createRateLimiter', () => {
-  let originalDateNow: () => number
-
-  beforeEach(() => {
-    originalDateNow = Date.now
-  })
-
-  afterEach(() => {
-    Date.now = originalDateNow
-  })
-
-  it('allows requests within the limit', () => {
+  it('allows requests within the limit', async () => {
     const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 3, keyPrefix: 'test' })
-    const next = vi.fn()
 
     for (let i = 0; i < 3; i++) {
       const req = createMockRequest()
       const res = createMockResponse()
-      limiter(req, res, next)
+      await runMiddleware(limiter, req, res)
+      expect(res._status).toBe(200)
     }
 
-    expect(next).toHaveBeenCalledTimes(3)
     limiter._cleanup()
   })
 
-  it('blocks requests exceeding the limit with 429', () => {
+  it('blocks requests exceeding the limit with 429', async () => {
     const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 2, keyPrefix: 'test' })
-    const next = vi.fn()
 
     // First two should pass
-    limiter(createMockRequest(), createMockResponse(), next)
-    limiter(createMockRequest(), createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(2)
+    await runMiddleware(limiter, createMockRequest(), createMockResponse())
+    await runMiddleware(limiter, createMockRequest(), createMockResponse())
 
     // Third should be blocked
     const res = createMockResponse()
-    limiter(createMockRequest(), res, next)
-    expect(next).toHaveBeenCalledTimes(2) // not called again
+    // The middleware calls res.status().json() and does NOT call next, so
+    // we need to handle the case where next is never called.
+    await new Promise<void>((resolve) => {
+      limiter(createMockRequest(), res as any, (() => resolve()) as NextFunction)
+      // If next isn't called within a tick, the request was blocked
+      setTimeout(resolve, 50)
+    })
     expect(res._status).toBe(429)
     expect(res._body).toMatchObject({
       ok: false,
@@ -80,155 +189,216 @@ describe('createRateLimiter', () => {
     limiter._cleanup()
   })
 
-  it('resets after window expires', () => {
-    let now = 1000000
+  it('resets after window expires', async () => {
+    const originalNow = Date.now
+    let now = 1_000_000
     Date.now = () => now
 
     const limiter = createRateLimiter({ windowMs: 10_000, maxRequests: 1, keyPrefix: 'test' })
-    const next = vi.fn()
 
     // First request passes
-    limiter(createMockRequest(), createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(1)
+    await runMiddleware(limiter, createMockRequest(), createMockResponse())
 
     // Second is blocked
-    limiter(createMockRequest(), createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(1)
+    const blockedRes = createMockResponse()
+    await new Promise<void>((resolve) => {
+      limiter(createMockRequest(), blockedRes as any, (() => resolve()) as NextFunction)
+      setTimeout(resolve, 50)
+    })
+    expect(blockedRes._status).toBe(429)
 
     // Advance time past window
     now += 10_001
-    limiter(createMockRequest(), createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(2) // passes again
+    const passRes = createMockResponse()
+    await runMiddleware(limiter, createMockRequest(), passRes)
+    expect(passRes._status).toBe(200)
+
     limiter._cleanup()
+    Date.now = originalNow
   })
 
-  it('different keys do not interfere', () => {
+  it('different keys do not interfere', async () => {
     const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 1, keyPrefix: 'test' })
-    const next = vi.fn()
 
     // IP 1
-    limiter(createMockRequest({ ip: '1.1.1.1' } as any), createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(1)
+    await runMiddleware(limiter, createMockRequest({ ip: '1.1.1.1' } as any), createMockResponse())
 
     // IP 1 blocked
     const res1 = createMockResponse()
-    limiter(createMockRequest({ ip: '1.1.1.1' } as any), res1, next)
+    await new Promise<void>((resolve) => {
+      limiter(createMockRequest({ ip: '1.1.1.1' } as any), res1 as any, (() => resolve()) as NextFunction)
+      setTimeout(resolve, 50)
+    })
     expect(res1._status).toBe(429)
 
     // IP 2 still passes
-    limiter(createMockRequest({ ip: '2.2.2.2' } as any), createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(2)
+    const res2 = createMockResponse()
+    await runMiddleware(limiter, createMockRequest({ ip: '2.2.2.2' } as any), res2)
+    expect(res2._status).toBe(200)
+
     limiter._cleanup()
   })
 
-  it('cleanup removes expired entries', () => {
-    let now = 1000000
-    Date.now = () => now
-
-    const limiter = createRateLimiter({ windowMs: 5_000, maxRequests: 10, keyPrefix: 'test' })
-    const next = vi.fn()
-
-    limiter(createMockRequest({ ip: '1.1.1.1' } as any), createMockResponse(), next)
-    limiter(createMockRequest({ ip: '2.2.2.2' } as any), createMockResponse(), next)
-    expect(limiter._store.size).toBe(2)
-
-    // Advance past window
-    now += 6_000
-
-    // Access one key to trigger on-access prune, but the periodic cleanup
-    // would also clean up. Trigger access for IP 1 only.
-    limiter(createMockRequest({ ip: '1.1.1.1' } as any), createMockResponse(), next)
-
-    // IP 1 was re-accessed so it stays. IP 2 entry still exists in map
-    // but its timestamps are stale. Verify the store prunes on next access.
-    const entry2 = limiter._store.get('test:2.2.2.2')
-    // The periodic cleanup hasn't fired yet, but on next access for IP 2 it would prune.
-    // Let's just verify that a fresh request from IP 2 now succeeds (proves window reset).
-    limiter(createMockRequest({ ip: '2.2.2.2' } as any), createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(4) // all passed
-    limiter._cleanup()
-  })
-
-  it('uses userId as key when available', () => {
+  it('uses userId as key when available', async () => {
     const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 1, keyPrefix: 'test' })
-    const next = vi.fn()
 
     const authReq = createMockRequest({ ip: '1.1.1.1' } as any)
     ;(authReq as any).userId = 'user-123'
-
-    limiter(authReq, createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(1)
+    await runMiddleware(limiter, authReq, createMockResponse())
 
     // Same userId from different IP should be blocked
     const authReq2 = createMockRequest({ ip: '2.2.2.2' } as any)
     ;(authReq2 as any).userId = 'user-123'
     const res = createMockResponse()
-    limiter(authReq2, res, next)
+    await new Promise<void>((resolve) => {
+      limiter(authReq2, res as any, (() => resolve()) as NextFunction)
+      setTimeout(resolve, 50)
+    })
     expect(res._status).toBe(429)
 
     // Different IP without userId should pass
-    limiter(createMockRequest({ ip: '3.3.3.3' } as any), createMockResponse(), next)
-    expect(next).toHaveBeenCalledTimes(2)
+    const res3 = createMockResponse()
+    await runMiddleware(limiter, createMockRequest({ ip: '3.3.3.3' } as any), res3)
+    expect(res3._status).toBe(200)
+
     limiter._cleanup()
   })
 })
 
+// ---------------------------------------------------------------------------
+// Redis-backed createRateLimiter tests
+// ---------------------------------------------------------------------------
+
+describe('createRateLimiter with Redis', () => {
+  function createMockRedis(): RedisClient & { _counters: Map<string, number> } {
+    const counters = new Map<string, number>()
+    const ttls = new Map<string, number>()
+    return {
+      _counters: counters,
+      async incr(key: string) {
+        const val = (counters.get(key) || 0) + 1
+        counters.set(key, val)
+        return val
+      },
+      async expire(key: string, seconds: number) {
+        ttls.set(key, seconds * 1000)
+        return 1
+      },
+      async pttl(key: string) {
+        return ttls.get(key) ?? -1
+      },
+    }
+  }
+
+  it('uses Redis store when redis option is provided', async () => {
+    const redis = createMockRedis()
+    const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 2, keyPrefix: 'redis-test', redis })
+
+    expect(limiter._redisStore).not.toBeNull()
+
+    await runMiddleware(limiter, createMockRequest(), createMockResponse())
+    await runMiddleware(limiter, createMockRequest(), createMockResponse())
+
+    // Should have 2 entries in Redis mock
+    expect(redis._counters.get('ratelimit:redis-test:127.0.0.1')).toBe(2)
+
+    limiter._cleanup()
+  })
+
+  it('falls back to memory when Redis throws', async () => {
+    const failingRedis: RedisClient = {
+      async incr() { throw new Error('Connection refused') },
+      async expire() { throw new Error('Connection refused') },
+      async pttl() { throw new Error('Connection refused') },
+    }
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 2, keyPrefix: 'fallback', redis: failingRedis })
+
+    // Should still work via memory fallback
+    await runMiddleware(limiter, createMockRequest(), createMockResponse())
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('Redis unavailable')
+
+    // Second call should not warn again
+    await runMiddleware(limiter, createMockRequest(), createMockResponse())
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+
+    // Third should be blocked (memory store has count 2 now, limit is 2)
+    const res = createMockResponse()
+    await new Promise<void>((resolve) => {
+      limiter(createMockRequest(), res as any, (() => resolve()) as NextFunction)
+      setTimeout(resolve, 50)
+    })
+    expect(res._status).toBe(429)
+
+    warnSpy.mockRestore()
+    limiter._cleanup()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// conditionalPublicRateLimiter tests
+// ---------------------------------------------------------------------------
+
 describe('conditionalPublicRateLimiter', () => {
-  it('applies rate limiter when publicToken is in query', () => {
+  it('applies rate limiter when publicToken is in query', async () => {
     const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 1, keyPrefix: 'cond' })
     const conditional = conditionalPublicRateLimiter(limiter)
-    const next = vi.fn()
 
     // First request with publicToken passes
-    conditional(
+    await runMiddleware(
+      conditional,
       createMockRequest({ query: { publicToken: 'abc123' } } as any),
       createMockResponse(),
-      next,
     )
-    expect(next).toHaveBeenCalledTimes(1)
 
     // Second is blocked
     const res = createMockResponse()
-    conditional(
-      createMockRequest({ query: { publicToken: 'abc123' } } as any),
-      res,
-      next,
-    )
+    await new Promise<void>((resolve) => {
+      conditional(
+        createMockRequest({ query: { publicToken: 'abc123' } } as any),
+        res as any,
+        (() => resolve()) as NextFunction,
+      )
+      setTimeout(resolve, 50)
+    })
     expect(res._status).toBe(429)
     limiter._cleanup()
   })
 
-  it('skips rate limiter when no publicToken', () => {
+  it('skips rate limiter when no publicToken', async () => {
     const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 1, keyPrefix: 'cond' })
     const conditional = conditionalPublicRateLimiter(limiter)
-    const next = vi.fn()
 
     // Multiple requests without publicToken should all pass
     for (let i = 0; i < 5; i++) {
-      conditional(createMockRequest(), createMockResponse(), next)
+      await runMiddleware(conditional, createMockRequest(), createMockResponse())
     }
-    expect(next).toHaveBeenCalledTimes(5)
+
     limiter._cleanup()
   })
 
-  it('applies rate limiter when publicToken is in body', () => {
+  it('applies rate limiter when publicToken is in body', async () => {
     const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 1, keyPrefix: 'cond-body' })
     const conditional = conditionalPublicRateLimiter(limiter)
-    const next = vi.fn()
 
-    conditional(
+    await runMiddleware(
+      conditional,
       createMockRequest({ body: { publicToken: 'token123' } } as any),
       createMockResponse(),
-      next,
     )
-    expect(next).toHaveBeenCalledTimes(1)
 
     const res = createMockResponse()
-    conditional(
-      createMockRequest({ body: { publicToken: 'token123' } } as any),
-      res,
-      next,
-    )
+    await new Promise<void>((resolve) => {
+      conditional(
+        createMockRequest({ body: { publicToken: 'token123' } } as any),
+        res as any,
+        (() => resolve()) as NextFunction,
+      )
+      setTimeout(resolve, 50)
+    })
     expect(res._status).toBe(429)
     limiter._cleanup()
   })


### PR DESCRIPTION
## Summary
- Refactor `packages/core-backend/src/middleware/rate-limiter.ts` from a hard-coded in-memory Map to a pluggable `RateLimitStore` interface with `MemoryRateLimitStore` (default) and `RedisRateLimitStore` (ioredis INCR+EXPIRE pattern)
- `createRateLimiter` accepts an optional `redis` client; on Redis failure it transparently falls back to in-memory with a console warning
- Add reusable ioredis singleton at `packages/core-backend/src/db/redis.ts` for shared Redis access
- Expand test suite from 8 to 15 tests covering both store implementations and fallback behavior

## Test plan
- [x] All 15 unit tests pass (`vitest run packages/core-backend/tests/unit/rate-limiter.test.ts`)
- [ ] Verify existing consumers (`univer-meta.ts` imports) still compile
- [ ] Integration test with real Redis (set `REDIS_URL` env var, pass client to `createRateLimiter`)
- [ ] Verify graceful fallback: stop Redis mid-traffic, confirm requests continue via memory store

🤖 Generated with [Claude Code](https://claude.com/claude-code)