### PR TITLE
feat(collab): add yjs persistence compaction

### DIFF
--- a/docs/development/yjs-persistence-hardening-development-20260416.md
+++ b/docs/development/yjs-persistence-hardening-development-20260416.md
@@ -1,0 +1,51 @@
+# Yjs Persistence Hardening Development
+
+Date: 2026-04-16
+Branch: `codex/yjs-persistence-hardening-20260416`
+
+## Scope
+
+Implement the next post-POC infrastructure step for Yjs storage:
+
+- snapshot compaction
+- incremental update cleanup
+- explicit crash-recovery verification for updates-only persistence
+
+This step intentionally does not touch:
+
+- editor UI wiring
+- awareness rendering
+- multi-instance/Redis rollout
+- non-text CRDT types
+
+## Backend changes
+
+Updated [packages/core-backend/src/collab/yjs-persistence-adapter.ts](/tmp/metasheet2-yjs-persistence/packages/core-backend/src/collab/yjs-persistence-adapter.ts:1):
+
+- kept `storeUpdate()` for normal incremental persistence
+- kept `storeSnapshot()` for raw snapshot writing
+- added `compactDoc(recordId, doc)`:
+  - encode full doc state
+  - upsert the snapshot in `meta_record_yjs_states`
+  - delete stale rows from `meta_record_yjs_updates`
+  - do both in one DB transaction
+
+Updated [packages/core-backend/src/collab/yjs-sync-service.ts](/tmp/metasheet2-yjs-persistence/packages/core-backend/src/collab/yjs-sync-service.ts:1):
+
+- added `persistSnapshot()` internal helper
+- `releaseDoc()`, `cleanupIdleDocs()`, and `destroy()` now prefer `compactDoc()` when available
+- fallback to `storeSnapshot()` remains in place for compatibility with older mocks and narrow callers
+
+## Test coverage
+
+Added [packages/core-backend/tests/unit/yjs-persistence-hardening.test.ts](/tmp/metasheet2-yjs-persistence/packages/core-backend/tests/unit/yjs-persistence-hardening.test.ts:1) to verify:
+
+- `YjsSyncService` prefers compaction on release
+- idle cleanup compacts before eviction
+- `compactDoc()` clears update rows inside the same transaction as snapshot upsert
+- `loadDoc()` can still recover correctly from updates-only persistence when no snapshot exists
+
+## Notes
+
+- This is the persistence-side follow-up to the merged Yjs POC and hardening work.
+- The intended effect is to keep restart recovery intact while preventing unbounded growth of `meta_record_yjs_updates` for docs that are eventually released or cleaned up.

--- a/docs/development/yjs-persistence-hardening-verification-20260416.md
+++ b/docs/development/yjs-persistence-hardening-verification-20260416.md
@@ -1,0 +1,38 @@
+# Yjs Persistence Hardening Verification
+
+Date: 2026-04-16
+Branch: `codex/yjs-persistence-hardening-20260416`
+
+## Commands run
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/yjs-poc.test.ts \
+  tests/unit/yjs-hardening.test.ts \
+  tests/unit/yjs-persistence-hardening.test.ts \
+  --reporter=dot
+```
+
+## Results
+
+- `tests/unit/yjs-persistence-hardening.test.ts` → `4/4` passed
+- `tests/unit/yjs-hardening.test.ts` → `7/7` passed
+- `tests/unit/yjs-poc.test.ts` → `25/25` passed
+- Total backend result → `36/36` passed
+
+## Temporary worktree setup
+
+This isolated worktree used temporary `node_modules` symlinks for local execution:
+
+- `/tmp/metasheet2-yjs-persistence/node_modules`
+- `/tmp/metasheet2-yjs-persistence/packages/core-backend/node_modules`
+
+They are local verification helpers only and must not be committed.
+
+## Related PR context
+
+During this turn, the Yjs awareness/presence follow-up was also opened for review:
+
+- PR `#885` — `feat(collab): add Yjs awareness presence primitives`
+
+This persistence hardening work is the next infrastructure slice after that awareness follow-up.

--- a/packages/core-backend/src/collab/yjs-persistence-adapter.ts
+++ b/packages/core-backend/src/collab/yjs-persistence-adapter.ts
@@ -71,4 +71,34 @@ export class YjsPersistenceAdapter {
       )
       .execute()
   }
+
+  async compactDoc(recordId: string, doc: Y.Doc): Promise<void> {
+    const state = Y.encodeStateAsUpdate(doc)
+    const stateVector = Y.encodeStateVector(doc)
+    const updatedAt = new Date()
+
+    await this.db.transaction().execute(async (trx) => {
+      await trx
+        .insertInto('meta_record_yjs_states')
+        .values({
+          record_id: recordId,
+          doc_state: Buffer.from(state),
+          state_vector: Buffer.from(stateVector),
+          updated_at: updatedAt,
+        })
+        .onConflict((oc) =>
+          oc.column('record_id').doUpdateSet({
+            doc_state: Buffer.from(state),
+            state_vector: Buffer.from(stateVector),
+            updated_at: updatedAt,
+          }),
+        )
+        .execute()
+
+      await trx
+        .deleteFrom('meta_record_yjs_updates')
+        .where('record_id', '=', recordId)
+        .execute()
+    })
+  }
 }

--- a/packages/core-backend/src/collab/yjs-sync-service.ts
+++ b/packages/core-backend/src/collab/yjs-sync-service.ts
@@ -13,6 +13,14 @@ export class YjsSyncService {
     this.cleanupTimer.unref()
   }
 
+  private async persistSnapshot(recordId: string, doc: Y.Doc): Promise<void> {
+    if (typeof (this.persistence as YjsPersistenceAdapter & { compactDoc?: (recordId: string, doc: Y.Doc) => Promise<void> }).compactDoc === 'function') {
+      await (this.persistence as YjsPersistenceAdapter & { compactDoc: (recordId: string, doc: Y.Doc) => Promise<void> }).compactDoc(recordId, doc)
+      return
+    }
+    await this.persistence.storeSnapshot(recordId, doc)
+  }
+
   async getOrCreateDoc(recordId: string): Promise<Y.Doc> {
     const existing = this.docs.get(recordId)
     if (existing) {
@@ -50,9 +58,10 @@ export class YjsSyncService {
   async releaseDoc(recordId: string): Promise<void> {
     const entry = this.docs.get(recordId)
     if (entry) {
-      // Snapshot before releasing so cross-restart recovery works
+      // Compact into a fresh snapshot before releasing so restart recovery
+      // stays bounded and old incremental updates do not accumulate forever.
       try {
-        await this.persistence.storeSnapshot(recordId, entry.doc)
+        await this.persistSnapshot(recordId, entry.doc)
       } catch (err) {
         console.error(`[yjs] Failed to snapshot doc ${recordId} on release:`, err)
       }
@@ -66,7 +75,7 @@ export class YjsSyncService {
     for (const [recordId, entry] of this.docs) {
       if (now - entry.lastAccess > idleThreshold) {
         try {
-          await this.persistence.storeSnapshot(recordId, entry.doc)
+          await this.persistSnapshot(recordId, entry.doc)
         } catch (err) {
           console.error(`[yjs] Failed to snapshot idle doc ${recordId}:`, err)
         }
@@ -80,7 +89,7 @@ export class YjsSyncService {
     clearInterval(this.cleanupTimer)
     for (const [recordId, entry] of this.docs) {
       try {
-        await this.persistence.storeSnapshot(recordId, entry.doc)
+        await this.persistSnapshot(recordId, entry.doc)
       } catch (err) {
         console.error(`[yjs] Failed to snapshot doc ${recordId} on destroy:`, err)
       }

--- a/packages/core-backend/tests/unit/yjs-persistence-hardening.test.ts
+++ b/packages/core-backend/tests/unit/yjs-persistence-hardening.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+import { YjsPersistenceAdapter } from '../../src/collab/yjs-persistence-adapter'
+import { YjsSyncService } from '../../src/collab/yjs-sync-service'
+
+function createMockPersistenceWithCompaction() {
+  return {
+    loadDoc: vi.fn().mockResolvedValue(null),
+    storeUpdate: vi.fn().mockResolvedValue(undefined),
+    storeSnapshot: vi.fn().mockResolvedValue(undefined),
+    compactDoc: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createTransactionalMockDb() {
+  const snapshotChain = {
+    values: vi.fn().mockReturnThis(),
+    onConflict: vi.fn().mockImplementation((fn: any) => {
+      fn({
+        column: vi.fn().mockReturnValue({
+          doUpdateSet: vi.fn().mockReturnValue(snapshotChain),
+        }),
+      })
+      return snapshotChain
+    }),
+    execute: vi.fn().mockResolvedValue([]),
+  }
+
+  const deleteChain = {
+    where: vi.fn().mockReturnThis(),
+    execute: vi.fn().mockResolvedValue([]),
+  }
+
+  const trx = {
+    insertInto: vi.fn((table: string) => {
+      expect(table).toBe('meta_record_yjs_states')
+      return snapshotChain
+    }),
+    deleteFrom: vi.fn((table: string) => {
+      expect(table).toBe('meta_record_yjs_updates')
+      return deleteChain
+    }),
+  }
+
+  return {
+    transaction: vi.fn(() => ({
+      execute: vi.fn(async (callback: (trx: typeof trx) => Promise<void>) => callback(trx)),
+    })),
+    _trx: trx,
+    _snapshotChain: snapshotChain,
+    _deleteChain: deleteChain,
+  }
+}
+
+describe('Yjs persistence hardening', () => {
+  describe('YjsSyncService compaction path', () => {
+    let persistence: ReturnType<typeof createMockPersistenceWithCompaction>
+    let service: YjsSyncService
+
+    beforeEach(() => {
+      persistence = createMockPersistenceWithCompaction()
+      service = new YjsSyncService(persistence as any)
+    })
+
+    afterEach(async () => {
+      await service.destroy()
+    })
+
+    it('releaseDoc prefers compactDoc over storeSnapshot', async () => {
+      await service.getOrCreateDoc('rec_compact_release')
+
+      await service.releaseDoc('rec_compact_release')
+
+      expect(persistence.compactDoc).toHaveBeenCalledWith('rec_compact_release', expect.any(Y.Doc))
+      expect(persistence.storeSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('cleanupIdleDocs compacts idle docs before eviction', async () => {
+      await service.getOrCreateDoc('rec_compact_idle')
+
+      const originalNow = Date.now
+      Date.now = () => originalNow() + 120_000
+      try {
+        await service.cleanupIdleDocs(60_000)
+      } finally {
+        Date.now = originalNow
+      }
+
+      expect(persistence.compactDoc).toHaveBeenCalledWith('rec_compact_idle', expect.any(Y.Doc))
+      expect(service.size).toBe(0)
+    })
+  })
+
+  describe('YjsPersistenceAdapter compaction + recovery', () => {
+    it('compactDoc upserts snapshot and clears incremental updates in one transaction', async () => {
+      const mockDb = createTransactionalMockDb()
+      const adapter = new YjsPersistenceAdapter(mockDb as any)
+      const doc = new Y.Doc()
+      doc.getText('body').insert(0, 'hello world')
+
+      await adapter.compactDoc('rec_compact_tx', doc)
+
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1)
+      expect(mockDb._trx.insertInto).toHaveBeenCalledWith('meta_record_yjs_states')
+      expect(mockDb._trx.deleteFrom).toHaveBeenCalledWith('meta_record_yjs_updates')
+      expect(mockDb._deleteChain.where).toHaveBeenCalledWith('record_id', '=', 'rec_compact_tx')
+      doc.destroy()
+    })
+
+    it('loadDoc recovers from updates-only persistence when snapshot is missing', async () => {
+      const baseDoc = new Y.Doc()
+      baseDoc.getText('body').insert(0, 'recovered-from-updates')
+      const updatesOnly = Y.encodeStateAsUpdate(baseDoc)
+      baseDoc.destroy()
+
+      const selectChain = {
+        select: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        executeTakeFirst: vi.fn().mockResolvedValue(null),
+        execute: vi.fn().mockResolvedValue([
+          { update_data: Buffer.from(updatesOnly) },
+        ]),
+      }
+
+      const mockDb = {
+        selectFrom: vi.fn(() => selectChain),
+      }
+
+      const adapter = new YjsPersistenceAdapter(mockDb as any)
+      const result = await adapter.loadDoc('rec_updates_only')
+
+      expect(result).not.toBeNull()
+      const recovered = new Y.Doc()
+      Y.applyUpdate(recovered, result!)
+      expect(recovered.getText('body').toString()).toBe('recovered-from-updates')
+      recovered.destroy()
+    })
+  })
+})


### PR DESCRIPTION
## What Changed

This PR adds the next persistence-side hardening step for the merged Yjs record-level collaboration POC.

Backend:
- add `compactDoc(recordId, doc)` to `YjsPersistenceAdapter`
- persist a fresh snapshot and clear old incremental updates in the same DB transaction
- make `YjsSyncService.releaseDoc()`, `cleanupIdleDocs()`, and `destroy()` prefer compaction over plain snapshot writes
- keep `storeSnapshot()` fallback compatibility for narrow callers and older mocks

Tests:
- add dedicated persistence hardening coverage
- re-run the original Yjs POC suite and the existing Yjs hardening suite on top

Docs:
- `docs/development/yjs-persistence-hardening-development-20260416.md`
- `docs/development/yjs-persistence-hardening-verification-20260416.md`

## Why

The merged Yjs POC and hardening work established:
- record-per-doc sync
- JWT-authenticated `/yjs`
- write-own enforcement
- crash recovery from updates-only state

The next infrastructure gap is storage growth:
- active docs keep appending rows to `meta_record_yjs_updates`
- released/idle docs should compact to a bounded snapshot form

This PR closes that gap by introducing explicit snapshot compaction on release/cleanup/shutdown.

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/yjs-poc.test.ts \
  tests/unit/yjs-hardening.test.ts \
  tests/unit/yjs-persistence-hardening.test.ts \
  --reporter=dot
```

Results:
- `tests/unit/yjs-persistence-hardening.test.ts` → `4/4`
- `tests/unit/yjs-hardening.test.ts` → `7/7`
- `tests/unit/yjs-poc.test.ts` → `25/25`
- total → `36/36`

## Notes

- This PR does not touch editor UI or awareness rendering.
- Presence remains ephemeral and is intentionally not persisted.
- The follow-up awareness PR is `#885`.
