### PR TITLE
feat(collab): add Yjs awareness presence primitives

### DIFF
--- a/apps/web/src/multitable/components/MetaYjsPresenceChip.vue
+++ b/apps/web/src/multitable/components/MetaYjsPresenceChip.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { YjsPresenceUser } from '../types'
+
+const props = withDefaults(defineProps<{
+  users: YjsPresenceUser[]
+  currentUserId?: string | null
+  fieldId?: string | null
+  label?: string
+}>(), {
+  currentUserId: null,
+  fieldId: null,
+  label: 'Collaborating now',
+})
+
+const filteredUsers = computed(() => {
+  const normalizedFieldId = props.fieldId?.trim() || null
+  return props.users.filter((user) => {
+    if (user.id === props.currentUserId) return false
+    if (!normalizedFieldId) return true
+    return user.fieldIds.includes(normalizedFieldId)
+  })
+})
+
+const summary = computed(() => {
+  const users = filteredUsers.value
+  if (users.length === 0) return ''
+  if (users.length === 1) return users[0]?.id ?? ''
+  if (users.length === 2) return `${users[0]?.id}, ${users[1]?.id}`
+  return `${users[0]?.id}, ${users[1]?.id} +${users.length - 2}`
+})
+</script>
+
+<template>
+  <div
+    v-if="filteredUsers.length > 0"
+    class="mt-yjs-presence-chip"
+    :title="`${label}: ${filteredUsers.map((user) => user.id).join(', ')}`"
+  >
+    <span class="mt-yjs-presence-chip__dot" aria-hidden="true" />
+    <span class="mt-yjs-presence-chip__label">{{ label }}</span>
+    <span class="mt-yjs-presence-chip__users">{{ summary }}</span>
+  </div>
+</template>
+
+<style scoped>
+.mt-yjs-presence-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(14, 116, 144, 0.12);
+  color: #155e75;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.mt-yjs-presence-chip__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.8;
+}
+
+.mt-yjs-presence-chip__label {
+  white-space: nowrap;
+}
+
+.mt-yjs-presence-chip__users {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/apps/web/src/multitable/composables/useYjsDocument.ts
+++ b/apps/web/src/multitable/composables/useYjsDocument.ts
@@ -1,4 +1,4 @@
-import { ref, shallowRef, onUnmounted, watch } from 'vue'
+import { computed, ref, shallowRef, onUnmounted, watch } from 'vue'
 import type { Ref } from 'vue'
 import * as Y from 'yjs'
 import * as syncProtocol from 'y-protocols/sync'
@@ -6,6 +6,7 @@ import * as encoding from 'lib0/encoding'
 import * as decoding from 'lib0/decoding'
 import { io as socketIO, type Socket } from 'socket.io-client'
 import { useAuth } from '../../composables/useAuth'
+import type { YjsRecordPresence, YjsPresenceUser } from '../types'
 
 const MSG_SYNC = 0
 
@@ -42,10 +43,41 @@ export function useYjsDocument(recordId: Ref<string | null>) {
   const connected = ref(false)
   const synced = ref(false)
   const error = ref<string | null>(null)
+  const presence = ref<YjsRecordPresence | null>(null)
+  const currentUserId = ref<string | null>(null)
 
   const auth = useAuth()
   let socket: Socket | null = null
   let currentRecordId: string | null = null
+
+  function normalizePresenceSnapshot(payload: unknown, expectedRecordId: string): YjsRecordPresence | null {
+    if (!payload || typeof payload !== 'object') return null
+    const record = payload as Record<string, unknown>
+    const nextRecordId = typeof record.recordId === 'string' ? record.recordId : ''
+    if (!nextRecordId || nextRecordId !== expectedRecordId) return null
+
+    const rawUsers = Array.isArray(record.users) ? record.users : []
+    const users: YjsPresenceUser[] = rawUsers.flatMap((entry) => {
+      if (!entry || typeof entry !== 'object') return []
+      const user = entry as Record<string, unknown>
+      const id = typeof user.id === 'string' ? user.id.trim() : ''
+      if (!id) return []
+      const fieldIds = Array.isArray(user.fieldIds)
+        ? user.fieldIds
+          .map((fieldId) => (typeof fieldId === 'string' ? fieldId.trim() : ''))
+          .filter((fieldId): fieldId is string => fieldId.length > 0)
+        : []
+      return [{ id, fieldIds: [...new Set(fieldIds)] }]
+    })
+
+    return {
+      recordId: nextRecordId,
+      activeCount: typeof record.activeCount === 'number' && Number.isFinite(record.activeCount)
+        ? record.activeCount
+        : users.length,
+      users,
+    }
+  }
 
   async function connect(rid: string) {
     disconnect()
@@ -58,6 +90,7 @@ export function useYjsDocument(recordId: Ref<string | null>) {
       error.value = 'Not authenticated'
       return
     }
+    currentUserId.value = await auth.getCurrentUserId().catch(() => null)
 
     const yDoc = new Y.Doc()
     doc.value = yDoc
@@ -90,6 +123,13 @@ export function useYjsDocument(recordId: Ref<string | null>) {
       },
     )
 
+    socket.on('yjs:presence', (payload: unknown) => {
+      const nextPresence = normalizePresenceSnapshot(payload, rid)
+      if (nextPresence) {
+        presence.value = nextPresence
+      }
+    })
+
     // Send local updates to server
     yDoc.on('update', (update: Uint8Array, origin: unknown) => {
       if (origin !== 'remote' && socket?.connected) {
@@ -107,7 +147,35 @@ export function useYjsDocument(recordId: Ref<string | null>) {
     socket.on('disconnect', () => {
       connected.value = false
       synced.value = false
+      presence.value = null
     })
+  }
+
+  function setActiveField(fieldId: string | null): void {
+    if (!socket || !currentRecordId) return
+    socket.emit('yjs:presence', {
+      recordId: currentRecordId,
+      fieldId: fieldId?.trim() ? fieldId.trim() : null,
+    })
+  }
+
+  const activeUsers = computed(() => presence.value?.users ?? [])
+
+  const activeCollaborators = computed(() => {
+    const selfId = currentUserId.value
+    return activeUsers.value.filter((user) => user.id !== selfId)
+  })
+
+  const activeCollaboratorCount = computed(() => activeCollaborators.value.length)
+
+  function getFieldCollaborators(fieldId: string): YjsPresenceUser[] {
+    const normalizedFieldId = fieldId.trim()
+    if (!normalizedFieldId) return []
+    const selfId = currentUserId.value
+    return activeUsers.value.filter((user) => (
+      user.id !== selfId
+      && user.fieldIds.includes(normalizedFieldId)
+    ))
   }
 
   function disconnect() {
@@ -125,6 +193,7 @@ export function useYjsDocument(recordId: Ref<string | null>) {
     currentRecordId = null
     connected.value = false
     synced.value = false
+    presence.value = null
   }
 
   // Auto-connect when recordId changes
@@ -139,5 +208,18 @@ export function useYjsDocument(recordId: Ref<string | null>) {
 
   onUnmounted(disconnect)
 
-  return { doc, connected, synced, error, connect, disconnect }
+  return {
+    doc,
+    connected,
+    synced,
+    error,
+    presence,
+    activeUsers,
+    activeCollaborators,
+    activeCollaboratorCount,
+    connect,
+    disconnect,
+    setActiveField,
+    getFieldCollaborators,
+  }
 }

--- a/apps/web/src/multitable/composables/useYjsTextField.ts
+++ b/apps/web/src/multitable/composables/useYjsTextField.ts
@@ -13,12 +13,16 @@ import * as Y from 'yjs'
 export function useYjsTextField(
   doc: ShallowRef<Y.Doc | null> | Ref<Y.Doc | null>,
   fieldId: string,
+  options?: {
+    setActiveField?: (fieldId: string | null) => void
+  },
 ) {
   const text = ref('')
   let yText: Y.Text | null = null
   let observer: ((event: Y.YTextEvent) => void) | null = null
 
   function cleanup() {
+    options?.setActiveField?.(null)
     if (yText && observer) {
       yText.unobserve(observer)
     }
@@ -45,6 +49,7 @@ export function useYjsTextField(
       yText = existing as Y.Text
 
       text.value = yText.toString()
+      options?.setActiveField?.(fieldId)
 
       observer = () => {
         text.value = yText!.toString()

--- a/apps/web/src/multitable/index.ts
+++ b/apps/web/src/multitable/index.ts
@@ -8,6 +8,8 @@ export { useMultitableGrid, buildSortInfo, buildFilterInfo, FILTER_OPERATORS_BY_
 export type { SortRule, FilterRule, FilterOperator, FilterConjunction, CellEdit } from './composables/useMultitableGrid'
 export { useMultitableCapabilities } from './composables/useMultitableCapabilities'
 export type { MultitableCapabilities, MultitableRole } from './composables/useMultitableCapabilities'
+export { useYjsDocument } from './composables/useYjsDocument'
+export { useYjsTextField } from './composables/useYjsTextField'
 export { useMultitableComments } from './composables/useMultitableComments'
 export { useMultitableCommentInboxSummary } from './composables/useMultitableCommentInboxSummary'
 export { useMultitableCommentPresence } from './composables/useMultitableCommentPresence'
@@ -27,6 +29,7 @@ export { default as MetaFieldHeader } from './components/MetaFieldHeader.vue'
 export { default as MetaViewTabBar } from './components/MetaViewTabBar.vue'
 export { default as MetaToolbar } from './components/MetaToolbar.vue'
 export { default as MetaFormView } from './components/MetaFormView.vue'
+export { default as MetaYjsPresenceChip } from './components/MetaYjsPresenceChip.vue'
 
 // View-type components
 export { default as MetaKanbanView } from './components/MetaKanbanView.vue'

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -178,6 +178,17 @@ export interface MetaCapabilities {
   canExport: boolean
 }
 
+export interface YjsPresenceUser {
+  id: string
+  fieldIds: string[]
+}
+
+export interface YjsRecordPresence {
+  recordId: string
+  activeCount: number
+  users: YjsPresenceUser[]
+}
+
 export interface MetaCapabilityOrigin {
   source: 'admin' | 'global-rbac' | 'sheet-grant' | 'sheet-scope'
   hasSheetAssignments: boolean

--- a/apps/web/tests/yjs-awareness-presence.spec.ts
+++ b/apps/web/tests/yjs-awareness-presence.spec.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import { useYjsDocument } from '../src/multitable/composables/useYjsDocument'
+import { useYjsTextField } from '../src/multitable/composables/useYjsTextField'
+import MetaYjsPresenceChip from '../src/multitable/components/MetaYjsPresenceChip.vue'
+
+type Handler = (...args: any[]) => void
+
+const handlers = new Map<string, Handler>()
+const emitMock = vi.fn()
+const disconnectMock = vi.fn()
+const ioMock = vi.fn(() => ({
+  connected: true,
+  on: (event: string, handler: Handler) => {
+    handlers.set(event, handler)
+  },
+  emit: emitMock,
+  disconnect: disconnectMock,
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: (...args: unknown[]) => ioMock(...args),
+}))
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getToken: vi.fn(() => 'jwt-token'),
+    getCurrentUserId: vi.fn().mockResolvedValue('user_self'),
+  }),
+}))
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('Yjs awareness presence', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    handlers.clear()
+    emitMock.mockReset()
+    disconnectMock.mockReset()
+    ioMock.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('tracks collaborators per field and emits active field presence', async () => {
+    const recordId = ref('rec_yjs_1')
+    let activeCollaboratorCount: { value: number } = ref(0)
+    let getFieldCollaborators: (fieldId: string) => Array<{ id: string; fieldIds: string[] }> = () => []
+
+    app = createApp(defineComponent({
+      setup() {
+        const yjs = useYjsDocument(recordId)
+        useYjsTextField(yjs.doc, 'fld_body', { setActiveField: yjs.setActiveField })
+        activeCollaboratorCount = yjs.activeCollaboratorCount
+        getFieldCollaborators = yjs.getFieldCollaborators
+        return () => h('div')
+      },
+    }))
+    app.mount(container!)
+    await flushUi()
+
+    expect(ioMock).toHaveBeenCalledTimes(1)
+    handlers.get('connect')?.()
+    await flushUi(2)
+
+    expect(emitMock).toHaveBeenCalledWith('yjs:subscribe', { recordId: 'rec_yjs_1' })
+    expect(emitMock).toHaveBeenCalledWith('yjs:presence', {
+      recordId: 'rec_yjs_1',
+      fieldId: 'fld_body',
+    })
+
+    handlers.get('yjs:presence')?.({
+      recordId: 'rec_yjs_1',
+      activeCount: 3,
+      users: [
+        { id: 'user_self', fieldIds: ['fld_body'] },
+        { id: 'user_other', fieldIds: ['fld_body'] },
+        { id: 'user_viewer', fieldIds: [] },
+      ],
+    })
+    await flushUi(2)
+
+    expect(activeCollaboratorCount.value).toBe(2)
+    expect(getFieldCollaborators('fld_body').map((user) => user.id)).toEqual(['user_other'])
+
+    app.unmount()
+    app = null
+    await flushUi(2)
+
+    expect(emitMock).toHaveBeenCalledWith('yjs:presence', {
+      recordId: 'rec_yjs_1',
+      fieldId: null,
+    })
+  })
+
+  it('renders a compact chip for filtered collaborators', async () => {
+    app = createApp(defineComponent({
+      setup() {
+        return () => h(MetaYjsPresenceChip, {
+          label: 'Editing now',
+          currentUserId: 'user_self',
+          fieldId: 'fld_body',
+          users: [
+            { id: 'user_self', fieldIds: ['fld_body'] },
+            { id: 'user_alpha', fieldIds: ['fld_body'] },
+            { id: 'user_beta', fieldIds: ['fld_body'] },
+            { id: 'user_gamma', fieldIds: [] },
+          ],
+        })
+      },
+    }))
+    app.mount(container!)
+    await flushUi(2)
+
+    expect(container?.textContent).toContain('Editing now')
+    expect(container?.textContent).toContain('user_alpha, user_beta')
+    expect(container?.textContent).not.toContain('user_self')
+    expect(container?.textContent).not.toContain('user_gamma')
+  })
+})

--- a/docs/development/yjs-awareness-mainline-rebase-development-20260416.md
+++ b/docs/development/yjs-awareness-mainline-rebase-development-20260416.md
@@ -1,0 +1,38 @@
+# Yjs Awareness Mainline Rebase Development
+
+Date: 2026-04-16
+Branch: `codex/yjs-awareness-presence-20260415`
+
+## Purpose
+
+Rebase the Yjs awareness/presence follow-up onto the latest `origin/main`, after the Yjs POC hardening work landed on main.
+
+This closes the risk that the awareness branch would accidentally revert:
+
+- `ENABLE_YJS_COLLAB` feature gating
+- JWT-authenticated `/yjs` sockets
+- `write-own` record enforcement
+- Yjs bridge observability / hardening
+- updates-only crash recovery
+
+## Mainline alignment
+
+Before rebase:
+
+- awareness branch base was still `73c73572a`
+- `origin/main` had advanced to `a5b48c7fe`
+
+After rebase:
+
+- awareness branch HEAD became `20216e8bc`
+- branch is now replayed on top of `a5b48c7fe`
+
+## What changed in this step
+
+- rebased `codex/yjs-awareness-presence-20260415` onto latest `origin/main`
+- verified no conflicts required manual resolution
+- reran the Yjs backend hardening suite, original POC suite, and awareness follow-up tests
+
+## Scope
+
+This step did not add new product behavior. It only confirmed that the awareness follow-up remains compatible with the hardening code now present in `main`.

--- a/docs/development/yjs-awareness-mainline-rebase-verification-20260416.md
+++ b/docs/development/yjs-awareness-mainline-rebase-verification-20260416.md
@@ -1,0 +1,73 @@
+# Yjs Awareness Mainline Rebase Verification
+
+Date: 2026-04-16
+Branch: `codex/yjs-awareness-presence-20260415`
+Head after rebase: `20216e8bc`
+Mainline base: `a5b48c7fe`
+
+## Commands run
+
+```bash
+git rebase origin/main
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/yjs-poc.test.ts \
+  tests/unit/yjs-hardening.test.ts \
+  tests/unit/yjs-awareness.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/web exec vitest run \
+  --watch=false \
+  tests/yjs-awareness-presence.spec.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+
+claude auth status
+```
+
+## Results
+
+### Rebase
+
+- `git rebase origin/main` completed successfully
+- no conflicts
+
+### Backend
+
+- `tests/unit/yjs-poc.test.ts`
+- `tests/unit/yjs-hardening.test.ts`
+- `tests/unit/yjs-awareness.test.ts`
+- Result: `34/34` tests passed
+
+### Frontend
+
+- `tests/yjs-awareness-presence.spec.ts`
+- Result: `2/2` tests passed
+
+### Type-check
+
+- `apps/web vue-tsc --noEmit`
+- Result: passed
+
+### Claude Code CLI
+
+`claude auth status` returned:
+
+- `loggedIn: true`
+- `authMethod: claude.ai`
+- `subscriptionType: max`
+
+## Temporary verification setup
+
+The isolated worktree used temporary `node_modules` symlinks for local execution:
+
+- `/tmp/metasheet2-yjs-awareness/node_modules`
+- `/tmp/metasheet2-yjs-awareness/apps/web/node_modules`
+- `/tmp/metasheet2-yjs-awareness/packages/core-backend/node_modules`
+
+They are only for local verification and must not be committed.
+
+## Conclusion
+
+The awareness/presence follow-up is now validated on top of the hardening-enabled `main` and no longer risks reverting `#884`.

--- a/docs/development/yjs-awareness-presence-development-20260416.md
+++ b/docs/development/yjs-awareness-presence-development-20260416.md
@@ -1,0 +1,71 @@
+# Yjs Awareness Presence Development
+
+Date: 2026-04-16
+Branch: `codex/yjs-awareness-presence-20260415`
+
+## Scope
+
+Follow up on the merged Yjs record-level POC with a minimal awareness/presence layer:
+
+- record-level presence snapshots on `/yjs`
+- field-level active editor hints for the current text field
+- reusable frontend awareness state for future rollout
+- a minimal presentation chip, without wiring it into the main workbench yet
+
+## Backend changes
+
+Updated [packages/core-backend/src/collab/yjs-websocket-adapter.ts](/tmp/metasheet2-yjs-awareness/packages/core-backend/src/collab/yjs-websocket-adapter.ts:1):
+
+- added `yjs:presence` socket event
+- track per-record socket presence as `recordId -> socketId -> { userId, fieldId }`
+- emit deduplicated `yjs:presence` snapshots back to the room
+- clean up cached presence on `unsubscribe` and `disconnect`
+- expose minimal metrics for active docs/sockets
+
+Added backend test coverage in [packages/core-backend/tests/unit/yjs-awareness.test.ts](/tmp/metasheet2-yjs-awareness/packages/core-backend/tests/unit/yjs-awareness.test.ts:1) for:
+
+- record presence publication
+- field-level presence updates
+- unsubscribe cleanup
+- unsubscribed presence rejection
+
+## Frontend changes
+
+Updated [apps/web/src/multitable/composables/useYjsDocument.ts](/tmp/metasheet2-yjs-awareness/apps/web/src/multitable/composables/useYjsDocument.ts:1):
+
+- track `presence`
+- expose `activeUsers`, `activeCollaborators`, `activeCollaboratorCount`
+- expose `getFieldCollaborators(fieldId)`
+- expose `setActiveField(fieldId | null)` to publish field focus over `/yjs`
+- load `currentUserId` and filter self out of collaborator summaries
+
+Updated [apps/web/src/multitable/composables/useYjsTextField.ts](/tmp/metasheet2-yjs-awareness/apps/web/src/multitable/composables/useYjsTextField.ts:1):
+
+- optional `setActiveField()` integration
+- marks the field as active when bound
+- clears active field on cleanup
+
+Added [apps/web/src/multitable/components/MetaYjsPresenceChip.vue](/tmp/metasheet2-yjs-awareness/apps/web/src/multitable/components/MetaYjsPresenceChip.vue:1):
+
+- compact collaborator chip
+- optional field filter
+- excludes current user when provided
+
+Updated [apps/web/src/multitable/index.ts](/tmp/metasheet2-yjs-awareness/apps/web/src/multitable/index.ts:1) to export:
+
+- `useYjsDocument`
+- `useYjsTextField`
+- `MetaYjsPresenceChip`
+
+Added frontend test coverage in [apps/web/tests/yjs-awareness-presence.spec.ts](/tmp/metasheet2-yjs-awareness/apps/web/tests/yjs-awareness-presence.spec.ts:1) for:
+
+- presence snapshot consumption
+- self filtering
+- field collaborator filtering
+- active field emission
+- chip rendering
+
+## Notes
+
+- This change intentionally does not wire awareness UI into the main multitable workbench yet.
+- It stays within the Yjs POC boundary: single-record collaboration with text-field awareness hints.

--- a/docs/development/yjs-awareness-presence-verification-20260416.md
+++ b/docs/development/yjs-awareness-presence-verification-20260416.md
@@ -1,0 +1,60 @@
+# Yjs Awareness Presence Verification
+
+Date: 2026-04-16
+Branch: `codex/yjs-awareness-presence-20260415`
+
+## Commands run
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/yjs-poc.test.ts tests/unit/yjs-awareness.test.ts --reporter=dot
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/yjs-awareness-presence.spec.ts --reporter=dot
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+## Results
+
+### Backend
+
+- `tests/unit/yjs-poc.test.ts` + `tests/unit/yjs-awareness.test.ts`
+- Result: `27/27` tests passed
+
+### Frontend
+
+- `tests/yjs-awareness-presence.spec.ts`
+- Result: `2/2` tests passed
+
+### Type-check
+
+- `apps/web vue-tsc --noEmit`
+- Result: passed
+
+## Temporary worktree setup
+
+This isolated worktree used temporary `node_modules` symlinks to the main repo in order to run tests locally:
+
+- `/tmp/metasheet2-yjs-awareness/node_modules`
+- `/tmp/metasheet2-yjs-awareness/apps/web/node_modules`
+- `/tmp/metasheet2-yjs-awareness/packages/core-backend/node_modules`
+
+They are for local verification only and should not be committed.
+
+## Claude Code CLI
+
+Checked in this worktree:
+
+```bash
+claude auth status
+```
+
+Result:
+
+- `loggedIn: true`
+- `authMethod: claude.ai`
+- `subscriptionType: max`
+
+I also attempted a narrow blocker review prompt. Auth was valid, but the prompt response was not needed for the final decision; the implementation outcome here is based on local test results.
+
+## Known limitations
+
+- Awareness is not yet surfaced in the main multitable workbench UI.
+- Presence currently reflects record/field activity for the Yjs POC only, not the older non-Yjs collab path.

--- a/packages/core-backend/src/collab/yjs-websocket-adapter.ts
+++ b/packages/core-backend/src/collab/yjs-websocket-adapter.ts
@@ -2,7 +2,7 @@ import * as Y from 'yjs'
 import * as syncProtocol from 'y-protocols/sync'
 import * as encoding from 'lib0/encoding'
 import * as decoding from 'lib0/decoding'
-import type { Server as SocketServer, Socket } from 'socket.io'
+import type { Server as SocketServer, Socket, Namespace } from 'socket.io'
 import type { YjsSyncService } from './yjs-sync-service'
 import type { YjsRecordBridge } from './yjs-record-bridge'
 
@@ -25,16 +25,36 @@ export type YjsAuthChecker = (
  */
 export type YjsTokenVerifier = (token: string) => Promise<string | null>
 
+export type YjsPresenceUser = {
+  id: string
+  fieldIds: string[]
+}
+
+export type YjsPresenceSnapshot = {
+  recordId: string
+  activeCount: number
+  users: YjsPresenceUser[]
+}
+
+type SocketPresenceState = {
+  userId: string
+  fieldId: string | null
+}
+
 export class YjsWebSocketAdapter {
   private bridge: YjsRecordBridge | null = null
   private authChecker: YjsAuthChecker | null = null
   private tokenVerifier: YjsTokenVerifier | null = null
+  private namespace: Namespace | null = null
 
   /** Per-socket verified userId (from JWT, not from client query) */
   private socketUserId = new Map<string, string>()
 
   /** Per-socket permission cache: socket.id → recordId → canWrite */
   private socketPermissions = new Map<string, Map<string, boolean>>()
+
+  /** Per-record presence state: recordId → socketId → { userId, fieldId } */
+  private recordPresence = new Map<string, Map<string, SocketPresenceState>>()
 
   constructor(private syncService: YjsSyncService) {}
 
@@ -58,8 +78,69 @@ export class YjsWebSocketAdapter {
     return this.socketUserId.get(socketId)
   }
 
+  getPresenceSnapshot(recordId: string): YjsPresenceSnapshot {
+    const bySocket = this.recordPresence.get(recordId)
+    const byUser = new Map<string, Set<string>>()
+
+    for (const [, state] of bySocket ?? []) {
+      const fieldIds = byUser.get(state.userId) ?? new Set<string>()
+      if (state.fieldId) fieldIds.add(state.fieldId)
+      byUser.set(state.userId, fieldIds)
+    }
+
+    const users = [...byUser.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([id, fieldIds]) => ({
+        id,
+        fieldIds: [...fieldIds].sort((left, right) => left.localeCompare(right)),
+      }))
+
+    return {
+      recordId,
+      activeCount: users.length,
+      users,
+    }
+  }
+
+  getMetrics(): { activeRecordCount: number; activeSocketCount: number } {
+    return {
+      activeRecordCount: this.recordPresence.size,
+      activeSocketCount: [...this.recordPresence.values()].reduce((total, perRecord) => total + perRecord.size, 0),
+    }
+  }
+
+  private normalizeFieldId(value: unknown): string | null {
+    if (typeof value !== 'string') return null
+    const next = value.trim()
+    return next.length > 0 ? next : null
+  }
+
+  private upsertPresence(recordId: string, socketId: string, userId: string, fieldId: string | null) {
+    const bySocket = this.recordPresence.get(recordId) ?? new Map<string, SocketPresenceState>()
+    bySocket.set(socketId, { userId, fieldId })
+    this.recordPresence.set(recordId, bySocket)
+  }
+
+  private removePresence(recordId: string, socketId: string): boolean {
+    const bySocket = this.recordPresence.get(recordId)
+    if (!bySocket) return false
+    const existed = bySocket.delete(socketId)
+    if (bySocket.size === 0) {
+      this.recordPresence.delete(recordId)
+    } else {
+      this.recordPresence.set(recordId, bySocket)
+    }
+    return existed
+  }
+
+  private emitPresence(recordId: string) {
+    if (!this.namespace) return
+    this.namespace.to(`yjs:${recordId}`).emit('yjs:presence', this.getPresenceSnapshot(recordId))
+  }
+
   register(io: SocketServer): void {
     const nsp = io.of('/yjs')
+    this.namespace = nsp
 
     // Verify JWT at connection time — reject unauthenticated sockets immediately
     nsp.use(async (socket, next) => {
@@ -112,6 +193,7 @@ export class YjsWebSocketAdapter {
         const doc = await this.syncService.getOrCreateDoc(recordId)
         const room = `yjs:${recordId}`
         socket.join(room)
+        this.upsertPresence(recordId, socket.id, userId, null)
 
         // Start bridge observation if bridge is attached
         if (this.bridge) {
@@ -126,6 +208,7 @@ export class YjsWebSocketAdapter {
           recordId,
           data: Array.from(encoding.toUint8Array(encoder)),
         })
+        this.emitPresence(recordId)
       })
 
       socket.on(
@@ -195,17 +278,47 @@ export class YjsWebSocketAdapter {
         },
       )
 
+      socket.on(
+        'yjs:presence',
+        ({ recordId, fieldId }: { recordId: string; fieldId?: string | null }) => {
+          if (!recordId || typeof recordId !== 'string') return
+
+          const userId = this.socketUserId.get(socket.id)
+          if (!userId) {
+            socket.emit('yjs:error', { recordId, code: 'UNAUTHENTICATED', message: 'Not authenticated' })
+            return
+          }
+
+          const perms = this.socketPermissions.get(socket.id)
+          if (this.authChecker && !perms?.has(recordId)) {
+            socket.emit('yjs:error', { recordId, code: 'FORBIDDEN', message: 'Not subscribed' })
+            return
+          }
+
+          this.upsertPresence(recordId, socket.id, userId, this.normalizeFieldId(fieldId))
+          this.emitPresence(recordId)
+        },
+      )
+
       socket.on('yjs:unsubscribe', ({ recordId }: { recordId: string }) => {
         if (!recordId) return
         socket.leave(`yjs:${recordId}`)
         // Clean up cached permission for this record
         const perms = this.socketPermissions.get(socket.id)
         if (perms) perms.delete(recordId)
+        if (this.removePresence(recordId, socket.id)) {
+          this.emitPresence(recordId)
+        }
       })
 
       socket.on('disconnect', () => {
         this.socketPermissions.delete(socket.id)
         this.socketUserId.delete(socket.id)
+        for (const [recordId] of this.recordPresence) {
+          if (this.removePresence(recordId, socket.id)) {
+            this.emitPresence(recordId)
+          }
+        }
       })
     })
   }

--- a/packages/core-backend/tests/unit/yjs-awareness.test.ts
+++ b/packages/core-backend/tests/unit/yjs-awareness.test.ts
@@ -1,0 +1,184 @@
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Server } from 'socket.io'
+import { io as ioClient, type Socket as ClientSocket } from 'socket.io-client'
+import * as Y from 'yjs'
+import { YjsWebSocketAdapter } from '../../src/collab/yjs-websocket-adapter'
+
+function createMockSyncService() {
+  const docs = new Map<string, Y.Doc>()
+  return {
+    async getOrCreateDoc(recordId: string) {
+      let doc = docs.get(recordId)
+      if (!doc) {
+        doc = new Y.Doc()
+        docs.set(recordId, doc)
+      }
+      return doc
+    },
+    getDoc(recordId: string) {
+      return docs.get(recordId) ?? null
+    },
+  }
+}
+
+async function connectClient(baseUrl: string, token: string): Promise<ClientSocket> {
+  const client = ioClient(`${baseUrl}/yjs`, {
+    transports: ['websocket'],
+    auth: { token },
+    forceNew: true,
+    reconnection: false,
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('connect timeout')), 3000)
+    client.once('connect', () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+    client.once('connect_error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+  })
+
+  return client
+}
+
+function waitForEvent<T>(
+  client: ClientSocket,
+  event: string,
+  predicate: (payload: T) => boolean,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let lastPayload: T | null = null
+    const timeout = setTimeout(() => {
+      client.off(event, handler)
+      reject(new Error(`timeout waiting for ${event}: ${JSON.stringify(lastPayload)}`))
+    }, 3000)
+
+    const handler = (payload: T) => {
+      lastPayload = payload
+      if (!predicate(payload)) return
+      clearTimeout(timeout)
+      client.off(event, handler)
+      resolve(payload)
+    }
+
+    client.on(event, handler)
+  })
+}
+
+describe('Yjs awareness presence socket protocol', () => {
+  let httpServer: ReturnType<typeof createServer>
+  let io: Server
+  let adapter: YjsWebSocketAdapter
+  let baseUrl = ''
+
+  beforeEach(async () => {
+    httpServer = createServer()
+    io = new Server(httpServer, {
+      cors: { origin: '*' },
+    })
+
+    const syncService = createMockSyncService()
+    adapter = new YjsWebSocketAdapter(syncService as any)
+    adapter.setTokenVerifier(async (token) => {
+      if (!token.startsWith('token-')) return null
+      return token.slice('token-'.length)
+    })
+    adapter.setAuthChecker(async (userId, recordId) => {
+      if (recordId !== 'rec_presence') return null
+      return {
+        canRead: true,
+        canWrite: userId !== 'user_readonly',
+      }
+    })
+    adapter.register(io)
+
+    await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', () => resolve()))
+    const address = httpServer.address() as AddressInfo
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      io.close(() => resolve())
+    })
+    if (!httpServer.listening) return
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((error) => {
+        if (error) reject(error)
+        else resolve()
+      })
+    })
+  })
+
+  it('publishes presence snapshots per record and cleans them up on unsubscribe', async () => {
+    const alice = await connectClient(baseUrl, 'token-user_alice')
+    const bob = await connectClient(baseUrl, 'token-user_bob')
+
+    try {
+      const alicePresence = waitForEvent(alice, 'yjs:presence', (payload: any) => (
+        payload.recordId === 'rec_presence'
+        && payload.activeCount === 1
+        && payload.users?.length === 1
+      ))
+      alice.emit('yjs:subscribe', { recordId: 'rec_presence' })
+      await alicePresence
+
+      const dualPresence = waitForEvent(alice, 'yjs:presence', (payload: any) => (
+        payload.recordId === 'rec_presence'
+        && payload.activeCount === 2
+      ))
+      bob.emit('yjs:subscribe', { recordId: 'rec_presence' })
+      await dualPresence
+
+      const fieldPresence = waitForEvent(alice, 'yjs:presence', (payload: any) => (
+        payload.recordId === 'rec_presence'
+        && payload.users?.some((user: any) => user.id === 'user_bob' && user.fieldIds?.includes('fld_body'))
+      ))
+      bob.emit('yjs:presence', { recordId: 'rec_presence', fieldId: 'fld_body' })
+      const snapshot = await fieldPresence
+
+      expect(snapshot.users).toEqual([
+        { id: 'user_alice', fieldIds: [] },
+        { id: 'user_bob', fieldIds: ['fld_body'] },
+      ])
+      expect(adapter.getMetrics()).toEqual({ activeRecordCount: 1, activeSocketCount: 2 })
+
+      const afterUnsubscribe = waitForEvent(alice, 'yjs:presence', (payload: any) => (
+        payload.recordId === 'rec_presence'
+        && payload.activeCount === 1
+        && payload.users?.every((user: any) => user.id !== 'user_bob')
+      ))
+      bob.emit('yjs:unsubscribe', { recordId: 'rec_presence' })
+      await afterUnsubscribe
+
+      expect(adapter.getPresenceSnapshot('rec_presence')).toEqual({
+        recordId: 'rec_presence',
+        activeCount: 1,
+        users: [{ id: 'user_alice', fieldIds: [] }],
+      })
+    } finally {
+      alice.disconnect()
+      bob.disconnect()
+    }
+  })
+
+  it('rejects presence updates from sockets that are not subscribed to the record', async () => {
+    const client = await connectClient(baseUrl, 'token-user_alice')
+
+    try {
+      const error = waitForEvent(client, 'yjs:error', (payload: any) => payload.code === 'FORBIDDEN')
+      client.emit('yjs:presence', { recordId: 'rec_presence', fieldId: 'fld_body' })
+      await expect(error).resolves.toMatchObject({
+        recordId: 'rec_presence',
+        code: 'FORBIDDEN',
+      })
+    } finally {
+      client.disconnect()
+    }
+  })
+})


### PR DESCRIPTION
## What Changed

This PR adds a minimal awareness/presence layer on top of the merged Yjs record-level POC.

Backend:
- extend `/yjs` with record presence snapshots
- add `yjs:presence` event for field-level active editor hints
- track per-record active sockets and deduplicated users
- expose minimal presence metrics from `YjsWebSocketAdapter`

Frontend:
- extend `useYjsDocument()` with:
  - `presence`
  - `activeUsers`
  - `activeCollaborators`
  - `activeCollaboratorCount`
  - `getFieldCollaborators(fieldId)`
  - `setActiveField(fieldId | null)`
- extend `useYjsTextField()` so a bound text field can publish active-field presence
- add `MetaYjsPresenceChip` as a minimal reusable UI primitive
- export the new composables/component from the multitable entrypoint

Tests:
- backend unit coverage for presence subscribe / update / unsubscribe
- frontend composable + chip coverage for awareness state and rendering

Docs:
- `docs/development/yjs-awareness-presence-development-20260416.md`
- `docs/development/yjs-awareness-presence-verification-20260416.md`
- `docs/development/yjs-awareness-mainline-rebase-development-20260416.md`
- `docs/development/yjs-awareness-mainline-rebase-verification-20260416.md`

## Why

`#883` established the record-level Yjs text-field POC and `#884` hardened it for internal experimentation.

This PR adds the next minimal collaboration layer:
- who else is active on the same record
- which text field is currently active
- a reusable awareness state surface for later rollout into the record editor

The scope stays intentionally small:
- no new CRDT field types
- no sheet-wide awareness
- no persistence of presence state
- no broad UI rollout into the full workbench/editor yet

## Verification

Ran after rebasing onto hardening-enabled `main`:

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/yjs-poc.test.ts \
  tests/unit/yjs-hardening.test.ts \
  tests/unit/yjs-awareness.test.ts \
  --reporter=dot

pnpm --filter @metasheet/web exec vitest run \
  --watch=false \
  tests/yjs-awareness-presence.spec.ts \
  --reporter=dot

pnpm --filter @metasheet/web exec vue-tsc --noEmit
```

Results:
- backend: `34/34` passed
- frontend: `2/2` passed
- frontend type-check: passed

## Notes

- This branch was rebased onto the latest `main` after Yjs hardening landed, so it does not revert `ENABLE_YJS_COLLAB`, JWT auth, write-own enforcement, or Yjs observability.
- Presence remains ephemeral by design; it is not persisted.
- `MetaYjsPresenceChip` currently shows user ids, not display names. That is acceptable for the current POC and can be upgraded when the awareness UI is wired into the real editor.
