### PR TITLE
feat(collab): add yjs ops status endpoint

### DIFF
--- a/docs/development/yjs-ops-visibility-development-20260416.md
+++ b/docs/development/yjs-ops-visibility-development-20260416.md
@@ -1,0 +1,70 @@
+# Yjs Ops Visibility Development
+
+Date: 2026-04-16
+Branch: `codex/yjs-ops-visibility-20260416`
+
+## Scope
+
+Add a minimal operational visibility surface for internal Yjs rollout.
+
+This step intentionally stays backend-only:
+
+- no editor UI wiring
+- no extra CRDT behavior
+- no rollout policy changes
+
+## What changed
+
+### Admin route
+
+Added [GET /api/admin/yjs/status](/tmp/metasheet2-yjs-ops/packages/core-backend/src/routes/admin-routes.ts:1362):
+
+- protected by `requireAdminRole()`
+- returns a compact runtime snapshot for Yjs
+- includes:
+  - `enabled`
+  - `initialized`
+  - `sync`
+  - `bridge`
+  - `socket`
+
+### Server wiring
+
+Updated [packages/core-backend/src/index.ts](/tmp/metasheet2-yjs-ops/packages/core-backend/src/index.ts:145) to retain references to:
+
+- `YjsSyncService`
+- `YjsRecordBridge`
+- `YjsWebSocketAdapter`
+
+Those references are now exposed to admin routes via `getYjsStatus()`, so operators can inspect:
+
+- active Yjs docs
+- tracked doc ids
+- pending bridge writes
+- bridge flush success/failure counts
+- active Yjs presence record/socket counts
+
+### Tests
+
+Added [packages/core-backend/tests/unit/admin-yjs-status-routes.test.ts](/tmp/metasheet2-yjs-ops/packages/core-backend/tests/unit/admin-yjs-status-routes.test.ts:1):
+
+- verifies injected runtime snapshot path
+- verifies feature-flag-only fallback when Yjs is not initialized
+
+## Why
+
+After:
+
+- Yjs POC merge
+- hardening
+- awareness follow-up
+- persistence compaction
+
+the next useful internal-rollout step is being able to answer:
+
+1. Is Yjs enabled?
+2. Is it initialized in this process?
+3. How many docs and sockets are active?
+4. Is bridge flushing succeeding or failing?
+
+This route provides that minimum runtime introspection without committing to a full admin UI yet.

--- a/docs/development/yjs-ops-visibility-verification-20260416.md
+++ b/docs/development/yjs-ops-visibility-verification-20260416.md
@@ -1,0 +1,64 @@
+# Yjs Ops Visibility Verification
+
+Date: 2026-04-16
+Branch: `codex/yjs-ops-visibility-20260416`
+
+## Commands run
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/admin-yjs-status-routes.test.ts \
+  tests/unit/yjs-hardening.test.ts \
+  tests/unit/yjs-persistence-hardening.test.ts \
+  --reporter=dot
+```
+
+## Results
+
+- `tests/unit/admin-yjs-status-routes.test.ts` → `2/2`
+- `tests/unit/yjs-hardening.test.ts` → `7/7`
+- `tests/unit/yjs-persistence-hardening.test.ts` → `4/4`
+- Total → `13/13` passed
+
+## Temporary worktree setup
+
+This isolated worktree used temporary `node_modules` symlinks for local execution:
+
+- `/tmp/metasheet2-yjs-ops/node_modules`
+- `/tmp/metasheet2-yjs-ops/packages/core-backend/node_modules`
+
+They are for local verification only and must not be committed.
+
+## Expected route shape
+
+The new admin route returns:
+
+```json
+{
+  "success": true,
+  "yjs": {
+    "enabled": true,
+    "initialized": true,
+    "sync": {
+      "activeDocCount": 2,
+      "docIds": ["rec_1", "rec_2"]
+    },
+    "bridge": {
+      "pendingWriteCount": 1,
+      "observedDocCount": 2,
+      "flushSuccessCount": 5,
+      "flushFailureCount": 1
+    },
+    "socket": {
+      "activeRecordCount": 2,
+      "activeSocketCount": 3
+    }
+  }
+}
+```
+
+When Yjs is feature-gated off or not initialized, the route falls back to:
+
+- `enabled` from `ENABLE_YJS_COLLAB`
+- `initialized: false`
+- `sync/bridge/socket: null`

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -164,6 +164,9 @@ export class MetaSheetServer {
   private stopOperationAuditRetention?: () => void
   private stopMultitableAttachmentCleanup?: () => void
   private automationService?: AutomationService
+  private yjsSyncMetricsSource?: { getMetrics(): { activeDocCount: number; docIds: string[] } }
+  private yjsBridgeMetricsSource?: { getMetrics(): { pendingWriteCount: number; observedDocCount: number; flushSuccessCount: number; flushFailureCount: number } }
+  private yjsSocketMetricsSource?: { getMetrics(): { activeRecordCount: number; activeSocketCount: number } }
   private afterSalesApprovalBridgeService: AfterSalesApprovalBridgeService
   // Optional bypass/degraded-mode flags for local debug
   private disableWorkflow = process.env.DISABLE_WORKFLOW === 'true'
@@ -904,6 +907,13 @@ export class MetaSheetServer {
       activatePlugin: this.activatePluginByName.bind(this),
       deactivatePlugin: this.deactivatePluginByName.bind(this),
       snapshotService: this.snapshotService,
+      getYjsStatus: () => ({
+        enabled: process.env.ENABLE_YJS_COLLAB === 'true',
+        initialized: !!(this.yjsSyncMetricsSource && this.yjsBridgeMetricsSource && this.yjsSocketMetricsSource),
+        sync: this.yjsSyncMetricsSource?.getMetrics() ?? null,
+        bridge: this.yjsBridgeMetricsSource?.getMetrics() ?? null,
+        socket: this.yjsSocketMetricsSource?.getMetrics() ?? null,
+      }),
     }))
     this.app.use(adminUsersRouter())
     this.app.use('/api/admin/directory', adminDirectoryRouter())
@@ -1816,6 +1826,9 @@ export class MetaSheetServer {
 
         yjsWsAdapter.setBridge(yjsBridge)
         yjsWsAdapter.register(collabIO)
+        this.yjsSyncMetricsSource = yjsSyncService
+        this.yjsBridgeMetricsSource = yjsBridge
+        this.yjsSocketMetricsSource = yjsWsAdapter
         this.logger.info('Yjs collaborative editing service initialized on /yjs namespace (bridge + auth active)')
       } else {
         this.logger.warn('Yjs: CollabService IO not available, skipping')

--- a/packages/core-backend/src/routes/admin-routes.ts
+++ b/packages/core-backend/src/routes/admin-routes.ts
@@ -47,6 +47,18 @@ interface AdminRouteServices {
   activatePlugin?: (pluginId: string) => Promise<{ status: 'active' | 'inactive' | 'failed'; error?: string; lastAttempt?: string }>;
   deactivatePlugin?: (pluginId: string) => Promise<{ status: 'active' | 'inactive' | 'failed'; error?: string; lastAttempt?: string }>;
   snapshotService?: SnapshotService;
+  getYjsStatus?: () => {
+    enabled: boolean
+    initialized: boolean
+    sync: { activeDocCount: number; docIds: string[] } | null
+    bridge: {
+      pendingWriteCount: number
+      observedDocCount: number
+      flushSuccessCount: number
+      flushFailureCount: number
+    } | null
+    socket: { activeRecordCount: number; activeSocketCount: number } | null
+  };
 }
 
 // Use the global Express.Request type which already includes user property
@@ -1348,6 +1360,25 @@ router.get('/slo/status', async (req: Request, res: Response) => {
     });
   }
 });
+
+/**
+ * GET /api/admin/yjs/status
+ * Minimal runtime snapshot for Yjs rollout/ops visibility.
+ */
+router.get('/yjs/status', requireAdminRole(), async (_req: Request, res: Response) => {
+  const status = services.getYjsStatus?.() ?? {
+    enabled: process.env.ENABLE_YJS_COLLAB === 'true',
+    initialized: false,
+    sync: null,
+    bridge: null,
+    socket: null,
+  }
+
+  res.json({
+    success: true,
+    yjs: status,
+  })
+})
 
 // ═══════════════════════════════════════════════════════════════════
 // DLQ Management (Protected)

--- a/packages/core-backend/tests/unit/admin-yjs-status-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-yjs-status-routes.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Router } from 'express'
+import { isAdmin } from '../../src/rbac/service'
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: null,
+}))
+
+vi.mock('../../src/services/SnapshotService', () => ({}))
+vi.mock('../../src/audit/audit', () => ({}))
+
+import { initAdminRoutes } from '../../src/routes/admin-routes'
+
+function getRouteHandler(router: Router, method: 'get', routePath: string) {
+  const layer = (router as unknown as {
+    stack?: Array<{
+      route?: {
+        path?: string
+        methods?: Record<string, boolean>
+        stack?: Array<{ handle: (req: any, res: any, next?: any) => Promise<void> | void }>
+      }
+    }>
+  }).stack?.find((item) => item.route?.path === routePath && item.route?.methods?.[method])
+
+  const stack = layer?.route?.stack ?? []
+  if (stack.length === 0) {
+    throw new Error(`Route handler not found for ${method.toUpperCase()} ${routePath}`)
+  }
+  return stack
+}
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+  }
+}
+
+describe('admin yjs status route', () => {
+  const originalFlag = process.env.ENABLE_YJS_COLLAB
+
+  beforeEach(() => {
+    process.env.ENABLE_YJS_COLLAB = 'false'
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    process.env.ENABLE_YJS_COLLAB = originalFlag
+    vi.restoreAllMocks()
+  })
+
+  it('returns injected Yjs runtime snapshot for admins', async () => {
+    const router = initAdminRoutes({
+      getYjsStatus: () => ({
+        enabled: true,
+        initialized: true,
+        sync: { activeDocCount: 2, docIds: ['rec_1', 'rec_2'] },
+        bridge: {
+          pendingWriteCount: 1,
+          observedDocCount: 2,
+          flushSuccessCount: 5,
+          flushFailureCount: 1,
+        },
+        socket: { activeRecordCount: 2, activeSocketCount: 3 },
+      }),
+    })
+
+    const handlers = getRouteHandler(router, 'get', '/yjs/status')
+    const response = createMockResponse()
+    const next = vi.fn()
+
+    await handlers[0]?.handle({ user: { id: 'admin_1', email: 'admin@example.com' } }, response, next)
+    expect(next).toHaveBeenCalledTimes(1)
+
+    await handlers[1]?.handle({ user: { id: 'admin_1', email: 'admin@example.com' } }, response)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toEqual({
+      success: true,
+      yjs: {
+        enabled: true,
+        initialized: true,
+        sync: { activeDocCount: 2, docIds: ['rec_1', 'rec_2'] },
+        bridge: {
+          pendingWriteCount: 1,
+          observedDocCount: 2,
+          flushSuccessCount: 5,
+          flushFailureCount: 1,
+        },
+        socket: { activeRecordCount: 2, activeSocketCount: 3 },
+      },
+    })
+  })
+
+  it('falls back to feature-flag status when runtime is not initialized', async () => {
+    process.env.ENABLE_YJS_COLLAB = 'true'
+    const router = initAdminRoutes()
+    const handlers = getRouteHandler(router, 'get', '/yjs/status')
+    const response = createMockResponse()
+
+    await handlers[0]?.handle({ user: { id: 'admin_2', email: 'admin@example.com' } }, response, vi.fn())
+    await handlers[1]?.handle({ user: { id: 'admin_2', email: 'admin@example.com' } }, response)
+
+    expect(response.body).toEqual({
+      success: true,
+      yjs: {
+        enabled: true,
+        initialized: false,
+        sync: null,
+        bridge: null,
+        socket: null,
+      },
+    })
+  })
+})


### PR DESCRIPTION
## What Changed

This PR adds a minimal operational visibility surface for the internal Yjs rollout.

Backend:
- add `GET /api/admin/yjs/status`
- expose:
  - `enabled`
  - `initialized`
  - `sync`
  - `bridge`
  - `socket`
- wire `MetaSheetServer` to retain Yjs runtime metric sources:
  - `YjsSyncService`
  - `YjsRecordBridge`
  - `YjsWebSocketAdapter`

Tests:
- add unit coverage for the admin Yjs status route
- rerun Yjs hardening + persistence hardening suites alongside it

Docs:
- `docs/development/yjs-ops-visibility-development-20260416.md`
- `docs/development/yjs-ops-visibility-verification-20260416.md`

## Why

The next internal-rollout question after:
- Yjs POC
- Yjs hardening
- awareness/presence
- persistence compaction

is simple operational introspection:

1. Is Yjs enabled in this process?
2. Did it initialize?
3. How many docs and sockets are active?
4. Is the bridge flushing successfully?

This PR adds that minimum runtime visibility without committing to a dedicated admin UI yet.

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/admin-yjs-status-routes.test.ts \
  tests/unit/yjs-hardening.test.ts \
  tests/unit/yjs-persistence-hardening.test.ts \
  --reporter=dot
```

Results:
- `admin-yjs-status-routes.test.ts` → `2/2`
- `yjs-hardening.test.ts` → `7/7`
- `yjs-persistence-hardening.test.ts` → `4/4`
- total → `13/13`

## Notes

- This PR is backend-only.
- It does not add a frontend admin page.
- It is intended to support internal rollout and ops visibility before broader enablement.
