### PR TITLE
feat(collab): add yjs rollout packet export

### DIFF
--- a/docs/development/yjs-rollout-packet-export-development-20260416.md
+++ b/docs/development/yjs-rollout-packet-export-development-20260416.md
@@ -1,0 +1,33 @@
+# Yjs Rollout Packet Export Development
+
+Date: 2026-04-16
+
+## Context
+
+The rollout stack already contains:
+
+- runtime status check
+- retention health check
+- rollout report capture
+- execution and operations docs
+
+The remaining operator convenience gap was packet assembly. A pilot owner still had to collect the right scripts and docs manually.
+
+## Change
+
+Added:
+
+- [scripts/ops/export-yjs-rollout-packet.mjs](/tmp/metasheet2-yjs-rollout-packet/scripts/ops/export-yjs-rollout-packet.mjs:1)
+- [docs/operations/yjs-rollout-packet-export-20260416.md](/tmp/metasheet2-yjs-rollout-packet/docs/operations/yjs-rollout-packet-export-20260416.md:1)
+
+Updated:
+
+- [docs/operations/yjs-internal-rollout-execution-20260416.md](/tmp/metasheet2-yjs-rollout-packet/docs/operations/yjs-internal-rollout-execution-20260416.md:1)
+
+## Behavior
+
+The export script copies the current rollout scripts and ops docs into one output directory and generates a small packet `README.md`.
+
+## Scope
+
+This does not change rollout checks or runtime behavior. It is packaging only.

--- a/docs/development/yjs-rollout-packet-export-verification-20260416.md
+++ b/docs/development/yjs-rollout-packet-export-verification-20260416.md
@@ -1,0 +1,24 @@
+# Yjs Rollout Packet Export Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+node scripts/ops/export-yjs-rollout-packet.mjs --help
+node --check scripts/ops/export-yjs-rollout-packet.mjs
+rm -rf artifacts/yjs-rollout-packet
+node scripts/ops/export-yjs-rollout-packet.mjs
+test -f artifacts/yjs-rollout-packet/README.md
+test -f artifacts/yjs-rollout-packet/scripts/ops/capture-yjs-rollout-report.mjs
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+## Result
+
+- help output: passed
+- syntax check: passed
+- packet export: passed
+- packet README exists: passed
+- packet capture script exists: passed
+- Claude Code CLI: `CLAUDE_CLI_OK`

--- a/docs/development/yjs-rollout-packet-mainline-rebase-development-20260416.md
+++ b/docs/development/yjs-rollout-packet-mainline-rebase-development-20260416.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Packet Mainline Rebase Development
+
+Date: 2026-04-16
+
+## Context
+
+- PR `#890` merged into `main` as `0446cf52a84619c6b0ecfab7355f3e8b8cdc5999`.
+- PR `#891` auto-retargeted to `main` and showed `BEHIND`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-packet-20260416` onto updated `origin/main`
+2. Letting Git auto-drop the already-upstream `#890` parent layer:
+   - `a663e6e21`
+   - `74acfac07`
+   - `a8c0786a7`
+   - `2edcd7f1c`
+3. Preserving only the packet-specific commits:
+   - `daf05bcf9` `feat(collab): add yjs rollout packet export`
+   - `c0b63f637` `docs: record yjs rollout packet stack rebase`
+
+## Result
+
+- `#891` is now a minimal delta over current `main`
+- The branch no longer replays any report-capture history
+- Packet export remains intact and ready for CI/review

--- a/docs/development/yjs-rollout-packet-mainline-rebase-verification-20260416.md
+++ b/docs/development/yjs-rollout-packet-mainline-rebase-verification-20260416.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Packet Mainline Rebase Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+git rebase origin/main
+node --check scripts/ops/export-yjs-rollout-packet.mjs
+node scripts/ops/export-yjs-rollout-packet.mjs --help
+git log --oneline --reverse origin/main..HEAD
+```
+
+## Results
+
+- Rebase onto `origin/main` completed successfully
+- The post-rebase branch range is now:
+  - `daf05bcf9` `feat(collab): add yjs rollout packet export`
+  - `c0b63f637` `docs: record yjs rollout packet stack rebase`
+- `node --check scripts/ops/export-yjs-rollout-packet.mjs` passed
+- `node scripts/ops/export-yjs-rollout-packet.mjs --help` passed
+
+## Notes
+
+- The rebased branch intentionally dropped all already-merged `#890` parent commits
+- This step changed branch topology only; no rollout runtime semantics changed

--- a/docs/development/yjs-rollout-packet-stack-rebase-development-20260416.md
+++ b/docs/development/yjs-rollout-packet-stack-rebase-development-20260416.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Packet Stack Rebase Development
+
+Date: 2026-04-16
+
+## Context
+
+- Parent PR `#890` was rebased and simplified to a pure report-capture delta.
+- Stacked PR `#891` still replayed the already-merged `#888/#889` layer plus the already-rebased `#890` parent layer.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-packet-20260416` onto `origin/codex/yjs-rollout-report-20260416`
+2. Skipping the replay of the old `#888` parent commit
+3. Dropping the already-upstream `#889`-layer commits:
+   - `a00e974ae`
+   - `e5d12f1cf`
+   - `1492a1d4c`
+   - `c6333e822`
+4. Keeping only the packet-export commit:
+   - `8c937c495` `feat(collab): add yjs rollout packet export`
+
+## Result
+
+- `#891` now sits cleanly on top of the updated `#890` branch
+- The branch is reduced to the intended packet-export delta only

--- a/docs/development/yjs-rollout-packet-stack-rebase-verification-20260416.md
+++ b/docs/development/yjs-rollout-packet-stack-rebase-verification-20260416.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Packet Stack Rebase Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+git rebase origin/codex/yjs-rollout-report-20260416
+node --check scripts/ops/export-yjs-rollout-packet.mjs
+node scripts/ops/export-yjs-rollout-packet.mjs --help
+git log --oneline --reverse origin/codex/yjs-rollout-report-20260416..HEAD
+```
+
+## Results
+
+- Rebase completed successfully
+- The post-rebase branch range is now only:
+  - `8c937c495` `feat(collab): add yjs rollout packet export`
+- `node --check scripts/ops/export-yjs-rollout-packet.mjs` passed
+- `node scripts/ops/export-yjs-rollout-packet.mjs --help` passed
+
+## Notes
+
+- This step intentionally removed the already-merged parent layers from the branch history
+- No rollout runtime semantics changed; this was stack cleanup plus script validation

--- a/docs/operations/yjs-internal-rollout-execution-20260416.md
+++ b/docs/operations/yjs-internal-rollout-execution-20260416.md
@@ -9,6 +9,12 @@ Run the first limited internal rollout with two operator-visible checks:
 1. runtime health from `GET /api/admin/yjs/status`
 2. storage/retention health from PostgreSQL
 
+Optional packet export:
+
+```bash
+node scripts/ops/export-yjs-rollout-packet.mjs
+```
+
 ## Runtime Check
 
 ```bash

--- a/docs/operations/yjs-rollout-packet-export-20260416.md
+++ b/docs/operations/yjs-rollout-packet-export-20260416.md
@@ -1,0 +1,33 @@
+# Yjs Rollout Packet Export
+
+Date: 2026-04-16
+
+## Command
+
+```bash
+node scripts/ops/export-yjs-rollout-packet.mjs
+```
+
+## Output
+
+Default output directory:
+
+```text
+artifacts/yjs-rollout-packet/
+```
+
+Included:
+
+- rollout checklist
+- rollout execution guide
+- ops runbook
+- retention policy
+- rollout report capture guide
+- runtime status check script
+- retention health check script
+- rollout report capture script
+- generated `README.md`
+
+## Purpose
+
+This export is for pilot owners who need one artifact folder containing the exact docs and scripts required to execute and record a limited Yjs internal rollout.

--- a/scripts/ops/export-yjs-rollout-packet.mjs
+++ b/scripts/ops/export-yjs-rollout-packet.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { cpSync, mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/export-yjs-rollout-packet.mjs [options]
+
+Exports the current Yjs rollout execution packet into one artifact directory.
+
+Options:
+  --output-dir <dir>   Output directory, default artifacts/yjs-rollout-packet
+  --help               Show this help
+`)
+}
+
+function parseArgs(argv) {
+  const opts = {
+    outputDir: path.resolve(process.cwd(), 'artifacts/yjs-rollout-packet'),
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+    switch (arg) {
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), next)
+        i += 1
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+      default:
+        console.error(`Unknown argument: ${arg}`)
+        printHelp()
+        process.exit(1)
+    }
+  }
+
+  return opts
+}
+
+const packetFiles = [
+  'docs/operations/yjs-internal-rollout-checklist-20260416.md',
+  'docs/operations/yjs-internal-rollout-execution-20260416.md',
+  'docs/operations/yjs-ops-runbook-20260416.md',
+  'docs/operations/yjs-retention-policy-20260416.md',
+  'docs/operations/yjs-rollout-report-capture-20260416.md',
+  'scripts/ops/check-yjs-rollout-status.mjs',
+  'scripts/ops/check-yjs-retention-health.mjs',
+  'scripts/ops/capture-yjs-rollout-report.mjs',
+]
+
+function renderReadme(outputDir) {
+  const rel = (file) => path.relative(outputDir, path.resolve(process.cwd(), file)).replaceAll('\\', '/')
+  return `# Yjs Rollout Packet
+
+Generated at: ${new Date().toISOString()}
+
+## Included Docs
+
+- ${rel('docs/operations/yjs-internal-rollout-checklist-20260416.md')}
+- ${rel('docs/operations/yjs-internal-rollout-execution-20260416.md')}
+- ${rel('docs/operations/yjs-ops-runbook-20260416.md')}
+- ${rel('docs/operations/yjs-retention-policy-20260416.md')}
+- ${rel('docs/operations/yjs-rollout-report-capture-20260416.md')}
+
+## Included Scripts
+
+- ${rel('scripts/ops/check-yjs-rollout-status.mjs')}
+- ${rel('scripts/ops/check-yjs-retention-health.mjs')}
+- ${rel('scripts/ops/capture-yjs-rollout-report.mjs')}
+
+## Recommended Order
+
+1. Read the checklist
+2. Run the runtime status check
+3. Run the retention health check
+4. Run the combined report capture
+5. Store generated report artifacts alongside the rollout packet
+`
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  mkdirSync(opts.outputDir, { recursive: true })
+
+  for (const file of packetFiles) {
+    const source = path.resolve(process.cwd(), file)
+    const destination = path.join(opts.outputDir, file)
+    mkdirSync(path.dirname(destination), { recursive: true })
+    cpSync(source, destination)
+    console.log(`Copied ${file}`)
+  }
+
+  const readmePath = path.join(opts.outputDir, 'README.md')
+  writeFileSync(readmePath, `${renderReadme(opts.outputDir)}\n`, 'utf8')
+  console.log(`Wrote ${path.relative(process.cwd(), readmePath)}`)
+}
+
+await main()


### PR DESCRIPTION
## What Changed

This PR adds one more operator-facing follow-up on top of `#890`: a packet export command for the Yjs pilot rollout.

Included:
- `scripts/ops/export-yjs-rollout-packet.mjs`
  - copies the current rollout docs and ops scripts into one artifact directory
  - writes a packet `README.md`
- docs:
  - `docs/operations/yjs-rollout-packet-export-20260416.md`
  - update to `docs/operations/yjs-internal-rollout-execution-20260416.md`
- development / verification records for this follow-up

## Why

The rollout stack already provides:
- runtime status check
- retention health check
- report capture

The remaining operator gap was packet assembly. This PR makes it easy to hand one artifact folder to a pilot owner without manually gathering files.

## Verification

```bash
node scripts/ops/export-yjs-rollout-packet.mjs --help
node --check scripts/ops/export-yjs-rollout-packet.mjs
rm -rf artifacts/yjs-rollout-packet
node scripts/ops/export-yjs-rollout-packet.mjs
test -f artifacts/yjs-rollout-packet/README.md
test -f artifacts/yjs-rollout-packet/scripts/ops/capture-yjs-rollout-report.mjs
claude -p "Return exactly: CLAUDE_CLI_OK"
```

Results:
- help output: passed
- syntax check: passed
- packet export: passed
- packet README exists: passed
- packet capture script exists: passed
- Claude Code CLI: `CLAUDE_CLI_OK`

## Notes

- This PR is intentionally stacked on `#890`.
- Merge order should remain: `#888` -> `#889` -> `#890` -> this PR.
- No Yjs runtime semantics were changed.
