### PR TITLE
feat(multitable): persist automation rules to PostgreSQL

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260414100000_extend_automation_rules.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260414100000_extend_automation_rules.ts
@@ -1,0 +1,88 @@
+/**
+ * Migration: Extend automation_rules table with V1 columns
+ *
+ * Purpose: Add conditions (JSONB) and actions (JSONB) columns, relax CHECK constraints
+ *          to support new trigger/action types from the V1 automation system.
+ * Tables: automation_rules (alter)
+ * Breaking: No
+ */
+
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { addColumnIfNotExists, checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const tableExists = await checkTableExists(db, 'automation_rules')
+  if (!tableExists) {
+    console.log('[Migration] automation_rules table does not exist — skipping extension')
+    return
+  }
+
+  console.log('[Migration] Extending automation_rules with V1 columns')
+
+  // Add conditions column (JSONB, nullable)
+  await addColumnIfNotExists(db, 'automation_rules', 'conditions', 'jsonb')
+
+  // Add actions column (JSONB array, nullable)
+  await addColumnIfNotExists(db, 'automation_rules', 'actions', 'jsonb')
+
+  // Drop overly-restrictive CHECK constraints and replace with broader ones
+  await sql`
+    ALTER TABLE automation_rules
+    DROP CONSTRAINT IF EXISTS chk_automation_trigger_type
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE automation_rules
+    DROP CONSTRAINT IF EXISTS chk_automation_action_type
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval',
+      'webhook.received'
+    ))
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (
+      'notify', 'update_field',
+      'update_record', 'create_record',
+      'send_webhook', 'send_notification', 'lock_record'
+    ))
+  `.execute(db)
+
+  console.log('[Migration] Extension completed successfully')
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  console.log('[Migration] Rolling back automation_rules extension')
+
+  // Drop expanded constraints and re-add original narrow ones
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN ('record.created', 'record.updated', 'field.changed'))
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN ('notify', 'update_field'))
+  `.execute(db)
+
+  // Drop added columns
+  await sql`ALTER TABLE automation_rules DROP COLUMN IF EXISTS conditions`.execute(db)
+  await sql`ALTER TABLE automation_rules DROP COLUMN IF EXISTS actions`.execute(db)
+
+  console.log('[Migration] Rollback completed')
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -102,6 +102,7 @@ export interface Database {
   meta_dashboards: MetaDashboardsTable
   meta_widgets: MetaWidgetsTable
   // Multitable automation & dashboard
+  automation_rules: AutomationRulesTable
   multitable_automation_executions: MultitableAutomationExecutionsTable
   multitable_charts: MultitableChartsTable
   multitable_dashboards: MultitableDashboardsTable
@@ -1194,6 +1195,22 @@ export interface AttendancePayrollCyclesTable {
 // ============================================
 // Multitable Automation & Dashboard Tables
 // ============================================
+
+export interface AutomationRulesTable {
+  id: string
+  sheet_id: string
+  name: string | null
+  trigger_type: string
+  trigger_config: JSONColumnType<Record<string, unknown>>
+  action_type: string
+  action_config: JSONColumnType<Record<string, unknown>>
+  enabled: boolean
+  created_at: CreatedAt
+  updated_at: UpdatedAt
+  created_by: string | null
+  conditions: JSONColumnType<Record<string, unknown> | null>
+  actions: JSONColumnType<Record<string, unknown>[] | null>
+}
 
 export interface MultitableAutomationExecutionsTable {
   id: string

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1617,8 +1617,10 @@ export class MetaSheetServer {
     // Initialize AutomationService
     try {
       const pool = poolManager.get()
-      this.automationService = new AutomationService(eventBus, pool.query.bind(pool))
+      const { db: kyselyDb } = await import('./db/db')
+      this.automationService = new AutomationService(eventBus, kyselyDb, pool.query.bind(pool))
       this.automationService.init()
+      await this.automationService.loadAndRegisterAllScheduled()
       this.logger.info('AutomationService initialized')
     } catch (e) {
       this.logger.error('AutomationService initialization failed; continuing in degraded mode', e as Error)

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1,5 +1,6 @@
+import { randomUUID } from 'crypto'
+import type { Kysely } from 'kysely'
 import type { EventBus } from '../integration/events/event-bus'
-import { patchRecord, type MultitableRecordsQueryFn } from './records'
 import { Logger } from '../core/logger'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, type AutomationTriggerType } from './automation-triggers'
 import type { ConditionGroup } from './automation-conditions'
@@ -8,6 +9,7 @@ import type { AutomationAction } from './automation-actions'
 import type { AutomationTrigger } from './automation-triggers'
 import { AutomationScheduler } from './automation-scheduler'
 import { AutomationLogService } from './automation-log-service'
+import type { Database } from '../db/types'
 
 const logger = new Logger('AutomationService')
 
@@ -60,6 +62,31 @@ export type AutomationEventPayload = {
   _triggeredBy?: string
 }
 
+/** Input for creating a rule */
+export interface CreateRuleInput {
+  name?: string | null
+  triggerType: string
+  triggerConfig?: Record<string, unknown>
+  actionType: string
+  actionConfig?: Record<string, unknown>
+  enabled?: boolean
+  createdBy?: string | null
+  conditions?: ConditionGroup | null
+  actions?: AutomationAction[] | null
+}
+
+/** Input for updating a rule */
+export interface UpdateRuleInput {
+  name?: string | null
+  triggerType?: string
+  triggerConfig?: Record<string, unknown>
+  actionType?: string
+  actionConfig?: Record<string, unknown>
+  enabled?: boolean
+  conditions?: ConditionGroup | null
+  actions?: AutomationAction[] | null
+}
+
 /**
  * Convert a legacy DB rule to the executor rule format.
  */
@@ -91,19 +118,22 @@ function toExecutorRule(rule: AutomationRule): ExecutorRule {
 
 export class AutomationService {
   private eventBus: EventBus
-  private query: AutomationQueryFn
+  private db: Kysely<Database>
   private subscriptionIds: string[] = []
   private executor: AutomationExecutor
   private scheduler: AutomationScheduler
   private logService: AutomationLogService
+  /** Kept for backward-compat with raw SQL in executor actions */
+  private queryFn: AutomationQueryFn
 
-  constructor(eventBus: EventBus, query: AutomationQueryFn, fetchFn?: typeof fetch) {
+  constructor(eventBus: EventBus, db: Kysely<Database>, queryFn: AutomationQueryFn, fetchFn?: typeof fetch) {
     this.eventBus = eventBus
-    this.query = query
+    this.db = db
+    this.queryFn = queryFn
 
     const deps: AutomationDeps = {
       eventBus,
-      queryFn: query,
+      queryFn,
       fetchFn,
     }
     this.executor = new AutomationExecutor(deps)
@@ -145,6 +175,165 @@ export class AutomationService {
     logger.info('AutomationService initialized (V1)')
   }
 
+  // ── Rule CRUD (Kysely) ──────────────────────────────────────────────────
+
+  /**
+   * Create a new automation rule persisted to PostgreSQL.
+   */
+  async createRule(sheetId: string, input: CreateRuleInput): Promise<AutomationRule> {
+    const ruleId = `atr_${randomUUID()}`
+    const now = new Date().toISOString()
+
+    const row = {
+      id: ruleId,
+      sheet_id: sheetId,
+      name: input.name ?? null,
+      trigger_type: input.triggerType,
+      trigger_config: JSON.stringify(input.triggerConfig ?? {}),
+      action_type: input.actionType,
+      action_config: JSON.stringify(input.actionConfig ?? {}),
+      enabled: input.enabled ?? true,
+      created_by: input.createdBy ?? null,
+      conditions: input.conditions ? JSON.stringify(input.conditions) : null,
+      actions: input.actions ? JSON.stringify(input.actions) : null,
+    }
+
+    await this.db
+      .insertInto('automation_rules')
+      .values(row as never)
+      .execute()
+
+    const rule: AutomationRule = {
+      id: ruleId,
+      sheet_id: sheetId,
+      name: input.name ?? null,
+      trigger_type: input.triggerType,
+      trigger_config: input.triggerConfig ?? {},
+      action_type: input.actionType,
+      action_config: input.actionConfig ?? {},
+      enabled: input.enabled ?? true,
+      created_at: now,
+      updated_at: now,
+      created_by: input.createdBy ?? null,
+      conditions: input.conditions ?? null,
+      actions: input.actions ?? null,
+    }
+
+    this.registerSchedule(rule)
+    return rule
+  }
+
+  /**
+   * Get a single automation rule by ID.
+   */
+  async getRule(ruleId: string): Promise<AutomationRule | null> {
+    const row = await this.db
+      .selectFrom('automation_rules')
+      .selectAll()
+      .where('id', '=', ruleId)
+      .executeTakeFirst()
+
+    if (!row) return null
+    return this.mapRow(row)
+  }
+
+  /**
+   * List all automation rules for a sheet.
+   */
+  async listRules(sheetId: string): Promise<AutomationRule[]> {
+    const rows = await this.db
+      .selectFrom('automation_rules')
+      .selectAll()
+      .where('sheet_id', '=', sheetId)
+      .orderBy('created_at', 'asc')
+      .execute()
+
+    return rows.map((r) => this.mapRow(r))
+  }
+
+  /**
+   * Update an existing automation rule.
+   * Returns the updated rule, or null if not found.
+   */
+  async updateRule(ruleId: string, sheetId: string, input: UpdateRuleInput): Promise<AutomationRule | null> {
+    const updates: Record<string, unknown> = {}
+
+    if (input.name !== undefined) updates.name = input.name
+    if (input.triggerType !== undefined) updates.trigger_type = input.triggerType
+    if (input.triggerConfig !== undefined) updates.trigger_config = JSON.stringify(input.triggerConfig)
+    if (input.actionType !== undefined) updates.action_type = input.actionType
+    if (input.actionConfig !== undefined) updates.action_config = JSON.stringify(input.actionConfig)
+    if (input.enabled !== undefined) updates.enabled = input.enabled
+    if (input.conditions !== undefined) updates.conditions = input.conditions ? JSON.stringify(input.conditions) : null
+    if (input.actions !== undefined) updates.actions = input.actions ? JSON.stringify(input.actions) : null
+
+    if (Object.keys(updates).length === 0) return this.getRule(ruleId)
+
+    updates.updated_at = new Date().toISOString()
+
+    const result = await this.db
+      .updateTable('automation_rules')
+      .set(updates as never)
+      .where('id', '=', ruleId)
+      .where('sheet_id', '=', sheetId)
+      .returningAll()
+      .execute()
+
+    if (result.length === 0) return null
+
+    const rule = this.mapRow(result[0])
+
+    // Re-register with scheduler if trigger changed
+    this.unregisterSchedule(ruleId)
+    if (rule.enabled) this.registerSchedule(rule)
+
+    return rule
+  }
+
+  /**
+   * Delete an automation rule.
+   * Returns true if deleted, false if not found.
+   */
+  async deleteRule(ruleId: string, sheetId: string): Promise<boolean> {
+    const result = await this.db
+      .deleteFrom('automation_rules')
+      .where('id', '=', ruleId)
+      .where('sheet_id', '=', sheetId)
+      .execute()
+
+    const deleted = result.length > 0 && Number(result[0].numDeletedRows) > 0
+    if (deleted) {
+      this.unregisterSchedule(ruleId)
+    }
+    return deleted
+  }
+
+  /**
+   * Enable or disable a rule.
+   */
+  async setRuleEnabled(ruleId: string, enabled: boolean): Promise<AutomationRule | null> {
+    const result = await this.db
+      .updateTable('automation_rules')
+      .set({ enabled, updated_at: new Date().toISOString() } as never)
+      .where('id', '=', ruleId)
+      .returningAll()
+      .execute()
+
+    if (result.length === 0) return null
+
+    const rule = this.mapRow(result[0])
+
+    if (enabled) {
+      this.registerSchedule(rule)
+    } else {
+      this.unregisterSchedule(ruleId)
+    }
+
+    return rule
+  }
+
+  // ── Schedule registration ───────────────────────────────────────────────
+
   /**
    * Register all scheduled rules from a given sheet.
    */
@@ -154,6 +343,28 @@ export class AutomationService {
       if (rule.trigger_type === 'schedule.cron' || rule.trigger_type === 'schedule.interval') {
         this.scheduler.register(toExecutorRule(rule))
       }
+    }
+  }
+
+  /**
+   * Load all enabled rules across all sheets and register scheduled ones.
+   * Called on startup.
+   */
+  async loadAndRegisterAllScheduled(): Promise<void> {
+    const rows = await this.db
+      .selectFrom('automation_rules')
+      .selectAll()
+      .where('enabled', '=', true)
+      .where('trigger_type', 'in', ['schedule.cron', 'schedule.interval'])
+      .execute()
+
+    for (const row of rows) {
+      const rule = this.mapRow(row)
+      this.scheduler.register(toExecutorRule(rule))
+    }
+
+    if (rows.length > 0) {
+      logger.info(`Registered ${rows.length} scheduled automation rule(s) on startup`)
     }
   }
 
@@ -228,9 +439,8 @@ export class AutomationService {
    * Manual test run: execute a rule immediately with synthetic event.
    */
   async testRun(ruleId: string, sheetId: string): Promise<AutomationExecution> {
-    const rules = await this.loadEnabledRules(sheetId)
-    const rule = rules.find((r) => r.id === ruleId)
-    if (!rule) {
+    const rule = await this.getRule(ruleId)
+    if (!rule || !rule.enabled) {
       throw new Error(`Rule ${ruleId} not found or not enabled`)
     }
     const execRule = toExecutorRule(rule)
@@ -244,14 +454,38 @@ export class AutomationService {
     return this.executeRule(execRule, syntheticEvent)
   }
 
+  /**
+   * Load enabled rules for a sheet (Kysely).
+   */
   async loadEnabledRules(sheetId: string): Promise<AutomationRule[]> {
-    const result = await this.query(
-      `SELECT id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_at, updated_at, created_by, conditions, actions
-       FROM automation_rules
-       WHERE sheet_id = $1 AND enabled = true
-       ORDER BY created_at ASC`,
-      [sheetId],
-    )
-    return result.rows as AutomationRule[]
+    const rows = await this.db
+      .selectFrom('automation_rules')
+      .selectAll()
+      .where('sheet_id', '=', sheetId)
+      .where('enabled', '=', true)
+      .orderBy('created_at', 'asc')
+      .execute()
+
+    return rows.map((r) => this.mapRow(r))
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────
+
+  private mapRow(row: Record<string, unknown>): AutomationRule {
+    return {
+      id: row.id as string,
+      sheet_id: row.sheet_id as string,
+      name: (row.name as string) ?? null,
+      trigger_type: row.trigger_type as string,
+      trigger_config: (row.trigger_config as Record<string, unknown>) ?? {},
+      action_type: row.action_type as string,
+      action_config: (row.action_config as Record<string, unknown>) ?? {},
+      enabled: row.enabled as boolean,
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at ?? ''),
+      updated_at: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at ?? ''),
+      created_by: (row.created_by as string) ?? null,
+      conditions: (row.conditions as ConditionGroup) ?? null,
+      actions: (row.actions as AutomationAction[]) ?? null,
+    }
   }
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import { Router } from 'express'
 import { z } from 'zod'
 import { poolManager } from '../integration/db/connection-pool'
+import { db as kyselyDb } from '../db/db'
 import { eventBus } from '../integration/events/event-bus'
 import {
   deriveFieldPermissions,
@@ -7633,14 +7634,14 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageAutomation) return sendForbidden(res)
 
-      const result = await pool.query(
-        `SELECT id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_at, updated_at, created_by
-         FROM automation_rules
-         WHERE sheet_id = $1
-         ORDER BY created_at ASC`,
-        [sheetId],
-      )
-      return res.json({ ok: true, data: { rules: result.rows } })
+      const rules = await kyselyDb
+        .selectFrom('automation_rules')
+        .selectAll()
+        .where('sheet_id', '=', sheetId)
+        .orderBy('created_at', 'asc')
+        .execute()
+
+      return res.json({ ok: true, data: { rules } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -7664,13 +7665,13 @@ export function univerMetaRouter(): Router {
       const body = req.body as Record<string, unknown> | undefined
       const name = typeof body?.name === 'string' ? body.name : null
       const triggerType = typeof body?.triggerType === 'string' ? body.triggerType : ''
-      const triggerConfig = (body?.triggerConfig && typeof body.triggerConfig === 'object') ? body.triggerConfig : {}
+      const triggerConfig = (body?.triggerConfig && typeof body.triggerConfig === 'object') ? body.triggerConfig as Record<string, unknown> : {}
       const actionType = typeof body?.actionType === 'string' ? body.actionType : ''
-      const actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig : {}
+      const actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig as Record<string, unknown> : {}
       const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
 
-      const validTriggers = new Set(['record.created', 'record.updated', 'field.changed'])
-      const validActions = new Set(['notify', 'update_field'])
+      const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
+      const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'lock_record'])
       if (!validTriggers.has(triggerType)) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid trigger_type: ${triggerType}` } })
       }
@@ -7679,11 +7680,25 @@ export function univerMetaRouter(): Router {
       }
 
       const ruleId = `atr_${randomUUID()}`
-      await pool.query(
-        `INSERT INTO automation_rules (id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_by)
-         VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, $8, $9)`,
-        [ruleId, sheetId, name, triggerType, JSON.stringify(triggerConfig), actionType, JSON.stringify(actionConfig), enabled, access.userId],
-      )
+      const conditions = body?.conditions && typeof body.conditions === 'object' ? body.conditions : null
+      const actions = Array.isArray(body?.actions) ? body.actions : null
+
+      await kyselyDb
+        .insertInto('automation_rules')
+        .values({
+          id: ruleId,
+          sheet_id: sheetId,
+          name,
+          trigger_type: triggerType,
+          trigger_config: JSON.stringify(triggerConfig),
+          action_type: actionType,
+          action_config: JSON.stringify(actionConfig),
+          enabled,
+          created_by: access.userId,
+          conditions: conditions ? JSON.stringify(conditions) : null,
+          actions: actions ? JSON.stringify(actions) : null,
+        } as never)
+        .execute()
 
       return res.json({
         ok: true,
@@ -7711,59 +7726,56 @@ export function univerMetaRouter(): Router {
       if (!capabilities.canManageAutomation) return sendForbidden(res)
 
       const body = req.body as Record<string, unknown> | undefined
-      const sets: string[] = []
-      const params: unknown[] = []
-      let paramIdx = 1
+      const updates: Record<string, unknown> = {}
 
-      if (typeof body?.name === 'string') {
-        sets.push(`name = $${paramIdx++}`)
-        params.push(body.name)
-      }
+      if (typeof body?.name === 'string') updates.name = body.name
       if (typeof body?.triggerType === 'string') {
-        const validTriggers = new Set(['record.created', 'record.updated', 'field.changed'])
+        const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
         if (!validTriggers.has(body.triggerType)) {
           return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid trigger_type: ${body.triggerType}` } })
         }
-        sets.push(`trigger_type = $${paramIdx++}`)
-        params.push(body.triggerType)
+        updates.trigger_type = body.triggerType
       }
       if (body?.triggerConfig && typeof body.triggerConfig === 'object') {
-        sets.push(`trigger_config = $${paramIdx++}::jsonb`)
-        params.push(JSON.stringify(body.triggerConfig))
+        updates.trigger_config = JSON.stringify(body.triggerConfig)
       }
       if (typeof body?.actionType === 'string') {
-        const validActions = new Set(['notify', 'update_field'])
+        const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'lock_record'])
         if (!validActions.has(body.actionType)) {
           return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid action_type: ${body.actionType}` } })
         }
-        sets.push(`action_type = $${paramIdx++}`)
-        params.push(body.actionType)
+        updates.action_type = body.actionType
       }
       if (body?.actionConfig && typeof body.actionConfig === 'object') {
-        sets.push(`action_config = $${paramIdx++}::jsonb`)
-        params.push(JSON.stringify(body.actionConfig))
+        updates.action_config = JSON.stringify(body.actionConfig)
       }
-      if (typeof body?.enabled === 'boolean') {
-        sets.push(`enabled = $${paramIdx++}`)
-        params.push(body.enabled)
+      if (typeof body?.enabled === 'boolean') updates.enabled = body.enabled
+      if (body?.conditions !== undefined) {
+        updates.conditions = body.conditions ? JSON.stringify(body.conditions) : null
+      }
+      if (body?.actions !== undefined) {
+        updates.actions = Array.isArray(body.actions) ? JSON.stringify(body.actions) : null
       }
 
-      if (sets.length === 0) {
+      if (Object.keys(updates).length === 0) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'No fields to update' } })
       }
 
-      sets.push(`updated_at = NOW()`)
-      params.push(ruleId, sheetId)
-      const result = await pool.query(
-        `UPDATE automation_rules SET ${sets.join(', ')} WHERE id = $${paramIdx++} AND sheet_id = $${paramIdx++} RETURNING *`,
-        params,
-      )
+      updates.updated_at = new Date().toISOString()
 
-      if ((result.rowCount ?? 0) === 0) {
+      const result = await kyselyDb
+        .updateTable('automation_rules')
+        .set(updates as never)
+        .where('id', '=', ruleId)
+        .where('sheet_id', '=', sheetId)
+        .returningAll()
+        .execute()
+
+      if (result.length === 0) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 
-      return res.json({ ok: true, data: { rule: result.rows[0] } })
+      return res.json({ ok: true, data: { rule: result[0] } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -7783,12 +7795,13 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageAutomation) return sendForbidden(res)
 
-      const result = await pool.query(
-        'DELETE FROM automation_rules WHERE id = $1 AND sheet_id = $2',
-        [ruleId, sheetId],
-      )
+      const result = await kyselyDb
+        .deleteFrom('automation_rules')
+        .where('id', '=', ruleId)
+        .where('sheet_id', '=', sheetId)
+        .execute()
 
-      if ((result.rowCount ?? 0) === 0) {
+      if (result.length === 0 || Number(result[0].numDeletedRows) === 0) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -33,6 +33,11 @@ function makeChain(): Record<string, unknown> {
   return self
 }
 
+const mockDb: Record<string, unknown> = {}
+for (const m of ['selectFrom', 'insertInto', 'updateTable', 'deleteFrom']) {
+  mockDb[m] = vi.fn(() => makeChain())
+}
+
 vi.mock('../../src/db/db', () => {
   const rootChain: Record<string, unknown> = {}
   for (const m of ['selectFrom', 'insertInto', 'updateTable', 'deleteFrom']) {
@@ -42,6 +47,7 @@ vi.mock('../../src/db/db', () => {
 })
 
 import { AutomationLogService } from '../../src/multitable/automation-log-service'
+import { AutomationService } from '../../src/multitable/automation-service'
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -711,5 +717,188 @@ describe('AutomationLogService', () => {
     _executeTakeFirstResults.push({ numDeletedRows: BigInt(5) })
     const count = await logService.cleanup(30)
     expect(count).toBe(5)
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════
+// AutomationService — Kysely-backed rule CRUD
+// ═════════════════════════════════════════════════════════════════════════
+
+describe('AutomationService — Rule CRUD', () => {
+  let service: AutomationService
+  let eventBus: EventBus
+  let queryFn: ReturnType<typeof vi.fn>
+
+  // Build a Kysely mock that returns controllable results
+  let dbExecuteResults: unknown[]
+  let dbExecuteTakeFirstResults: unknown[]
+
+  function makeMockDb() {
+    dbExecuteResults = []
+    dbExecuteTakeFirstResults = []
+
+    const chain: Record<string, unknown> = {}
+    const chainFn = (..._args: unknown[]) => chain
+    const methods = [
+      'selectFrom', 'selectAll', 'select', 'where', 'orderBy',
+      'limit', 'offset', 'groupBy', 'insertInto', 'values',
+      'onConflict', 'columns', 'doUpdateSet',
+      'updateTable', 'set', 'deleteFrom', 'returningAll',
+      'leftJoin',
+    ]
+    for (const m of methods) {
+      chain[m] = vi.fn(chainFn)
+    }
+    chain.execute = vi.fn(async () => {
+      return dbExecuteResults.shift() ?? []
+    })
+    chain.executeTakeFirst = vi.fn(async () => {
+      return dbExecuteTakeFirstResults.shift()
+    })
+    return chain
+  }
+
+  beforeEach(() => {
+    eventBus = new EventBus()
+    queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+    const db = makeMockDb()
+    service = new AutomationService(eventBus, db as never, queryFn)
+  })
+
+  it('createRule inserts a rule and returns it', async () => {
+    dbExecuteResults.push([]) // for insertInto().execute()
+    const rule = await service.createRule('sheet_1', {
+      name: 'My Rule',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'update_record',
+      actionConfig: { fields: { status: 'done' } },
+      createdBy: 'user_1',
+    })
+
+    expect(rule.id).toMatch(/^atr_/)
+    expect(rule.sheet_id).toBe('sheet_1')
+    expect(rule.name).toBe('My Rule')
+    expect(rule.trigger_type).toBe('record.created')
+    expect(rule.enabled).toBe(true)
+  })
+
+  it('getRule returns a rule when found', async () => {
+    const mockRow = {
+      id: 'atr_123',
+      sheet_id: 'sheet_1',
+      name: 'Test',
+      trigger_type: 'record.created',
+      trigger_config: {},
+      action_type: 'update_record',
+      action_config: { fields: { x: 1 } },
+      enabled: true,
+      created_at: new Date('2026-01-01'),
+      updated_at: new Date('2026-01-01'),
+      created_by: 'user_1',
+      conditions: null,
+      actions: null,
+    }
+    dbExecuteTakeFirstResults.push(mockRow)
+    const rule = await service.getRule('atr_123')
+    expect(rule).not.toBeNull()
+    expect(rule!.id).toBe('atr_123')
+    expect(rule!.trigger_type).toBe('record.created')
+  })
+
+  it('getRule returns null when not found', async () => {
+    dbExecuteTakeFirstResults.push(undefined)
+    const rule = await service.getRule('nonexistent')
+    expect(rule).toBeNull()
+  })
+
+  it('listRules returns rules for a sheet', async () => {
+    dbExecuteResults.push([
+      {
+        id: 'atr_1', sheet_id: 'sheet_1', name: 'R1',
+        trigger_type: 'record.created', trigger_config: {},
+        action_type: 'update_record', action_config: {},
+        enabled: true, created_at: new Date(), updated_at: new Date(),
+        created_by: 'u1', conditions: null, actions: null,
+      },
+      {
+        id: 'atr_2', sheet_id: 'sheet_1', name: 'R2',
+        trigger_type: 'record.updated', trigger_config: {},
+        action_type: 'send_notification', action_config: {},
+        enabled: false, created_at: new Date(), updated_at: new Date(),
+        created_by: 'u1', conditions: null, actions: null,
+      },
+    ])
+    const rules = await service.listRules('sheet_1')
+    expect(rules).toHaveLength(2)
+    expect(rules[0].id).toBe('atr_1')
+    expect(rules[1].id).toBe('atr_2')
+  })
+
+  it('updateRule returns updated rule', async () => {
+    const updatedRow = {
+      id: 'atr_1', sheet_id: 'sheet_1', name: 'Updated',
+      trigger_type: 'record.created', trigger_config: {},
+      action_type: 'update_record', action_config: {},
+      enabled: true, created_at: new Date(), updated_at: new Date(),
+      created_by: 'u1', conditions: null, actions: null,
+    }
+    dbExecuteResults.push([updatedRow])
+    const rule = await service.updateRule('atr_1', 'sheet_1', { name: 'Updated' })
+    expect(rule).not.toBeNull()
+    expect(rule!.name).toBe('Updated')
+  })
+
+  it('updateRule returns null when rule not found', async () => {
+    dbExecuteResults.push([]) // empty RETURNING
+    const rule = await service.updateRule('nonexistent', 'sheet_1', { name: 'X' })
+    expect(rule).toBeNull()
+  })
+
+  it('deleteRule returns true when deleted', async () => {
+    dbExecuteResults.push([{ numDeletedRows: BigInt(1) }])
+    const deleted = await service.deleteRule('atr_1', 'sheet_1')
+    expect(deleted).toBe(true)
+  })
+
+  it('deleteRule returns false when not found', async () => {
+    dbExecuteResults.push([{ numDeletedRows: BigInt(0) }])
+    const deleted = await service.deleteRule('nonexistent', 'sheet_1')
+    expect(deleted).toBe(false)
+  })
+
+  it('setRuleEnabled enables a rule', async () => {
+    const updatedRow = {
+      id: 'atr_1', sheet_id: 'sheet_1', name: 'Rule',
+      trigger_type: 'schedule.cron', trigger_config: { expression: '*/5 * * * *' },
+      action_type: 'update_record', action_config: {},
+      enabled: true, created_at: new Date(), updated_at: new Date(),
+      created_by: 'u1', conditions: null, actions: null,
+    }
+    dbExecuteResults.push([updatedRow])
+    const rule = await service.setRuleEnabled('atr_1', true)
+    expect(rule).not.toBeNull()
+    expect(rule!.enabled).toBe(true)
+  })
+
+  it('setRuleEnabled returns null when rule not found', async () => {
+    dbExecuteResults.push([])
+    const rule = await service.setRuleEnabled('nonexistent', false)
+    expect(rule).toBeNull()
+  })
+
+  it('loadEnabledRules returns only enabled rules via Kysely', async () => {
+    dbExecuteResults.push([
+      {
+        id: 'atr_1', sheet_id: 'sheet_1', name: 'Active',
+        trigger_type: 'record.created', trigger_config: {},
+        action_type: 'update_record', action_config: {},
+        enabled: true, created_at: new Date(), updated_at: new Date(),
+        created_by: 'u1', conditions: null, actions: null,
+      },
+    ])
+    const rules = await service.loadEnabledRules('sheet_1')
+    expect(rules).toHaveLength(1)
+    expect(rules[0].enabled).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Refactored `AutomationService` to use Kysely for all rule CRUD operations (`createRule`, `getRule`, `listRules`, `updateRule`, `deleteRule`, `setRuleEnabled`) replacing raw SQL queries
- Added migration `zzzz20260414100000_extend_automation_rules.ts` to extend the `automation_rules` table with `conditions` (JSONB) and `actions` (JSONB) columns, and broadened CHECK constraints to support all V1 trigger/action types
- Added `AutomationRulesTable` interface to `db/types.ts` and registered in the `Database` interface
- Updated route handlers in `univer-meta.ts` to use Kysely instead of raw `pool.query` for automation CRUD
- On startup, all enabled scheduled rules are loaded from PostgreSQL and registered with the scheduler via `loadAndRegisterAllScheduled()`
- Added 10 new unit tests for service CRUD methods (91 total tests passing)

## Test plan
- [x] All 91 automation tests pass (`vitest run automation-v1.test.ts`)
- [ ] Verify migration runs cleanly against dev PostgreSQL
- [ ] Verify automation CRUD routes work end-to-end (list, create, update, delete)
- [ ] Verify scheduled rules survive service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)