### PR TITLE
refactor(multitable): move field validation into RecordWriteService — shared write seam

### DIFF
--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -91,9 +91,23 @@ export class RecordNotFoundError extends Error {
 }
 
 export class RecordValidationError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    public code: string = 'VALIDATION_ERROR',
+  ) {
     super(message)
     this.name = 'RecordValidationError'
+  }
+}
+
+export class RecordFieldForbiddenError extends Error {
+  constructor(
+    message: string,
+    public fieldId: string,
+    public code: string = 'FIELD_READONLY',
+  ) {
+    super(message)
+    this.name = 'RecordFieldForbiddenError'
   }
 }
 
@@ -229,6 +243,12 @@ export interface RecordWriteHelpers {
     rows: UniverMetaRecord[],
     attachmentFields: UniverMetaField[],
   ) => Promise<Map<string, Map<string, MultitableAttachment[]>>>
+  ensureAttachmentIdsExist: (
+    query: QueryFn,
+    sheetId: string,
+    fieldId: string,
+    ids: string[],
+  ) => Promise<string | null>
 }
 
 // ---------------------------------------------------------------------------
@@ -243,9 +263,105 @@ export class RecordWriteService {
   ) {}
 
   /**
+   * Validate all changes before executing the write pipeline.
+   *
+   * Checks:
+   * - expectedVersion consistency (no multiple different versions per record)
+   * - Field existence (fieldId must be in fieldById)
+   * - Field writability (not hidden, not readOnly, not lookup/rollup)
+   * - Select option whitelist
+   * - Link single-record constraint and ID length
+   * - Attachment ID length and existence
+   *
+   * Throws RecordValidationError or RecordFieldForbiddenError on failure.
+   */
+  async validateChanges(input: {
+    sheetId: string
+    changesByRecord: Map<string, RecordChange[]>
+    fieldById: Map<string, FieldMutationGuard>
+  }): Promise<void> {
+    const { sheetId, changesByRecord, fieldById } = input
+    const h = this.helpers
+
+    for (const [recordId, changes] of changesByRecord.entries()) {
+      // expectedVersion consistency: reject multiple different values for same record
+      const expectedVersions = Array.from(
+        new Set(changes.map((c) => c.expectedVersion).filter((v): v is number => typeof v === 'number')),
+      )
+      if (expectedVersions.length > 1) {
+        throw new RecordValidationError(
+          `Multiple expectedVersion values provided for ${recordId}`,
+        )
+      }
+
+      for (const change of changes) {
+        const field = fieldById.get(change.fieldId)
+        if (!field) {
+          throw new RecordValidationError(`Unknown fieldId: ${change.fieldId}`)
+        }
+
+        if (field.hidden) {
+          throw new RecordFieldForbiddenError(`Field is hidden: ${change.fieldId}`, change.fieldId, 'FIELD_HIDDEN')
+        }
+
+        if (field.readOnly === true) {
+          throw new RecordFieldForbiddenError(`Field is readonly: ${change.fieldId}`, change.fieldId)
+        }
+
+        if (field.type === 'lookup' || field.type === 'rollup') {
+          throw new RecordFieldForbiddenError(`Field is readonly: ${change.fieldId}`, change.fieldId)
+        }
+
+        if (field.type === 'select') {
+          if (typeof change.value !== 'string') {
+            throw new RecordValidationError(`Select value must be string: ${change.fieldId}`)
+          }
+          const allowed = new Set(field.options ?? [])
+          if (change.value !== '' && !allowed.has(change.value)) {
+            throw new RecordValidationError(`Invalid select option for ${change.fieldId}: ${change.value}`)
+          }
+        }
+
+        if (field.type === 'link') {
+          if (field.link) {
+            const ids = h.normalizeLinkIds(change.value)
+            if (field.link.limitSingleRecord && ids.length > 1) {
+              throw new RecordValidationError(`Link field only allows a single record: ${change.fieldId}`)
+            }
+            const tooLong = ids.find((id) => id.length > 50)
+            if (tooLong) {
+              throw new RecordValidationError(`Link id too long (>50): ${tooLong}`)
+            }
+          } else if (typeof change.value !== 'string') {
+            throw new RecordValidationError(`Link value must be string: ${change.fieldId}`)
+          }
+        }
+
+        if (field.type === 'attachment') {
+          const ids = h.normalizeAttachmentIds(change.value)
+          const tooLong = ids.find((id) => id.length > 100)
+          if (tooLong) {
+            throw new RecordValidationError(`Attachment id too long: ${tooLong}`)
+          }
+          const attachmentError = await h.ensureAttachmentIdsExist(
+            this.pool.query.bind(this.pool) as unknown as QueryFn,
+            sheetId,
+            change.fieldId,
+            ids,
+          )
+          if (attachmentError) {
+            throw new RecordValidationError(attachmentError)
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Complete record-patch pipeline.
    *
    * Steps:
+   * 0. Validate changes (field writability, value constraints, expectedVersion consistency)
    * 1. DB transaction: SELECT FOR UPDATE → version check → field-type handling
    *    → `data || patch::jsonb` → link mutation → version++
    * 2. Computed field recalculation (lookup/rollup)
@@ -270,6 +386,11 @@ export class RecordWriteService {
     } = input
 
     const h = this.helpers
+
+    // -----------------------------------------------------------------------
+    // Step 0: Validate changes (field writability + value constraints)
+    // -----------------------------------------------------------------------
+    await this.validateChanges({ sheetId, changesByRecord, fieldById })
 
     // -----------------------------------------------------------------------
     // Step 1: DB transaction

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -42,6 +42,7 @@ import {
   VersionConflictError as ServiceVersionConflictError,
   RecordNotFoundError as ServiceNotFoundError,
   RecordValidationError as ServiceValidationError,
+  RecordFieldForbiddenError as ServiceFieldForbiddenError,
   type RecordWriteHelpers,
 } from '../multitable/record-write-service'
 
@@ -7236,107 +7237,7 @@ export function univerMetaRouter(): Router {
         else changesByRecord.set(change.recordId, [change])
       }
 
-      for (const [recordId, changes] of changesByRecord.entries()) {
-        const expectedVersions = Array.from(new Set(changes.map(c => c.expectedVersion).filter((v): v is number => typeof v === 'number')))
-        if (expectedVersions.length > 1) {
-          return res.status(400).json({
-            ok: false,
-            error: { code: 'VALIDATION_ERROR', message: `Multiple expectedVersion values provided for ${recordId}` },
-          })
-        }
-
-        for (const change of changes) {
-          const field = fieldById.get(change.fieldId)
-          if (!field) {
-            return res.status(400).json({
-              ok: false,
-              error: { code: 'VALIDATION_ERROR', message: `Unknown fieldId: ${change.fieldId}` },
-            })
-          }
-
-          if (field.hidden) {
-            return res.status(403).json({
-              ok: false,
-              error: { code: 'FIELD_HIDDEN', message: `Field is hidden: ${change.fieldId}` },
-            })
-          }
-
-          // P0.3: Field-level readonly permission check
-          if (field.readOnly === true) {
-            return res.status(403).json({
-              ok: false,
-              error: { code: 'FIELD_READONLY', message: `Field is readonly: ${change.fieldId}` },
-            })
-          }
-
-          if (field.type === 'lookup' || field.type === 'rollup') {
-            return res.status(403).json({
-              ok: false,
-              error: { code: 'FIELD_READONLY', message: `Field is readonly: ${change.fieldId}` },
-            })
-          }
-
-          if (field.type === 'select') {
-            if (typeof change.value !== 'string') {
-              return res.status(400).json({
-                ok: false,
-                error: { code: 'VALIDATION_ERROR', message: `Select value must be string: ${change.fieldId}` },
-              })
-            }
-            const allowed = new Set(field.options ?? [])
-            if (change.value !== '' && !allowed.has(change.value)) {
-              return res.status(400).json({
-                ok: false,
-                error: { code: 'VALIDATION_ERROR', message: `Invalid select option for ${change.fieldId}: ${change.value}` },
-              })
-            }
-          }
-
-          if (field.type === 'link') {
-            if (field.link) {
-              const ids = normalizeLinkIds(change.value)
-              if (field.link.limitSingleRecord && ids.length > 1) {
-                return res.status(400).json({
-                  ok: false,
-                  error: { code: 'VALIDATION_ERROR', message: `Link field only allows a single record: ${change.fieldId}` },
-                })
-              }
-              const tooLong = ids.find((id) => id.length > 50)
-              if (tooLong) {
-                return res.status(400).json({
-                  ok: false,
-                  error: { code: 'VALIDATION_ERROR', message: `Link id too long (>50): ${tooLong}` },
-                })
-              }
-            } else if (typeof change.value !== 'string') {
-              return res.status(400).json({
-                ok: false,
-                error: { code: 'VALIDATION_ERROR', message: `Link value must be string: ${change.fieldId}` },
-              })
-            }
-          }
-
-          if (field.type === 'attachment') {
-            const ids = normalizeAttachmentIds(change.value)
-            const tooLong = ids.find((id) => id.length > 100)
-            if (tooLong) {
-              return res.status(400).json({
-                ok: false,
-                error: { code: 'VALIDATION_ERROR', message: `Attachment id too long: ${tooLong}` },
-              })
-            }
-            const attachmentError = await ensureAttachmentIdsExist(pool.query.bind(pool), sheetId, change.fieldId, ids)
-            if (attachmentError) {
-              return res.status(400).json({
-                ok: false,
-                error: { code: 'VALIDATION_ERROR', message: attachmentError },
-              })
-            }
-          }
-        }
-      }
-
-      // --------------- Delegate to RecordWriteService ---------------
+      // --------------- Delegate to RecordWriteService (validation + pipeline) ---------------
       const writeHelpers: RecordWriteHelpers = {
         normalizeLinkIds,
         normalizeAttachmentIds,
@@ -7355,6 +7256,7 @@ export function univerMetaRouter(): Router {
         loadLinkValuesByRecord,
         buildLinkSummaries: (q, rows, rl, lv) => buildLinkSummaries(req, q, rows, rl, lv),
         buildAttachmentSummaries: (q, sid, rows, af) => buildAttachmentSummaries(q, req, sid, rows, af),
+        ensureAttachmentIdsExist,
       }
       const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
 
@@ -7399,8 +7301,12 @@ export function univerMetaRouter(): Router {
       if (err instanceof NotFoundError || err instanceof ServiceNotFoundError) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
       }
+      if (err instanceof ServiceFieldForbiddenError) {
+        return res.status(403).json({ ok: false, error: { code: err.code, message: err.message } })
+      }
       if (err instanceof ValidationError || err instanceof ServiceValidationError) {
-        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: err.message } })
+        const code = err instanceof ServiceValidationError ? (err.code || 'VALIDATION_ERROR') : 'VALIDATION_ERROR'
+        return res.status(400).json({ ok: false, error: { code, message: err.message } })
       }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -4,6 +4,7 @@ import {
   VersionConflictError,
   RecordNotFoundError,
   RecordValidationError,
+  RecordFieldForbiddenError,
   type ConnectionPool,
   type RecordWriteHelpers,
   type RecordPatchInput,
@@ -50,6 +51,7 @@ function createMockHelpers(overrides: Partial<RecordWriteHelpers> = {}): RecordW
     loadLinkValuesByRecord: vi.fn().mockResolvedValue(new Map()),
     buildLinkSummaries: vi.fn().mockResolvedValue(new Map()),
     buildAttachmentSummaries: vi.fn().mockResolvedValue(new Map()),
+    ensureAttachmentIdsExist: vi.fn().mockResolvedValue(null),
     ...overrides,
   }
 }
@@ -328,12 +330,15 @@ describe('RecordWriteService', () => {
   })
 
   it('should not emit events when no records are updated', async () => {
-    // Pass a change with a fieldId that doesn't exist in fieldById, so applied === 0
+    // Pass a formula field change with invalid value (not starting with =), so applied === 0
     const changesByRecord = new Map([
-      ['rec1', [{ fieldId: 'nonexistent_field', value: 'x' }]],
+      ['rec1', [{ fieldId: 'fld_formula', value: 123 }]],
     ])
-
-    const input = buildTestInput({ changesByRecord })
+    // Add formula field to fieldById so validation passes
+    const fieldByIdWithFormula = new Map([
+      ['fld_formula', { type: 'formula' as const, readOnly: false, hidden: false }],
+    ])
+    const input = buildTestInput({ changesByRecord, fieldById: fieldByIdWithFormula })
     const service = new RecordWriteService(pool, eventBus as any, helpers)
     const result = await service.patchRecords(input)
 
@@ -351,5 +356,131 @@ describe('RecordWriteService', () => {
     const input = buildTestInput()
 
     await expect(service.patchRecords(input)).rejects.toThrow(RecordValidationError)
+  })
+
+  // -----------------------------------------------------------------------
+  // validateChanges — field writability and value constraint tests
+  // -----------------------------------------------------------------------
+
+  describe('validateChanges', () => {
+    it('rejects multiple expectedVersion values for same record', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const changesByRecord = new Map([
+        ['rec1', [
+          { fieldId: 'fld1', value: 'a', expectedVersion: 1 },
+          { fieldId: 'fld2', value: 'b', expectedVersion: 2 },
+        ]],
+      ])
+      const fieldById = new Map([
+        ['fld1', { type: 'string' as const, readOnly: false, hidden: false }],
+        ['fld2', { type: 'string' as const, readOnly: false, hidden: false }],
+      ])
+
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(RecordValidationError)
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(/Multiple expectedVersion/)
+    })
+
+    it('rejects unknown fieldId', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const changesByRecord = new Map([
+        ['rec1', [{ fieldId: 'nonexistent', value: 'x' }]],
+      ])
+      const fieldById = new Map<string, any>()
+
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(RecordValidationError)
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(/Unknown fieldId/)
+    })
+
+    it('rejects hidden field', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const changesByRecord = new Map([
+        ['rec1', [{ fieldId: 'fld1', value: 'x' }]],
+      ])
+      const fieldById = new Map([
+        ['fld1', { type: 'string' as const, readOnly: false, hidden: true }],
+      ])
+
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(RecordFieldForbiddenError)
+    })
+
+    it('rejects readOnly field', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const changesByRecord = new Map([
+        ['rec1', [{ fieldId: 'fld1', value: 'x' }]],
+      ])
+      const fieldById = new Map([
+        ['fld1', { type: 'string' as const, readOnly: true, hidden: false }],
+      ])
+
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(RecordFieldForbiddenError)
+    })
+
+    it('rejects lookup/rollup fields', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      for (const type of ['lookup', 'rollup'] as const) {
+        const changesByRecord = new Map([
+          ['rec1', [{ fieldId: 'fld1', value: 'x' }]],
+        ])
+        const fieldById = new Map([
+          ['fld1', { type, readOnly: false, hidden: false }],
+        ])
+
+        await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+          .rejects.toThrow(RecordFieldForbiddenError)
+      }
+    })
+
+    it('rejects invalid select option', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const changesByRecord = new Map([
+        ['rec1', [{ fieldId: 'fld1', value: 'invalid' }]],
+      ])
+      const fieldById = new Map([
+        ['fld1', { type: 'select' as const, readOnly: false, hidden: false, options: ['a', 'b'] }],
+      ])
+
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(RecordValidationError)
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(/Invalid select option/)
+    })
+
+    it('rejects link field with multiple records when limitSingleRecord', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const changesByRecord = new Map([
+        ['rec1', [{ fieldId: 'fld1', value: ['r1', 'r2'] }]],
+      ])
+      const fieldById = new Map([
+        ['fld1', { type: 'link' as const, readOnly: false, hidden: false, link: { foreignSheetId: 's2', limitSingleRecord: true } }],
+      ])
+
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(RecordValidationError)
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(/single record/)
+    })
+
+    it('passes valid changes', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const changesByRecord = new Map([
+        ['rec1', [
+          { fieldId: 'fld1', value: 'hello', expectedVersion: 1 },
+          { fieldId: 'fld2', value: 42, expectedVersion: 1 },
+        ]],
+      ])
+      const fieldById = new Map([
+        ['fld1', { type: 'string' as const, readOnly: false, hidden: false }],
+        ['fld2', { type: 'number' as const, readOnly: false, hidden: false }],
+      ])
+
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .resolves.not.toThrow()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #881. Moves field writability validation and value constraint checks from the route handler into `RecordWriteService.validateChanges()`.

### What moved into the service

- `expectedVersion` consistency check (reject multiple different values per record)
- Unknown fieldId rejection
- Hidden field rejection (`FIELD_HIDDEN`)
- ReadOnly field rejection (`FIELD_READONLY`)
- Lookup/rollup field rejection (computed, not writable)
- Select option whitelist validation
- Link `limitSingleRecord` constraint + ID length check
- Attachment ID length + existence check

### Why

`RecordWriteService` is the shared write seam for REST and the future Yjs bridge. Without validation in the service, the Yjs bridge would bypass all field constraints. Now any caller of `patchRecords()` gets the full authoritative path: **validation → DB transaction → computed recalc → realtime → eventBus**.

### Changes

- `record-write-service.ts`: +`validateChanges()`, +`RecordFieldForbiddenError`, +`ensureAttachmentIdsExist` in helpers
- `univer-meta.ts`: -100 lines of inline validation, +error handling for new error types
- `record-write-service.test.ts`: +8 validation tests (18 total)

## Test plan

- [x] `npx vitest run tests/unit/record-write-service.test.ts` → 18/18 passed
- [x] No functional changes to REST API behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)