### PR TITLE
feat(dingtalk): complete directory governance review loop

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -37,7 +37,7 @@
           class="directory-admin__item"
           :class="{ 'directory-admin__item--active': selectedIntegrationId === integration.id }"
           type="button"
-          @click="selectIntegration(integration.id)"
+          @click="void selectIntegration(integration.id)"
         >
           <strong>{{ integration.name }}</strong>
           <span>{{ integration.corpId }}</span>
@@ -373,6 +373,21 @@
             <p v-if="item.kind === 'pending_binding' && readBindingSearchError(item.account.id)" class="directory-admin__status directory-admin__status--error">
               {{ readBindingSearchError(item.account.id) }}
             </p>
+            <p
+              v-if="item.kind === 'pending_binding' && readMobileConflictHint(item.account.id)"
+              class="directory-admin__status directory-admin__status--error"
+            >
+              {{ readMobileConflictHint(item.account.id) }}
+            </p>
+            <p
+              v-if="item.kind === 'pending_binding' && item.account.mobile && readSelectedBindingUser(item)"
+              class="directory-admin__hint"
+              :class="{ 'directory-admin__status directory-admin__status--error': hasSelectedBindingUserMobileConflict(item) }"
+            >
+              平台手机号：{{ readSelectedBindingUser(item)?.mobile || '未设置' }} ·
+              目录手机号：{{ item.account.mobile }} ·
+              {{ hasSelectedBindingUserMobileConflict(item) ? '存在差异，覆盖前需确认。' : '可直接回填到平台用户。' }}
+            </p>
             <div class="directory-admin__actions">
               <button
                 v-if="item.kind === 'pending_binding'"
@@ -390,6 +405,13 @@
               >
                 定位到成员
               </button>
+              <router-link
+                v-if="item.kind === 'pending_binding' && readSelectedBindingUser(item)"
+                class="directory-admin__button directory-admin__button--secondary"
+                :to="buildUserManagementLocation(readSelectedBindingUser(item)!.id, item.account)"
+              >
+                查看本地用户
+              </router-link>
               <button
                 v-if="item.kind === 'pending_binding'"
                 class="directory-admin__button"
@@ -398,6 +420,42 @@
                 @click="void confirmRecommendedReviewBinding(item)"
               >
                 {{ reviewProcessingAccountId === item.account.id ? '处理中...' : '确认推荐' }}
+              </button>
+              <button
+                v-if="item.kind === 'pending_binding' && item.account.mobile && readSelectedBindingUser(item)"
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="reviewProcessingAccountId === item.account.id"
+                @click="void backfillUserMobileAndBindReviewItem(item)"
+              >
+                {{ reviewProcessingAccountId === item.account.id ? '处理中...' : readBackfillAndBindLabel(item) }}
+              </button>
+              <button
+                v-if="item.kind === 'pending_binding' && isAwaitingMobileOverrideConfirmation(item.account.id)"
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="reviewProcessingAccountId === item.account.id"
+                @click="clearMobileOverrideConfirmation(item.account.id)"
+              >
+                取消覆盖确认
+              </button>
+              <button
+                v-if="item.kind === 'pending_binding' && readMobileConflictHint(item.account.id)"
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="reviewProcessingAccountId === item.account.id"
+                @click="clearMobileConflictHint(item.account.id)"
+              >
+                关闭冲突提示
+              </button>
+              <button
+                v-if="item.kind === 'pending_binding' && readMobileConflictHint(item.account.id)"
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="reviewProcessingAccountId === item.account.id"
+                @click="void retryBackfillUserMobileAndBindReviewItem(item)"
+              >
+                按最新手机号重试
               </button>
               <button
                 v-if="item.kind === 'pending_binding'"
@@ -558,6 +616,58 @@
               </button>
             </div>
           </div>
+          <article v-if="routeNavigationFailureNotice" class="directory-admin__route-banner">
+            <div class="directory-admin__alert-head">
+              <div>
+                <strong>定位未完成</strong>
+                <p class="directory-admin__hint">{{ routeNavigationFailureNotice.message }}</p>
+                <p v-if="routeNavigationFailureNotice.targetIntegrationId" class="directory-admin__hint">
+                  目标集成：{{ routeNavigationFailureNotice.targetIntegrationId }}
+                </p>
+                <p v-if="routeNavigationFailureNotice.targetAccountId" class="directory-admin__hint">
+                  目标成员：{{ routeNavigationFailureNotice.targetAccountId }}
+                </p>
+                <p v-if="routeNavigationFailureNotice.currentIntegrationName" class="directory-admin__hint">
+                  当前仍停留在 {{ routeNavigationFailureNotice.currentIntegrationName }}
+                </p>
+              </div>
+              <div class="directory-admin__chips">
+                <span class="directory-admin__chip directory-admin__chip--danger">导航失败</span>
+                <span class="directory-admin__chip">
+                  {{ routeNavigationFailureNotice.kind === 'missing_integration' ? '集成不存在' : '成员不存在' }}
+                </span>
+              </div>
+            </div>
+            <div class="directory-admin__actions">
+              <button
+                class="directory-admin__button"
+                type="button"
+                :disabled="routeNavigationFailureAction.length > 0"
+                @click="void retryRouteNavigationFailureNotice()"
+              >
+                {{ routeNavigationFailureAction === 'retry' ? '重试中...' : '重试定位' }}
+              </button>
+              <router-link
+                v-if="routeNavigationFailureUserManagementLocation"
+                class="directory-admin__button directory-admin__button--secondary"
+                :to="routeNavigationFailureUserManagementLocation"
+              >
+                返回用户管理
+              </router-link>
+              <button
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="routeNavigationFailureAction.length > 0"
+                @click="clearFailedDirectoryNavigation()"
+              >
+                {{
+                  routeNavigationFailureNotice.currentIntegrationName
+                    ? `留在 ${routeNavigationFailureNotice.currentIntegrationName}`
+                    : '清除失败定位'
+                }}
+              </button>
+            </div>
+          </article>
 
           <article v-if="focusedAccountId" class="directory-admin__focus-card">
             <div>
@@ -571,6 +681,13 @@
               </p>
             </div>
             <div class="directory-admin__focus-actions">
+              <router-link
+                v-if="focusedVisibleAccount?.localUser?.id"
+                class="directory-admin__button directory-admin__button--secondary"
+                :to="buildUserManagementLocation(focusedVisibleAccount.localUser.id, focusedVisibleAccount)"
+              >
+                前往用户管理
+              </router-link>
               <button
                 v-if="focusedVisibleAccount && focusedVisibleAccountBindDraft.length > 0"
                 class="directory-admin__button"
@@ -623,6 +740,14 @@
             <p class="directory-admin__hint">
               部门：{{ account.departmentPaths.join('，') || '未分配部门' }}
             </p>
+            <div v-if="account.localUser?.id" class="directory-admin__actions">
+              <router-link
+                class="directory-admin__button directory-admin__button--secondary"
+                :to="buildUserManagementLocation(account.localUser.id, account)"
+              >
+                前往用户管理
+              </router-link>
+            </div>
 
             <div class="directory-admin__form-grid directory-admin__form-grid--account">
               <label class="directory-admin__field">
@@ -777,8 +902,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, reactive, ref } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref } from 'vue'
 import { apiFetch } from '../utils/api'
+import { subscribeToLocationChanges } from '../utils/browserLocation'
 
 type DirectoryIntegration = {
   id: string
@@ -948,8 +1074,24 @@ type LocalUserOption = {
   id: string
   email: string
   name: string | null
+  mobile?: string | null
   role: string
   is_active: boolean
+}
+
+type InitialDirectoryNavigation = {
+  integrationId: string
+  accountId: string
+  source: string
+  userId: string
+}
+
+type DirectoryRouteNavigationFailureNotice = {
+  kind: 'missing_integration' | 'missing_account'
+  message: string
+  targetIntegrationId: string
+  targetAccountId: string
+  currentIntegrationName: string
 }
 
 type TestResult = {
@@ -1014,6 +1156,8 @@ const reviewBatchProcessing = ref(false)
 const reviewBatchProgress = ref<ReviewBatchProgress | null>(null)
 const status = ref('')
 const statusTone = ref<'info' | 'error'>('info')
+const routeNavigationFailureNotice = ref<DirectoryRouteNavigationFailureNotice | null>(null)
+const routeNavigationFailureAction = ref<'retry' | 'clear' | ''>('')
 const testResult = ref<TestResult | null>(null)
 const accountQuery = ref('')
 const alertFilter = ref<DirectoryAlertFilter>('all')
@@ -1022,6 +1166,9 @@ const pendingBindingView = ref<PendingBindingView>('recommended')
 const pendingBindingViewTouched = ref(false)
 const pendingBindingManualReason = ref<PendingBindingManualReasonFilter>('all')
 const bindingDrafts = reactive<Record<string, string>>({})
+const selectedBindingUsers = reactive<Record<string, LocalUserOption>>({})
+const mobileOverrideConfirmations = reactive<Record<string, boolean>>({})
+const mobileConflictHints = reactive<Record<string, string>>({})
 const userSearchResults = reactive<Record<string, LocalUserOption[]>>({})
 const userSearchLoading = reactive<Record<string, boolean>>({})
 const userSearchError = reactive<Record<string, string>>({})
@@ -1031,6 +1178,7 @@ const reviewDisableDingTalkGrant = ref(true)
 const reviewPageSize = 100
 const reviewPage = ref(1)
 const reviewTotal = ref(0)
+const appliedDirectoryNavigationKey = ref('')
 const alertFilterOptions = [
   { value: 'all' as const, label: '全部' },
   { value: 'pending' as const, label: '待确认' },
@@ -1052,6 +1200,7 @@ const pendingBindingManualReasonOptions = [
   { value: 'no_exact_match' as const, label: '无精确匹配' },
   { value: 'conflict' as const, label: '冲突待复核' },
 ]
+const directoryNavigation = ref(readInitialDirectoryNavigation())
 
 const draft = reactive<DirectoryDraft>({
   name: '',
@@ -1070,6 +1219,21 @@ const draft = reactive<DirectoryDraft>({
 const selectedIntegration = computed(() =>
   integrations.value.find((integration) => integration.id === selectedIntegrationId.value) ?? null,
 )
+const routeNavigationFailureUserManagementLocation = computed(() => {
+  const navigation = directoryNavigation.value
+  if (navigation.source !== 'user-management' || navigation.userId.trim().length === 0) return ''
+  const params = new URLSearchParams({
+    userId: navigation.userId.trim(),
+    source: 'directory-sync',
+  })
+  const failureKind = routeNavigationFailureNotice.value?.kind?.trim() || ''
+  const integrationId = routeNavigationFailureNotice.value?.targetIntegrationId?.trim() || navigation.integrationId.trim()
+  const accountId = routeNavigationFailureNotice.value?.targetAccountId?.trim() || navigation.accountId.trim()
+  if (failureKind.length > 0) params.set('directoryFailure', failureKind)
+  if (integrationId.length > 0) params.set('integrationId', integrationId)
+  if (accountId.length > 0) params.set('accountId', accountId)
+  return `/admin/users?${params.toString()}`
+})
 const accountPageCount = computed(() => Math.max(1, Math.ceil(accountTotal.value / accountPageSize.value)))
 const accountRangeStart = computed(() => (
   accountTotal.value === 0
@@ -1199,6 +1363,57 @@ function setStatus(message: string, tone: 'info' | 'error' = 'info') {
   statusTone.value = tone
 }
 
+function readInitialDirectoryNavigation(): InitialDirectoryNavigation {
+  if (typeof window === 'undefined') {
+    return { integrationId: '', accountId: '', source: '', userId: '' }
+  }
+  const params = new URL(window.location.href).searchParams
+  return {
+    integrationId: params.get('integrationId')?.trim() || '',
+    accountId: params.get('accountId')?.trim() || '',
+    source: params.get('source')?.trim() || '',
+    userId: params.get('userId')?.trim() || '',
+  }
+}
+
+function buildDirectoryNavigationKey(navigation: InitialDirectoryNavigation): string {
+  return [
+    navigation.integrationId.trim(),
+    navigation.accountId.trim(),
+    navigation.source.trim(),
+    navigation.userId.trim(),
+  ].join('|')
+}
+
+function buildDirectoryLocation(navigation: InitialDirectoryNavigation): string {
+  if (typeof window === 'undefined') return '/admin/directory'
+  const url = new URL(window.location.href)
+  const params = new URLSearchParams(url.search)
+  const updateParam = (key: string, value: string) => {
+    if (value.trim().length > 0) params.set(key, value.trim())
+    else params.delete(key)
+  }
+  updateParam('integrationId', navigation.integrationId)
+  updateParam('accountId', navigation.accountId)
+  updateParam('source', navigation.source)
+  updateParam('userId', navigation.userId)
+  const search = params.toString()
+  return `${url.pathname}${search ? `?${search}` : ''}${url.hash}`
+}
+
+function replaceDirectoryNavigation(navigation: InitialDirectoryNavigation): void {
+  if (typeof window === 'undefined') return
+  window.history.replaceState(window.history.state, '', buildDirectoryLocation(navigation))
+}
+
+function syncDirectoryNavigationFromLocation(): boolean {
+  const next = readInitialDirectoryNavigation()
+  const currentKey = buildDirectoryNavigationKey(directoryNavigation.value)
+  const nextKey = buildDirectoryNavigationKey(next)
+  directoryNavigation.value = next
+  return currentKey !== nextKey
+}
+
 function resetDraft() {
   selectedIntegrationId.value = ''
   testResult.value = null
@@ -1221,6 +1436,9 @@ function resetDraft() {
   pendingBindingManualReason.value = 'all'
   reviewDisableDingTalkGrant.value = true
   for (const key of Object.keys(bindingDrafts)) delete bindingDrafts[key]
+  for (const key of Object.keys(selectedBindingUsers)) delete selectedBindingUsers[key]
+  for (const key of Object.keys(mobileOverrideConfirmations)) delete mobileOverrideConfirmations[key]
+  for (const key of Object.keys(mobileConflictHints)) delete mobileConflictHints[key]
   for (const key of Object.keys(userSearchResults)) delete userSearchResults[key]
   for (const key of Object.keys(userSearchLoading)) delete userSearchLoading[key]
   for (const key of Object.keys(userSearchError)) delete userSearchError[key]
@@ -1253,7 +1471,7 @@ function applyIntegrationToDraft(integration: DirectoryIntegration) {
   draft.syncEnabled = integration.syncEnabled
 }
 
-function selectIntegration(integrationId: string) {
+async function selectIntegration(integrationId: string): Promise<void> {
   selectedIntegrationId.value = integrationId
   testResult.value = null
   clearFocusedAccount()
@@ -1271,7 +1489,8 @@ function selectIntegration(integrationId: string) {
   const integration = integrations.value.find((item) => item.id === integrationId)
   if (!integration) return
   applyIntegrationToDraft(integration)
-  void Promise.all([
+  await applyInitialDirectoryNavigationBeforeLoads(integrationId)
+  await Promise.all([
     loadRuns(integrationId),
     loadScheduleSnapshot(integrationId),
     loadAlerts(integrationId),
@@ -1283,6 +1502,11 @@ function selectIntegration(integrationId: string) {
 function readApiError(payload: unknown, fallback: string): string {
   const error = payload && typeof payload === 'object' ? (payload as { error?: { message?: unknown } }).error : undefined
   return typeof error?.message === 'string' && error.message.trim().length > 0 ? error.message : fallback
+}
+
+function readApiErrorCode(payload: unknown): string {
+  const error = payload && typeof payload === 'object' ? (payload as { error?: { code?: unknown } }).error : undefined
+  return typeof error?.code === 'string' ? error.code : ''
 }
 
 async function readJson(response: Response): Promise<any> {
@@ -1301,8 +1525,54 @@ async function loadIntegrations() {
     if (!response.ok) throw new Error(readApiError(payload, '加载目录集成失败'))
 
     integrations.value = Array.isArray(payload?.data?.items) ? payload.data.items : []
+    const navigation = directoryNavigation.value
+    const navigationKey = buildDirectoryNavigationKey(navigation)
+    const hasPendingCrossIntegrationNavigation = (
+      navigation.accountId.length > 0
+      && navigation.integrationId.length > 0
+      && navigation.integrationId !== selectedIntegrationId.value
+      && navigationKey !== appliedDirectoryNavigationKey.value
+    )
     if (!selectedIntegrationId.value && integrations.value.length > 0) {
-      selectIntegration(integrations.value[0].id)
+      const requestedIntegrationId = navigation.integrationId
+      const requestedIntegration = requestedIntegrationId
+        ? integrations.value.find((item) => item.id === requestedIntegrationId)
+        : null
+      if (requestedIntegrationId && !requestedIntegration) {
+        clearFocusedAccountNavigationState()
+        const message = readDirectoryIntegrationMissingMessage(requestedIntegrationId)
+        setStatus(message, 'error')
+        setRouteNavigationFailureNotice({
+          kind: 'missing_integration',
+          message,
+          targetIntegrationId: requestedIntegrationId,
+          targetAccountId: navigation.accountId,
+          currentIntegrationName: integrations.value[0]?.name ?? '',
+        })
+      }
+      const targetIntegration = requestedIntegration || integrations.value[0]
+      if (targetIntegration) await selectIntegration(targetIntegration.id)
+    } else if (hasPendingCrossIntegrationNavigation) {
+      const targetIntegration = integrations.value.find((item) => item.id === navigation.integrationId)
+      if (targetIntegration) {
+        await selectIntegration(targetIntegration.id)
+        return
+      }
+      clearFocusedAccountNavigationState()
+      const message = readDirectoryIntegrationMissingMessage(navigation.integrationId)
+      setStatus(message, 'error')
+      setRouteNavigationFailureNotice({
+        kind: 'missing_integration',
+        message,
+        targetIntegrationId: navigation.integrationId,
+        targetAccountId: navigation.accountId,
+        currentIntegrationName: selectedIntegration.value?.name ?? '',
+      })
+      const current = integrations.value.find((item) => item.id === selectedIntegrationId.value)
+      if (current) {
+        applyIntegrationToDraft(current)
+        await loadAccounts(current.id)
+      }
     } else if (selectedIntegrationId.value) {
       const current = integrations.value.find((item) => item.id === selectedIntegrationId.value)
       if (current) applyIntegrationToDraft(current)
@@ -1329,8 +1599,68 @@ function clearFocusedAccount() {
   pendingFocusedAccountScroll.value = false
 }
 
+function clearFocusedAccountNavigationState() {
+  clearFocusedAccount()
+  accountQuery.value = ''
+  accountPage.value = 1
+}
+
+function clearRouteNavigationFailureNotice() {
+  routeNavigationFailureNotice.value = null
+}
+
+async function retryRouteNavigationFailureNotice(): Promise<void> {
+  if (!routeNavigationFailureNotice.value || routeNavigationFailureAction.value.length > 0) return
+  routeNavigationFailureAction.value = 'retry'
+  try {
+    appliedDirectoryNavigationKey.value = ''
+    await handleDirectoryNavigationChange()
+  } finally {
+    routeNavigationFailureAction.value = ''
+  }
+}
+
+function clearFailedDirectoryNavigation() {
+  if (!routeNavigationFailureNotice.value || routeNavigationFailureAction.value.length > 0) return
+  routeNavigationFailureAction.value = 'clear'
+  try {
+    const retainedIntegrationId = selectedIntegration.value?.id ?? selectedIntegrationId.value
+    const retainedIntegrationName = selectedIntegration.value?.name ?? routeNavigationFailureNotice.value.currentIntegrationName
+    clearRouteNavigationFailureNotice()
+    replaceDirectoryNavigation({
+      integrationId: retainedIntegrationId,
+      accountId: '',
+      source: '',
+      userId: '',
+    })
+    setStatus(retainedIntegrationName ? `已保留当前目录上下文 ${retainedIntegrationName}` : '已清除失败定位条件')
+  } finally {
+    routeNavigationFailureAction.value = ''
+  }
+}
+
+function setRouteNavigationFailureNotice(notice: DirectoryRouteNavigationFailureNotice) {
+  routeNavigationFailureNotice.value = notice
+}
+
+function readDirectoryIntegrationMissingMessage(integrationId: string): string {
+  return `未找到目录集成 ${integrationId}，请确认该集成仍存在或稍后刷新列表重试`
+}
+
+function readDirectoryAccountMissingMessage(accountId: string): string {
+  return `未找到目录成员 ${accountId}，请确认该成员仍存在`
+}
+
 function updateBindingDraft(accountId: string, value: string) {
   bindingDrafts[accountId] = value
+  const selectedUser = selectedBindingUsers[accountId]
+  if (!selectedUser) return
+  const normalizedValue = value.trim()
+  if (normalizedValue !== selectedUser.id && normalizedValue !== (selectedUser.email || '')) {
+    delete selectedBindingUsers[accountId]
+    delete mobileOverrideConfirmations[accountId]
+    delete mobileConflictHints[accountId]
+  }
 }
 
 function onBindingDraftInput(accountId: string, event: Event) {
@@ -1388,12 +1718,81 @@ async function searchLocalUsers(accountId: string) {
 
 function chooseLocalUser(accountId: string, user: LocalUserOption) {
   updateBindingDraft(accountId, user.email || user.id)
+  selectedBindingUsers[accountId] = user
+  delete mobileOverrideConfirmations[accountId]
+  delete mobileConflictHints[accountId]
   setBindingSearchState(accountId, { results: [] })
 }
 
 function applyRecommendedLocalUser(accountId: string, recommendation: DirectoryBindingRecommendation) {
   updateBindingDraft(accountId, recommendation.localUser.email || recommendation.localUser.id)
+  selectedBindingUsers[accountId] = recommendation.localUser
+  delete mobileOverrideConfirmations[accountId]
+  delete mobileConflictHints[accountId]
   clearBindingSearch(accountId)
+}
+
+function readSelectedBindingUser(item: DirectoryReviewItem): LocalUserOption | null {
+  return selectedBindingUsers[item.account.id] ?? item.recommendations[0]?.localUser ?? null
+}
+
+function hasSelectedBindingUserMobileConflict(item: DirectoryReviewItem): boolean {
+  const selectedUser = readSelectedBindingUser(item)
+  const accountMobile = item.account.mobile?.trim() || ''
+  const userMobile = selectedUser?.mobile?.trim() || ''
+  return accountMobile.length > 0 && userMobile.length > 0 && accountMobile !== userMobile
+}
+
+function isAwaitingMobileOverrideConfirmation(accountId: string): boolean {
+  return mobileOverrideConfirmations[accountId] === true
+}
+
+function clearMobileOverrideConfirmation(accountId: string): void {
+  delete mobileOverrideConfirmations[accountId]
+}
+
+function readBackfillAndBindLabel(item: DirectoryReviewItem): string {
+  if (hasSelectedBindingUserMobileConflict(item)) {
+    return isAwaitingMobileOverrideConfirmation(item.account.id) ? '确认覆盖手机号并绑定' : '回填手机号后绑定'
+  }
+  return '回填手机号后绑定'
+}
+
+async function refreshSingleReviewItem(accountId: string): Promise<void> {
+  const response = await apiFetch(`/api/admin/directory/accounts/${encodeURIComponent(accountId)}/review-item`)
+  const body = await readJson(response)
+  if (!response.ok) throw new Error(readApiError(body, '刷新待绑定项失败'))
+  const item = body?.data?.item
+  if (!item || typeof item !== 'object') return
+  const normalizedItem = normalizeReviewItems([item])[0]
+  if (!normalizedItem) return
+  const currentIndex = reviewItems.value.findIndex((entry) => entry.account.id === accountId)
+  if (currentIndex >= 0) {
+    reviewItems.value = reviewItems.value.map((entry, index) => index === currentIndex ? normalizedItem : entry)
+  } else {
+    reviewItems.value = [normalizedItem, ...reviewItems.value]
+  }
+  syncPendingBindingQueueDefaults()
+}
+
+function readMobileConflictHint(accountId: string): string {
+  return mobileConflictHints[accountId] ?? ''
+}
+
+function clearMobileConflictHint(accountId: string): void {
+  delete mobileConflictHints[accountId]
+}
+
+async function refreshSingleAccount(accountId: string): Promise<void> {
+  const response = await apiFetch(`/api/admin/directory/accounts/${encodeURIComponent(accountId)}`)
+  const body = await readJson(response)
+  if (!response.ok) throw new Error(readApiError(body, '刷新目录成员失败'))
+  const account = body?.data?.account as DirectoryAccount | undefined
+  if (!account) return
+  const currentIndex = accounts.value.findIndex((entry) => entry.id === accountId)
+  if (currentIndex >= 0) {
+    accounts.value = accounts.value.map((entry, index) => index === currentIndex ? account : entry)
+  }
 }
 
 function readRecommendationReasonLabel(reasons: DirectoryBindingRecommendationReason[]): string {
@@ -1457,7 +1856,7 @@ async function saveIntegration() {
     setStatus(selectedIntegration.value ? '目录集成已更新' : '目录集成已创建')
     testResult.value = null
     await loadIntegrations()
-    if (integration?.id) selectIntegration(integration.id)
+    if (integration?.id) await selectIntegration(integration.id)
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '保存目录集成失败', 'error')
   } finally {
@@ -1951,6 +2350,92 @@ function focusReviewAccount(item: DirectoryReviewItem) {
   }
 }
 
+async function applyInitialDirectoryNavigationBeforeLoads(integrationId: string): Promise<void> {
+  const navigation = directoryNavigation.value
+  const navigationKey = buildDirectoryNavigationKey(navigation)
+  if (navigationKey && appliedDirectoryNavigationKey.value === navigationKey) return
+  const targetAccountId = navigation.accountId
+  if (!targetAccountId) {
+    appliedDirectoryNavigationKey.value = navigationKey
+    return
+  }
+  if (navigation.integrationId && navigation.integrationId !== integrationId) return
+
+  try {
+    clearFocusedAccountNavigationState()
+    const response = await apiFetch(`/api/admin/directory/accounts/${encodeURIComponent(targetAccountId)}`)
+    const body = await readJson(response)
+    if (!response.ok) {
+      const fallback = response.status === 404
+        ? readDirectoryAccountMissingMessage(targetAccountId)
+        : '定位目录成员失败'
+      throw new Error(readApiError(body, fallback))
+    }
+    const account = body?.data?.account as DirectoryAccount | undefined
+    if (!account) throw new Error(readDirectoryAccountMissingMessage(targetAccountId))
+    clearRouteNavigationFailureNotice()
+    focusedAccountId.value = account.id
+    pendingFocusedAccountScroll.value = true
+    accountQuery.value = account.externalUserId
+    accountPage.value = 1
+    if (navigation.source === 'user-management') {
+      setStatus(`已从用户管理定位到目录成员 ${account.name}`)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '定位目录成员失败'
+    setStatus(message, 'error')
+    setRouteNavigationFailureNotice({
+      kind: 'missing_account',
+      message,
+      targetIntegrationId: navigation.integrationId || integrationId,
+      targetAccountId,
+      currentIntegrationName: selectedIntegration.value?.name ?? '',
+    })
+  } finally {
+    appliedDirectoryNavigationKey.value = navigationKey
+  }
+}
+
+async function handleDirectoryNavigationChange(): Promise<void> {
+  const navigation = directoryNavigation.value
+  const navigationKey = buildDirectoryNavigationKey(navigation)
+  if (!navigation.accountId) {
+    clearRouteNavigationFailureNotice()
+    appliedDirectoryNavigationKey.value = navigationKey
+    return
+  }
+  if (navigationKey && appliedDirectoryNavigationKey.value === navigationKey) return
+
+  const targetIntegrationId = navigation.integrationId || selectedIntegrationId.value || integrations.value[0]?.id || ''
+  if (!targetIntegrationId) return
+
+  if (selectedIntegrationId.value !== targetIntegrationId) {
+    const targetExists = integrations.value.some((item) => item.id === targetIntegrationId)
+    if (targetExists) {
+      await selectIntegration(targetIntegrationId)
+      return
+    }
+    await loadIntegrations()
+    return
+  }
+
+  await applyInitialDirectoryNavigationBeforeLoads(targetIntegrationId)
+  await Promise.all([
+    loadReviewItems(targetIntegrationId),
+    loadAccounts(targetIntegrationId),
+  ])
+}
+
+function buildUserManagementLocation(userId: string, account: Pick<DirectoryAccount, 'id' | 'integrationId'>): string {
+  const params = new URLSearchParams({
+    userId,
+    source: 'directory-sync',
+    integrationId: account.integrationId,
+    accountId: account.id,
+  })
+  return `/admin/users?${params.toString()}`
+}
+
 async function handleReviewUnbind(item: DirectoryReviewItem) {
   reviewProcessingAccountId.value = item.account.id
   try {
@@ -2041,6 +2526,70 @@ async function handleReviewBind(item: DirectoryReviewItem) {
   } finally {
     reviewProcessingAccountId.value = ''
   }
+}
+
+async function backfillUserMobileAndBindReviewItem(item: DirectoryReviewItem) {
+  const selectedUser = readSelectedBindingUser(item)
+  const mobile = item.account.mobile?.trim()
+  if (!selectedUser || !mobile) return
+  if (hasSelectedBindingUserMobileConflict(item) && !isAwaitingMobileOverrideConfirmation(item.account.id)) {
+    mobileOverrideConfirmations[item.account.id] = true
+    setStatus(`待处理成员 ${item.account.name} 的平台手机号与目录手机号不一致，请再次确认后覆盖并绑定`, 'error')
+    return
+  }
+
+  reviewProcessingAccountId.value = item.account.id
+  try {
+    delete mobileConflictHints[item.account.id]
+    const profileResponse = await apiFetch(`/api/admin/users/${encodeURIComponent(selectedUser.id)}/profile`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        mobile,
+        expectedMobile: selectedUser.mobile ?? null,
+      }),
+    })
+    const profileBody = await readJson(profileResponse)
+    if (!profileResponse.ok) {
+      if (readApiErrorCode(profileBody) === 'PROFILE_MOBILE_CONFLICT') {
+        delete mobileOverrideConfirmations[item.account.id]
+        delete selectedBindingUsers[item.account.id]
+        await Promise.all([
+          refreshSingleReviewItem(item.account.id),
+          refreshSingleAccount(item.account.id),
+        ])
+        const refreshedItem = reviewItems.value.find((entry) => entry.account.id === item.account.id)
+        const refreshedUser = refreshedItem ? readSelectedBindingUser(refreshedItem) : null
+        mobileConflictHints[item.account.id] = refreshedUser?.mobile
+          ? `待处理成员 ${item.account.name} 的平台手机号已更新为 ${refreshedUser.mobile}，请按最新差异重新确认。`
+          : `待处理成员 ${item.account.name} 的平台手机号已被其他操作更新，请按最新差异重新确认。`
+        setStatus(`待处理成员 ${item.account.name} 的平台手机号已被其他操作更新，请刷新后的最新差异为准`, 'error')
+        return
+      }
+      throw new Error(readApiError(profileBody, '回填用户手机号失败'))
+    }
+
+    selectedBindingUsers[item.account.id] = {
+      ...selectedUser,
+      mobile,
+    }
+    delete mobileOverrideConfirmations[item.account.id]
+
+    await submitReviewBindings([{
+      accountId: item.account.id,
+      localUserRef: selectedUser.id,
+      enableDingTalkGrant: readGrantToggle(item.account.id),
+    }], `待处理成员 ${item.account.name} 已回填手机号并完成绑定`, '回填手机号并绑定失败')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '回填手机号并绑定失败', 'error')
+  } finally {
+    reviewProcessingAccountId.value = ''
+  }
+}
+
+async function retryBackfillUserMobileAndBindReviewItem(item: DirectoryReviewItem) {
+  clearMobileConflictHint(item.account.id)
+  clearMobileOverrideConfirmation(item.account.id)
+  await backfillUserMobileAndBindReviewItem(item)
 }
 
 async function batchBindReviewItems() {
@@ -2221,8 +2770,17 @@ function formatSampleUsers(users: Array<{ userId: string; name: string }>, hasMo
   return hasMore ? `${summary} 等` : summary
 }
 
+const stopDirectoryLocationSync = subscribeToLocationChanges(() => {
+  if (!syncDirectoryNavigationFromLocation()) return
+  void handleDirectoryNavigationChange()
+})
+
 onMounted(() => {
   void loadIntegrations()
+})
+
+onUnmounted(() => {
+  stopDirectoryLocationSync()
 })
 </script>
 
@@ -2420,6 +2978,16 @@ onMounted(() => {
 
 .directory-admin__empty {
   color: #64748b;
+}
+
+.directory-admin__route-banner {
+  border: 1px solid #fca5a5;
+  border-radius: 14px;
+  padding: 14px;
+  background: linear-gradient(180deg, #fff1f2 0%, #fff7ed 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .directory-admin__focus-card {

--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -380,7 +380,7 @@
               {{ readMobileConflictHint(item.account.id) }}
             </p>
             <p
-              v-if="item.kind === 'pending_binding' && item.account.mobile && readSelectedBindingUser(item)"
+              v-if="shouldOfferMobileBackfill(item)"
               class="directory-admin__hint"
               :class="{ 'directory-admin__status directory-admin__status--error': hasSelectedBindingUserMobileConflict(item) }"
             >
@@ -422,7 +422,7 @@
                 {{ reviewProcessingAccountId === item.account.id ? '处理中...' : '确认推荐' }}
               </button>
               <button
-                v-if="item.kind === 'pending_binding' && item.account.mobile && readSelectedBindingUser(item)"
+                v-if="shouldOfferMobileBackfill(item)"
                 class="directory-admin__button directory-admin__button--secondary"
                 type="button"
                 :disabled="reviewProcessingAccountId === item.account.id"
@@ -1741,6 +1741,13 @@ function hasSelectedBindingUserMobileConflict(item: DirectoryReviewItem): boolea
   const accountMobile = item.account.mobile?.trim() || ''
   const userMobile = selectedUser?.mobile?.trim() || ''
   return accountMobile.length > 0 && userMobile.length > 0 && accountMobile !== userMobile
+}
+
+function shouldOfferMobileBackfill(item: DirectoryReviewItem): boolean {
+  const selectedUser = readSelectedBindingUser(item)
+  const accountMobile = item.account.mobile?.trim() || ''
+  const userMobile = selectedUser?.mobile?.trim() || ''
+  return item.kind === 'pending_binding' && accountMobile.length > 0 && selectedUser !== null && accountMobile !== userMobile
 }
 
 function isAwaitingMobileOverrideConfirmation(accountId: string): boolean {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -23,6 +23,26 @@ function createJsonResponse(payload: unknown, status = 200) {
   }
 }
 
+function registerRouterLink(app: App<Element>, withHref = false): void {
+  app.component('RouterLink', {
+    props: ['to'],
+    computed: {
+      resolvedHref(): string {
+        return typeof this.to === 'string' ? this.to : String(this.to || '')
+      },
+    },
+    template: withHref ? '<a :href="resolvedHref"><slot /></a>' : '<a><slot /></a>',
+  })
+}
+
+function findAccountsSection(container: HTMLElement): HTMLElement {
+  const section = Array.from(container.querySelectorAll('.directory-admin__section')).find((candidate) => candidate.textContent?.includes('成员账号'))
+  if (!(section instanceof HTMLElement)) {
+    throw new Error('Accounts section not found')
+  }
+  return section
+}
+
 function createIntegration(overrides: Record<string, unknown> = {}) {
   return {
     id: 'dir-1',
@@ -221,6 +241,7 @@ describe('DirectoryManagementView', () => {
       configurable: true,
       value: originalScrollIntoView,
     })
+    window.history.replaceState({}, '', '/')
     app = null
     container = null
   })
@@ -294,10 +315,7 @@ describe('DirectoryManagementView', () => {
       ))
 
     app = createApp(DirectoryManagementView)
-    app.component('RouterLink', {
-      props: ['to'],
-      template: '<a><slot /></a>',
-    })
+    registerRouterLink(app)
     app.mount(container!)
     await flushUi()
 
@@ -853,6 +871,681 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('alpha@example.com')
   })
 
+  it('can auto-focus a directory member from user-management query params and expose a link back to user management', async () => {
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-1&accountId=account-focus&source=user-management&userId=user-1')
+
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(12)
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/accounts/account-focus')
+    expect(container?.textContent).toContain('已从用户管理定位到目录成员 定位成员')
+    expect(container?.textContent).toContain('当前定位成员：定位成员')
+
+    const userLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往用户管理'))
+    expect(userLink?.getAttribute('href')).toBe('/admin/users?userId=user-1&source=directory-sync&integrationId=dir-1&accountId=account-focus')
+  })
+
+  it('clears stale focus and shows a specific error when query targets a missing integration', async () => {
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-1&accountId=account-focus&source=user-management&userId=user-1')
+
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+          createAccount({
+            id: 'account-other',
+            name: '恢复成员列表',
+            externalUserId: '0447654442691200',
+            linkStatus: 'unmatched',
+            matchStrategy: 'none',
+            localUser: null,
+          }),
+        ], { total: 2 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(12)
+
+    expect(container?.textContent).toContain('当前定位成员：定位成员')
+
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-missing&accountId=account-missing&source=user-management&userId=user-2')
+    await flushUi(12)
+
+    const accountsSection = findAccountsSection(container!)
+    const routeBanner = accountsSection.querySelector('.directory-admin__route-banner')
+    expect(routeBanner).toBeInstanceOf(HTMLElement)
+    expect(routeBanner?.textContent).toContain('定位未完成')
+    expect(routeBanner?.textContent).toContain('未找到目录集成 dir-missing')
+    expect(routeBanner?.textContent).toContain('目标集成：dir-missing')
+    expect(routeBanner?.textContent).toContain('目标成员：account-missing')
+    expect(routeBanner?.textContent).toContain('当前仍停留在 DingTalk CN')
+    const returnUserLink = Array.from(accountsSection.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('返回用户管理'))
+    expect(returnUserLink?.getAttribute('href')).toBe('/admin/users?userId=user-2&source=directory-sync&directoryFailure=missing_integration&integrationId=dir-missing&accountId=account-missing')
+    expect(container?.querySelector('.directory-admin__focus-card')).toBeNull()
+    expect(container?.querySelector('.directory-admin__account--focused')).toBeNull()
+    const accountSearch = container?.querySelector('input[placeholder="搜索姓名 / 邮箱 / 手机 / 钉钉 ID / 本地用户"]')
+    expect(accountSearch).toBeInstanceOf(HTMLInputElement)
+    expect((accountSearch as HTMLInputElement).value).toBe('')
+    expect(container?.textContent).toContain('恢复成员列表')
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/accounts/account-missing')).toHaveLength(0)
+
+    const retainButton = Array.from(accountsSection.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('留在 DingTalk CN'))
+    expect(retainButton).toBeTruthy()
+    retainButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(4)
+    expect(window.location.search).toBe('?integrationId=dir-1')
+    expect(container?.textContent).toContain('已保留当前目录上下文 DingTalk CN')
+    expect(findAccountsSection(container!).querySelector('.directory-admin__route-banner')).toBeNull()
+  })
+
+  it('clears stale focus and shows a specific error when query targets a missing account', async () => {
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-1&accountId=account-focus&source=user-management&userId=user-1')
+
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({ ok: false }, 404))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(12)
+
+    expect(container?.textContent).toContain('当前定位成员：定位成员')
+
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-1&accountId=account-missing&source=user-management&userId=user-2')
+    await flushUi(12)
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/accounts/account-missing')
+    const accountsSection = findAccountsSection(container!)
+    const routeBanner = accountsSection.querySelector('.directory-admin__route-banner')
+    expect(routeBanner).toBeInstanceOf(HTMLElement)
+    expect(routeBanner?.textContent).toContain('定位未完成')
+    expect(routeBanner?.textContent).toContain('未找到目录成员 account-missing')
+    expect(routeBanner?.textContent).toContain('目标集成：dir-1')
+    expect(routeBanner?.textContent).toContain('目标成员：account-missing')
+    expect(routeBanner?.textContent).toContain('当前仍停留在 DingTalk CN')
+    const returnUserLink = Array.from(accountsSection.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('返回用户管理'))
+    expect(returnUserLink?.getAttribute('href')).toBe('/admin/users?userId=user-2&source=directory-sync&directoryFailure=missing_account&integrationId=dir-1&accountId=account-missing')
+    expect(container?.querySelector('.directory-admin__focus-card')).toBeNull()
+    expect(container?.querySelector('.directory-admin__account--focused')).toBeNull()
+    const accountSearch = container?.querySelector('input[placeholder="搜索姓名 / 邮箱 / 手机 / 钉钉 ID / 本地用户"]')
+    expect(accountSearch).toBeInstanceOf(HTMLInputElement)
+    expect((accountSearch as HTMLInputElement).value).toBe('')
+  })
+
+  it('can retry route navigation from the failure banner after a missing account result', async () => {
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-1&accountId=account-focus&source=user-management&userId=user-1')
+
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({ ok: false }, 404))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-missing',
+            name: '重试定位成员',
+            externalUserId: '0447654442692299',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-2',
+              email: 'bravo@example.com',
+              name: 'Bravo',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-missing',
+            name: '重试定位成员',
+            externalUserId: '0447654442692299',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-2',
+              email: 'bravo@example.com',
+              name: 'Bravo',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(12)
+
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-1&accountId=account-missing&source=user-management&userId=user-2')
+    await flushUi(12)
+
+    const accountsSection = findAccountsSection(container!)
+    const retryButton = Array.from(accountsSection.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('重试定位'))
+    expect(retryButton).toBeTruthy()
+    retryButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(12)
+
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/accounts/account-missing')).toHaveLength(2)
+    expect(findAccountsSection(container!).querySelector('.directory-admin__route-banner')).toBeNull()
+    expect(container?.textContent).toContain('已从用户管理定位到目录成员 重试定位成员')
+    expect(container?.textContent).toContain('当前定位成员：重试定位成员')
+  })
+
+  it('can re-focus a directory member when query params change on the same mounted instance', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([
+        createAccount({
+          id: 'account-initial',
+          name: '初始成员',
+          externalUserId: '0447654442691100',
+          linkStatus: 'linked',
+          matchStrategy: 'manual_admin',
+          localUser: {
+            id: 'user-0',
+            email: 'initial@example.com',
+            name: 'Initial',
+          },
+        }),
+      ], { total: 1 })))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-focus',
+            name: '定位成员',
+            externalUserId: '0447654442691199',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        ], { total: 1 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(12)
+
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-1&accountId=account-focus&source=user-management&userId=user-1')
+    await flushUi(12)
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/accounts/account-focus')
+    expect(container?.textContent).toContain('已从用户管理定位到目录成员 定位成员')
+
+    const userLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往用户管理'))
+    expect(userLink?.getAttribute('href')).toBe('/admin/users?userId=user-1&source=directory-sync&integrationId=dir-1&accountId=account-focus')
+  })
+
+  it('can switch to a newly refreshed integration when query params target another integration', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({ id: 'dir-1', name: 'DingTalk CN 1', corpId: 'dingcorp-1' })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload({ integrationId: 'dir-1' })))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([
+        createAccount({
+          id: 'account-dir-1',
+          integrationId: 'dir-1',
+          name: '成员一',
+          externalUserId: 'dir1-user',
+        }),
+      ], { total: 1 })))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            createIntegration({ id: 'dir-1', name: 'DingTalk CN 1', corpId: 'dingcorp-1' }),
+            createIntegration({ id: 'dir-2', name: 'DingTalk CN 2', corpId: 'dingcorp-2' }),
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-dir-2',
+            integrationId: 'dir-2',
+            name: '切换成员',
+            externalUserId: 'dir2-user',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-2',
+              email: 'bravo@example.com',
+              name: 'Bravo',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload({ integrationId: 'dir-2' })))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([
+        createAccount({
+          id: 'account-dir-2',
+          integrationId: 'dir-2',
+          name: '切换成员',
+          externalUserId: 'dir2-user',
+          linkStatus: 'linked',
+          matchStrategy: 'manual_admin',
+          localUser: {
+            id: 'user-2',
+            email: 'bravo@example.com',
+            name: 'Bravo',
+          },
+        }),
+      ], { total: 1 })))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(12)
+
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-2&accountId=account-dir-2&source=user-management&userId=user-2')
+    await flushUi(16)
+
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/integrations')).toHaveLength(2)
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/accounts/account-dir-2')
+    expect(container?.textContent).toContain('已从用户管理定位到目录成员 切换成员')
+    expect(container?.textContent).toContain('DingTalk CN 2')
+
+    const userLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往用户管理'))
+    expect(userLink?.getAttribute('href')).toBe('/admin/users?userId=user-2&source=directory-sync&integrationId=dir-2&accountId=account-dir-2')
+  })
+
+  it('keeps pending cross-integration navigation until a later refresh reveals the target integration', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({ id: 'dir-1', name: 'DingTalk CN 1', corpId: 'dingcorp-1' })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload({ integrationId: 'dir-1' })))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([
+        createAccount({
+          id: 'account-dir-1',
+          integrationId: 'dir-1',
+          name: '成员一',
+          externalUserId: 'dir1-user',
+        }),
+      ], { total: 1 })))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({ id: 'dir-1', name: 'DingTalk CN 1', corpId: 'dingcorp-1' })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([
+        createAccount({
+          id: 'account-dir-1',
+          integrationId: 'dir-1',
+          name: '成员一',
+          externalUserId: 'dir1-user',
+        }),
+        createAccount({
+          id: 'account-dir-1b',
+          integrationId: 'dir-1',
+          name: '成员二',
+          externalUserId: 'dir1-user-b',
+        }),
+      ], { total: 2 })))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            createIntegration({ id: 'dir-1', name: 'DingTalk CN 1', corpId: 'dingcorp-1' }),
+            createIntegration({ id: 'dir-2', name: 'DingTalk CN 2', corpId: 'dingcorp-2' }),
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            id: 'account-dir-2-late',
+            integrationId: 'dir-2',
+            name: '延迟出现成员',
+            externalUserId: 'dir2-late-user',
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-2',
+              email: 'bravo@example.com',
+              name: 'Bravo',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload({ integrationId: 'dir-2' })))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([
+        createAccount({
+          id: 'account-dir-2-late',
+          integrationId: 'dir-2',
+          name: '延迟出现成员',
+          externalUserId: 'dir2-late-user',
+          linkStatus: 'linked',
+          matchStrategy: 'manual_admin',
+          localUser: {
+            id: 'user-2',
+            email: 'bravo@example.com',
+            name: 'Bravo',
+          },
+        }),
+      ], { total: 1 })))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            createIntegration({ id: 'dir-1', name: 'DingTalk CN 1', corpId: 'dingcorp-1' }),
+            createIntegration({ id: 'dir-2', name: 'DingTalk CN 2', corpId: 'dingcorp-2' }),
+          ],
+        },
+      }))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi(12)
+
+    window.history.replaceState({}, '', '/admin/directory?integrationId=dir-2&accountId=account-dir-2-late&source=user-management&userId=user-2')
+    await flushUi(12)
+
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/integrations')).toHaveLength(2)
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/accounts/account-dir-2-late')).toHaveLength(0)
+    expect(container?.textContent).not.toContain('已从用户管理定位到目录成员 延迟出现成员')
+    expect(container?.textContent).toContain('成员二')
+
+    const refreshButton = Array.from(container!.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('刷新列表'))
+    expect(refreshButton).toBeTruthy()
+    refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(16)
+
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/integrations')).toHaveLength(3)
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/accounts/account-dir-2-late')).toHaveLength(1)
+    expect(container?.textContent).toContain('已从用户管理定位到目录成员 延迟出现成员')
+
+    refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(10)
+
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/integrations')).toHaveLength(4)
+    expect(apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/directory/accounts/account-dir-2-late')).toHaveLength(1)
+  })
+
   it('confirms a recommended pending binding', async () => {
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({
@@ -977,6 +1670,329 @@ describe('DirectoryManagementView', () => {
       }),
     )
     expect(container?.textContent).toContain('已确认推荐绑定')
+  })
+
+  it('requires explicit confirmation before overriding an existing user mobile during recommended binding', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-mobile-bind',
+              mobile: '13758875801',
+              linkStatus: 'pending',
+              matchStrategy: 'mobile',
+              localUser: null,
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                mobile: '13600000000',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['mobile'],
+            }],
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          id: 'account-mobile-bind',
+          mobile: '13758875801',
+          linkStatus: 'pending',
+          matchStrategy: 'mobile',
+        })]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          user: {
+            id: 'user-1',
+            email: 'alpha@example.com',
+            name: 'Alpha',
+            mobile: '13758875801',
+          },
+          roles: ['user'],
+          permissions: [],
+          isAdmin: false,
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'account-mobile-bind',
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+              },
+            },
+          ],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          id: 'account-mobile-bind',
+          mobile: '13758875801',
+          linkStatus: 'linked',
+          matchStrategy: 'manual_admin',
+          localUser: {
+            id: 'user-1',
+            email: 'alpha@example.com',
+            name: 'Alpha',
+          },
+        })]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const backfillAndBindButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('回填手机号后绑定'))
+    expect(backfillAndBindButton).toBeTruthy()
+    backfillAndBindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(4)
+
+    expect(apiFetchMock).not.toHaveBeenCalledWith(
+      '/api/admin/users/user-1/profile',
+      expect.anything(),
+    )
+    expect(container?.textContent).toContain('平台手机号：13600000000')
+    expect(container?.textContent).toContain('目录手机号：13758875801')
+    expect(container?.textContent).toContain('存在差异，覆盖前需确认。')
+    expect(container?.textContent).toContain('确认覆盖手机号并绑定')
+
+    const confirmOverrideButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('确认覆盖手机号并绑定'))
+    expect(confirmOverrideButton).toBeTruthy()
+    confirmOverrideButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(10)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/users/user-1/profile',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({
+          mobile: '13758875801',
+          expectedMobile: '13600000000',
+        }),
+      }),
+    )
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          bindings: [
+            {
+              accountId: 'account-mobile-bind',
+              localUserRef: 'user-1',
+              enableDingTalkGrant: true,
+            },
+          ],
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('已回填手机号并完成绑定')
+  })
+
+  it('clears override confirmation and refreshes review data when mobile CAS returns conflict', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-mobile-conflict',
+              mobile: '13758875801',
+              linkStatus: 'pending',
+              matchStrategy: 'mobile',
+              localUser: null,
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                mobile: '13600000000',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['mobile'],
+            }],
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          id: 'account-mobile-conflict',
+          mobile: '13758875801',
+          linkStatus: 'pending',
+          matchStrategy: 'mobile',
+        })]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: false,
+        error: {
+          code: 'PROFILE_MOBILE_CONFLICT',
+          message: 'User mobile changed before update was applied',
+        },
+      }, 409))
+      .mockResolvedValueOnce(createJsonResponse(
+        {
+          ok: true,
+          data: {
+            item: {
+              kind: 'pending_binding',
+              reason: '目录成员当前不是已确认绑定状态，建议复核。',
+              account: createAccount({
+                id: 'account-mobile-conflict',
+                mobile: '13758875801',
+                linkStatus: 'pending',
+                matchStrategy: 'mobile',
+                localUser: null,
+              }),
+              recommendations: [{
+                localUser: {
+                  id: 'user-1',
+                  email: 'alpha@example.com',
+                  name: 'Alpha',
+                  mobile: '13700000000',
+                  role: 'user',
+                  isActive: true,
+                },
+                reasons: ['mobile'],
+              }],
+              flags: {
+                missingUnionId: false,
+                missingOpenId: false,
+              },
+              actionable: {
+                canBatchUnbind: false,
+                canConfirmRecommendation: true,
+              },
+            },
+          },
+        },
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+          id: 'account-mobile-conflict',
+          mobile: '13758875801',
+          linkStatus: 'pending',
+          matchStrategy: 'mobile',
+        }),
+        },
+      }))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const initialBackfillButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('回填手机号后绑定'))
+    expect(initialBackfillButton).toBeTruthy()
+    initialBackfillButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(4)
+
+    const confirmOverrideButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('确认覆盖手机号并绑定'))
+    expect(confirmOverrideButton).toBeTruthy()
+    confirmOverrideButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(10)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/users/user-1/profile',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({
+          mobile: '13758875801',
+          expectedMobile: '13600000000',
+        }),
+      }),
+    )
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/accounts/account-mobile-conflict/review-item')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/accounts/account-mobile-conflict')
+    expect(apiFetchMock).not.toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-bind',
+      expect.anything(),
+    )
+    expect(container?.textContent).toContain('平台手机号已被其他操作更新，请刷新后的最新差异为准')
+    expect(container?.textContent).toContain('平台手机号已更新为 13700000000，请按最新差异重新确认。')
+    expect(container?.textContent).not.toContain('确认覆盖手机号并绑定')
+    expect(container?.textContent).toContain('按最新手机号重试')
+    expect(container?.textContent).toContain('平台手机号：13700000000')
   })
 
   it('batch-binds selected pending review items', async () => {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -1995,6 +1995,81 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('平台手机号：13700000000')
   })
 
+  it('hides mobile backfill affordances when the directory and platform mobile already match', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员当前不是已确认绑定状态，建议复核。',
+            account: createAccount({
+              id: 'account-mobile-same',
+              mobile: '13758875801',
+              linkStatus: 'pending',
+              matchStrategy: 'mobile',
+              localUser: null,
+            }),
+            recommendations: [{
+              localUser: {
+                id: 'user-1',
+                email: 'alpha@example.com',
+                name: 'Alpha',
+                mobile: '13758875801',
+                role: 'user',
+                isActive: true,
+              },
+              reasons: ['mobile'],
+            }],
+            flags: {
+              missingUnionId: false,
+              missingOpenId: false,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          id: 'account-mobile-same',
+          mobile: '13758875801',
+          linkStatus: 'pending',
+          matchStrategy: 'mobile',
+        })]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).not.toContain('平台手机号：13758875801')
+    expect(container?.textContent).not.toContain('目录手机号：13758875801')
+    expect(container?.textContent).not.toContain('回填手机号后绑定')
+    expect(container?.textContent).not.toContain('确认覆盖手机号并绑定')
+  })
+
   it('batch-binds selected pending review items', async () => {
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -339,6 +339,7 @@ export type DirectoryBindingRecommendation = {
     id: string
     email: string
     name: string | null
+    mobile: string | null
     role: string
     isActive: boolean
   }
@@ -857,6 +858,7 @@ async function loadDirectoryReviewRecommendations(
           id: user.id,
           email: user.email,
           name: user.name,
+          mobile: user.mobile,
           role: user.role,
           isActive: user.is_active,
         },
@@ -2013,6 +2015,69 @@ export async function listDirectoryReviewItems(
   }
 }
 
+export async function getDirectoryReviewItem(
+  accountId: string,
+): Promise<DirectoryReviewItemSummary | null> {
+  const normalizedAccountId = normalizeText(accountId)
+  if (!normalizedAccountId) throw new Error('accountId is required')
+
+  const rowsResult = await query<DirectoryReviewItemRow>(
+    `SELECT
+        a.integration_id,
+        a.provider,
+        a.corp_id,
+        a.id AS directory_account_id,
+        a.external_user_id,
+        a.union_id,
+        a.open_id,
+        a.external_key,
+        a.name AS account_name,
+        a.email AS account_email,
+        a.mobile AS account_mobile,
+        a.is_active AS account_is_active,
+        a.updated_at AS account_updated_at,
+        l.link_status,
+        l.match_strategy,
+        l.reviewed_by,
+        l.review_note,
+        l.updated_at AS link_updated_at,
+        u.id AS local_user_id,
+        u.email AS local_user_email,
+        u.name AS local_user_name,
+        COALESCE(array_remove(array_agg(DISTINCT d.full_path), NULL), ARRAY[]::text[]) AS department_paths,
+        CASE
+          WHEN COALESCE(a.union_id, '') = '' AND COALESCE(a.open_id, '') = '' THEN 'missing_identifier'
+          WHEN a.is_active = FALSE AND l.local_user_id IS NOT NULL THEN 'inactive_linked'
+          ELSE 'pending_binding'
+        END AS review_kind,
+        CASE
+          WHEN COALESCE(a.union_id, '') = '' AND COALESCE(a.open_id, '') = '' THEN '目录成员缺少 unionId/openId，无法用于钉钉登录绑定。'
+          WHEN a.is_active = FALSE AND l.local_user_id IS NOT NULL THEN '目录成员已停用，但仍绑定本地用户，需要停权处理。'
+          WHEN l.local_user_id IS NULL THEN '目录成员尚未绑定本地用户。'
+          ELSE '目录成员当前不是已确认绑定状态，建议复核。'
+        END AS review_reason,
+        (COALESCE(a.union_id, '') = '') AS missing_union_id,
+        (COALESCE(a.open_id, '') = '') AS missing_open_id
+     FROM directory_accounts a
+     LEFT JOIN directory_account_links l ON l.directory_account_id = a.id
+     LEFT JOIN users u ON u.id = l.local_user_id
+     LEFT JOIN directory_account_departments ad ON ad.directory_account_id = a.id
+     LEFT JOIN directory_departments d ON d.id = ad.directory_department_id
+     WHERE a.id = $1
+     GROUP BY
+       a.integration_id, a.provider, a.corp_id, a.id, a.external_user_id, a.union_id, a.open_id, a.external_key,
+       a.name, a.email, a.mobile, a.is_active, a.updated_at,
+       l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
+       u.id, u.email, u.name`,
+    [normalizedAccountId],
+  )
+
+  const row = rowsResult.rows[0]
+  if (!row) return null
+  const recommendationsByAccount = await loadDirectoryReviewRecommendations([row])
+  return summarizeReviewItem(row, recommendationsByAccount.get(row.directory_account_id) ?? null)
+}
+
 export async function batchUnbindDirectoryAccounts(
   directoryAccountIds: string[],
   input: DirectoryAccountUnbindInput,
@@ -2052,7 +2117,7 @@ export async function batchBindDirectoryAccounts(
   return results
 }
 
-async function getDirectoryAccountSummary(accountId: string): Promise<DirectoryIntegrationAccountSummary | null> {
+export async function getDirectoryAccountSummary(accountId: string): Promise<DirectoryIntegrationAccountSummary | null> {
   const result = await query<DirectoryIntegrationAccountRow>(
     `SELECT
         a.integration_id,

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -2118,6 +2118,9 @@ export async function batchBindDirectoryAccounts(
 }
 
 export async function getDirectoryAccountSummary(accountId: string): Promise<DirectoryIntegrationAccountSummary | null> {
+  const normalizedAccountId = normalizeText(accountId)
+  if (!normalizedAccountId) throw new Error('accountId is required')
+
   const result = await query<DirectoryIntegrationAccountRow>(
     `SELECT
         a.integration_id,
@@ -2153,7 +2156,7 @@ export async function getDirectoryAccountSummary(accountId: string): Promise<Dir
        a.name, a.email, a.mobile, a.is_active, a.updated_at,
        l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
        u.id, u.email, u.name`,
-    [accountId],
+    [normalizedAccountId],
   )
 
   const row = result.rows[0]

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -8,6 +8,8 @@ import {
   bindDirectoryAccount,
   createDirectoryIntegration,
   getDirectorySyncScheduleSnapshot,
+  getDirectoryAccountSummary,
+  getDirectoryReviewItem,
   listDirectoryIntegrationAccounts,
   listDirectoryIntegrations,
   listDirectoryReviewItems,
@@ -272,6 +274,40 @@ export function adminDirectoryRouter(): Router {
     } catch (error) {
       const message = readErrorMessage(error, 'Failed to load directory accounts')
       jsonError(res, /required|invalid/i.test(message) ? 400 : 500, 'DIRECTORY_ACCOUNTS_FAILED', message)
+    }
+  })
+
+  router.get('/accounts/:accountId', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const account = await getDirectoryAccountSummary(req.params.accountId)
+      if (!account) {
+        jsonError(res, 404, 'DIRECTORY_ACCOUNT_NOT_FOUND', 'Directory account not found')
+        return
+      }
+      jsonOk(res, { account })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory account')
+      jsonError(res, /required/i.test(message) ? 400 : 500, 'DIRECTORY_ACCOUNT_FAILED', message)
+    }
+  })
+
+  router.get('/accounts/:accountId/review-item', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const item = await getDirectoryReviewItem(req.params.accountId)
+      if (!item) {
+        jsonError(res, 404, 'DIRECTORY_REVIEW_ITEM_NOT_FOUND', 'Directory review item not found')
+        return
+      }
+      jsonOk(res, { item })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory review item')
+      jsonError(res, /required/i.test(message) ? 400 : 500, 'DIRECTORY_REVIEW_ITEM_FAILED', message)
     }
   })
 

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -16,6 +16,8 @@ const directoryMocks = vi.hoisted(() => ({
   bindDirectoryAccount: vi.fn(),
   createDirectoryIntegration: vi.fn(),
   getDirectorySyncScheduleSnapshot: vi.fn(),
+  getDirectoryAccountSummary: vi.fn(),
+  getDirectoryReviewItem: vi.fn(),
   listDirectoryIntegrationAccounts: vi.fn(),
   listDirectoryIntegrations: vi.fn(),
   listDirectoryReviewItems: vi.fn(),
@@ -46,6 +48,8 @@ vi.mock('../../src/directory/directory-sync', () => ({
   bindDirectoryAccount: directoryMocks.bindDirectoryAccount,
   createDirectoryIntegration: directoryMocks.createDirectoryIntegration,
   getDirectorySyncScheduleSnapshot: directoryMocks.getDirectorySyncScheduleSnapshot,
+  getDirectoryAccountSummary: directoryMocks.getDirectoryAccountSummary,
+  getDirectoryReviewItem: directoryMocks.getDirectoryReviewItem,
   listDirectoryIntegrationAccounts: directoryMocks.listDirectoryIntegrationAccounts,
   listDirectoryIntegrations: directoryMocks.listDirectoryIntegrations,
   listDirectoryReviewItems: directoryMocks.listDirectoryReviewItems,
@@ -140,6 +144,8 @@ describe('adminDirectoryRouter', () => {
     directoryMocks.bindDirectoryAccount.mockReset()
     directoryMocks.createDirectoryIntegration.mockReset()
     directoryMocks.getDirectorySyncScheduleSnapshot.mockReset()
+    directoryMocks.getDirectoryAccountSummary.mockReset()
+    directoryMocks.getDirectoryReviewItem.mockReset()
     directoryMocks.listDirectoryIntegrationAccounts.mockReset()
     directoryMocks.listDirectoryIntegrations.mockReset()
     directoryMocks.listDirectoryReviewItems.mockReset()
@@ -450,6 +456,76 @@ describe('adminDirectoryRouter', () => {
       data: {
         total: 1,
         query: '0447',
+      },
+    })
+  })
+
+  it('returns a single directory account summary', async () => {
+    directoryMocks.getDirectoryAccountSummary.mockResolvedValue({
+      id: 'account-1',
+      integrationId: 'dir-1',
+      name: '周华',
+    })
+
+    const response = await invokeRoute('get', '/accounts/:accountId', {
+      params: { accountId: 'account-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.getDirectoryAccountSummary).toHaveBeenCalledWith('account-1')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        account: {
+          id: 'account-1',
+          integrationId: 'dir-1',
+          name: '周华',
+        },
+      },
+    })
+  })
+
+  it('returns a single directory review item', async () => {
+    directoryMocks.getDirectoryReviewItem.mockResolvedValue({
+      kind: 'pending_binding',
+      reason: '目录成员当前不是已确认绑定状态，建议复核。',
+      account: {
+        id: 'account-1',
+        integrationId: 'dir-1',
+        name: '周华',
+      },
+      recommendations: [],
+      recommendationStatus: {
+        code: 'no_exact_match',
+        message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+      },
+      flags: {
+        missingUnionId: false,
+        missingOpenId: false,
+      },
+      actionable: {
+        canBatchUnbind: false,
+        canConfirmRecommendation: false,
+      },
+    })
+
+    const response = await invokeRoute('get', '/accounts/:accountId/review-item', {
+      params: { accountId: 'account-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.getDirectoryReviewItem).toHaveBeenCalledWith('account-1')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        item: {
+          kind: 'pending_binding',
+          account: {
+            id: 'account-1',
+          },
+        },
       },
     })
   })

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -486,6 +486,24 @@ describe('adminDirectoryRouter', () => {
     })
   })
 
+  it('returns 400 when a single directory account lookup is missing accountId', async () => {
+    directoryMocks.getDirectoryAccountSummary.mockRejectedValue(new Error('accountId is required'))
+
+    const response = await invokeRoute('get', '/accounts/:accountId', {
+      params: { accountId: '   ' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'DIRECTORY_ACCOUNT_FAILED',
+        message: 'accountId is required',
+      },
+    })
+  })
+
   it('returns a single directory review item', async () => {
     directoryMocks.getDirectoryReviewItem.mockResolvedValue({
       kind: 'pending_binding',


### PR DESCRIPTION
## What changed

This stacked PR finishes the remaining DingTalk directory-governance loop on top of #896.

It focuses on the admin directory review experience:

- lets admins jump directly between directory members and local users
- supports mobile backfill before confirming a bind recommendation
- adds conflict confirmation and conflict-recovery flows for mobile overwrite
- makes route-driven focus resilient across query changes and cross-integration navigation
- adds explicit failure/recovery banners when a requested integration or account no longer exists
- narrows post-conflict refresh from full-list reloads to single-card/account refreshes

## User-facing behavior

- Pending-binding cards can now link to the matched local user in user management.
- When a directory member has a mobile number and the matched local user differs, admins can:
  - backfill the mobile to the local user
  - confirm overwrite if the numbers differ
  - retry from the same card after a `PROFILE_MOBILE_CONFLICT`
- Conflict handling is now card-scoped instead of forcing a full review-page refresh.
- Directory pages can deep-link from user management via `integrationId/accountId/userId/source` and keep working when:
  - the query changes on the same mounted page
  - the target integration appears only after a later integration refresh
- When the target integration or account does not exist, the page clears stale focus and shows explicit recovery actions:
  - retry focus
  - return to user management
  - stay on the current integration

## Backend changes

- recommendation payloads now expose candidate user `mobile`
- `GET /api/admin/directory/accounts/:accountId`
  - returns a single directory account summary
- `GET /api/admin/directory/accounts/:accountId/review-item`
  - returns a single review item for targeted card refresh
- `getDirectoryAccountSummary` is now exported for route use

## Frontend changes

- `DirectoryManagementView`
  - tracks selected local-user candidates per account
  - supports mobile backfill + bind flow
  - requires explicit confirmation before overwriting a conflicting mobile
  - shows retryable conflict hints after CAS failures
  - refreshes only the affected account/review card after conflicts
  - adds router links into user management
  - responds to route/query changes without requiring a full remount
  - shows route-failure recovery banners for missing integration/account targets
- `directoryManagementView.spec.ts`
  - now covers focused navigation, cross-page/user-management links, route failure recovery, mobile backfill conflict flows, and retry behavior

## Files included

- `apps/web/src/views/DirectoryManagementView.vue`
- `apps/web/tests/directoryManagementView.spec.ts`
- `packages/core-backend/src/directory/directory-sync.ts`
- `packages/core-backend/src/routes/admin-directory.ts`
- `packages/core-backend/tests/unit/admin-directory-routes.test.ts`

## Verification

Ran:

```bash
pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts tests/userManagementView.spec.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts --watch=false
```

Results:

- frontend
  - `directoryManagementView.spec.ts`: `30 passed`
  - `userManagementView.spec.ts`: `13 passed`
- backend
  - `admin-directory-routes.test.ts`: `18 passed`

## Stack / scope

- Base branch: `codex/dingtalk-merge-ready-20260417` (#896)
- This PR intentionally excludes Yjs, GHCR, release-artifact, and unrelated ops changes.
