### PR TITLE
docs(collab): add yjs rollout signoff template

### DIFF
--- a/docs/development/yjs-rollout-signoff-mainline-rebase-development-20260416.md
+++ b/docs/development/yjs-rollout-signoff-mainline-rebase-development-20260416.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Signoff Mainline Rebase Development
+
+Date: 2026-04-16
+
+## Context
+
+- PR `#891` merged into `main` as `c7030b342707424bfbc724498f8a6a27d66b76a2`.
+- PR `#892` auto-retargeted to `main` and became `DIRTY`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-signoff-20260416` onto updated `origin/main`
+2. Letting Git auto-drop the already-upstream `#891` parent layer:
+   - `daf05bcf9`
+   - `c0b63f637`
+   - `dcccc0a67`
+3. Preserving only the signoff-specific commits:
+   - `008268bb7` `docs(collab): add yjs rollout signoff template`
+   - `78275209d` `docs: record yjs rollout signoff stack rebase`
+
+## Result
+
+- `#892` is now a minimal delta over current `main`
+- The branch no longer replays packet-export history
+- The signoff template remains exportable through the rollout packet flow

--- a/docs/development/yjs-rollout-signoff-mainline-rebase-verification-20260416.md
+++ b/docs/development/yjs-rollout-signoff-mainline-rebase-verification-20260416.md
@@ -1,0 +1,29 @@
+# Yjs Rollout Signoff Mainline Rebase Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+git rebase origin/main
+node --check scripts/ops/export-yjs-rollout-packet.mjs
+rm -rf artifacts/yjs-rollout-packet
+node scripts/ops/export-yjs-rollout-packet.mjs
+test -f artifacts/yjs-rollout-packet/docs/operations/yjs-internal-rollout-signoff-template-20260416.md
+git log --oneline --reverse origin/main..HEAD
+```
+
+## Results
+
+- Rebase onto `origin/main` completed successfully
+- The post-rebase branch range is now:
+  - `008268bb7` `docs(collab): add yjs rollout signoff template`
+  - `78275209d` `docs: record yjs rollout signoff stack rebase`
+- `node --check scripts/ops/export-yjs-rollout-packet.mjs` passed
+- Export packet run passed
+- Signoff template exists in exported packet
+
+## Notes
+
+- The rebased branch intentionally dropped all already-merged `#891` parent commits
+- This step changed branch topology only; no runtime semantics changed

--- a/docs/development/yjs-rollout-signoff-stack-rebase-development-20260416.md
+++ b/docs/development/yjs-rollout-signoff-stack-rebase-development-20260416.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Signoff Stack Rebase Development
+
+Date: 2026-04-16
+
+## Context
+
+- Parent PRs `#888`, `#889`, and `#890` are already upstream for this stack.
+- PR `#892` still replayed those parent layers while being based on `codex/yjs-rollout-packet-20260416`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-signoff-20260416` onto `origin/codex/yjs-rollout-packet-20260416`
+2. Dropping all already-upstream parent-layer commits from the rebase todo:
+   - `a00e974ae`
+   - `e5d12f1cf`
+   - `1492a1d4c`
+   - `c6333e822`
+   - `649ca31be`
+   - `163cc2a18`
+3. Keeping only the signoff-template commit:
+   - `c2e7cee5d` `docs(collab): add yjs rollout signoff template`
+
+## Result
+
+- `#892` now sits cleanly on top of the updated `#891` branch
+- The branch is reduced to its intended signoff-template delta only

--- a/docs/development/yjs-rollout-signoff-stack-rebase-verification-20260416.md
+++ b/docs/development/yjs-rollout-signoff-stack-rebase-verification-20260416.md
@@ -1,0 +1,28 @@
+# Yjs Rollout Signoff Stack Rebase Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+git rebase origin/codex/yjs-rollout-packet-20260416
+node --check scripts/ops/export-yjs-rollout-packet.mjs
+rm -rf artifacts/yjs-rollout-packet
+node scripts/ops/export-yjs-rollout-packet.mjs
+test -f artifacts/yjs-rollout-packet/docs/operations/yjs-internal-rollout-signoff-template-20260416.md
+git log --oneline --reverse origin/codex/yjs-rollout-packet-20260416..HEAD
+```
+
+## Results
+
+- Rebase completed successfully
+- The post-rebase branch range is now only:
+  - `c2e7cee5d` `docs(collab): add yjs rollout signoff template`
+- `node --check scripts/ops/export-yjs-rollout-packet.mjs` passed
+- Export packet run passed
+- Signoff template exists in exported packet
+
+## Notes
+
+- This step intentionally removed all already-merged parent layers from the branch history
+- No runtime semantics changed; this was stack cleanup plus packet verification

--- a/docs/development/yjs-rollout-signoff-template-development-20260416.md
+++ b/docs/development/yjs-rollout-signoff-template-development-20260416.md
@@ -1,0 +1,31 @@
+# Yjs Rollout Signoff Template Development
+
+Date: 2026-04-16
+
+## Context
+
+The rollout stack already provided:
+
+- execution checklist
+- runtime status check
+- retention health check
+- rollout report capture
+- packet export
+
+The remaining operator gap was human signoff. A pilot owner could run the checks, but there was no repo-native place to record the actual GO / HOLD / NO-GO decision with the captured evidence.
+
+## Change
+
+Added:
+
+- [docs/operations/yjs-internal-rollout-signoff-template-20260416.md](/tmp/metasheet2-yjs-rollout-signoff/docs/operations/yjs-internal-rollout-signoff-template-20260416.md:1)
+
+Updated:
+
+- [scripts/ops/export-yjs-rollout-packet.mjs](/tmp/metasheet2-yjs-rollout-signoff/scripts/ops/export-yjs-rollout-packet.mjs:1)
+- [docs/operations/yjs-rollout-packet-export-20260416.md](/tmp/metasheet2-yjs-rollout-signoff/docs/operations/yjs-rollout-packet-export-20260416.md:1)
+- [docs/operations/yjs-internal-rollout-execution-20260416.md](/tmp/metasheet2-yjs-rollout-signoff/docs/operations/yjs-internal-rollout-execution-20260416.md:1)
+
+## Scope
+
+This is rollout documentation and packaging only. No Yjs runtime logic changed.

--- a/docs/development/yjs-rollout-signoff-template-verification-20260416.md
+++ b/docs/development/yjs-rollout-signoff-template-verification-20260416.md
@@ -1,0 +1,20 @@
+# Yjs Rollout Signoff Template Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+node --check scripts/ops/export-yjs-rollout-packet.mjs
+rm -rf artifacts/yjs-rollout-packet
+node scripts/ops/export-yjs-rollout-packet.mjs
+test -f artifacts/yjs-rollout-packet/docs/operations/yjs-internal-rollout-signoff-template-20260416.md
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+## Result
+
+- packet export syntax: passed
+- packet export rerun: passed
+- exported signoff template exists: passed
+- Claude Code CLI: `CLAUDE_CLI_OK`

--- a/docs/operations/yjs-internal-rollout-execution-20260416.md
+++ b/docs/operations/yjs-internal-rollout-execution-20260416.md
@@ -60,7 +60,13 @@ YJS_DATABASE_URL=$DATABASE_URL \
 node scripts/ops/capture-yjs-rollout-report.mjs
 ```
 
-8. If both checks stay healthy, keep the pilot enabled
+8. Fill the signoff template:
+
+```text
+docs/operations/yjs-internal-rollout-signoff-template-20260416.md
+```
+
+9. If both checks stay healthy, keep the pilot enabled
 
 ## Abort Conditions
 

--- a/docs/operations/yjs-internal-rollout-signoff-template-20260416.md
+++ b/docs/operations/yjs-internal-rollout-signoff-template-20260416.md
@@ -1,0 +1,65 @@
+# Yjs Internal Rollout Signoff Template
+
+Date: 2026-04-16
+
+Use this after the first limited internal rollout run.
+
+## Rollout Context
+
+- Environment:
+- Rollout owner:
+- Review approver:
+- Rollout window:
+- Enabled by:
+- `ENABLE_YJS_COLLAB` value:
+
+## Target Scope
+
+- Pilot sheets:
+- Pilot users:
+- Expected concurrent editors:
+- Excluded critical sheets:
+
+## Evidence
+
+- Runtime status report path:
+- Retention health report path:
+- Combined rollout report path:
+- Packet export path:
+
+## Runtime Snapshot
+
+- `enabled`:
+- `initialized`:
+- `activeDocCount`:
+- `pendingWriteCount`:
+- `flushFailureCount`:
+- `activeSocketCount`:
+
+## Retention Snapshot
+
+- `statesCount`:
+- `updatesCount`:
+- `orphanStatesCount`:
+- `orphanUpdatesCount`:
+- Hottest record observed:
+
+## User Validation
+
+- Text field collaborative editing verified:
+- Reconnect / resume verified:
+- Presence / awareness verified:
+- Unexpected write failures:
+- Unexpected flush failures:
+
+## Decision
+
+- [ ] GO: keep pilot enabled
+- [ ] HOLD: keep enabled but do not expand
+- [ ] NO-GO: disable `ENABLE_YJS_COLLAB`
+
+## Notes
+
+- Follow-up actions:
+- Known limitations accepted:
+- Rollback required:

--- a/docs/operations/yjs-rollout-packet-export-20260416.md
+++ b/docs/operations/yjs-rollout-packet-export-20260416.md
@@ -20,6 +20,7 @@ Included:
 
 - rollout checklist
 - rollout execution guide
+- rollout signoff template
 - ops runbook
 - retention policy
 - rollout report capture guide

--- a/scripts/ops/export-yjs-rollout-packet.mjs
+++ b/scripts/ops/export-yjs-rollout-packet.mjs
@@ -43,6 +43,7 @@ function parseArgs(argv) {
 const packetFiles = [
   'docs/operations/yjs-internal-rollout-checklist-20260416.md',
   'docs/operations/yjs-internal-rollout-execution-20260416.md',
+  'docs/operations/yjs-internal-rollout-signoff-template-20260416.md',
   'docs/operations/yjs-ops-runbook-20260416.md',
   'docs/operations/yjs-retention-policy-20260416.md',
   'docs/operations/yjs-rollout-report-capture-20260416.md',
@@ -61,6 +62,7 @@ Generated at: ${new Date().toISOString()}
 
 - ${rel('docs/operations/yjs-internal-rollout-checklist-20260416.md')}
 - ${rel('docs/operations/yjs-internal-rollout-execution-20260416.md')}
+- ${rel('docs/operations/yjs-internal-rollout-signoff-template-20260416.md')}
 - ${rel('docs/operations/yjs-ops-runbook-20260416.md')}
 - ${rel('docs/operations/yjs-retention-policy-20260416.md')}
 - ${rel('docs/operations/yjs-rollout-report-capture-20260416.md')}
@@ -77,7 +79,8 @@ Generated at: ${new Date().toISOString()}
 2. Run the runtime status check
 3. Run the retention health check
 4. Run the combined report capture
-5. Store generated report artifacts alongside the rollout packet
+5. Fill the signoff template
+6. Store generated report artifacts alongside the rollout packet
 `
 }
 


### PR DESCRIPTION
## What Changed

This PR adds one more operator-facing follow-up on top of `#891`: a repo-native internal rollout signoff template.

Included:
- `docs/operations/yjs-internal-rollout-signoff-template-20260416.md`
- packet export updated to include the signoff template
- docs updates so rollout execution explicitly ends with filling the signoff record
- development / verification records for this follow-up

## Why

The rollout stack already supports:
- runtime health checks
- retention health checks
- report capture
- packet export

The remaining operator gap was the final human decision record. This PR makes the GO / HOLD / NO-GO step explicit and keeps it in the exported rollout packet.

## Verification

```bash
node --check scripts/ops/export-yjs-rollout-packet.mjs
rm -rf artifacts/yjs-rollout-packet
node scripts/ops/export-yjs-rollout-packet.mjs
test -f artifacts/yjs-rollout-packet/docs/operations/yjs-internal-rollout-signoff-template-20260416.md
claude -p "Return exactly: CLAUDE_CLI_OK"
```

Results:
- packet export syntax: passed
- packet export rerun: passed
- exported signoff template exists: passed
- Claude Code CLI: `CLAUDE_CLI_OK`

## Notes

- This PR is intentionally stacked on `#891`.
- Merge order should remain: `#888` -> `#889` -> `#890` -> `#891` -> this PR.
- No Yjs runtime semantics were changed.
