### PR TITLE
fix(multitable): sync automation scheduler on CRUD

### DIFF
--- a/docs/development/automation-scheduler-sync-fix-development-20260415.md
+++ b/docs/development/automation-scheduler-sync-fix-development-20260415.md
@@ -1,0 +1,90 @@
+# Automation Scheduler Sync Fix Development
+
+日期：2026-04-15
+
+## 背景
+
+在审阅 Claude 的 Phase 1 收口说明时，我核到了一个真实风险：
+
+- `#878` 已合并且 checks 全绿，基本可以接受
+- `#879` 虽已合并，但不是“全绿完成”
+  - `test (18.x)` 失败
+  - `test (20.x)` 被取消
+  - 失败集中在 `tests/unit/multitable-automation-service.test.ts`
+
+进一步读代码后确认，`#879` 还有一个更关键的运行时洞：
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+  的 automation CRUD 仍然直接写 `kyselyDb`
+- 没有走 `AutomationService.createRule/updateRule/deleteRule`
+- 因此不会触发：
+  - `registerSchedule()`
+  - `unregisterSchedule()`
+
+结果是：
+- 新建/更新定时规则后，调度器不会立即生效
+- 删除定时规则后，旧 schedule 仍可能继续跑到服务重启
+
+## 本轮修复
+
+### 1. 给 AutomationService 增加共享实例接线
+
+文件：
+- `packages/core-backend/src/multitable/automation-service.ts`
+- `packages/core-backend/src/index.ts`
+
+新增：
+- `setAutomationServiceInstance()`
+- `getAutomationServiceInstance()`
+
+接线：
+- 服务启动后把真实 `AutomationService` 实例注册成共享实例
+- 服务 shutdown 时清空共享实例
+
+### 2. 让 univer-meta automation CRUD 改走 AutomationService
+
+文件：
+- `packages/core-backend/src/routes/univer-meta.ts`
+
+改动：
+- `GET /sheets/:sheetId/automations` → `automationService.listRules()`
+- `POST /sheets/:sheetId/automations` → `automationService.createRule()`
+- `PATCH /sheets/:sheetId/automations/:ruleId` → `automationService.updateRule()`
+- `DELETE /sheets/:sheetId/automations/:ruleId` → `automationService.deleteRule()`
+
+效果：
+- 调度型规则的 register/unregister 语义重新跟 CRUD 对齐
+- 如果 automation service 处于 degraded/unavailable，路由显式返回 `503 SERVICE_UNAVAILABLE`
+
+### 3. 修复 #879 打断的旧单测
+
+文件：
+- `packages/core-backend/tests/unit/multitable-automation-service.test.ts`
+
+原因：
+- 这组旧测试仍用“raw query fn = db”的旧构造方式
+- `#879` 后 `AutomationService` 需要 `Kysely db + queryFn`
+
+处理：
+- 补了最小 `Kysely-like` mock
+- 保留原有 queryFn 断言，用于 action 执行语义验证
+- 修正递归 guard 场景里误传空规则集的测试输入
+
+## 对 Claude Phase 1 说法的审阅结论
+
+我认可的部分：
+- `#878` 限流器 → Redis store 的方向和合并状态基本成立
+- platform shell wave1 已在 `main`
+- 钉钉身份层已合入 `main`
+
+我不认可直接照抄的部分：
+- “Phase 1 全部完成” 这个说法过满
+- `#879` 不能写成“91 tests + 完成”然后直接略过 CI 失败
+- 至少应该补一句：
+  - 已合并，但当时带着 `multitable-automation-service` 回归失败
+  - 本轮 follow-up 专门补 scheduler sync 和这组保护网
+
+## 当前分支
+
+- worktree: `/tmp/metasheet2-automation-scheduler-fix`
+- branch: `codex/automation-scheduler-sync-fix-20260415`

--- a/docs/development/automation-scheduler-sync-fix-pr-opening-development-20260415.md
+++ b/docs/development/automation-scheduler-sync-fix-pr-opening-development-20260415.md
@@ -1,0 +1,76 @@
+# Automation Scheduler Sync Fix PR Opening
+
+日期：2026-04-15
+
+## 目标
+
+把 `codex/automation-scheduler-sync-fix-20260415` 从本地 follow-up 修复正式开成可审 PR，并把对 Claude Phase 1 结论的审阅结果落库。
+
+## 背景结论
+
+对 Claude 的 `Phase 1 closure` 说法，我的判断是：
+
+- `#878` 基本成立，Redis store 可插拔方向没有明显问题
+- `#879` 的“已完成”表述过满
+  - PR 已合并
+  - 但合并当时并不是全绿
+  - `test (18.x)` 失败
+  - `test (20.x)` 被取消
+
+更关键的是，`#879` 留下了一个运行时洞：
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+  的 automation CRUD 直接写 `kyselyDb`
+- 没有走 `AutomationService.createRule/updateRule/deleteRule`
+- 所以不会触发 scheduler 的 `register/unregister`
+
+这意味着：
+
+- 新建或更新 `schedule.cron` / `schedule.interval` 规则后，不会立即进内存调度器
+- 删除 schedule 规则后，旧任务可能继续跑到服务重启
+
+## 本轮动作
+
+### 1. 复核 fix 分支状态
+
+- branch: `codex/automation-scheduler-sync-fix-20260415`
+- head: `b79cc3f2e`
+- 远端分支已存在且已同步
+
+### 2. 复核 Claude Code CLI
+
+在本 worktree 下执行：
+
+```bash
+claude auth status
+claude -p "Return exactly: CLAUDE_CLI_OK"
+claude -p "Review the automation scheduler sync fix on the current branch. Reply with exactly NO_BLOCKERS or one short blocker sentence."
+```
+
+结果：
+
+- 当前 worktree 已登录
+- CLI 可执行
+- 窄范围 review 返回 `NO_BLOCKERS`
+
+### 3. 创建正式 PR
+
+已创建：
+
+- PR `#880`
+- 标题：`fix(multitable): sync automation scheduler on CRUD`
+
+PR body 明确说明了：
+
+- 这是一条 `#879` 的 follow-up
+- 目标是恢复 scheduler 与 CRUD 的一致性
+- 同时修复被 `#879` 打断的 `multitable-automation-service` 单测保护网
+
+## 当前结论
+
+这条 follow-up 现在已经从“本地修补”变成“可 review 的正式 PR”。  
+对外表述上，最准确的说法不是“Claude 总结错了”，而是：
+
+- Claude 的 Phase 1 总体方向可参考
+- 但 `#879` 的收口质量被高估了
+- `#880` 是必须补的一条 correctness fix

--- a/docs/development/automation-scheduler-sync-fix-pr-opening-verification-20260415.md
+++ b/docs/development/automation-scheduler-sync-fix-pr-opening-verification-20260415.md
@@ -1,0 +1,90 @@
+# Automation Scheduler Sync Fix PR Opening Verification
+
+日期：2026-04-15
+
+## Git / PR 状态
+
+已确认：
+
+- 分支：`codex/automation-scheduler-sync-fix-20260415`
+- 本地 head：`b79cc3f2e`
+- 远端 tracking：`origin/codex/automation-scheduler-sync-fix-20260415`
+- PR：[#880](https://github.com/zensgit/metasheet2/pull/880)
+
+## 定向验证
+
+### Backend Vitest
+
+命令：
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-service.test.ts tests/unit/automation-v1.test.ts --reporter=dot
+```
+
+结果：
+
+- `2` 个文件通过
+- `102/102` 用例通过
+
+### Backend TypeScript
+
+命令：
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+结果：
+
+- 仍失败
+
+失败点仍是仓库既有的 Kysely 类型噪音，主要位于：
+
+- `src/db/types.ts`
+- `src/multitable/api-token-service.ts`
+- `src/multitable/automation-log-service.ts`
+- `src/multitable/dashboard-service.ts`
+- `src/multitable/webhook-service.ts`
+
+本轮 follow-up 没有新增 `univer-meta.ts` automation route 的类型错误。
+
+## Claude Code CLI
+
+命令：
+
+```bash
+claude auth status
+claude -p "Return exactly: CLAUDE_CLI_OK"
+claude -p "Review the automation scheduler sync fix on the current branch. Reply with exactly NO_BLOCKERS or one short blocker sentence."
+```
+
+结果：
+
+- `claude auth status`：已登录
+- smoke：返回 `CLAUDE_CLI_OK`
+- 窄范围 review：返回 `NO_BLOCKERS`
+
+## GitHub 验证
+
+命令：
+
+```bash
+gh pr view 879 --json number,title,state,mergeCommit,headRefName,baseRefName,statusCheckRollup
+gh pr view 880 --json number,title,state,headRefName,baseRefName,url
+```
+
+结果：
+
+- `#879` 已确认是 `MERGED`
+- `#879` 合并时 `test (18.x)` 为 `FAILURE`
+- `#879` 合并时 `test (20.x)` 为 `CANCELLED`
+- `#880` 已成功创建，等待 review / CI
+
+## 本地环境说明
+
+isolated worktree 中仍保留本地测试用 symlink：
+
+- `/tmp/metasheet2-automation-scheduler-fix/node_modules`
+- `/tmp/metasheet2-automation-scheduler-fix/packages/core-backend/node_modules`
+
+它们不在 git 跟踪范围内，不会进入提交。

--- a/docs/development/automation-scheduler-sync-fix-verification-20260415.md
+++ b/docs/development/automation-scheduler-sync-fix-verification-20260415.md
@@ -1,0 +1,63 @@
+# Automation Scheduler Sync Fix Verification
+
+日期：2026-04-15
+
+## 定向验证
+
+### 单测
+
+命令：
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-service.test.ts tests/unit/automation-v1.test.ts --reporter=dot
+```
+
+结果：
+- `2` 个文件通过
+- `102/102` 用例通过
+
+覆盖含义：
+- 旧的 `multitable-automation-service` 回归重新恢复
+- `automation-v1` 的 Kysely CRUD / scheduler 相关能力仍通过
+
+### TypeScript
+
+命令：
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+结果：
+- 仍失败
+
+但这次失败点是仓库既有 Kysely 类型噪音，主要分布在：
+- `src/db/types.ts`
+- `src/multitable/api-token-service.ts`
+- `src/multitable/automation-log-service.ts`
+- `src/multitable/dashboard-service.ts`
+- `src/multitable/webhook-service.ts`
+
+本轮新增的 `univer-meta.ts` scheduler sync 接线没有再产生新的类型错误。
+
+## Claude Code CLI
+
+本轮在这个 isolated worktree 下复核：
+
+```bash
+claude auth status
+claude -p "Review the automation scheduler sync fix on the current branch. Reply with exactly NO_BLOCKERS or one short blocker sentence."
+```
+
+结果：
+- 当前返回未登录
+- 本轮没有依赖 Claude CLI 参与修复或验证
+
+## 本地环境说明
+
+为了让 isolated worktree 复用已有依赖，补了本地 symlink：
+
+- `/tmp/metasheet2-automation-scheduler-fix/node_modules`
+- `/tmp/metasheet2-automation-scheduler-fix/packages/core-backend/node_modules`
+
+它们只用于本地执行，不会进入 git。

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -67,7 +67,7 @@ import { getPoolStats } from './db/pg'
 import { isDatabaseSchemaError } from './utils/database-errors'
 import { startOperationAuditRetention } from './audit/operation-audit-retention'
 import { startMultitableAttachmentCleanup } from './multitable/attachment-orphan-retention'
-import { AutomationService } from './multitable/automation-service'
+import { AutomationService, setAutomationServiceInstance } from './multitable/automation-service'
 import { tenantContext } from './db/sharding/tenant-context'
 import { attendanceAuditMiddleware, attendanceSecurityMiddleware } from './middleware/attendance-production'
 import { approvalsRouter } from './routes/approvals'
@@ -1461,6 +1461,7 @@ export class MetaSheetServer {
     shutdownTasks.push(Promise.resolve().then(() => {
       try {
         this.automationService?.shutdown()
+        setAutomationServiceInstance(null)
       } catch (err) {
         this.logger.warn(`AutomationService shutdown error: ${err instanceof Error ? err.message : String(err)}`)
       }
@@ -1620,6 +1621,7 @@ export class MetaSheetServer {
       const { db: kyselyDb } = await import('./db/db')
       this.automationService = new AutomationService(eventBus, kyselyDb, pool.query.bind(pool))
       this.automationService.init()
+      setAutomationServiceInstance(this.automationService)
       await this.automationService.loadAndRegisterAllScheduled()
       this.logger.info('AutomationService initialized')
     } catch (e) {

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -116,6 +116,16 @@ function toExecutorRule(rule: AutomationRule): ExecutorRule {
   }
 }
 
+let sharedAutomationService: AutomationService | null = null
+
+export function setAutomationServiceInstance(service: AutomationService | null): void {
+  sharedAutomationService = service
+}
+
+export function getAutomationServiceInstance(): AutomationService | null {
+  return sharedAutomationService
+}
+
 export class AutomationService {
   private eventBus: EventBus
   private db: Kysely<Database>

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -31,6 +31,7 @@ import { MultitableFormulaEngine } from '../multitable/formula-engine'
 import { validateRecord, getDefaultValidationRules } from '../multitable/field-validation-engine'
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
+import { getAutomationServiceInstance } from '../multitable/automation-service'
 
 const multitableFormulaEngine = new MultitableFormulaEngine()
 
@@ -7633,13 +7634,12 @@ export function univerMetaRouter(): Router {
       const pool = poolManager.get()
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageAutomation) return sendForbidden(res)
+      const automationService = getAutomationServiceInstance()
+      if (!automationService) {
+        return res.status(503).json({ ok: false, error: { code: 'SERVICE_UNAVAILABLE', message: 'Automation service is not available' } })
+      }
 
-      const rules = await kyselyDb
-        .selectFrom('automation_rules')
-        .selectAll()
-        .where('sheet_id', '=', sheetId)
-        .orderBy('created_at', 'asc')
-        .execute()
+      const rules = await automationService.listRules(sheetId)
 
       return res.json({ ok: true, data: { rules } })
     } catch (err) {
@@ -7661,6 +7661,10 @@ export function univerMetaRouter(): Router {
       if (!access.userId) return res.status(401).json({ error: 'Authentication required' })
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageAutomation) return sendForbidden(res)
+      const automationService = getAutomationServiceInstance()
+      if (!automationService) {
+        return res.status(503).json({ ok: false, error: { code: 'SERVICE_UNAVAILABLE', message: 'Automation service is not available' } })
+      }
 
       const body = req.body as Record<string, unknown> | undefined
       const name = typeof body?.name === 'string' ? body.name : null
@@ -7679,31 +7683,34 @@ export function univerMetaRouter(): Router {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid action_type: ${actionType}` } })
       }
 
-      const ruleId = `atr_${randomUUID()}`
-      const conditions = body?.conditions && typeof body.conditions === 'object' ? body.conditions : null
+      const conditions = body?.conditions && typeof body.conditions === 'object' ? body.conditions as never : null
       const actions = Array.isArray(body?.actions) ? body.actions : null
 
-      await kyselyDb
-        .insertInto('automation_rules')
-        .values({
-          id: ruleId,
-          sheet_id: sheetId,
-          name,
-          trigger_type: triggerType,
-          trigger_config: JSON.stringify(triggerConfig),
-          action_type: actionType,
-          action_config: JSON.stringify(actionConfig),
-          enabled,
-          created_by: access.userId,
-          conditions: conditions ? JSON.stringify(conditions) : null,
-          actions: actions ? JSON.stringify(actions) : null,
-        } as never)
-        .execute()
+      const rule = await automationService.createRule(sheetId, {
+        name,
+        triggerType,
+        triggerConfig,
+        actionType,
+        actionConfig,
+        enabled,
+        createdBy: access.userId,
+        conditions,
+        actions: actions as never,
+      })
 
       return res.json({
         ok: true,
         data: {
-          rule: { id: ruleId, sheetId, name, triggerType, triggerConfig, actionType, actionConfig, enabled },
+          rule: {
+            id: rule.id,
+            sheetId,
+            name: rule.name,
+            triggerType: rule.trigger_type,
+            triggerConfig: rule.trigger_config,
+            actionType: rule.action_type,
+            actionConfig: rule.action_config,
+            enabled: rule.enabled,
+          },
         },
       })
     } catch (err) {
@@ -7724,6 +7731,10 @@ export function univerMetaRouter(): Router {
       const pool = poolManager.get()
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageAutomation) return sendForbidden(res)
+      const automationService = getAutomationServiceInstance()
+      if (!automationService) {
+        return res.status(503).json({ ok: false, error: { code: 'SERVICE_UNAVAILABLE', message: 'Automation service is not available' } })
+      }
 
       const body = req.body as Record<string, unknown> | undefined
       const updates: Record<string, unknown> = {}
@@ -7761,21 +7772,26 @@ export function univerMetaRouter(): Router {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'No fields to update' } })
       }
 
-      updates.updated_at = new Date().toISOString()
+      const updated = await automationService.updateRule(ruleId, sheetId, {
+        name: updates.name as string | null | undefined,
+        triggerType: updates.trigger_type as string | undefined,
+        triggerConfig: body?.triggerConfig && typeof body.triggerConfig === 'object'
+          ? body.triggerConfig as Record<string, unknown>
+          : undefined,
+        actionType: updates.action_type as string | undefined,
+        actionConfig: body?.actionConfig && typeof body.actionConfig === 'object'
+          ? body.actionConfig as Record<string, unknown>
+          : undefined,
+        enabled: typeof body?.enabled === 'boolean' ? body.enabled : undefined,
+        conditions: body?.conditions !== undefined ? (body.conditions as never) : undefined,
+        actions: body?.actions !== undefined ? (Array.isArray(body.actions) ? body.actions : null) as never : undefined,
+      })
 
-      const result = await kyselyDb
-        .updateTable('automation_rules')
-        .set(updates as never)
-        .where('id', '=', ruleId)
-        .where('sheet_id', '=', sheetId)
-        .returningAll()
-        .execute()
-
-      if (result.length === 0) {
+      if (!updated) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 
-      return res.json({ ok: true, data: { rule: result[0] } })
+      return res.json({ ok: true, data: { rule: updated } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -7794,14 +7810,14 @@ export function univerMetaRouter(): Router {
       const pool = poolManager.get()
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageAutomation) return sendForbidden(res)
+      const automationService = getAutomationServiceInstance()
+      if (!automationService) {
+        return res.status(503).json({ ok: false, error: { code: 'SERVICE_UNAVAILABLE', message: 'Automation service is not available' } })
+      }
 
-      const result = await kyselyDb
-        .deleteFrom('automation_rules')
-        .where('id', '=', ruleId)
-        .where('sheet_id', '=', sheetId)
-        .execute()
+      const deleted = await automationService.deleteRule(ruleId, sheetId)
 
-      if (result.length === 0 || Number(result[0].numDeletedRows) === 0) {
+      if (!deleted) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -53,6 +53,18 @@ function createMockQuery(rules: AutomationRule[]): AutomationQueryFn {
   }))
 }
 
+function createMockDb(rules: AutomationRule[]) {
+  const chain: Record<string, unknown> = {}
+  const chainFn = (..._args: unknown[]) => chain
+  for (const method of ['selectAll', 'where', 'orderBy']) {
+    chain[method] = vi.fn(chainFn)
+  }
+  chain.execute = vi.fn(async () => rules)
+  return {
+    selectFrom: vi.fn(() => chain),
+  }
+}
+
 describe('AutomationService', () => {
   let bus: EventBus
   let service: AutomationService
@@ -71,7 +83,7 @@ describe('AutomationService', () => {
     it('matches record.created trigger on multitable.record.created event', async () => {
       const rule = createMockRule({ trigger_type: 'record.created', action_type: 'send_notification' })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -93,7 +105,7 @@ describe('AutomationService', () => {
     it('matches record.updated trigger on multitable.record.updated event', async () => {
       const rule = createMockRule({ trigger_type: 'record.updated', action_type: 'send_notification' })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -117,7 +129,7 @@ describe('AutomationService', () => {
         action_type: 'send_notification',
       })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -140,7 +152,7 @@ describe('AutomationService', () => {
         action_type: 'send_notification',
       })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -161,7 +173,7 @@ describe('AutomationService', () => {
         action_type: 'send_notification',
       })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -183,7 +195,7 @@ describe('AutomationService', () => {
         action_config: { userIds: ['user_a', 'user_b'], message: 'Record changed' },
       })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -211,7 +223,7 @@ describe('AutomationService', () => {
         action_config: { fields: { target_field: 'auto_value' } },
       })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -241,7 +253,7 @@ describe('AutomationService', () => {
     it('blocks execution at depth >= 3', async () => {
       const rule = createMockRule({ action_type: 'send_notification' })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -261,7 +273,7 @@ describe('AutomationService', () => {
     it('allows execution at depth < 3', async () => {
       const rule = createMockRule({ action_type: 'send_notification' })
       const query = createMockQuery([rule])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -284,7 +296,7 @@ describe('AutomationService', () => {
     it('skips disabled rules (query returns only enabled)', async () => {
       // The query only returns enabled rules, so we simulate empty result
       const query = createMockQuery([])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([]) as never, query)
 
       const emitSpy = vi.spyOn(bus, 'emit')
 
@@ -302,7 +314,7 @@ describe('AutomationService', () => {
   describe('init / shutdown', () => {
     it('subscribes to events on init and unsubscribes on shutdown', () => {
       const query = createMockQuery([])
-      service = new AutomationService(bus, query)
+      service = new AutomationService(bus, createMockDb([]) as never, query)
 
       const subscribeSpy = vi.spyOn(bus, 'subscribe')
       const unsubscribeSpy = vi.spyOn(bus, 'unsubscribe')


### PR DESCRIPTION
## What Changed
- route multitable automation CRUD in `univer-meta.ts` through the shared `AutomationService` instance instead of direct Kysely writes
- restore scheduler register/unregister behavior for create, update, and delete flows
- repair the legacy `multitable-automation-service` unit tests to use a minimal Kysely-style db mock after the `#879` persistence refactor
- record the follow-up audit and verification in development docs

## Why
PR `#879` persisted automation rules to PostgreSQL, but the API CRUD path still bypassed `AutomationService`. That meant `schedule.cron` and `schedule.interval` rules would not sync with the in-memory scheduler until restart, and deleted schedules could keep firing until restart.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-service.test.ts tests/unit/automation-v1.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`

## Notes
- targeted Vitest passes `102/102`
- backend `tsc` still reports existing Kysely typing noise in api-token/dashboard/webhook services; this follow-up does not introduce new automation route type errors
- Claude Phase 1 closure summary was directionally useful, but `#879` was not actually all-green when merged
