### PR TITLE
feat(collab): add yjs rollout report capture

### DIFF
--- a/docs/development/yjs-rollout-report-capture-development-20260416.md
+++ b/docs/development/yjs-rollout-report-capture-development-20260416.md
@@ -1,0 +1,37 @@
+# Yjs Rollout Report Capture Development
+
+Date: 2026-04-16
+
+## Context
+
+`#889` already adds:
+
+- runtime rollout status check
+- retention/orphan health check
+- execution sequence docs
+
+The remaining operator gap was artifact capture. A rollout owner could run the checks, but there was no one-command way to save a timestamped checkpoint for pilot evidence.
+
+## Change
+
+Added:
+
+- [scripts/ops/capture-yjs-rollout-report.mjs](/tmp/metasheet2-yjs-rollout-report/scripts/ops/capture-yjs-rollout-report.mjs:1)
+- [docs/operations/yjs-rollout-report-capture-20260416.md](/tmp/metasheet2-yjs-rollout-report/docs/operations/yjs-rollout-report-capture-20260416.md:1)
+
+Updated:
+
+- [docs/operations/yjs-internal-rollout-execution-20260416.md](/tmp/metasheet2-yjs-rollout-report/docs/operations/yjs-internal-rollout-execution-20260416.md:1)
+- `check-yjs-rollout-status.mjs` to support `--json-only`
+- `check-yjs-retention-health.mjs` to support `--json-only`
+
+## Output Shape
+
+The report capture script writes:
+
+- JSON artifact with runtime + retention payloads and exit codes
+- Markdown summary artifact for operator review
+
+## Scope
+
+This is rollout evidence tooling only. It does not change Yjs runtime, retention SQL, or admin APIs.

--- a/docs/development/yjs-rollout-report-capture-verification-20260416.md
+++ b/docs/development/yjs-rollout-report-capture-verification-20260416.md
@@ -1,0 +1,28 @@
+# Yjs Rollout Report Capture Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+node scripts/ops/check-yjs-rollout-status.mjs --help
+node scripts/ops/check-yjs-retention-health.mjs --help
+node --check scripts/ops/check-yjs-rollout-status.mjs
+node --check scripts/ops/check-yjs-retention-health.mjs
+node --check scripts/ops/capture-yjs-rollout-report.mjs
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+## Result
+
+- runtime status script help: passed
+- retention health script help: passed
+- runtime status script syntax: passed
+- retention health script syntax: passed
+- rollout report capture syntax: passed
+- Claude Code CLI: `CLAUDE_CLI_OK`
+
+## Notes
+
+- This verification does not call a live rollout target because no base URL, admin token, and database URL were injected for this local run.
+- The report script is validated as a composition layer on top of the two existing rollout checks.

--- a/docs/development/yjs-rollout-report-mainline-rebase-development-20260416.md
+++ b/docs/development/yjs-rollout-report-mainline-rebase-development-20260416.md
@@ -1,0 +1,27 @@
+# Yjs Rollout Report Mainline Rebase Development
+
+Date: 2026-04-16
+
+## Context
+
+- PR `#889` merged into `main` as `8e0831f1c823223660c05d30a4aba25cb04b2bdb`.
+- PR `#890` auto-retargeted to `main` and became `DIRTY` because it still replayed the merged `#889` stack locally.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-report-20260416` onto updated `origin/main`
+2. Skipping the replay of the merged parent commit `47e137214`
+3. Dropping the three `#889`-layer commits now already represented by the squash merge on `main`:
+   - `cc92c6be2`
+   - `fcbd950a5`
+   - `e331ed68b`
+4. Keeping only the report-specific commits on top of `main`:
+   - `a663e6e21` `feat(collab): add yjs rollout report capture`
+   - `74acfac07` `docs: add yjs rollout stack merge readiness`
+   - `a8c0786a7` `docs: record yjs rollout report stack rebase`
+
+## Result
+
+- `#890` is now a clean, minimal delta over current `main`
+- The branch no longer replays any already-merged rollout-execution history
+- The report-capture scripts and docs are preserved intact

--- a/docs/development/yjs-rollout-report-mainline-rebase-verification-20260416.md
+++ b/docs/development/yjs-rollout-report-mainline-rebase-verification-20260416.md
@@ -1,0 +1,29 @@
+# Yjs Rollout Report Mainline Rebase Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+git rebase origin/main
+node --check scripts/ops/check-yjs-rollout-status.mjs
+node --check scripts/ops/check-yjs-retention-health.mjs
+node --check scripts/ops/capture-yjs-rollout-report.mjs
+git log --oneline --reverse origin/main..HEAD
+```
+
+## Results
+
+- Rebase onto `origin/main` completed successfully
+- The post-rebase branch range is now:
+  - `a663e6e21` `feat(collab): add yjs rollout report capture`
+  - `74acfac07` `docs: add yjs rollout stack merge readiness`
+  - `a8c0786a7` `docs: record yjs rollout report stack rebase`
+- `node --check scripts/ops/check-yjs-rollout-status.mjs` passed
+- `node --check scripts/ops/check-yjs-retention-health.mjs` passed
+- `node --check scripts/ops/capture-yjs-rollout-report.mjs` passed
+
+## Notes
+
+- This rebase intentionally removed the already-merged `#889` layer from the branch history
+- No runtime behavior changed in this step; it was branch hygiene plus verification

--- a/docs/development/yjs-rollout-report-stack-rebase-development-20260416.md
+++ b/docs/development/yjs-rollout-report-stack-rebase-development-20260416.md
@@ -1,0 +1,23 @@
+# Yjs Rollout Report Stack Rebase Development
+
+Date: 2026-04-16
+
+## Context
+
+- Parent PR `#889` was rebased onto merged `main` after `#888` landed.
+- Stacked PR `#890` (`codex/yjs-rollout-report-20260416`) needed to be replayed onto the updated `codex/yjs-rollout-execution-20260416` head.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-report-20260416` onto `origin/codex/yjs-rollout-execution-20260416`
+2. Skipping the already-upstream parent commit `572800945`
+3. Letting Git auto-drop `a00e974ae` because the cleanup-timer fix was already upstream
+4. Resolving the rollout status script conflict by keeping both script paths in the ops docs:
+   - `check-yjs-rollout-status.mjs`
+   - `check-yjs-retention-health.mjs`
+
+## Result
+
+- `#890` now sits cleanly on top of the updated `#889` branch
+- The branch still only carries the intended report-capture delta
+- The retention/status script guidance remains present in both checklist and runbook

--- a/docs/development/yjs-rollout-report-stack-rebase-verification-20260416.md
+++ b/docs/development/yjs-rollout-report-stack-rebase-verification-20260416.md
@@ -1,0 +1,24 @@
+# Yjs Rollout Report Stack Rebase Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+git rebase origin/codex/yjs-rollout-execution-20260416
+node --check scripts/ops/check-yjs-rollout-status.mjs
+node --check scripts/ops/check-yjs-retention-health.mjs
+node --check scripts/ops/capture-yjs-rollout-report.mjs
+```
+
+## Results
+
+- Rebase completed successfully after resolving the ops doc conflicts
+- `node --check scripts/ops/check-yjs-rollout-status.mjs` passed
+- `node --check scripts/ops/check-yjs-retention-health.mjs` passed
+- `node --check scripts/ops/capture-yjs-rollout-report.mjs` passed
+
+## Notes
+
+- The rebased branch preserved both rollout-status and retention-health script guidance
+- No Yjs runtime or persistence semantics changed in this step; it was a stack-alignment replay only

--- a/docs/development/yjs-rollout-stack-merge-readiness-development-20260416.md
+++ b/docs/development/yjs-rollout-stack-merge-readiness-development-20260416.md
@@ -1,0 +1,44 @@
+# Yjs Rollout Stack Merge Readiness Development
+
+Date: 2026-04-16
+
+## Scope
+
+This note captures the current stacked rollout state for:
+
+- `#888` internal rollout ops
+- `#889` rollout execution packet
+- `#890` rollout report capture
+
+## Current Stack
+
+1. `#888`
+   - base: `main`
+   - purpose: rollout baseline, runbook, retention policy, cleanup job
+2. `#889`
+   - base: `codex/yjs-internal-rollout-202605`
+   - purpose: execution packet and retention health check
+3. `#890`
+   - base: `codex/yjs-rollout-execution-20260416`
+   - purpose: report capture artifact generation
+
+## Why This Matters
+
+All three PRs are independently small enough to review, but merge order must remain strict. Merging `#889` or `#890` ahead of their parent would collapse the stack into the base feature branch and blur reviewer scope.
+
+## Actions Taken
+
+1. Confirmed `#888` is still blocked only by reviewer approval
+2. Confirmed `#889` is clean on top of `#888`
+3. Confirmed `#890` is clean on top of `#889`
+4. Left stacked dependency comments on:
+   - [#889 comment](https://github.com/zensgit/metasheet2/pull/889#issuecomment-4257856959)
+   - [#890 comment](https://github.com/zensgit/metasheet2/pull/890#issuecomment-4257887609)
+
+## Merge Order
+
+1. `#888`
+2. `#889`
+3. `#890`
+
+After each parent merge, the child PR should be retargeted or rebased to the new upstream before final merge.

--- a/docs/development/yjs-rollout-stack-merge-readiness-verification-20260416.md
+++ b/docs/development/yjs-rollout-stack-merge-readiness-verification-20260416.md
@@ -1,0 +1,44 @@
+# Yjs Rollout Stack Merge Readiness Verification
+
+Date: 2026-04-16
+
+## Verified PR State
+
+### `#888`
+
+- state: `OPEN`
+- base: `main`
+- checks: green
+- remaining gate: `REVIEW_REQUIRED`
+
+### `#889`
+
+- state: `OPEN`
+- base: `codex/yjs-internal-rollout-202605`
+- merge state: `CLEAN`
+- `pr-validate`: success
+
+### `#890`
+
+- state: `OPEN`
+- base: `codex/yjs-rollout-execution-20260416`
+- merge state: `CLEAN`
+- `pr-validate`: success
+
+## Claude Code CLI
+
+```bash
+claude auth status
+claude -p "Return exactly: CLAUDE_CLI_OK"
+claude -p "In the current git repo, review only whether the rollout report capture follow-up introduces any obvious merge blockers. Reply with exactly NO_BLOCKERS or one short blocker line."
+```
+
+Results:
+
+- `loggedIn: true`
+- smoke response: `CLAUDE_CLI_OK`
+- narrow review response: `NO_BLOCKERS`
+
+## Conclusion
+
+No new implementation blockers were found in the stacked rollout follow-ups. The remaining blocker is merge order and reviewer approval on `#888`.

--- a/docs/operations/yjs-internal-rollout-execution-20260416.md
+++ b/docs/operations/yjs-internal-rollout-execution-20260416.md
@@ -45,7 +45,16 @@ Expected:
 4. Have pilot users open the selected test sheets
 5. Run `check-yjs-rollout-status.mjs` again after live editing begins
 6. Run `check-yjs-retention-health.mjs`
-7. If both checks stay healthy, keep the pilot enabled
+7. Optionally capture a rollout report artifact:
+
+```bash
+YJS_BASE_URL=http://localhost:3000 \
+YJS_ADMIN_TOKEN=$ADMIN_TOKEN \
+YJS_DATABASE_URL=$DATABASE_URL \
+node scripts/ops/capture-yjs-rollout-report.mjs
+```
+
+8. If both checks stay healthy, keep the pilot enabled
 
 ## Abort Conditions
 

--- a/docs/operations/yjs-rollout-report-capture-20260416.md
+++ b/docs/operations/yjs-rollout-report-capture-20260416.md
@@ -1,0 +1,29 @@
+# Yjs Rollout Report Capture
+
+Date: 2026-04-16
+
+## Command
+
+```bash
+YJS_BASE_URL=http://localhost:3000 \
+YJS_ADMIN_TOKEN=$ADMIN_TOKEN \
+YJS_DATABASE_URL=$DATABASE_URL \
+node scripts/ops/capture-yjs-rollout-report.mjs
+```
+
+## Output
+
+The script writes two artifacts under `artifacts/yjs-rollout/`:
+
+- `yjs-rollout-report-<timestamp>.json`
+- `yjs-rollout-report-<timestamp>.md`
+
+## Purpose
+
+This is the smallest repeatable way to capture one rollout checkpoint that includes:
+
+- runtime health
+- retention/orphan health
+- hottest records by update volume
+
+It is intended for pilot signoff, not for continuous monitoring.

--- a/scripts/ops/capture-yjs-rollout-report.mjs
+++ b/scripts/ops/capture-yjs-rollout-report.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/capture-yjs-rollout-report.mjs [options]
+
+Captures one combined Yjs rollout report from:
+- runtime status
+- retention/storage health
+
+Options:
+  --base-url <url>        Base URL, default from YJS_BASE_URL or http://localhost:3000
+  --token <token>         Admin bearer token, default from YJS_ADMIN_TOKEN or ADMIN_TOKEN
+  --database-url <url>    Database URL, default from YJS_DATABASE_URL or DATABASE_URL
+  --output-dir <dir>      Output directory, default artifacts/yjs-rollout
+  --help                  Show this help
+`)
+}
+
+function parseArgs(argv) {
+  const opts = {
+    baseUrl: process.env.YJS_BASE_URL || 'http://localhost:3000',
+    token: process.env.YJS_ADMIN_TOKEN || process.env.ADMIN_TOKEN || '',
+    databaseUrl: process.env.YJS_DATABASE_URL || process.env.DATABASE_URL || '',
+    outputDir: path.resolve(process.cwd(), 'artifacts/yjs-rollout'),
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+    switch (arg) {
+      case '--base-url':
+        opts.baseUrl = next
+        i += 1
+        break
+      case '--token':
+        opts.token = next
+        i += 1
+        break
+      case '--database-url':
+        opts.databaseUrl = next
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), next)
+        i += 1
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+      default:
+        console.error(`Unknown argument: ${arg}`)
+        printHelp()
+        process.exit(1)
+    }
+  }
+
+  return opts
+}
+
+function runNodeScript(scriptPath, args, extraEnv = {}) {
+  const result = spawnSync('node', [scriptPath, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0 && result.status !== 2) {
+    throw new Error(result.stderr.trim() || result.stdout.trim() || `${path.basename(scriptPath)} exited with status ${result.status}`)
+  }
+
+  return {
+    exitCode: result.status ?? 1,
+    payload: JSON.parse(result.stdout.trim()),
+  }
+}
+
+function toHeadline(result) {
+  return result.exitCode === 0 ? 'HEALTHY' : 'UNHEALTHY'
+}
+
+function renderMarkdown(report) {
+  const runtime = report.runtime.payload
+  const retention = report.retention.payload
+
+  return `# Yjs Rollout Report
+
+Date: ${report.generatedAt}
+
+## Runtime
+
+- status: ${toHeadline(report.runtime)}
+- base URL: ${runtime.baseUrl}
+- enabled: ${runtime.metrics.enabled}
+- initialized: ${runtime.metrics.initialized}
+- active docs: ${runtime.metrics.activeDocCount}
+- pending writes: ${runtime.metrics.pendingWriteCount}
+- flush failures: ${runtime.metrics.flushFailureCount}
+- active sockets: ${runtime.metrics.activeSocketCount}
+
+## Retention
+
+- status: ${toHeadline(report.retention)}
+- states count: ${retention.stats.statesCount}
+- updates count: ${retention.stats.updatesCount}
+- orphan states: ${retention.stats.orphanStatesCount}
+- orphan updates: ${retention.stats.orphanUpdatesCount}
+
+## Hottest Records
+
+${Array.isArray(retention.hottestRecords) && retention.hottestRecords.length > 0
+    ? retention.hottestRecords.map((row) => `- ${row.record_id}: ${row.updateCount ?? row.updatecount}`).join('\n')
+    : '- none'}
+
+## Failures
+
+### Runtime
+
+${runtime.failures.length > 0 ? runtime.failures.map((failure) => `- ${failure}`).join('\n') : '- none'}
+
+### Retention
+
+${retention.failures.length > 0 ? retention.failures.map((failure) => `- ${failure}`).join('\n') : '- none'}
+`
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  if (!opts.token) {
+    console.error('Missing admin token. Use --token, YJS_ADMIN_TOKEN, or ADMIN_TOKEN.')
+    process.exit(1)
+  }
+  if (!opts.databaseUrl) {
+    console.error('Missing database URL. Use --database-url, YJS_DATABASE_URL, or DATABASE_URL.')
+    process.exit(1)
+  }
+
+  const runtimeScript = path.resolve(process.cwd(), 'scripts/ops/check-yjs-rollout-status.mjs')
+  const retentionScript = path.resolve(process.cwd(), 'scripts/ops/check-yjs-retention-health.mjs')
+
+  const runtime = runNodeScript(runtimeScript, ['--json-only'], {
+    YJS_BASE_URL: opts.baseUrl,
+    YJS_ADMIN_TOKEN: opts.token,
+  })
+  const retention = runNodeScript(retentionScript, ['--json-only'], {
+    YJS_DATABASE_URL: opts.databaseUrl,
+  })
+
+  const generatedAt = new Date().toISOString()
+  const timestamp = generatedAt.replace(/[:.]/g, '-')
+  mkdirSync(opts.outputDir, { recursive: true })
+
+  const report = {
+    generatedAt,
+    runtime,
+    retention,
+  }
+
+  const jsonPath = path.join(opts.outputDir, `yjs-rollout-report-${timestamp}.json`)
+  const mdPath = path.join(opts.outputDir, `yjs-rollout-report-${timestamp}.md`)
+
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+  writeFileSync(mdPath, `${renderMarkdown(report)}\n`, 'utf8')
+
+  console.log(`Wrote ${jsonPath}`)
+  console.log(`Wrote ${mdPath}`)
+
+  const exitCode = runtime.exitCode === 0 && retention.exitCode === 0 ? 0 : 2
+  process.exit(exitCode)
+}
+
+await main()

--- a/scripts/ops/check-yjs-retention-health.mjs
+++ b/scripts/ops/check-yjs-retention-health.mjs
@@ -21,6 +21,7 @@ Options:
   --max-orphan-updates <count>   Alert threshold, default ${DEFAULTS.maxOrphanUpdates}
   --top-limit <count>            Number of hottest records to print, default ${DEFAULTS.topLimit}
   --json                         Print raw JSON payload after the summary
+  --json-only                    Print JSON payload only
   --help                         Show this help
 
 Exit codes:
@@ -38,6 +39,7 @@ function parseArgs(argv) {
     maxOrphanUpdates: DEFAULTS.maxOrphanUpdates,
     topLimit: DEFAULTS.topLimit,
     showJson: false,
+    jsonOnly: false,
   }
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -66,6 +68,9 @@ function parseArgs(argv) {
         break
       case '--json':
         opts.showJson = true
+        break
+      case '--json-only':
+        opts.jsonOnly = true
         break
       case '--help':
         printHelp()
@@ -191,10 +196,25 @@ async function main() {
   try {
     const payload = buildPayload(opts.databaseUrl, opts.topLimit)
     const failures = assessPayload(payload, opts)
-    printSummary(payload, failures)
+    const outputPayload = {
+      databaseUrlPresent: Boolean(opts.databaseUrl),
+      thresholds: {
+        maxUpdates: opts.maxUpdates,
+        maxOrphanStates: opts.maxOrphanStates,
+        maxOrphanUpdates: opts.maxOrphanUpdates,
+        topLimit: opts.topLimit,
+      },
+      failures,
+      ...payload,
+    }
 
-    if (opts.showJson) {
-      console.log(JSON.stringify(payload, null, 2))
+    if (opts.jsonOnly) {
+      console.log(JSON.stringify(outputPayload, null, 2))
+    } else {
+      printSummary(payload, failures)
+      if (opts.showJson) {
+        console.log(JSON.stringify(outputPayload, null, 2))
+      }
     }
 
     process.exit(failures.length === 0 ? 0 : 2)

--- a/scripts/ops/check-yjs-rollout-status.mjs
+++ b/scripts/ops/check-yjs-rollout-status.mjs
@@ -22,6 +22,7 @@ Options:
   --max-pending-writes <count> Alert threshold, default ${DEFAULTS.maxPendingWrites}
   --max-active-sockets <count> Alert threshold, default ${DEFAULTS.maxActiveSockets}
   --json                       Print raw JSON payload after the summary
+  --json-only                  Print JSON payload only
   --help                       Show this help
 
 Exit codes:
@@ -41,6 +42,7 @@ function parseArgs(argv) {
     maxPendingWrites: DEFAULTS.maxPendingWrites,
     maxActiveSockets: DEFAULTS.maxActiveSockets,
     showJson: false,
+    jsonOnly: false,
   }
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -77,6 +79,9 @@ function parseArgs(argv) {
         break
       case '--json':
         opts.showJson = true
+        break
+      case '--json-only':
+        opts.jsonOnly = true
         break
       case '--help':
         printHelp()
@@ -129,7 +134,7 @@ function assessStatus(payload, thresholds) {
     failures.push(`activeSocketCount ${metrics.activeSocketCount} > ${thresholds.maxActiveSockets}`)
   }
 
-  return { metrics, failures }
+  return { metrics, failures, payload }
 }
 
 function printSummary(baseUrl, metrics, failures) {
@@ -179,14 +184,24 @@ async function main() {
     }
 
     const payload = await response.json()
-    const { metrics, failures } = assessStatus(payload, opts)
-    printSummary(opts.baseUrl, metrics, failures)
-
-    if (opts.showJson) {
-      console.log(JSON.stringify(payload, null, 2))
+    const assessed = assessStatus(payload, opts)
+    const outputPayload = {
+      baseUrl: opts.baseUrl,
+      metrics: assessed.metrics,
+      failures: assessed.failures,
+      payload,
     }
 
-    process.exit(failures.length === 0 ? 0 : 2)
+    if (opts.jsonOnly) {
+      console.log(JSON.stringify(outputPayload, null, 2))
+    } else {
+      printSummary(opts.baseUrl, assessed.metrics, assessed.failures)
+      if (opts.showJson) {
+        console.log(JSON.stringify(outputPayload, null, 2))
+      }
+    }
+
+    process.exit(assessed.failures.length === 0 ? 0 : 2)
   } catch (error) {
     console.error(`Failed to fetch Yjs status: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)


### PR DESCRIPTION
## What Changed

This PR adds one more operator-facing follow-up on top of `#889`: a timestamped rollout report capture command.

Included:
- `scripts/ops/capture-yjs-rollout-report.mjs`
  - captures runtime status
  - captures retention/orphan health
  - writes JSON + Markdown artifacts under `artifacts/yjs-rollout/`
- `--json-only` support for:
  - `check-yjs-rollout-status.mjs`
  - `check-yjs-retention-health.mjs`
- docs:
  - `docs/operations/yjs-rollout-report-capture-20260416.md`
  - update to `docs/operations/yjs-internal-rollout-execution-20260416.md`
- development / verification records for this follow-up

## Why

`#889` lets operators run the two checks separately.
This PR adds the smallest repeatable way to save one rollout checkpoint as evidence for pilot signoff or rollback analysis.

## Verification

```bash
node scripts/ops/check-yjs-rollout-status.mjs --help
node scripts/ops/check-yjs-retention-health.mjs --help
node --check scripts/ops/check-yjs-rollout-status.mjs
node --check scripts/ops/check-yjs-retention-health.mjs
node --check scripts/ops/capture-yjs-rollout-report.mjs
claude -p "Return exactly: CLAUDE_CLI_OK"
```

Results:
- runtime status script help: passed
- retention health script help: passed
- runtime status script syntax: passed
- retention health script syntax: passed
- rollout report capture syntax: passed
- Claude Code CLI: `CLAUDE_CLI_OK`

## Notes

- This PR is intentionally stacked on `#889`.
- Merge order should remain: `#888` -> `#889` -> this PR.
- No Yjs runtime semantics were changed.
