### PR TITLE
feat(dingtalk): link projected member groups to default governance

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -202,6 +202,24 @@
               placeholder="填写需要投影为平台用户组的部门 ID，支持逗号或换行分隔"
             />
           </label>
+          <label class="directory-admin__field directory-admin__field--wide">
+            <span>成员组默认业务角色</span>
+            <textarea
+              v-model.trim="draft.memberGroupDefaultRoleIdsText"
+              class="directory-admin__input directory-admin__textarea"
+              rows="2"
+              placeholder="填写 role ID，支持逗号或换行分隔；仅对投影成员组里的已链接用户做单向补齐"
+            />
+          </label>
+          <label class="directory-admin__field directory-admin__field--wide">
+            <span>成员组默认插件开通</span>
+            <textarea
+              v-model.trim="draft.memberGroupDefaultNamespacesText"
+              class="directory-admin__input directory-admin__textarea"
+              rows="2"
+              placeholder="填写命名空间，例如 crm；支持逗号或换行分隔"
+            />
+          </label>
           <label class="directory-admin__field">
             <span>状态</span>
             <select v-model="draft.status" class="directory-admin__input">
@@ -1095,6 +1113,8 @@ type DirectoryIntegration = {
     excludeDepartmentIds: string[]
     memberGroupSyncMode: 'disabled' | 'sync_scoped_departments'
     memberGroupDepartmentIds: string[]
+    memberGroupDefaultRoleIds: string[]
+    memberGroupDefaultNamespaces: string[]
   }
   stats: {
     departmentCount: number
@@ -1324,6 +1344,8 @@ type DirectoryDraft = {
   excludeDepartmentIdsText: string
   memberGroupSyncMode: 'disabled' | 'sync_scoped_departments'
   memberGroupDepartmentIdsText: string
+  memberGroupDefaultRoleIdsText: string
+  memberGroupDefaultNamespacesText: string
   status: string
   scheduleCron: string
   defaultDeprovisionPolicy: string
@@ -1422,6 +1444,8 @@ const draft = reactive<DirectoryDraft>({
   excludeDepartmentIdsText: '',
   memberGroupSyncMode: 'disabled',
   memberGroupDepartmentIdsText: '',
+  memberGroupDefaultRoleIdsText: '',
+  memberGroupDefaultNamespacesText: '',
   status: 'active',
   scheduleCron: '',
   defaultDeprovisionPolicy: 'mark_inactive',
@@ -1668,6 +1692,8 @@ function resetDraft() {
   draft.excludeDepartmentIdsText = ''
   draft.memberGroupSyncMode = 'disabled'
   draft.memberGroupDepartmentIdsText = ''
+  draft.memberGroupDefaultRoleIdsText = ''
+  draft.memberGroupDefaultNamespacesText = ''
   draft.status = 'active'
   draft.scheduleCron = ''
   draft.defaultDeprovisionPolicy = 'mark_inactive'
@@ -1687,6 +1713,8 @@ function applyIntegrationToDraft(integration: DirectoryIntegration) {
   draft.excludeDepartmentIdsText = integration.config.excludeDepartmentIds.join('\n')
   draft.memberGroupSyncMode = integration.config.memberGroupSyncMode
   draft.memberGroupDepartmentIdsText = integration.config.memberGroupDepartmentIds.join('\n')
+  draft.memberGroupDefaultRoleIdsText = integration.config.memberGroupDefaultRoleIds.join('\n')
+  draft.memberGroupDefaultNamespacesText = integration.config.memberGroupDefaultNamespaces.join('\n')
   draft.status = integration.status
   draft.scheduleCron = integration.scheduleCron ?? ''
   draft.defaultDeprovisionPolicy = integration.defaultDeprovisionPolicy
@@ -1716,7 +1744,15 @@ function readAdmissionModeLabel(integration: DirectoryIntegration): string {
 function readMemberGroupSyncLabel(integration: DirectoryIntegration): string {
   if (integration.config.memberGroupSyncMode === 'sync_scoped_departments') {
     const count = integration.config.memberGroupDepartmentIds.length
-    return count > 0 ? `成员组同步 · ${count} 个部门` : '成员组同步 · 未配置部门'
+    const governanceParts: string[] = []
+    if (integration.config.memberGroupDefaultRoleIds.length > 0) {
+      governanceParts.push(`默认角色 ${integration.config.memberGroupDefaultRoleIds.length}`)
+    }
+    if (integration.config.memberGroupDefaultNamespaces.length > 0) {
+      governanceParts.push(`默认开通 ${integration.config.memberGroupDefaultNamespaces.length}`)
+    }
+    const scopeLabel = count > 0 ? `成员组同步 · ${count} 个部门` : '成员组同步 · 未配置部门'
+    return governanceParts.length > 0 ? `${scopeLabel} / ${governanceParts.join(' / ')}` : scopeLabel
   }
   return '成员组同步已关闭'
 }
@@ -2155,6 +2191,8 @@ function buildPayload() {
     excludeDepartmentIds: parseAdmissionDepartmentIdsText(draft.excludeDepartmentIdsText),
     memberGroupSyncMode: draft.memberGroupSyncMode,
     memberGroupDepartmentIds: parseAdmissionDepartmentIdsText(draft.memberGroupDepartmentIdsText),
+    memberGroupDefaultRoleIds: parseAdmissionDepartmentIdsText(draft.memberGroupDefaultRoleIdsText),
+    memberGroupDefaultNamespaces: parseAdmissionDepartmentIdsText(draft.memberGroupDefaultNamespacesText),
     status: draft.status,
     scheduleCron: draft.scheduleCron.trim(),
     defaultDeprovisionPolicy: draft.defaultDeprovisionPolicy,
@@ -2221,11 +2259,15 @@ async function syncIntegration() {
     const autoAdmissionExcludedCount = Number(body?.data?.run?.stats?.autoAdmissionExcludedCount ?? 0)
     const memberGroupsSyncedCount = Number(body?.data?.run?.stats?.memberGroupsSyncedCount ?? 0)
     const memberGroupsCreatedCount = Number(body?.data?.run?.stats?.memberGroupsCreatedCount ?? 0)
+    const memberGroupGovernedUserCount = Number(body?.data?.run?.stats?.memberGroupGovernedUserCount ?? 0)
+    const memberGroupDefaultRoleAssignmentsCount = Number(body?.data?.run?.stats?.memberGroupDefaultRoleAssignmentsCount ?? 0)
+    const memberGroupDefaultNamespaceAdmissionsCount = Number(body?.data?.run?.stats?.memberGroupDefaultNamespaceAdmissionsCount ?? 0)
     if (
       autoAdmittedCount > 0
       || autoAdmissionSkippedMissingEmailCount > 0
       || autoAdmissionExcludedCount > 0
       || memberGroupsSyncedCount > 0
+      || memberGroupGovernedUserCount > 0
     ) {
       const parts = ['目录同步已完成']
       if (autoAdmittedCount > 0) parts.push(`自动准入 ${autoAdmittedCount} 位成员`)
@@ -2237,6 +2279,16 @@ async function syncIntegration() {
         } else {
           parts.push(`同步 ${memberGroupsSyncedCount} 个成员组`)
         }
+      }
+      if (memberGroupGovernedUserCount > 0) {
+        const governanceDetails: string[] = []
+        if (memberGroupDefaultRoleAssignmentsCount > 0) governanceDetails.push(`角色新增 ${memberGroupDefaultRoleAssignmentsCount} 项`)
+        if (memberGroupDefaultNamespaceAdmissionsCount > 0) governanceDetails.push(`插件开通新增 ${memberGroupDefaultNamespaceAdmissionsCount} 项`)
+        parts.push(
+          governanceDetails.length > 0
+            ? `为 ${memberGroupGovernedUserCount} 位成员补齐默认治理（${governanceDetails.join('，')}）`
+            : `为 ${memberGroupGovernedUserCount} 位成员补齐默认治理`,
+        )
       }
       setStatus(parts.join('，'))
     } else {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -66,6 +66,8 @@ function createIntegration(overrides: Record<string, unknown> = {}) {
       excludeDepartmentIds: [],
       memberGroupSyncMode: 'disabled',
       memberGroupDepartmentIds: [],
+      memberGroupDefaultRoleIds: [],
+      memberGroupDefaultNamespaces: [],
     },
     stats: {
       departmentCount: 12,
@@ -399,6 +401,9 @@ describe('DirectoryManagementView', () => {
               autoAdmissionExcludedCount: 1,
               memberGroupsSyncedCount: 2,
               memberGroupsCreatedCount: 1,
+              memberGroupGovernedUserCount: 3,
+              memberGroupDefaultRoleAssignmentsCount: 4,
+              memberGroupDefaultNamespaceAdmissionsCount: 6,
             },
           },
         },
@@ -437,6 +442,9 @@ describe('DirectoryManagementView', () => {
                 autoAdmissionExcludedCount: 1,
                 memberGroupsSyncedCount: 2,
                 memberGroupsCreatedCount: 1,
+                memberGroupGovernedUserCount: 3,
+                memberGroupDefaultRoleAssignmentsCount: 4,
+                memberGroupDefaultNamespaceAdmissionsCount: 6,
               },
               errorMessage: null,
             },
@@ -525,7 +533,7 @@ describe('DirectoryManagementView', () => {
     expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/alerts?page=1&pageSize=20&filter=all')
     expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/review-items?page=1&pageSize=100&filter=all')
     expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=25')
-    expect(container?.textContent).toContain('目录同步已完成，自动准入 2 位成员，1 位成员命中排除部门，未自动创建，同步 2 个成员组（新建 1 个）')
+    expect(container?.textContent).toContain('目录同步已完成，自动准入 2 位成员，1 位成员命中排除部门，未自动创建，同步 2 个成员组（新建 1 个），为 3 位成员补齐默认治理（角色新增 4 项，插件开通新增 6 项）')
     expect(container?.textContent).toContain('账号 99')
   })
 
@@ -4237,12 +4245,20 @@ describe('DirectoryManagementView', () => {
 
     const includeTextarea = container!.querySelector('textarea[placeholder*="将覆盖所选部门及其子部门"]') as HTMLTextAreaElement | null
     const excludeTextarea = container!.querySelector('textarea[placeholder*="会覆盖白名单父部门"]') as HTMLTextAreaElement | null
+    const roleTextarea = container!.querySelector('textarea[placeholder*="填写 role ID"]') as HTMLTextAreaElement | null
+    const namespaceTextarea = container!.querySelector('textarea[placeholder*="填写命名空间"]') as HTMLTextAreaElement | null
     expect(includeTextarea).toBeTruthy()
     expect(excludeTextarea).toBeTruthy()
+    expect(roleTextarea).toBeTruthy()
+    expect(namespaceTextarea).toBeTruthy()
     includeTextarea!.value = 'dept-root\ndept-child'
     includeTextarea!.dispatchEvent(new Event('input', { bubbles: true }))
     excludeTextarea!.value = 'dept-private'
     excludeTextarea!.dispatchEvent(new Event('input', { bubbles: true }))
+    roleTextarea!.value = 'crm_user\nsales_user'
+    roleTextarea!.dispatchEvent(new Event('input', { bubbles: true }))
+    namespaceTextarea!.value = 'crm\nsales'
+    namespaceTextarea!.dispatchEvent(new Event('input', { bubbles: true }))
     await flushUi(2)
 
     const testButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('测试连通性'))
@@ -4268,6 +4284,8 @@ describe('DirectoryManagementView', () => {
           excludeDepartmentIds: ['dept-private'],
           memberGroupSyncMode: 'disabled',
           memberGroupDepartmentIds: [],
+          memberGroupDefaultRoleIds: ['crm_user', 'sales_user'],
+          memberGroupDefaultNamespaces: ['crm', 'sales'],
           status: 'active',
           scheduleCron: '',
           defaultDeprovisionPolicy: 'mark_inactive',

--- a/docs/development/dingtalk-directory-auto-admission-and-password-governance-design-20260418.md
+++ b/docs/development/dingtalk-directory-auto-admission-and-password-governance-design-20260418.md
@@ -27,6 +27,16 @@
     - `memberGroupSyncMode = sync_scoped_departments`
     - `memberGroupDepartmentIds = [...]`
   - Each selected department projects to one platform member group containing linked local users from that department subtree
+- Apply safe default governance to projected member-group members: **supported in this branch**
+  - Integration config:
+    - `memberGroupDefaultRoleIds = [...]`
+    - `memberGroupDefaultNamespaces = [...]`
+  - Sync fills only missing grants for linked local users inside projected groups
+  - Current safety rule:
+    - ordinary business roles only
+    - no `admin`
+    - no delegated-admin style roles
+    - namespaces must be admission-controlled resources
 
 ### Password capabilities
 
@@ -72,6 +82,15 @@ Still not implemented:
 
 - role templates or member-group projection during admission;
 - dedicated operator notification delivery for auto-admitted users.
+
+The branch now also allows projected member groups to add a safe downstream
+governance baseline after admission:
+
+- default business roles
+- default namespace admissions
+
+This is additive only and intentionally does not revoke grants when a user
+later leaves scope.
 
 ### Phase 3: password governance
 

--- a/docs/development/dingtalk-directory-member-group-governance-linkage-development-20260418.md
+++ b/docs/development/dingtalk-directory-member-group-governance-linkage-development-20260418.md
@@ -1,0 +1,158 @@
+# DingTalk Directory Member Group Governance Linkage Development
+
+- Date: 2026-04-18
+- Worktree: `.worktrees/dingtalk-member-group-role-sync-20260418`
+- Branch: `codex/dingtalk-member-group-role-sync-20260418`
+
+## Goal
+
+Extend DingTalk department-to-member-group projection so projected groups can
+also grant a safe default governance baseline to already linked local users.
+
+This round does not attempt full RBAC templating. It only adds two explicit,
+operator-configured defaults:
+
+- default business roles
+- default namespace admissions
+
+Both are one-way “fill missing grants” operations during sync.
+
+## Problem
+
+The previous branch already supported:
+
+- manual admission from synced DingTalk members;
+- scoped auto-admission with include/exclude departments;
+- forced password change for temporary-password users;
+- projection of selected DingTalk departments into `platform_member_groups`.
+
+But projected member groups still stopped at membership. Operators could keep a
+department subtree synchronized as a platform member group, yet they still had
+to separately grant downstream business roles or plugin admissions for the
+same set of linked users.
+
+That made the projection useful for visibility, but incomplete for real
+governance rollout.
+
+## Implementation
+
+### Integration config
+
+Files:
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+- `apps/web/src/views/DirectoryManagementView.vue`
+
+Added config fields:
+
+- `memberGroupDefaultRoleIds`
+- `memberGroupDefaultNamespaces`
+
+These fields now round-trip through:
+
+- create integration
+- update integration
+- list/summarize integration
+- frontend edit form
+- frontend integration test payload
+
+### Governance grant planning
+
+File:
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+
+Added pure helper:
+
+- `buildDirectoryProjectedGovernanceGrantSet(...)`
+
+Behavior:
+
+- dedupe projected linked users across multiple selected departments;
+- dedupe configured role IDs;
+- dedupe configured namespace admissions.
+
+This helper intentionally keeps planning logic pure so the sync-time DB write
+path can stay narrow.
+
+### Config validation
+
+File:
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+
+Added backend validation:
+
+- configured role IDs must exist;
+- `admin` and delegated-admin style roles are rejected;
+- configured namespaces must be admission-controlled resources.
+
+This keeps the feature in a safe baseline:
+
+- operators can grant ordinary business roles;
+- operators cannot use this sync path to mass-grant broad admin power.
+
+### Sync-time governance application
+
+File:
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+
+Added transactional helper:
+
+- `applyDirectoryProjectedMemberGroupGovernanceInTransaction(...)`
+
+Behavior:
+
+- after projected groups and memberships are synchronized, collect all linked
+  users in scope;
+- bulk insert missing `user_roles` for configured default roles;
+- bulk upsert enabled `user_namespace_admissions` for configured namespaces;
+- keep the operation additive only:
+  - no automatic role removal
+  - no automatic namespace admission revocation
+- invalidate permission caches for users whose projected governance was touched.
+
+### Sync stats
+
+Extended sync run stats with:
+
+- `memberGroupGovernedUserCount`
+- `memberGroupDefaultRoleAssignmentsCount`
+- `memberGroupDefaultNamespaceAdmissionsCount`
+
+These counters are reported alongside the existing projected member-group
+counts.
+
+### Directory management UI
+
+File:
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+
+Added UI controls:
+
+- `成员组默认业务角色`
+- `成员组默认插件开通`
+
+Added UI feedback:
+
+- integration summary label now shows when member-group projection also carries
+  default governance;
+- sync success message now reports how many projected users received missing
+  governance grants, plus counts for role inserts and namespace admissions.
+
+## Scope Notes
+
+This round intentionally does not yet implement:
+
+- automatic revocation when a user leaves the projected department;
+- per-group role templates beyond explicit role ID lists;
+- default permission-scope templates;
+- time-window password policy;
+- remote deployment.
+
+## Deployment
+
+No remote deployment was performed in this round.
+No database migration was added in this round.

--- a/docs/development/dingtalk-directory-member-group-governance-linkage-verification-20260418.md
+++ b/docs/development/dingtalk-directory-member-group-governance-linkage-verification-20260418.md
@@ -1,0 +1,75 @@
+# DingTalk Directory Member Group Governance Linkage Verification
+
+- Date: 2026-04-18
+- Worktree: `.worktrees/dingtalk-member-group-role-sync-20260418`
+- Branch: `codex/dingtalk-member-group-role-sync-20260418`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-member-group-projection.test.ts tests/unit/admin-directory-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+### Backend tests
+
+- `tests/unit/directory-sync-member-group-projection.test.ts`
+- `tests/unit/admin-directory-routes.test.ts`
+
+Result:
+
+- `2 files passed`
+- `23 passed`
+
+Covered in this round:
+
+- projected member groups still derive linked local users from selected
+  department subtrees;
+- governance grant planning dedupes users, role IDs, and namespaces;
+- admin-directory integration payload round-trip accepts the new governance
+  config fields.
+
+### Frontend tests
+
+- `tests/directoryManagementView.spec.ts`
+
+Result:
+
+- `1 file passed`
+- `32 passed`
+
+Covered in this round:
+
+- integration test/save payload now carries member-group default role IDs and
+  namespace admissions;
+- sync success feedback includes governed-user counts and additive role/plugin
+  grant counts;
+- existing directory management review/admission flows remain intact.
+
+Observed existing non-blocking warning:
+
+- Vitest prints `WebSocket server error: Port is already in use`
+
+This warning was already present before this change and did not affect test
+results.
+
+### Builds
+
+- `pnpm --filter @metasheet/core-backend build` — passed
+- `pnpm --filter @metasheet/web build` — passed
+
+Observed existing non-blocking warnings:
+
+- Vite prints a dynamic import chunking note for `WorkflowDesigner.vue`
+- Vite prints existing chunk-size warnings
+
+Neither warning was introduced by this change.
+
+## Deployment
+
+No remote deployment was performed in this round.

--- a/docs/development/dingtalk-directory-sync-admission-and-scoped-sync-design-20260418.md
+++ b/docs/development/dingtalk-directory-sync-admission-and-scoped-sync-design-20260418.md
@@ -41,6 +41,7 @@ Updated branch status:
 - manual local-user admission: implemented
 - scoped auto-admission with include/exclude departments: implemented
 - selected department -> platform member group projection: implemented
+- projected member groups -> safe default role/plugin governance linkage: implemented
 
 ## Recommendation
 
@@ -125,6 +126,16 @@ Behavior:
 - group membership is derived from linked local users inside that department
   subtree;
 - projected groups are tracked by a deterministic description marker.
+- projected groups can also fill a safe additive governance baseline for linked
+  users via:
+  - `memberGroupDefaultRoleIds`
+  - `memberGroupDefaultNamespaces`
+
+Current safety boundary:
+
+- configured roles must exist;
+- `admin` and delegated-admin style roles are rejected;
+- configured namespaces must be admission-controlled.
 
 ### Phase 3: Scoped auto-admission for selected departments
 
@@ -221,6 +232,7 @@ Recommended order:
 1. manual user admission
 2. department -> member group projection
 3. scoped auto-admission
+4. safe default role / namespace linkage for projected member groups
 
 Do **not** ship auto-admission before manual admission and audit visibility are
 available.
@@ -233,7 +245,9 @@ mirroring, the best path is:
 1. keep DingTalk sync as the source directory mirror;
 2. add manual `create local user + bind`;
 3. project selected synced departments into `platform_member_groups`;
-4. later add scoped auto-admission for allowlisted departments only.
+4. add scoped auto-admission for allowlisted departments only;
+5. use projected groups to fill a safe default governance baseline where
+   needed.
 
 That gives:
 

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -15,6 +15,12 @@ import {
   type DingTalkDirectoryUser,
 } from '../integrations/dingtalk/client'
 import { assertDingTalkCorpAllowed } from '../integrations/dingtalk/runtime-policy'
+import {
+  deriveDelegatedAdminNamespace,
+  isNamespaceAdmissionControlledResource,
+  normalizeNamespace,
+} from '../rbac/namespace-admission'
+import { invalidateUserPerms } from '../rbac/service'
 import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../security/encrypted-secrets'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 import { SimpleCronExpression } from '../services/SchedulerService'
@@ -42,6 +48,8 @@ type DirectoryIntegrationConfig = {
   excludeDepartmentIds: string[]
   memberGroupSyncMode: DirectoryMemberGroupSyncMode
   memberGroupDepartmentIds: string[]
+  memberGroupDefaultRoleIds: string[]
+  memberGroupDefaultNamespaces: string[]
 }
 
 type DirectoryIntegrationRow = {
@@ -244,6 +252,8 @@ export type DirectoryIntegrationSummary = {
     excludeDepartmentIds: string[]
     memberGroupSyncMode: DirectoryMemberGroupSyncMode
     memberGroupDepartmentIds: string[]
+    memberGroupDefaultRoleIds: string[]
+    memberGroupDefaultNamespaces: string[]
   }
   stats: {
     departmentCount: number
@@ -267,6 +277,8 @@ export type DirectoryIntegrationInput = {
   excludeDepartmentIds?: string[] | string
   memberGroupSyncMode?: DirectoryMemberGroupSyncMode | string
   memberGroupDepartmentIds?: string[] | string
+  memberGroupDefaultRoleIds?: string[] | string
+  memberGroupDefaultNamespaces?: string[] | string
   syncEnabled?: boolean
   scheduleCron?: string | null
   defaultDeprovisionPolicy?: string
@@ -275,6 +287,39 @@ export type DirectoryIntegrationInput = {
 
 export type DirectoryIntegrationTestInput = DirectoryIntegrationInput & {
   integrationId?: string
+}
+
+type NormalizedDirectoryIntegrationInput = Omit<
+  DirectoryIntegrationInput,
+  | 'name'
+  | 'corpId'
+  | 'appKey'
+  | 'appSecret'
+  | 'rootDepartmentId'
+  | 'admissionMode'
+  | 'admissionDepartmentIds'
+  | 'excludeDepartmentIds'
+  | 'memberGroupSyncMode'
+  | 'memberGroupDepartmentIds'
+  | 'memberGroupDefaultRoleIds'
+  | 'memberGroupDefaultNamespaces'
+  | 'defaultDeprovisionPolicy'
+  | 'status'
+> & {
+  name: string
+  corpId: string
+  appKey: string
+  appSecret: string
+  rootDepartmentId: string
+  admissionMode: DirectoryAdmissionMode
+  admissionDepartmentIds: string[]
+  excludeDepartmentIds: string[]
+  memberGroupSyncMode: DirectoryMemberGroupSyncMode
+  memberGroupDepartmentIds: string[]
+  memberGroupDefaultRoleIds: string[]
+  memberGroupDefaultNamespaces: string[]
+  defaultDeprovisionPolicy: string
+  status: string
 }
 
 export type DirectoryIntegrationTestResult = {
@@ -485,6 +530,12 @@ export type DirectoryProjectedMemberGroupPlan = {
   memberUserIds: string[]
 }
 
+export type DirectoryProjectedGovernanceGrantSet = {
+  userIds: string[]
+  roleIds: string[]
+  namespaces: string[]
+}
+
 function parseJsonRecord(value: JsonRecord | string | null | undefined): JsonRecord {
   if (!value) return {}
   if (typeof value === 'string') {
@@ -567,6 +618,36 @@ function normalizeExcludeDepartmentIds(value: unknown, fallback: string[] = []):
 
 function normalizeMemberGroupDepartmentIds(value: unknown, fallback: string[] = []): string[] {
   return normalizeAdmissionDepartmentIds(value, fallback)
+}
+
+function normalizeMemberGroupDefaultRoleIds(value: unknown, fallback: string[] = []): string[] {
+  const rawValues = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(/[\n,]+/)
+      : fallback
+  const deduped = new Set<string>()
+  for (const entry of rawValues) {
+    const normalized = normalizeText(entry)
+    if (!normalized) continue
+    deduped.add(normalized)
+  }
+  return Array.from(deduped)
+}
+
+function normalizeMemberGroupDefaultNamespaces(value: unknown, fallback: string[] = []): string[] {
+  const rawValues = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(/[\n,]+/)
+      : fallback
+  const deduped = new Set<string>()
+  for (const entry of rawValues) {
+    const normalized = normalizeNamespace(entry)
+    if (!normalized || !isNamespaceAdmissionControlledResource(normalized)) continue
+    deduped.add(normalized)
+  }
+  return Array.from(deduped)
 }
 
 export function isDirectoryUserWithinAdmissionScope(
@@ -687,6 +768,54 @@ export function buildDirectoryProjectedMemberGroupPlans(options: {
   return plans
 }
 
+export function buildDirectoryProjectedGovernanceGrantSet(options: {
+  plans: DirectoryProjectedMemberGroupPlan[]
+  defaultRoleIds: string[]
+  defaultNamespaces: string[]
+}): DirectoryProjectedGovernanceGrantSet {
+  const userIds = Array.from(new Set(
+    options.plans.flatMap((plan) => plan.memberUserIds.map((value) => normalizeText(value)).filter(Boolean)),
+  )).sort()
+  return {
+    userIds,
+    roleIds: normalizeMemberGroupDefaultRoleIds(options.defaultRoleIds),
+    namespaces: normalizeMemberGroupDefaultNamespaces(options.defaultNamespaces),
+  }
+}
+
+async function assertDirectoryProjectedGovernanceConfigValid(config: Pick<
+  DirectoryIntegrationConfig,
+  'memberGroupDefaultRoleIds' | 'memberGroupDefaultNamespaces'
+>): Promise<void> {
+  const roleIds = normalizeMemberGroupDefaultRoleIds(config.memberGroupDefaultRoleIds)
+  const namespaces = normalizeMemberGroupDefaultNamespaces(config.memberGroupDefaultNamespaces)
+
+  for (const roleId of roleIds) {
+    if (roleId === 'admin' || deriveDelegatedAdminNamespace(roleId)) {
+      throw new Error('Projected member-group default roles cannot include platform admin or delegated admin roles')
+    }
+  }
+
+  if (roleIds.length > 0) {
+    const existingRoles = await query<{ id: string }>(
+      `SELECT id
+       FROM roles
+       WHERE id = ANY($1::text[])`,
+      [roleIds],
+    )
+    const existingRoleIds = new Set(existingRoles.rows.map((row) => normalizeText(row.id)).filter(Boolean))
+    const missingRoleIds = roleIds.filter((roleId) => !existingRoleIds.has(roleId))
+    if (missingRoleIds.length > 0) {
+      throw new Error(`Projected member-group default roles not found: ${missingRoleIds.join(', ')}`)
+    }
+  }
+
+  const unsupportedNamespaces = namespaces.filter((namespace) => !isNamespaceAdmissionControlledResource(namespace))
+  if (unsupportedNamespaces.length > 0) {
+    throw new Error(`Projected member-group default namespaces are not admission-controlled: ${unsupportedNamespaces.join(', ')}`)
+  }
+}
+
 function parseIntegrationConfig(row: Pick<DirectoryIntegrationRow, 'config'>): DirectoryIntegrationConfig {
   const config = parseJsonRecord(row.config)
   const appKey = normalizeText(config.appKey)
@@ -700,6 +829,8 @@ function parseIntegrationConfig(row: Pick<DirectoryIntegrationRow, 'config'>): D
   const excludeDepartmentIds = normalizeExcludeDepartmentIds(config.excludeDepartmentIds)
   const memberGroupSyncMode = normalizeMemberGroupSyncMode(config.memberGroupSyncMode)
   const memberGroupDepartmentIds = normalizeMemberGroupDepartmentIds(config.memberGroupDepartmentIds)
+  const memberGroupDefaultRoleIds = normalizeMemberGroupDefaultRoleIds(config.memberGroupDefaultRoleIds)
+  const memberGroupDefaultNamespaces = normalizeMemberGroupDefaultNamespaces(config.memberGroupDefaultNamespaces)
   return {
     appKey,
     appSecret,
@@ -711,6 +842,8 @@ function parseIntegrationConfig(row: Pick<DirectoryIntegrationRow, 'config'>): D
     excludeDepartmentIds,
     memberGroupSyncMode,
     memberGroupDepartmentIds,
+    memberGroupDefaultRoleIds,
+    memberGroupDefaultNamespaces,
   }
 }
 
@@ -742,6 +875,8 @@ function summarizeIntegration(row: DirectoryIntegrationRow): DirectoryIntegratio
       excludeDepartmentIds: config.excludeDepartmentIds,
       memberGroupSyncMode: config.memberGroupSyncMode,
       memberGroupDepartmentIds: config.memberGroupDepartmentIds,
+      memberGroupDefaultRoleIds: config.memberGroupDefaultRoleIds,
+      memberGroupDefaultNamespaces: config.memberGroupDefaultNamespaces,
     },
     stats: {
       departmentCount: Number(row.department_count ?? 0),
@@ -1134,7 +1269,7 @@ async function loadDirectoryReviewRecommendations(
 function normalizeIntegrationInput(
   input: DirectoryIntegrationInput,
   current?: DirectoryIntegrationConfig,
-): DirectoryIntegrationInput & Required<Pick<DirectoryIntegrationInput, 'name' | 'corpId' | 'appKey' | 'appSecret' | 'rootDepartmentId' | 'defaultDeprovisionPolicy' | 'status'>> {
+): NormalizedDirectoryIntegrationInput {
   const name = normalizeText(input.name)
   const corpId = normalizeText(input.corpId)
   const appKey = normalizeText(input.appKey)
@@ -1145,6 +1280,8 @@ function normalizeIntegrationInput(
   const excludeDepartmentIds = normalizeExcludeDepartmentIds(input.excludeDepartmentIds, current?.excludeDepartmentIds ?? [])
   const memberGroupSyncMode = normalizeMemberGroupSyncMode(input.memberGroupSyncMode, current?.memberGroupSyncMode ?? DEFAULT_MEMBER_GROUP_SYNC_MODE)
   const memberGroupDepartmentIds = normalizeMemberGroupDepartmentIds(input.memberGroupDepartmentIds, current?.memberGroupDepartmentIds ?? [])
+  const memberGroupDefaultRoleIds = normalizeMemberGroupDefaultRoleIds(input.memberGroupDefaultRoleIds, current?.memberGroupDefaultRoleIds ?? [])
+  const memberGroupDefaultNamespaces = normalizeMemberGroupDefaultNamespaces(input.memberGroupDefaultNamespaces, current?.memberGroupDefaultNamespaces ?? [])
   const defaultDeprovisionPolicy = normalizeText(input.defaultDeprovisionPolicy) || 'mark_inactive'
   const status = normalizeText(input.status) || 'active'
 
@@ -1168,6 +1305,8 @@ function normalizeIntegrationInput(
     excludeDepartmentIds,
     memberGroupSyncMode,
     memberGroupDepartmentIds,
+    memberGroupDefaultRoleIds,
+    memberGroupDefaultNamespaces,
     syncEnabled: input.syncEnabled ?? false,
     scheduleCron: normalizeOptionalText(input.scheduleCron),
     defaultDeprovisionPolicy,
@@ -1222,6 +1361,10 @@ export async function listDirectoryIntegrations(orgId = DEFAULT_ORG_ID): Promise
 
 export async function createDirectoryIntegration(input: DirectoryIntegrationInput): Promise<DirectoryIntegrationSummary> {
   const normalized = normalizeIntegrationInput(input)
+  await assertDirectoryProjectedGovernanceConfigValid({
+    memberGroupDefaultRoleIds: normalized.memberGroupDefaultRoleIds,
+    memberGroupDefaultNamespaces: normalized.memberGroupDefaultNamespaces,
+  })
   const result = await query<DirectoryIntegrationRow>(
     `INSERT INTO directory_integrations (
        org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron,
@@ -1247,6 +1390,8 @@ export async function createDirectoryIntegration(input: DirectoryIntegrationInpu
         excludeDepartmentIds: normalized.excludeDepartmentIds,
         memberGroupSyncMode: normalized.memberGroupSyncMode,
         memberGroupDepartmentIds: normalized.memberGroupDepartmentIds,
+        memberGroupDefaultRoleIds: normalized.memberGroupDefaultRoleIds,
+        memberGroupDefaultNamespaces: normalized.memberGroupDefaultNamespaces,
       }),
       Boolean(normalized.syncEnabled),
       normalized.scheduleCron,
@@ -1266,6 +1411,10 @@ export async function updateDirectoryIntegration(
 
   const currentConfig = parseIntegrationConfig(current)
   const normalized = normalizeIntegrationInput(input, currentConfig)
+  await assertDirectoryProjectedGovernanceConfigValid({
+    memberGroupDefaultRoleIds: normalized.memberGroupDefaultRoleIds,
+    memberGroupDefaultNamespaces: normalized.memberGroupDefaultNamespaces,
+  })
   const result = await query<DirectoryIntegrationRow>(
     `UPDATE directory_integrations
      SET name = $2,
@@ -1295,6 +1444,8 @@ export async function updateDirectoryIntegration(
         excludeDepartmentIds: normalized.excludeDepartmentIds,
         memberGroupSyncMode: normalized.memberGroupSyncMode,
         memberGroupDepartmentIds: normalized.memberGroupDepartmentIds,
+        memberGroupDefaultRoleIds: normalized.memberGroupDefaultRoleIds,
+        memberGroupDefaultNamespaces: normalized.memberGroupDefaultNamespaces,
       }),
       Boolean(normalized.syncEnabled),
       normalized.scheduleCron,
@@ -1644,6 +1795,7 @@ export async function syncDirectoryIntegration(
   triggeredBy: string,
   triggerSource: 'manual' | 'scheduler' = 'manual',
 ): Promise<{ integration: DirectoryIntegrationSummary; run: DirectorySyncRunSummary }> {
+  const governedUserIds = new Set<string>()
   const integration = await getIntegrationRow(integrationId)
   if (!integration) throw new Error('Directory integration not found')
 
@@ -1975,8 +2127,16 @@ export async function syncDirectoryIntegration(
       const memberGroupProjection = await syncProjectedDepartmentMemberGroupsInTransaction(
         client,
         memberGroupPlans,
+        {
+          defaultRoleIds: config.memberGroupDefaultRoleIds,
+          defaultNamespaces: config.memberGroupDefaultNamespaces,
+        },
         triggeredBy,
       )
+      for (const userId of memberGroupProjection.governedUserIds) {
+        const normalizedUserId = normalizeText(userId)
+        if (normalizedUserId) governedUserIds.add(normalizedUserId)
+      }
 
       const stats = {
         departmentsSynced: departments.size,
@@ -1992,6 +2152,9 @@ export async function syncDirectoryIntegration(
         memberGroupsCreatedCount: memberGroupProjection.memberGroupsCreatedCount,
         memberGroupsSyncedCount: memberGroupProjection.memberGroupsSyncedCount,
         memberGroupMembershipsUpdatedCount: memberGroupProjection.memberGroupMembershipsUpdatedCount,
+        memberGroupGovernedUserCount: memberGroupProjection.memberGroupGovernedUserCount,
+        memberGroupDefaultRoleAssignmentsCount: memberGroupProjection.memberGroupDefaultRoleAssignmentsCount,
+        memberGroupDefaultNamespaceAdmissionsCount: memberGroupProjection.memberGroupDefaultNamespaceAdmissionsCount,
       }
 
       await client.query(
@@ -2024,6 +2187,10 @@ export async function syncDirectoryIntegration(
         invitedBy: triggeredBy,
         inviteToken: invite.inviteToken,
       })
+    }
+
+    for (const userId of governedUserIds) {
+      invalidateUserPerms(userId)
     }
 
     const [updatedIntegration, updatedRun] = await Promise.all([
@@ -2714,20 +2881,124 @@ async function createDirectoryAdmittedUserInTransaction(
   return { userId }
 }
 
+async function applyDirectoryProjectedMemberGroupGovernanceInTransaction(
+  client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> },
+  options: {
+    plans: DirectoryProjectedMemberGroupPlan[]
+    defaultRoleIds: string[]
+    defaultNamespaces: string[]
+    adminUserId: string
+  },
+): Promise<{
+  governedUserIds: string[]
+  defaultRoleAssignmentsCount: number
+  defaultNamespaceAdmissionsCount: number
+}> {
+  const grantSet = buildDirectoryProjectedGovernanceGrantSet({
+    plans: options.plans,
+    defaultRoleIds: options.defaultRoleIds,
+    defaultNamespaces: options.defaultNamespaces,
+  })
+  if (
+    grantSet.userIds.length === 0
+    || (grantSet.roleIds.length === 0 && grantSet.namespaces.length === 0)
+  ) {
+    return {
+      governedUserIds: [],
+      defaultRoleAssignmentsCount: 0,
+      defaultNamespaceAdmissionsCount: 0,
+    }
+  }
+
+  const auditUserId = normalizeDirectorySyncAuditUserId(options.adminUserId)
+  let defaultRoleAssignmentsCount = 0
+  let defaultNamespaceAdmissionsCount = 0
+
+  if (grantSet.roleIds.length > 0) {
+    const insertedRolesResult = await client.query(
+      `INSERT INTO user_roles (user_id, role_id)
+       SELECT u.user_id, r.role_id
+       FROM unnest($1::text[]) AS u(user_id)
+       CROSS JOIN unnest($2::text[]) AS r(role_id)
+       ON CONFLICT DO NOTHING
+       RETURNING user_id, role_id`,
+      [grantSet.userIds, grantSet.roleIds],
+    )
+    defaultRoleAssignmentsCount = insertedRolesResult.rows.length
+  }
+
+  if (grantSet.namespaces.length > 0) {
+    const existingAdmissionsResult = await client.query(
+      `SELECT user_id, namespace, enabled
+       FROM user_namespace_admissions
+       WHERE user_id = ANY($1::text[])
+         AND namespace = ANY($2::text[])`,
+      [grantSet.userIds, grantSet.namespaces],
+    )
+    const existingEnabledPairs = new Set(
+      existingAdmissionsResult.rows
+        .filter((row) => row.enabled === true)
+        .map((row) => `${normalizeText(row.user_id)}:${normalizeNamespace(row.namespace)}`),
+    )
+    for (const userId of grantSet.userIds) {
+      for (const namespace of grantSet.namespaces) {
+        if (!existingEnabledPairs.has(`${userId}:${namespace}`)) {
+          defaultNamespaceAdmissionsCount += 1
+        }
+      }
+    }
+
+    await client.query(
+      `INSERT INTO user_namespace_admissions (
+         user_id, namespace, enabled, source, granted_by, updated_by, created_at, updated_at
+       )
+       SELECT u.user_id, n.namespace, TRUE, $3, $4, $4, NOW(), NOW()
+       FROM unnest($1::text[]) AS u(user_id)
+       CROSS JOIN unnest($2::text[]) AS n(namespace)
+       ON CONFLICT (user_id, namespace)
+       DO UPDATE SET
+         enabled = TRUE,
+         source = EXCLUDED.source,
+         granted_by = EXCLUDED.granted_by,
+         updated_by = EXCLUDED.updated_by,
+         updated_at = NOW()`,
+      [grantSet.userIds, grantSet.namespaces, 'directory_member_group_sync', auditUserId],
+    )
+  }
+
+  return {
+    governedUserIds: grantSet.userIds,
+    defaultRoleAssignmentsCount,
+    defaultNamespaceAdmissionsCount,
+  }
+}
+
 async function syncProjectedDepartmentMemberGroupsInTransaction(
   client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> },
   plans: DirectoryProjectedMemberGroupPlan[],
+  options: {
+    defaultRoleIds: string[]
+    defaultNamespaces: string[]
+  },
   adminUserId: string,
 ): Promise<{
   memberGroupsCreatedCount: number
   memberGroupsSyncedCount: number
   memberGroupMembershipsUpdatedCount: number
+  memberGroupGovernedUserCount: number
+  memberGroupDefaultRoleAssignmentsCount: number
+  memberGroupDefaultNamespaceAdmissionsCount: number
+  governedUserIds: string[]
 }> {
   if (plans.length === 0) {
     return {
       memberGroupsCreatedCount: 0,
       memberGroupsSyncedCount: 0,
       memberGroupMembershipsUpdatedCount: 0,
+      memberGroupGovernedUserCount: 0,
+      memberGroupDefaultRoleAssignmentsCount: 0,
+      memberGroupDefaultNamespaceAdmissionsCount: 0,
+      governedUserIds: [],
     }
   }
 
@@ -2814,10 +3085,21 @@ async function syncProjectedDepartmentMemberGroupsInTransaction(
     memberGroupMembershipsUpdatedCount += membersToDelete.length + membersToInsert.length
   }
 
+  const governance = await applyDirectoryProjectedMemberGroupGovernanceInTransaction(client, {
+    plans,
+    defaultRoleIds: options.defaultRoleIds,
+    defaultNamespaces: options.defaultNamespaces,
+    adminUserId,
+  })
+
   return {
     memberGroupsCreatedCount,
     memberGroupsSyncedCount,
     memberGroupMembershipsUpdatedCount,
+    memberGroupGovernedUserCount: governance.governedUserIds.length,
+    memberGroupDefaultRoleAssignmentsCount: governance.defaultRoleAssignmentsCount,
+    memberGroupDefaultNamespaceAdmissionsCount: governance.defaultNamespaceAdmissionsCount,
+    governedUserIds: governance.governedUserIds,
   }
 }
 

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -197,6 +197,8 @@ describe('adminDirectoryRouter', () => {
       appSecret: 'secret',
       syncEnabled: true,
       scheduleCron: '*/15 * * * *',
+      memberGroupDefaultRoleIds: ['crm_user'],
+      memberGroupDefaultNamespaces: ['crm'],
     }
 
     const response = await invokeRoute('post', '/integrations', {
@@ -216,6 +218,8 @@ describe('adminDirectoryRouter', () => {
       name: 'DingTalk CN',
       scheduleCron: '*/10 * * * *',
       syncEnabled: true,
+      memberGroupDefaultRoleIds: ['crm_user'],
+      memberGroupDefaultNamespaces: ['crm'],
     }
 
     const response = await invokeRoute('put', '/integrations/:integrationId', {

--- a/packages/core-backend/tests/unit/directory-sync-member-group-projection.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-member-group-projection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { buildDirectoryProjectedMemberGroupPlans } from '../../src/directory/directory-sync'
+import {
+  buildDirectoryProjectedGovernanceGrantSet,
+  buildDirectoryProjectedMemberGroupPlans,
+} from '../../src/directory/directory-sync'
 
 describe('directory member-group projection', () => {
   it('projects a selected department subtree to linked local users', () => {
@@ -65,5 +68,32 @@ describe('directory member-group projection', () => {
     })
 
     expect(plans).toEqual([])
+  })
+
+  it('builds a deduplicated governance grant set for projected member groups', () => {
+    const grantSet = buildDirectoryProjectedGovernanceGrantSet({
+      plans: [
+        {
+          externalDepartmentId: 'dept-sales',
+          marker: 'marker-1',
+          name: '销售',
+          memberUserIds: ['user-1', 'user-2'],
+        },
+        {
+          externalDepartmentId: 'dept-sales-east',
+          marker: 'marker-2',
+          name: '华东销售',
+          memberUserIds: ['user-2', 'user-3'],
+        },
+      ],
+      defaultRoleIds: ['crm_user', 'crm_user', 'sales_user'],
+      defaultNamespaces: ['crm', 'crm', 'sales'],
+    })
+
+    expect(grantSet).toEqual({
+      userIds: ['user-1', 'user-2', 'user-3'],
+      roleIds: ['crm_user', 'sales_user'],
+      namespaces: ['crm', 'sales'],
+    })
   })
 })


### PR DESCRIPTION
## What changed

This stacked PR extends DingTalk directory department projection so projected `platform_member_groups` can also apply a safe default governance baseline to already linked local users.

Added integration config:

- `memberGroupDefaultRoleIds`
- `memberGroupDefaultNamespaces`

Behavior:

- selected DingTalk departments still project to `platform_member_groups`
- linked local users inside those projected groups can now receive additive default governance during sync
- only missing grants are filled
- no automatic revocation is introduced in this round

## Safety constraints

Backend validation blocks unsafe config:

- configured roles must exist
- `admin` is rejected
- delegated-admin style roles are rejected
- namespaces must be admission-controlled resources

## User-facing changes

Directory integration settings now include:

- `成员组默认业务角色`
- `成员组默认插件开通`

Sync success feedback now reports:

- governed user count
- added role assignment count
- added namespace admission count

## Files

- `packages/core-backend/src/directory/directory-sync.ts`
- `packages/core-backend/tests/unit/directory-sync-member-group-projection.test.ts`
- `packages/core-backend/tests/unit/admin-directory-routes.test.ts`
- `apps/web/src/views/DirectoryManagementView.vue`
- `apps/web/tests/directoryManagementView.spec.ts`
- `docs/development/dingtalk-directory-member-group-governance-linkage-development-20260418.md`
- `docs/development/dingtalk-directory-member-group-governance-linkage-verification-20260418.md`
- updated design docs for directory sync governance

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-member-group-projection.test.ts tests/unit/admin-directory-routes.test.ts --watch=false
pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
```

Results:

- backend tests: `23 passed`
- frontend tests: `32 passed`
- backend build: passed
- web build: passed

## Notes

This PR is intentionally additive and stacked on top of #900.
It does not yet implement automatic governance revocation or role-scope templates.
