### PR TITLE
feat(dingtalk): close self-bind, stable user deep-link, and mobile CAS loop

### DIFF
--- a/apps/web/src/utils/browserLocation.ts
+++ b/apps/web/src/utils/browserLocation.ts
@@ -15,12 +15,12 @@ export function ensureLocationChangeEvents(): void {
   const originalPushState = window.history.pushState.bind(window.history)
   const originalReplaceState = window.history.replaceState.bind(window.history)
 
-  window.history.pushState = function pushState(...args): void {
+  window.history.pushState = function pushState(...args: Parameters<History['pushState']>): void {
     originalPushState(...args)
     dispatchLocationChange()
   }
 
-  window.history.replaceState = function replaceState(...args): void {
+  window.history.replaceState = function replaceState(...args: Parameters<History['replaceState']>): void {
     originalReplaceState(...args)
     dispatchLocationChange()
   }

--- a/apps/web/src/utils/browserLocation.ts
+++ b/apps/web/src/utils/browserLocation.ts
@@ -1,0 +1,42 @@
+const LOCATION_CHANGE_EVENT = 'metasheet:locationchange'
+const PATCHED_FLAG = '__metasheetLocationPatched__'
+
+function dispatchLocationChange(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT))
+}
+
+export function ensureLocationChangeEvents(): void {
+  if (typeof window === 'undefined') return
+
+  const historyRecord = window.history as History & { [PATCHED_FLAG]?: boolean }
+  if (historyRecord[PATCHED_FLAG]) return
+
+  const originalPushState = window.history.pushState.bind(window.history)
+  const originalReplaceState = window.history.replaceState.bind(window.history)
+
+  window.history.pushState = function pushState(...args): void {
+    originalPushState(...args)
+    dispatchLocationChange()
+  }
+
+  window.history.replaceState = function replaceState(...args): void {
+    originalReplaceState(...args)
+    dispatchLocationChange()
+  }
+
+  historyRecord[PATCHED_FLAG] = true
+}
+
+export function subscribeToLocationChanges(listener: () => void): () => void {
+  if (typeof window === 'undefined') return () => {}
+
+  ensureLocationChangeEvents()
+  window.addEventListener('popstate', listener)
+  window.addEventListener(LOCATION_CHANGE_EVENT, listener)
+
+  return () => {
+    window.removeEventListener('popstate', listener)
+    window.removeEventListener(LOCATION_CHANGE_EVENT, listener)
+  }
+}

--- a/apps/web/src/views/DingTalkAuthCallbackView.vue
+++ b/apps/web/src/views/DingTalkAuthCallbackView.vue
@@ -52,23 +52,19 @@ const text = computed(() => {
   if (isZh.value) {
     return {
       loading: '正在验证钉钉登录，请稍候...',
-      bindLoading: '正在完成钉钉绑定，请稍候...',
       backToLogin: '返回登录',
       missingCode: '缺少授权码参数',
       missingToken: '登录成功但未获取到令牌',
       failed: '钉钉登录失败，请稍后重试。',
-      bindMissingSession: '绑定失败：当前未登录或登录已过期，请重新登录后再绑定钉钉。',
       bindFailed: '钉钉绑定失败，请稍后重试。',
     }
   }
   return {
     loading: 'Completing DingTalk sign-in...',
-    bindLoading: 'Completing DingTalk bind...',
     backToLogin: 'Back to Sign In',
     missingCode: 'Missing authorization code',
     missingToken: 'Sign-in succeeded but no token was returned',
     failed: 'DingTalk sign-in failed. Please try again.',
-    bindMissingSession: 'DingTalk bind failed: current session is missing or expired. Please sign in again before binding.',
     bindFailed: 'DingTalk bind failed. Please try again.',
   }
 })
@@ -90,111 +86,52 @@ function extractUserPermissions(user: AuthUserPayload | null): string[] {
   return user.permissions.filter((item): item is string => typeof item === 'string')
 }
 
-function persistAuthContext(user: AuthUserPayload | null, features: AuthFeaturePayload | null): void {
-  if (typeof localStorage === 'undefined') return
-
-  const roles = extractUserRoles(user)
-  const permissions = extractUserPermissions(user)
-
-  if (roles.length > 0) {
-    localStorage.setItem('user_roles', JSON.stringify(roles))
-  } else {
-    localStorage.removeItem('user_roles')
-  }
-
-  if (permissions.length > 0) {
-    localStorage.setItem('user_permissions', JSON.stringify(permissions))
-  } else {
-    localStorage.removeItem('user_permissions')
-  }
-
-  if (features && typeof features === 'object') {
-    localStorage.setItem('metasheet_features', JSON.stringify(features))
-    if (typeof features.mode === 'string' && features.mode.trim().length > 0) {
-      localStorage.setItem('metasheet_product_mode', features.mode)
-    }
-  }
-}
-
-function readBindIntent(state: string): 'bind' | null {
-  if (!state || typeof sessionStorage === 'undefined') return null
+function safeLocalStorageSet(key: string, value: string): void {
   try {
-    const key = `metasheet_dingtalk_intent_${state}`
-    const value = sessionStorage.getItem(key)
-    return value === 'bind' ? 'bind' : null
+    localStorage.setItem(key, value)
   } catch {
-    return null
+    // localStorage can throw in restricted contexts (private mode, test stubs).
   }
 }
 
-function clearBindIntent(state: string): void {
-  if (!state || typeof sessionStorage === 'undefined') return
+function safeLocalStorageRemove(key: string): void {
   try {
-    sessionStorage.removeItem(`metasheet_dingtalk_intent_${state}`)
+    localStorage.removeItem(key)
   } catch {
     // Ignore storage errors.
   }
 }
 
-async function handleBindCallback(code: string, state: string): Promise<void> {
-  clearBindIntent(state)
+function persistAuthContext(user: AuthUserPayload | null, features: AuthFeaturePayload | null): void {
+  if (typeof localStorage === 'undefined') return
+  if (typeof localStorage.setItem !== 'function') return
 
-  const existingToken = auth.getToken()
-  if (!existingToken) {
-    loading.value = false
-    errorMessage.value = text.value.bindMissingSession
-    return
+  const roles = extractUserRoles(user)
+  const permissions = extractUserPermissions(user)
+
+  if (roles.length > 0) {
+    safeLocalStorageSet('user_roles', JSON.stringify(roles))
+  } else {
+    safeLocalStorageRemove('user_roles')
   }
 
-  try {
-    const response = await apiFetch('/api/auth/dingtalk/callback', {
-      method: 'POST',
-      body: JSON.stringify({ code, state }),
-      suppressUnauthorizedRedirect: true,
-    })
-    const payload = await response.json().catch(() => null)
+  if (permissions.length > 0) {
+    safeLocalStorageSet('user_permissions', JSON.stringify(permissions))
+  } else {
+    safeLocalStorageRemove('user_permissions')
+  }
 
-    if (!response.ok || !payload?.success) {
-      loading.value = false
-      errorMessage.value = readErrorMessage(payload, text.value.bindFailed)
-      return
+  if (features && typeof features === 'object') {
+    safeLocalStorageSet('metasheet_features', JSON.stringify(features))
+    if (typeof features.mode === 'string' && features.mode.trim().length > 0) {
+      safeLocalStorageSet('metasheet_product_mode', features.mode)
     }
-
-    const redirectPath =
-      normalizePostLoginRedirect(payload?.data?.redirectPath) ||
-      normalizePostLoginRedirect(route.query.redirect) ||
-      '/settings?dingtalk=bound'
-    await router.replace(redirectPath)
-  } catch (error) {
-    loading.value = false
-    errorMessage.value = readErrorMessage(error, text.value.bindFailed)
   }
 }
 
 async function handleCallback(): Promise<void> {
   const code = typeof route.query.code === 'string' ? route.query.code : ''
   const state = typeof route.query.state === 'string' ? route.query.state : ''
-  const bindIntent = readBindIntent(state)
-
-  if (bindIntent !== 'bind') {
-    const existingToken = auth.getToken()
-    if (existingToken) {
-      const currentSession = await auth.bootstrapSession()
-      if (currentSession.ok) {
-        let fallbackPath = resolveHomePath()
-        try {
-          await loadProductFeatures()
-          fallbackPath = resolveHomePath()
-        } catch {
-          // Keep authenticated users on their current session even if feature probing fails.
-        }
-
-        const redirectPath = normalizePostLoginRedirect(route.query.redirect)
-        await router.replace(redirectPath || fallbackPath)
-        return
-      }
-    }
-  }
 
   if (!code) {
     loading.value = false
@@ -202,11 +139,8 @@ async function handleCallback(): Promise<void> {
     return
   }
 
-  if (bindIntent === 'bind') {
-    await handleBindCallback(code, state)
-    return
-  }
-
+  // Backend state is the source of truth for login vs bind; we always POST
+  // when a code is present and let data.mode drive the post-callback action.
   try {
     const response = await apiFetch('/api/auth/dingtalk/callback', {
       method: 'POST',
@@ -217,7 +151,22 @@ async function handleCallback(): Promise<void> {
 
     if (!response.ok || !payload?.success) {
       loading.value = false
-      errorMessage.value = readErrorMessage(payload, text.value.failed)
+      const mode = payload?.data?.mode
+      errorMessage.value = readErrorMessage(
+        payload,
+        mode === 'bind' ? text.value.bindFailed : text.value.failed,
+      )
+      return
+    }
+
+    const mode: 'bind' | 'login' = payload?.data?.mode === 'bind' ? 'bind' : 'login'
+
+    if (mode === 'bind') {
+      const redirectPath =
+        normalizePostLoginRedirect(payload?.data?.redirectPath) ||
+        normalizePostLoginRedirect(route.query.redirect) ||
+        '/settings?dingtalk=bound'
+      await router.replace(redirectPath)
       return
     }
 

--- a/apps/web/src/views/DingTalkAuthCallbackView.vue
+++ b/apps/web/src/views/DingTalkAuthCallbackView.vue
@@ -52,18 +52,24 @@ const text = computed(() => {
   if (isZh.value) {
     return {
       loading: '正在验证钉钉登录，请稍候...',
+      bindLoading: '正在完成钉钉绑定，请稍候...',
       backToLogin: '返回登录',
       missingCode: '缺少授权码参数',
       missingToken: '登录成功但未获取到令牌',
       failed: '钉钉登录失败，请稍后重试。',
+      bindMissingSession: '绑定失败：当前未登录或登录已过期，请重新登录后再绑定钉钉。',
+      bindFailed: '钉钉绑定失败，请稍后重试。',
     }
   }
   return {
     loading: 'Completing DingTalk sign-in...',
+    bindLoading: 'Completing DingTalk bind...',
     backToLogin: 'Back to Sign In',
     missingCode: 'Missing authorization code',
     missingToken: 'Sign-in succeeded but no token was returned',
     failed: 'DingTalk sign-in failed. Please try again.',
+    bindMissingSession: 'DingTalk bind failed: current session is missing or expired. Please sign in again before binding.',
+    bindFailed: 'DingTalk bind failed. Please try again.',
   }
 })
 
@@ -110,31 +116,94 @@ function persistAuthContext(user: AuthUserPayload | null, features: AuthFeatureP
   }
 }
 
-async function handleCallback(): Promise<void> {
-  const existingToken = auth.getToken()
-  if (existingToken) {
-    const currentSession = await auth.bootstrapSession()
-    if (currentSession.ok) {
-      let fallbackPath = resolveHomePath()
-      try {
-        await loadProductFeatures()
-        fallbackPath = resolveHomePath()
-      } catch {
-        // Keep authenticated users on their current session even if feature probing fails.
-      }
+function readBindIntent(state: string): 'bind' | null {
+  if (!state || typeof sessionStorage === 'undefined') return null
+  try {
+    const key = `metasheet_dingtalk_intent_${state}`
+    const value = sessionStorage.getItem(key)
+    return value === 'bind' ? 'bind' : null
+  } catch {
+    return null
+  }
+}
 
-      const redirectPath = normalizePostLoginRedirect(route.query.redirect)
-      await router.replace(redirectPath || fallbackPath)
-      return
-    }
+function clearBindIntent(state: string): void {
+  if (!state || typeof sessionStorage === 'undefined') return
+  try {
+    sessionStorage.removeItem(`metasheet_dingtalk_intent_${state}`)
+  } catch {
+    // Ignore storage errors.
+  }
+}
+
+async function handleBindCallback(code: string, state: string): Promise<void> {
+  clearBindIntent(state)
+
+  const existingToken = auth.getToken()
+  if (!existingToken) {
+    loading.value = false
+    errorMessage.value = text.value.bindMissingSession
+    return
   }
 
+  try {
+    const response = await apiFetch('/api/auth/dingtalk/callback', {
+      method: 'POST',
+      body: JSON.stringify({ code, state }),
+      suppressUnauthorizedRedirect: true,
+    })
+    const payload = await response.json().catch(() => null)
+
+    if (!response.ok || !payload?.success) {
+      loading.value = false
+      errorMessage.value = readErrorMessage(payload, text.value.bindFailed)
+      return
+    }
+
+    const redirectPath =
+      normalizePostLoginRedirect(payload?.data?.redirectPath) ||
+      normalizePostLoginRedirect(route.query.redirect) ||
+      '/settings?dingtalk=bound'
+    await router.replace(redirectPath)
+  } catch (error) {
+    loading.value = false
+    errorMessage.value = readErrorMessage(error, text.value.bindFailed)
+  }
+}
+
+async function handleCallback(): Promise<void> {
   const code = typeof route.query.code === 'string' ? route.query.code : ''
   const state = typeof route.query.state === 'string' ? route.query.state : ''
+  const bindIntent = readBindIntent(state)
+
+  if (bindIntent !== 'bind') {
+    const existingToken = auth.getToken()
+    if (existingToken) {
+      const currentSession = await auth.bootstrapSession()
+      if (currentSession.ok) {
+        let fallbackPath = resolveHomePath()
+        try {
+          await loadProductFeatures()
+          fallbackPath = resolveHomePath()
+        } catch {
+          // Keep authenticated users on their current session even if feature probing fails.
+        }
+
+        const redirectPath = normalizePostLoginRedirect(route.query.redirect)
+        await router.replace(redirectPath || fallbackPath)
+        return
+      }
+    }
+  }
 
   if (!code) {
     loading.value = false
     errorMessage.value = text.value.missingCode
+    return
+  }
+
+  if (bindIntent === 'bind') {
+    await handleBindCallback(code, state)
     return
   }
 

--- a/apps/web/src/views/SessionCenterView.vue
+++ b/apps/web/src/views/SessionCenterView.vue
@@ -421,17 +421,9 @@ async function launchDingTalkBind() {
 
     const data = payload && typeof payload === 'object' ? (payload as Record<string, unknown>).data : null
     const url = data && typeof data === 'object' ? (data as Record<string, unknown>).url : null
-    const state = data && typeof data === 'object' ? (data as Record<string, unknown>).state : null
     if (typeof url !== 'string' || url.trim().length === 0) {
       setStatus('发起钉钉绑定失败', 'error')
       return
-    }
-    if (typeof state === 'string' && state.trim().length > 0 && typeof sessionStorage !== 'undefined') {
-      try {
-        sessionStorage.setItem(`metasheet_dingtalk_intent_${state.trim()}`, 'bind')
-      } catch {
-        // sessionStorage may be unavailable (private mode); bind callback will fail gracefully.
-      }
     }
     window.open(url, '_self')
   } catch {

--- a/apps/web/src/views/SessionCenterView.vue
+++ b/apps/web/src/views/SessionCenterView.vue
@@ -37,6 +37,76 @@
         </div>
       </div>
 
+      <section class="session-center__dingtalk">
+        <div class="session-center__dingtalk-head">
+          <div>
+            <h2>钉钉登录</h2>
+            <p class="session-center__current-meta">
+              查看当前账号的钉钉开通、绑定和目录接管状态，并发起自助绑定。
+            </p>
+          </div>
+          <button
+            class="session-center__button session-center__button--secondary"
+            type="button"
+            :disabled="dingtalkLoading || dingtalkBinding || dingtalkUnbinding"
+            @click="void loadDingTalkAccess()"
+          >
+            {{ dingtalkLoading ? '刷新中...' : '刷新钉钉状态' }}
+          </button>
+        </div>
+
+        <div v-if="dingtalkAccess" class="session-center__dingtalk-grid">
+          <article class="session-center__dingtalk-card">
+            <div class="session-center__badges">
+              <span class="session-center__badge" :class="{ 'session-center__badge--current': dingtalkAccess.available }">
+                {{ dingtalkAccess.available ? '可用' : '不可用' }}
+              </span>
+              <span class="session-center__badge" :class="{ 'session-center__badge--current': dingtalkAccess.grant.enabled }">
+                {{ dingtalkAccess.grant.enabled ? '已开通' : '未开通' }}
+              </span>
+              <span class="session-center__badge" :class="{ 'session-center__badge--current': dingtalkAccess.identity.exists }">
+                {{ dingtalkAccess.identity.exists ? '钉钉账号已绑定' : '未绑定钉钉账号' }}
+              </span>
+            </div>
+            <dl class="session-center__meta">
+              <div>
+                <dt>Corp ID</dt>
+                <dd>{{ dingtalkAccess.identity.corpId || dingtalkAccess.server?.corpId || '—' }}</dd>
+              </div>
+              <div>
+                <dt>目录接管</dt>
+                <dd>{{ dingtalkAccess.directory.linked ? `已关联 ${dingtalkAccess.directory.linkedCount} 个目录成员` : '未被目录接管' }}</dd>
+              </div>
+              <div>
+                <dt>最近钉钉登录</dt>
+                <dd>{{ formatDate(dingtalkAccess.identity.lastLoginAt) }}</dd>
+              </div>
+            </dl>
+            <p v-if="dingtalkAccess.directory.linked" class="session-center__status session-center__status--error">
+              当前钉钉身份由目录同步接管，请联系平台管理员。
+            </p>
+            <div class="session-center__actions">
+              <button
+                class="session-center__button"
+                type="button"
+                :disabled="dingtalkBinding || !dingtalkAccess.available"
+                @click="void launchDingTalkBind()"
+              >
+                {{ dingtalkBinding ? '跳转中...' : dingtalkAccess.identity.exists ? '重新绑定钉钉账号' : '绑定钉钉账号' }}
+              </button>
+              <button
+                class="session-center__button session-center__button--secondary"
+                type="button"
+                :disabled="dingtalkUnbinding || !canUnbindDingTalk"
+                @click="void unbindDingTalk()"
+              >
+                {{ dingtalkUnbinding ? '处理中...' : '解除当前绑定' }}
+              </button>
+            </div>
+          </article>
+        </div>
+      </section>
+
       <section v-if="currentSession" class="session-center__current">
         <div class="session-center__current-copy">
           <p class="session-center__current-label">当前设备</p>
@@ -131,7 +201,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '../composables/useAuth'
 import { apiFetch } from '../utils/api'
 
@@ -151,6 +221,44 @@ type SessionRecord = {
 
 type StatusTone = 'info' | 'error'
 
+type DingTalkAccessSnapshot = {
+  available: boolean
+  userId: string
+  provider: 'dingtalk'
+  requireGrant: boolean
+  autoLinkEmail: boolean
+  autoProvision: boolean
+  server: {
+    configured: boolean
+    available: boolean
+    corpId: string | null
+    allowedCorpIds: string[]
+    requireGrant: boolean
+    autoLinkEmail: boolean
+    autoProvision: boolean
+    unavailableReason: string | null
+  }
+  directory: {
+    linked: boolean
+    linkedCount: number
+  }
+  grant: {
+    exists: boolean
+    enabled: boolean
+    grantedBy: string | null
+    createdAt: string | null
+    updatedAt: string | null
+  }
+  identity: {
+    exists: boolean
+    corpId: string | null
+    lastLoginAt: string | null
+    createdAt: string | null
+    updatedAt: string | null
+  }
+}
+
+const route = useRoute()
 const router = useRouter()
 const auth = useAuth()
 
@@ -161,12 +269,22 @@ const sessions = ref<SessionRecord[]>([])
 const currentSessionId = ref<string | null>(null)
 const status = ref('')
 const statusTone = ref<StatusTone>('info')
+const dingtalkLoading = ref(false)
+const dingtalkBinding = ref(false)
+const dingtalkUnbinding = ref(false)
+const dingtalkAccess = ref<DingTalkAccessSnapshot | null>(null)
 let heartbeatTimer: ReturnType<typeof setTimeout> | null = null
 
 const accountEmail = computed(() => auth.getAccessSnapshot().email)
 const activeSessionCount = computed(() => sessions.value.filter((session) => !session.revokedAt).length)
 const revokedSessionCount = computed(() => sessions.value.filter((session) => Boolean(session.revokedAt)).length)
 const currentSession = computed(() => sessions.value.find((session) => session.id === currentSessionId.value) ?? null)
+const canUnbindDingTalk = computed(() =>
+  Boolean(
+    dingtalkAccess.value?.identity.exists
+    && !dingtalkAccess.value.directory.linked,
+  ),
+)
 
 function setStatus(message: string, tone: StatusTone = 'info') {
   status.value = message
@@ -253,6 +371,102 @@ async function loadSessions() {
     setStatus('加载会话失败，请稍后重试', 'error')
   } finally {
     loading.value = false
+  }
+}
+
+async function loadDingTalkAccess() {
+  dingtalkLoading.value = true
+
+  try {
+    const response = await apiFetch('/api/auth/dingtalk/access')
+    const payload = await response.json().catch(() => null)
+
+    if (response.status === 401) {
+      await redirectToLogin()
+      return
+    }
+
+    if (!response.ok) {
+      setStatus(extractError(payload) || '加载钉钉状态失败', 'error')
+      return
+    }
+
+    const data = payload && typeof payload === 'object' ? (payload as Record<string, unknown>).data : null
+    dingtalkAccess.value = data && typeof data === 'object' ? data as DingTalkAccessSnapshot : null
+  } catch {
+    setStatus('加载钉钉状态失败，请稍后重试', 'error')
+  } finally {
+    dingtalkLoading.value = false
+  }
+}
+
+async function launchDingTalkBind() {
+  dingtalkBinding.value = true
+  try {
+    const response = await apiFetch('/api/auth/dingtalk/launch?intent=bind&redirect=%2Fsettings%3Fdingtalk%3Dbound', {
+      method: 'GET',
+      suppressUnauthorizedRedirect: true,
+    })
+    const payload = await response.json().catch(() => null)
+
+    if (response.status === 401) {
+      await redirectToLogin()
+      return
+    }
+
+    if (!response.ok) {
+      setStatus(extractError(payload) || '发起钉钉绑定失败', 'error')
+      return
+    }
+
+    const data = payload && typeof payload === 'object' ? (payload as Record<string, unknown>).data : null
+    const url = data && typeof data === 'object' ? (data as Record<string, unknown>).url : null
+    const state = data && typeof data === 'object' ? (data as Record<string, unknown>).state : null
+    if (typeof url !== 'string' || url.trim().length === 0) {
+      setStatus('发起钉钉绑定失败', 'error')
+      return
+    }
+    if (typeof state === 'string' && state.trim().length > 0 && typeof sessionStorage !== 'undefined') {
+      try {
+        sessionStorage.setItem(`metasheet_dingtalk_intent_${state.trim()}`, 'bind')
+      } catch {
+        // sessionStorage may be unavailable (private mode); bind callback will fail gracefully.
+      }
+    }
+    window.open(url, '_self')
+  } catch {
+    setStatus('发起钉钉绑定失败，请稍后重试', 'error')
+  } finally {
+    dingtalkBinding.value = false
+  }
+}
+
+async function unbindDingTalk() {
+  dingtalkUnbinding.value = true
+  try {
+    const response = await apiFetch('/api/auth/dingtalk/unbind', {
+      method: 'POST',
+      suppressUnauthorizedRedirect: true,
+    })
+    const payload = await response.json().catch(() => null)
+
+    if (response.status === 401) {
+      await redirectToLogin()
+      return
+    }
+
+    if (!response.ok) {
+      setStatus(extractError(payload) || '解除钉钉绑定失败', 'error')
+      return
+    }
+
+    const data = payload && typeof payload === 'object' ? (payload as Record<string, unknown>).data : null
+    dingtalkAccess.value = data && typeof data === 'object' ? data as DingTalkAccessSnapshot : dingtalkAccess.value
+    setStatus('当前钉钉绑定已解除')
+  } catch {
+    setStatus('解除钉钉绑定失败，请稍后重试', 'error')
+  } finally {
+    dingtalkUnbinding.value = false
   }
 }
 
@@ -358,6 +572,10 @@ async function revokeSession(sessionId: string) {
 
 onMounted(() => {
   void loadSessions()
+  void loadDingTalkAccess()
+  if (route.query.dingtalk === 'bound') {
+    setStatus('已返回钉钉绑定流程，请确认当前账号状态')
+  }
 })
 
 onBeforeUnmount(() => {
@@ -427,6 +645,40 @@ onBeforeUnmount(() => {
   background: #fff;
   border: 1px solid #e2e8f0;
   box-shadow: 0 8px 30px rgba(15, 23, 42, 0.05);
+}
+
+.session-center__dingtalk {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.session-center__dingtalk-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.session-center__dingtalk-head h2 {
+  margin: 0 0 6px;
+  font-size: 20px;
+  color: #0f172a;
+}
+
+.session-center__dingtalk-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.session-center__dingtalk-card {
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
 }
 
 .session-center__summary {
@@ -602,7 +854,8 @@ onBeforeUnmount(() => {
   }
 
   .session-center__header,
-  .session-center__card-head {
+  .session-center__card-head,
+  .session-center__dingtalk-head {
     flex-direction: column;
   }
 

--- a/apps/web/src/views/SessionCenterView.vue
+++ b/apps/web/src/views/SessionCenterView.vue
@@ -89,7 +89,7 @@
               <button
                 class="session-center__button"
                 type="button"
-                :disabled="dingtalkBinding || !dingtalkAccess.available"
+                :disabled="dingtalkBinding || !canBindDingTalk"
                 @click="void launchDingTalkBind()"
               >
                 {{ dingtalkBinding ? '跳转中...' : dingtalkAccess.identity.exists ? '重新绑定钉钉账号' : '绑定钉钉账号' }}
@@ -279,6 +279,12 @@ const accountEmail = computed(() => auth.getAccessSnapshot().email)
 const activeSessionCount = computed(() => sessions.value.filter((session) => !session.revokedAt).length)
 const revokedSessionCount = computed(() => sessions.value.filter((session) => Boolean(session.revokedAt)).length)
 const currentSession = computed(() => sessions.value.find((session) => session.id === currentSessionId.value) ?? null)
+const canBindDingTalk = computed(() =>
+  Boolean(
+    dingtalkAccess.value?.available
+    && !dingtalkAccess.value.directory.linked,
+  ),
+)
 const canUnbindDingTalk = computed(() =>
   Boolean(
     dingtalkAccess.value?.identity.exists
@@ -401,6 +407,7 @@ async function loadDingTalkAccess() {
 }
 
 async function launchDingTalkBind() {
+  if (!canBindDingTalk.value) return
   dingtalkBinding.value = true
   try {
     const response = await apiFetch('/api/auth/dingtalk/launch?intent=bind&redirect=%2Fsettings%3Fdingtalk%3Dbound', {

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -30,36 +30,6 @@
     <p v-if="status" class="user-admin__status" :class="{ 'user-admin__status--error': statusTone === 'error' }">
       {{ status }}
     </p>
-    <article v-if="directoryFailureNotice" class="user-admin__status user-admin__status--error user-admin__source-banner">
-      <strong>目录页返回</strong>
-      <p>{{ directoryFailureNotice.message }}</p>
-      <p v-if="directoryFailureNotice.integrationId">目标集成：{{ directoryFailureNotice.integrationId }}</p>
-      <p v-if="directoryFailureNotice.accountId">目标成员：{{ directoryFailureNotice.accountId }}</p>
-      <p>你可以继续检查当前用户的目录绑定状态，再决定是否重新跳转目录页处理。</p>
-      <div v-if="directoryFailureDirectoryLocation" class="user-admin__source-actions">
-        <router-link
-          class="user-admin__button user-admin__button--secondary user-admin__button-link"
-          :to="directoryFailureDirectoryLocation"
-        >
-          重新前往目录页
-        </router-link>
-        <router-link
-          v-if="directoryFailureRecoveryLocation"
-          class="user-admin__button user-admin__button--secondary user-admin__button-link"
-          :to="directoryFailureRecoveryLocation"
-        >
-          前往当前已链接成员
-        </router-link>
-        <button
-          class="user-admin__button user-admin__button--secondary"
-          type="button"
-          @click="clearDirectoryFailureContext()"
-        >
-          保留当前用户
-        </button>
-      </div>
-    </article>
-
     <section class="user-admin__panel user-admin__panel--create">
       <div class="user-admin__section-head">
         <div>
@@ -381,13 +351,6 @@
                 <small>{{ membership.email || membership.mobile || membership.externalUserId }}</small>
                 <p v-if="membership.departmentPaths.length">部门：{{ membership.departmentPaths.join(' / ') }}</p>
                 <p>目录账号：{{ membership.accountEnabled ? '启用' : '停用' }} · 同步于 {{ formatDate(membership.accountUpdatedAt) }}</p>
-                <router-link
-                  v-if="access"
-                  class="user-admin__link"
-                  :to="buildDirectoryLocation(membership, access.user.id)"
-                >
-                  前往目录成员
-                </router-link>
               </article>
             </div>
             <div v-if="memberAdmission?.businessRoleIds.length" class="user-admin__chips">
@@ -797,9 +760,6 @@ type UserSessionRecord = {
 type InitialUserNavigation = {
   userId: string
   source: string
-  integrationId: string
-  accountId: string
-  directoryFailure: string
 }
 
 const { hasAdminAccess } = useAuth()
@@ -915,15 +875,12 @@ function setStatus(message: string, tone: 'info' | 'error' = 'info'): void {
 
 function readInitialUserNavigation(): InitialUserNavigation {
   if (typeof window === 'undefined') {
-    return { userId: '', source: '', integrationId: '', accountId: '', directoryFailure: '' }
+    return { userId: '', source: '' }
   }
   const params = new URL(window.location.href).searchParams
   return {
     userId: params.get('userId')?.trim() || '',
     source: params.get('source')?.trim() || '',
-    integrationId: params.get('integrationId')?.trim() || '',
-    accountId: params.get('accountId')?.trim() || '',
-    directoryFailure: params.get('directoryFailure')?.trim() || '',
   }
 }
 
@@ -931,9 +888,6 @@ function buildUserNavigationKey(navigation: InitialUserNavigation): string {
   return [
     navigation.userId.trim(),
     navigation.source.trim(),
-    navigation.integrationId.trim(),
-    navigation.accountId.trim(),
-    navigation.directoryFailure.trim(),
   ].join('|')
 }
 
@@ -943,9 +897,6 @@ function buildUserLocation(navigation: InitialUserNavigation): string {
   const params = new URLSearchParams()
   if (navigation.userId.trim().length > 0) params.set('userId', navigation.userId.trim())
   if (navigation.source.trim().length > 0) params.set('source', navigation.source.trim())
-  if (navigation.integrationId.trim().length > 0) params.set('integrationId', navigation.integrationId.trim())
-  if (navigation.accountId.trim().length > 0) params.set('accountId', navigation.accountId.trim())
-  if (navigation.directoryFailure.trim().length > 0) params.set('directoryFailure', navigation.directoryFailure.trim())
   const search = params.toString()
   return `${url.pathname}${search ? `?${search}` : ''}${url.hash}`
 }
@@ -953,58 +904,6 @@ function buildUserLocation(navigation: InitialUserNavigation): string {
 function replaceUserNavigation(navigation: InitialUserNavigation): void {
   if (typeof window === 'undefined') return
   window.history.replaceState(window.history.state, '', buildUserLocation(navigation))
-}
-
-const directoryFailureNotice = computed(() => {
-  const navigation = userNavigation.value
-  if (navigation.source !== 'directory-sync') return null
-  const failureKind = navigation.directoryFailure.trim()
-  if (failureKind !== 'missing_integration' && failureKind !== 'missing_account') return null
-  const targetId = failureKind === 'missing_integration' ? navigation.integrationId.trim() : navigation.accountId.trim()
-  const message = failureKind === 'missing_integration'
-    ? `目录页未找到目录集成 ${targetId || '--'}。`
-    : `目录页未找到目录成员 ${targetId || '--'}。`
-  return {
-    kind: failureKind,
-    message,
-    integrationId: navigation.integrationId.trim(),
-    accountId: navigation.accountId.trim(),
-  }
-})
-const directoryFailureDirectoryLocation = computed(() => {
-  const navigation = userNavigation.value
-  if (navigation.source !== 'directory-sync') return ''
-  const userId = navigation.userId.trim()
-  const integrationId = navigation.integrationId.trim()
-  if (!userId || !integrationId) return ''
-  return buildDirectoryNavigationLocation({
-    userId,
-    integrationId,
-    accountId: navigation.accountId.trim(),
-  })
-})
-const directoryFailureRecoveryLocation = computed(() => {
-  if (!directoryFailureNotice.value || !access.value) return ''
-  const memberships = memberAdmission.value?.directoryMemberships || []
-  if (memberships.length === 0) return ''
-  const targetIntegrationId = directoryFailureNotice.value.integrationId.trim()
-  const matchedMembership = memberships.find((membership) => membership.integrationId === targetIntegrationId) || memberships[0]
-  if (!matchedMembership) return ''
-  const location = buildDirectoryLocation(matchedMembership, access.value.user.id)
-  return location === directoryFailureDirectoryLocation.value ? '' : location
-})
-
-function clearDirectoryFailureContext(): void {
-  const fallbackUserId = selectedUserId.value || access.value?.user.id || userNavigation.value.userId.trim()
-  replaceUserNavigation({
-    userId: fallbackUserId,
-    source: '',
-    integrationId: '',
-    accountId: '',
-    directoryFailure: '',
-  })
-  const fallbackUserName = access.value?.user.name || access.value?.user.email || fallbackUserId
-  setStatus(fallbackUserName ? `已清除目录失败提示，保留当前用户 ${fallbackUserName}` : '已清除目录失败提示')
 }
 
 function syncUserNavigationFromLocation(): boolean {
@@ -1799,31 +1698,6 @@ async function assignRole(): Promise<void> {
 
 async function unassignRole(): Promise<void> {
   await updateRole('unassign')
-}
-
-function buildDirectoryNavigationLocation({
-  userId,
-  integrationId,
-  accountId,
-}: {
-  userId: string
-  integrationId: string
-  accountId: string
-}): string {
-  const params = new URLSearchParams()
-  params.set('integrationId', integrationId)
-  if (accountId.trim().length > 0) params.set('accountId', accountId)
-  params.set('source', 'user-management')
-  params.set('userId', userId)
-  return `/admin/directory?${params.toString()}`
-}
-
-function buildDirectoryLocation(membership: MemberDirectoryMembership, userId: string): string {
-  return buildDirectoryNavigationLocation({
-    userId,
-    integrationId: membership.integrationId,
-    accountId: membership.directoryAccountId,
-  })
 }
 
 async function saveUserProfile(): Promise<void> {

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -1289,6 +1289,15 @@ async function loadUserSessions(userId?: string): Promise<void> {
   }
 }
 
+async function fetchUserAccessOrThrow(userId: string): Promise<UserAccess> {
+  const response = await apiFetch(`/api/admin/users/${encodeURIComponent(userId)}/access`)
+  const payload = await readJson(response)
+  if (!response.ok || payload.ok !== true) {
+    throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '加载用户权限失败'))
+  }
+  return payload.data as UserAccess
+}
+
 async function selectUser(userId: string): Promise<void> {
   selectedUserId.value = userId
   selectedRoleId.value = ''
@@ -1298,13 +1307,7 @@ async function selectUser(userId: string): Promise<void> {
   dingtalkAccess.value = null
   memberAdmission.value = null
   try {
-    const response = await apiFetch(`/api/admin/users/${encodeURIComponent(userId)}/access`)
-    const payload = await readJson(response)
-    if (!response.ok || payload.ok !== true) {
-      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '加载用户权限失败'))
-    }
-
-    access.value = payload.data as UserAccess
+    access.value = await fetchUserAccessOrThrow(userId)
     syncProfileDraftFromAccess()
     const navigationKey = buildUserNavigationKey(userNavigation.value)
     if (userNavigation.value.userId === userId && appliedUserNavigationKey.value !== navigationKey) {
@@ -1844,10 +1847,19 @@ async function saveUserProfile(): Promise<void> {
     if (response.status === 409) {
       const errorCode = (payload.error as Record<string, unknown> | undefined)?.code
       if (errorCode === 'PROFILE_MOBILE_CONFLICT') {
-        await selectUser(baselineUserId)
-        const latest = access.value?.user.mobile ?? null
-        const latestLabel = latest === null || latest === '' ? '（空）' : latest
-        setStatus(`用户手机号已被其他操作更新为 ${latestLabel}，请确认最新值后重新保存`, 'error')
+        try {
+          const latestAccess = await fetchUserAccessOrThrow(baselineUserId)
+          access.value = latestAccess
+          syncProfileDraftFromAccess()
+          const latest = latestAccess.user.mobile ?? null
+          const latestLabel = latest === null || latest === '' ? '（空）' : latest
+          setStatus(`用户手机号已被其他操作更新为 ${latestLabel}，请确认最新值后重新保存`, 'error')
+        } catch {
+          // If the refresh itself failed we must not advertise a stale value
+          // as the "latest" — it would mislead the admin about what the
+          // backend currently holds.
+          setStatus('用户手机号已被其他操作更新，请刷新后重试', 'error')
+        }
         return
       }
     }

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -289,6 +289,7 @@
             <div>
               <h2>{{ access.user.name || access.user.email }}</h2>
               <p>{{ access.user.email }}</p>
+              <p v-if="access.user.mobile" class="user-admin__hint">手机号：{{ access.user.mobile }}</p>
             </div>
             <div class="user-admin__badges">
               <span class="user-admin__badge">{{ access.user.role }}</span>
@@ -298,6 +299,34 @@
               <span class="user-admin__badge" :class="{ 'user-admin__badge--admin': access.isAdmin }">
                 {{ access.isAdmin ? '管理员' : '普通用户' }}
               </span>
+            </div>
+          </div>
+
+          <div class="user-admin__section">
+            <div class="user-admin__section-head">
+              <div>
+                <h3>基础资料</h3>
+                <p class="user-admin__hint">管理员可直接维护姓名和手机号，用于目录推荐绑定与钉钉匹配。</p>
+              </div>
+            </div>
+            <div class="user-admin__create-grid">
+              <input
+                v-model.trim="profileDraftName"
+                class="user-admin__search"
+                type="text"
+                placeholder="姓名"
+              />
+              <input
+                v-model.trim="profileDraftMobile"
+                class="user-admin__search"
+                type="text"
+                placeholder="手机号，可留空"
+              />
+            </div>
+            <div class="user-admin__role-actions">
+              <button class="user-admin__button" type="button" :disabled="busy || !hasProfileDraftChanges" @click="void saveUserProfile()">
+                保存资料
+              </button>
             </div>
           </div>
 
@@ -805,6 +834,8 @@ const userSessions = ref<UserSessionRecord[]>([])
 const access = ref<UserAccess | null>(null)
 const dingtalkAccess = ref<DingTalkAccess | null>(null)
 const memberAdmission = ref<MemberAdmission | null>(null)
+const profileDraftName = ref('')
+const profileDraftMobile = ref('')
 const appliedUserNavigationKey = ref('')
 const createForm = ref<CreateUserForm>({
   name: '',
@@ -849,6 +880,10 @@ const hasAttendanceAdminAccess = computed(() => {
 })
 const filteredAccessPresets = computed(() => {
   return accessPresets.value.filter((preset) => !presetModeFilter.value || preset.productMode === presetModeFilter.value)
+})
+const hasProfileDraftChanges = computed(() => {
+  if (!access.value) return false
+  return profileDraftName.value !== (access.value.user.name || '') || profileDraftMobile.value !== (access.value.user.mobile || '')
 })
 const namespaceOptions = computed(() => {
   const namespaces: string[] = []
@@ -978,6 +1013,11 @@ function syncUserNavigationFromLocation(): boolean {
   const nextKey = buildUserNavigationKey(next)
   userNavigation.value = next
   return currentKey !== nextKey
+}
+
+function syncProfileDraftFromAccess(): void {
+  profileDraftName.value = access.value?.user.name || ''
+  profileDraftMobile.value = access.value?.user.mobile || ''
 }
 
 function extractNamespaceFromPermission(permission: string): string | null {
@@ -1265,6 +1305,7 @@ async function selectUser(userId: string): Promise<void> {
     }
 
     access.value = payload.data as UserAccess
+    syncProfileDraftFromAccess()
     const navigationKey = buildUserNavigationKey(userNavigation.value)
     if (userNavigation.value.userId === userId && appliedUserNavigationKey.value !== navigationKey) {
       if (userNavigation.value.source === 'directory-sync') {
@@ -1504,6 +1545,7 @@ async function createUser(): Promise<void> {
     }
 
     access.value = payload.data as UserAccess
+    syncProfileDraftFromAccess()
     selectedUserId.value = access.value.user.id
     createdTemporaryPassword.value = String((payload.data as Record<string, unknown>).temporaryPassword || '')
     createdOnboarding.value = ((payload.data as Record<string, unknown>).onboarding as OnboardingPacket | undefined) || null
@@ -1618,6 +1660,7 @@ async function toggleUserStatus(): Promise<void> {
     }
 
     access.value = payload.data as UserAccess
+    syncProfileDraftFromAccess()
     await loadUsers()
     await loadMemberAdmission(access.value.user.id)
     setStatus(access.value.user.is_active ? '账号已启用' : '账号已停用')
@@ -1710,6 +1753,7 @@ async function updateRole(action: 'assign' | 'unassign'): Promise<void> {
     }
 
     access.value = payload.data as UserAccess
+    syncProfileDraftFromAccess()
     await loadUsers()
     await loadMemberAdmission(selectedUserId.value)
     setStatus(action === 'assign' ? '角色已分配' : '角色已撤销')
@@ -1734,6 +1778,7 @@ async function updateNamedRole(roleId: string, enabled: boolean): Promise<void> 
     }
 
     access.value = payload.data as UserAccess
+    syncProfileDraftFromAccess()
     await loadUsers()
     await loadMemberAdmission(selectedUserId.value)
     const label = roleId === 'admin' ? '平台管理员' : roleId === 'attendance_admin' ? '考勤管理员' : roleId
@@ -1776,6 +1821,49 @@ function buildDirectoryLocation(membership: MemberDirectoryMembership, userId: s
     integrationId: membership.integrationId,
     accountId: membership.directoryAccountId,
   })
+}
+
+async function saveUserProfile(): Promise<void> {
+  if (!access.value) return
+  busy.value = true
+  // Snapshot the mobile we believed the server held when we rendered the
+  // form; the backend uses this as a CAS witness on UPDATE so a concurrent
+  // edit can't get silently overwritten.
+  const baselineUserId = access.value.user.id
+  const baselineMobile = access.value.user.mobile ?? null
+  try {
+    const response = await apiFetch(`/api/admin/users/${encodeURIComponent(baselineUserId)}/profile`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        name: profileDraftName.value,
+        mobile: profileDraftMobile.value,
+        expectedMobile: baselineMobile,
+      }),
+    })
+    const payload = await readJson(response)
+    if (response.status === 409) {
+      const errorCode = (payload.error as Record<string, unknown> | undefined)?.code
+      if (errorCode === 'PROFILE_MOBILE_CONFLICT') {
+        await selectUser(baselineUserId)
+        const latest = access.value?.user.mobile ?? null
+        const latestLabel = latest === null || latest === '' ? '（空）' : latest
+        setStatus(`用户手机号已被其他操作更新为 ${latestLabel}，请确认最新值后重新保存`, 'error')
+        return
+      }
+    }
+    if (!response.ok || payload.ok !== true) {
+      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '更新用户资料失败'))
+    }
+
+    access.value = payload.data as UserAccess
+    syncProfileDraftFromAccess()
+    await loadUsers()
+    setStatus('用户资料已更新')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '更新用户资料失败', 'error')
+  } finally {
+    busy.value = false
+  }
 }
 
 const stopUserLocationSync = subscribeToLocationChanges(() => {

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -30,6 +30,35 @@
     <p v-if="status" class="user-admin__status" :class="{ 'user-admin__status--error': statusTone === 'error' }">
       {{ status }}
     </p>
+    <article v-if="directoryFailureNotice" class="user-admin__status user-admin__status--error user-admin__source-banner">
+      <strong>目录页返回</strong>
+      <p>{{ directoryFailureNotice.message }}</p>
+      <p v-if="directoryFailureNotice.integrationId">目标集成：{{ directoryFailureNotice.integrationId }}</p>
+      <p v-if="directoryFailureNotice.accountId">目标成员：{{ directoryFailureNotice.accountId }}</p>
+      <p>你可以继续检查当前用户的目录绑定状态，再决定是否重新跳转目录页处理。</p>
+      <div v-if="directoryFailureDirectoryLocation" class="user-admin__source-actions">
+        <router-link
+          class="user-admin__button user-admin__button--secondary user-admin__button-link"
+          :to="directoryFailureDirectoryLocation"
+        >
+          重新前往目录页
+        </router-link>
+        <router-link
+          v-if="directoryFailureRecoveryLocation"
+          class="user-admin__button user-admin__button--secondary user-admin__button-link"
+          :to="directoryFailureRecoveryLocation"
+        >
+          前往当前已链接成员
+        </router-link>
+        <button
+          class="user-admin__button user-admin__button--secondary"
+          type="button"
+          @click="clearDirectoryFailureContext()"
+        >
+          保留当前用户
+        </button>
+      </div>
+    </article>
 
     <section class="user-admin__panel user-admin__panel--create">
       <div class="user-admin__section-head">
@@ -323,6 +352,13 @@
                 <small>{{ membership.email || membership.mobile || membership.externalUserId }}</small>
                 <p v-if="membership.departmentPaths.length">部门：{{ membership.departmentPaths.join(' / ') }}</p>
                 <p>目录账号：{{ membership.accountEnabled ? '启用' : '停用' }} · 同步于 {{ formatDate(membership.accountUpdatedAt) }}</p>
+                <router-link
+                  v-if="access"
+                  class="user-admin__link"
+                  :to="buildDirectoryLocation(membership, access.user.id)"
+                >
+                  前往目录成员
+                </router-link>
               </article>
             </div>
             <div v-if="memberAdmission?.businessRoleIds.length" class="user-admin__chips">
@@ -555,14 +591,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useAuth } from '../composables/useAuth'
 import { apiFetch } from '../utils/api'
+import { subscribeToLocationChanges } from '../utils/browserLocation'
 
 type ManagedUser = {
   id: string
   email: string
   name: string | null
+  mobile?: string | null
   role: string
   is_active: boolean
   is_admin: boolean
@@ -727,6 +765,14 @@ type UserSessionRecord = {
   userAgent: string | null
 }
 
+type InitialUserNavigation = {
+  userId: string
+  source: string
+  integrationId: string
+  accountId: string
+  directoryFailure: string
+}
+
 const { hasAdminAccess } = useAuth()
 
 const adminAllowed = hasAdminAccess()
@@ -759,6 +805,7 @@ const userSessions = ref<UserSessionRecord[]>([])
 const access = ref<UserAccess | null>(null)
 const dingtalkAccess = ref<DingTalkAccess | null>(null)
 const memberAdmission = ref<MemberAdmission | null>(null)
+const appliedUserNavigationKey = ref('')
 const createForm = ref<CreateUserForm>({
   name: '',
   email: '',
@@ -824,10 +871,113 @@ const namespaceOptions = computed(() => {
 
   return namespaces
 })
+const userNavigation = ref(readInitialUserNavigation())
 
 function setStatus(message: string, tone: 'info' | 'error' = 'info'): void {
   status.value = message
   statusTone.value = tone
+}
+
+function readInitialUserNavigation(): InitialUserNavigation {
+  if (typeof window === 'undefined') {
+    return { userId: '', source: '', integrationId: '', accountId: '', directoryFailure: '' }
+  }
+  const params = new URL(window.location.href).searchParams
+  return {
+    userId: params.get('userId')?.trim() || '',
+    source: params.get('source')?.trim() || '',
+    integrationId: params.get('integrationId')?.trim() || '',
+    accountId: params.get('accountId')?.trim() || '',
+    directoryFailure: params.get('directoryFailure')?.trim() || '',
+  }
+}
+
+function buildUserNavigationKey(navigation: InitialUserNavigation): string {
+  return [
+    navigation.userId.trim(),
+    navigation.source.trim(),
+    navigation.integrationId.trim(),
+    navigation.accountId.trim(),
+    navigation.directoryFailure.trim(),
+  ].join('|')
+}
+
+function buildUserLocation(navigation: InitialUserNavigation): string {
+  if (typeof window === 'undefined') return '/admin/users'
+  const url = new URL(window.location.href)
+  const params = new URLSearchParams()
+  if (navigation.userId.trim().length > 0) params.set('userId', navigation.userId.trim())
+  if (navigation.source.trim().length > 0) params.set('source', navigation.source.trim())
+  if (navigation.integrationId.trim().length > 0) params.set('integrationId', navigation.integrationId.trim())
+  if (navigation.accountId.trim().length > 0) params.set('accountId', navigation.accountId.trim())
+  if (navigation.directoryFailure.trim().length > 0) params.set('directoryFailure', navigation.directoryFailure.trim())
+  const search = params.toString()
+  return `${url.pathname}${search ? `?${search}` : ''}${url.hash}`
+}
+
+function replaceUserNavigation(navigation: InitialUserNavigation): void {
+  if (typeof window === 'undefined') return
+  window.history.replaceState(window.history.state, '', buildUserLocation(navigation))
+}
+
+const directoryFailureNotice = computed(() => {
+  const navigation = userNavigation.value
+  if (navigation.source !== 'directory-sync') return null
+  const failureKind = navigation.directoryFailure.trim()
+  if (failureKind !== 'missing_integration' && failureKind !== 'missing_account') return null
+  const targetId = failureKind === 'missing_integration' ? navigation.integrationId.trim() : navigation.accountId.trim()
+  const message = failureKind === 'missing_integration'
+    ? `目录页未找到目录集成 ${targetId || '--'}。`
+    : `目录页未找到目录成员 ${targetId || '--'}。`
+  return {
+    kind: failureKind,
+    message,
+    integrationId: navigation.integrationId.trim(),
+    accountId: navigation.accountId.trim(),
+  }
+})
+const directoryFailureDirectoryLocation = computed(() => {
+  const navigation = userNavigation.value
+  if (navigation.source !== 'directory-sync') return ''
+  const userId = navigation.userId.trim()
+  const integrationId = navigation.integrationId.trim()
+  if (!userId || !integrationId) return ''
+  return buildDirectoryNavigationLocation({
+    userId,
+    integrationId,
+    accountId: navigation.accountId.trim(),
+  })
+})
+const directoryFailureRecoveryLocation = computed(() => {
+  if (!directoryFailureNotice.value || !access.value) return ''
+  const memberships = memberAdmission.value?.directoryMemberships || []
+  if (memberships.length === 0) return ''
+  const targetIntegrationId = directoryFailureNotice.value.integrationId.trim()
+  const matchedMembership = memberships.find((membership) => membership.integrationId === targetIntegrationId) || memberships[0]
+  if (!matchedMembership) return ''
+  const location = buildDirectoryLocation(matchedMembership, access.value.user.id)
+  return location === directoryFailureDirectoryLocation.value ? '' : location
+})
+
+function clearDirectoryFailureContext(): void {
+  const fallbackUserId = selectedUserId.value || access.value?.user.id || userNavigation.value.userId.trim()
+  replaceUserNavigation({
+    userId: fallbackUserId,
+    source: '',
+    integrationId: '',
+    accountId: '',
+    directoryFailure: '',
+  })
+  const fallbackUserName = access.value?.user.name || access.value?.user.email || fallbackUserId
+  setStatus(fallbackUserName ? `已清除目录失败提示，保留当前用户 ${fallbackUserName}` : '已清除目录失败提示')
+}
+
+function syncUserNavigationFromLocation(): boolean {
+  const next = readInitialUserNavigation()
+  const currentKey = buildUserNavigationKey(userNavigation.value)
+  const nextKey = buildUserNavigationKey(next)
+  userNavigation.value = next
+  return currentKey !== nextKey
 }
 
 function extractNamespaceFromPermission(permission: string): string | null {
@@ -951,6 +1101,8 @@ async function loadUsers(): Promise<void> {
   try {
     const params = new URLSearchParams()
     params.set('q', search.value)
+    const pinUserId = userNavigation.value.userId.trim()
+    if (pinUserId) params.set('userId', pinUserId)
     const response = await apiFetch(`/api/admin/users?${params.toString()}`)
     const payload = await readJson(response)
     if (!response.ok || payload.ok !== true) {
@@ -971,7 +1123,19 @@ async function loadUsers(): Promise<void> {
     reconcileSelectedUsers()
 
     if (!selectedUserId.value && users.value.length > 0) {
-      await selectUser(users.value[0].id)
+      const requestedUser = userNavigation.value.userId
+        ? users.value.find((item) => item.id === userNavigation.value.userId)
+        : null
+      await selectUser((requestedUser || users.value[0]).id)
+    } else if (userNavigation.value.userId) {
+      const navigationKey = buildUserNavigationKey(userNavigation.value)
+      const requestedUser = users.value.find((item) => item.id === userNavigation.value.userId)
+      if (
+        requestedUser
+        && (selectedUserId.value !== requestedUser.id || appliedUserNavigationKey.value !== navigationKey)
+      ) {
+        await selectUser(requestedUser.id)
+      }
     }
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '加载用户失败', 'error')
@@ -1101,10 +1265,41 @@ async function selectUser(userId: string): Promise<void> {
     }
 
     access.value = payload.data as UserAccess
+    const navigationKey = buildUserNavigationKey(userNavigation.value)
+    if (userNavigation.value.userId === userId && appliedUserNavigationKey.value !== navigationKey) {
+      if (userNavigation.value.source === 'directory-sync') {
+        setStatus(`已从目录同步定位到用户 ${access.value.user.name || access.value.user.email}`)
+      }
+      appliedUserNavigationKey.value = navigationKey
+    }
     await Promise.all([loadInviteRecords(userId), loadUserSessions(userId), loadDingTalkAccess(userId), loadMemberAdmission(userId)])
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '加载用户权限失败', 'error')
   }
+}
+
+async function handleUserNavigationChange(): Promise<void> {
+  const navigation = userNavigation.value
+  const navigationKey = buildUserNavigationKey(navigation)
+  if (!navigation.userId) {
+    appliedUserNavigationKey.value = navigationKey
+    return
+  }
+  if (navigationKey && appliedUserNavigationKey.value === navigationKey && selectedUserId.value === navigation.userId) return
+
+  if (search.value) {
+    search.value = ''
+    await loadUsers()
+    return
+  }
+
+  const requestedUser = users.value.find((item) => item.id === navigation.userId)
+  if (!requestedUser) {
+    await loadUsers()
+    return
+  }
+
+  await selectUser(requestedUser.id)
 }
 
 async function loadDingTalkAccess(userId?: string): Promise<void> {
@@ -1558,8 +1753,42 @@ async function unassignRole(): Promise<void> {
   await updateRole('unassign')
 }
 
+function buildDirectoryNavigationLocation({
+  userId,
+  integrationId,
+  accountId,
+}: {
+  userId: string
+  integrationId: string
+  accountId: string
+}): string {
+  const params = new URLSearchParams()
+  params.set('integrationId', integrationId)
+  if (accountId.trim().length > 0) params.set('accountId', accountId)
+  params.set('source', 'user-management')
+  params.set('userId', userId)
+  return `/admin/directory?${params.toString()}`
+}
+
+function buildDirectoryLocation(membership: MemberDirectoryMembership, userId: string): string {
+  return buildDirectoryNavigationLocation({
+    userId,
+    integrationId: membership.integrationId,
+    accountId: membership.directoryAccountId,
+  })
+}
+
+const stopUserLocationSync = subscribeToLocationChanges(() => {
+  if (!syncUserNavigationFromLocation()) return
+  void handleUserNavigationChange()
+})
+
 onMounted(async () => {
   await Promise.all([loadRoles(), loadUsers(), loadAccessPresets(), loadInviteRecords()])
+})
+
+onUnmounted(() => {
+  stopUserLocationSync()
 })
 </script>
 
@@ -1650,6 +1879,32 @@ onMounted(async () => {
 .user-admin__status--error {
   background: #fef2f2;
   color: #dc2626;
+}
+
+.user-admin__source-banner {
+  display: grid;
+  gap: 4px;
+}
+
+.user-admin__source-banner p {
+  margin: 0;
+}
+
+.user-admin__source-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.user-admin__button-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
+.user-admin__button-link:hover {
+  text-decoration: none;
 }
 
 .user-admin__layout {

--- a/apps/web/tests/dingtalk-auth-callback.spec.ts
+++ b/apps/web/tests/dingtalk-auth-callback.spec.ts
@@ -168,4 +168,70 @@ describe('DingTalkAuthCallbackView', () => {
     expect(setTokenMock).not.toHaveBeenCalled()
     expect(replaceMock).toHaveBeenCalledWith('/attendance')
   })
+
+  it('completes a DingTalk bind callback without overwriting the current session', async () => {
+    routeState.query.state = 'state-bind-1'
+    sessionStorage.setItem('metasheet_dingtalk_intent_state-bind-1', 'bind')
+    getTokenMock.mockReturnValue('existing-token')
+    bootstrapSessionMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      payload: {
+        data: {
+          user: {
+            id: 'user-1',
+          },
+        },
+      },
+    })
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          mode: 'bind',
+          bound: true,
+          redirectPath: '/settings?dingtalk=bound',
+          identity: {
+            userId: 'user-1',
+            identity: { exists: true },
+          },
+        },
+      }),
+    })
+
+    app = createApp(DingTalkAuthCallbackView)
+    app.mount(container!)
+    await flushUi(6)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/auth/dingtalk/callback',
+      expect.objectContaining({
+        method: 'POST',
+        suppressUnauthorizedRedirect: true,
+      }),
+    )
+    expect(setTokenMock).not.toHaveBeenCalled()
+    expect(primeSessionMock).not.toHaveBeenCalled()
+    expect(replaceMock).toHaveBeenCalledWith('/settings?dingtalk=bound')
+    expect(sessionStorage.getItem('metasheet_dingtalk_intent_state-bind-1')).toBeNull()
+    sessionStorage.clear()
+  })
+
+  it('shows an error when attempting DingTalk bind without an active session', async () => {
+    routeState.query.state = 'state-bind-2'
+    sessionStorage.setItem('metasheet_dingtalk_intent_state-bind-2', 'bind')
+    getTokenMock.mockReturnValue(null)
+
+    app = createApp(DingTalkAuthCallbackView)
+    app.mount(container!)
+    await flushUi(6)
+
+    expect(apiFetchMock).not.toHaveBeenCalled()
+    expect(setTokenMock).not.toHaveBeenCalled()
+    expect(container?.textContent ?? '').toContain('绑定失败')
+    expect(sessionStorage.getItem('metasheet_dingtalk_intent_state-bind-2')).toBeNull()
+    sessionStorage.clear()
+  })
 })

--- a/apps/web/tests/dingtalk-auth-callback.spec.ts
+++ b/apps/web/tests/dingtalk-auth-callback.spec.ts
@@ -51,7 +51,7 @@ vi.mock('vue-router', () => ({
   }),
 }))
 
-async function flushUi(cycles = 4): Promise<void> {
+async function flushUi(cycles = 6): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
     await nextTick()
@@ -96,6 +96,7 @@ describe('DingTalkAuthCallbackView', () => {
       json: async () => ({
         success: true,
         data: {
+          mode: 'login',
           token: 'jwt-dingtalk-token',
           redirectPath: '/workflows',
           user: {
@@ -145,33 +146,7 @@ describe('DingTalkAuthCallbackView', () => {
     expect(container?.textContent).toContain('缺少授权码参数')
   })
 
-  it('keeps an existing authenticated session instead of overwriting it via callback', async () => {
-    getTokenMock.mockReturnValue('existing-token')
-    bootstrapSessionMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      payload: {
-        data: {
-          user: {
-            id: 'user-1',
-          },
-        },
-      },
-    })
-    loadProductFeaturesMock.mockResolvedValue(undefined)
-
-    app = createApp(DingTalkAuthCallbackView)
-    app.mount(container!)
-    await flushUi(6)
-
-    expect(apiFetchMock).not.toHaveBeenCalled()
-    expect(setTokenMock).not.toHaveBeenCalled()
-    expect(replaceMock).toHaveBeenCalledWith('/attendance')
-  })
-
-  it('completes a DingTalk bind callback without overwriting the current session', async () => {
-    routeState.query.state = 'state-bind-1'
-    sessionStorage.setItem('metasheet_dingtalk_intent_state-bind-1', 'bind')
+  it('still POSTs the callback when an existing session is present (mode=bind keeps token)', async () => {
     getTokenMock.mockReturnValue('existing-token')
     bootstrapSessionMock.mockResolvedValue({
       ok: true,
@@ -215,23 +190,32 @@ describe('DingTalkAuthCallbackView', () => {
     expect(setTokenMock).not.toHaveBeenCalled()
     expect(primeSessionMock).not.toHaveBeenCalled()
     expect(replaceMock).toHaveBeenCalledWith('/settings?dingtalk=bound')
-    expect(sessionStorage.getItem('metasheet_dingtalk_intent_state-bind-1')).toBeNull()
-    sessionStorage.clear()
   })
 
-  it('shows an error when attempting DingTalk bind without an active session', async () => {
-    routeState.query.state = 'state-bind-2'
-    sessionStorage.setItem('metasheet_dingtalk_intent_state-bind-2', 'bind')
-    getTokenMock.mockReturnValue(null)
+  it('surfaces a DingTalk bind error when the backend returns a conflict', async () => {
+    getTokenMock.mockReturnValue('existing-token')
+    apiFetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        success: false,
+        error: 'DingTalk identity is already bound to another local user',
+        code: 'identity_already_bound',
+        data: {
+          mode: 'bind',
+        },
+      }),
+    })
 
     app = createApp(DingTalkAuthCallbackView)
     app.mount(container!)
     await flushUi(6)
 
-    expect(apiFetchMock).not.toHaveBeenCalled()
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/auth/dingtalk/callback',
+      expect.objectContaining({ method: 'POST' }),
+    )
     expect(setTokenMock).not.toHaveBeenCalled()
-    expect(container?.textContent ?? '').toContain('绑定失败')
-    expect(sessionStorage.getItem('metasheet_dingtalk_intent_state-bind-2')).toBeNull()
-    sessionStorage.clear()
+    expect(container?.textContent ?? '').toContain('already bound')
   })
 })

--- a/apps/web/tests/sessionCenterView.spec.ts
+++ b/apps/web/tests/sessionCenterView.spec.ts
@@ -318,8 +318,11 @@ describe('SessionCenterView', () => {
 
     expect(container?.textContent).toContain('已关联 1 个目录成员')
     expect(container?.textContent).toContain('请联系平台管理员')
+    const bindButton = Array.from(container?.querySelectorAll('button') ?? []).find((button) => button.textContent?.includes('重新绑定钉钉账号'))
+    expect(bindButton?.hasAttribute('disabled')).toBe(true)
     const unbindButton = Array.from(container?.querySelectorAll('button') ?? []).find((button) => button.textContent?.includes('解除当前绑定'))
     expect(unbindButton?.hasAttribute('disabled')).toBe(true)
+    bindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(apiFetchMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/web/tests/sessionCenterView.spec.ts
+++ b/apps/web/tests/sessionCenterView.spec.ts
@@ -119,7 +119,6 @@ describe('SessionCenterView', () => {
   })
 
   it('starts DingTalk self-bind from settings', async () => {
-    sessionStorage.clear()
     const openMock = vi.spyOn(window, 'open').mockImplementation(() => null)
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({
@@ -182,10 +181,8 @@ describe('SessionCenterView', () => {
         suppressUnauthorizedRedirect: true,
       }),
     )
-    expect(sessionStorage.getItem('metasheet_dingtalk_intent_state-bind-1')).toBe('bind')
     expect(openMock).toHaveBeenCalledWith('https://login.dingtalk.test/oauth-bind', '_self')
     openMock.mockRestore()
-    sessionStorage.clear()
   })
 
   it('allows a self-managed DingTalk identity to be unbound from settings', async () => {

--- a/apps/web/tests/sessionCenterView.spec.ts
+++ b/apps/web/tests/sessionCenterView.spec.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import SessionCenterView from '../src/views/SessionCenterView.vue'
+
+const apiFetchMock = vi.fn()
+const clearTokenMock = vi.fn()
+const replaceMock = vi.fn(() => Promise.resolve())
+
+const routeState = {
+  query: {} as Record<string, unknown>,
+}
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    clearToken: clearTokenMock,
+    getAccessSnapshot: () => ({
+      email: 'manager@example.com',
+    }),
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}))
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function createJsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  }
+}
+
+describe('SessionCenterView', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    clearTokenMock.mockReset()
+    replaceMock.mockReset()
+    replaceMock.mockResolvedValue(undefined)
+    routeState.query = {}
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('loads current-user DingTalk access status in settings', async () => {
+    routeState.query = { dingtalk: 'bound' }
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          items: [],
+          currentSessionId: null,
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          available: true,
+          userId: 'user-1',
+          provider: 'dingtalk',
+          requireGrant: false,
+          autoLinkEmail: false,
+          autoProvision: false,
+          directory: {
+            linked: false,
+            linkedCount: 0,
+          },
+          grant: {
+            exists: true,
+            enabled: true,
+            grantedBy: 'admin-1',
+            createdAt: '2026-04-11T12:00:00.000Z',
+            updatedAt: '2026-04-11T12:00:00.000Z',
+          },
+          identity: {
+            exists: true,
+            corpId: 'dingcorp',
+            lastLoginAt: '2026-04-11T12:00:00.000Z',
+            createdAt: '2026-04-11T12:00:00.000Z',
+            updatedAt: '2026-04-11T12:00:00.000Z',
+          },
+        },
+      }))
+
+    app = createApp(SessionCenterView)
+    app.mount(container!)
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenNthCalledWith(1, '/api/auth/sessions')
+    expect(apiFetchMock).toHaveBeenNthCalledWith(2, '/api/auth/dingtalk/access')
+    expect(container?.textContent).toContain('钉钉登录')
+    expect(container?.textContent).toContain('钉钉账号已绑定')
+    expect(container?.textContent).toContain('已开通')
+    expect(container?.textContent).toContain('dingcorp')
+  })
+
+  it('starts DingTalk self-bind from settings', async () => {
+    sessionStorage.clear()
+    const openMock = vi.spyOn(window, 'open').mockImplementation(() => null)
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          items: [],
+          currentSessionId: null,
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          available: true,
+          userId: 'user-1',
+          provider: 'dingtalk',
+          requireGrant: false,
+          autoLinkEmail: false,
+          autoProvision: false,
+          directory: {
+            linked: false,
+            linkedCount: 0,
+          },
+          grant: {
+            exists: false,
+            enabled: false,
+            grantedBy: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+          identity: {
+            exists: false,
+            corpId: null,
+            lastLoginAt: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          mode: 'bind',
+          url: 'https://login.dingtalk.test/oauth-bind',
+          state: 'state-bind-1',
+        },
+      }))
+
+    app = createApp(SessionCenterView)
+    app.mount(container!)
+    await flushUi()
+
+    const bindButton = Array.from(container?.querySelectorAll('button') ?? []).find((button) => button.textContent?.includes('绑定钉钉账号'))
+    expect(bindButton).toBeTruthy()
+    bindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenLastCalledWith(
+      '/api/auth/dingtalk/launch?intent=bind&redirect=%2Fsettings%3Fdingtalk%3Dbound',
+      expect.objectContaining({
+        suppressUnauthorizedRedirect: true,
+      }),
+    )
+    expect(sessionStorage.getItem('metasheet_dingtalk_intent_state-bind-1')).toBe('bind')
+    expect(openMock).toHaveBeenCalledWith('https://login.dingtalk.test/oauth-bind', '_self')
+    openMock.mockRestore()
+    sessionStorage.clear()
+  })
+
+  it('allows a self-managed DingTalk identity to be unbound from settings', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          items: [],
+          currentSessionId: null,
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          available: true,
+          userId: 'user-1',
+          provider: 'dingtalk',
+          requireGrant: false,
+          autoLinkEmail: false,
+          autoProvision: false,
+          directory: {
+            linked: false,
+            linkedCount: 0,
+          },
+          grant: {
+            exists: true,
+            enabled: true,
+            grantedBy: 'admin-1',
+            createdAt: '2026-04-11T12:00:00.000Z',
+            updatedAt: '2026-04-11T12:00:00.000Z',
+          },
+          identity: {
+            exists: true,
+            corpId: 'dingcorp',
+            lastLoginAt: '2026-04-11T12:00:00.000Z',
+            createdAt: '2026-04-11T12:00:00.000Z',
+            updatedAt: '2026-04-11T12:00:00.000Z',
+          },
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          available: true,
+          userId: 'user-1',
+          provider: 'dingtalk',
+          requireGrant: false,
+          autoLinkEmail: false,
+          autoProvision: false,
+          directory: {
+            linked: false,
+            linkedCount: 0,
+          },
+          grant: {
+            exists: true,
+            enabled: true,
+            grantedBy: 'admin-1',
+            createdAt: '2026-04-11T12:00:00.000Z',
+            updatedAt: '2026-04-11T12:00:00.000Z',
+          },
+          identity: {
+            exists: false,
+            corpId: null,
+            lastLoginAt: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+        },
+      }))
+
+    app = createApp(SessionCenterView)
+    app.mount(container!)
+    await flushUi()
+
+    const unbindButton = Array.from(container?.querySelectorAll('button') ?? []).find((button) => button.textContent?.includes('解除当前绑定'))
+    expect(unbindButton).toBeTruthy()
+    unbindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenLastCalledWith(
+      '/api/auth/dingtalk/unbind',
+      expect.objectContaining({
+        method: 'POST',
+        suppressUnauthorizedRedirect: true,
+      }),
+    )
+    expect(container?.textContent).toContain('当前钉钉绑定已解除')
+    expect(container?.textContent).toContain('绑定钉钉账号')
+  })
+
+  it('blocks self-unbind in settings when the identity is directory-managed', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          items: [],
+          currentSessionId: null,
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        success: true,
+        data: {
+          available: true,
+          userId: 'user-1',
+          provider: 'dingtalk',
+          requireGrant: false,
+          autoLinkEmail: false,
+          autoProvision: false,
+          directory: {
+            linked: true,
+            linkedCount: 1,
+          },
+          grant: {
+            exists: true,
+            enabled: true,
+            grantedBy: 'admin-1',
+            createdAt: '2026-04-11T12:00:00.000Z',
+            updatedAt: '2026-04-11T12:00:00.000Z',
+          },
+          identity: {
+            exists: true,
+            corpId: 'dingcorp',
+            lastLoginAt: '2026-04-11T12:00:00.000Z',
+            createdAt: '2026-04-11T12:00:00.000Z',
+            updatedAt: '2026-04-11T12:00:00.000Z',
+          },
+        },
+      }))
+
+    app = createApp(SessionCenterView)
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('已关联 1 个目录成员')
+    expect(container?.textContent).toContain('请联系平台管理员')
+    const unbindButton = Array.from(container?.querySelectorAll('button') ?? []).find((button) => button.textContent?.includes('解除当前绑定'))
+    expect(unbindButton?.hasAttribute('disabled')).toBe(true)
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -814,7 +814,7 @@ describe('UserManagementView', () => {
     expect(container?.textContent).not.toContain('用户资料已更新')
   })
 
-  it('can auto-focus a user from directory query params and expose a link back to the directory member', async () => {
+  it('can auto-focus a user from directory query params', async () => {
     window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-1&accountId=user-2-directory')
     const state = createApiState()
     const bravo = state.find((user) => user.id === 'user-2')
@@ -829,61 +829,6 @@ describe('UserManagementView', () => {
 
     expect(container?.textContent).toContain('已从目录同步定位到用户 Bravo')
     expect(container?.textContent).toContain('Bravo')
-
-    const directoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往目录成员'))
-    expect(directoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
-  })
-
-  it('shows a directory failure notice when returning from a missing directory account', async () => {
-    window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-1&accountId=user-2-directory&directoryFailure=missing_account')
-    const state = createApiState()
-    const bravo = state.find((user) => user.id === 'user-2')
-    if (!bravo) throw new Error('Bravo fixture not found')
-    bravo.directoryLinked = true
-    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
-
-    app = createApp(UserManagementView)
-    registerRouterLink(app, true)
-    app.mount(container!)
-    await flushUi(20)
-
-    expect(container?.textContent).toContain('已从目录同步定位到用户 Bravo')
-    expect(container?.textContent).toContain('目录页返回')
-    expect(container?.textContent).toContain('目录页未找到目录成员 user-2-directory。')
-    expect(container?.textContent).toContain('目标集成：ding-1')
-    expect(container?.textContent).toContain('目标成员：user-2-directory')
-    const retryDirectoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('重新前往目录页'))
-    expect(retryDirectoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
-
-    const keepUserButton = Array.from(container!.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('保留当前用户'))
-    expect(keepUserButton).toBeTruthy()
-    keepUserButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    await waitForCondition(() => !(container?.textContent?.includes('目录页返回') ?? false))
-
-    expect(window.location.search).toBe('?userId=user-2')
-    expect(container?.textContent).toContain('已清除目录失败提示，保留当前用户 Bravo')
-    expect(container?.textContent).toContain('Bravo')
-  })
-
-  it('offers a recovery link to the current linked directory member when the failed target is stale', async () => {
-    window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-1&accountId=stale-directory&directoryFailure=missing_account')
-    const state = createApiState()
-    const bravo = state.find((user) => user.id === 'user-2')
-    if (!bravo) throw new Error('Bravo fixture not found')
-    bravo.directoryLinked = true
-    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
-
-    app = createApp(UserManagementView)
-    registerRouterLink(app, true)
-    app.mount(container!)
-    await flushUi(20)
-
-    expect(container?.textContent).toContain('目录页未找到目录成员 stale-directory。')
-    const retryDirectoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('重新前往目录页'))
-    expect(retryDirectoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=stale-directory&source=user-management&userId=user-2')
-
-    const recoveryDirectoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往当前已链接成员'))
-    expect(recoveryDirectoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
   })
 
   it('can re-focus a user when query params change on the same mounted instance', async () => {
@@ -909,9 +854,6 @@ describe('UserManagementView', () => {
     const searchInput = container!.querySelector('input[type="search"]')
     expect(searchInput).toBeInstanceOf(HTMLInputElement)
     expect((searchInput as HTMLInputElement).value).toBe('')
-
-    const directoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往目录成员'))
-    expect(directoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
   })
 
   it('auto-focuses a deep-linked user whose row is outside the paginated first page', async () => {
@@ -948,30 +890,5 @@ describe('UserManagementView', () => {
     await waitForCondition(() => container?.textContent?.includes('已从目录同步定位到用户 Delta') ?? false)
 
     expect(container?.textContent).toContain('Delta')
-  })
-
-  it('updates the directory failure notice when query params change on the same mounted instance', async () => {
-    const state = createApiState()
-    const bravo = state.find((user) => user.id === 'user-2')
-    if (!bravo) throw new Error('Bravo fixture not found')
-    bravo.directoryLinked = true
-    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
-
-    app = createApp(UserManagementView)
-    registerRouterLink(app, true)
-    app.mount(container!)
-    await flushUi(20)
-
-    expect(container?.textContent).not.toContain('目录页返回')
-
-    window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-missing&accountId=user-2-directory&directoryFailure=missing_integration')
-    await waitForCondition(() => container?.textContent?.includes('目录页未找到目录集成 ding-missing。') ?? false)
-
-    expect(container?.textContent).toContain('目录页返回')
-    expect(container?.textContent).toContain('目录页未找到目录集成 ding-missing。')
-    expect(container?.textContent).toContain('目标集成：ding-missing')
-    expect(container?.textContent).toContain('目标成员：user-2-directory')
-    const retryDirectoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('重新前往目录页'))
-    expect(retryDirectoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-missing&accountId=user-2-directory&source=user-management&userId=user-2')
   })
 })

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -334,7 +334,12 @@ function createApiImplementation(
       const items = visible.map((user) => buildUserPayload(user))
       if (pinUserId && !items.some((item) => item.id === pinUserId)) {
         const pinned = state.find((user) => user.id === pinUserId)
-        if (pinned) items.unshift(buildUserPayload(pinned))
+        if (pinned) {
+          items.unshift(buildUserPayload(pinned))
+          if (typeof options.paginatedPageSize === 'number' && items.length > options.paginatedPageSize) {
+            items.length = options.paginatedPageSize
+          }
+        }
       }
       return createJsonResponse({
         ok: true,

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -416,6 +416,24 @@ function createApiImplementation(
       })
     }
 
+    const profileMatch = pathname.match(/^\/api\/admin\/users\/([^/]+)\/profile$/)
+    if (profileMatch) {
+      const user = findUserById(decodeURIComponent(profileMatch[1]))
+      const rawBody = typeof init?.body === 'string' ? init.body : ''
+      const parsed = rawBody ? JSON.parse(rawBody) as { name?: unknown; mobile?: unknown } : {}
+      if (typeof parsed.name === 'string') user.name = parsed.name
+      if (typeof parsed.mobile === 'string') user.mobile = parsed.mobile.trim() || null
+      return createJsonResponse({
+        ok: true,
+        data: {
+          user: buildUserPayload(user),
+          roles: ['crm_admin'],
+          permissions: ['crm:admin'],
+          isAdmin: user.role === 'admin',
+        },
+      })
+    }
+
     if (pathname === '/api/admin/invites') {
       return createJsonResponse({
         ok: true,
@@ -647,6 +665,97 @@ describe('UserManagementView', () => {
     expect(container?.textContent).toContain('已批量开通 finance 插件使用')
     expect(container?.textContent).toContain('finance')
     expect(container?.textContent).toContain('插件使用已开通')
+  })
+
+  it('can update user mobile profile and persist the refreshed detail snapshot', async () => {
+    app = createApp(UserManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi(20)
+
+    const bravoRow = findUserRow(container!, 'Bravo')
+    const bravoDetailButton = Array.from(bravoRow.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('Bravo'))
+    if (!(bravoDetailButton instanceof HTMLButtonElement)) {
+      throw new Error('Bravo detail button not found')
+    }
+    bravoDetailButton.click()
+    await waitForCondition(() => callLog.includes('/api/admin/users/user-2/access'))
+
+    const inputs = Array.from(container!.querySelectorAll('input[type="text"]'))
+    const mobileInput = inputs.find((candidate) => (candidate as HTMLInputElement).placeholder === '手机号，可留空')
+    if (!(mobileInput instanceof HTMLInputElement)) {
+      throw new Error('Profile mobile input not found')
+    }
+
+    mobileInput.value = '13800138000'
+    mobileInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    findButtonByText(container!, '保存资料').click()
+    await waitForCondition(() => apiFetchMock.mock.calls.some((args) => String(args[0]) === '/api/admin/users/user-2/profile'))
+
+    const profileCall = apiFetchMock.mock.calls.find((args) => String(args[0]) === '/api/admin/users/user-2/profile')
+    if (!profileCall) throw new Error('Profile update request not found')
+    expect(JSON.parse(String((profileCall[1] as RequestInit | undefined)?.body))).toEqual({
+      name: 'Bravo',
+      mobile: '13800138000',
+      expectedMobile: null,
+    })
+
+    await waitForCondition(() => container?.textContent?.includes('用户资料已更新') ?? false)
+    expect(container?.textContent).toContain('手机号：13800138000')
+  })
+
+  it('refreshes and surfaces the latest mobile when a PROFILE_MOBILE_CONFLICT happens', async () => {
+    const state = createApiState()
+    const bravo = state.find((user) => user.id === 'user-2')
+    if (!bravo) throw new Error('Bravo fixture not found')
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi(20)
+
+    const bravoRow = findUserRow(container!, 'Bravo')
+    const bravoDetailButton = Array.from(bravoRow.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('Bravo'))
+    if (!(bravoDetailButton instanceof HTMLButtonElement)) {
+      throw new Error('Bravo detail button not found')
+    }
+    bravoDetailButton.click()
+    await waitForCondition(() => callLog.includes('/api/admin/users/user-2/access'))
+
+    const inputs = Array.from(container!.querySelectorAll('input[type="text"]'))
+    const mobileInput = inputs.find((candidate) => (candidate as HTMLInputElement).placeholder === '手机号，可留空')
+    if (!(mobileInput instanceof HTMLInputElement)) {
+      throw new Error('Profile mobile input not found')
+    }
+    mobileInput.value = '13800000000'
+    mobileInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    // Simulate a concurrent backend edit landing right before our PATCH lands.
+    bravo.mobile = '13999999999'
+    apiFetchMock.mockImplementationOnce(async (input) => {
+      callLog.push(String(input))
+      return createJsonResponse({
+        ok: false,
+        error: {
+          code: 'PROFILE_MOBILE_CONFLICT',
+          message: 'User mobile changed before update was applied',
+        },
+      }, 409)
+    })
+
+    const accessCallsBefore = callLog.filter((url) => url === '/api/admin/users/user-2/access').length
+    findButtonByText(container!, '保存资料').click()
+
+    await waitForCondition(() => container?.textContent?.includes('用户手机号已被其他操作更新为 13999999999') ?? false)
+
+    expect(container?.textContent).not.toContain('用户资料已更新')
+    expect(container?.textContent).toContain('手机号：13999999999')
+    const accessCallsAfter = callLog.filter((url) => url === '/api/admin/users/user-2/access').length
+    expect(accessCallsAfter).toBeGreaterThan(accessCallsBefore)
   })
 
   it('can auto-focus a user from directory query params and expose a link back to the directory member', async () => {

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -78,10 +78,23 @@ async function setSelectValue(select: HTMLSelectElement, value: string): Promise
   await flushUi()
 }
 
+function registerRouterLink(app: App<Element>, withHref = false): void {
+  app.component('RouterLink', {
+    props: ['to'],
+    computed: {
+      resolvedHref(): string {
+        return typeof this.to === 'string' ? this.to : String(this.to || '')
+      },
+    },
+    template: withHref ? '<a :href="resolvedHref"><slot /></a>' : '<a><slot /></a>',
+  })
+}
+
 type UserFixture = {
   id: string
   email: string
   name: string
+  mobile: string | null
   role: string
   is_active: boolean
   grantEnabled: boolean
@@ -101,6 +114,7 @@ function createApiState(): UserFixture[] {
       id: 'user-1',
       email: 'alpha@example.com',
       name: 'Alpha',
+      mobile: null,
       role: 'user',
       is_active: true,
       grantEnabled: true,
@@ -119,6 +133,7 @@ function createApiState(): UserFixture[] {
       id: 'user-2',
       email: 'bravo@example.com',
       name: 'Bravo',
+      mobile: null,
       role: 'user',
       is_active: true,
       grantEnabled: false,
@@ -137,6 +152,7 @@ function createApiState(): UserFixture[] {
       id: 'user-3',
       email: 'charlie@example.com',
       name: 'Charlie',
+      mobile: null,
       role: 'user',
       is_active: false,
       grantEnabled: true,
@@ -155,6 +171,7 @@ function createApiState(): UserFixture[] {
       id: 'user-4',
       email: 'delta@example.com',
       name: 'Delta',
+      mobile: '13800000004',
       role: 'admin',
       is_active: true,
       grantEnabled: false,
@@ -172,7 +189,16 @@ function createApiState(): UserFixture[] {
   ]
 }
 
-function createApiImplementation(callLog: string[], state = createApiState()) {
+interface ApiImplementationOptions {
+  /** Limit the default user list to the first N rows so deep-link pinning can be exercised. */
+  paginatedPageSize?: number
+}
+
+function createApiImplementation(
+  callLog: string[],
+  state = createApiState(),
+  options: ApiImplementationOptions = {},
+) {
   return async (input: unknown, init?: RequestInit) => {
     const rawUrl = String(input)
     callLog.push(rawUrl)
@@ -180,7 +206,7 @@ function createApiImplementation(callLog: string[], state = createApiState()) {
     const pathname = url.pathname
     const query = url.searchParams.get('q')?.trim().toLowerCase() || ''
     const filteredUsers = query
-      ? state.filter((user) => [user.name, user.email, user.id, user.role].some((field) => field.toLowerCase().includes(query)))
+      ? state.filter((user) => [user.name, user.email, user.id, user.role, user.mobile || ''].some((field) => field.toLowerCase().includes(query)))
       : state
 
     const findUserById = (userId: string) => state.find((user) => user.id === userId) || state[0]
@@ -189,6 +215,7 @@ function createApiImplementation(callLog: string[], state = createApiState()) {
       id: user.id,
       email: user.email,
       name: user.name,
+      mobile: user.mobile,
       role: user.role,
       is_active: user.is_active,
       is_admin: user.role === 'admin',
@@ -300,10 +327,21 @@ function createApiImplementation(callLog: string[], state = createApiState()) {
     }
 
     if (pathname === '/api/admin/users') {
+      const pinUserId = url.searchParams.get('userId')?.trim() || ''
+      const visible = typeof options.paginatedPageSize === 'number'
+        ? filteredUsers.slice(0, Math.max(options.paginatedPageSize, 0))
+        : filteredUsers
+      const items = visible.map((user) => buildUserPayload(user))
+      if (pinUserId && !items.some((item) => item.id === pinUserId)) {
+        const pinned = state.find((user) => user.id === pinUserId)
+        if (pinned) items.unshift(buildUserPayload(pinned))
+      }
       return createJsonResponse({
         ok: true,
         data: {
-          items: filteredUsers.map((user) => buildUserPayload(user)),
+          items,
+          pinUserId,
+          pinUserIncluded: pinUserId ? items.some((item) => item.id === pinUserId) : null,
         },
       })
     }
@@ -450,6 +488,7 @@ describe('UserManagementView', () => {
   afterEach(() => {
     if (app) app.unmount()
     if (container) container.remove()
+    window.history.replaceState({}, '', '/')
     app = null
     container = null
   })
@@ -608,5 +647,166 @@ describe('UserManagementView', () => {
     expect(container?.textContent).toContain('已批量开通 finance 插件使用')
     expect(container?.textContent).toContain('finance')
     expect(container?.textContent).toContain('插件使用已开通')
+  })
+
+  it('can auto-focus a user from directory query params and expose a link back to the directory member', async () => {
+    window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-1&accountId=user-2-directory')
+    const state = createApiState()
+    const bravo = state.find((user) => user.id === 'user-2')
+    if (!bravo) throw new Error('Bravo fixture not found')
+    bravo.directoryLinked = true
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(20)
+
+    expect(container?.textContent).toContain('已从目录同步定位到用户 Bravo')
+    expect(container?.textContent).toContain('Bravo')
+
+    const directoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往目录成员'))
+    expect(directoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
+  })
+
+  it('shows a directory failure notice when returning from a missing directory account', async () => {
+    window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-1&accountId=user-2-directory&directoryFailure=missing_account')
+    const state = createApiState()
+    const bravo = state.find((user) => user.id === 'user-2')
+    if (!bravo) throw new Error('Bravo fixture not found')
+    bravo.directoryLinked = true
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(20)
+
+    expect(container?.textContent).toContain('已从目录同步定位到用户 Bravo')
+    expect(container?.textContent).toContain('目录页返回')
+    expect(container?.textContent).toContain('目录页未找到目录成员 user-2-directory。')
+    expect(container?.textContent).toContain('目标集成：ding-1')
+    expect(container?.textContent).toContain('目标成员：user-2-directory')
+    const retryDirectoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('重新前往目录页'))
+    expect(retryDirectoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
+
+    const keepUserButton = Array.from(container!.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('保留当前用户'))
+    expect(keepUserButton).toBeTruthy()
+    keepUserButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await waitForCondition(() => !(container?.textContent?.includes('目录页返回') ?? false))
+
+    expect(window.location.search).toBe('?userId=user-2')
+    expect(container?.textContent).toContain('已清除目录失败提示，保留当前用户 Bravo')
+    expect(container?.textContent).toContain('Bravo')
+  })
+
+  it('offers a recovery link to the current linked directory member when the failed target is stale', async () => {
+    window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-1&accountId=stale-directory&directoryFailure=missing_account')
+    const state = createApiState()
+    const bravo = state.find((user) => user.id === 'user-2')
+    if (!bravo) throw new Error('Bravo fixture not found')
+    bravo.directoryLinked = true
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(20)
+
+    expect(container?.textContent).toContain('目录页未找到目录成员 stale-directory。')
+    const retryDirectoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('重新前往目录页'))
+    expect(retryDirectoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=stale-directory&source=user-management&userId=user-2')
+
+    const recoveryDirectoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往当前已链接成员'))
+    expect(recoveryDirectoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
+  })
+
+  it('can re-focus a user when query params change on the same mounted instance', async () => {
+    const state = createApiState()
+    const bravo = state.find((user) => user.id === 'user-2')
+    if (!bravo) throw new Error('Bravo fixture not found')
+    bravo.directoryLinked = true
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(20)
+
+    await setSearchValue(container!, 'Alpha')
+    findButtonByText(container!, '查询').click()
+    await waitForCondition(() => callLog.includes('/api/admin/users?q=Alpha'))
+    expect(container?.textContent).toContain('Alpha')
+
+    window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-1&accountId=user-2-directory')
+    await waitForCondition(() => container?.textContent?.includes('已从目录同步定位到用户 Bravo') ?? false)
+
+    const searchInput = container!.querySelector('input[type="search"]')
+    expect(searchInput).toBeInstanceOf(HTMLInputElement)
+    expect((searchInput as HTMLInputElement).value).toBe('')
+
+    const directoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往目录成员'))
+    expect(directoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
+  })
+
+  it('auto-focuses a deep-linked user whose row is outside the paginated first page', async () => {
+    window.history.replaceState({}, '', '/admin/users?userId=user-4&source=directory-sync&integrationId=ding-1&accountId=user-4-directory')
+    const state = createApiState()
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state, { paginatedPageSize: 2 }))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(20)
+
+    const pinnedCall = callLog.find((url) => url.startsWith('/api/admin/users?') && url.includes('userId=user-4'))
+    expect(pinnedCall, 'expected loadUsers to forward the deep-link userId to the backend').toBeTruthy()
+
+    expect(container?.textContent).toContain('Delta')
+    expect(container?.textContent).toContain('已从目录同步定位到用户 Delta')
+  })
+
+  it('re-loads with the pinned userId when the deep link changes on the same instance', async () => {
+    const state = createApiState()
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state, { paginatedPageSize: 2 }))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(20)
+
+    // Initially no deep link — Alpha (first row) should be selected.
+    expect(container?.textContent).toContain('Alpha')
+
+    window.history.replaceState({}, '', '/admin/users?userId=user-4&source=directory-sync&integrationId=ding-1&accountId=user-4-directory')
+    await waitForCondition(() => callLog.some((url) => url.startsWith('/api/admin/users?') && url.includes('userId=user-4')))
+    await waitForCondition(() => container?.textContent?.includes('已从目录同步定位到用户 Delta') ?? false)
+
+    expect(container?.textContent).toContain('Delta')
+  })
+
+  it('updates the directory failure notice when query params change on the same mounted instance', async () => {
+    const state = createApiState()
+    const bravo = state.find((user) => user.id === 'user-2')
+    if (!bravo) throw new Error('Bravo fixture not found')
+    bravo.directoryLinked = true
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(20)
+
+    expect(container?.textContent).not.toContain('目录页返回')
+
+    window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-missing&accountId=user-2-directory&directoryFailure=missing_integration')
+    await waitForCondition(() => container?.textContent?.includes('目录页未找到目录集成 ding-missing。') ?? false)
+
+    expect(container?.textContent).toContain('目录页返回')
+    expect(container?.textContent).toContain('目录页未找到目录集成 ding-missing。')
+    expect(container?.textContent).toContain('目标集成：ding-missing')
+    expect(container?.textContent).toContain('目标成员：user-2-directory')
+    const retryDirectoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('重新前往目录页'))
+    expect(retryDirectoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-missing&accountId=user-2-directory&source=user-management&userId=user-2')
   })
 })

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -758,6 +758,62 @@ describe('UserManagementView', () => {
     expect(accessCallsAfter).toBeGreaterThan(accessCallsBefore)
   })
 
+  it('falls back to a generic message when the post-conflict access refresh fails', async () => {
+    const state = createApiState()
+    const bravo = state.find((user) => user.id === 'user-2')
+    if (!bravo) throw new Error('Bravo fixture not found')
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+
+    app = createApp(UserManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi(20)
+
+    const bravoRow = findUserRow(container!, 'Bravo')
+    const bravoDetailButton = Array.from(bravoRow.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('Bravo'))
+    if (!(bravoDetailButton instanceof HTMLButtonElement)) {
+      throw new Error('Bravo detail button not found')
+    }
+    bravoDetailButton.click()
+    await waitForCondition(() => callLog.includes('/api/admin/users/user-2/access'))
+
+    const inputs = Array.from(container!.querySelectorAll('input[type="text"]'))
+    const mobileInput = inputs.find((candidate) => (candidate as HTMLInputElement).placeholder === '手机号，可留空')
+    if (!(mobileInput instanceof HTMLInputElement)) {
+      throw new Error('Profile mobile input not found')
+    }
+    mobileInput.value = '13800000000'
+    mobileInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    // Backend reports a CAS conflict…
+    apiFetchMock.mockImplementationOnce(async (input) => {
+      callLog.push(String(input))
+      return createJsonResponse({
+        ok: false,
+        error: {
+          code: 'PROFILE_MOBILE_CONFLICT',
+          message: 'User mobile changed before update was applied',
+        },
+      }, 409)
+    })
+    // …and the follow-up access GET also fails, so the view can't confirm the
+    // true latest value. The UI must NOT advertise a stale mobile as "latest".
+    apiFetchMock.mockImplementationOnce(async (input) => {
+      callLog.push(String(input))
+      return createJsonResponse({
+        ok: false,
+        error: { code: 'USER_ACCESS_FAILED', message: 'downstream unavailable' },
+      }, 500)
+    })
+
+    findButtonByText(container!, '保存资料').click()
+    await waitForCondition(() => container?.textContent?.includes('用户手机号已被其他操作更新，请刷新后重试') ?? false)
+
+    expect(container?.textContent).not.toContain('用户手机号已被其他操作更新为')
+    expect(container?.textContent).not.toContain('用户资料已更新')
+  })
+
   it('can auto-focus a user from directory query params and expose a link back to the directory member', async () => {
     window.history.replaceState({}, '', '/admin/users?userId=user-2&source=directory-sync&integrationId=ding-1&accountId=user-2-directory')
     const state = createApiState()

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -51,15 +51,21 @@ interface LocalUserRow {
   is_active: boolean
 }
 
+export type DingTalkOAuthIntent = 'login' | 'bind'
+
 interface StateRecord {
   expiresAt: number
   redirectPath?: string
+  intent?: DingTalkOAuthIntent
+  bindUserId?: string
 }
 
 export interface StateValidationResult {
   valid: boolean
   error?: string
   redirectPath?: string
+  intent?: DingTalkOAuthIntent
+  bindUserId?: string
 }
 
 export type DingTalkRuntimeUnavailableReason =
@@ -322,6 +328,8 @@ async function validateStateFromRedis(state: string): Promise<StateValidationRes
     return {
       valid: true,
       redirectPath: parsed.redirectPath,
+      intent: parsed.intent,
+      bindUserId: parsed.bindUserId,
     }
   } catch (error) {
     logRedisFallback('Redis state validation failed', error)
@@ -351,6 +359,8 @@ function validateStateFromMemory(state: string): StateValidationResult {
   return {
     valid: true,
     redirectPath: record.redirectPath,
+    intent: record.intent,
+    bindUserId: record.bindUserId,
   }
 }
 
@@ -681,13 +691,23 @@ export function getDingTalkRuntimeStatus(): DingTalkRuntimeStatus {
   }
 }
 
-export async function generateState(options: { redirectPath?: string | null } = {}): Promise<string> {
+export async function generateState(options: {
+  redirectPath?: string | null
+  intent?: DingTalkOAuthIntent | null
+  bindUserId?: string | null
+} = {}): Promise<string> {
   const state = crypto.randomUUID()
+  const normalizedIntent = options.intent === 'bind' ? 'bind' : null
+  const normalizedBindUserId = typeof options.bindUserId === 'string' && options.bindUserId.trim().length > 0
+    ? options.bindUserId.trim()
+    : null
   const record: StateRecord = {
     expiresAt: Date.now() + STATE_TTL_MS,
     ...(typeof options.redirectPath === 'string' && options.redirectPath.trim().length > 0
       ? { redirectPath: options.redirectPath.trim() }
       : {}),
+    ...(normalizedIntent ? { intent: normalizedIntent } : {}),
+    ...(normalizedIntent === 'bind' && normalizedBindUserId ? { bindUserId: normalizedBindUserId } : {}),
   }
 
   const storedInRedis = await writeStateToRedis(state, record)
@@ -730,11 +750,10 @@ export function buildAuthUrl(state: string): string {
   return `https://login.dingtalk.com/oauth2/auth?${params.toString()}`
 }
 
-export async function exchangeCodeForUser(code: string): Promise<DingTalkExchangeResult> {
+export async function exchangeCodeForDingTalkProfile(code: string): Promise<DingTalkUserInfo> {
   const token = await exchangeCodeForUserAccessToken(code)
   const profile = await fetchDingTalkCurrentUser(token.accessToken)
-
-  const dingtalkUser: DingTalkUserInfo = {
+  return {
     openId: profile.openId,
     unionId: profile.unionId,
     nick: profile.nick,
@@ -742,7 +761,10 @@ export async function exchangeCodeForUser(code: string): Promise<DingTalkExchang
     mobile: profile.mobile,
     avatarUrl: profile.avatarUrl,
   }
+}
 
+export async function exchangeCodeForUser(code: string): Promise<DingTalkExchangeResult> {
+  const dingtalkUser = await exchangeCodeForDingTalkProfile(code)
   const { localUser, isNewUser } = await resolveLocalUser(dingtalkUser)
 
   return {
@@ -753,4 +775,94 @@ export async function exchangeCodeForUser(code: string): Promise<DingTalkExchang
     localUserRole: localUser.role,
     isNewUser,
   }
+}
+
+export async function bindDingTalkIdentityToUser(input: {
+  localUserId: string
+  dtUser: DingTalkUserInfo
+  boundBy?: string
+  enableGrant?: boolean
+}): Promise<void> {
+  const { localUserId, dtUser, enableGrant } = input
+  const boundBy = typeof input.boundBy === 'string' && input.boundBy.trim().length > 0
+    ? input.boundBy.trim()
+    : localUserId
+
+  const config = readDingTalkOauthConfig()
+  const externalKey = buildExternalKey(dtUser)
+  const profile = JSON.stringify(dtUser)
+  const openId = dtUser.openId || ''
+  const unionId = dtUser.unionId || ''
+
+  await transaction(async (client) => {
+    const conflictResult = await client.query(
+      `SELECT local_user_id
+       FROM user_external_identities
+       WHERE provider = $1
+         AND local_user_id <> $2
+         AND (
+           external_key = $3
+           OR ($4 <> '' AND provider_open_id = $4 AND corp_id IS NOT DISTINCT FROM $6)
+           OR ($5 <> '' AND provider_union_id = $5 AND corp_id IS NOT DISTINCT FROM $6)
+         )
+       LIMIT 1`,
+      [PROVIDER, localUserId, externalKey, openId, unionId, config.corpId || null],
+    )
+    if (conflictResult.rows.length > 0) {
+      throw createPolicyError('DingTalk identity is already bound to another local user', {
+        statusCode: 409,
+        code: 'identity_already_bound',
+      })
+    }
+
+    const existingByUser = await client.query(
+      `SELECT id
+       FROM user_external_identities
+       WHERE provider = $1 AND local_user_id = $2
+       LIMIT 1`,
+      [PROVIDER, localUserId],
+    )
+
+    if (existingByUser.rows.length > 0) {
+      await client.query(
+        `UPDATE user_external_identities
+         SET external_key = $3,
+             provider_union_id = $4,
+             provider_open_id = $5,
+             corp_id = $6,
+             profile = $7::jsonb,
+             bound_by = COALESCE(bound_by, $8),
+             updated_at = NOW()
+         WHERE provider = $1 AND local_user_id = $2`,
+        [PROVIDER, localUserId, externalKey, dtUser.unionId || null, dtUser.openId, config.corpId, profile, boundBy],
+      )
+    } else {
+      await client.query(
+        `INSERT INTO user_external_identities (
+           provider,
+           external_key,
+           provider_union_id,
+           provider_open_id,
+           corp_id,
+           local_user_id,
+           profile,
+           bound_by,
+           created_at,
+           updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, NOW(), NOW())`,
+        [PROVIDER, externalKey, dtUser.unionId || null, dtUser.openId, config.corpId, localUserId, profile, boundBy],
+      )
+    }
+
+    if (enableGrant) {
+      await client.query(
+        `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+         VALUES ($1, $2, TRUE, $3, NOW(), NOW())
+         ON CONFLICT (provider, local_user_id)
+         DO UPDATE SET enabled = TRUE, granted_by = EXCLUDED.granted_by, updated_at = NOW()`,
+        [PROVIDER, localUserId, boundBy],
+      )
+    }
+  })
 }

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -777,6 +777,11 @@ export async function exchangeCodeForUser(code: string): Promise<DingTalkExchang
   }
 }
 
+// Binds a DingTalk identity to a local user. Rebind semantics: if the user
+// already owns a DingTalk identity row it is updated to the incoming profile
+// (self-replacement is allowed by design — the user is opting in via callback).
+// A different user owning this identity always returns 409; cross-user
+// takeover must go through the admin directory flow, not self-service.
 export async function bindDingTalkIdentityToUser(input: {
   localUserId: string
   dtUser: DingTalkUserInfo

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -31,6 +31,7 @@ type AdminUserProfile = {
   id: string
   email: string
   name: string | null
+  mobile: string | null
   role: string
   is_active: boolean
   is_admin: boolean
@@ -281,7 +282,7 @@ async function ensurePlatformAdmin(req: Request, res: Response): Promise<string 
 
 async function fetchUserProfile(userId: string): Promise<AdminUserProfile | null> {
   const result = await query<AdminUserProfile>(
-    `SELECT id, email, name, role, is_active, is_admin, last_login_at, created_at, updated_at
+    `SELECT id, email, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
      FROM users
      WHERE id = $1`,
     [userId],
@@ -2141,10 +2142,10 @@ export function adminUsersRouter(): Router {
           Promise.resolve([]),
           (async () => {
             const term = q ? `%${q}%` : '%'
-            const where = q ? 'WHERE email ILIKE $1 OR name ILIKE $1 OR id ILIKE $1' : ''
+            const where = q ? 'WHERE email ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR id ILIKE $1' : ''
             const countSql = `SELECT COUNT(*)::int AS c FROM users ${where}`
             const listSql = `
-              SELECT id, email, name, role, is_active, is_admin, last_login_at, created_at, updated_at
+              SELECT id, email, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
               FROM users
               ${where}
               ORDER BY created_at DESC
@@ -2439,6 +2440,7 @@ export function adminUsersRouter(): Router {
 
     try {
       const q = String(req.query.q || '').trim()
+      const pinUserId = String(req.query.userId || '').trim()
       const { page, pageSize, offset } = parsePagination(req.query as Record<string, unknown>, {
         defaultPage: 1,
         defaultPageSize: 20,
@@ -2446,10 +2448,10 @@ export function adminUsersRouter(): Router {
       })
 
       const term = q ? `%${q}%` : '%'
-      const where = q ? 'WHERE email ILIKE $1 OR name ILIKE $1 OR id ILIKE $1' : ''
+      const where = q ? 'WHERE email ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR id ILIKE $1' : ''
       const countSql = `SELECT COUNT(*)::int AS c FROM users ${where}`
       const listSql = `
-        SELECT id, email, name, role, is_active, is_admin, last_login_at, created_at, updated_at
+        SELECT id, email, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
         FROM users
         ${where}
         ORDER BY created_at DESC
@@ -2460,12 +2462,32 @@ export function adminUsersRouter(): Router {
       const total = count.rows[0]?.c ?? 0
       const list = await query<AdminUserProfile>(listSql, q ? [term, pageSize, offset] : [pageSize, offset])
 
+      const items = list.rows
+      let pinnedUserIncluded = true
+      if (pinUserId && !items.some((row) => row.id === pinUserId)) {
+        // Deep-link target was not in the paginated window — fetch the single
+        // row so the caller can focus it without a second round-trip.
+        const pinned = await query<AdminUserProfile>(
+          `SELECT id, email, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+           FROM users
+           WHERE id = $1`,
+          [pinUserId],
+        )
+        if (pinned.rows[0]) {
+          items.unshift(pinned.rows[0])
+        } else {
+          pinnedUserIncluded = false
+        }
+      }
+
       return jsonOk(res, {
-        items: list.rows,
+        items,
         page,
         pageSize,
         total,
         query: q,
+        pinUserId: pinUserId || '',
+        pinUserIncluded: pinUserId ? pinnedUserIncluded : null,
         actorId: adminUserId,
       })
     } catch (error) {

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -353,6 +353,12 @@ function sanitizeName(name: string): string {
   return name.trim().replace(/[<>'"&;]/g, '').slice(0, 100)
 }
 
+function sanitizeMobile(mobile: string): string | null {
+  const value = mobile.trim().replace(/\s+/g, '')
+  if (!value) return null
+  return value.slice(0, 32)
+}
+
 function parseAuditRangeBoundary(value: unknown, mode: AuditRangeBoundaryMode): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
@@ -2908,6 +2914,84 @@ export function adminUsersRouter(): Router {
       })
     } catch (error) {
       return jsonError(res, 500, 'USER_CREATE_FAILED', (error as Error)?.message || 'Failed to create user')
+    }
+  })
+
+  r.patch('/api/admin/users/:userId/profile', authenticate, async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const userId = String(req.params.userId || '').trim()
+      if (!userId) return jsonError(res, 400, 'USER_ID_REQUIRED', 'userId is required')
+
+      const hasName = typeof req.body?.name === 'string'
+      const hasMobile = typeof req.body?.mobile === 'string'
+      const hasExpectedMobile = Object.prototype.hasOwnProperty.call(req.body ?? {}, 'expectedMobile')
+      if (!hasName && !hasMobile) {
+        return jsonError(res, 400, 'PROFILE_FIELDS_REQUIRED', 'name or mobile is required')
+      }
+
+      const profile = await fetchUserProfile(userId)
+      if (!profile) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
+
+      const nextName = hasName ? sanitizeName(String(req.body.name)) : profile.name
+      const nextMobile = hasMobile ? sanitizeMobile(String(req.body.mobile)) : profile.mobile
+      const expectedMobile = hasExpectedMobile
+        ? req.body?.expectedMobile === null
+          ? null
+          : typeof req.body?.expectedMobile === 'string'
+            ? sanitizeMobile(String(req.body.expectedMobile))
+            : undefined
+        : undefined
+
+      if (hasName && (!nextName || nextName.length < 2 || nextName.length > 100)) {
+        return jsonError(res, 400, 'INVALID_NAME', 'Name must be between 2 and 100 characters')
+      }
+      if (hasExpectedMobile && expectedMobile === undefined) {
+        return jsonError(res, 400, 'INVALID_EXPECTED_MOBILE', 'expectedMobile must be string or null')
+      }
+
+      const updateResult = await query<{ id: string }>(
+        `UPDATE users
+         SET name = $1,
+             mobile = $2,
+             updated_at = NOW()
+         WHERE id = $3
+           AND ($4::boolean = FALSE OR (($5::text IS NULL AND mobile IS NULL) OR mobile = $5::text))
+         RETURNING id`,
+        [nextName, nextMobile, userId, hasExpectedMobile, expectedMobile ?? null],
+      )
+      if (updateResult.rows.length === 0) {
+        return jsonError(res, 409, 'PROFILE_MOBILE_CONFLICT', 'User mobile changed before update was applied')
+      }
+
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'update',
+        resourceType: 'user',
+        resourceId: userId,
+        meta: {
+          adminUserId,
+          before: {
+            name: profile.name,
+            mobile: profile.mobile,
+          },
+          after: {
+            name: nextName,
+            mobile: nextMobile,
+          },
+        },
+      })
+
+      const snapshot = await fetchUserAccessSnapshot(userId)
+      return jsonOk(res, {
+        ...snapshot,
+        actorId: adminUserId,
+      })
+    } catch (error) {
+      return jsonError(res, 500, 'USER_PROFILE_UPDATE_FAILED', (error as Error)?.message || 'Failed to update user profile')
     }
   })
 

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -2952,13 +2952,22 @@ export function adminUsersRouter(): Router {
         return jsonError(res, 400, 'INVALID_EXPECTED_MOBILE', 'expectedMobile must be string or null')
       }
 
+      // Both the stored value and the witness are normalised the same way
+      // (strip all whitespace, map empty to NULL) before comparison so legacy
+      // rows like "138 0013 8000" don't spuriously fail CAS when the client
+      // sends the already-sanitised "13800138000" witness.
       const updateResult = await query<{ id: string }>(
         `UPDATE users
          SET name = $1,
              mobile = $2,
              updated_at = NOW()
          WHERE id = $3
-           AND ($4::boolean = FALSE OR (($5::text IS NULL AND mobile IS NULL) OR mobile = $5::text))
+           AND (
+             $4::boolean = FALSE
+             OR NULLIF(regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g'), '')
+                IS NOT DISTINCT FROM
+                NULLIF(regexp_replace(COALESCE($5::text, ''), '\\s+', '', 'g'), '')
+           )
          RETURNING id`,
         [nextName, nextMobile, userId, hasExpectedMobile, expectedMobile ?? null],
       )

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -2481,6 +2481,7 @@ export function adminUsersRouter(): Router {
         )
         if (pinned.rows[0]) {
           items.unshift(pinned.rows[0])
+          if (items.length > pageSize) items.length = pageSize
         } else {
           pinnedUserIncluded = false
         }

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -1099,6 +1099,17 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
         })
       }
 
+      // Directory-managed users must not self-rebind — their DingTalk identity
+      // is owned by the admin directory sync flow.
+      const preSnapshot = await fetchCurrentUserDingTalkAccessSnapshot(authResult.user.id)
+      if (preSnapshot.directory.linked) {
+        return res.status(409).json({
+          success: false,
+          error: 'Current user is directory-managed for DingTalk. Please contact an administrator to rebind.',
+          code: 'directory_managed_conflict',
+        })
+      }
+
       const dtUser = await exchangeCodeForDingTalkProfile(code)
       await bindDingTalkIdentityToUser({
         localUserId: authResult.user.id,

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -11,8 +11,10 @@ import jwt, { type SignOptions } from 'jsonwebtoken'
 import { authService, type User } from '../auth/AuthService'
 import { buildOnboardingPacket, getAccessPreset } from '../auth/access-presets'
 import {
+  bindDingTalkIdentityToUser,
   buildAuthUrl,
   DingTalkLoginPolicyError,
+  exchangeCodeForDingTalkProfile,
   exchangeCodeForUser,
   getDingTalkRuntimeStatus,
   generateState,
@@ -249,6 +251,120 @@ function isTruthyQueryFlag(value: unknown): boolean {
   if (typeof value === 'boolean') return value
   if (typeof value !== 'string') return false
   return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+type DingTalkAccessSnapshot = {
+  available: boolean
+  userId: string
+  provider: 'dingtalk'
+  requireGrant: boolean
+  autoLinkEmail: boolean
+  autoProvision: boolean
+  server: ReturnType<typeof getDingTalkRuntimeStatus>
+  directory: {
+    linked: boolean
+    linkedCount: number
+  }
+  grant: {
+    exists: boolean
+    enabled: boolean
+    grantedBy: string | null
+    createdAt: string | null
+    updatedAt: string | null
+  }
+  identity: {
+    exists: boolean
+    corpId: string | null
+    lastLoginAt: string | null
+    createdAt: string | null
+    updatedAt: string | null
+  }
+}
+
+async function requireAuthenticatedUser(req: Request, res: Response): Promise<{ token: string; user: User } | null> {
+  const authHeader = req.headers.authorization
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null
+
+  if (!token) {
+    res.status(401).json({
+      success: false,
+      error: 'No token provided',
+    })
+    return null
+  }
+
+  const user = await authService.verifyToken(token)
+  if (!user) {
+    res.status(401).json({
+      success: false,
+      error: 'Invalid token',
+    })
+    return null
+  }
+
+  return { token, user }
+}
+
+async function fetchCurrentUserDingTalkAccessSnapshot(userId: string): Promise<DingTalkAccessSnapshot> {
+  const [grantResult, identityResult, linkedDirectoryResult] = await Promise.all([
+    query<{ enabled: boolean; granted_by: string | null; created_at: string | null; updated_at: string | null }>(
+      `SELECT enabled, granted_by, created_at, updated_at
+       FROM user_external_auth_grants
+       WHERE provider = $1 AND local_user_id = $2
+       LIMIT 1`,
+      ['dingtalk', userId],
+    ),
+    query<{ corp_id: string | null; last_login_at: string | null; created_at: string | null; updated_at: string | null }>(
+      `SELECT corp_id, last_login_at, created_at, updated_at
+       FROM user_external_identities
+       WHERE provider = $1 AND local_user_id = $2
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      ['dingtalk', userId],
+    ),
+    query<{ linked_count: number | string }>(
+      `SELECT COUNT(*)::int AS linked_count
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE l.local_user_id = $1
+         AND l.link_status = 'linked'
+         AND a.provider = $2`,
+      [userId, 'dingtalk'],
+    ),
+  ])
+
+  const runtime = getDingTalkRuntimeStatus()
+  const grant = grantResult.rows[0] ?? null
+  const identity = identityResult.rows[0] ?? null
+  const linkedCount = Number(linkedDirectoryResult.rows[0]?.linked_count || 0)
+
+  return {
+    available: runtime.available,
+    userId,
+    provider: 'dingtalk',
+    requireGrant: runtime.requireGrant,
+    autoLinkEmail: runtime.autoLinkEmail,
+    autoProvision: runtime.autoProvision,
+    server: runtime,
+    directory: {
+      linked: linkedCount > 0,
+      linkedCount,
+    },
+    grant: {
+      exists: grant !== null,
+      enabled: grant?.enabled === true,
+      grantedBy: grant?.granted_by ?? null,
+      createdAt: grant?.created_at ?? null,
+      updatedAt: grant?.updated_at ?? null,
+    },
+    identity: {
+      exists: identity !== null,
+      corpId: identity?.corp_id ?? null,
+      lastLoginAt: identity?.last_login_at ?? null,
+      createdAt: identity?.created_at ?? null,
+      updatedAt: identity?.updated_at ?? null,
+    },
+  }
 }
 
 async function loadAuthPermissions(userId: string): Promise<string[]> {
@@ -719,23 +835,9 @@ authRouter.post('/logout', async (req: Request, res: Response) => {
  */
 authRouter.get('/sessions', async (req: Request, res: Response) => {
   try {
-    const authHeader = req.headers.authorization
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null
-
-    if (!token) {
-      return res.status(401).json({
-        success: false,
-        error: 'No token provided'
-      })
-    }
-
-    const user = await authService.verifyToken(token)
-    if (!user) {
-      return res.status(401).json({
-        success: false,
-        error: 'Invalid token'
-      })
-    }
+    const authResult = await requireAuthenticatedUser(req, res)
+    if (!authResult) return
+    const { token, user } = authResult
 
     const payload = authService.readTokenPayload(token)
     const currentSessionId = typeof payload?.sid === 'string' && payload.sid.trim().length > 0 ? payload.sid.trim() : null
@@ -763,23 +865,9 @@ authRouter.get('/sessions', async (req: Request, res: Response) => {
  */
 authRouter.post('/sessions/current/ping', async (req: Request, res: Response) => {
   try {
-    const authHeader = req.headers.authorization
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null
-
-    if (!token) {
-      return res.status(401).json({
-        success: false,
-        error: 'No token provided'
-      })
-    }
-
-    const user = await authService.verifyToken(token)
-    if (!user) {
-      return res.status(401).json({
-        success: false,
-        error: 'Invalid token'
-      })
-    }
+    const authResult = await requireAuthenticatedUser(req, res)
+    if (!authResult) return
+    const { token, user } = authResult
 
     const payload = authService.readTokenPayload(token)
     const sessionId = typeof payload?.sid === 'string' && payload.sid.trim().length > 0 ? payload.sid.trim() : null
@@ -820,23 +908,9 @@ authRouter.post('/sessions/current/ping', async (req: Request, res: Response) =>
  */
 authRouter.post('/sessions/:sessionId/logout', async (req: Request, res: Response) => {
   try {
-    const authHeader = req.headers.authorization
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null
-
-    if (!token) {
-      return res.status(401).json({
-        success: false,
-        error: 'No token provided'
-      })
-    }
-
-    const user = await authService.verifyToken(token)
-    if (!user) {
-      return res.status(401).json({
-        success: false,
-        error: 'Invalid token'
-      })
-    }
+    const authResult = await requireAuthenticatedUser(req, res)
+    if (!authResult) return
+    const { user } = authResult
 
     const sessionId = String(req.params.sessionId || '').trim()
     if (!sessionId) {
@@ -876,6 +950,58 @@ authRouter.post('/sessions/:sessionId/logout', async (req: Request, res: Respons
   }
 })
 
+authRouter.get('/dingtalk/access', async (req: Request, res: Response) => {
+  try {
+    const authResult = await requireAuthenticatedUser(req, res)
+    if (!authResult) return
+
+    const snapshot = await fetchCurrentUserDingTalkAccessSnapshot(authResult.user.id)
+    return res.json({
+      success: true,
+      data: snapshot,
+    })
+  } catch (error) {
+    logger.error('DingTalk access snapshot error', error instanceof Error ? error : undefined)
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to load DingTalk access status',
+    })
+  }
+})
+
+authRouter.post('/dingtalk/unbind', async (req: Request, res: Response) => {
+  try {
+    const authResult = await requireAuthenticatedUser(req, res)
+    if (!authResult) return
+
+    const snapshot = await fetchCurrentUserDingTalkAccessSnapshot(authResult.user.id)
+    if (snapshot.directory.linked) {
+      return res.status(409).json({
+        success: false,
+        error: 'Current DingTalk identity is directory-managed. Please contact an administrator.',
+      })
+    }
+
+    await query(
+      `DELETE FROM user_external_identities
+       WHERE provider = $1 AND local_user_id = $2`,
+      ['dingtalk', authResult.user.id],
+    )
+
+    const nextSnapshot = await fetchCurrentUserDingTalkAccessSnapshot(authResult.user.id)
+    return res.json({
+      success: true,
+      data: nextSnapshot,
+    })
+  } catch (error) {
+    logger.error('DingTalk self-unbind error', error instanceof Error ? error : undefined)
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to unbind DingTalk identity',
+    })
+  }
+})
+
 // ============================================
 // DingTalk OAuth
 // ============================================
@@ -898,8 +1024,22 @@ authRouter.get('/dingtalk/launch', async (req: Request, res: Response) => {
       })
     }
 
+    const rawIntent = typeof req.query.intent === 'string' ? req.query.intent.trim().toLowerCase() : ''
+    const mode: 'bind' | 'login' = rawIntent === 'bind' ? 'bind' : 'login'
     const redirectPath = normalizeDingTalkRedirectPath(req.query.redirect)
-    const state = await generateState({ redirectPath })
+
+    let bindUserId: string | null = null
+    if (mode === 'bind') {
+      const authResult = await requireAuthenticatedUser(req, res)
+      if (!authResult) return
+      bindUserId = authResult.user.id
+    }
+
+    const state = await generateState(
+      mode === 'bind'
+        ? { redirectPath, intent: 'bind', bindUserId }
+        : { redirectPath },
+    )
     const url = buildAuthUrl(state)
 
     return res.json({
@@ -907,6 +1047,7 @@ authRouter.get('/dingtalk/launch', async (req: Request, res: Response) => {
       data: {
         url,
         state,
+        mode,
       },
     })
   } catch (error) {
@@ -945,6 +1086,42 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
       })
     }
 
+    if (stateCheck.intent === 'bind') {
+      const authResult = await requireAuthenticatedUser(req, res)
+      if (!authResult) return
+
+      const expectedUserId = stateCheck.bindUserId || ''
+      if (!expectedUserId || authResult.user.id !== expectedUserId) {
+        return res.status(403).json({
+          success: false,
+          error: 'DingTalk bind session does not match the current user',
+          code: 'bind_user_mismatch',
+        })
+      }
+
+      const dtUser = await exchangeCodeForDingTalkProfile(code)
+      await bindDingTalkIdentityToUser({
+        localUserId: authResult.user.id,
+        dtUser,
+        boundBy: authResult.user.id,
+        enableGrant: true,
+      })
+
+      const snapshot = await fetchCurrentUserDingTalkAccessSnapshot(authResult.user.id)
+
+      logger.info(`DingTalk self-bind for ${authResult.user.email} (openId: ${dtUser.openId})`)
+
+      return res.json({
+        success: true,
+        data: {
+          mode: 'bind',
+          bound: true,
+          redirectPath: stateCheck.redirectPath || null,
+          identity: snapshot,
+        },
+      })
+    }
+
     const result = await exchangeCodeForUser(code)
     const permissions = await loadAuthPermissions(result.localUserId)
     const user: User = {
@@ -963,6 +1140,7 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
     return res.json({
       success: true,
       data: {
+        mode: 'login',
         user: {
           id: user.id,
           email: user.email,

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -239,6 +239,7 @@ describe('admin-users routes', () => {
             id: 'user-1',
             email: 'alpha@example.com',
             name: 'Alpha',
+            mobile: '13800138000',
             role: 'user',
             is_active: true,
             is_admin: false,
@@ -266,7 +267,119 @@ describe('admin-users routes', () => {
     expect((response.body as Record<string, any>).data.items[0]).toMatchObject({
       id: 'user-1',
       email: 'alpha@example.com',
+      mobile: '13800138000',
     })
+  })
+
+  it('pins a deep-linked user when the row is outside the paginated window', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [{ c: 42 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'user-first',
+            email: 'first@example.com',
+            name: 'First',
+            mobile: null,
+            role: 'user',
+            is_active: true,
+            is_admin: false,
+            last_login_at: null,
+            created_at: '2026-03-12T00:00:00.000Z',
+            updated_at: '2026-03-12T00:00:00.000Z',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'user-pinned',
+            email: 'pinned@example.com',
+            name: 'Pinned',
+            mobile: null,
+            role: 'user',
+            is_active: true,
+            is_admin: false,
+            last_login_at: null,
+            created_at: '2026-03-01T00:00:00.000Z',
+            updated_at: '2026-03-01T00:00:00.000Z',
+          },
+        ],
+      })
+
+    const response = await invokeRoute('get', '/api/admin/users', {
+      query: { userId: 'user-pinned', page: '1', pageSize: '20' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(pgMocks.query).toHaveBeenCalledTimes(3)
+    const items = (response.body as Record<string, any>).data.items
+    expect(items[0].id).toBe('user-pinned')
+    expect(items.map((row: Record<string, unknown>) => row.id)).toEqual(['user-pinned', 'user-first'])
+    expect((response.body as Record<string, any>).data.pinUserId).toBe('user-pinned')
+    expect((response.body as Record<string, any>).data.pinUserIncluded).toBe(true)
+  })
+
+  it('skips the extra pin lookup when the deep-linked user already appears in the first page', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [{ c: 3 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'user-a',
+            email: 'a@example.com',
+            name: 'A',
+            mobile: null,
+            role: 'user',
+            is_active: true,
+            is_admin: false,
+            last_login_at: null,
+            created_at: '2026-03-10T00:00:00.000Z',
+            updated_at: '2026-03-10T00:00:00.000Z',
+          },
+          {
+            id: 'user-b',
+            email: 'b@example.com',
+            name: 'B',
+            mobile: null,
+            role: 'user',
+            is_active: true,
+            is_admin: false,
+            last_login_at: null,
+            created_at: '2026-03-09T00:00:00.000Z',
+            updated_at: '2026-03-09T00:00:00.000Z',
+          },
+        ],
+      })
+
+    const response = await invokeRoute('get', '/api/admin/users', {
+      query: { userId: 'user-a' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(pgMocks.query).toHaveBeenCalledTimes(2)
+    expect((response.body as Record<string, any>).data.items.map((row: Record<string, unknown>) => row.id)).toEqual(['user-a', 'user-b'])
+    expect((response.body as Record<string, any>).data.pinUserIncluded).toBe(true)
+  })
+
+  it('reports pinUserIncluded=false when the deep-linked user does not exist', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [{ c: 0 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const response = await invokeRoute('get', '/api/admin/users', {
+      query: { userId: 'missing-user' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(pgMocks.query).toHaveBeenCalledTimes(3)
+    expect((response.body as Record<string, any>).data.items).toEqual([])
+    expect((response.body as Record<string, any>).data.pinUserId).toBe('missing-user')
+    expect((response.body as Record<string, any>).data.pinUserIncluded).toBe(false)
   })
 
   it('rejects non-admin requests', async () => {
@@ -294,6 +407,7 @@ describe('admin-users routes', () => {
           id: 'user-1',
           email: 'alpha@example.com',
           name: 'Alpha',
+          mobile: '13800138000',
           role: 'user',
           is_active: true,
           is_admin: false,

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -550,6 +550,57 @@ describe('admin-users routes', () => {
     })
   })
 
+  it('normalises whitespace on both sides of the mobile CAS witness', async () => {
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue([])
+    pgMocks.query
+      // fetchUserProfile returns legacy dirty data with embedded whitespace.
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: '138 0013 8000',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+        }],
+      })
+      // UPDATE still matches because both sides are normalised in SQL.
+      .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: '13800138000',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-13T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { mobile: '13800138000', expectedMobile: '13800138000' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const updateCall = pgMocks.query.mock.calls[1]
+    expect(String(updateCall[0])).toContain('regexp_replace')
+    expect(String(updateCall[0])).toContain('IS NOT DISTINCT FROM')
+    expect(updateCall[1]).toEqual(['Alpha', '13800138000', 'user-1', true, '13800138000'])
+  })
+
   it('returns 409 when expected mobile no longer matches current value', async () => {
     rbacMocks.isAdmin.mockResolvedValue(true)
     pgMocks.query

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -309,14 +309,15 @@ describe('admin-users routes', () => {
       })
 
     const response = await invokeRoute('get', '/api/admin/users', {
-      query: { userId: 'user-pinned', page: '1', pageSize: '20' },
+      query: { userId: 'user-pinned', page: '1', pageSize: '1' },
     })
 
     expect(response.statusCode).toBe(200)
     expect(pgMocks.query).toHaveBeenCalledTimes(3)
     const items = (response.body as Record<string, any>).data.items
     expect(items[0].id).toBe('user-pinned')
-    expect(items.map((row: Record<string, unknown>) => row.id)).toEqual(['user-pinned', 'user-first'])
+    expect(items.map((row: Record<string, unknown>) => row.id)).toEqual(['user-pinned'])
+    expect(items).toHaveLength(1)
     expect((response.body as Record<string, any>).data.pinUserId).toBe('user-pinned')
     expect((response.body as Record<string, any>).data.pinUserIncluded).toBe(true)
   })

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -430,6 +430,155 @@ describe('admin-users routes', () => {
     expect((response.body as Record<string, any>).data.isAdmin).toBe(false)
   })
 
+  it('updates user profile name and mobile', async () => {
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue(['crm:admin'])
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: null,
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha Prime',
+          mobile: '13800138000',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-13T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ role_id: 'crm_admin' }],
+      })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { name: 'Alpha Prime', mobile: '13800138000', expectedMobile: null },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(pgMocks.query).toHaveBeenNthCalledWith(2,
+      expect.stringContaining('UPDATE users'),
+      ['Alpha Prime', '13800138000', 'user-1', true, null],
+    )
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'update',
+      resourceType: 'user',
+      resourceId: 'user-1',
+      meta: expect.objectContaining({
+        before: { name: 'Alpha', mobile: null },
+        after: { name: 'Alpha Prime', mobile: '13800138000' },
+      }),
+    }))
+    expect((response.body as Record<string, any>).data.user).toMatchObject({
+      id: 'user-1',
+      name: 'Alpha Prime',
+      mobile: '13800138000',
+    })
+  })
+
+  it('clears user mobile profile field', async () => {
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue([])
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: '13800138000',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: null,
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-13T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [],
+      })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { mobile: '   ', expectedMobile: '13800138000' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(pgMocks.query).toHaveBeenNthCalledWith(2,
+      expect.stringContaining('UPDATE users'),
+      ['Alpha', null, 'user-1', true, '13800138000'],
+    )
+    expect((response.body as Record<string, any>).data.user).toMatchObject({
+      id: 'user-1',
+      mobile: null,
+    })
+  })
+
+  it('returns 409 when expected mobile no longer matches current value', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: '13600000000',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { mobile: '13758875801', expectedMobile: '13500000000' },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect((response.body as Record<string, any>).error.code).toBe('PROFILE_MOBILE_CONFLICT')
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
   it('returns dingtalk access details for a user', async () => {
     vi.stubEnv('DINGTALK_AUTH_REQUIRE_GRANT', '1')
     vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '0')

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -42,6 +42,8 @@ const dingtalkOauthMocks = vi.hoisted(() => ({
   buildAuthUrl: vi.fn(),
   validateState: vi.fn(),
   exchangeCodeForUser: vi.fn(),
+  exchangeCodeForDingTalkProfile: vi.fn(),
+  bindDingTalkIdentityToUser: vi.fn(),
   DingTalkLoginPolicyError: class DingTalkLoginPolicyError extends Error {
     statusCode: number
     code: string
@@ -106,6 +108,8 @@ vi.mock('../../src/auth/dingtalk-oauth', () => ({
   buildAuthUrl: dingtalkOauthMocks.buildAuthUrl,
   validateState: dingtalkOauthMocks.validateState,
   exchangeCodeForUser: dingtalkOauthMocks.exchangeCodeForUser,
+  exchangeCodeForDingTalkProfile: dingtalkOauthMocks.exchangeCodeForDingTalkProfile,
+  bindDingTalkIdentityToUser: dingtalkOauthMocks.bindDingTalkIdentityToUser,
   DingTalkLoginPolicyError: dingtalkOauthMocks.DingTalkLoginPolicyError,
 }))
 
@@ -213,6 +217,8 @@ describe('auth login routes', () => {
     dingtalkOauthMocks.buildAuthUrl.mockReset()
     dingtalkOauthMocks.validateState.mockReset()
     dingtalkOauthMocks.exchangeCodeForUser.mockReset()
+    dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockReset()
+    dingtalkOauthMocks.bindDingTalkIdentityToUser.mockReset()
     rbacMocks.listUserPermissions.mockReset()
     dingtalkOauthMocks.getDingTalkRuntimeStatus.mockReturnValue({
       configured: true,
@@ -580,6 +586,353 @@ describe('auth login routes', () => {
     })
     expect(sessionMocks.revokeUserSessions).not.toHaveBeenCalled()
     expect((response.body as Record<string, any>).data.scope).toBe('current-session')
+  })
+
+  it('returns the current-user DingTalk access snapshot', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'manager@example.com',
+      name: 'Manager',
+      role: 'user',
+      permissions: ['attendance:read'],
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          enabled: true,
+          granted_by: 'admin-1',
+          created_at: '2026-04-11T12:00:00.000Z',
+          updated_at: '2026-04-11T12:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          corp_id: 'dingcorp',
+          last_login_at: '2026-04-11T12:00:00.000Z',
+          created_at: '2026-04-11T12:00:00.000Z',
+          updated_at: '2026-04-11T12:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ linked_count: 1 }],
+      })
+
+    const response = await invokeRoute('get', '/dingtalk/access', {
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect((response.body as Record<string, any>).data).toMatchObject({
+      available: true,
+      userId: 'user-1',
+      provider: 'dingtalk',
+      directory: {
+        linked: true,
+        linkedCount: 1,
+      },
+      grant: {
+        exists: true,
+        enabled: true,
+      },
+      identity: {
+        exists: true,
+        corpId: 'dingcorp',
+      },
+    })
+  })
+
+  it('unbinds a self-managed DingTalk identity for the current user', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'manager@example.com',
+      name: 'Manager',
+      role: 'user',
+      permissions: ['attendance:read'],
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          corp_id: 'dingcorp',
+          last_login_at: '2026-04-11T12:00:00.000Z',
+          created_at: '2026-04-11T12:00:00.000Z',
+          updated_at: '2026-04-11T12:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ linked_count: 0 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ linked_count: 0 }] })
+
+    const response = await invokeRoute('post', '/dingtalk/unbind', {
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(pgMocks.query).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('DELETE FROM user_external_identities'),
+      ['dingtalk', 'user-1'],
+    )
+    expect((response.body as Record<string, any>).data.identity.exists).toBe(false)
+    expect((response.body as Record<string, any>).data.directory.linked).toBe(false)
+  })
+
+  it('blocks DingTalk self-unbind when the identity is directory-managed', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'manager@example.com',
+      name: 'Manager',
+      role: 'user',
+      permissions: ['attendance:read'],
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          corp_id: 'dingcorp',
+          last_login_at: '2026-04-11T12:00:00.000Z',
+          created_at: '2026-04-11T12:00:00.000Z',
+          updated_at: '2026-04-11T12:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ linked_count: 2 }] })
+
+    const response = await invokeRoute('post', '/dingtalk/unbind', {
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect((response.body as Record<string, any>).error).toContain('directory-managed')
+    expect(pgMocks.query).toHaveBeenCalledTimes(3)
+  })
+
+  it('requires authentication before issuing a DingTalk bind auth URL', async () => {
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    authServiceMocks.verifyToken.mockResolvedValue(null)
+
+    const response = await invokeRoute('get', '/dingtalk/launch', {
+      query: {
+        intent: 'bind',
+        redirect: '/settings?dingtalk=bound',
+      },
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(dingtalkOauthMocks.generateState).not.toHaveBeenCalled()
+    expect(dingtalkOauthMocks.buildAuthUrl).not.toHaveBeenCalled()
+  })
+
+  it('builds a DingTalk bind auth URL tagged with the current user', async () => {
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.generateState.mockResolvedValue('state-bind-1')
+    dingtalkOauthMocks.buildAuthUrl.mockReturnValue('https://login.dingtalk.test/oauth-bind')
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'manager@example.com',
+      name: 'Manager',
+      role: 'user',
+      permissions: [],
+    })
+
+    const response = await invokeRoute('get', '/dingtalk/launch', {
+      query: {
+        intent: 'bind',
+        redirect: '/settings?dingtalk=bound',
+      },
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(dingtalkOauthMocks.generateState).toHaveBeenCalledWith({
+      redirectPath: '/settings?dingtalk=bound',
+      intent: 'bind',
+      bindUserId: 'user-1',
+    })
+    expect(dingtalkOauthMocks.buildAuthUrl).toHaveBeenCalledWith('state-bind-1')
+    expect((response.body as Record<string, any>).data).toMatchObject({
+      url: 'https://login.dingtalk.test/oauth-bind',
+      state: 'state-bind-1',
+      mode: 'bind',
+    })
+  })
+
+  it('rejects a bind callback when no session token is provided', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/settings?dingtalk=bound',
+      intent: 'bind',
+      bindUserId: 'user-1',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: {
+        code: 'auth-code',
+        state: 'state-bind-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(dingtalkOauthMocks.exchangeCodeForDingTalkProfile).not.toHaveBeenCalled()
+    expect(dingtalkOauthMocks.bindDingTalkIdentityToUser).not.toHaveBeenCalled()
+  })
+
+  it('rejects a bind callback when the session user does not match the bind target', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/settings?dingtalk=bound',
+      intent: 'bind',
+      bindUserId: 'user-1',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-other',
+      email: 'other@example.com',
+      name: 'Other',
+      role: 'user',
+      permissions: [],
+    })
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+      body: {
+        code: 'auth-code',
+        state: 'state-bind-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect((response.body as Record<string, any>).code).toBe('bind_user_mismatch')
+    expect(dingtalkOauthMocks.exchangeCodeForDingTalkProfile).not.toHaveBeenCalled()
+    expect(dingtalkOauthMocks.bindDingTalkIdentityToUser).not.toHaveBeenCalled()
+  })
+
+  it('surfaces 409 when the DingTalk identity is already bound to another user', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/settings?dingtalk=bound',
+      intent: 'bind',
+      bindUserId: 'user-1',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'manager@example.com',
+      name: 'Manager',
+      role: 'user',
+      permissions: [],
+    })
+    dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockResolvedValue({
+      openId: 'open-id-1',
+      unionId: 'union-id-1',
+      nick: 'Ding User',
+      email: 'manager@example.com',
+    })
+    dingtalkOauthMocks.bindDingTalkIdentityToUser.mockRejectedValue(
+      new dingtalkOauthMocks.DingTalkLoginPolicyError(
+        'DingTalk identity is already bound to another local user',
+        { statusCode: 409, code: 'identity_already_bound' },
+      ),
+    )
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+      body: {
+        code: 'auth-code',
+        state: 'state-bind-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect((response.body as Record<string, any>).error).toContain('already bound')
+  })
+
+  it('binds a DingTalk identity to the current user without reissuing a token', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/settings?dingtalk=bound',
+      intent: 'bind',
+      bindUserId: 'user-1',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'manager@example.com',
+      name: 'Manager',
+      role: 'user',
+      permissions: [],
+    })
+    dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockResolvedValue({
+      openId: 'open-id-1',
+      unionId: 'union-id-1',
+      nick: 'Ding User',
+      email: 'manager@example.com',
+    })
+    dingtalkOauthMocks.bindDingTalkIdentityToUser.mockResolvedValue(undefined)
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          enabled: true,
+          granted_by: 'user-1',
+          created_at: '2026-04-11T12:00:00.000Z',
+          updated_at: '2026-04-11T12:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          corp_id: 'dingcorp',
+          last_login_at: null,
+          created_at: '2026-04-11T12:00:00.000Z',
+          updated_at: '2026-04-11T12:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ linked_count: 0 }] })
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+      body: {
+        code: 'auth-code',
+        state: 'state-bind-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(dingtalkOauthMocks.exchangeCodeForDingTalkProfile).toHaveBeenCalledWith('auth-code')
+    expect(dingtalkOauthMocks.bindDingTalkIdentityToUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localUserId: 'user-1',
+        boundBy: 'user-1',
+        enableGrant: true,
+      }),
+    )
+    expect(authServiceMocks.createToken).not.toHaveBeenCalled()
+    expect(sessionRegistryMocks.createUserSession).not.toHaveBeenCalled()
+    expect((response.body as Record<string, any>).data).toMatchObject({
+      mode: 'bind',
+      bound: true,
+      redirectPath: '/settings?dingtalk=bound',
+      identity: expect.objectContaining({
+        userId: 'user-1',
+        identity: expect.objectContaining({ exists: true }),
+      }),
+    })
+    expect((response.body as Record<string, any>).data.token).toBeUndefined()
   })
 
   it('builds a DingTalk auth URL and preserves a safe redirect path in state', async () => {

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -819,6 +819,49 @@ describe('auth login routes', () => {
     expect(dingtalkOauthMocks.bindDingTalkIdentityToUser).not.toHaveBeenCalled()
   })
 
+  it('rejects a bind callback when the current user is directory-managed for DingTalk', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/settings?dingtalk=bound',
+      intent: 'bind',
+      bindUserId: 'user-1',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'manager@example.com',
+      name: 'Manager',
+      role: 'user',
+      permissions: [],
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          corp_id: 'dingcorp',
+          last_login_at: '2026-04-11T12:00:00.000Z',
+          created_at: '2026-04-11T12:00:00.000Z',
+          updated_at: '2026-04-11T12:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ linked_count: 2 }] })
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+      body: {
+        code: 'auth-code',
+        state: 'state-bind-1',
+      },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect((response.body as Record<string, any>).code).toBe('directory_managed_conflict')
+    expect(dingtalkOauthMocks.exchangeCodeForDingTalkProfile).not.toHaveBeenCalled()
+    expect(dingtalkOauthMocks.bindDingTalkIdentityToUser).not.toHaveBeenCalled()
+  })
+
   it('surfaces 409 when the DingTalk identity is already bound to another user', async () => {
     dingtalkOauthMocks.validateState.mockResolvedValue({
       valid: true,
@@ -834,6 +877,10 @@ describe('auth login routes', () => {
       role: 'user',
       permissions: [],
     })
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ linked_count: 0 }] })
     dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockResolvedValue({
       openId: 'open-id-1',
       unionId: 'union-id-1',
@@ -884,6 +931,11 @@ describe('auth login routes', () => {
     })
     dingtalkOauthMocks.bindDingTalkIdentityToUser.mockResolvedValue(undefined)
     pgMocks.query
+      // preSnapshot: directory-managed check must pass (linked_count=0)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ linked_count: 0 }] })
+      // postSnapshot: returned in success payload
       .mockResolvedValueOnce({
         rows: [{
           enabled: true,


### PR DESCRIPTION
## What changed

This PR closes three reviewed DingTalk gaps:

- completes self-service DingTalk bind for already-authenticated users
- stabilizes `/admin/users?userId=...` deep-links when the target row is outside the first paginated page
- closes the mobile profile CAS loop so concurrent admin edits no longer overwrite silently

## User-facing behavior

- Starting DingTalk bind from settings now completes a true bind flow for the current logged-in account.
- DingTalk callback always posts back to the backend when `code` is present, and the frontend now branches on backend `data.mode`:
  - `bind`: keep current session/token, redirect back to settings
  - `login`: preserve existing login behavior
- Directory-managed users are explicitly blocked from self-bind with `409`.
- User management deep-links no longer depend on the target user being present in page 1.
- Admin mobile edits now send an `expectedMobile` CAS witness.
- On `PROFILE_MOBILE_CONFLICT`, the UI refreshes access and shows the true latest value if refresh succeeds; if refresh fails, it falls back to a neutral retry message instead of showing stale data.

## Backend changes

- DingTalk OAuth state now carries bind intent and `bindUserId`
- `GET /api/auth/dingtalk/launch` supports authenticated bind mode
- `POST /api/auth/dingtalk/callback` now supports explicit `bind` vs `login` branching
- self-bind is blocked when the current user is directory-managed
- `GET /api/admin/users` supports deep-link pinning via `userId`
- `PATCH /api/admin/users/:userId/profile` supports `expectedMobile` CAS
- mobile CAS SQL guard now normalizes both sides to avoid false conflicts on legacy whitespace-formatted phone data

## Frontend changes

- `DingTalkAuthCallbackView` no longer relies on a frontend-local bind hint; backend `data.mode` is now the source of truth
- `SessionCenterView` launches bind without writing local intent state
- `UserManagementView`
  - supports stable deep-link focus by `userId`
  - sends `expectedMobile` on profile save
  - handles `PROFILE_MOBILE_CONFLICT` with refresh + correct messaging

## Files included

- `apps/web/src/views/DingTalkAuthCallbackView.vue`
- `apps/web/src/views/SessionCenterView.vue`
- `apps/web/src/views/UserManagementView.vue`
- `apps/web/src/utils/browserLocation.ts`
- `apps/web/tests/dingtalk-auth-callback.spec.ts`
- `apps/web/tests/sessionCenterView.spec.ts`
- `apps/web/tests/userManagementView.spec.ts`
- `packages/core-backend/src/auth/dingtalk-oauth.ts`
- `packages/core-backend/src/routes/auth.ts`
- `packages/core-backend/src/routes/admin-users.ts`
- `packages/core-backend/tests/unit/auth-login-routes.test.ts`
- `packages/core-backend/tests/unit/admin-users-routes.test.ts`

## Verification

Ran:

```bash
pnpm --filter @metasheet/web exec vitest run tests/dingtalk-auth-callback.spec.ts tests/sessionCenterView.spec.ts tests/userManagementView.spec.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts tests/unit/admin-users-routes.test.ts --watch=false
```

Results:

- frontend
  - `dingtalk-auth-callback.spec.ts`: `4 passed`
  - `sessionCenterView.spec.ts`: `4 passed`
  - `userManagementView.spec.ts`: `13 passed`
- backend
  - `auth-login-routes.test.ts`: `29 passed`
  - `admin-users-routes.test.ts`: `58 passed`

## Not in scope

This PR does not include:

- larger `DirectoryManagementView` governance changes
- `admin-directory` / `directory-sync` work
- Yjs rollout changes
- GHCR / release artifact / ops scripts
- `output/` artifacts
