### PR TITLE
refactor(multitable): extract RecordWriteService from route handler

### DIFF
--- a/packages/core-backend/src/multitable/realtime-publish.ts
+++ b/packages/core-backend/src/multitable/realtime-publish.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared realtime publish helper for multitable record mutations.
+ *
+ * Extracted from `univer-meta.ts` so that both the REST route handler
+ * and the future Yjs CRDT bridge can publish to the same channel.
+ */
+
+import { eventBus } from '../integration/events/event-bus'
+
+export type MultitableSheetRealtimePayload = {
+  spreadsheetId: string
+  actorId?: string | null
+  source: 'multitable'
+  kind: 'record-created' | 'record-updated' | 'record-deleted' | 'attachment-updated'
+  recordId?: string
+  recordIds?: string[]
+  fieldIds?: string[]
+  recordPatches?: Array<{
+    recordId: string
+    version?: number
+    patch: Record<string, unknown>
+  }>
+}
+
+/**
+ * Invalidate the lightweight cursor-paginated records cache for a sheet.
+ *
+ * Accepts an external invalidation function so we don't couple this module
+ * to the cache implementation living inside `univer-meta.ts`.
+ */
+export type InvalidateCacheFn = (sheetId: string) => void
+
+let _invalidateCache: InvalidateCacheFn = () => {}
+
+/** Register the cache invalidation callback (called once at router setup). */
+export function setRealtimeCacheInvalidator(fn: InvalidateCacheFn): void {
+  _invalidateCache = fn
+}
+
+export function publishMultitableSheetRealtime(payload: MultitableSheetRealtimePayload): void {
+  if (!payload.spreadsheetId) return
+  _invalidateCache(payload.spreadsheetId)
+  try {
+    eventBus.publish('spreadsheet.cell.updated', payload)
+  } catch (err) {
+    console.warn('[multitable] failed to publish multitable sheet realtime update', err)
+  }
+}

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -1,0 +1,597 @@
+/**
+ * RecordWriteService — shared write-path for multitable record mutations.
+ *
+ * Extracts the 6-step record-patch pipeline from the PATCH route handler
+ * in `univer-meta.ts` so that both REST and the future Yjs CRDT bridge
+ * can share the same transactional write semantics.
+ *
+ * Steps:
+ * 1. DB transaction (SELECT FOR UPDATE → version check → field-type handling → data || patch::jsonb → link mutation → version++)
+ * 2. Computed field recalculation (lookup/rollup via applyLookupRollup)
+ * 3. Related record recomputation (cross-sheet dependent lookup/rollup)
+ * 4. Link/attachment summary rebuild
+ * 5. Realtime broadcast
+ * 6. EventBus emit (webhook/automation trigger)
+ */
+
+import type { EventBus } from '../integration/events/event-bus'
+import { publishMultitableSheetRealtime } from './realtime-publish'
+
+// ---------------------------------------------------------------------------
+// Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
+// ---------------------------------------------------------------------------
+
+export type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export type TransactionHandler<T> = (client: { query: QueryFn }) => Promise<T>
+
+/** Minimal pool interface required by the service. */
+export interface ConnectionPool {
+  query: QueryFn
+  transaction: <T>(handler: TransactionHandler<T>) => Promise<T>
+}
+
+export type UniverMetaField = {
+  id: string
+  name: string
+  type: 'string' | 'number' | 'boolean' | 'date' | 'formula' | 'select' | 'link' | 'lookup' | 'rollup' | 'attachment'
+  options?: Array<{ value: string; color?: string }>
+  order?: number
+  property?: Record<string, unknown>
+}
+
+export type UniverMetaRecord = {
+  id: string
+  version: number
+  data: Record<string, unknown>
+  createdBy?: string | null
+}
+
+export type LinkFieldConfig = {
+  foreignSheetId: string
+  limitSingleRecord: boolean
+}
+
+export type RelationalLinkField = { fieldId: string; cfg: LinkFieldConfig }
+
+export type LinkedRecordSummary = {
+  id: string
+  display: string
+}
+
+export type MultitableAttachment = {
+  id: string
+  filename: string
+  mimeType: string
+  size: number
+  url: string
+  thumbnailUrl: string | null
+  uploadedAt: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Error types (re-exported so callers don't need to import from univer-meta)
+// ---------------------------------------------------------------------------
+
+export class VersionConflictError extends Error {
+  constructor(
+    public recordId: string,
+    public serverVersion: number,
+  ) {
+    super(`Version conflict for ${recordId}`)
+    this.name = 'VersionConflictError'
+  }
+}
+
+export class RecordNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RecordNotFoundError'
+  }
+}
+
+export class RecordValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RecordValidationError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input / output types
+// ---------------------------------------------------------------------------
+
+export type RecordChange = {
+  recordId?: string
+  fieldId: string
+  value: unknown
+  expectedVersion?: number
+}
+
+export type MultitableCapabilities = {
+  canRead: boolean
+  canCreateRecord: boolean
+  canEditRecord: boolean
+  canDeleteRecord: boolean
+  canManageFields: boolean
+  canManageSheetAccess: boolean
+  canManageViews: boolean
+  canComment: boolean
+  canManageAutomation: boolean
+  canExport: boolean
+}
+
+export type SheetPermissionScope = {
+  hasAssignments: boolean
+  canRead: boolean
+  canWrite: boolean
+  canWriteOwn: boolean
+  canAdmin: boolean
+}
+
+export type AccessInfo = {
+  userId: string
+  permissions: string[]
+  isAdminRole: boolean
+}
+
+export type FieldMutationGuard = {
+  type: UniverMetaField['type']
+  options?: string[]
+  readOnly: boolean
+  hidden: boolean
+  link?: LinkFieldConfig | null
+}
+
+export interface RecordPatchInput {
+  sheetId: string
+  changesByRecord: Map<string, RecordChange[]>
+  actorId: string | null
+  fields: UniverMetaField[]
+  visiblePropertyFields: UniverMetaField[]
+  visiblePropertyFieldIds: Set<string>
+  attachmentFields: UniverMetaField[]
+  fieldById: Map<string, FieldMutationGuard>
+  capabilities: MultitableCapabilities
+  sheetScope?: SheetPermissionScope
+  access: AccessInfo
+}
+
+export interface RecordPatchResult {
+  updated: Array<{ recordId: string; version: number }>
+  records?: Array<{ recordId: string; data: Record<string, unknown> }>
+  linkSummaries?: Record<string, unknown>
+  attachmentSummaries?: Record<string, unknown>
+  relatedRecords?: Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }>
+}
+
+// ---------------------------------------------------------------------------
+// Injectable helpers — these live in univer-meta.ts and depend on `req`
+// ---------------------------------------------------------------------------
+
+/** Helpers injected at construction time so we don't couple to Express `req`. */
+export interface RecordWriteHelpers {
+  normalizeLinkIds: (value: unknown) => string[]
+  normalizeAttachmentIds: (value: unknown) => string[]
+  normalizeJson: (value: unknown) => Record<string, unknown>
+  parseLinkFieldConfig: (property: unknown) => LinkFieldConfig | null
+  buildId: (prefix: string) => string
+  ensureRecordWriteAllowed: (
+    capabilities: MultitableCapabilities,
+    sheetScope: SheetPermissionScope | undefined,
+    access: AccessInfo,
+    createdBy: string | null | undefined,
+    action: 'edit' | 'delete',
+  ) => boolean
+  filterRecordDataByFieldIds: (data: unknown, allowedFieldIds: Set<string>) => Record<string, unknown>
+  extractLookupRollupData: (fields: UniverMetaField[], rowData: Record<string, unknown>) => Record<string, unknown>
+  mergeComputedRecords: (
+    base: Array<{ recordId: string; data: Record<string, unknown> }> | undefined,
+    extra: Array<{ recordId: string; data: Record<string, unknown> }>,
+  ) => Array<{ recordId: string; data: Record<string, unknown> }> | undefined
+  filterRecordFieldSummaryMap: <T>(
+    summaryMap: Record<string, Record<string, T>> | undefined,
+    allowedFieldIds: Set<string>,
+  ) => Record<string, Record<string, T>> | undefined
+  serializeLinkSummaryMap: (
+    linkSummaries: Map<string, Map<string, LinkedRecordSummary[]>>,
+  ) => Record<string, Record<string, LinkedRecordSummary[]>>
+  serializeAttachmentSummaryMap: (
+    attachmentSummaries: Map<string, Map<string, MultitableAttachment[]>>,
+  ) => Record<string, Record<string, MultitableAttachment[]>>
+
+  /** Async helpers that depend on `req` context (permission resolution). */
+  applyLookupRollup: (
+    query: QueryFn,
+    fields: UniverMetaField[],
+    rows: UniverMetaRecord[],
+    relationalLinkFields: RelationalLinkField[],
+    linkValuesByRecord: Map<string, Map<string, string[]>>,
+  ) => Promise<void>
+  computeDependentLookupRollupRecords: (
+    query: QueryFn,
+    updatedRecordIds: string[],
+  ) => Promise<Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }>>
+  loadLinkValuesByRecord: (
+    query: QueryFn,
+    recordIds: string[],
+    relationalLinkFields: RelationalLinkField[],
+  ) => Promise<Map<string, Map<string, string[]>>>
+  buildLinkSummaries: (
+    query: QueryFn,
+    rows: UniverMetaRecord[],
+    relationalLinkFields: RelationalLinkField[],
+    linkValuesByRecord: Map<string, Map<string, string[]>>,
+  ) => Promise<Map<string, Map<string, LinkedRecordSummary[]>>>
+  buildAttachmentSummaries: (
+    query: QueryFn,
+    sheetId: string,
+    rows: UniverMetaRecord[],
+    attachmentFields: UniverMetaField[],
+  ) => Promise<Map<string, Map<string, MultitableAttachment[]>>>
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class RecordWriteService {
+  constructor(
+    private pool: ConnectionPool,
+    private eventBus: EventBus,
+    private helpers: RecordWriteHelpers,
+  ) {}
+
+  /**
+   * Complete record-patch pipeline.
+   *
+   * Steps:
+   * 1. DB transaction: SELECT FOR UPDATE → version check → field-type handling
+   *    → `data || patch::jsonb` → link mutation → version++
+   * 2. Computed field recalculation (lookup/rollup)
+   * 3. Related record recomputation (cross-sheet)
+   * 4. Link/attachment summary rebuild for response
+   * 5. Realtime broadcast via `publishMultitableSheetRealtime()`
+   * 6. EventBus emit → webhook/automation trigger
+   */
+  async patchRecords(input: RecordPatchInput): Promise<RecordPatchResult> {
+    const {
+      sheetId,
+      changesByRecord,
+      actorId,
+      fields,
+      visiblePropertyFields,
+      visiblePropertyFieldIds,
+      attachmentFields,
+      fieldById,
+      capabilities,
+      sheetScope,
+      access,
+    } = input
+
+    const h = this.helpers
+
+    // -----------------------------------------------------------------------
+    // Step 1: DB transaction
+    // -----------------------------------------------------------------------
+    const updates = await this.pool.transaction(async ({ query }) => {
+      const updated: Array<{ recordId: string; version: number }> = []
+
+      for (const [recordId, changes] of changesByRecord.entries()) {
+        const expectedVersion = Array.from(
+          new Set(changes.map((c) => c.expectedVersion).filter((v): v is number => typeof v === 'number')),
+        )[0]
+
+        const recordRes = await query(
+          'SELECT id, version, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE',
+          [sheetId, recordId],
+        )
+        if ((recordRes.rows as any[]).length === 0) {
+          throw new RecordNotFoundError(`Record not found: ${recordId}`)
+        }
+        const recordRow: any = (recordRes.rows as any[])[0]
+
+        if (
+          !h.ensureRecordWriteAllowed(
+            capabilities,
+            sheetScope,
+            access,
+            typeof recordRow?.created_by === 'string' ? recordRow.created_by : null,
+            'edit',
+          )
+        ) {
+          throw new RecordValidationError(`Record editing is not allowed for ${recordId}`)
+        }
+
+        const serverVersion = Number(recordRow?.version ?? 1)
+        if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
+          throw new VersionConflictError(recordId, serverVersion)
+        }
+
+        const patch: Record<string, unknown> = {}
+        const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
+        let applied = 0
+
+        for (const change of changes) {
+          const field = fieldById.get(change.fieldId)
+          if (!field) continue
+
+          if (field.type === 'formula') {
+            if (typeof change.value !== 'string') continue
+            if (change.value !== '' && !change.value.startsWith('=')) continue
+          }
+
+          if (field.type === 'link' && field.link) {
+            const ids = h.normalizeLinkIds(change.value)
+            patch[change.fieldId] = ids
+            linkUpdates.set(change.fieldId, { ids, cfg: field.link })
+            applied += 1
+            continue
+          }
+
+          if (field.type === 'attachment') {
+            patch[change.fieldId] = h.normalizeAttachmentIds(change.value)
+            applied += 1
+            continue
+          }
+
+          patch[change.fieldId] = change.value
+          applied += 1
+        }
+
+        if (applied === 0) continue
+
+        // Validate link targets exist
+        for (const { ids, cfg } of linkUpdates.values()) {
+          if (ids.length === 0) continue
+          const exists = await query(
+            'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
+            [cfg.foreignSheetId, ids],
+          )
+          const found = new Set((exists as any).rows.map((r: any) => String(r.id)))
+          const missing = ids.filter((id) => !found.has(id))
+          if (missing.length > 0) {
+            throw new RecordValidationError(
+              `Linked record(s) not found in sheet ${cfg.foreignSheetId}: ${missing.join(', ')}`,
+            )
+          }
+        }
+
+        // Apply patch
+        const updateRes = await query(
+          `UPDATE meta_records
+           SET data = data || $1::jsonb, updated_at = now(), version = version + 1
+           WHERE sheet_id = $2 AND id = $3
+           RETURNING version`,
+          [JSON.stringify(patch), sheetId, recordId],
+        )
+        if ((updateRes.rows as any[]).length === 0) {
+          throw new RecordNotFoundError(`Record not found: ${recordId}`)
+        }
+
+        // Sync link table
+        if (linkUpdates.size > 0) {
+          for (const [fieldId, { ids }] of linkUpdates.entries()) {
+            if (ids.length === 0) {
+              try {
+                await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [fieldId, recordId])
+              } catch (err) {
+                throw err
+              }
+              continue
+            }
+
+            let existingIds: string[] = []
+            try {
+              const current = await query(
+                'SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2',
+                [fieldId, recordId],
+              )
+              existingIds = (current as any).rows.map((r: any) => String(r.foreign_record_id))
+            } catch (err) {
+              throw err
+            }
+
+            const existing = new Set(existingIds)
+            const next = new Set(ids)
+            const toDelete = existingIds.filter((id) => !next.has(id))
+            const toInsert = ids.filter((id) => !existing.has(id))
+
+            if (toDelete.length > 0) {
+              try {
+                await query(
+                  'DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY($3::text[])',
+                  [fieldId, recordId, toDelete],
+                )
+              } catch (err) {
+                throw err
+              }
+            }
+
+            for (const foreignId of toInsert) {
+              try {
+                await query(
+                  `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+                   VALUES ($1, $2, $3, $4)
+                   ON CONFLICT DO NOTHING`,
+                  [h.buildId('lnk').slice(0, 50), fieldId, recordId, foreignId],
+                )
+              } catch (err) {
+                throw err
+              }
+            }
+          }
+        }
+
+        updated.push({ recordId, version: Number((updateRes.rows[0] as any).version) })
+      }
+
+      return updated
+    })
+
+    // -----------------------------------------------------------------------
+    // Step 2: Computed field recalculation (lookup / rollup)
+    // -----------------------------------------------------------------------
+    let computedRecords: Array<{ recordId: string; data: Record<string, unknown> }> | undefined
+    let updatedRowsForSummaries: UniverMetaRecord[] = []
+    const computedFieldIds = visiblePropertyFields.filter((f) => f.type === 'lookup' || f.type === 'rollup')
+
+    if (updates.length > 0 && (computedFieldIds.length > 0 || attachmentFields.length > 0)) {
+      const recordIds = updates.map((u) => u.recordId)
+      const recordRes = await this.pool.query(
+        'SELECT id, version, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
+        [sheetId, recordIds],
+      )
+      const rows = (recordRes.rows as any[]).map((row) => ({
+        id: String(row.id),
+        version: Number(row.version ?? 0),
+        data: h.normalizeJson(row.data),
+      })) as UniverMetaRecord[]
+      updatedRowsForSummaries = rows
+
+      const relationalLinkFields = fields
+        .map((f) => (f.type === 'link' ? { fieldId: f.id, cfg: h.parseLinkFieldConfig(f.property) } : null))
+        .filter((v): v is { fieldId: string; cfg: LinkFieldConfig } => !!v && !!v.cfg)
+
+      const linkValuesByRecord = await h.loadLinkValuesByRecord(
+        this.pool.query.bind(this.pool),
+        rows.map((r) => r.id),
+        relationalLinkFields,
+      )
+
+      await h.applyLookupRollup(
+        this.pool.query.bind(this.pool),
+        fields,
+        rows,
+        relationalLinkFields,
+        linkValuesByRecord,
+      )
+
+      for (const row of rows) {
+        row.data = h.filterRecordDataByFieldIds(row.data, visiblePropertyFieldIds)
+      }
+
+      if (computedFieldIds.length > 0) {
+        computedRecords = rows.map((row) => ({
+          recordId: row.id,
+          data: h.extractLookupRollupData(visiblePropertyFields, row.data),
+        }))
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 3: Related record recomputation (cross-sheet)
+    // -----------------------------------------------------------------------
+    const relatedRecords =
+      updates.length > 0
+        ? await h.computeDependentLookupRollupRecords(
+            this.pool.query.bind(this.pool),
+            updates.map((u) => u.recordId),
+          )
+        : []
+
+    const sameSheetRelated = relatedRecords
+      .filter((record) => record.sheetId === sheetId)
+      .map((record) => ({
+        recordId: record.recordId,
+        data: h.filterRecordDataByFieldIds(record.data, visiblePropertyFieldIds),
+      }))
+    const crossSheetRelated = relatedRecords.filter((record) => record.sheetId !== sheetId)
+    const mergedRecords = h.mergeComputedRecords(computedRecords, sameSheetRelated)
+
+    // -----------------------------------------------------------------------
+    // Step 4: Link / attachment summary rebuild
+    // -----------------------------------------------------------------------
+    const relationalLinkFields = fields
+      .map((field) => (field.type === 'link' ? { fieldId: field.id, cfg: h.parseLinkFieldConfig(field.property) } : null))
+      .filter((value): value is RelationalLinkField => !!value && !!value.cfg)
+
+    const patchLinkSummaries =
+      relationalLinkFields.length > 0 && updates.length > 0
+        ? h.filterRecordFieldSummaryMap(
+            h.serializeLinkSummaryMap(
+              await h.buildLinkSummaries(
+                this.pool.query.bind(this.pool),
+                updates.map((update) => ({ id: update.recordId, version: 0, data: {} })),
+                relationalLinkFields,
+                await h.loadLinkValuesByRecord(
+                  this.pool.query.bind(this.pool),
+                  updates.map((update) => update.recordId),
+                  relationalLinkFields,
+                ),
+              ),
+            ),
+            visiblePropertyFieldIds,
+          )
+        : undefined
+
+    const patchAttachmentSummaries =
+      attachmentFields.length > 0 && updatedRowsForSummaries.length > 0
+        ? h.filterRecordFieldSummaryMap(
+            h.serializeAttachmentSummaryMap(
+              await h.buildAttachmentSummaries(
+                this.pool.query.bind(this.pool),
+                sheetId,
+                updatedRowsForSummaries,
+                attachmentFields,
+              ),
+            ),
+            visiblePropertyFieldIds,
+          )
+        : undefined
+
+    // -----------------------------------------------------------------------
+    // Step 5: Realtime broadcast
+    // -----------------------------------------------------------------------
+    if (updates.length > 0) {
+      publishMultitableSheetRealtime({
+        spreadsheetId: sheetId,
+        actorId,
+        source: 'multitable',
+        kind: 'record-updated',
+        recordIds: updates.map((update) => update.recordId),
+        fieldIds: [
+          ...new Set(
+            Array.from(changesByRecord.values()).flatMap((changes) => changes.map((change) => change.fieldId)),
+          ),
+        ],
+        recordPatches: updates.map((update) => ({
+          recordId: update.recordId,
+          version: update.version,
+          patch: Object.fromEntries(
+            (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
+          ),
+        })),
+      })
+
+      // -------------------------------------------------------------------
+      // Step 6: EventBus emit
+      // -------------------------------------------------------------------
+      for (const update of updates) {
+        const changes = Object.fromEntries(
+          (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
+        )
+        this.eventBus.emit('multitable.record.updated', {
+          sheetId,
+          recordId: update.recordId,
+          changes,
+          actorId,
+        })
+      }
+    }
+
+    return {
+      updated: updates,
+      ...(mergedRecords ? { records: mergedRecords } : {}),
+      ...(patchLinkSummaries ? { linkSummaries: patchLinkSummaries } : {}),
+      ...(patchAttachmentSummaries ? { attachmentSummaries: patchAttachmentSummaries } : {}),
+      ...(crossSheetRelated.length > 0 ? { relatedRecords: crossSheetRelated } : {}),
+    }
+  }
+
+  // TODO: Extract createRecord() and deleteRecord() methods in a follow-up.
+  // The CREATE handler (line ~7050-7080 in univer-meta.ts) and DELETE handler
+  // (line ~7130-7160) share a similar eventBus + realtime pattern but have
+  // simpler transaction logic. They should be extracted in a future PR to
+  // complete the shared write seam.
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -32,6 +32,18 @@ import { validateRecord, getDefaultValidationRules } from '../multitable/field-v
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import { getAutomationServiceInstance } from '../multitable/automation-service'
+import {
+  publishMultitableSheetRealtime as publishMultitableSheetRealtimeShared,
+  setRealtimeCacheInvalidator,
+  type MultitableSheetRealtimePayload as SharedRealtimePayload,
+} from '../multitable/realtime-publish'
+import {
+  RecordWriteService,
+  VersionConflictError as ServiceVersionConflictError,
+  RecordNotFoundError as ServiceNotFoundError,
+  RecordValidationError as ServiceValidationError,
+  type RecordWriteHelpers,
+} from '../multitable/record-write-service'
 
 const multitableFormulaEngine = new MultitableFormulaEngine()
 
@@ -2579,14 +2591,8 @@ function getRequestActorId(req: Request): string | null {
 }
 
 function publishMultitableSheetRealtime(payload: MultitableSheetRealtimePayload): void {
-  if (!payload.spreadsheetId) return
-  // Invalidate cursor-paginated record cache on any record mutation
-  invalidateRecordsCacheForSheet(payload.spreadsheetId)
-  try {
-    eventBus.publish('spreadsheet.cell.updated', payload)
-  } catch (err) {
-    console.warn('[univer-meta] failed to publish multitable sheet realtime update', err)
-  }
+  // Delegate to the shared module (extracted for reuse by future Yjs bridge)
+  publishMultitableSheetRealtimeShared(payload as SharedRealtimePayload)
 }
 
 function isImageMimeType(mimeType: string | null | undefined): boolean {
@@ -3251,6 +3257,9 @@ class PermissionError extends Error {
 
 export function univerMetaRouter(): Router {
   const router = Router()
+
+  // Wire up the shared realtime cache invalidator
+  setRealtimeCacheInvalidator(invalidateRecordsCacheForSheet)
 
   router.get('/bases', async (req: Request, res: Response) => {
     try {
@@ -7327,280 +7336,57 @@ export function univerMetaRouter(): Router {
         }
       }
 
-      const updates = await pool.transaction(async ({ query }) => {
-        const updated: Array<{ recordId: string; version: number }> = []
+      // --------------- Delegate to RecordWriteService ---------------
+      const writeHelpers: RecordWriteHelpers = {
+        normalizeLinkIds,
+        normalizeAttachmentIds,
+        normalizeJson,
+        parseLinkFieldConfig,
+        buildId,
+        ensureRecordWriteAllowed,
+        filterRecordDataByFieldIds,
+        extractLookupRollupData,
+        mergeComputedRecords,
+        filterRecordFieldSummaryMap,
+        serializeLinkSummaryMap,
+        serializeAttachmentSummaryMap,
+        applyLookupRollup: (q, f, rows, rl, lv) => applyLookupRollup(req, q, f, rows, rl, lv),
+        computeDependentLookupRollupRecords: (q, ids) => computeDependentLookupRollupRecords(req, q, ids),
+        loadLinkValuesByRecord,
+        buildLinkSummaries: (q, rows, rl, lv) => buildLinkSummaries(req, q, rows, rl, lv),
+        buildAttachmentSummaries: (q, sid, rows, af) => buildAttachmentSummaries(q, req, sid, rows, af),
+      }
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
 
-        for (const [recordId, changes] of changesByRecord.entries()) {
-          const expectedVersion = Array.from(new Set(changes.map(c => c.expectedVersion).filter((v): v is number => typeof v === 'number')))[0]
-          const recordRes = await query(
-            'SELECT id, version, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE',
-            [sheetId, recordId],
-          )
-          if (recordRes.rows.length === 0) {
-            throw new NotFoundError(`Record not found: ${recordId}`)
-          }
-          const recordRow: any = recordRes.rows[0]
-          if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, typeof recordRow?.created_by === 'string' ? recordRow.created_by : null, 'edit')) {
-            throw new ValidationError(`Record editing is not allowed for ${recordId}`)
-          }
-          const serverVersion = Number(recordRow?.version ?? 1)
-          if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
-            throw new VersionConflictError(recordId, serverVersion)
-          }
-
-          const patch: Record<string, unknown> = {}
-          const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
-          let applied = 0
-          for (const change of changes) {
-            const field = fieldById.get(change.fieldId)
-            if (!field) continue
-
-            if (field.type === 'formula') {
-              if (typeof change.value !== 'string') continue
-              if (change.value !== '' && !change.value.startsWith('=')) continue
-            }
-
-            if (field.type === 'link' && field.link) {
-              const ids = normalizeLinkIds(change.value)
-              patch[change.fieldId] = ids
-              linkUpdates.set(change.fieldId, { ids, cfg: field.link })
-              applied += 1
-              continue
-            }
-
-            if (field.type === 'attachment') {
-              patch[change.fieldId] = normalizeAttachmentIds(change.value)
-              applied += 1
-              continue
-            }
-
-            patch[change.fieldId] = change.value
-            applied += 1
-          }
-
-          if (applied === 0) continue
-
-          for (const { ids, cfg } of linkUpdates.values()) {
-            if (ids.length === 0) continue
-            const exists = await query(
-              'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
-              [cfg.foreignSheetId, ids],
-            )
-            const found = new Set((exists as any).rows.map((r: any) => String(r.id)))
-            const missing = ids.filter((id) => !found.has(id))
-            if (missing.length > 0) {
-              throw new ValidationError(`Linked record(s) not found in sheet ${cfg.foreignSheetId}: ${missing.join(', ')}`)
-            }
-          }
-
-          const updateRes = await query(
-            `UPDATE meta_records
-             SET data = data || $1::jsonb, updated_at = now(), version = version + 1
-             WHERE sheet_id = $2 AND id = $3
-             RETURNING version`,
-            [JSON.stringify(patch), sheetId, recordId],
-          )
-          if (updateRes.rows.length === 0) {
-            throw new NotFoundError(`Record not found: ${recordId}`)
-          }
-
-          if (linkUpdates.size > 0) {
-            for (const [fieldId, { ids }] of linkUpdates.entries()) {
-              if (ids.length === 0) {
-                try {
-                  await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [fieldId, recordId])
-                } catch (err) {
-                  throw err
-                }
-                continue
-              }
-
-              let existingIds: string[] = []
-              try {
-                const current = await query(
-                  'SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2',
-                  [fieldId, recordId],
-                )
-                existingIds = (current as any).rows.map((r: any) => String(r.foreign_record_id))
-              } catch (err) {
-                throw err
-              }
-
-              const existing = new Set(existingIds)
-              const next = new Set(ids)
-              const toDelete = existingIds.filter((id) => !next.has(id))
-              const toInsert = ids.filter((id) => !existing.has(id))
-
-              if (toDelete.length > 0) {
-                try {
-                  await query(
-                    'DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY($3::text[])',
-                    [fieldId, recordId, toDelete],
-                  )
-                } catch (err) {
-                  throw err
-                }
-              }
-
-              for (const foreignId of toInsert) {
-                try {
-                  await query(
-                    `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
-                     VALUES ($1, $2, $3, $4)
-                     ON CONFLICT DO NOTHING`,
-                    [buildId('lnk').slice(0, 50), fieldId, recordId, foreignId],
-                  )
-                } catch (err) {
-                  throw err
-                }
-              }
-            }
-          }
-
-          updated.push({ recordId, version: Number((updateRes.rows[0] as any).version) })
-        }
-
-        return updated
+      const result = await recordWriteService.patchRecords({
+        sheetId,
+        changesByRecord: changesByRecord as Map<string, Array<{ fieldId: string; value: unknown; expectedVersion?: number }>>,
+        actorId: getRequestActorId(req),
+        fields,
+        visiblePropertyFields,
+        visiblePropertyFieldIds,
+        attachmentFields,
+        fieldById,
+        capabilities,
+        sheetScope,
+        access,
       })
-
-      let computedRecords: Array<{ recordId: string; data: Record<string, unknown> }> | undefined
-      let updatedRowsForSummaries: UniverMetaRecord[] = []
-      const computedFieldIds = visiblePropertyFields.filter((f) => f.type === 'lookup' || f.type === 'rollup')
-      if (updates.length > 0 && (computedFieldIds.length > 0 || attachmentFields.length > 0)) {
-        const recordIds = updates.map((u) => u.recordId)
-        const recordRes = await pool.query(
-          'SELECT id, version, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
-          [sheetId, recordIds],
-        )
-        const rows = (recordRes.rows as any[]).map((row) => ({
-          id: String(row.id),
-          version: Number(row.version ?? 0),
-          data: normalizeJson(row.data),
-        })) as UniverMetaRecord[]
-        updatedRowsForSummaries = rows
-
-        const relationalLinkFields = fields
-          .map((f) => (f.type === 'link' ? { fieldId: f.id, cfg: parseLinkFieldConfig(f.property) } : null))
-          .filter((v): v is { fieldId: string; cfg: LinkFieldConfig } => !!v && !!v.cfg)
-
-        const linkValuesByRecord = await loadLinkValuesByRecord(
-          pool.query.bind(pool),
-          rows.map((r) => r.id),
-          relationalLinkFields,
-        )
-
-        await applyLookupRollup(
-          req,
-          pool.query.bind(pool),
-          fields,
-          rows,
-          relationalLinkFields,
-          linkValuesByRecord,
-        )
-        for (const row of rows) {
-          row.data = filterRecordDataByFieldIds(row.data, visiblePropertyFieldIds)
-        }
-
-        if (computedFieldIds.length > 0) {
-          computedRecords = rows.map((row) => ({
-            recordId: row.id,
-            data: extractLookupRollupData(visiblePropertyFields, row.data),
-          }))
-        }
-      }
-
-      const relatedRecords = updates.length > 0
-        ? await computeDependentLookupRollupRecords(
-            req,
-            pool.query.bind(pool),
-            updates.map((u) => u.recordId),
-          )
-        : []
-      const sameSheetRelated = relatedRecords
-        .filter((record) => record.sheetId === sheetId)
-        .map((record) => ({ recordId: record.recordId, data: filterRecordDataByFieldIds(record.data, visiblePropertyFieldIds) }))
-      const crossSheetRelated = relatedRecords.filter((record) => record.sheetId !== sheetId)
-      const mergedRecords = mergeComputedRecords(computedRecords, sameSheetRelated)
-      const relationalLinkFields = fields
-        .map((field) => (field.type === 'link' ? { fieldId: field.id, cfg: parseLinkFieldConfig(field.property) } : null))
-        .filter((value): value is RelationalLinkField => !!value && !!value.cfg)
-      const patchLinkSummaries = relationalLinkFields.length > 0 && updates.length > 0
-        ? filterRecordFieldSummaryMap(
-            serializeLinkSummaryMap(
-              await buildLinkSummaries(
-                req,
-                pool.query.bind(pool),
-                updates.map((update) => ({ id: update.recordId, version: 0, data: {} })),
-                relationalLinkFields,
-                await loadLinkValuesByRecord(
-                  pool.query.bind(pool),
-                  updates.map((update) => update.recordId),
-                  relationalLinkFields,
-                ),
-              ),
-            ),
-            visiblePropertyFieldIds,
-          )
-        : undefined
-      const patchAttachmentSummaries = attachmentFields.length > 0 && updatedRowsForSummaries.length > 0
-        ? filterRecordFieldSummaryMap(
-            serializeAttachmentSummaryMap(
-              await buildAttachmentSummaries(
-                pool.query.bind(pool),
-                req,
-                sheetId,
-                updatedRowsForSummaries,
-                attachmentFields,
-              ),
-            ),
-            visiblePropertyFieldIds,
-          )
-        : undefined
-
-      if (updates.length > 0) {
-        publishMultitableSheetRealtime({
-          spreadsheetId: sheetId,
-          actorId: getRequestActorId(req),
-          source: 'multitable',
-          kind: 'record-updated',
-          recordIds: updates.map((update) => update.recordId),
-          fieldIds: [...new Set(Array.from(changesByRecord.values()).flatMap((changes) => changes.map((change) => change.fieldId)))],
-          recordPatches: updates.map((update) => ({
-            recordId: update.recordId,
-            version: update.version,
-            patch: Object.fromEntries(
-              (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
-            ),
-          })),
-        })
-        for (const update of updates) {
-          const changes = Object.fromEntries(
-            (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
-          )
-          eventBus.emit('multitable.record.updated', {
-            sheetId,
-            recordId: update.recordId,
-            changes,
-            actorId: getRequestActorId(req),
-          })
-        }
-      }
 
       return res.json({
         ok: true,
         data: {
-          updated: updates,
-          ...(mergedRecords ? { records: mergedRecords } : {}),
-          ...(patchLinkSummaries ? { linkSummaries: patchLinkSummaries } : {}),
-          ...(patchAttachmentSummaries ? { attachmentSummaries: patchAttachmentSummaries } : {}),
-          ...(crossSheetRelated.length > 0 ? { relatedRecords: crossSheetRelated } : {}),
+          updated: result.updated,
+          ...(result.records ? { records: result.records } : {}),
+          ...(result.linkSummaries ? { linkSummaries: result.linkSummaries } : {}),
+          ...(result.attachmentSummaries ? { attachmentSummaries: result.attachmentSummaries } : {}),
+          ...(result.relatedRecords ? { relatedRecords: result.relatedRecords } : {}),
         },
       })
     } catch (err) {
       if (err instanceof ConflictError) {
         return res.status(409).json({ ok: false, error: { code: 'CONFLICT', message: err.message } })
       }
-      if (err instanceof VersionConflictError) {
+      if (err instanceof VersionConflictError || err instanceof ServiceVersionConflictError) {
         return res.status(409).json({
           ok: false,
           error: {
@@ -7610,10 +7396,10 @@ export function univerMetaRouter(): Router {
           },
         })
       }
-      if (err instanceof NotFoundError) {
+      if (err instanceof NotFoundError || err instanceof ServiceNotFoundError) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
       }
-      if (err instanceof ValidationError) {
+      if (err instanceof ValidationError || err instanceof ServiceValidationError) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: err.message } })
       }
       const hint = getDbNotReadyMessage(err)

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  RecordWriteService,
+  VersionConflictError,
+  RecordNotFoundError,
+  RecordValidationError,
+  type ConnectionPool,
+  type RecordWriteHelpers,
+  type RecordPatchInput,
+  type UniverMetaField,
+  type UniverMetaRecord,
+} from '../../src/multitable/record-write-service'
+
+// ---------------------------------------------------------------------------
+// Mock: publishMultitableSheetRealtime
+// ---------------------------------------------------------------------------
+const mockPublish = vi.fn()
+vi.mock('../../src/multitable/realtime-publish', () => ({
+  publishMultitableSheetRealtime: (...args: unknown[]) => mockPublish(...args),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers factory
+// ---------------------------------------------------------------------------
+
+function createMockHelpers(overrides: Partial<RecordWriteHelpers> = {}): RecordWriteHelpers {
+  return {
+    normalizeLinkIds: (v) => (Array.isArray(v) ? v.map(String) : []),
+    normalizeAttachmentIds: (v) => (Array.isArray(v) ? v.map(String) : []),
+    normalizeJson: (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v as Record<string, unknown> : {}),
+    parseLinkFieldConfig: () => null,
+    buildId: (prefix) => `${prefix}_test123`,
+    ensureRecordWriteAllowed: () => true,
+    filterRecordDataByFieldIds: (data, ids) => {
+      if (!data || typeof data !== 'object') return {}
+      return Object.fromEntries(
+        Object.entries(data as Record<string, unknown>).filter(([k]) => ids.has(k)),
+      )
+    },
+    extractLookupRollupData: () => ({}),
+    mergeComputedRecords: (base, extra) => {
+      if ((!base || base.length === 0) && extra.length === 0) return undefined
+      return [...(base ?? []), ...extra]
+    },
+    filterRecordFieldSummaryMap: (map) => map,
+    serializeLinkSummaryMap: () => ({}),
+    serializeAttachmentSummaryMap: () => ({}),
+    applyLookupRollup: vi.fn().mockResolvedValue(undefined),
+    computeDependentLookupRollupRecords: vi.fn().mockResolvedValue([]),
+    loadLinkValuesByRecord: vi.fn().mockResolvedValue(new Map()),
+    buildLinkSummaries: vi.fn().mockResolvedValue(new Map()),
+    buildAttachmentSummaries: vi.fn().mockResolvedValue(new Map()),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock pool factory
+// ---------------------------------------------------------------------------
+
+function createMockPool(queryResponses: Record<string, { rows: unknown[] }> = {}): ConnectionPool {
+  const defaultQueryResponse = { rows: [] }
+
+  const queryFn = vi.fn(async (sql: string, _params?: unknown[]) => {
+    // Match SQL patterns to return the correct responses
+    if (sql.includes('SELECT id, version, created_by FROM meta_records') && sql.includes('FOR UPDATE')) {
+      return queryResponses['SELECT_FOR_UPDATE'] ?? { rows: [{ id: 'rec1', version: 1, created_by: 'user1' }] }
+    }
+    if (sql.includes('UPDATE meta_records')) {
+      return queryResponses['UPDATE'] ?? { rows: [{ version: 2 }] }
+    }
+    if (sql.includes('SELECT id, version, data FROM meta_records')) {
+      return queryResponses['SELECT_UPDATED'] ?? defaultQueryResponse
+    }
+    if (sql.includes('SELECT id FROM meta_records WHERE sheet_id')) {
+      return queryResponses['SELECT_LINK_TARGETS'] ?? { rows: [] }
+    }
+    return defaultQueryResponse
+  })
+
+  return {
+    query: queryFn,
+    transaction: vi.fn(async <T>(handler: (client: { query: typeof queryFn }) => Promise<T>) => {
+      return handler({ query: queryFn })
+    }),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock eventBus factory
+// ---------------------------------------------------------------------------
+
+function createMockEventBus() {
+  return {
+    emit: vi.fn(),
+    publish: vi.fn(),
+    subscribe: vi.fn().mockReturnValue('sub_1'),
+    unsubscribe: vi.fn(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared test input builder
+// ---------------------------------------------------------------------------
+
+function buildTestFields(): UniverMetaField[] {
+  return [
+    { id: 'fld_name', name: 'Name', type: 'string', order: 0 },
+    { id: 'fld_age', name: 'Age', type: 'number', order: 1 },
+  ]
+}
+
+function buildTestInput(
+  overrides: Partial<RecordPatchInput> = {},
+): RecordPatchInput {
+  const fields = buildTestFields()
+  const fieldById = new Map(
+    fields.map((f) => [f.id, { type: f.type, readOnly: false, hidden: false }]),
+  )
+  const changesByRecord = new Map([
+    ['rec1', [{ fieldId: 'fld_name', value: 'Alice' }]],
+  ])
+
+  return {
+    sheetId: 'sheet1',
+    changesByRecord,
+    actorId: 'user1',
+    fields,
+    visiblePropertyFields: fields,
+    visiblePropertyFieldIds: new Set(fields.map((f) => f.id)),
+    attachmentFields: [],
+    fieldById: fieldById as any,
+    capabilities: {
+      canRead: true,
+      canCreateRecord: true,
+      canEditRecord: true,
+      canDeleteRecord: true,
+      canManageFields: true,
+      canManageSheetAccess: true,
+      canManageViews: true,
+      canComment: true,
+      canManageAutomation: true,
+      canExport: true,
+    },
+    access: { userId: 'user1', permissions: [], isAdminRole: false },
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RecordWriteService', () => {
+  let pool: ReturnType<typeof createMockPool>
+  let eventBus: ReturnType<typeof createMockEventBus>
+  let helpers: RecordWriteHelpers
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pool = createMockPool()
+    eventBus = createMockEventBus()
+    helpers = createMockHelpers()
+  })
+
+  it('should execute the full patch pipeline and return updated records', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    const input = buildTestInput()
+
+    const result = await service.patchRecords(input)
+
+    expect(result.updated).toHaveLength(1)
+    expect(result.updated[0]).toEqual({ recordId: 'rec1', version: 2 })
+  })
+
+  it('should call eventBus.emit with correct payload', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    const input = buildTestInput()
+
+    await service.patchRecords(input)
+
+    expect(eventBus.emit).toHaveBeenCalledTimes(1)
+    expect(eventBus.emit).toHaveBeenCalledWith('multitable.record.updated', {
+      sheetId: 'sheet1',
+      recordId: 'rec1',
+      changes: { fld_name: 'Alice' },
+      actorId: 'user1',
+    })
+  })
+
+  it('should call publishMultitableSheetRealtime', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    const input = buildTestInput()
+
+    await service.patchRecords(input)
+
+    expect(mockPublish).toHaveBeenCalledTimes(1)
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spreadsheetId: 'sheet1',
+        kind: 'record-updated',
+        recordIds: ['rec1'],
+      }),
+    )
+  })
+
+  it('should throw VersionConflictError when expectedVersion does not match', async () => {
+    pool = createMockPool({
+      SELECT_FOR_UPDATE: { rows: [{ id: 'rec1', version: 5, created_by: 'user1' }] },
+    })
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+    const changesByRecord = new Map([
+      ['rec1', [{ fieldId: 'fld_name', value: 'Alice', expectedVersion: 3 }]],
+    ])
+    const input = buildTestInput({ changesByRecord })
+
+    await expect(service.patchRecords(input)).rejects.toThrow(VersionConflictError)
+    await expect(service.patchRecords(input)).rejects.toMatchObject({
+      serverVersion: 5,
+      recordId: 'rec1',
+    })
+  })
+
+  it('should throw RecordNotFoundError when record does not exist', async () => {
+    pool = createMockPool({
+      SELECT_FOR_UPDATE: { rows: [] },
+    })
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    const input = buildTestInput()
+
+    await expect(service.patchRecords(input)).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('should handle link field mutations by validating targets exist', async () => {
+    const linkHelpers = createMockHelpers({
+      normalizeLinkIds: () => ['foreign_rec1'],
+      parseLinkFieldConfig: () => ({ foreignSheetId: 'sheet2', limitSingleRecord: false }),
+    })
+
+    const linkField: UniverMetaField = {
+      id: 'fld_link',
+      name: 'Related',
+      type: 'link',
+      order: 2,
+      property: { foreignSheetId: 'sheet2' },
+    }
+
+    const linkPool = createMockPool({
+      SELECT_FOR_UPDATE: { rows: [{ id: 'rec1', version: 1, created_by: 'user1' }] },
+      UPDATE: { rows: [{ version: 2 }] },
+      SELECT_LINK_TARGETS: { rows: [{ id: 'foreign_rec1' }] },
+    })
+
+    const fields = [...buildTestFields(), linkField]
+    const fieldById = new Map([
+      ...buildTestFields().map((f) => [f.id, { type: f.type, readOnly: false, hidden: false }] as const),
+      ['fld_link', { type: 'link' as const, readOnly: false, hidden: false, link: { foreignSheetId: 'sheet2', limitSingleRecord: false } }],
+    ])
+
+    const changesByRecord = new Map([
+      ['rec1', [{ fieldId: 'fld_link', value: ['foreign_rec1'] }]],
+    ])
+
+    const input = buildTestInput({
+      fields,
+      visiblePropertyFields: fields,
+      visiblePropertyFieldIds: new Set(fields.map((f) => f.id)),
+      fieldById: fieldById as any,
+      changesByRecord,
+    })
+
+    const service = new RecordWriteService(linkPool, eventBus as any, linkHelpers)
+    const result = await service.patchRecords(input)
+
+    expect(result.updated).toHaveLength(1)
+  })
+
+  it('should throw RecordValidationError when linked records are missing', async () => {
+    const linkHelpers = createMockHelpers({
+      normalizeLinkIds: () => ['missing_rec'],
+    })
+
+    const linkPool = createMockPool({
+      SELECT_FOR_UPDATE: { rows: [{ id: 'rec1', version: 1, created_by: 'user1' }] },
+      SELECT_LINK_TARGETS: { rows: [] },
+    })
+
+    const fieldById = new Map([
+      ['fld_link', { type: 'link' as const, readOnly: false, hidden: false, link: { foreignSheetId: 'sheet2', limitSingleRecord: false } }],
+    ])
+
+    const changesByRecord = new Map([
+      ['rec1', [{ fieldId: 'fld_link', value: ['missing_rec'] }]],
+    ])
+
+    const input = buildTestInput({
+      fieldById: fieldById as any,
+      changesByRecord,
+    })
+
+    const service = new RecordWriteService(linkPool, eventBus as any, linkHelpers)
+    await expect(service.patchRecords(input)).rejects.toThrow(RecordValidationError)
+  })
+
+  it('should trigger computed field recalculation when lookup/rollup fields exist', async () => {
+    const fieldsWithLookup: UniverMetaField[] = [
+      { id: 'fld_name', name: 'Name', type: 'string', order: 0 },
+      { id: 'fld_lookup', name: 'Lookup', type: 'lookup', order: 1, property: {} },
+    ]
+
+    const lookupPool = createMockPool({
+      SELECT_FOR_UPDATE: { rows: [{ id: 'rec1', version: 1, created_by: 'user1' }] },
+      UPDATE: { rows: [{ version: 2 }] },
+      SELECT_UPDATED: { rows: [{ id: 'rec1', version: 2, data: { fld_name: 'Alice' } }] },
+    })
+
+    const input = buildTestInput({
+      fields: fieldsWithLookup,
+      visiblePropertyFields: fieldsWithLookup,
+      visiblePropertyFieldIds: new Set(fieldsWithLookup.map((f) => f.id)),
+    })
+
+    const service = new RecordWriteService(lookupPool, eventBus as any, helpers)
+    await service.patchRecords(input)
+
+    expect(helpers.applyLookupRollup).toHaveBeenCalled()
+  })
+
+  it('should not emit events when no records are updated', async () => {
+    // Pass a change with a fieldId that doesn't exist in fieldById, so applied === 0
+    const changesByRecord = new Map([
+      ['rec1', [{ fieldId: 'nonexistent_field', value: 'x' }]],
+    ])
+
+    const input = buildTestInput({ changesByRecord })
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    const result = await service.patchRecords(input)
+
+    expect(result.updated).toHaveLength(0)
+    expect(eventBus.emit).not.toHaveBeenCalled()
+    expect(mockPublish).not.toHaveBeenCalled()
+  })
+
+  it('should throw RecordValidationError when record editing is not allowed', async () => {
+    const restrictedHelpers = createMockHelpers({
+      ensureRecordWriteAllowed: () => false,
+    })
+
+    const service = new RecordWriteService(pool, eventBus as any, restrictedHelpers)
+    const input = buildTestInput()
+
+    await expect(service.patchRecords(input)).rejects.toThrow(RecordValidationError)
+  })
+})


### PR DESCRIPTION
## Summary

- Extracted the 6-step record-patch pipeline (DB transaction, computed field recalc, related record recomputation, link/attachment summaries, realtime broadcast, eventBus emit) from the PATCH `/patch` route handler in `univer-meta.ts` into a new `RecordWriteService` class
- Moved `publishMultitableSheetRealtime` into a shared module at `multitable/realtime-publish.ts` so both REST and the future Yjs CRDT bridge can reuse it
- Refactored the route handler to delegate to `RecordWriteService.patchRecords()` while keeping HTTP parsing, auth, field validation, and response formatting in the handler
- Added TODO comment for follow-up extraction of CREATE and DELETE record methods

## Test plan

- [x] All 10 new unit tests pass (`record-write-service.test.ts`): pipeline execution, eventBus emit payload, realtime publish, version conflict, not found, link validation, computed field trigger, no-op changes, permission denial
- [x] All 2102 existing tests pass with no regressions (1 pre-existing unrelated failure in `api-token-webhook-migration.test.ts`)
- [x] TypeScript compiles cleanly for all modified files (pre-existing errors in unrelated files only)
- [ ] Manual smoke test: PATCH `/patch` endpoint returns same response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)