### PR TITLE
fix(collab): restore main build baseline before yjs rollout

### DIFF
--- a/docs/development/yjs-backend-build-baseline-fix-development-20260418.md
+++ b/docs/development/yjs-backend-build-baseline-fix-development-20260418.md
@@ -74,3 +74,10 @@ Current `main` backend build is unblocked again without replaying old mixed-bran
 - producing a real Yjs-ready GHCR image
 - continuing remote rollout validation
 - keeping multitable JSON persistence code type-safe on current `main`
+
+## Delivery Notes
+
+- The repair was committed on branch `codex/yjs-main-clean-20260418`
+- Code commit:
+  - `0f10cd181 fix(collab): restore backend build baseline on main`
+- A clean exported build context was used for Docker verification so local `node_modules` noise in the worktree would not affect image build results

--- a/docs/development/yjs-backend-build-baseline-fix-development-20260418.md
+++ b/docs/development/yjs-backend-build-baseline-fix-development-20260418.md
@@ -30,7 +30,7 @@ There was also one non-JSON issue:
 
 ### 1. Normalize DB JSON column typings
 
-Updated [packages/core-backend/src/db/types.ts](/Users/chouhua/Downloads/Github/metasheet2/tmp/yjs-main-clean/packages/core-backend/src/db/types.ts:1):
+Updated `packages/core-backend/src/db/types.ts`:
 
 - added `JsonStringArrayColumn`
 - added `JsonValueColumn`
@@ -47,11 +47,11 @@ This makes Kysely treat insert/update payloads as actual JSON arrays/objects ins
 
 ### 2. Stop stringifying JSON before insert/update
 
-Updated [packages/core-backend/src/multitable/automation-log-service.ts](/Users/chouhua/Downloads/Github/metasheet2/tmp/yjs-main-clean/packages/core-backend/src/multitable/automation-log-service.ts:1):
+Updated `packages/core-backend/src/multitable/automation-log-service.ts`:
 
 - `steps` now writes the execution step array directly
 
-Updated [packages/core-backend/src/multitable/dashboard-service.ts](/Users/chouhua/Downloads/Github/metasheet2/tmp/yjs-main-clean/packages/core-backend/src/multitable/dashboard-service.ts:1):
+Updated `packages/core-backend/src/multitable/dashboard-service.ts`:
 
 - chart `data_source` now writes the structured object directly
 - chart `display` now writes the structured object directly
@@ -61,7 +61,7 @@ This removed the `JSON.stringify(... as unknown as Record<string, unknown>)` pat
 
 ### 3. Replace raw retention cutoff SQL with typed cutoff date
 
-Updated [packages/core-backend/src/multitable/automation-log-service.ts](/Users/chouhua/Downloads/Github/metasheet2/tmp/yjs-main-clean/packages/core-backend/src/multitable/automation-log-service.ts:1):
+Updated `packages/core-backend/src/multitable/automation-log-service.ts`:
 
 - `cleanup(retentionDays)` now computes a JS `Date` cutoff and compares `created_at < cutoff`
 

--- a/docs/development/yjs-backend-build-baseline-fix-development-20260418.md
+++ b/docs/development/yjs-backend-build-baseline-fix-development-20260418.md
@@ -1,0 +1,76 @@
+# Yjs Backend Build Baseline Fix Development
+
+- Date: 2026-04-18
+- Scope: unblock current `main` backend build so Yjs rollout work can continue from a clean baseline
+
+## Problem
+
+`pnpm --filter @metasheet/core-backend build` was failing on current `main` before any new Yjs rollout work:
+
+- `packages/core-backend/src/db/types.ts`
+- `packages/core-backend/src/multitable/api-token-service.ts`
+- `packages/core-backend/src/multitable/webhook-service.ts`
+- `packages/core-backend/src/multitable/automation-log-service.ts`
+- `packages/core-backend/src/multitable/dashboard-service.ts`
+
+The failures were not Yjs feature logic regressions. They were TypeScript/Kysely typing mismatches in recently-added multitable JSON columns.
+
+## Root Cause
+
+Two issues were mixed together:
+
+1. JSON column schema types were too loose or used `JSONColumnType<T>` defaults that implied string insert/update types.
+2. Service code wrote JSON columns by `JSON.stringify(...) as unknown as ...`, which no longer matched Kysely's typed `ValueExpression` expectations.
+
+There was also one non-JSON issue:
+
+- `AutomationLogService.cleanup()` used a raw interval SQL expression that no longer matched the typed `created_at` operand.
+
+## Changes
+
+### 1. Normalize DB JSON column typings
+
+Updated [packages/core-backend/src/db/types.ts](/Users/chouhua/Downloads/Github/metasheet2/tmp/yjs-main-clean/packages/core-backend/src/db/types.ts:1):
+
+- added `JsonStringArrayColumn`
+- added `JsonValueColumn`
+- switched these multitable columns to explicit aliases:
+  - `multitable_automation_executions.steps`
+  - `multitable_charts.data_source`
+  - `multitable_charts.display`
+  - `multitable_dashboards.panels`
+  - `multitable_api_tokens.scopes`
+  - `multitable_webhooks.events`
+  - `multitable_webhook_deliveries.payload`
+
+This makes Kysely treat insert/update payloads as actual JSON arrays/objects instead of default string JSON text.
+
+### 2. Stop stringifying JSON before insert/update
+
+Updated [packages/core-backend/src/multitable/automation-log-service.ts](/Users/chouhua/Downloads/Github/metasheet2/tmp/yjs-main-clean/packages/core-backend/src/multitable/automation-log-service.ts:1):
+
+- `steps` now writes the execution step array directly
+
+Updated [packages/core-backend/src/multitable/dashboard-service.ts](/Users/chouhua/Downloads/Github/metasheet2/tmp/yjs-main-clean/packages/core-backend/src/multitable/dashboard-service.ts:1):
+
+- chart `data_source` now writes the structured object directly
+- chart `display` now writes the structured object directly
+- dashboard `panels` now writes structured arrays directly
+
+This removed the `JSON.stringify(... as unknown as Record<string, unknown>)` pattern that was only satisfying runtime, not the type system.
+
+### 3. Replace raw retention cutoff SQL with typed cutoff date
+
+Updated [packages/core-backend/src/multitable/automation-log-service.ts](/Users/chouhua/Downloads/Github/metasheet2/tmp/yjs-main-clean/packages/core-backend/src/multitable/automation-log-service.ts:1):
+
+- `cleanup(retentionDays)` now computes a JS `Date` cutoff and compares `created_at < cutoff`
+
+That keeps the behavior equivalent for retention cleanup while matching the typed timestamp operand.
+
+## Outcome
+
+Current `main` backend build is unblocked again without replaying old mixed-branch Yjs commits. This restores a usable baseline for:
+
+- producing a real Yjs-ready GHCR image
+- continuing remote rollout validation
+- keeping multitable JSON persistence code type-safe on current `main`

--- a/docs/development/yjs-backend-build-baseline-fix-verification-20260418.md
+++ b/docs/development/yjs-backend-build-baseline-fix-verification-20260418.md
@@ -1,0 +1,42 @@
+# Yjs Backend Build Baseline Fix Verification
+
+- Date: 2026-04-18
+- Branch baseline: clean worktree from latest `main`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/api-token-webhook.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/chart-dashboard.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/yjs-cleanup.test.ts --watch=false
+```
+
+## Results
+
+### Build
+
+```text
+pnpm --filter @metasheet/core-backend build
+-> success
+```
+
+### Unit Tests
+
+```text
+tests/unit/api-token-webhook.test.ts
+-> 41 passed
+
+tests/unit/chart-dashboard.test.ts
+-> 49 passed
+
+tests/unit/automation-v1.test.ts
+tests/unit/yjs-cleanup.test.ts
+-> 96 passed
+```
+
+## Notes
+
+- Vite printed its existing CJS deprecation warning during Vitest startup.
+- No new failing unit tests were introduced by this fix set.
+- The touched code path is backend-only; no frontend validation was needed for this repair.

--- a/docs/development/yjs-backend-build-baseline-fix-verification-20260418.md
+++ b/docs/development/yjs-backend-build-baseline-fix-verification-20260418.md
@@ -58,5 +58,5 @@ docker build -f Dockerfile.frontend -t metasheet2-web:yjs-baseline-fix-0f10cd181
 - Vite printed its existing CJS deprecation warning during Vitest startup.
 - Frontend build and frontend Docker build both printed the existing large-chunk warnings from Vite, but completed successfully.
 - No new failing unit tests were introduced by this fix set.
-- The touched code path is backend-only; no frontend validation was needed for this repair.
+- The code changes are backend-only; frontend verification here was limited to build-level regression checks so the next GHCR release can use a clean full-stack baseline.
 - Docker verification used a clean `git archive` export instead of the active worktree because the worktree had local `node_modules` noise from `pnpm install`.

--- a/docs/development/yjs-backend-build-baseline-fix-verification-20260418.md
+++ b/docs/development/yjs-backend-build-baseline-fix-verification-20260418.md
@@ -10,6 +10,7 @@ pnpm --filter @metasheet/core-backend build
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/api-token-webhook.test.ts --watch=false
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/chart-dashboard.test.ts --watch=false
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/yjs-cleanup.test.ts --watch=false
+docker build -f Dockerfile.backend -t metasheet2-backend:yjs-baseline-fix-0f10cd181 <clean-exported-context>
 ```
 
 ## Results
@@ -35,8 +36,17 @@ tests/unit/yjs-cleanup.test.ts
 -> 96 passed
 ```
 
+### Docker Build
+
+```text
+docker build -f Dockerfile.backend -t metasheet2-backend:yjs-baseline-fix-0f10cd181 <clean-exported-context>
+-> success
+-> local image tag: metasheet2-backend:yjs-baseline-fix-0f10cd181
+```
+
 ## Notes
 
 - Vite printed its existing CJS deprecation warning during Vitest startup.
 - No new failing unit tests were introduced by this fix set.
 - The touched code path is backend-only; no frontend validation was needed for this repair.
+- Docker verification used a clean `git archive` export instead of the active worktree because the worktree had local `node_modules` noise from `pnpm install`.

--- a/docs/development/yjs-backend-build-baseline-fix-verification-20260418.md
+++ b/docs/development/yjs-backend-build-baseline-fix-verification-20260418.md
@@ -7,10 +7,12 @@
 
 ```bash
 pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/api-token-webhook.test.ts --watch=false
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/chart-dashboard.test.ts --watch=false
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/yjs-cleanup.test.ts --watch=false
 docker build -f Dockerfile.backend -t metasheet2-backend:yjs-baseline-fix-0f10cd181 <clean-exported-context>
+docker build -f Dockerfile.frontend -t metasheet2-web:yjs-baseline-fix-0f10cd181 <clean-exported-context>
 ```
 
 ## Results
@@ -19,6 +21,9 @@ docker build -f Dockerfile.backend -t metasheet2-backend:yjs-baseline-fix-0f10cd
 
 ```text
 pnpm --filter @metasheet/core-backend build
+-> success
+
+pnpm --filter @metasheet/web build
 -> success
 ```
 
@@ -42,11 +47,16 @@ tests/unit/yjs-cleanup.test.ts
 docker build -f Dockerfile.backend -t metasheet2-backend:yjs-baseline-fix-0f10cd181 <clean-exported-context>
 -> success
 -> local image tag: metasheet2-backend:yjs-baseline-fix-0f10cd181
+
+docker build -f Dockerfile.frontend -t metasheet2-web:yjs-baseline-fix-0f10cd181 <clean-exported-context>
+-> success
+-> local image tag: metasheet2-web:yjs-baseline-fix-0f10cd181
 ```
 
 ## Notes
 
 - Vite printed its existing CJS deprecation warning during Vitest startup.
+- Frontend build and frontend Docker build both printed the existing large-chunk warnings from Vite, but completed successfully.
 - No new failing unit tests were introduced by this fix set.
 - The touched code path is backend-only; no frontend validation was needed for this repair.
 - Docker verification used a clean `git archive` export instead of the active worktree because the worktree had local `node_modules` noise from `pnpm install`.

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -11,6 +11,8 @@ export type UpdatedAt = ColumnType<Date, string | undefined, Date | string>
 export type NullableTimestamp = ColumnType<Date, string | undefined, Date | string | null> | null
 type JsonObjectColumn = JSONColumnType<Record<string, unknown> | null, Record<string, unknown> | null, Record<string, unknown> | null>
 type JsonObjectArrayColumn = JSONColumnType<Record<string, unknown>[] | null, Record<string, unknown>[] | null, Record<string, unknown>[] | null>
+type JsonStringArrayColumn = JSONColumnType<string[], string[], string[]>
+type JsonValueColumn = ColumnType<unknown | null, unknown | null, unknown | null>
 
 export interface Database {
   // Core tables
@@ -1218,7 +1220,7 @@ export interface MultitableAutomationExecutionsTable {
   triggered_by: string
   triggered_at: CreatedAt
   status: string
-  steps: JSONColumnType<Record<string, unknown>[]>
+  steps: JsonObjectArrayColumn
   error: string | null
   duration: number | null
   created_at: CreatedAt
@@ -1230,8 +1232,8 @@ export interface MultitableChartsTable {
   type: string
   sheet_id: string
   view_id: string | null
-  data_source: JSONColumnType<Record<string, unknown>>
-  display: JSONColumnType<Record<string, unknown>>
+  data_source: JsonObjectColumn
+  display: JsonObjectColumn
   created_by: string
   created_at: CreatedAt
   updated_at: UpdatedAt
@@ -1241,7 +1243,7 @@ export interface MultitableDashboardsTable {
   id: string
   name: string
   sheet_id: string
-  panels: JSONColumnType<Record<string, unknown>[]>
+  panels: JsonObjectArrayColumn
   created_by: string
   created_at: CreatedAt
   updated_at: UpdatedAt
@@ -1256,7 +1258,7 @@ export interface MultitableApiTokensTable {
   name: string
   token_hash: string
   token_prefix: string
-  scopes: JSONColumnType<string[]>
+  scopes: JsonStringArrayColumn
   created_by: string
   created_at: CreatedAt
   last_used_at: NullableTimestamp
@@ -1270,7 +1272,7 @@ export interface MultitableWebhooksTable {
   name: string
   url: string
   secret: string | null
-  events: JSONColumnType<string[]>
+  events: JsonStringArrayColumn
   active: boolean
   created_by: string
   created_at: CreatedAt
@@ -1284,7 +1286,7 @@ export interface MultitableWebhookDeliveriesTable {
   id: string
   webhook_id: string
   event: string
-  payload: JSONColumnType<unknown>
+  payload: JsonValueColumn
   status: string
   http_status: number | null
   response_body: string | null

--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -29,7 +29,7 @@ export class AutomationLogService {
         triggered_by: execution.triggeredBy,
         triggered_at: execution.triggeredAt,
         status: execution.status,
-        steps: JSON.stringify(execution.steps) as unknown as Record<string, unknown>[],
+        steps: execution.steps as unknown as Record<string, unknown>[],
         error: execution.error ?? null,
         duration: execution.duration ?? null,
       })
@@ -111,9 +111,10 @@ export class AutomationLogService {
    * Remove execution logs older than the given retention period.
    */
   async cleanup(retentionDays = 30): Promise<number> {
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000)
     const result = await db
       .deleteFrom('multitable_automation_executions')
-      .where('created_at', '<', sql`NOW() - INTERVAL '${sql.raw(String(retentionDays))} days'`)
+      .where('created_at', '<', cutoff)
       .executeTakeFirst()
 
     return Number(result.numDeletedRows ?? 0)

--- a/packages/core-backend/src/multitable/dashboard-service.ts
+++ b/packages/core-backend/src/multitable/dashboard-service.ts
@@ -60,8 +60,8 @@ export class DashboardService {
         type: chart.type,
         sheet_id: chart.sheetId,
         view_id: chart.viewId ?? null,
-        data_source: JSON.stringify(chart.dataSource) as unknown as Record<string, unknown>,
-        display: JSON.stringify(chart.display) as unknown as Record<string, unknown>,
+        data_source: chart.dataSource as unknown as Record<string, unknown>,
+        display: chart.display as Record<string, unknown>,
         created_by: chart.createdBy,
       })
       .execute()
@@ -109,8 +109,8 @@ export class DashboardService {
         name: updated.name,
         type: updated.type,
         view_id: updated.viewId ?? null,
-        data_source: JSON.stringify(updated.dataSource) as unknown as Record<string, unknown>,
-        display: JSON.stringify(updated.display) as unknown as Record<string, unknown>,
+        data_source: updated.dataSource as unknown as Record<string, unknown>,
+        display: updated.display as Record<string, unknown>,
       })
       .where('id', '=', chartId)
       .execute()
@@ -139,7 +139,7 @@ export class DashboardService {
         await db
           .updateTable('multitable_dashboards')
           .set({
-            panels: JSON.stringify(filtered) as unknown as Record<string, unknown>[],
+            panels: filtered as unknown as Record<string, unknown>[],
           })
           .where('id', '=', dash.id)
           .execute()
@@ -169,7 +169,7 @@ export class DashboardService {
         id: dashboard.id,
         name: dashboard.name,
         sheet_id: dashboard.sheetId,
-        panels: JSON.stringify(dashboard.panels) as unknown as Record<string, unknown>[],
+        panels: dashboard.panels as unknown as Record<string, unknown>[],
         created_by: dashboard.createdBy,
       })
       .execute()
@@ -212,7 +212,7 @@ export class DashboardService {
       .updateTable('multitable_dashboards')
       .set({
         name: updated.name,
-        panels: JSON.stringify(updated.panels) as unknown as Record<string, unknown>[],
+        panels: updated.panels as unknown as Record<string, unknown>[],
       })
       .where('id', '=', dashboardId)
       .execute()


### PR DESCRIPTION
## What changed

This PR restores the current `main` build baseline so Yjs rollout work can continue from a clean branch instead of a mixed local workaround.

Included changes:

- fix Kysely JSON column typings for multitable persistence tables
- stop stringifying JSON payloads before insert/update in backend services
- replace the raw interval retention comparison in `AutomationLogService.cleanup()` with a typed cutoff date
- add development and verification notes for the baseline repair

## Why

Current `main` was failing before rollout work could continue:

- `pnpm --filter @metasheet/core-backend build` failed on TypeScript/Kysely type mismatches in multitable JSON columns
- that also blocked `Dockerfile.backend` from building a clean image for Yjs rollout

This PR fixes the baseline first, so the next step can be a real GHCR image and remote rollout validation.

## Files in scope

- `packages/core-backend/src/db/types.ts`
- `packages/core-backend/src/multitable/automation-log-service.ts`
- `packages/core-backend/src/multitable/dashboard-service.ts`
- `docs/development/yjs-backend-build-baseline-fix-development-20260418.md`
- `docs/development/yjs-backend-build-baseline-fix-verification-20260418.md`

## Verification

Ran:

```bash
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/api-token-webhook.test.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/chart-dashboard.test.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/yjs-cleanup.test.ts --watch=false
```

Results:

- backend build: passed
- frontend build: passed
- `api-token-webhook.test.ts`: `41 passed`
- `chart-dashboard.test.ts`: `49 passed`
- `automation-v1.test.ts` + `yjs-cleanup.test.ts`: `96 passed`

Also verified clean Docker builds from an exported `git archive` context:

```bash
docker build -f Dockerfile.backend -t metasheet2-backend:yjs-baseline-fix-0f10cd181 <clean-exported-context>
docker build -f Dockerfile.frontend -t metasheet2-web:yjs-baseline-fix-0f10cd181 <clean-exported-context>
```

Results:

- backend Docker build: passed
- frontend Docker build: passed

## Notes

The active worktree had local `node_modules` noise after `pnpm install`, so Docker verification used a clean exported context instead of the live worktree.
