### PR TITLE
feat(collab): add yjs rollout gate script

### DIFF
--- a/docs/development/yjs-rollout-gate-development-20260416.md
+++ b/docs/development/yjs-rollout-gate-development-20260416.md
@@ -1,0 +1,38 @@
+# Yjs Rollout Gate Development
+
+Date: 2026-04-16
+
+## Context
+
+The rollout stack already had all the individual pieces:
+
+- runtime status check
+- retention health check
+- report capture
+- packet export
+- signoff template
+
+The remaining operator gap was a single gate command. A pilot owner still had to remember and sequence multiple scripts manually.
+
+## Change
+
+Added:
+
+- [scripts/ops/run-yjs-rollout-gate.mjs](/tmp/metasheet2-yjs-rollout-gate/scripts/ops/run-yjs-rollout-gate.mjs:1)
+- [docs/operations/yjs-rollout-gate-20260416.md](/tmp/metasheet2-yjs-rollout-gate/docs/operations/yjs-rollout-gate-20260416.md:1)
+
+Updated:
+
+- [docs/operations/yjs-internal-rollout-execution-20260416.md](/tmp/metasheet2-yjs-rollout-gate/docs/operations/yjs-internal-rollout-execution-20260416.md:1)
+
+## Behavior
+
+The gate script:
+
+1. runs the runtime status check
+2. runs the retention health check
+3. exports the current rollout packet
+4. captures a rollout report
+5. copies a signoff draft into the gate output directory
+
+It supports `--print-plan` so maintainers can validate the sequence without live credentials.

--- a/docs/development/yjs-rollout-gate-mainline-rebase-development-20260417.md
+++ b/docs/development/yjs-rollout-gate-mainline-rebase-development-20260417.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Gate Mainline Rebase Development
+
+Date: 2026-04-17
+
+## Context
+
+- PR `#893` merged into `main` as `c461e756b08dd06739b1515eac27375d78e70667`.
+- PR `#894` auto-retargeted to `main` and became `BEHIND`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-gate-20260416` onto updated `origin/main`
+2. Letting Git auto-drop the already-upstream `#893` parent layer:
+   - `9eb077342`
+   - `8074d3d10`
+   - `2e6efbbea`
+3. Preserving only the rollout-gate-specific commits:
+   - `9fd858c86` `feat(collab): add yjs rollout gate script`
+   - `6a0bf72b5` `docs: record yjs rollout gate stack rebase`
+
+## Result
+
+- `#894` is now a minimal delta over current `main`
+- The branch no longer replays stack-advance history
+- Rollout-gate scripting remains intact and ready for CI/review

--- a/docs/development/yjs-rollout-gate-mainline-rebase-verification-20260417.md
+++ b/docs/development/yjs-rollout-gate-mainline-rebase-verification-20260417.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Gate Mainline Rebase Verification
+
+Date: 2026-04-17
+
+## Commands
+
+```bash
+git rebase origin/main
+node --check scripts/ops/run-yjs-rollout-gate.mjs
+node scripts/ops/run-yjs-rollout-gate.mjs --help
+git log --oneline --reverse origin/main..HEAD
+```
+
+## Results
+
+- Rebase onto `origin/main` completed successfully
+- The post-rebase branch range is now:
+  - `9fd858c86` `feat(collab): add yjs rollout gate script`
+  - `6a0bf72b5` `docs: record yjs rollout gate stack rebase`
+- `node --check scripts/ops/run-yjs-rollout-gate.mjs` passed
+- `node scripts/ops/run-yjs-rollout-gate.mjs --help` passed
+
+## Notes
+
+- The rebased branch intentionally dropped all already-merged `#893` parent commits
+- This step changed branch topology only; no rollout runtime semantics changed

--- a/docs/development/yjs-rollout-gate-stack-rebase-development-20260417.md
+++ b/docs/development/yjs-rollout-gate-stack-rebase-development-20260417.md
@@ -1,0 +1,28 @@
+# Yjs Rollout Gate Stack Rebase Development
+
+Date: 2026-04-17
+
+## Context
+
+- Parent PR layers up through `#893` were already upstream or freshly rebased.
+- PR `#894` still replayed those parent layers while based on `codex/yjs-rollout-stack-advance-20260416`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-gate-20260416` onto `origin/codex/yjs-rollout-stack-advance-20260416`
+2. Dropping the already-upstream parent-layer commits from the rebase todo:
+   - `a00e974ae`
+   - `e5d12f1cf`
+   - `1492a1d4c`
+   - `c6333e822`
+   - `649ca31be`
+   - `163cc2a18`
+   - `5c2dda0d2`
+   - `9585cc0fb`
+3. Keeping only the rollout-gate commit:
+   - `56212fe8e` `feat(collab): add yjs rollout gate script`
+
+## Result
+
+- `#894` now sits cleanly on top of the updated `#893` branch
+- The branch is reduced to the intended rollout-gate delta only

--- a/docs/development/yjs-rollout-gate-stack-rebase-verification-20260417.md
+++ b/docs/development/yjs-rollout-gate-stack-rebase-verification-20260417.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Gate Stack Rebase Verification
+
+Date: 2026-04-17
+
+## Commands
+
+```bash
+git rebase origin/codex/yjs-rollout-stack-advance-20260416
+node --check scripts/ops/run-yjs-rollout-gate.mjs
+node scripts/ops/run-yjs-rollout-gate.mjs --help
+git log --oneline --reverse origin/codex/yjs-rollout-stack-advance-20260416..HEAD
+```
+
+## Results
+
+- Rebase completed successfully
+- The post-rebase branch range is now only:
+  - `56212fe8e` `feat(collab): add yjs rollout gate script`
+- `node --check scripts/ops/run-yjs-rollout-gate.mjs` passed
+- `node scripts/ops/run-yjs-rollout-gate.mjs --help` passed
+
+## Notes
+
+- This step intentionally removed all already-upstream parent layers from the branch history
+- No rollout runtime semantics changed; this was stack cleanup plus script verification

--- a/docs/development/yjs-rollout-gate-verification-20260416.md
+++ b/docs/development/yjs-rollout-gate-verification-20260416.md
@@ -1,0 +1,24 @@
+# Yjs Rollout Gate Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+node scripts/ops/run-yjs-rollout-gate.mjs --help
+node --check scripts/ops/run-yjs-rollout-gate.mjs
+node scripts/ops/run-yjs-rollout-gate.mjs --print-plan
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+## Result
+
+- help output: passed
+- syntax check: passed
+- print-plan: passed
+- Claude Code CLI: `CLAUDE_CLI_OK`
+
+## Notes
+
+- This verification does not call a live rollout target because no runtime credentials were injected for this local run.
+- The goal here is to validate orchestration shape, not live environment data.

--- a/docs/operations/yjs-internal-rollout-execution-20260416.md
+++ b/docs/operations/yjs-internal-rollout-execution-20260416.md
@@ -15,6 +15,15 @@ Optional packet export:
 node scripts/ops/export-yjs-rollout-packet.mjs
 ```
 
+Single-command gate:
+
+```bash
+YJS_BASE_URL=http://localhost:3000 \
+YJS_ADMIN_TOKEN=$ADMIN_TOKEN \
+YJS_DATABASE_URL=$DATABASE_URL \
+node scripts/ops/run-yjs-rollout-gate.mjs
+```
+
 ## Runtime Check
 
 ```bash

--- a/docs/operations/yjs-rollout-gate-20260416.md
+++ b/docs/operations/yjs-rollout-gate-20260416.md
@@ -1,0 +1,44 @@
+# Yjs Rollout Gate
+
+Date: 2026-04-16
+
+## Command
+
+```bash
+YJS_BASE_URL=http://localhost:3000 \
+YJS_ADMIN_TOKEN=$ADMIN_TOKEN \
+YJS_DATABASE_URL=$DATABASE_URL \
+node scripts/ops/run-yjs-rollout-gate.mjs
+```
+
+## What It Does
+
+This is the one-command internal rollout gate.
+
+It runs:
+
+1. runtime status check
+2. retention health check
+3. packet export
+4. rollout report capture
+5. signoff draft copy
+
+## Output
+
+Default output directory:
+
+```text
+artifacts/yjs-rollout-gate/
+```
+
+Contents:
+
+- `packet/`
+- `reports/`
+- `yjs-internal-rollout-signoff.md`
+
+## Dry Run
+
+```bash
+node scripts/ops/run-yjs-rollout-gate.mjs --print-plan
+```

--- a/scripts/ops/run-yjs-rollout-gate.mjs
+++ b/scripts/ops/run-yjs-rollout-gate.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { cpSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/run-yjs-rollout-gate.mjs [options]
+
+Runs the Yjs internal rollout gate sequence:
+- runtime status check
+- retention health check
+- packet export
+- rollout report capture
+- signoff draft copy
+
+Options:
+  --base-url <url>        Base URL, default from YJS_BASE_URL or http://localhost:3000
+  --token <token>         Admin bearer token, default from YJS_ADMIN_TOKEN or ADMIN_TOKEN
+  --database-url <url>    Database URL, default from YJS_DATABASE_URL or DATABASE_URL
+  --output-dir <dir>      Output directory, default artifacts/yjs-rollout-gate
+  --print-plan            Print the execution plan only
+  --help                  Show this help
+`)
+}
+
+function parseArgs(argv) {
+  const opts = {
+    baseUrl: process.env.YJS_BASE_URL || 'http://localhost:3000',
+    token: process.env.YJS_ADMIN_TOKEN || process.env.ADMIN_TOKEN || '',
+    databaseUrl: process.env.YJS_DATABASE_URL || process.env.DATABASE_URL || '',
+    outputDir: path.resolve(process.cwd(), 'artifacts/yjs-rollout-gate'),
+    printPlan: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+    switch (arg) {
+      case '--base-url':
+        opts.baseUrl = next
+        i += 1
+        break
+      case '--token':
+        opts.token = next
+        i += 1
+        break
+      case '--database-url':
+        opts.databaseUrl = next
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), next)
+        i += 1
+        break
+      case '--print-plan':
+        opts.printPlan = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+      default:
+        console.error(`Unknown argument: ${arg}`)
+        printHelp()
+        process.exit(1)
+    }
+  }
+
+  return opts
+}
+
+function runNodeScript(scriptPath, args, extraEnv = {}) {
+  const result = spawnSync('node', [scriptPath, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  }
+}
+
+function printPlan(opts) {
+  console.log('Yjs rollout gate plan')
+  console.log(`- base URL: ${opts.baseUrl}`)
+  console.log(`- output dir: ${opts.outputDir}`)
+  console.log(`- token present: ${Boolean(opts.token)}`)
+  console.log(`- database URL present: ${Boolean(opts.databaseUrl)}`)
+  console.log('- steps:')
+  console.log('  1. check-yjs-rollout-status.mjs')
+  console.log('  2. check-yjs-retention-health.mjs')
+  console.log('  3. export-yjs-rollout-packet.mjs')
+  console.log('  4. capture-yjs-rollout-report.mjs')
+  console.log('  5. copy signoff template into gate output directory')
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  if (opts.printPlan) {
+    printPlan(opts)
+    process.exit(0)
+  }
+
+  if (!opts.token) {
+    console.error('Missing admin token. Use --token, YJS_ADMIN_TOKEN, or ADMIN_TOKEN.')
+    process.exit(1)
+  }
+  if (!opts.databaseUrl) {
+    console.error('Missing database URL. Use --database-url, YJS_DATABASE_URL, or DATABASE_URL.')
+    process.exit(1)
+  }
+
+  const statusScript = path.resolve(process.cwd(), 'scripts/ops/check-yjs-rollout-status.mjs')
+  const retentionScript = path.resolve(process.cwd(), 'scripts/ops/check-yjs-retention-health.mjs')
+  const exportScript = path.resolve(process.cwd(), 'scripts/ops/export-yjs-rollout-packet.mjs')
+  const reportScript = path.resolve(process.cwd(), 'scripts/ops/capture-yjs-rollout-report.mjs')
+  const signoffTemplate = path.resolve(process.cwd(), 'docs/operations/yjs-internal-rollout-signoff-template-20260416.md')
+
+  const packetDir = path.join(opts.outputDir, 'packet')
+  const reportsDir = path.join(opts.outputDir, 'reports')
+  mkdirSync(opts.outputDir, { recursive: true })
+
+  const statusResult = runNodeScript(statusScript, ['--json-only'], {
+    YJS_BASE_URL: opts.baseUrl,
+    YJS_ADMIN_TOKEN: opts.token,
+  })
+  if (statusResult.exitCode !== 0 && statusResult.exitCode !== 2) {
+    process.stderr.write(statusResult.stderr)
+    process.exit(statusResult.exitCode)
+  }
+
+  const retentionResult = runNodeScript(retentionScript, ['--json-only'], {
+    YJS_DATABASE_URL: opts.databaseUrl,
+  })
+  if (retentionResult.exitCode !== 0 && retentionResult.exitCode !== 2) {
+    process.stderr.write(retentionResult.stderr)
+    process.exit(retentionResult.exitCode)
+  }
+
+  const exportResult = runNodeScript(exportScript, ['--output-dir', packetDir])
+  if (exportResult.exitCode !== 0) {
+    process.stderr.write(exportResult.stderr)
+    process.exit(exportResult.exitCode)
+  }
+
+  const reportResult = runNodeScript(reportScript, ['--output-dir', reportsDir], {
+    YJS_BASE_URL: opts.baseUrl,
+    YJS_ADMIN_TOKEN: opts.token,
+    YJS_DATABASE_URL: opts.databaseUrl,
+  })
+  if (reportResult.exitCode !== 0 && reportResult.exitCode !== 2) {
+    process.stderr.write(reportResult.stderr)
+    process.exit(reportResult.exitCode)
+  }
+
+  const signoffCopy = path.join(opts.outputDir, 'yjs-internal-rollout-signoff.md')
+  cpSync(signoffTemplate, signoffCopy)
+
+  console.log(`Wrote packet: ${packetDir}`)
+  console.log(`Wrote reports: ${reportsDir}`)
+  console.log(`Wrote signoff draft: ${signoffCopy}`)
+
+  const unhealthy = statusResult.exitCode === 2 || retentionResult.exitCode === 2 || reportResult.exitCode === 2
+  process.exit(unhealthy ? 2 : 0)
+}
+
+await main()


### PR DESCRIPTION
## What Changed

This PR adds one more operator-facing follow-up on top of `#893`: a single-command Yjs rollout gate.

Included:
- `scripts/ops/run-yjs-rollout-gate.mjs`
  - runtime status check
  - retention health check
  - packet export
  - report capture
  - signoff draft copy
- `docs/operations/yjs-rollout-gate-20260416.md`
- update to `docs/operations/yjs-internal-rollout-execution-20260416.md`
- development / verification records for this follow-up

## Why

The rollout stack already had all the individual pieces, but operators still had to remember the sequence.

This PR adds a single gate command plus a dry-run mode so a pilot owner can validate the sequence before using real credentials.

## Verification

```bash
node scripts/ops/run-yjs-rollout-gate.mjs --help
node --check scripts/ops/run-yjs-rollout-gate.mjs
node scripts/ops/run-yjs-rollout-gate.mjs --print-plan
claude -p "Return exactly: CLAUDE_CLI_OK"
```

Results:
- help output: passed
- syntax check: passed
- print-plan: passed
- Claude Code CLI: `CLAUDE_CLI_OK`

## Notes

- This PR is intentionally stacked on `#893`.
- Merge order should remain: `#888` -> `#889` -> `#890` -> `#891` -> `#892` -> `#893` -> this PR.
- No Yjs runtime semantics were changed.
