### PR TITLE
feat(collab): add yjs rollout stack advance script

### DIFF
--- a/docs/development/yjs-rollout-stack-advance-development-20260416.md
+++ b/docs/development/yjs-rollout-stack-advance-development-20260416.md
@@ -1,0 +1,40 @@
+# Yjs Rollout Stack Advance Development
+
+Date: 2026-04-16
+
+## Context
+
+The rollout work no longer consists of a single PR. It is now a stacked chain:
+
+- `#888`
+- `#889`
+- `#890`
+- `#891`
+- `#892`
+
+The repeated maintainer task after each merge is:
+
+1. detect whether the parent is merged
+2. retarget the child to `main`
+3. continue with rebase / verification
+
+## Change
+
+Added:
+
+- [scripts/ops/advance-yjs-rollout-stack.mjs](/tmp/metasheet2-yjs-rollout-stack-advance/scripts/ops/advance-yjs-rollout-stack.mjs:1)
+- [docs/operations/yjs-rollout-stack-advance-20260416.md](/tmp/metasheet2-yjs-rollout-stack-advance/docs/operations/yjs-rollout-stack-advance-20260416.md:1)
+
+## Behavior
+
+Default mode is dry-run only.
+
+With `--apply`, the script:
+
+- checks the live GitHub state for `#888-#892`
+- finds open child PRs whose parent is already merged
+- runs `gh pr edit --base main` for those PRs
+
+## Scope
+
+This is maintainer automation only. It does not change runtime code, rollout docs, or pilot scripts.

--- a/docs/development/yjs-rollout-stack-advance-mainline-rebase-development-20260417.md
+++ b/docs/development/yjs-rollout-stack-advance-mainline-rebase-development-20260417.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Stack Advance Mainline Rebase Development
+
+Date: 2026-04-17
+
+## Context
+
+- PR `#892` merged into `main` as `5d79e388d4d412032fb742e8b51928e5beb6162f`.
+- PR `#893` auto-retargeted to `main` and became `BEHIND`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-stack-advance-20260416` onto updated `origin/main`
+2. Dropping the already-upstream packet/signoff parent layer:
+   - `c0b63f637`
+   - `dcccc0a67`
+   - `c2e7cee5d`
+   - `67eac3e81`
+3. Preserving only the stack-advance-specific commits:
+   - `9eb077342` `feat(collab): add yjs rollout stack advance script`
+   - `8074d3d10` `docs: record yjs rollout stack advance rebase`
+
+## Result
+
+- `#893` is now a minimal delta over current `main`
+- The branch no longer replays packet/signoff history
+- Stack-advance scripting remains intact and ready for CI/review

--- a/docs/development/yjs-rollout-stack-advance-mainline-rebase-verification-20260417.md
+++ b/docs/development/yjs-rollout-stack-advance-mainline-rebase-verification-20260417.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Stack Advance Mainline Rebase Verification
+
+Date: 2026-04-17
+
+## Commands
+
+```bash
+git rebase origin/main
+node --check scripts/ops/advance-yjs-rollout-stack.mjs
+node scripts/ops/advance-yjs-rollout-stack.mjs --help
+git log --oneline --reverse origin/main..HEAD
+```
+
+## Results
+
+- Rebase onto `origin/main` completed successfully
+- The post-rebase branch range is now:
+  - `9eb077342` `feat(collab): add yjs rollout stack advance script`
+  - `8074d3d10` `docs: record yjs rollout stack advance rebase`
+- `node --check scripts/ops/advance-yjs-rollout-stack.mjs` passed
+- `node scripts/ops/advance-yjs-rollout-stack.mjs --help` passed
+
+## Notes
+
+- The rebased branch intentionally dropped all already-merged packet/signoff parent commits
+- This step changed branch topology only; no rollout runtime semantics changed

--- a/docs/development/yjs-rollout-stack-advance-stack-rebase-development-20260416.md
+++ b/docs/development/yjs-rollout-stack-advance-stack-rebase-development-20260416.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Stack Advance Stack Rebase Development
+
+Date: 2026-04-16
+
+## Context
+
+- Parent PR chain up to `#892` changed after the `#891` packet branch and `#892` signoff branch were rewritten.
+- PR `#893` still replayed already-upstream parent layers while targeting `codex/yjs-rollout-signoff-20260416`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-stack-advance-20260416` onto `origin/codex/yjs-rollout-signoff-20260416`
+2. Dropping the already-upstream parent-layer commits:
+   - `a00e974ae`
+   - `e5d12f1cf`
+   - `1492a1d4c`
+   - `c6333e822`
+   - `649ca31be`
+   - `163cc2a18`
+3. Keeping only the stack-advance script commit:
+   - `a61296822` `feat(collab): add yjs rollout stack advance script`
+
+## Result
+
+- `#893` now sits cleanly on top of the updated `#892` branch
+- The branch is reduced to the intended stack-advance delta only

--- a/docs/development/yjs-rollout-stack-advance-stack-rebase-verification-20260416.md
+++ b/docs/development/yjs-rollout-stack-advance-stack-rebase-verification-20260416.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Stack Advance Stack Rebase Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+git rebase origin/codex/yjs-rollout-signoff-20260416
+node --check scripts/ops/advance-yjs-rollout-stack.mjs
+node scripts/ops/advance-yjs-rollout-stack.mjs --help
+git log --oneline --reverse origin/codex/yjs-rollout-signoff-20260416..HEAD
+```
+
+## Results
+
+- Rebase completed successfully
+- The post-rebase branch range is now only:
+  - `a61296822` `feat(collab): add yjs rollout stack advance script`
+- `node --check scripts/ops/advance-yjs-rollout-stack.mjs` passed
+- `node scripts/ops/advance-yjs-rollout-stack.mjs --help` passed
+
+## Notes
+
+- This step intentionally removed all already-upstream parent layers from the branch history
+- No runtime semantics changed; this was stack cleanup plus script verification

--- a/docs/development/yjs-rollout-stack-advance-verification-20260416.md
+++ b/docs/development/yjs-rollout-stack-advance-verification-20260416.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Stack Advance Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+node scripts/ops/advance-yjs-rollout-stack.mjs --help
+node --check scripts/ops/advance-yjs-rollout-stack.mjs
+node scripts/ops/advance-yjs-rollout-stack.mjs
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+## Result
+
+- help output: passed
+- syntax check: passed
+- dry-run: passed
+- Claude Code CLI: `CLAUDE_CLI_OK`
+
+## Observed Dry-Run State
+
+At verification time:
+
+- `#888` was still `OPEN`
+- `#889-#892` were correctly reported as waiting on their parent PRs

--- a/docs/operations/yjs-rollout-stack-advance-20260416.md
+++ b/docs/operations/yjs-rollout-stack-advance-20260416.md
@@ -1,0 +1,42 @@
+# Yjs Rollout Stack Advance
+
+Date: 2026-04-16
+
+## Purpose
+
+The Yjs rollout follow-ups are intentionally stacked:
+
+1. `#888`
+2. `#889`
+3. `#890`
+4. `#891`
+5. `#892`
+
+This script helps maintainers advance the stack after each parent PR merges.
+
+## Dry Run
+
+```bash
+node scripts/ops/advance-yjs-rollout-stack.mjs
+```
+
+This prints:
+
+- which PR is still waiting on its parent
+- which PR is already based on `main`
+- which PR should now be retargeted to `main`
+
+## Apply
+
+```bash
+node scripts/ops/advance-yjs-rollout-stack.mjs --apply
+```
+
+This will run `gh pr edit <number> --base main` for any child PR whose parent has already merged.
+
+## Notes
+
+- The script only retargets open child PRs.
+- It does not merge PRs.
+- It does not rewrite local git history.
+- Run it after a parent merge, then do the final rebase/verification on the child branch if needed.

--- a/scripts/ops/advance-yjs-rollout-stack.mjs
+++ b/scripts/ops/advance-yjs-rollout-stack.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+
+const STACK = [
+  { pr: 888, branch: 'codex/yjs-internal-rollout-202605', parent: null },
+  { pr: 889, branch: 'codex/yjs-rollout-execution-20260416', parent: 888 },
+  { pr: 890, branch: 'codex/yjs-rollout-report-20260416', parent: 889 },
+  { pr: 891, branch: 'codex/yjs-rollout-packet-20260416', parent: 890 },
+  { pr: 892, branch: 'codex/yjs-rollout-signoff-20260416', parent: 891 },
+]
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/advance-yjs-rollout-stack.mjs [options]
+
+Checks the Yjs rollout PR stack and optionally retargets children to main once their parent PR is merged.
+
+Options:
+  --apply    Perform gh pr edit --base main for eligible child PRs
+  --json     Print JSON output
+  --help     Show this help
+`)
+}
+
+function parseArgs(argv) {
+  const opts = {
+    apply: false,
+    showJson: false,
+  }
+
+  for (const arg of argv) {
+    if (arg === '--apply') {
+      opts.apply = true
+    } else if (arg === '--json') {
+      opts.showJson = true
+    } else if (arg === '--help') {
+      printHelp()
+      process.exit(0)
+    } else {
+      console.error(`Unknown argument: ${arg}`)
+      printHelp()
+      process.exit(1)
+    }
+  }
+
+  return opts
+}
+
+function runGh(args) {
+  const result = spawnSync('gh', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || result.stdout.trim() || `gh ${args.join(' ')} exited with status ${result.status}`)
+  }
+
+  return result.stdout.trim()
+}
+
+function loadPr(prNumber) {
+  return JSON.parse(runGh([
+    'pr',
+    'view',
+    String(prNumber),
+    '--json',
+    'number,state,mergedAt,mergeStateStatus,reviewDecision,baseRefName,headRefName,url',
+  ]))
+}
+
+function renderSummary(entry) {
+  const status = entry.pr
+  const line = `#${status.number} ${status.headRefName} -> ${status.baseRefName} [${status.state}]`
+  const action = entry.action ? ` action=${entry.action}` : ''
+  const reason = entry.reason ? ` reason=${entry.reason}` : ''
+  return `${line}${action}${reason}`
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  const statusMap = new Map()
+
+  for (const item of STACK) {
+    statusMap.set(item.pr, loadPr(item.pr))
+  }
+
+  const decisions = []
+
+  for (const item of STACK) {
+    const pr = statusMap.get(item.pr)
+    if (!item.parent) {
+      decisions.push({
+        pr,
+        action: null,
+        reason: pr.state === 'OPEN' ? 'root PR still controls the stack' : 'root PR already merged',
+      })
+      continue
+    }
+
+    const parent = statusMap.get(item.parent)
+
+    if (pr.state !== 'OPEN') {
+      decisions.push({ pr, action: null, reason: 'already merged or closed' })
+      continue
+    }
+
+    if (!parent?.mergedAt) {
+      decisions.push({ pr, action: null, reason: `waiting for parent #${item.parent}` })
+      continue
+    }
+
+    if (pr.baseRefName === 'main') {
+      decisions.push({ pr, action: null, reason: 'already retargeted to main' })
+      continue
+    }
+
+    decisions.push({
+      pr,
+      action: 'retarget-to-main',
+      reason: `parent #${item.parent} merged`,
+    })
+  }
+
+  const applied = []
+  if (opts.apply) {
+    for (const decision of decisions) {
+      if (decision.action === 'retarget-to-main') {
+        runGh(['pr', 'edit', String(decision.pr.number), '--base', 'main'])
+        applied.push(decision.pr.number)
+      }
+    }
+  }
+
+  const output = {
+    apply: opts.apply,
+    applied,
+    decisions: decisions.map((decision) => ({
+      number: decision.pr.number,
+      state: decision.pr.state,
+      baseRefName: decision.pr.baseRefName,
+      headRefName: decision.pr.headRefName,
+      mergedAt: decision.pr.mergedAt,
+      action: decision.action,
+      reason: decision.reason,
+      url: decision.pr.url,
+    })),
+  }
+
+  if (opts.showJson) {
+    console.log(JSON.stringify(output, null, 2))
+    return
+  }
+
+  for (const decision of decisions) {
+    console.log(renderSummary(decision))
+  }
+
+  if (opts.apply) {
+    console.log(applied.length > 0 ? `Applied retargets: ${applied.join(', ')}` : 'No retargets applied')
+  }
+}
+
+await main()


### PR DESCRIPTION
## What Changed

This PR adds one more maintainer-facing follow-up on top of `#892`: a stack advancement helper for the Yjs rollout PR chain.

Included:
- `scripts/ops/advance-yjs-rollout-stack.mjs`
  - dry-run by default
  - checks live GitHub state for `#888-#892`
  - with `--apply`, retargets eligible child PRs to `main`
- `docs/operations/yjs-rollout-stack-advance-20260416.md`
- development / verification records for this follow-up

## Why

The rollout work is now a stacked PR chain. After each parent merge, the next child needs to be retargeted to `main` before final rebase / verification.

This script turns that repeated maintainer step into one explicit command.

## Verification

```bash
node scripts/ops/advance-yjs-rollout-stack.mjs --help
node --check scripts/ops/advance-yjs-rollout-stack.mjs
node scripts/ops/advance-yjs-rollout-stack.mjs
claude -p "Return exactly: CLAUDE_CLI_OK"
```

Results:
- help output: passed
- syntax check: passed
- dry-run: passed
- Claude Code CLI: `CLAUDE_CLI_OK`

Observed dry-run state at verification time:
- `#888` still open and blocking the stack
- `#889-#892` correctly reported as waiting on their parent PRs

## Notes

- This PR is intentionally stacked on `#892`.
- Merge order should remain: `#888` -> `#889` -> `#890` -> `#891` -> `#892` -> this PR.
- No Yjs runtime or rollout packet contents changed here.
