### PR TITLE
fix(collab): unblock yjs rollout migrations and harden report capture

### DIFF
--- a/docs/development/yjs-unordered-migration-and-report-hardening-development-20260418.md
+++ b/docs/development/yjs-unordered-migration-and-report-hardening-development-20260418.md
@@ -1,0 +1,71 @@
+# Yjs Unordered Migration And Report Hardening Development
+
+Date: 2026-04-18
+
+## Summary
+
+This change set closes two rollout blockers that showed up on the live Yjs validation path:
+
+1. some deployed databases had already executed later `zzzz20260413*` migrations before a newly-added earlier-named migration was introduced, which caused the stock Kysely migration order check to hard-fail before the Yjs tables could be created;
+2. `capture-yjs-rollout-report.mjs` trusted whatever JSON it got back from the runtime/retention child scripts, which allowed incomplete retention payloads to be rendered as a healthy report.
+
+## Code Changes
+
+### 1. Allow unordered migration histories in the main migrator
+
+Updated `packages/core-backend/src/db/migrate.ts` to initialize `Migrator` with:
+
+- `allowUnorderedMigrations: true`
+
+This keeps the migration runner compatible with environments where:
+
+- `zzzz20260413130000_create_formula_dependencies`
+  had already been recorded as executed;
+- a later mainline sync then introduced
+  `zzzz20260413120000_create_automation_rules`;
+- the default Kysely prefix-order check would otherwise reject all future migrations, including
+  `zzzz20260501100000_create_yjs_state_tables`.
+
+The change is intentionally narrow:
+
+- migration names are still loaded from the same folder;
+- underscore-prefixed helper files are still filtered out;
+- only the strict executed-prefix validation is relaxed.
+
+### 2. Fail closed when rollout report payloads are incomplete
+
+Updated `scripts/ops/capture-yjs-rollout-report.mjs` so it now validates both child payloads before writing any report artifact:
+
+- runtime payload must include `baseUrl`, `metrics`, and the expected boolean/number fields;
+- retention payload must include a `stats` object with numeric
+  `statesCount`, `updatesCount`, `orphanStatesCount`, and `orphanUpdatesCount`;
+- missing/partial payloads now terminate the script with exit code `1`
+  and a clear error instead of producing a misleading healthy report.
+
+This specifically protects against the live validation case where a retention execution path returned:
+
+- `failures: []`
+- `stats: {}`
+
+and the old script would still render:
+
+- `status: HEALTHY`
+- `states count: undefined`
+
+### 3. Add a focused script test
+
+Added `scripts/ops/capture-yjs-rollout-report.test.mjs` with two cases:
+
+- complete runtime + retention payloads write JSON and Markdown report files;
+- missing retention stats fails closed and does not write an output directory.
+
+## Scope
+
+This change does not alter:
+
+- Yjs runtime logic;
+- Yjs websocket behavior;
+- retention SQL thresholds;
+- the rollout gate decision policy itself.
+
+It only restores migration continuity and hardens the report capture boundary so the rollout evidence cannot silently degrade.

--- a/docs/development/yjs-unordered-migration-and-report-hardening-verification-20260418.md
+++ b/docs/development/yjs-unordered-migration-and-report-hardening-verification-20260418.md
@@ -1,0 +1,143 @@
+# Yjs Unordered Migration And Report Hardening Verification
+
+Date: 2026-04-18
+
+## Local Verification
+
+Ran in the clean release worktree:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migrations.rollback.test.ts tests/unit/db.test.ts --watch=false
+node --test scripts/ops/capture-yjs-rollout-report.test.mjs
+```
+
+Results:
+
+- backend build: passed
+- `tests/unit/migrations.rollback.test.ts` + `tests/unit/db.test.ts`: `17 passed`
+- `scripts/ops/capture-yjs-rollout-report.test.mjs`: `2 passed`
+
+## Remote Rollout Baseline Verification
+
+Target:
+
+- host: `142.171.239.56`
+- repo: `~/metasheet2`
+
+### Deployment alignment
+
+Updated remote `.env` to:
+
+```bash
+IMAGE_TAG=20260418-yjs-rollout-r2
+```
+
+Then ran:
+
+```bash
+docker compose -f docker-compose.app.yml pull backend web
+docker compose -f docker-compose.app.yml up -d backend web
+```
+
+Observed running images:
+
+- `ghcr.io/zensgit/metasheet2-backend:20260418-yjs-rollout-r2`
+- `ghcr.io/zensgit/metasheet2-web:20260418-yjs-rollout-r2`
+
+### One-off unordered migration execution
+
+Before the fix, the normal migration entrypoint failed because the database had already recorded:
+
+- `zzzz20260413130000_create_formula_dependencies`
+
+but not:
+
+- `zzzz20260413120000_create_automation_rules`
+
+Using a one-off migrator run with `allowUnorderedMigrations: true`, the remote environment successfully applied:
+
+- `zzzz20260413120000_create_automation_rules`
+- `zzzz20260413130000_create_platform_app_instances`
+- `zzzz20260414100000_extend_automation_rules`
+- `zzzz20260414100001_create_automation_executions_and_dashboard_charts`
+- `zzzz20260414100002_create_multitable_api_tokens_and_webhooks`
+- `zzzz20260501100000_create_yjs_state_tables`
+
+### Runtime status
+
+Saved local evidence:
+
+- `output/yjs-rollout/remote-yjs-rollout-r2-20260418-115922/status.json`
+
+Result:
+
+```json
+{
+  "baseUrl": "http://127.0.0.1:8900",
+  "metrics": {
+    "enabled": true,
+    "initialized": true,
+    "activeDocCount": 0,
+    "pendingWriteCount": 0,
+    "flushSuccessCount": 0,
+    "flushFailureCount": 0,
+    "activeSocketCount": 0,
+    "activeRecordCount": 0
+  },
+  "failures": []
+}
+```
+
+Direct authenticated curl also returned `200 OK` from `/api/admin/yjs/status`.
+
+### Retention health
+
+Saved local evidence:
+
+- `output/yjs-rollout/remote-yjs-rollout-r2-20260418-115922/retention.json`
+
+Result:
+
+```json
+{
+  "failures": [],
+  "stats": {
+    "statesCount": 0,
+    "updatesCount": 0,
+    "orphanStatesCount": 0,
+    "orphanUpdatesCount": 0
+  },
+  "hottestRecords": []
+}
+```
+
+### Combined report / gate behavior
+
+Live validation also exposed an evidence-quality issue in the current deployed script path:
+
+- `capture-yjs-rollout-report.mjs` could still serialize a retention payload with `stats: {}`
+  as a healthy report when the environment used a temporary `psql` proxy;
+- the resulting Markdown showed `states count: undefined`.
+
+That exact runtime observation is why the report hardening change was added in this patch:
+
+- future runs will fail closed instead of generating a misleading healthy report.
+
+Remote raw operator outputs saved locally:
+
+- `output/yjs-rollout/remote-yjs-rollout-r2-20260418-115922/report.stdout.txt`
+- `output/yjs-rollout/remote-yjs-rollout-r2-20260418-115922/report.stderr.txt`
+- `output/yjs-rollout/remote-yjs-rollout-r2-20260418-115922/gate.stdout.txt`
+- `output/yjs-rollout/remote-yjs-rollout-r2-20260418-115922/gate.stderr.txt`
+
+## Conclusion
+
+The rollout environment is now unblocked at the infrastructure layer:
+
+- the backend/web deployment is on the explicit `20260418-yjs-rollout-r2` tag;
+- Yjs admin status is enabled and initialized;
+- Yjs retention tables exist;
+- retention baseline is clean.
+
+The remaining code-side hardening in this patch ensures future rollout reports cannot silently pass with incomplete retention evidence.

--- a/packages/core-backend/src/db/migrate.ts
+++ b/packages/core-backend/src/db/migrate.ts
@@ -16,6 +16,11 @@ async function migrateToLatest() {
 
   const migrator = new Migrator({
     db,
+    // Some deployed environments already executed later migrations before
+    // newly-added earlier-named migrations were merged into main. Allow
+    // unordered histories so those environments can continue applying the
+    // still-missing migrations instead of hard-failing on order checks.
+    allowUnorderedMigrations: true,
     provider: {
       async getMigrations() {
         const migrations = await baseProvider.getMigrations()

--- a/scripts/ops/capture-yjs-rollout-report.mjs
+++ b/scripts/ops/capture-yjs-rollout-report.mjs
@@ -85,6 +85,68 @@ function runNodeScript(scriptPath, args, extraEnv = {}) {
   }
 }
 
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function assertBoolean(value, label) {
+  if (typeof value !== 'boolean') {
+    throw new Error(`Incomplete ${label}: expected boolean`)
+  }
+}
+
+function assertNonNegativeNumber(value, label) {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Incomplete ${label}: expected non-negative number`)
+  }
+}
+
+function assertArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new Error(`Incomplete ${label}: expected array`)
+  }
+}
+
+function validateRuntimePayload(payload) {
+  if (!isPlainObject(payload)) {
+    throw new Error('Incomplete runtime payload: expected object')
+  }
+  if (typeof payload.baseUrl !== 'string' || payload.baseUrl.trim().length === 0) {
+    throw new Error('Incomplete runtime payload: missing baseUrl')
+  }
+  if (!isPlainObject(payload.metrics)) {
+    throw new Error('Incomplete runtime payload: missing metrics object')
+  }
+
+  const { metrics } = payload
+  assertBoolean(metrics.enabled, 'runtime payload metrics.enabled')
+  assertBoolean(metrics.initialized, 'runtime payload metrics.initialized')
+  assertNonNegativeNumber(metrics.activeDocCount, 'runtime payload metrics.activeDocCount')
+  assertNonNegativeNumber(metrics.pendingWriteCount, 'runtime payload metrics.pendingWriteCount')
+  assertNonNegativeNumber(metrics.flushSuccessCount, 'runtime payload metrics.flushSuccessCount')
+  assertNonNegativeNumber(metrics.flushFailureCount, 'runtime payload metrics.flushFailureCount')
+  assertNonNegativeNumber(metrics.activeSocketCount, 'runtime payload metrics.activeSocketCount')
+  assertNonNegativeNumber(metrics.activeRecordCount, 'runtime payload metrics.activeRecordCount')
+  assertArray(payload.failures, 'runtime payload failures')
+}
+
+function validateRetentionPayload(payload) {
+  if (!isPlainObject(payload)) {
+    throw new Error('Incomplete retention payload: expected object')
+  }
+  if (!isPlainObject(payload.stats)) {
+    throw new Error('Incomplete retention payload: missing stats object')
+  }
+
+  const { stats } = payload
+  assertNonNegativeNumber(stats.statesCount, 'retention payload stats.statesCount')
+  assertNonNegativeNumber(stats.updatesCount, 'retention payload stats.updatesCount')
+  assertNonNegativeNumber(stats.orphanStatesCount, 'retention payload stats.orphanStatesCount')
+  assertNonNegativeNumber(stats.orphanUpdatesCount, 'retention payload stats.orphanUpdatesCount')
+  assertArray(payload.failures, 'retention payload failures')
+  assertArray(payload.hottestRecords, 'retention payload hottestRecords')
+}
+
 function toHeadline(result) {
   return result.exitCode === 0 ? 'HEALTHY' : 'UNHEALTHY'
 }
@@ -135,48 +197,56 @@ ${retention.failures.length > 0 ? retention.failures.map((failure) => `- ${failu
 }
 
 async function main() {
-  const opts = parseArgs(process.argv.slice(2))
-  if (!opts.token) {
-    console.error('Missing admin token. Use --token, YJS_ADMIN_TOKEN, or ADMIN_TOKEN.')
+  try {
+    const opts = parseArgs(process.argv.slice(2))
+    if (!opts.token) {
+      console.error('Missing admin token. Use --token, YJS_ADMIN_TOKEN, or ADMIN_TOKEN.')
+      process.exit(1)
+    }
+    if (!opts.databaseUrl) {
+      console.error('Missing database URL. Use --database-url, YJS_DATABASE_URL, or DATABASE_URL.')
+      process.exit(1)
+    }
+
+    const runtimeScript = path.resolve(process.cwd(), 'scripts/ops/check-yjs-rollout-status.mjs')
+    const retentionScript = path.resolve(process.cwd(), 'scripts/ops/check-yjs-retention-health.mjs')
+
+    const runtime = runNodeScript(runtimeScript, ['--json-only'], {
+      YJS_BASE_URL: opts.baseUrl,
+      YJS_ADMIN_TOKEN: opts.token,
+    })
+    const retention = runNodeScript(retentionScript, ['--json-only'], {
+      YJS_DATABASE_URL: opts.databaseUrl,
+    })
+
+    validateRuntimePayload(runtime.payload)
+    validateRetentionPayload(retention.payload)
+
+    const generatedAt = new Date().toISOString()
+    const timestamp = generatedAt.replace(/[:.]/g, '-')
+    mkdirSync(opts.outputDir, { recursive: true })
+
+    const report = {
+      generatedAt,
+      runtime,
+      retention,
+    }
+
+    const jsonPath = path.join(opts.outputDir, `yjs-rollout-report-${timestamp}.json`)
+    const mdPath = path.join(opts.outputDir, `yjs-rollout-report-${timestamp}.md`)
+
+    writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+    writeFileSync(mdPath, `${renderMarkdown(report)}\n`, 'utf8')
+
+    console.log(`Wrote ${jsonPath}`)
+    console.log(`Wrote ${mdPath}`)
+
+    const exitCode = runtime.exitCode === 0 && retention.exitCode === 0 ? 0 : 2
+    process.exit(exitCode)
+  } catch (error) {
+    console.error(`Failed to capture Yjs rollout report: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)
   }
-  if (!opts.databaseUrl) {
-    console.error('Missing database URL. Use --database-url, YJS_DATABASE_URL, or DATABASE_URL.')
-    process.exit(1)
-  }
-
-  const runtimeScript = path.resolve(process.cwd(), 'scripts/ops/check-yjs-rollout-status.mjs')
-  const retentionScript = path.resolve(process.cwd(), 'scripts/ops/check-yjs-retention-health.mjs')
-
-  const runtime = runNodeScript(runtimeScript, ['--json-only'], {
-    YJS_BASE_URL: opts.baseUrl,
-    YJS_ADMIN_TOKEN: opts.token,
-  })
-  const retention = runNodeScript(retentionScript, ['--json-only'], {
-    YJS_DATABASE_URL: opts.databaseUrl,
-  })
-
-  const generatedAt = new Date().toISOString()
-  const timestamp = generatedAt.replace(/[:.]/g, '-')
-  mkdirSync(opts.outputDir, { recursive: true })
-
-  const report = {
-    generatedAt,
-    runtime,
-    retention,
-  }
-
-  const jsonPath = path.join(opts.outputDir, `yjs-rollout-report-${timestamp}.json`)
-  const mdPath = path.join(opts.outputDir, `yjs-rollout-report-${timestamp}.md`)
-
-  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
-  writeFileSync(mdPath, `${renderMarkdown(report)}\n`, 'utf8')
-
-  console.log(`Wrote ${jsonPath}`)
-  console.log(`Wrote ${mdPath}`)
-
-  const exitCode = runtime.exitCode === 0 && retention.exitCode === 0 ? 0 : 2
-  process.exit(exitCode)
 }
 
 await main()

--- a/scripts/ops/capture-yjs-rollout-report.test.mjs
+++ b/scripts/ops/capture-yjs-rollout-report.test.mjs
@@ -1,0 +1,139 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const captureScript = path.join(__dirname, 'capture-yjs-rollout-report.mjs')
+
+function createFixtureDir() {
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), 'yjs-rollout-report-'))
+  mkdirSync(path.join(fixtureDir, 'scripts/ops'), { recursive: true })
+  return fixtureDir
+}
+
+function writeScript(fixtureDir, name, payload, exitCode = 0) {
+  const scriptPath = path.join(fixtureDir, 'scripts/ops', name)
+  writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env node
+console.log(JSON.stringify(${JSON.stringify(payload, null, 2)}))
+process.exit(${exitCode})
+`,
+    'utf8',
+  )
+}
+
+function runCapture(fixtureDir) {
+  return spawnSync(
+    process.execPath,
+    [captureScript, '--token', 'test-token', '--database-url', 'postgres://example/test', '--output-dir', 'artifacts-out'],
+    {
+      cwd: fixtureDir,
+      encoding: 'utf8',
+    },
+  )
+}
+
+test('capture-yjs-rollout-report writes report files when runtime and retention payloads are complete', () => {
+  const fixtureDir = createFixtureDir()
+
+  try {
+    writeScript(fixtureDir, 'check-yjs-rollout-status.mjs', {
+      baseUrl: 'http://127.0.0.1:8900',
+      metrics: {
+        enabled: true,
+        initialized: true,
+        activeDocCount: 0,
+        pendingWriteCount: 0,
+        flushSuccessCount: 0,
+        flushFailureCount: 0,
+        activeSocketCount: 0,
+        activeRecordCount: 0,
+      },
+      failures: [],
+      payload: { success: true, yjs: {} },
+    })
+    writeScript(fixtureDir, 'check-yjs-retention-health.mjs', {
+      databaseUrlPresent: true,
+      thresholds: {
+        maxUpdates: 100000,
+        maxOrphanStates: 0,
+        maxOrphanUpdates: 0,
+        topLimit: 10,
+      },
+      failures: [],
+      stats: {
+        statesCount: 0,
+        updatesCount: 0,
+        orphanStatesCount: 0,
+        orphanUpdatesCount: 0,
+      },
+      hottestRecords: [],
+    })
+
+    const result = runCapture(fixtureDir)
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Wrote .*yjs-rollout-report-.*\.json/)
+
+    const outputDir = path.join(fixtureDir, 'artifacts-out')
+    const files = readdirSync(outputDir)
+    const jsonFile = files.find((file) => file.endsWith('.json'))
+    const mdFile = files.find((file) => file.endsWith('.md'))
+    assert.ok(jsonFile)
+    assert.ok(mdFile)
+
+    const report = JSON.parse(readFileSync(path.join(outputDir, jsonFile), 'utf8'))
+    assert.equal(report.runtime.payload.metrics.enabled, true)
+    assert.equal(report.retention.payload.stats.statesCount, 0)
+    assert.equal(report.retention.payload.stats.orphanUpdatesCount, 0)
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  }
+})
+
+test('capture-yjs-rollout-report fails closed when retention stats are missing', () => {
+  const fixtureDir = createFixtureDir()
+
+  try {
+    writeScript(fixtureDir, 'check-yjs-rollout-status.mjs', {
+      baseUrl: 'http://127.0.0.1:8900',
+      metrics: {
+        enabled: true,
+        initialized: true,
+        activeDocCount: 0,
+        pendingWriteCount: 0,
+        flushSuccessCount: 0,
+        flushFailureCount: 0,
+        activeSocketCount: 0,
+        activeRecordCount: 0,
+      },
+      failures: [],
+      payload: { success: true, yjs: {} },
+    })
+    writeScript(fixtureDir, 'check-yjs-retention-health.mjs', {
+      databaseUrlPresent: true,
+      thresholds: {
+        maxUpdates: 100000,
+        maxOrphanStates: 0,
+        maxOrphanUpdates: 0,
+        topLimit: 10,
+      },
+      failures: [],
+      stats: {},
+      hottestRecords: [],
+    })
+
+    const result = runCapture(fixtureDir)
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /Incomplete retention payload/)
+
+    const outputDir = path.join(fixtureDir, 'artifacts-out')
+    assert.equal(existsSync(outputDir), false)
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## What changed

This PR closes two rollout blockers discovered during live Yjs validation on the production-like host:

- the main migration runner now tolerates historic unordered migration histories, which unblocks `zzzz20260501100000_create_yjs_state_tables` on environments that had already executed later `zzzz20260413*` migrations first
- `capture-yjs-rollout-report.mjs` now fails closed when runtime or retention payloads are incomplete instead of rendering a misleading healthy report

## Code changes

- `packages/core-backend/src/db/migrate.ts`
  - enable `allowUnorderedMigrations: true`
- `scripts/ops/capture-yjs-rollout-report.mjs`
  - validate runtime payload shape
  - validate retention payload shape
  - exit `1` on incomplete evidence instead of writing a false-positive report
- `scripts/ops/capture-yjs-rollout-report.test.mjs`
  - adds success-path and fail-closed coverage
- development / verification notes
  - `docs/development/yjs-unordered-migration-and-report-hardening-development-20260418.md`
  - `docs/development/yjs-unordered-migration-and-report-hardening-verification-20260418.md`

## Why this is needed

On the remote rollout target, the stock migrator hard-failed because the database had already recorded:

- `zzzz20260413130000_create_formula_dependencies`

but not:

- `zzzz20260413120000_create_automation_rules`

That blocked all later migrations, including the Yjs tables.

During the same live validation pass, the combined rollout report script also proved too trusting: a retention payload with `stats: {}` could still be rendered as healthy evidence. This PR makes that path fail closed.

## Verification

Local:

```bash
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migrations.rollback.test.ts tests/unit/db.test.ts --watch=false
node --test scripts/ops/capture-yjs-rollout-report.test.mjs
```

Results:

- backend build passed
- `17` backend tests passed
- `2` rollout-report script tests passed

Remote evidence is documented in:

- `docs/development/yjs-unordered-migration-and-report-hardening-verification-20260418.md`

Key remote outcomes:

- deployment aligned to `IMAGE_TAG=20260418-yjs-rollout-r2`
- unordered migration run successfully applied the missing `zzzz20260413120000_*` / `zzzz2026041410000*` / `zzzz20260501100000_create_yjs_state_tables`
- `/api/admin/yjs/status` returned `enabled=true` and `initialized=true`
- retention baseline was clean (`statesCount=0`, `updatesCount=0`, no orphans)

## Scope

This PR does not change Yjs runtime behavior or websocket semantics. It only restores migration continuity and hardens rollout evidence capture.
