### PR TITLE
feat(collab): add yjs rollout stack promote mode

### DIFF
--- a/docs/development/yjs-rollout-stack-promote-development-20260416.md
+++ b/docs/development/yjs-rollout-stack-promote-development-20260416.md
@@ -1,0 +1,35 @@
+# Yjs Rollout Stack Promote Development
+
+Date: 2026-04-16
+
+## Context
+
+The earlier stack helper could only retarget children to `main`.
+
+That still left one manual maintainer step after each retarget:
+
+1. open the child PR
+2. enable `auto-merge`
+
+## Change
+
+Enhanced:
+
+- [scripts/ops/advance-yjs-rollout-stack.mjs](/tmp/metasheet2-yjs-rollout-stack-promote/scripts/ops/advance-yjs-rollout-stack.mjs:1)
+
+Updated:
+
+- [docs/operations/yjs-rollout-stack-advance-20260416.md](/tmp/metasheet2-yjs-rollout-stack-promote/docs/operations/yjs-rollout-stack-advance-20260416.md:1)
+
+## New Behavior
+
+The script now:
+
+- includes the full stack through `#894`
+- supports `--enable-auto-merge`
+- can retarget eligible child PRs to `main`
+- can immediately run `gh pr merge --auto --squash` for those same PRs
+
+## Scope
+
+This is maintainer workflow automation only. It does not change runtime rollout behavior.

--- a/docs/development/yjs-rollout-stack-promote-gate-rebase-development-20260417.md
+++ b/docs/development/yjs-rollout-stack-promote-gate-rebase-development-20260417.md
@@ -1,0 +1,24 @@
+# Yjs Rollout Stack Promote Gate Rebase Development
+
+Date: 2026-04-17
+
+## Context
+
+- PR `#894` was rewritten on top of the updated `#893` branch.
+- PR `#895` still targeted the pre-rebase `codex/yjs-rollout-gate-20260416` head.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-stack-promote-20260416` onto `origin/codex/yjs-rollout-gate-20260416`
+2. Letting Git auto-drop the already-upstream `#893` parent layer:
+   - `9eb077342`
+   - `8074d3d10`
+   - `2e6efbbea`
+3. Preserving only the promote-specific commits:
+   - `99517fc87` `feat(collab): add yjs rollout stack promote mode`
+   - `b505d1508` `docs: record yjs rollout stack promote rebase`
+
+## Result
+
+- `#895` now sits cleanly on top of the updated `#894` branch
+- The branch is reduced to the intended promote-mode delta only

--- a/docs/development/yjs-rollout-stack-promote-gate-rebase-verification-20260417.md
+++ b/docs/development/yjs-rollout-stack-promote-gate-rebase-verification-20260417.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Stack Promote Gate Rebase Verification
+
+Date: 2026-04-17
+
+## Commands
+
+```bash
+git rebase origin/codex/yjs-rollout-gate-20260416
+node --check scripts/ops/advance-yjs-rollout-stack.mjs
+node scripts/ops/advance-yjs-rollout-stack.mjs --help
+git log --oneline --reverse origin/codex/yjs-rollout-gate-20260416..HEAD
+```
+
+## Results
+
+- Rebase completed successfully
+- The post-rebase branch range is now:
+  - `99517fc87` `feat(collab): add yjs rollout stack promote mode`
+  - `b505d1508` `docs: record yjs rollout stack promote rebase`
+- `node --check scripts/ops/advance-yjs-rollout-stack.mjs` passed
+- `node scripts/ops/advance-yjs-rollout-stack.mjs --help` passed
+
+## Notes
+
+- The rebased branch intentionally dropped all already-upstream `#893` parent commits
+- This step changed branch topology only; no rollout runtime semantics changed

--- a/docs/development/yjs-rollout-stack-promote-mainline-rebase-development-20260417.md
+++ b/docs/development/yjs-rollout-stack-promote-mainline-rebase-development-20260417.md
@@ -1,0 +1,26 @@
+# Yjs Rollout Stack Promote Mainline Rebase Development
+
+Date: 2026-04-17
+
+## Context
+
+- PR `#894` merged into `main` as `7aca08449c4dade68b23df2fa6a60fa94cc2d3e4`.
+- PR `#895` auto-retargeted to `main` and became `BEHIND`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-stack-promote-20260416` onto updated `origin/main`
+2. Letting Git auto-drop the already-upstream `#894` parent layer:
+   - `9fd858c86`
+   - `6a0bf72b5`
+   - `c448761ae`
+3. Preserving only the promote-specific commits:
+   - `3a8441754` `feat(collab): add yjs rollout stack promote mode`
+   - `87b688c37` `docs: record yjs rollout stack promote rebase`
+   - `17f2501d5` `docs: record yjs rollout stack promote gate rebase`
+
+## Result
+
+- `#895` is now a minimal delta over current `main`
+- The branch no longer replays rollout-gate history
+- Promote-mode scripting remains intact and ready for CI/review

--- a/docs/development/yjs-rollout-stack-promote-mainline-rebase-verification-20260417.md
+++ b/docs/development/yjs-rollout-stack-promote-mainline-rebase-verification-20260417.md
@@ -1,0 +1,27 @@
+# Yjs Rollout Stack Promote Mainline Rebase Verification
+
+Date: 2026-04-17
+
+## Commands
+
+```bash
+git rebase origin/main
+node --check scripts/ops/advance-yjs-rollout-stack.mjs
+node scripts/ops/advance-yjs-rollout-stack.mjs --help
+git log --oneline --reverse origin/main..HEAD
+```
+
+## Results
+
+- Rebase onto `origin/main` completed successfully
+- The post-rebase branch range is now:
+  - `3a8441754` `feat(collab): add yjs rollout stack promote mode`
+  - `87b688c37` `docs: record yjs rollout stack promote rebase`
+  - `17f2501d5` `docs: record yjs rollout stack promote gate rebase`
+- `node --check scripts/ops/advance-yjs-rollout-stack.mjs` passed
+- `node scripts/ops/advance-yjs-rollout-stack.mjs --help` passed
+
+## Notes
+
+- The rebased branch intentionally dropped all already-merged `#894` parent commits
+- This step changed branch topology only; no rollout runtime semantics changed

--- a/docs/development/yjs-rollout-stack-promote-stack-rebase-development-20260417.md
+++ b/docs/development/yjs-rollout-stack-promote-stack-rebase-development-20260417.md
@@ -1,0 +1,28 @@
+# Yjs Rollout Stack Promote Stack Rebase Development
+
+Date: 2026-04-17
+
+## Context
+
+- Parent PR layers up through `#894` were already upstream or freshly rebased.
+- PR `#895` still replayed those parent layers while targeting `codex/yjs-rollout-gate-20260416`.
+
+## What Changed
+
+1. Rebasing `codex/yjs-rollout-stack-promote-20260416` onto `origin/codex/yjs-rollout-gate-20260416`
+2. Dropping the already-upstream parent-layer commits from the rebase todo:
+   - `a00e974ae`
+   - `e5d12f1cf`
+   - `1492a1d4c`
+   - `c6333e822`
+   - `649ca31be`
+   - `163cc2a18`
+   - `5c2dda0d2`
+   - `9585cc0fb`
+3. Keeping only the promote-mode commit:
+   - `f210fb443` `feat(collab): add yjs rollout stack promote mode`
+
+## Result
+
+- `#895` now sits cleanly on top of the updated `#894` branch
+- The branch is reduced to the intended promote-mode delta only

--- a/docs/development/yjs-rollout-stack-promote-stack-rebase-verification-20260417.md
+++ b/docs/development/yjs-rollout-stack-promote-stack-rebase-verification-20260417.md
@@ -1,0 +1,25 @@
+# Yjs Rollout Stack Promote Stack Rebase Verification
+
+Date: 2026-04-17
+
+## Commands
+
+```bash
+git rebase origin/codex/yjs-rollout-gate-20260416
+node --check scripts/ops/advance-yjs-rollout-stack.mjs
+node scripts/ops/advance-yjs-rollout-stack.mjs --help
+git log --oneline --reverse origin/codex/yjs-rollout-gate-20260416..HEAD
+```
+
+## Results
+
+- Rebase completed successfully
+- The post-rebase branch range is now only:
+  - `f210fb443` `feat(collab): add yjs rollout stack promote mode`
+- `node --check scripts/ops/advance-yjs-rollout-stack.mjs` passed
+- `node scripts/ops/advance-yjs-rollout-stack.mjs --help` passed
+
+## Notes
+
+- This step intentionally removed all already-upstream parent layers from the branch history
+- No rollout runtime semantics changed; this was stack cleanup plus script verification

--- a/docs/development/yjs-rollout-stack-promote-verification-20260416.md
+++ b/docs/development/yjs-rollout-stack-promote-verification-20260416.md
@@ -1,0 +1,28 @@
+# Yjs Rollout Stack Promote Verification
+
+Date: 2026-04-16
+
+## Commands
+
+```bash
+node scripts/ops/advance-yjs-rollout-stack.mjs --help
+node --check scripts/ops/advance-yjs-rollout-stack.mjs
+node scripts/ops/advance-yjs-rollout-stack.mjs
+node scripts/ops/advance-yjs-rollout-stack.mjs --json
+claude -p "Return exactly: CLAUDE_CLI_OK"
+```
+
+## Result
+
+- help output: passed
+- syntax check: passed
+- dry-run text output: passed
+- dry-run JSON output: passed
+- Claude Code CLI: `CLAUDE_CLI_OK`
+
+## Notes
+
+- This verification stays in dry-run mode because `#888` is still open.
+- At verification time the script correctly reported:
+  - `#888` as the root blocker
+  - `#889-#894` as waiting on their parent PRs

--- a/docs/operations/yjs-rollout-stack-advance-20260416.md
+++ b/docs/operations/yjs-rollout-stack-advance-20260416.md
@@ -11,6 +11,8 @@ The Yjs rollout follow-ups are intentionally stacked:
 3. `#890`
 4. `#891`
 5. `#892`
+6. `#893`
+7. `#894`
 
 This script helps maintainers advance the stack after each parent PR merges.
 
@@ -34,9 +36,21 @@ node scripts/ops/advance-yjs-rollout-stack.mjs --apply
 
 This will run `gh pr edit <number> --base main` for any child PR whose parent has already merged.
 
+## Apply + Auto-Merge
+
+```bash
+node scripts/ops/advance-yjs-rollout-stack.mjs --apply --enable-auto-merge
+```
+
+This will:
+
+1. retarget eligible child PRs to `main`
+2. run `gh pr merge --auto --squash` for those same PRs
+
 ## Notes
 
 - The script only retargets open child PRs.
+- `--enable-auto-merge` only affects eligible open child PRs.
 - It does not merge PRs.
 - It does not rewrite local git history.
 - Run it after a parent merge, then do the final rebase/verification on the child branch if needed.

--- a/scripts/ops/advance-yjs-rollout-stack.mjs
+++ b/scripts/ops/advance-yjs-rollout-stack.mjs
@@ -8,6 +8,8 @@ const STACK = [
   { pr: 890, branch: 'codex/yjs-rollout-report-20260416', parent: 889 },
   { pr: 891, branch: 'codex/yjs-rollout-packet-20260416', parent: 890 },
   { pr: 892, branch: 'codex/yjs-rollout-signoff-20260416', parent: 891 },
+  { pr: 893, branch: 'codex/yjs-rollout-stack-advance-20260416', parent: 892 },
+  { pr: 894, branch: 'codex/yjs-rollout-gate-20260416', parent: 893 },
 ]
 
 function printHelp() {
@@ -16,21 +18,25 @@ function printHelp() {
 Checks the Yjs rollout PR stack and optionally retargets children to main once their parent PR is merged.
 
 Options:
-  --apply    Perform gh pr edit --base main for eligible child PRs
-  --json     Print JSON output
-  --help     Show this help
+  --apply                Perform gh pr edit --base main for eligible child PRs
+  --enable-auto-merge    After retargeting, enable gh pr merge --auto --squash
+  --json                 Print JSON output
+  --help                 Show this help
 `)
 }
 
 function parseArgs(argv) {
   const opts = {
     apply: false,
+    enableAutoMerge: false,
     showJson: false,
   }
 
   for (const arg of argv) {
     if (arg === '--apply') {
       opts.apply = true
+    } else if (arg === '--enable-auto-merge') {
+      opts.enableAutoMerge = true
     } else if (arg === '--json') {
       opts.showJson = true
     } else if (arg === '--help') {
@@ -68,16 +74,16 @@ function loadPr(prNumber) {
     'view',
     String(prNumber),
     '--json',
-    'number,state,mergedAt,mergeStateStatus,reviewDecision,baseRefName,headRefName,url',
+    'number,state,mergedAt,mergeStateStatus,reviewDecision,baseRefName,headRefName,url,autoMergeRequest',
   ]))
 }
 
 function renderSummary(entry) {
   const status = entry.pr
   const line = `#${status.number} ${status.headRefName} -> ${status.baseRefName} [${status.state}]`
-  const action = entry.action ? ` action=${entry.action}` : ''
+  const actions = entry.actions?.length ? ` actions=${entry.actions.join('+')}` : ''
   const reason = entry.reason ? ` reason=${entry.reason}` : ''
-  return `${line}${action}${reason}`
+  return `${line}${actions}${reason}`
 }
 
 async function main() {
@@ -95,7 +101,7 @@ async function main() {
     if (!item.parent) {
       decisions.push({
         pr,
-        action: null,
+        actions: [],
         reason: pr.state === 'OPEN' ? 'root PR still controls the stack' : 'root PR already merged',
       })
       continue
@@ -104,33 +110,38 @@ async function main() {
     const parent = statusMap.get(item.parent)
 
     if (pr.state !== 'OPEN') {
-      decisions.push({ pr, action: null, reason: 'already merged or closed' })
+      decisions.push({ pr, actions: [], reason: 'already merged or closed' })
       continue
     }
 
     if (!parent?.mergedAt) {
-      decisions.push({ pr, action: null, reason: `waiting for parent #${item.parent}` })
+      decisions.push({ pr, actions: [], reason: `waiting for parent #${item.parent}` })
       continue
     }
 
-    if (pr.baseRefName === 'main') {
-      decisions.push({ pr, action: null, reason: 'already retargeted to main' })
-      continue
+    const actions = []
+
+    if (pr.baseRefName !== 'main') {
+      actions.push('retarget-to-main')
     }
 
-    decisions.push({
-      pr,
-      action: 'retarget-to-main',
-      reason: `parent #${item.parent} merged`,
-    })
+    if (opts.enableAutoMerge && !pr.autoMergeRequest) {
+      actions.push('enable-auto-merge')
+    }
+
+    decisions.push({ pr, actions, reason: `parent #${item.parent} merged` })
   }
 
   const applied = []
   if (opts.apply) {
     for (const decision of decisions) {
-      if (decision.action === 'retarget-to-main') {
+      if (decision.actions.includes('retarget-to-main')) {
         runGh(['pr', 'edit', String(decision.pr.number), '--base', 'main'])
-        applied.push(decision.pr.number)
+        applied.push(`retarget:${decision.pr.number}`)
+      }
+      if (opts.enableAutoMerge && decision.actions.includes('enable-auto-merge')) {
+        runGh(['pr', 'merge', String(decision.pr.number), '--auto', '--squash'])
+        applied.push(`auto-merge:${decision.pr.number}`)
       }
     }
   }
@@ -144,7 +155,7 @@ async function main() {
       baseRefName: decision.pr.baseRefName,
       headRefName: decision.pr.headRefName,
       mergedAt: decision.pr.mergedAt,
-      action: decision.action,
+      actions: decision.actions,
       reason: decision.reason,
       url: decision.pr.url,
     })),


### PR DESCRIPTION
## What Changed

This PR extends the earlier stack-advance helper with a promote mode.

Included:
- `advance-yjs-rollout-stack.mjs` now covers the full stack through `#894`
- new `--enable-auto-merge` flag
- updated stack-advance operations doc
- development / verification records for this enhancement

## Why

Retargeting stacked child PRs to `main` still left a manual maintainer step: opening each child PR and enabling auto-merge.

This follow-up closes that gap so the same helper can:
- retarget eligible children to `main`
- immediately enable `gh pr merge --auto --squash`

## Verification

```bash
node scripts/ops/advance-yjs-rollout-stack.mjs --help
node --check scripts/ops/advance-yjs-rollout-stack.mjs
node scripts/ops/advance-yjs-rollout-stack.mjs
node scripts/ops/advance-yjs-rollout-stack.mjs --json
claude -p "Return exactly: CLAUDE_CLI_OK"
```

Results:
- help output: passed
- syntax check: passed
- dry-run text output: passed
- dry-run JSON output: passed
- Claude Code CLI: `CLAUDE_CLI_OK`

## Notes

- This PR is intentionally stacked on `#894`.
- Merge order should remain: `#888` -> `#889` -> `#890` -> `#891` -> `#892` -> `#893` -> `#894` -> this PR.
- Verification stayed in dry-run mode because `#888` is still open.
