### PR TITLE
feat(collab): add yjs rollout execution packet

### DIFF
--- a/docs/development/yjs-internal-rollout-execution-development-20260416.md
+++ b/docs/development/yjs-internal-rollout-execution-development-20260416.md
@@ -1,0 +1,38 @@
+# Yjs Internal Rollout Execution Development
+
+Date: 2026-04-16
+
+## Context
+
+The main rollout branch already included:
+
+- runtime status script
+- rollout checklist
+- ops runbook
+- retention policy
+
+The remaining operator gap was that DB-side retention checks still depended on manual SQL.
+
+## Change
+
+Added:
+
+- [scripts/ops/check-yjs-retention-health.mjs](/tmp/metasheet2-yjs-rollout-execution/scripts/ops/check-yjs-retention-health.mjs:1)
+- [docs/operations/yjs-internal-rollout-execution-20260416.md](/tmp/metasheet2-yjs-rollout-execution/docs/operations/yjs-internal-rollout-execution-20260416.md:1)
+
+Updated:
+
+- [docs/operations/yjs-internal-rollout-checklist-20260416.md](/tmp/metasheet2-yjs-rollout-execution/docs/operations/yjs-internal-rollout-checklist-20260416.md:1)
+- [docs/operations/yjs-ops-runbook-20260416.md](/tmp/metasheet2-yjs-rollout-execution/docs/operations/yjs-ops-runbook-20260416.md:1)
+
+## Script Scope
+
+`check-yjs-retention-health.mjs` queries PostgreSQL through `psql` and reports:
+
+- `statesCount`
+- `updatesCount`
+- `orphanStatesCount`
+- `orphanUpdatesCount`
+- hottest records by update count
+
+It exits non-zero when thresholds are exceeded, so it can be used in rollout or smoke automation.

--- a/docs/development/yjs-internal-rollout-execution-verification-20260416.md
+++ b/docs/development/yjs-internal-rollout-execution-verification-20260416.md
@@ -1,0 +1,24 @@
+# Yjs Internal Rollout Execution Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+node scripts/ops/check-yjs-retention-health.mjs --help
+node --check scripts/ops/check-yjs-retention-health.mjs
+psql --version
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+## Result
+
+- retention script help output: passed
+- retention script syntax check: passed
+- `psql` availability check: passed
+- Claude Code CLI: `CLAUDE_CLI_OK`
+
+## Notes
+
+- This verification does not hit a live PostgreSQL instance because no rollout database URL was injected in this local run.
+- Runtime status validation remains covered by the existing rollout status script on the parent branch.

--- a/docs/development/yjs-rollout-execution-mainline-rebase-development-20260416.md
+++ b/docs/development/yjs-rollout-execution-mainline-rebase-development-20260416.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Execution Mainline Rebase Development
+
+Date: 2026-04-16
+
+## Context
+
+- Parent PR `#888` merged into `main` as `018af8deb43180556609742beb0724c8b85ac772`.
+- Stacked PR `#889` (`codex/yjs-rollout-execution-20260416`) was still based on the pre-merge parent branch.
+- The goal of this step was to replay `#889` onto updated `origin/main` without losing the lifecycle fix or the rollout status script/docs.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-execution-20260416` onto `origin/main`
+2. Resolving the `docs/operations/yjs-internal-rollout-checklist-20260416.md` conflict by keeping the rollout status script block
+3. Keeping the `MetaSheetServer.yjsCleanupTimer` lifecycle path already present on `main`
+4. Allowing Git to drop `a00e974ae` automatically because that cleanup-timer fix was already upstream via `#888`
+
+## Result
+
+- `#889` is now based on merged `main`, not on the old `codex/yjs-internal-rollout-202605` parent.
+- The branch still carries its intended delta:
+  - `check-yjs-retention-health.mjs`
+  - rollout execution docs
+  - stacked handoff docs
+- No `#888` hardening or cleanup-timer behavior was reverted during the rebase.

--- a/docs/development/yjs-rollout-execution-mainline-rebase-verification-20260416.md
+++ b/docs/development/yjs-rollout-execution-mainline-rebase-verification-20260416.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Execution Mainline Rebase Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+git rebase origin/main
+node scripts/ops/check-yjs-retention-health.mjs --help
+node --check scripts/ops/check-yjs-retention-health.mjs
+psql --version
+```
+
+## Results
+
+- Rebase completed successfully after resolving the checklist doc conflict
+- `a00e974ae` (`clear yjs cleanup timer on shutdown`) was auto-dropped as already upstream
+- `node scripts/ops/check-yjs-retention-health.mjs --help` passed
+- `node --check scripts/ops/check-yjs-retention-health.mjs` passed
+- `psql --version` passed
+
+## Notes
+
+- The rebase preserved `main`'s `this.yjsCleanupTimer` shutdown lifecycle behavior from `#888`
+- The rollout checklist still includes the scripted `check-yjs-rollout-status.mjs` step after replay

--- a/docs/development/yjs-rollout-execution-stacked-handoff-development-20260416.md
+++ b/docs/development/yjs-rollout-execution-stacked-handoff-development-20260416.md
@@ -1,0 +1,29 @@
+# Yjs Rollout Execution Stacked Handoff Development
+
+Date: 2026-04-16
+
+## Context
+
+`#889` is intentionally stacked on top of `#888`.
+
+- `#888`: internal rollout ops baseline
+- `#889`: rollout execution packet
+
+At the time of this handoff:
+
+- `#888` remains `OPEN`
+- required checks are green
+- remaining gate is reviewer approval
+- `#889` is clean and should merge only after `#888`
+
+## Actions Taken
+
+1. Confirmed `#888` is still blocked only by review
+2. Confirmed `#889` is clean against its current base
+3. Ran a narrow Claude Code CLI review on the `#889` branch
+4. Added a dependency note on the PR:
+   - [PR #889 comment](https://github.com/zensgit/metasheet2/pull/889#issuecomment-4257856959)
+
+## Outcome
+
+`#889` is ready as a stacked follow-up, but should be retargeted or rebased onto `main` only after `#888` merges.

--- a/docs/development/yjs-rollout-execution-stacked-handoff-verification-20260416.md
+++ b/docs/development/yjs-rollout-execution-stacked-handoff-verification-20260416.md
@@ -1,0 +1,33 @@
+# Yjs Rollout Execution Stacked Handoff Verification
+
+Date: 2026-04-16
+
+## Verified
+
+### PR status
+
+- `#888`
+  - state: `OPEN`
+  - checks: green
+  - gate: `REVIEW_REQUIRED`
+- `#889`
+  - state: `OPEN`
+  - base: `codex/yjs-internal-rollout-202605`
+  - merge state: `CLEAN`
+
+### Claude Code CLI
+
+```bash
+claude auth status
+claude -p "In the current git repo, review only whether the added rollout execution packet introduces any obvious merge blockers. Reply with exactly NO_BLOCKERS or one short blocker line."
+```
+
+Result:
+
+- `loggedIn: true`
+- review response: `NO_BLOCKERS`
+
+## Notes
+
+- This verification does not change merge order.
+- `#889` remains dependent on `#888` and should not merge ahead of it.

--- a/docs/operations/yjs-internal-rollout-checklist-20260416.md
+++ b/docs/operations/yjs-internal-rollout-checklist-20260416.md
@@ -24,6 +24,9 @@ Date: 2026-04-16
 YJS_BASE_URL=http://localhost:3000 \
 YJS_ADMIN_TOKEN=$ADMIN_TOKEN \
 node scripts/ops/check-yjs-rollout-status.mjs
+
+YJS_DATABASE_URL=$DATABASE_URL \
+node scripts/ops/check-yjs-retention-health.mjs
 ```
 ## 监控项
 

--- a/docs/operations/yjs-internal-rollout-checklist-20260416.md
+++ b/docs/operations/yjs-internal-rollout-checklist-20260416.md
@@ -25,7 +25,6 @@ YJS_BASE_URL=http://localhost:3000 \
 YJS_ADMIN_TOKEN=$ADMIN_TOKEN \
 node scripts/ops/check-yjs-rollout-status.mjs
 ```
-
 ## 监控项
 
 | 指标 | 来源 | 预期 | 告警阈值 |

--- a/docs/operations/yjs-internal-rollout-execution-20260416.md
+++ b/docs/operations/yjs-internal-rollout-execution-20260416.md
@@ -1,0 +1,62 @@
+# Yjs Internal Rollout Execution
+
+Date: 2026-04-16
+
+## Goal
+
+Run the first limited internal rollout with two operator-visible checks:
+
+1. runtime health from `GET /api/admin/yjs/status`
+2. storage/retention health from PostgreSQL
+
+## Runtime Check
+
+```bash
+YJS_BASE_URL=http://localhost:3000 \
+YJS_ADMIN_TOKEN=$ADMIN_TOKEN \
+node scripts/ops/check-yjs-rollout-status.mjs
+```
+
+Expected:
+
+- `enabled: true`
+- `initialized: true`
+- `flushFailureCount: 0`
+- `pendingWriteCount` low and stable
+
+## Retention Check
+
+```bash
+YJS_DATABASE_URL=$DATABASE_URL \
+node scripts/ops/check-yjs-retention-health.mjs
+```
+
+Expected:
+
+- `orphanStatesCount = 0`
+- `orphanUpdatesCount = 0`
+- `updatesCount` below the rollout threshold
+
+## Recommended Sequence
+
+1. Enable `ENABLE_YJS_COLLAB=true`
+2. Restart the target service
+3. Run `check-yjs-rollout-status.mjs`
+4. Have pilot users open the selected test sheets
+5. Run `check-yjs-rollout-status.mjs` again after live editing begins
+6. Run `check-yjs-retention-health.mjs`
+7. If both checks stay healthy, keep the pilot enabled
+
+## Abort Conditions
+
+- runtime status reports `initialized: false`
+- `flushFailureCount` keeps increasing
+- `orphanStatesCount` or `orphanUpdatesCount` is non-zero
+- `updatesCount` grows past the agreed pilot threshold
+
+## Rollback
+
+1. Set `ENABLE_YJS_COLLAB=false`
+2. Restart the service
+3. Re-run `check-yjs-rollout-status.mjs`
+4. Keep DB data intact unless there is a separate cleanup decision

--- a/docs/operations/yjs-ops-runbook-20260416.md
+++ b/docs/operations/yjs-ops-runbook-20260416.md
@@ -13,6 +13,10 @@ YJS_BASE_URL=http://localhost:3000 \
 YJS_ADMIN_TOKEN=$ADMIN_TOKEN \
 node scripts/ops/check-yjs-rollout-status.mjs
 
+# retention / orphan health
+YJS_DATABASE_URL=$DATABASE_URL \
+node scripts/ops/check-yjs-retention-health.mjs
+
 # 预期输出
 {
   "success": true,
@@ -93,3 +97,7 @@ DELETE FROM meta_record_yjs_states WHERE record_id = 'rec_xxx';
 TRUNCATE meta_record_yjs_updates;
 TRUNCATE meta_record_yjs_states;
 ```
+
+## 5. 执行包
+
+- [yjs-internal-rollout-execution-20260416.md](/tmp/metasheet2-yjs-rollout-execution/docs/operations/yjs-internal-rollout-execution-20260416.md:1)

--- a/scripts/ops/check-yjs-retention-health.mjs
+++ b/scripts/ops/check-yjs-retention-health.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+
+const DEFAULTS = {
+  maxUpdates: 100000,
+  maxOrphanStates: 0,
+  maxOrphanUpdates: 0,
+  topLimit: 10,
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/check-yjs-retention-health.mjs [options]
+
+Checks Yjs retention/storage health directly from PostgreSQL.
+
+Options:
+  --database-url <url>           Database URL, default from YJS_DATABASE_URL or DATABASE_URL
+  --max-updates <count>          Alert threshold, default ${DEFAULTS.maxUpdates}
+  --max-orphan-states <count>    Alert threshold, default ${DEFAULTS.maxOrphanStates}
+  --max-orphan-updates <count>   Alert threshold, default ${DEFAULTS.maxOrphanUpdates}
+  --top-limit <count>            Number of hottest records to print, default ${DEFAULTS.topLimit}
+  --json                         Print raw JSON payload after the summary
+  --help                         Show this help
+
+Exit codes:
+  0  healthy
+  1  usage or execution failure
+  2  data fetched but retention state is unhealthy
+`)
+}
+
+function parseArgs(argv) {
+  const opts = {
+    databaseUrl: process.env.YJS_DATABASE_URL || process.env.DATABASE_URL || '',
+    maxUpdates: DEFAULTS.maxUpdates,
+    maxOrphanStates: DEFAULTS.maxOrphanStates,
+    maxOrphanUpdates: DEFAULTS.maxOrphanUpdates,
+    topLimit: DEFAULTS.topLimit,
+    showJson: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+    switch (arg) {
+      case '--database-url':
+        opts.databaseUrl = next
+        i += 1
+        break
+      case '--max-updates':
+        opts.maxUpdates = Number(next)
+        i += 1
+        break
+      case '--max-orphan-states':
+        opts.maxOrphanStates = Number(next)
+        i += 1
+        break
+      case '--max-orphan-updates':
+        opts.maxOrphanUpdates = Number(next)
+        i += 1
+        break
+      case '--top-limit':
+        opts.topLimit = Number(next)
+        i += 1
+        break
+      case '--json':
+        opts.showJson = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+      default:
+        console.error(`Unknown argument: ${arg}`)
+        printHelp()
+        process.exit(1)
+    }
+  }
+
+  return opts
+}
+
+function runPsql(databaseUrl, sql) {
+  const result = spawnSync(
+    'psql',
+    [databaseUrl, '-X', '-q', '-t', '-A', '-c', sql],
+    {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `psql exited with status ${result.status}`)
+  }
+
+  return result.stdout.trim()
+}
+
+function buildPayload(databaseUrl, topLimit) {
+  const statsSql = `
+SELECT json_build_object(
+  'statesCount', (SELECT count(*)::int FROM meta_record_yjs_states),
+  'updatesCount', (SELECT count(*)::int FROM meta_record_yjs_updates),
+  'orphanStatesCount', (
+    SELECT count(*)::int
+    FROM meta_record_yjs_states s
+    LEFT JOIN meta_records r ON r.id = s.record_id
+    WHERE r.id IS NULL
+  ),
+  'orphanUpdatesCount', (
+    SELECT count(*)::int
+    FROM meta_record_yjs_updates u
+    LEFT JOIN meta_records r ON r.id = u.record_id
+    WHERE r.id IS NULL
+  )
+);
+`
+
+  const topSql = `
+SELECT COALESCE(json_agg(row_to_json(t)), '[]'::json)
+FROM (
+  SELECT record_id, count(*)::int AS updateCount
+  FROM meta_record_yjs_updates
+  GROUP BY record_id
+  ORDER BY updateCount DESC, record_id ASC
+  LIMIT ${Math.max(1, topLimit)}
+) t;
+`
+
+  const stats = JSON.parse(runPsql(databaseUrl, statsSql) || '{}')
+  const hottestRecords = JSON.parse(runPsql(databaseUrl, topSql) || '[]')
+
+  return {
+    stats,
+    hottestRecords,
+  }
+}
+
+function assessPayload(payload, thresholds) {
+  const stats = payload.stats ?? {}
+  const failures = []
+
+  if ((stats.updatesCount ?? 0) > thresholds.maxUpdates) {
+    failures.push(`updatesCount ${stats.updatesCount} > ${thresholds.maxUpdates}`)
+  }
+  if ((stats.orphanStatesCount ?? 0) > thresholds.maxOrphanStates) {
+    failures.push(`orphanStatesCount ${stats.orphanStatesCount} > ${thresholds.maxOrphanStates}`)
+  }
+  if ((stats.orphanUpdatesCount ?? 0) > thresholds.maxOrphanUpdates) {
+    failures.push(`orphanUpdatesCount ${stats.orphanUpdatesCount} > ${thresholds.maxOrphanUpdates}`)
+  }
+
+  return failures
+}
+
+function printSummary(payload, failures) {
+  const stats = payload.stats ?? {}
+  console.log(`Yjs retention health: ${failures.length === 0 ? 'HEALTHY' : 'UNHEALTHY'}`)
+  console.log(`States count: ${stats.statesCount ?? 0}`)
+  console.log(`Updates count: ${stats.updatesCount ?? 0}`)
+  console.log(`Orphan states: ${stats.orphanStatesCount ?? 0}`)
+  console.log(`Orphan updates: ${stats.orphanUpdatesCount ?? 0}`)
+
+  if (Array.isArray(payload.hottestRecords) && payload.hottestRecords.length > 0) {
+    console.log('Hottest records:')
+    for (const row of payload.hottestRecords) {
+      console.log(`- ${row.record_id}: ${row.updatecount ?? row.updateCount}`)
+    }
+  }
+
+  if (failures.length > 0) {
+    console.log('Failures:')
+    for (const failure of failures) {
+      console.log(`- ${failure}`)
+    }
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  if (!opts.databaseUrl) {
+    console.error('Missing database URL. Use --database-url, YJS_DATABASE_URL, or DATABASE_URL.')
+    process.exit(1)
+  }
+
+  try {
+    const payload = buildPayload(opts.databaseUrl, opts.topLimit)
+    const failures = assessPayload(payload, opts)
+    printSummary(payload, failures)
+
+    if (opts.showJson) {
+      console.log(JSON.stringify(payload, null, 2))
+    }
+
+    process.exit(failures.length === 0 ? 0 : 2)
+  } catch (error) {
+    console.error(`Failed to query Yjs retention health: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+}
+
+await main()


### PR DESCRIPTION
## What Changed

This PR adds the next operator-facing Yjs internal rollout packet on top of `#888`.

Included:
- `scripts/ops/check-yjs-retention-health.mjs`
  - checks `meta_record_yjs_states`
  - checks `meta_record_yjs_updates`
  - checks orphan state/update rows
  - prints hottest records by update volume
  - exits non-zero when thresholds are exceeded
- `docs/operations/yjs-internal-rollout-execution-20260416.md`
  - concrete runtime + retention execution sequence
- updates to:
  - `docs/operations/yjs-internal-rollout-checklist-20260416.md`
  - `docs/operations/yjs-ops-runbook-20260416.md`
- development / verification records for this follow-up

## Why

`#888` prepares the internal rollout policy and cleanup baseline, but operators still had to run manual SQL to validate DB-side retention health.

This PR closes that gap by turning the storage-side check into a reusable script so rollout owners can run:
- one command for runtime health
- one command for retention/orphan health

## Verification

```bash
node scripts/ops/check-yjs-retention-health.mjs --help
node --check scripts/ops/check-yjs-retention-health.mjs
psql --version
claude -p "Return exactly: CLAUDE_CLI_OK"
```

Results:
- retention script help output: passed
- retention script syntax check: passed
- `psql` availability: passed
- Claude Code CLI: `CLAUDE_CLI_OK`

## Notes

- This PR is based on `codex/yjs-internal-rollout-202605` and should merge after `#888`.
- No Yjs runtime behavior changed here; this is rollout execution tooling + docs only.
