### PR TITLE
feat(multitable): add member-group acl subjects

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -565,6 +565,8 @@ export class MultitableApiClient {
             subjectType: item.subjectType,
             subjectId: item.subjectId,
             subjectLabel: typeof item.subjectLabel === 'string' ? item.subjectLabel : undefined,
+            subjectSubtitle: typeof item.subjectSubtitle === 'string' || item.subjectSubtitle === null ? item.subjectSubtitle ?? null : null,
+            isActive: item.isActive !== false,
             visible: item.visible !== false,
             readOnly: item.readOnly === true,
           }))
@@ -577,7 +579,7 @@ export class MultitableApiClient {
     fieldId: string,
     subjectType: 'user' | 'role' | 'member-group',
     subjectId: string,
-    perm: { visible: boolean; readOnly: boolean },
+    perm: { visible?: boolean; readOnly?: boolean; remove?: boolean },
   ): Promise<{ fieldId: string; subjectType: string; subjectId: string; visible: boolean; readOnly: boolean }> {
     const res = await this.fetch(
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/field-permissions/${encodeURIComponent(fieldId)}/${encodeURIComponent(subjectType)}/${encodeURIComponent(subjectId)}`,
@@ -607,6 +609,8 @@ export class MultitableApiClient {
             subjectType: item.subjectType,
             subjectId: item.subjectId,
             subjectLabel: typeof item.subjectLabel === 'string' ? item.subjectLabel : undefined,
+            subjectSubtitle: typeof item.subjectSubtitle === 'string' || item.subjectSubtitle === null ? item.subjectSubtitle ?? null : null,
+            isActive: item.isActive !== false,
             permission: item.permission,
           }))
         : [],

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -405,6 +405,47 @@ function normalizeSheetPermissionCandidates(
   }
 }
 
+function normalizeRecordPermissionEntry(
+  payload: Partial<RecordPermissionEntry> | null | undefined,
+): RecordPermissionEntry | null {
+  const subjectType =
+    payload?.subjectType === 'user' || payload?.subjectType === 'role' || payload?.subjectType === 'member-group'
+      ? payload.subjectType
+      : null
+  const id = typeof payload?.id === 'string' ? payload.id : ''
+  const sheetId = typeof payload?.sheetId === 'string' ? payload.sheetId : ''
+  const recordId = typeof payload?.recordId === 'string' ? payload.recordId : ''
+  const subjectId = typeof payload?.subjectId === 'string' ? payload.subjectId : ''
+  const accessLevel =
+    payload?.accessLevel === 'read' || payload?.accessLevel === 'write' || payload?.accessLevel === 'admin'
+      ? payload.accessLevel
+      : null
+  if (!id || !sheetId || !recordId || !subjectType || !subjectId || !accessLevel) return null
+  return {
+    id,
+    sheetId,
+    recordId,
+    subjectType,
+    subjectId,
+    accessLevel,
+    label: typeof payload?.label === 'string' ? payload.label : subjectId,
+    subtitle: typeof payload?.subtitle === 'string' || payload?.subtitle === null ? payload.subtitle ?? null : null,
+    isActive: payload?.isActive !== false,
+    createdAt: typeof payload?.createdAt === 'string' ? payload.createdAt : undefined,
+    createdBy: typeof payload?.createdBy === 'string' ? payload.createdBy : undefined,
+  }
+}
+
+function normalizeRecordPermissionEntries(
+  payload: { items?: Array<Partial<RecordPermissionEntry>> } | null | undefined,
+): RecordPermissionEntry[] {
+  return Array.isArray(payload?.items)
+    ? payload.items
+      .map((item) => normalizeRecordPermissionEntry(item))
+      .filter((item): item is RecordPermissionEntry => !!item)
+    : []
+}
+
 function normalizeCommentsParams(params: { containerId: string; targetId: string; targetFieldId?: string | null } | MetaCommentsScope) {
   if ('containerType' in params) {
     return {
@@ -755,8 +796,8 @@ export class MultitableApiClient {
   // --- Record permissions ---
   async listRecordPermissions(sheetId: string, recordId: string): Promise<RecordPermissionEntry[]> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/permissions`)
-    const data = await parseJson<{ permissions?: RecordPermissionEntry[] }>(res)
-    return Array.isArray(data?.permissions) ? data.permissions : []
+    const data = await parseJson<{ items?: Array<Partial<RecordPermissionEntry>> }>(res)
+    return normalizeRecordPermissionEntries(data)
   }
 
   async updateRecordPermission(

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -338,7 +338,10 @@ function normalizeCommentMentionSuggestions(
 function normalizeSheetPermissionEntry(
   payload: Partial<MetaSheetPermissionEntry> | null | undefined,
 ): MetaSheetPermissionEntry | null {
-  const subjectType = payload?.subjectType === 'user' || payload?.subjectType === 'role' ? payload.subjectType : null
+  const subjectType =
+    payload?.subjectType === 'user' || payload?.subjectType === 'role' || payload?.subjectType === 'member-group'
+      ? payload.subjectType
+      : null
   const subjectId = typeof payload?.subjectId === 'string' ? payload.subjectId : ''
   const accessLevel = payload?.accessLevel
   if (!subjectType || !subjectId || (accessLevel !== 'read' && accessLevel !== 'write' && accessLevel !== 'write-own' && accessLevel !== 'admin')) {
@@ -375,7 +378,10 @@ function normalizeSheetPermissionCandidates(
   const items: MetaSheetPermissionCandidate[] = []
   if (Array.isArray(payload?.items)) {
     for (const item of payload.items) {
-      const subjectType = item?.subjectType === 'user' || item?.subjectType === 'role' ? item.subjectType : null
+      const subjectType =
+        item?.subjectType === 'user' || item?.subjectType === 'role' || item?.subjectType === 'member-group'
+          ? item.subjectType
+          : null
       const subjectId = typeof item?.subjectId === 'string' ? item.subjectId : ''
       const label = typeof item?.label === 'string' ? item.label : ''
       if (!subjectType || !subjectId || !label) continue
@@ -474,23 +480,26 @@ export class MultitableApiClient {
 
   async updateSheetPermission(
     sheetId: string,
-    subjectType: 'user' | 'role',
+    subjectType: 'user' | 'role' | 'member-group',
     subjectId: string,
     accessLevel: MetaSheetPermissionAccessLevel | 'none',
-  ): Promise<{ subjectType: 'user' | 'role'; subjectId: string; accessLevel: MetaSheetPermissionAccessLevel | 'none'; entry: MetaSheetPermissionEntry | null }> {
+  ): Promise<{ subjectType: 'user' | 'role' | 'member-group'; subjectId: string; accessLevel: MetaSheetPermissionAccessLevel | 'none'; entry: MetaSheetPermissionEntry | null }> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/permissions/${encodeURIComponent(subjectType)}/${encodeURIComponent(subjectId)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ accessLevel }),
     })
     const data = await parseJson<{
-      subjectType?: 'user' | 'role'
+      subjectType?: 'user' | 'role' | 'member-group'
       subjectId?: string
       accessLevel?: MetaSheetPermissionAccessLevel | 'none'
       entry?: Partial<MetaSheetPermissionEntry> | null
     }>(res)
     return {
-      subjectType: data?.subjectType === 'user' || data?.subjectType === 'role' ? data.subjectType : subjectType,
+      subjectType:
+        data?.subjectType === 'user' || data?.subjectType === 'role' || data?.subjectType === 'member-group'
+          ? data.subjectType
+          : subjectType,
       subjectId: typeof data?.subjectId === 'string' ? data.subjectId : subjectId,
       accessLevel: data?.accessLevel === 'read' || data?.accessLevel === 'write' || data?.accessLevel === 'write-own' || data?.accessLevel === 'admin' || data?.accessLevel === 'none'
         ? data.accessLevel
@@ -508,7 +517,7 @@ export class MultitableApiClient {
         ? data.items
           .filter((item): item is MetaFieldPermissionEntry =>
             typeof item?.fieldId === 'string' &&
-            (item?.subjectType === 'user' || item?.subjectType === 'role') &&
+            (item?.subjectType === 'user' || item?.subjectType === 'role' || item?.subjectType === 'member-group') &&
             typeof item?.subjectId === 'string')
           .map((item) => ({
             fieldId: item.fieldId,
@@ -525,7 +534,7 @@ export class MultitableApiClient {
   async updateFieldPermission(
     sheetId: string,
     fieldId: string,
-    subjectType: 'user' | 'role',
+    subjectType: 'user' | 'role' | 'member-group',
     subjectId: string,
     perm: { visible: boolean; readOnly: boolean },
   ): Promise<{ fieldId: string; subjectType: string; subjectId: string; visible: boolean; readOnly: boolean }> {
@@ -549,7 +558,7 @@ export class MultitableApiClient {
         ? data.items
           .filter((item): item is MetaViewPermissionEntry =>
             typeof item?.viewId === 'string' &&
-            (item?.subjectType === 'user' || item?.subjectType === 'role') &&
+            (item?.subjectType === 'user' || item?.subjectType === 'role' || item?.subjectType === 'member-group') &&
             typeof item?.subjectId === 'string' &&
             typeof item?.permission === 'string')
           .map((item) => ({
@@ -565,7 +574,7 @@ export class MultitableApiClient {
 
   async updateViewPermission(
     viewId: string,
-    subjectType: 'user' | 'role',
+    subjectType: 'user' | 'role' | 'member-group',
     subjectId: string,
     permission: string,
   ): Promise<{ viewId: string; subjectType: string; subjectId: string; permission: string }> {

--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -19,7 +19,7 @@
             <strong>Current access</strong>
           </div>
           <div v-if="loading" class="meta-record-perm__empty">Loading permissions&#x2026;</div>
-          <div v-else-if="!entries.length" class="meta-record-perm__empty">No record-specific permissions yet.</div>
+        <div v-else-if="!entries.length" class="meta-record-perm__empty">No record-specific permissions yet.</div>
           <template v-else>
           <div
             v-for="entry in entries"
@@ -28,9 +28,10 @@
             :data-record-permission-entry="entry.id"
           >
             <div class="meta-record-perm__identity">
-              <strong>{{ entry.subjectId }}</strong>
-              <span>{{ subjectTypeLabel(entry.subjectType) }}</span>
+              <strong>{{ entry.label }}</strong>
+              <span>{{ entry.subtitle || entry.subjectId }}</span>
             </div>
+            <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeLabel(entry.subjectType) }}</span>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
               {{ accessLevelLabel(entryDrafts[entry.id] ?? entry.accessLevel) }}
             </span>
@@ -67,35 +68,123 @@
         <!-- Add permission -->
         <section class="meta-record-perm__section">
           <div class="meta-record-perm__section-header">
-            <strong>Add permission</strong>
+            <strong>Grant to people, member groups, or roles</strong>
           </div>
-          <div class="meta-record-perm__add-row" data-record-permission-add="true">
-            <select v-model="addSubjectType" class="meta-record-perm__select">
-              <option value="user">User</option>
-              <option value="role">Role</option>
-              <option value="member-group">Member group</option>
-            </select>
-            <input
-              v-model="addSubjectId"
-              class="meta-record-perm__input"
-              type="text"
-              placeholder="Subject ID"
-              data-record-permission-subject-input="true"
-            />
-            <select v-model="addAccessLevel" class="meta-record-perm__select">
-              <option value="read">Read</option>
-              <option value="write">Write</option>
-              <option value="admin">Admin</option>
-            </select>
-            <button
-              class="meta-record-perm__action meta-record-perm__action--primary"
-              type="button"
-              :disabled="!addSubjectId.trim() || busyKey === 'add'"
-              @click="grantNew"
+          <input
+            v-model="candidateSearch"
+            class="meta-record-perm__search"
+            type="search"
+            placeholder="Search people, member groups, or roles"
+            data-record-permission-search="true"
+          />
+          <div v-if="candidatesLoading" class="meta-record-perm__empty">Loading eligible people, member groups, and roles&#x2026;</div>
+          <div v-else-if="!availableCandidates.length" class="meta-record-perm__empty">No matching eligible people, member groups, or roles.</div>
+          <template v-else>
+            <div class="meta-record-perm__section-header">
+              <strong>People</strong>
+            </div>
+            <div v-if="!peopleCandidates.length" class="meta-record-perm__empty">No matching people.</div>
+            <div
+              v-for="candidate in peopleCandidates"
+              :key="`people-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
+              class="meta-record-perm__row"
+              :data-record-permission-candidate="subjectKey(candidate.subjectType, candidate.subjectId)"
             >
-              Grant
-            </button>
-          </div>
+              <div class="meta-record-perm__identity">
+                <strong>{{ candidate.label }}</strong>
+                <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+              </div>
+              <span class="meta-record-perm__subject" data-subject-type="user">User</span>
+              <select
+                :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
+                class="meta-record-perm__select"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
+              >
+                <option value="read">Read</option>
+                <option value="write">Write</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button
+                class="meta-record-perm__action meta-record-perm__action--primary"
+                type="button"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
+              >
+                Grant
+              </button>
+            </div>
+
+            <div class="meta-record-perm__section-header">
+              <strong>Member groups</strong>
+            </div>
+            <div v-if="!memberGroupCandidates.length" class="meta-record-perm__empty">No matching member groups.</div>
+            <div
+              v-for="candidate in memberGroupCandidates"
+              :key="`member-group-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
+              class="meta-record-perm__row"
+              :data-record-permission-candidate="subjectKey(candidate.subjectType, candidate.subjectId)"
+            >
+              <div class="meta-record-perm__identity">
+                <strong>{{ candidate.label }}</strong>
+                <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+              </div>
+              <span class="meta-record-perm__subject" data-subject-type="member-group">Member group</span>
+              <select
+                :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
+                class="meta-record-perm__select"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
+              >
+                <option value="read">Read</option>
+                <option value="write">Write</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button
+                class="meta-record-perm__action meta-record-perm__action--primary"
+                type="button"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
+              >
+                Grant
+              </button>
+            </div>
+
+            <div class="meta-record-perm__section-header">
+              <strong>Roles</strong>
+            </div>
+            <div v-if="!roleCandidates.length" class="meta-record-perm__empty">No matching roles.</div>
+            <div
+              v-for="candidate in roleCandidates"
+              :key="`role-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
+              class="meta-record-perm__row"
+              :data-record-permission-candidate="subjectKey(candidate.subjectType, candidate.subjectId)"
+            >
+              <div class="meta-record-perm__identity">
+                <strong>{{ candidate.label }}</strong>
+                <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+              </div>
+              <span class="meta-record-perm__subject" data-subject-type="role">Role</span>
+              <select
+                :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
+                class="meta-record-perm__select"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
+              >
+                <option value="read">Read</option>
+                <option value="write">Write</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button
+                class="meta-record-perm__action meta-record-perm__action--primary"
+                type="button"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
+              >
+                Grant
+              </button>
+            </div>
+          </template>
         </section>
       </div>
     </div>
@@ -103,9 +192,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { MultitableApiClient } from '../api/client'
-import type { RecordPermissionEntry, RecordPermissionAccessLevel } from '../types'
+import type { MetaSheetPermissionCandidate, MetaSheetPermissionEntry, RecordPermissionAccessLevel, RecordPermissionEntry } from '../types'
 
 const props = defineProps<{
   visible: boolean
@@ -125,10 +214,11 @@ const error = ref('')
 const busyKey = ref<string | null>(null)
 const status = ref('')
 const entryDrafts = ref<Record<string, RecordPermissionAccessLevel>>({})
-
-const addSubjectType = ref<'user' | 'role' | 'member-group'>('user')
-const addSubjectId = ref('')
-const addAccessLevel = ref<RecordPermissionAccessLevel>('read')
+const candidateSearch = ref('')
+const candidatesLoading = ref(false)
+const subjectCandidates = ref<MetaSheetPermissionCandidate[]>([])
+const candidateDrafts = ref<Record<string, RecordPermissionAccessLevel>>({})
+let candidateLoadVersion = 0
 
 function accessLevelLabel(level: string): string {
   if (level === 'read') return 'Read'
@@ -145,6 +235,10 @@ function subjectTypeLabel(subjectType: string): string {
 
 function requestClose() {
   emit('close')
+}
+
+function subjectKey(subjectType: string, subjectId: string) {
+  return `${subjectType}:${subjectId}`
 }
 
 function clearMessages() {
@@ -165,6 +259,41 @@ function syncEntryDrafts() {
   )
 }
 
+function matchesCandidateSearch(candidate: MetaSheetPermissionCandidate, query: string): boolean {
+  if (!query) return true
+  const haystack = `${candidate.label} ${candidate.subtitle ?? ''} ${candidate.subjectId}`.toLowerCase()
+  return haystack.includes(query)
+}
+
+function normalizeSheetEntryCandidate(entry: MetaSheetPermissionEntry): MetaSheetPermissionCandidate {
+  return {
+    subjectType: entry.subjectType,
+    subjectId: entry.subjectId,
+    label: entry.label,
+    subtitle: entry.subtitle ?? null,
+    isActive: entry.isActive,
+    accessLevel: entry.accessLevel,
+  }
+}
+
+const availableCandidates = computed(() => {
+  const activeSubjects = new Set(entries.value.map((entry) => subjectKey(entry.subjectType, entry.subjectId)))
+  return subjectCandidates.value.filter((candidate) => !activeSubjects.has(subjectKey(candidate.subjectType, candidate.subjectId)))
+})
+
+const peopleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'user'))
+const memberGroupCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'member-group'))
+const roleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'role'))
+
+function syncCandidateDrafts() {
+  const next: Record<string, RecordPermissionAccessLevel> = {}
+  for (const candidate of availableCandidates.value) {
+    const key = subjectKey(candidate.subjectType, candidate.subjectId)
+    next[key] = candidateDrafts.value[key] ?? candidate.accessLevel ?? 'read'
+  }
+  candidateDrafts.value = next
+}
+
 async function loadPermissions() {
   if (!props.sheetId || !props.recordId) {
     entries.value = []
@@ -179,6 +308,43 @@ async function loadPermissions() {
     error.value = cause?.message ?? 'Failed to load record permissions'
   } finally {
     loading.value = false
+  }
+}
+
+async function loadCandidates() {
+  if (!props.sheetId) {
+    subjectCandidates.value = []
+    return
+  }
+  const currentVersion = ++candidateLoadVersion
+  candidatesLoading.value = true
+  try {
+    const query = candidateSearch.value.trim().toLowerCase()
+    const [sheetEntries, candidatePage] = await Promise.all([
+      props.client.listSheetPermissions(props.sheetId),
+      props.client.listSheetPermissionCandidates(props.sheetId, { q: candidateSearch.value.trim() || undefined, limit: 20 }),
+    ])
+    if (currentVersion !== candidateLoadVersion) return
+
+    const combined = new Map<string, MetaSheetPermissionCandidate>()
+    for (const entry of sheetEntries.items.map((item) => normalizeSheetEntryCandidate(item))) {
+      if (!matchesCandidateSearch(entry, query)) continue
+      combined.set(subjectKey(entry.subjectType, entry.subjectId), entry)
+    }
+    for (const candidate of candidatePage.items) {
+      const key = subjectKey(candidate.subjectType, candidate.subjectId)
+      if (!matchesCandidateSearch(candidate, query) || combined.has(key)) continue
+      combined.set(key, candidate)
+    }
+    subjectCandidates.value = Array.from(combined.values())
+    syncCandidateDrafts()
+  } catch (cause: any) {
+    if (currentVersion !== candidateLoadVersion) return
+    error.value = cause?.message ?? 'Failed to load permission candidates'
+  } finally {
+    if (currentVersion === candidateLoadVersion) {
+      candidatesLoading.value = false
+    }
   }
 }
 
@@ -213,17 +379,28 @@ async function removeEntry(entry: RecordPermissionEntry) {
   }
 }
 
-async function grantNew() {
-  const subjectId = addSubjectId.value.trim()
-  if (!subjectId) return
-  busyKey.value = 'add'
+function setCandidateDraft(subjectType: string, subjectId: string, event: Event) {
+  const key = subjectKey(subjectType, subjectId)
+  candidateDrafts.value = {
+    ...candidateDrafts.value,
+    [key]: (event.target as HTMLSelectElement).value as RecordPermissionAccessLevel,
+  }
+}
+
+async function grantCandidate(subjectType: RecordPermissionEntry['subjectType'], subjectId: string) {
+  const key = subjectKey(subjectType, subjectId)
+  busyKey.value = key
   clearMessages()
   try {
-    await props.client.updateRecordPermission(props.sheetId, props.recordId, addSubjectType.value, subjectId, addAccessLevel.value)
-    await loadPermissions()
+    await props.client.updateRecordPermission(
+      props.sheetId,
+      props.recordId,
+      subjectType,
+      subjectId,
+      candidateDrafts.value[key] ?? 'read',
+    )
+    await Promise.all([loadPermissions(), loadCandidates()])
     status.value = 'Permission granted'
-    addSubjectId.value = ''
-    addAccessLevel.value = 'read'
     emit('updated')
   } catch (cause: any) {
     error.value = cause?.message ?? 'Failed to grant permission'
@@ -237,8 +414,17 @@ watch(
   ([visible, sheetId, recordId]) => {
     if (!visible || !sheetId || !recordId) return
     void loadPermissions()
+    void loadCandidates()
   },
   { immediate: true },
+)
+
+watch(
+  () => candidateSearch.value,
+  () => {
+    if (!props.visible || !props.sheetId) return
+    void loadCandidates()
+  },
 )
 </script>
 
@@ -312,22 +498,12 @@ watch(
   align-items: center;
   justify-content: space-between;
   color: #0f172a;
+  gap: 12px;
 }
 
 .meta-record-perm__row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 80px 120px auto auto;
-  gap: 10px;
-  align-items: center;
-  padding: 10px 12px;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  background: #f8fafc;
-}
-
-.meta-record-perm__add-row {
-  display: grid;
-  grid-template-columns: 100px minmax(0, 1fr) 120px auto;
   gap: 10px;
   align-items: center;
   padding: 10px 12px;
@@ -358,6 +534,28 @@ watch(
   text-overflow: ellipsis;
 }
 
+.meta-record-perm__subject {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.meta-record-perm__subject[data-subject-type='member-group'] {
+  background: #ecfeff;
+  color: #155e75;
+}
+
+.meta-record-perm__subject[data-subject-type='role'] {
+  background: #f5f3ff;
+  color: #6d28d9;
+}
+
 .meta-record-perm__badge {
   display: inline-flex;
   justify-content: center;
@@ -386,7 +584,7 @@ watch(
 }
 
 .meta-record-perm__select,
-.meta-record-perm__input {
+.meta-record-perm__search {
   width: 100%;
   min-width: 0;
   border: 1px solid #cbd5e1;
@@ -447,10 +645,6 @@ watch(
 
 @media (max-width: 640px) {
   .meta-record-perm__row {
-    grid-template-columns: 1fr;
-  }
-
-  .meta-record-perm__add-row {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -26,11 +26,18 @@
             :key="entry.id"
             class="meta-record-perm__row"
             :data-record-permission-entry="entry.id"
-          >
-            <div class="meta-record-perm__identity">
-              <strong>{{ entry.label }}</strong>
-              <span>{{ entry.subtitle || entry.subjectId }}</span>
-            </div>
+            >
+              <div class="meta-record-perm__identity">
+                <strong>{{ entry.label }}</strong>
+                <span>{{ entry.subtitle || entry.subjectId }}</span>
+                <span
+                  v-if="subjectIsInactive(entry.subjectType, entry.isActive)"
+                  class="meta-record-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
+              </div>
             <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeLabel(entry.subjectType) }}</span>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
               {{ accessLevelLabel(entryDrafts[entry.id] ?? entry.accessLevel) }}
@@ -93,6 +100,13 @@
               <div class="meta-record-perm__identity">
                 <strong>{{ candidate.label }}</strong>
                 <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                <span
+                  v-if="subjectIsInactive(candidate.subjectType, candidate.isActive)"
+                  class="meta-record-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
               </div>
               <span class="meta-record-perm__subject" data-subject-type="user">User</span>
               <select
@@ -231,6 +245,10 @@ function subjectTypeLabel(subjectType: string): string {
   if (subjectType === 'role') return 'Role'
   if (subjectType === 'member-group') return 'Member group'
   return 'User'
+}
+
+function subjectIsInactive(subjectType: string, isActive: boolean) {
+  return subjectType === 'user' && isActive === false
 }
 
 function requestClose() {
@@ -532,6 +550,18 @@ watch(
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.meta-record-perm__lifecycle {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .meta-record-perm__subject {

--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -29,7 +29,7 @@
           >
             <div class="meta-record-perm__identity">
               <strong>{{ entry.subjectId }}</strong>
-              <span>{{ entry.subjectType === 'role' ? 'Role' : 'User' }}</span>
+              <span>{{ subjectTypeLabel(entry.subjectType) }}</span>
             </div>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
               {{ accessLevelLabel(entryDrafts[entry.id] ?? entry.accessLevel) }}
@@ -73,6 +73,7 @@
             <select v-model="addSubjectType" class="meta-record-perm__select">
               <option value="user">User</option>
               <option value="role">Role</option>
+              <option value="member-group">Member group</option>
             </select>
             <input
               v-model="addSubjectId"
@@ -125,7 +126,7 @@ const busyKey = ref<string | null>(null)
 const status = ref('')
 const entryDrafts = ref<Record<string, RecordPermissionAccessLevel>>({})
 
-const addSubjectType = ref<'user' | 'role'>('user')
+const addSubjectType = ref<'user' | 'role' | 'member-group'>('user')
 const addSubjectId = ref('')
 const addAccessLevel = ref<RecordPermissionAccessLevel>('read')
 
@@ -134,6 +135,12 @@ function accessLevelLabel(level: string): string {
   if (level === 'write') return 'Write'
   if (level === 'admin') return 'Admin'
   return level
+}
+
+function subjectTypeLabel(subjectType: string): string {
+  if (subjectType === 'role') return 'Role'
+  if (subjectType === 'member-group') return 'Member group'
+  return 'User'
 }
 
 function requestClose() {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -223,6 +223,41 @@
             <div v-if="!fields.length" class="meta-sheet-perm__empty">No fields available.</div>
             <div v-else-if="!entries.length && !hasFieldOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure field permissions.</div>
             <template v-else>
+              <div v-if="entries.length" class="meta-sheet-perm__section">
+                <div class="meta-sheet-perm__section-header">
+                  <strong>Bulk apply to all fields</strong>
+                </div>
+                <div
+                  v-for="entry in entries"
+                  :key="`fp-template-${subjectKey(entry.subjectType, entry.subjectId)}`"
+                  class="meta-sheet-perm__row meta-sheet-perm__row--template"
+                  :data-field-permission-template="subjectKey(entry.subjectType, entry.subjectId)"
+                >
+                  <div class="meta-sheet-perm__identity">
+                    <strong>{{ entry.label }}</strong>
+                    <span>{{ entry.subtitle || entry.subjectId }}</span>
+                  </div>
+                  <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                  <select
+                    :value="fieldTemplateDraftValue(entry.subjectType, entry.subjectId)"
+                    class="meta-sheet-perm__select"
+                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    @change="setFieldTemplateDraft(entry.subjectType, entry.subjectId, $event)"
+                  >
+                    <option value="default">Default</option>
+                    <option value="hidden">Hidden</option>
+                    <option value="readonly">Read-only</option>
+                  </select>
+                  <button
+                    class="meta-sheet-perm__action meta-sheet-perm__action--primary"
+                    type="button"
+                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    @click="applyFieldTemplate(entry.subjectType, entry.subjectId)"
+                  >
+                    Apply to all fields
+                  </button>
+                </div>
+              </div>
               <div
                 v-for="field in fields"
                 :key="field.id"
@@ -307,6 +342,42 @@
             <div v-if="!views.length" class="meta-sheet-perm__empty">No views available.</div>
             <div v-else-if="!entries.length && !hasViewOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure view permissions.</div>
             <template v-else>
+              <div v-if="entries.length" class="meta-sheet-perm__section">
+                <div class="meta-sheet-perm__section-header">
+                  <strong>Bulk apply to all views</strong>
+                </div>
+                <div
+                  v-for="entry in entries"
+                  :key="`vp-template-${subjectKey(entry.subjectType, entry.subjectId)}`"
+                  class="meta-sheet-perm__row meta-sheet-perm__row--template"
+                  :data-view-permission-template="subjectKey(entry.subjectType, entry.subjectId)"
+                >
+                  <div class="meta-sheet-perm__identity">
+                    <strong>{{ entry.label }}</strong>
+                    <span>{{ entry.subtitle || entry.subjectId }}</span>
+                  </div>
+                  <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                  <select
+                    :value="viewTemplateDraftValue(entry.subjectType, entry.subjectId)"
+                    class="meta-sheet-perm__select"
+                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    @change="setViewTemplateDraft(entry.subjectType, entry.subjectId, $event)"
+                  >
+                    <option value="none">None</option>
+                    <option value="read">Read</option>
+                    <option value="write">Write</option>
+                    <option value="admin">Admin</option>
+                  </select>
+                  <button
+                    class="meta-sheet-perm__action meta-sheet-perm__action--primary"
+                    type="button"
+                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    @click="applyViewTemplate(entry.subjectType, entry.subjectId)"
+                  >
+                    Apply to all views
+                  </button>
+                </div>
+              </div>
               <div
                 v-for="view in views"
                 :key="view.id"
@@ -455,10 +526,14 @@ let searchTimer: number | null = null
 // Field permission drafts
 const fieldPermDrafts = ref<Record<string, string>>({})
 const busyFieldPermKey = ref<string | null>(null)
+const fieldTemplateDrafts = ref<Record<string, string>>({})
+const busyFieldTemplateKey = ref<string | null>(null)
 
 // View permission drafts
 const viewPermDrafts = ref<Record<string, string>>({})
 const busyViewPermKey = ref<string | null>(null)
+const viewTemplateDrafts = ref<Record<string, string>>({})
+const busyViewTemplateKey = ref<string | null>(null)
 
 function subjectKey(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   return `${subjectType}:${subjectId}`
@@ -491,11 +566,22 @@ function fieldPermDraftLabel(fieldId: string, subjectType: string, subjectId: st
   return 'Default'
 }
 
+function fieldTemplateDraftValue(subjectType: string, subjectId: string): string {
+  return fieldTemplateDrafts.value[subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)] ?? 'default'
+}
+
 function setFieldPermDraft(fieldId: string, subjectType: string, subjectId: string, event: Event) {
   const key = fieldPermKey(fieldId, subjectType, subjectId)
   fieldPermDrafts.value = {
     ...fieldPermDrafts.value,
     [key]: (event.target as HTMLSelectElement).value,
+  }
+}
+
+function setFieldTemplateDraft(subjectType: string, subjectId: string, event: Event) {
+  fieldTemplateDrafts.value = {
+    ...fieldTemplateDrafts.value,
+    [subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)]: (event.target as HTMLSelectElement).value,
   }
 }
 
@@ -542,6 +628,38 @@ async function clearFieldPerm(fieldId: string, subjectType: string, subjectId: s
   }
 }
 
+async function applyFieldTemplate(subjectType: string, subjectId: string) {
+  if (!props.fields.length) return
+  const key = subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)
+  const draft = fieldTemplateDraftValue(subjectType, subjectId)
+  const perm: { remove: true } | { visible: boolean; readOnly: boolean } = draft === 'default'
+    ? { remove: true }
+    : fieldPermFromDraftValue(draft)
+  busyFieldTemplateKey.value = key
+  clearMessages()
+  try {
+    await Promise.all(
+      props.fields.map((field) =>
+        props.client.updateFieldPermission(
+          props.sheetId,
+          field.id,
+          subjectType as MetaSheetPermissionSubjectType,
+          subjectId,
+          perm,
+        ),
+      ),
+    )
+    status.value = draft === 'default'
+      ? `Cleared field permission overrides on ${props.fields.length} fields`
+      : `Applied field permission to ${props.fields.length} fields`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to apply field permission template'
+  } finally {
+    busyFieldTemplateKey.value = null
+  }
+}
+
 // --- View permission helpers ---
 function viewPermKey(viewId: string, subjectType: string, subjectId: string) {
   return `${viewId}:${subjectType}:${subjectId}`
@@ -559,6 +677,10 @@ function viewPermDraftValue(viewId: string, subjectType: string, subjectId: stri
   return viewPermDrafts.value[key] ?? resolveViewPerm(viewId, subjectType, subjectId)
 }
 
+function viewTemplateDraftValue(subjectType: string, subjectId: string): string {
+  return viewTemplateDrafts.value[subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)] ?? 'read'
+}
+
 function viewPermDisplayLabel(val: string): string {
   if (val === 'read') return 'Read'
   if (val === 'write') return 'Write'
@@ -571,6 +693,13 @@ function setViewPermDraft(viewId: string, subjectType: string, subjectId: string
   viewPermDrafts.value = {
     ...viewPermDrafts.value,
     [key]: (event.target as HTMLSelectElement).value,
+  }
+}
+
+function setViewTemplateDraft(subjectType: string, subjectId: string, event: Event) {
+  viewTemplateDrafts.value = {
+    ...viewTemplateDrafts.value,
+    [subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)]: (event.target as HTMLSelectElement).value,
   }
 }
 
@@ -609,6 +738,32 @@ async function clearViewPerm(viewId: string, subjectType: string, subjectId: str
     error.value = cause?.message ?? 'Failed to clear view permission'
   } finally {
     busyViewPermKey.value = null
+  }
+}
+
+async function applyViewTemplate(subjectType: string, subjectId: string) {
+  if (!props.views.length) return
+  const key = subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)
+  const permission = viewTemplateDraftValue(subjectType, subjectId)
+  busyViewTemplateKey.value = key
+  clearMessages()
+  try {
+    await Promise.all(
+      props.views.map((view) =>
+        props.client.updateViewPermission(
+          view.id,
+          subjectType as MetaSheetPermissionSubjectType,
+          subjectId,
+          permission,
+        ),
+      ),
+    )
+    status.value = `Applied view permission to ${props.views.length} views`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to apply view permission template'
+  } finally {
+    busyViewTemplateKey.value = null
   }
 }
 
@@ -924,6 +1079,10 @@ onBeforeUnmount(() => {
   grid-template-columns: minmax(0, 1fr) 100px 120px auto;
 }
 
+.meta-sheet-perm__row--template {
+  grid-template-columns: minmax(0, 1fr) 100px 140px auto;
+}
+
 .meta-sheet-perm__field-group {
   display: flex;
   flex-direction: column;
@@ -1093,6 +1252,10 @@ onBeforeUnmount(() => {
   }
 
   .meta-sheet-perm__row--field {
+    grid-template-columns: 1fr;
+  }
+
+  .meta-sheet-perm__row--template {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -45,6 +45,13 @@
                 <strong>{{ entry.label }}</strong>
                 <span>{{ entry.subtitle || entry.subjectId }}</span>
                 <span
+                  v-if="subjectIsInactive(entry.subjectType, entry.isActive)"
+                  class="meta-sheet-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
+                <span
                   v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
                   class="meta-sheet-perm__hint meta-sheet-perm__hint--inline"
                 >
@@ -123,6 +130,13 @@
                 <div class="meta-sheet-perm__identity">
                   <strong>{{ candidate.label }}</strong>
                   <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                  <span
+                    v-if="subjectIsInactive(candidate.subjectType, candidate.isActive)"
+                    class="meta-sheet-perm__lifecycle"
+                    data-lifecycle="inactive"
+                  >
+                    Inactive user
+                  </span>
                 </div>
                 <span class="meta-sheet-perm__subject" data-subject-type="user">Person</span>
                 <select
@@ -863,6 +877,10 @@ function subjectTypeBadgeLabel(subjectType: MetaSheetPermissionSubjectType) {
   return 'Person'
 }
 
+function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+  return subjectType === 'user' && isActive === false
+}
+
 function requestClose() {
   emit('close')
 }
@@ -1194,6 +1212,18 @@ onBeforeUnmount(() => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.meta-sheet-perm__lifecycle {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .meta-sheet-perm__badge {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -4,7 +4,7 @@
       <div class="meta-sheet-perm__header">
         <div>
           <h4 class="meta-sheet-perm__title">Manage Access</h4>
-          <p class="meta-sheet-perm__subtitle">Override sheet-level access for eligible people or roles. Admin includes sharing and sheet deletion. Write-own remains user-only.</p>
+          <p class="meta-sheet-perm__subtitle">Override sheet-level access for eligible people, member groups, or roles. Admin includes sharing and sheet deletion. Write-own remains user-only.</p>
         </div>
         <button class="meta-sheet-perm__close" type="button" @click="requestClose">&times;</button>
       </div>
@@ -45,7 +45,7 @@
                 <strong>{{ entry.label }}</strong>
                 <span>{{ entry.subtitle || entry.subjectId }}</span>
               </div>
-              <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ entry.subjectType === 'role' ? 'Role' : 'Person' }}</span>
+              <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
               <span class="meta-sheet-perm__badge" :data-access-level="entry.accessLevel">{{ accessLevelLabel(entry.accessLevel) }}</span>
               <select
                 :value="entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel"
@@ -82,7 +82,7 @@
 
           <section class="meta-sheet-perm__section">
             <div class="meta-sheet-perm__section-header">
-              <strong>Eligible people or roles</strong>
+              <strong>Eligible people, member groups, or roles</strong>
             </div>
             <input
               v-model="search"
@@ -91,8 +91,8 @@
               placeholder="Search people or roles"
               data-sheet-permission-search="true"
             />
-            <div v-if="candidatesLoading" class="meta-sheet-perm__empty">Searching eligible people and roles&#x2026;</div>
-            <div v-else-if="!availableCandidates.length" class="meta-sheet-perm__empty">No matching eligible people or roles.</div>
+            <div v-if="candidatesLoading" class="meta-sheet-perm__empty">Searching eligible people, member groups, and roles&#x2026;</div>
+            <div v-else-if="!availableCandidates.length" class="meta-sheet-perm__empty">No matching eligible people, member groups, or roles.</div>
             <template v-else>
               <div class="meta-sheet-perm__section-header">
                 <strong>People</strong>
@@ -109,6 +109,45 @@
                   <span>{{ candidate.subtitle || candidate.subjectId }}</span>
                 </div>
                 <span class="meta-sheet-perm__subject" data-subject-type="user">Person</span>
+                <select
+                  :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
+                  class="meta-sheet-perm__select"
+                  :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                  @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
+                >
+                  <option
+                    v-for="option in accessLevelOptionsFor(candidate.subjectType)"
+                    :key="`${candidate.subjectType}:${option.value}`"
+                    :value="option.value"
+                  >
+                    {{ option.label }}
+                  </option>
+                </select>
+                <button
+                  class="meta-sheet-perm__action meta-sheet-perm__action--primary"
+                  type="button"
+                  :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                  @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
+                >
+                  Apply
+                </button>
+              </div>
+
+              <div class="meta-sheet-perm__section-header">
+                <strong>Member groups</strong>
+              </div>
+              <div v-if="!memberGroupCandidates.length" class="meta-sheet-perm__empty">No matching member groups.</div>
+              <div
+                v-for="candidate in memberGroupCandidates"
+                :key="subjectKey(candidate.subjectType, candidate.subjectId)"
+                class="meta-sheet-perm__row"
+                :data-sheet-permission-candidate="subjectKey(candidate.subjectType, candidate.subjectId)"
+              >
+                <div class="meta-sheet-perm__identity">
+                  <strong>{{ candidate.label }}</strong>
+                  <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                </div>
+                <span class="meta-sheet-perm__subject" data-subject-type="member-group">Member group</span>
                 <select
                   :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                   class="meta-sheet-perm__select"
@@ -201,7 +240,7 @@
                 >
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
-                    <span>{{ entry.subjectType === 'role' ? 'Role' : 'Person' }}</span>
+                    <span>{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   </div>
                   <span
                     class="meta-sheet-perm__badge"
@@ -259,7 +298,7 @@
                 >
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
-                    <span>{{ entry.subjectType === 'role' ? 'Role' : 'Person' }}</span>
+                    <span>{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   </div>
                   <span
                     class="meta-sheet-perm__badge"
@@ -424,7 +463,7 @@ async function applyFieldPerm(fieldId: string, subjectType: string, subjectId: s
     await props.client.updateFieldPermission(
       props.sheetId,
       fieldId,
-      subjectType as 'user' | 'role',
+      subjectType as MetaSheetPermissionSubjectType,
       subjectId,
       perm,
     )
@@ -478,7 +517,7 @@ async function applyViewPerm(viewId: string, subjectType: string, subjectId: str
   try {
     await props.client.updateViewPermission(
       viewId,
-      subjectType as 'user' | 'role',
+      subjectType as MetaSheetPermissionSubjectType,
       subjectId,
       permission,
     )
@@ -499,6 +538,7 @@ const availableCandidates = computed(() => {
 })
 
 const peopleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'user'))
+const memberGroupCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'member-group'))
 const roleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'role'))
 
 function accessLevelLabel(accessLevel: MetaSheetPermissionAccessLevel) {
@@ -506,7 +546,13 @@ function accessLevelLabel(accessLevel: MetaSheetPermissionAccessLevel) {
 }
 
 function accessLevelOptionsFor(subjectType: MetaSheetPermissionSubjectType) {
-  return subjectType === 'role' ? ROLE_ACCESS_LEVEL_OPTIONS : ACCESS_LEVEL_OPTIONS
+  return subjectType === 'user' ? ACCESS_LEVEL_OPTIONS : ROLE_ACCESS_LEVEL_OPTIONS
+}
+
+function subjectTypeBadgeLabel(subjectType: MetaSheetPermissionSubjectType) {
+  if (subjectType === 'role') return 'Role'
+  if (subjectType === 'member-group') return 'Member group'
+  return 'Person'
 }
 
 function requestClose() {
@@ -526,7 +572,7 @@ function syncCandidateDrafts(nextCandidates: MetaSheetPermissionCandidate[]) {
   const nextDrafts: Record<string, MetaSheetPermissionAccessLevel> = { ...candidateDrafts.value }
   for (const candidate of nextCandidates) {
     const key = subjectKey(candidate.subjectType, candidate.subjectId)
-    const fallback = candidate.subjectType === 'role' ? 'read' : 'read'
+    const fallback = 'read'
     nextDrafts[key] = candidate.accessLevel ?? nextDrafts[key] ?? fallback
   }
   candidateDrafts.value = nextDrafts

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -221,7 +221,7 @@
               <strong>Field-level permissions</strong>
             </div>
             <div v-if="!fields.length" class="meta-sheet-perm__empty">No fields available.</div>
-            <div v-else-if="!entries.length" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure field permissions.</div>
+            <div v-else-if="!entries.length && !hasFieldOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure field permissions.</div>
             <template v-else>
               <div
                 v-for="field in fields"
@@ -267,6 +267,32 @@
                     Save
                   </button>
                 </div>
+                <div
+                  v-for="orphan in fieldPermissionOrphansByField[field.id] ?? []"
+                  :key="`fp-orphan-${field.id}-${subjectKey(orphan.subjectType, orphan.subjectId)}`"
+                  class="meta-sheet-perm__row meta-sheet-perm__row--field"
+                  :data-field-permission-orphan-row="`${field.id}:${subjectKey(orphan.subjectType, orphan.subjectId)}`"
+                >
+                  <div class="meta-sheet-perm__identity">
+                    <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
+                    <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  </div>
+                  <span
+                    class="meta-sheet-perm__badge"
+                    :data-access-level="fieldPermDraftLabel(field.id, orphan.subjectType, orphan.subjectId)"
+                  >
+                    {{ fieldPermDraftLabel(field.id, orphan.subjectType, orphan.subjectId) }}
+                  </span>
+                  <span class="meta-sheet-perm__hint">No current sheet access</span>
+                  <button
+                    class="meta-sheet-perm__action meta-sheet-perm__action--danger"
+                    type="button"
+                    :disabled="busyFieldPermKey === fieldPermKey(field.id, orphan.subjectType, orphan.subjectId)"
+                    @click="clearFieldPerm(field.id, orphan.subjectType, orphan.subjectId)"
+                  >
+                    Clear
+                  </button>
+                </div>
               </div>
             </template>
           </section>
@@ -279,7 +305,7 @@
               <strong>View-level permissions</strong>
             </div>
             <div v-if="!views.length" class="meta-sheet-perm__empty">No views available.</div>
-            <div v-else-if="!entries.length" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure view permissions.</div>
+            <div v-else-if="!entries.length && !hasViewOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure view permissions.</div>
             <template v-else>
               <div
                 v-for="view in views"
@@ -324,6 +350,32 @@
                     @click="applyViewPerm(view.id, entry.subjectType, entry.subjectId)"
                   >
                     Save
+                  </button>
+                </div>
+                <div
+                  v-for="orphan in viewPermissionOrphansByView[view.id] ?? []"
+                  :key="`vp-orphan-${view.id}-${subjectKey(orphan.subjectType, orphan.subjectId)}`"
+                  class="meta-sheet-perm__row meta-sheet-perm__row--field"
+                  :data-view-permission-orphan-row="`${view.id}:${subjectKey(orphan.subjectType, orphan.subjectId)}`"
+                >
+                  <div class="meta-sheet-perm__identity">
+                    <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
+                    <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  </div>
+                  <span
+                    class="meta-sheet-perm__badge"
+                    :data-access-level="viewPermDraftValue(view.id, orphan.subjectType, orphan.subjectId)"
+                  >
+                    {{ viewPermDisplayLabel(viewPermDraftValue(view.id, orphan.subjectType, orphan.subjectId)) }}
+                  </span>
+                  <span class="meta-sheet-perm__hint">No current sheet access</span>
+                  <button
+                    class="meta-sheet-perm__action meta-sheet-perm__action--danger"
+                    type="button"
+                    :disabled="busyViewPermKey === viewPermKey(view.id, orphan.subjectType, orphan.subjectId)"
+                    @click="clearViewPerm(view.id, orphan.subjectType, orphan.subjectId)"
+                  >
+                    Clear
                   </button>
                 </div>
               </div>
@@ -382,7 +434,7 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   (e: 'close'): void
   (e: 'updated'): void
-  (e: 'update-field-permission', fieldId: string, subjectType: string, subjectId: string, perm: { visible: boolean; readOnly: boolean }): void
+  (e: 'update-field-permission', fieldId: string, subjectType: string, subjectId: string, perm: { visible: boolean; readOnly: boolean } | { remove: true }): void
   (e: 'update-view-permission', viewId: string, subjectType: string, subjectId: string, permission: string): void
 }>()
 
@@ -456,22 +508,35 @@ function fieldPermFromDraftValue(val: string): { visible: boolean; readOnly: boo
 async function applyFieldPerm(fieldId: string, subjectType: string, subjectId: string) {
   const key = fieldPermKey(fieldId, subjectType, subjectId)
   const val = fieldPermDrafts.value[key] ?? resolveFieldPerm(fieldId, subjectType, subjectId)
-  const perm = fieldPermFromDraftValue(val)
   busyFieldPermKey.value = key
   clearMessages()
   try {
-    await props.client.updateFieldPermission(
-      props.sheetId,
-      fieldId,
-      subjectType as MetaSheetPermissionSubjectType,
-      subjectId,
-      perm,
-    )
-    status.value = 'Field permission updated'
-    emit('update-field-permission', fieldId, subjectType, subjectId, perm)
+    const isDefault = val === 'default'
+    const perm: { remove: true } | { visible: boolean; readOnly: boolean } = isDefault
+      ? { remove: true }
+      : fieldPermFromDraftValue(val)
+    await props.client.updateFieldPermission(props.sheetId, fieldId, subjectType as MetaSheetPermissionSubjectType, subjectId, perm)
+    status.value = isDefault ? 'Field permission cleared' : 'Field permission updated'
+    emit('update-field-permission', fieldId, subjectType, subjectId, isDefault ? { visible: true, readOnly: false } : perm)
     emit('updated')
   } catch (cause: any) {
     error.value = cause?.message ?? 'Failed to update field permission'
+  } finally {
+    busyFieldPermKey.value = null
+  }
+}
+
+async function clearFieldPerm(fieldId: string, subjectType: string, subjectId: string) {
+  const key = fieldPermKey(fieldId, subjectType, subjectId)
+  busyFieldPermKey.value = key
+  clearMessages()
+  try {
+    await props.client.updateFieldPermission(props.sheetId, fieldId, subjectType as MetaSheetPermissionSubjectType, subjectId, { remove: true })
+    status.value = 'Field permission cleared'
+    emit('update-field-permission', fieldId, subjectType, subjectId, { visible: true, readOnly: false })
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear field permission'
   } finally {
     busyFieldPermKey.value = null
   }
@@ -531,6 +596,22 @@ async function applyViewPerm(viewId: string, subjectType: string, subjectId: str
   }
 }
 
+async function clearViewPerm(viewId: string, subjectType: string, subjectId: string) {
+  const key = viewPermKey(viewId, subjectType, subjectId)
+  busyViewPermKey.value = key
+  clearMessages()
+  try {
+    await props.client.updateViewPermission(viewId, subjectType as MetaSheetPermissionSubjectType, subjectId, 'none')
+    status.value = 'View permission cleared'
+    emit('update-view-permission', viewId, subjectType, subjectId, 'none')
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear view permission'
+  } finally {
+    busyViewPermKey.value = null
+  }
+}
+
 // --- Sheet access helpers (existing) ---
 const availableCandidates = computed(() => {
   const activeSubjectKeys = new Set(entries.value.map((entry) => subjectKey(entry.subjectType, entry.subjectId)))
@@ -540,6 +621,29 @@ const availableCandidates = computed(() => {
 const peopleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'user'))
 const memberGroupCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'member-group'))
 const roleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'role'))
+const activeSheetSubjectKeys = computed(() => new Set(entries.value.map((entry) => subjectKey(entry.subjectType, entry.subjectId))))
+const fieldPermissionOrphans = computed(() =>
+  props.fieldPermissionEntries.filter((entry) => !activeSheetSubjectKeys.value.has(subjectKey(entry.subjectType, entry.subjectId))),
+)
+const viewPermissionOrphans = computed(() =>
+  props.viewPermissionEntries.filter((entry) => !activeSheetSubjectKeys.value.has(subjectKey(entry.subjectType, entry.subjectId))),
+)
+const fieldPermissionOrphansByField = computed<Record<string, MetaFieldPermissionEntry[]>>(() => {
+  const grouped: Record<string, MetaFieldPermissionEntry[]> = {}
+  for (const entry of fieldPermissionOrphans.value) {
+    ;(grouped[entry.fieldId] ??= []).push(entry)
+  }
+  return grouped
+})
+const viewPermissionOrphansByView = computed<Record<string, MetaViewPermissionEntry[]>>(() => {
+  const grouped: Record<string, MetaViewPermissionEntry[]> = {}
+  for (const entry of viewPermissionOrphans.value) {
+    ;(grouped[entry.viewId] ??= []).push(entry)
+  }
+  return grouped
+})
+const hasFieldOrphans = computed(() => fieldPermissionOrphans.value.length > 0)
+const hasViewOrphans = computed(() => viewPermissionOrphans.value.length > 0)
 
 function accessLevelLabel(accessLevel: MetaSheetPermissionAccessLevel) {
   return ACCESS_LEVEL_OPTIONS.find((option) => option.value === accessLevel)?.label ?? accessLevel
@@ -894,6 +998,12 @@ onBeforeUnmount(() => {
 .meta-sheet-perm__badge[data-access-level='Read-only'] {
   background: #fef3c7;
   color: #92400e;
+}
+
+.meta-sheet-perm__hint {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .meta-sheet-perm__subject {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -295,7 +295,19 @@
               >
                 <div class="meta-sheet-perm__section-header">
                   <strong>{{ field.name }}</strong>
-                  <span class="meta-sheet-perm__badge">{{ field.type }}</span>
+                  <div class="meta-sheet-perm__section-actions">
+                    <span class="meta-sheet-perm__badge">{{ field.type }}</span>
+                    <button
+                      v-if="(fieldPermissionOrphansByField[field.id]?.length ?? 0) > 1"
+                      class="meta-sheet-perm__action meta-sheet-perm__action--danger"
+                      type="button"
+                      :data-field-permission-clear-orphans="field.id"
+                      :disabled="busyFieldOrphanBulkKey === field.id"
+                      @click="clearFieldOrphans(field.id)"
+                    >
+                      Clear orphan overrides
+                    </button>
+                  </div>
                 </div>
                 <div
                   v-for="entry in entries"
@@ -415,7 +427,19 @@
               >
                 <div class="meta-sheet-perm__section-header">
                   <strong>{{ view.name }}</strong>
-                  <span class="meta-sheet-perm__badge">{{ view.type }}</span>
+                  <div class="meta-sheet-perm__section-actions">
+                    <span class="meta-sheet-perm__badge">{{ view.type }}</span>
+                    <button
+                      v-if="(viewPermissionOrphansByView[view.id]?.length ?? 0) > 1"
+                      class="meta-sheet-perm__action meta-sheet-perm__action--danger"
+                      type="button"
+                      :data-view-permission-clear-orphans="view.id"
+                      :disabled="busyViewOrphanBulkKey === view.id"
+                      @click="clearViewOrphans(view.id)"
+                    >
+                      Clear orphan overrides
+                    </button>
+                  </div>
                 </div>
                 <div
                   v-for="entry in entries"
@@ -558,12 +582,14 @@ const fieldPermDrafts = ref<Record<string, string>>({})
 const busyFieldPermKey = ref<string | null>(null)
 const fieldTemplateDrafts = ref<Record<string, string>>({})
 const busyFieldTemplateKey = ref<string | null>(null)
+const busyFieldOrphanBulkKey = ref<string | null>(null)
 
 // View permission drafts
 const viewPermDrafts = ref<Record<string, string>>({})
 const busyViewPermKey = ref<string | null>(null)
 const viewTemplateDrafts = ref<Record<string, string>>({})
 const busyViewTemplateKey = ref<string | null>(null)
+const busyViewOrphanBulkKey = ref<string | null>(null)
 
 function subjectKey(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   return `${subjectType}:${subjectId}`
@@ -655,6 +681,26 @@ async function clearFieldPerm(fieldId: string, subjectType: string, subjectId: s
     error.value = cause?.message ?? 'Failed to clear field permission'
   } finally {
     busyFieldPermKey.value = null
+  }
+}
+
+async function clearFieldOrphans(fieldId: string) {
+  const orphans = fieldPermissionOrphansByField.value[fieldId] ?? []
+  if (!orphans.length) return
+  busyFieldOrphanBulkKey.value = fieldId
+  clearMessages()
+  try {
+    await Promise.all(
+      orphans.map((entry) =>
+        props.client.updateFieldPermission(props.sheetId, fieldId, entry.subjectType, entry.subjectId, { remove: true }),
+      ),
+    )
+    status.value = `Cleared ${orphans.length} orphan field override${orphans.length === 1 ? '' : 's'}`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear orphan field overrides'
+  } finally {
+    busyFieldOrphanBulkKey.value = null
   }
 }
 
@@ -768,6 +814,26 @@ async function clearViewPerm(viewId: string, subjectType: string, subjectId: str
     error.value = cause?.message ?? 'Failed to clear view permission'
   } finally {
     busyViewPermKey.value = null
+  }
+}
+
+async function clearViewOrphans(viewId: string) {
+  const orphans = viewPermissionOrphansByView.value[viewId] ?? []
+  if (!orphans.length) return
+  busyViewOrphanBulkKey.value = viewId
+  clearMessages()
+  try {
+    await Promise.all(
+      orphans.map((entry) =>
+        props.client.updateViewPermission(viewId, entry.subjectType, entry.subjectId, 'none'),
+      ),
+    )
+    status.value = `Cleared ${orphans.length} orphan view override${orphans.length === 1 ? '' : 's'}`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear orphan view overrides'
+  } finally {
+    busyViewOrphanBulkKey.value = null
   }
 }
 
@@ -1159,6 +1225,14 @@ onBeforeUnmount(() => {
   align-items: center;
   justify-content: space-between;
   color: #0f172a;
+}
+
+.meta-sheet-perm__section-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .meta-sheet-perm__row {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -44,6 +44,12 @@
               <div class="meta-sheet-perm__identity">
                 <strong>{{ entry.label }}</strong>
                 <span>{{ entry.subtitle || entry.subjectId }}</span>
+                <span
+                  v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
+                  class="meta-sheet-perm__hint meta-sheet-perm__hint--inline"
+                >
+                  {{ subjectOverrideSummaryLabel(entry.subjectType, entry.subjectId) }}
+                </span>
               </div>
               <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
               <span class="meta-sheet-perm__badge" :data-access-level="entry.accessLevel">{{ accessLevelLabel(entry.accessLevel) }}</span>
@@ -68,6 +74,16 @@
                 @click="applyEntry(entry.subjectType, entry.subjectId)"
               >
                 Save
+              </button>
+              <button
+                v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
+                class="meta-sheet-perm__action"
+                type="button"
+                :data-sheet-permission-clear-overrides="subjectKey(entry.subjectType, entry.subjectId)"
+                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId)"
+                @click="clearSubjectOverrides(entry.subjectType, entry.subjectId)"
+              >
+                Clear overrides
               </button>
               <button
                 class="meta-sheet-perm__action meta-sheet-perm__action--danger"
@@ -777,6 +793,22 @@ const peopleCandidates = computed(() => availableCandidates.value.filter((candid
 const memberGroupCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'member-group'))
 const roleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'role'))
 const activeSheetSubjectKeys = computed(() => new Set(entries.value.map((entry) => subjectKey(entry.subjectType, entry.subjectId))))
+const subjectOverrideCounts = computed<Record<string, { fieldCount: number; viewCount: number }>>(() => {
+  const counts: Record<string, { fieldCount: number; viewCount: number }> = {}
+  for (const entry of props.fieldPermissionEntries) {
+    const key = subjectKey(entry.subjectType, entry.subjectId)
+    const current = counts[key] ?? { fieldCount: 0, viewCount: 0 }
+    current.fieldCount += 1
+    counts[key] = current
+  }
+  for (const entry of props.viewPermissionEntries) {
+    const key = subjectKey(entry.subjectType, entry.subjectId)
+    const current = counts[key] ?? { fieldCount: 0, viewCount: 0 }
+    current.viewCount += 1
+    counts[key] = current
+  }
+  return counts
+})
 const fieldPermissionOrphans = computed(() =>
   props.fieldPermissionEntries.filter((entry) => !activeSheetSubjectKeys.value.has(subjectKey(entry.subjectType, entry.subjectId))),
 )
@@ -799,6 +831,23 @@ const viewPermissionOrphansByView = computed<Record<string, MetaViewPermissionEn
 })
 const hasFieldOrphans = computed(() => fieldPermissionOrphans.value.length > 0)
 const hasViewOrphans = computed(() => viewPermissionOrphans.value.length > 0)
+
+function subjectOverrideCountsFor(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
+  return subjectOverrideCounts.value[subjectKey(subjectType, subjectId)] ?? { fieldCount: 0, viewCount: 0 }
+}
+
+function hasSubjectOverrides(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
+  const counts = subjectOverrideCountsFor(subjectType, subjectId)
+  return counts.fieldCount > 0 || counts.viewCount > 0
+}
+
+function subjectOverrideSummaryLabel(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
+  const counts = subjectOverrideCountsFor(subjectType, subjectId)
+  const parts: string[] = []
+  if (counts.fieldCount > 0) parts.push(`${counts.fieldCount} field override${counts.fieldCount === 1 ? '' : 's'}`)
+  if (counts.viewCount > 0) parts.push(`${counts.viewCount} view override${counts.viewCount === 1 ? '' : 's'}`)
+  return parts.join(' · ')
+}
 
 function accessLevelLabel(accessLevel: MetaSheetPermissionAccessLevel) {
   return ACCESS_LEVEL_OPTIONS.find((option) => option.value === accessLevel)?.label ?? accessLevel
@@ -939,6 +988,36 @@ async function removeEntry(subjectType: MetaSheetPermissionSubjectType, subjectI
 async function grantCandidate(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   const key = subjectKey(subjectType, subjectId)
   await updateSubjectAccess(subjectType, subjectId, candidateDrafts.value[key] ?? 'read', 'Sheet access override saved')
+}
+
+async function clearSubjectOverrides(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
+  const key = subjectKey(subjectType, subjectId)
+  const fieldOverrides = props.fieldPermissionEntries.filter(
+    (entry) => entry.subjectType === subjectType && entry.subjectId === subjectId,
+  )
+  const viewOverrides = props.viewPermissionEntries.filter(
+    (entry) => entry.subjectType === subjectType && entry.subjectId === subjectId,
+  )
+  if (!fieldOverrides.length && !viewOverrides.length) return
+
+  busySubjectKey.value = key
+  clearMessages()
+  try {
+    await Promise.all([
+      ...fieldOverrides.map((entry) =>
+        props.client.updateFieldPermission(props.sheetId, entry.fieldId, subjectType, subjectId, { remove: true }),
+      ),
+      ...viewOverrides.map((entry) =>
+        props.client.updateViewPermission(entry.viewId, subjectType, subjectId, 'none'),
+      ),
+    ])
+    status.value = `Cleared ${subjectOverrideSummaryLabel(subjectType, subjectId)}`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear subject overrides'
+  } finally {
+    busySubjectKey.value = null
+  }
 }
 
 watch(
@@ -1163,6 +1242,10 @@ onBeforeUnmount(() => {
   color: #64748b;
   font-size: 12px;
   font-weight: 500;
+}
+
+.meta-sheet-perm__hint--inline {
+  margin-top: 2px;
 }
 
 .meta-sheet-perm__subject {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -534,6 +534,9 @@ export interface RecordPermissionEntry {
   subjectType: RecordPermissionSubjectType
   subjectId: string
   accessLevel: RecordPermissionAccessLevel
+  label: string
+  subtitle?: string | null
+  isActive: boolean
   createdAt?: string
   createdBy?: string
 }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -221,6 +221,8 @@ export interface MetaFieldPermissionEntry {
   subjectType: MetaSheetPermissionSubjectType
   subjectId: string
   subjectLabel?: string
+  subjectSubtitle?: string | null
+  isActive?: boolean
   visible: boolean
   readOnly: boolean
 }
@@ -230,6 +232,8 @@ export interface MetaViewPermissionEntry {
   subjectType: MetaSheetPermissionSubjectType
   subjectId: string
   subjectLabel?: string
+  subjectSubtitle?: string | null
+  isActive?: boolean
   permission: string
 }
 

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -195,7 +195,7 @@ export interface MetaCapabilityOrigin {
 }
 
 export type MetaSheetPermissionAccessLevel = 'read' | 'write' | 'write-own' | 'admin'
-export type MetaSheetPermissionSubjectType = 'user' | 'role'
+export type MetaSheetPermissionSubjectType = 'user' | 'role' | 'member-group'
 
 export interface MetaSheetPermissionEntry {
   subjectType: MetaSheetPermissionSubjectType
@@ -525,7 +525,7 @@ export interface MetaTimelineViewConfig {
 
 // --- Record-level permissions ---
 export type RecordPermissionAccessLevel = 'read' | 'write' | 'admin'
-export type RecordPermissionSubjectType = 'user' | 'role'
+export type RecordPermissionSubjectType = 'user' | 'role' | 'member-group'
 
 export interface RecordPermissionEntry {
   id: string

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -14,11 +14,15 @@ async function flushUi(cycles = 4) {
 
 function makeClient(overrides?: {
   listRecordPermissions?: ReturnType<typeof vi.fn>
+  listSheetPermissions?: ReturnType<typeof vi.fn>
+  listSheetPermissionCandidates?: ReturnType<typeof vi.fn>
   updateRecordPermission?: ReturnType<typeof vi.fn>
   deleteRecordPermission?: ReturnType<typeof vi.fn>
 }) {
   return {
     listRecordPermissions: overrides?.listRecordPermissions ?? vi.fn().mockResolvedValue([]),
+    listSheetPermissions: overrides?.listSheetPermissions ?? vi.fn().mockResolvedValue({ items: [] }),
+    listSheetPermissionCandidates: overrides?.listSheetPermissionCandidates ?? vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, query: '' }),
     updateRecordPermission: overrides?.updateRecordPermission ?? vi.fn().mockResolvedValue(undefined),
     deleteRecordPermission: overrides?.deleteRecordPermission ?? vi.fn().mockResolvedValue(undefined),
   }
@@ -61,6 +65,9 @@ describe('MetaRecordPermissionManager', () => {
           subjectType: 'user',
           subjectId: 'user_alice',
           accessLevel: 'write',
+          label: 'Alice',
+          subtitle: 'alice@example.com',
+          isActive: true,
           createdAt: '2026-01-01T00:00:00Z',
         },
         {
@@ -70,6 +77,9 @@ describe('MetaRecordPermissionManager', () => {
           subjectType: 'role',
           subjectId: 'role_ops',
           accessLevel: 'read',
+          label: 'Ops Reviewers',
+          subtitle: 'Operations review role',
+          isActive: true,
         },
       ]),
     })
@@ -80,11 +90,12 @@ describe('MetaRecordPermissionManager', () => {
     expect(client.listRecordPermissions).toHaveBeenCalledWith('sheet_1', 'record_1')
     expect(container!.querySelector('[data-record-permission-entry="perm_1"]')).not.toBeNull()
     expect(container!.querySelector('[data-record-permission-entry="perm_2"]')).not.toBeNull()
-    expect(container!.textContent).toContain('user_alice')
-    expect(container!.textContent).toContain('role_ops')
+    expect(container!.textContent).toContain('Alice')
+    expect(container!.textContent).toContain('alice@example.com')
+    expect(container!.textContent).toContain('Ops Reviewers')
   })
 
-  it('calls API on grant', async () => {
+  it('grants record access from sheet subjects without raw subject-id input', async () => {
     const client = makeClient({
       listRecordPermissions: vi.fn()
         .mockResolvedValueOnce([])
@@ -96,30 +107,37 @@ describe('MetaRecordPermissionManager', () => {
             subjectType: 'user',
             subjectId: 'user_bob',
             accessLevel: 'write',
+            label: 'Bob',
+            subtitle: 'bob@example.com',
+            isActive: true,
           },
         ]),
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_bob',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'Bob',
+            subtitle: 'bob@example.com',
+            isActive: true,
+          },
+        ],
+      }),
     })
     const updatedSpy = vi.fn()
 
     mountManager({ client, onUpdated: updatedSpy })
     await flushUi()
 
-    // Fill in the add form
-    const subjectInput = container!.querySelector('[data-record-permission-subject-input]') as HTMLInputElement
-    subjectInput.value = 'user_bob'
-    subjectInput.dispatchEvent(new Event('input', { bubbles: true }))
-    await flushUi()
-
-    // Change access level to write
-    const addRow = container!.querySelector('[data-record-permission-add]')!
-    const selects = addRow.querySelectorAll('select')
-    const accessSelect = selects[1] as HTMLSelectElement
+    const candidateRow = container!.querySelector('[data-record-permission-candidate="user:user_bob"]')!
+    const accessSelect = candidateRow.querySelector('select') as HTMLSelectElement
     accessSelect.value = 'write'
     accessSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushUi()
 
-    // Click grant
-    const grantBtn = addRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
+    const grantBtn = candidateRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
     grantBtn.click()
     await flushUi()
 
@@ -139,32 +157,84 @@ describe('MetaRecordPermissionManager', () => {
             subjectType: 'member-group',
             subjectId: '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d',
             accessLevel: 'read',
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
           },
         ]),
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
     })
     const updatedSpy = vi.fn()
 
     mountManager({ client, onUpdated: updatedSpy })
     await flushUi()
 
-    const addRow = container!.querySelector('[data-record-permission-add]')!
-    const selects = addRow.querySelectorAll('select')
-    const subjectTypeSelect = selects[0] as HTMLSelectElement
-    expect(Array.from(subjectTypeSelect.options).map((option) => option.value)).toEqual(['user', 'role', 'member-group'])
-    subjectTypeSelect.value = 'member-group'
-    subjectTypeSelect.dispatchEvent(new Event('change', { bubbles: true }))
-
-    const subjectInput = container!.querySelector('[data-record-permission-subject-input]') as HTMLInputElement
-    subjectInput.value = '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d'
-    subjectInput.dispatchEvent(new Event('input', { bubbles: true }))
-    await flushUi()
-
-    const grantBtn = addRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
+    const candidateRow = container!.querySelector('[data-record-permission-candidate="member-group:4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d"]')!
+    expect(candidateRow.textContent).toContain('North Region')
+    expect(candidateRow.textContent).toContain('Member group')
+    const grantBtn = candidateRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
     grantBtn.click()
     await flushUi()
 
     expect(client.updateRecordPermission).toHaveBeenCalledWith('sheet_1', 'record_1', 'member-group', '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d', 'read')
     expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('searches across sheet subjects and global candidates when granting record access', async () => {
+    const client = makeClient({
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'role',
+            subjectId: 'role_ops',
+            label: 'Ops Reviewers',
+            subtitle: 'Operations review role',
+            isActive: true,
+            accessLevel: null,
+          },
+        ],
+        total: 1,
+        limit: 20,
+        query: 'north',
+      }),
+    })
+
+    mountManager({ client })
+    await flushUi()
+
+    const searchInput = container!.querySelector('[data-record-permission-search]') as HTMLInputElement
+    searchInput.value = 'north'
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    expect(client.listSheetPermissionCandidates).toHaveBeenLastCalledWith('sheet_1', { q: 'north', limit: 20 })
+    expect(container!.querySelector('[data-record-permission-candidate="member-group:group_north"]')).not.toBeNull()
+    expect(container!.querySelector('[data-record-permission-candidate="role:role_ops"]')).toBeNull()
   })
 
   it('calls API on revoke', async () => {

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -127,6 +127,46 @@ describe('MetaRecordPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('supports granting member-group record permissions', async () => {
+    const client = makeClient({
+      listRecordPermissions: vi.fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 'perm_group',
+            sheetId: 'sheet_1',
+            recordId: 'record_1',
+            subjectType: 'member-group',
+            subjectId: '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d',
+            accessLevel: 'read',
+          },
+        ]),
+    })
+    const updatedSpy = vi.fn()
+
+    mountManager({ client, onUpdated: updatedSpy })
+    await flushUi()
+
+    const addRow = container!.querySelector('[data-record-permission-add]')!
+    const selects = addRow.querySelectorAll('select')
+    const subjectTypeSelect = selects[0] as HTMLSelectElement
+    expect(Array.from(subjectTypeSelect.options).map((option) => option.value)).toEqual(['user', 'role', 'member-group'])
+    subjectTypeSelect.value = 'member-group'
+    subjectTypeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const subjectInput = container!.querySelector('[data-record-permission-subject-input]') as HTMLInputElement
+    subjectInput.value = '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d'
+    subjectInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const grantBtn = addRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
+    grantBtn.click()
+    await flushUi()
+
+    expect(client.updateRecordPermission).toHaveBeenCalledWith('sheet_1', 'record_1', 'member-group', '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d', 'read')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('calls API on revoke', async () => {
     const client = makeClient({
       listRecordPermissions: vi.fn().mockResolvedValue([

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -192,6 +192,45 @@ describe('MetaRecordPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('surfaces inactive users in current record access and candidate results', async () => {
+    const client = makeClient({
+      listRecordPermissions: vi.fn().mockResolvedValue([
+        {
+          id: 'perm_inactive',
+          sheetId: 'sheet_1',
+          recordId: 'record_1',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          accessLevel: 'read',
+          label: 'Morgan',
+          subtitle: 'morgan@example.com',
+          isActive: false,
+        },
+      ]),
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_candidate_inactive',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'Taylor',
+            subtitle: 'taylor@example.com',
+            isActive: false,
+          },
+        ],
+      }),
+    })
+
+    mountManager({ client })
+    await flushUi()
+
+    const inactiveEntry = container!.querySelector('[data-record-permission-entry="perm_inactive"]')!
+    const inactiveCandidate = container!.querySelector('[data-record-permission-candidate="user:user_candidate_inactive"]')!
+    expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Inactive user')
+  })
+
   it('searches across sheet subjects and global candidates when granting record access', async () => {
     const client = makeClient({
       listSheetPermissions: vi.fn().mockResolvedValue({

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -362,4 +362,108 @@ describe('MetaSheetPermissionManager', () => {
     expect(client.updateViewPermission).toHaveBeenCalledWith('view_grid', 'member-group', 'group_north', 'none')
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('applies a field template to all fields for a member-group subject', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+        { id: 'fld_owner', name: 'Owner', type: 'string', property: {}, order: 1, options: [] },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    const templateRow = container!.querySelector('[data-field-permission-template="member-group:group_north"]')!
+    const select = templateRow.querySelector('select') as HTMLSelectElement
+    select.value = 'readonly'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(templateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(1, 'sheet_orders', 'fld_title', 'member-group', 'group_north', { visible: true, readOnly: true })
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(2, 'sheet_orders', 'fld_owner', 'member-group', 'group_north', { visible: true, readOnly: true })
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies a view template to all views for a member-group subject', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+        { id: 'view_board', name: 'Board View', type: 'board', sheetId: 'sheet_orders' },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    const templateRow = container!.querySelector('[data-view-permission-template="member-group:group_north"]')!
+    const select = templateRow.querySelector('select') as HTMLSelectElement
+    select.value = 'admin'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(templateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateViewPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateViewPermission).toHaveBeenNthCalledWith(1, 'view_grid', 'member-group', 'group_north', 'admin')
+    expect(client.updateViewPermission).toHaveBeenNthCalledWith(2, 'view_board', 'member-group', 'group_north', 'admin')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -17,8 +17,14 @@ function mountManager(props: {
     listSheetPermissions: ReturnType<typeof vi.fn>
     listSheetPermissionCandidates: ReturnType<typeof vi.fn>
     updateSheetPermission: ReturnType<typeof vi.fn>
+    updateFieldPermission?: ReturnType<typeof vi.fn>
+    updateViewPermission?: ReturnType<typeof vi.fn>
   }
   onUpdated?: () => void
+  fields?: Array<{ id: string; name: string; type: string; property?: Record<string, unknown>; order?: number; options?: unknown[] }>
+  views?: Array<{ id: string; name: string; type?: string; sheetId?: string }>
+  fieldPermissionEntries?: Array<any>
+  viewPermissionEntries?: Array<any>
 }) {
   container = document.createElement('div')
   document.body.appendChild(container)
@@ -26,6 +32,10 @@ function mountManager(props: {
     visible: true,
     sheetId: 'sheet_orders',
     client: props.client,
+    fields: props.fields ?? [],
+    views: props.views ?? [],
+    fieldPermissionEntries: props.fieldPermissionEntries ?? [],
+    viewPermissionEntries: props.viewPermissionEntries ?? [],
     onClose: () => {},
     onUpdated: props.onUpdated ?? (() => {}),
   })
@@ -73,6 +83,8 @@ describe('MetaSheetPermissionManager', () => {
         ],
       }),
       updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
     }
 
     mountManager({ client })
@@ -123,6 +135,8 @@ describe('MetaSheetPermissionManager', () => {
           ],
         }),
       updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
     }
 
     mountManager({ client, onUpdated: updatedSpy })
@@ -188,6 +202,8 @@ describe('MetaSheetPermissionManager', () => {
           ],
         }),
       updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
     }
 
     mountManager({ client, onUpdated: updatedSpy })
@@ -206,5 +222,144 @@ describe('MetaSheetPermissionManager', () => {
     expect(client.updateSheetPermission).toHaveBeenCalledWith('sheet_orders', 'member-group', '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c', 'write')
     expect(updatedSpy).toHaveBeenCalledTimes(1)
     expect(container!.querySelector('[data-sheet-permission-entry="member-group:3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c"]')).not.toBeNull()
+  })
+
+  it('clears field defaults by removing overrides and shows orphan field overrides', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_alex',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'Alex',
+            subtitle: 'alex@example.com',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'user',
+          subjectId: 'user_alex',
+          subjectLabel: 'Alex',
+          subjectSubtitle: 'alex@example.com',
+          visible: false,
+          readOnly: false,
+          isActive: true,
+        },
+        {
+          fieldId: 'fld_title',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          visible: true,
+          readOnly: true,
+          isActive: true,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    const activeRow = container!.querySelector('[data-field-permission-row="fld_title:user:user_alex"]')!
+    const activeSelect = activeRow.querySelector('select') as HTMLSelectElement
+    activeSelect.value = 'default'
+    activeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(activeRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenCalledWith('sheet_orders', 'fld_title', 'user', 'user_alex', { remove: true })
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+
+    const orphanRow = container!.querySelector('[data-field-permission-orphan-row="fld_title:member-group:group_north"]')!
+    expect(orphanRow.textContent).toContain('North Region')
+    expect(orphanRow.textContent).toContain('No current sheet access')
+
+    ;(orphanRow.querySelector('.meta-sheet-perm__action--danger') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenLastCalledWith('sheet_orders', 'fld_title', 'member-group', 'group_north', { remove: true })
+    expect(updatedSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows orphan view overrides and clears them', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_alex',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'Alex',
+            subtitle: 'alex@example.com',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          permission: 'admin',
+          isActive: true,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    const orphanRow = container!.querySelector('[data-view-permission-orphan-row="view_grid:member-group:group_north"]')!
+    expect(orphanRow.textContent).toContain('North Region')
+    expect(orphanRow.textContent).toContain('Admin')
+
+    ;(orphanRow.querySelector('.meta-sheet-perm__action--danger') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateViewPermission).toHaveBeenCalledWith('view_grid', 'member-group', 'group_north', 'none')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -404,6 +404,114 @@ describe('MetaSheetPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('clears all orphan field overrides for a field in one action', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({ items: [] }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          visible: true,
+          readOnly: true,
+          isActive: true,
+        },
+        {
+          fieldId: 'fld_title',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          subjectLabel: 'Morgan',
+          subjectSubtitle: 'morgan@example.com',
+          visible: false,
+          readOnly: false,
+          isActive: false,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    ;(container!.querySelector('[data-field-permission-clear-orphans="fld_title"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(1, 'sheet_orders', 'fld_title', 'member-group', 'group_north', { remove: true })
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(2, 'sheet_orders', 'fld_title', 'user', 'user_inactive', { remove: true })
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears all orphan view overrides for a view in one action', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({ items: [] }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          permission: 'admin',
+          isActive: true,
+        },
+        {
+          viewId: 'view_grid',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          subjectLabel: 'Morgan',
+          subjectSubtitle: 'morgan@example.com',
+          permission: 'read',
+          isActive: false,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    ;(container!.querySelector('[data-view-permission-clear-orphans="view_grid"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateViewPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateViewPermission).toHaveBeenNthCalledWith(1, 'view_grid', 'member-group', 'group_north', 'none')
+    expect(client.updateViewPermission).toHaveBeenNthCalledWith(2, 'view_grid', 'user', 'user_inactive', 'none')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('shows subject override summaries and clears downstream overrides for a sheet subject', async () => {
     const updatedSpy = vi.fn()
     const client = {

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -80,7 +80,7 @@ describe('MetaSheetPermissionManager', () => {
 
     expect(client.listSheetPermissions).toHaveBeenCalledWith('sheet_orders')
     expect(client.listSheetPermissionCandidates).toHaveBeenCalledWith('sheet_orders', { q: undefined, limit: 12 })
-    expect(container!.textContent).toContain('Override sheet-level access for eligible people or roles. Admin includes sharing and sheet deletion. Write-own remains user-only.')
+    expect(container!.textContent).toContain('Override sheet-level access for eligible people, member groups, or roles. Admin includes sharing and sheet deletion. Write-own remains user-only.')
     expect(container!.querySelector('[data-sheet-permission-entry="user:user_1"]')).not.toBeNull()
     expect(container!.querySelector('[data-sheet-permission-entry="role:role_ops"]')).not.toBeNull()
     expect(container!.querySelector('[data-sheet-permission-candidate="user:user_1"]')).toBeNull()
@@ -142,5 +142,69 @@ describe('MetaSheetPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
     expect(container!.querySelector('[data-sheet-permission-entry="role:role_ops_writer"]')).not.toBeNull()
     expect(container!.querySelector('[data-sheet-permission-candidate="role:role_ops_writer"]')).toBeNull()
+  })
+
+  it('renders member-group candidates and applies sheet access without write-own', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn()
+        .mockResolvedValueOnce({ items: [] })
+        .mockResolvedValueOnce({
+          items: [
+            {
+              subjectType: 'member-group',
+              subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+              accessLevel: 'write',
+              permissions: ['spreadsheet:write'],
+              label: 'North Region',
+              subtitle: '12 members',
+              isActive: true,
+            },
+          ],
+        }),
+      listSheetPermissionCandidates: vi.fn()
+        .mockResolvedValueOnce({
+          items: [
+            {
+              subjectType: 'member-group',
+              subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+              label: 'North Region',
+              subtitle: '12 members',
+              isActive: true,
+              accessLevel: null,
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          items: [
+            {
+              subjectType: 'member-group',
+              subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+              label: 'North Region',
+              subtitle: '12 members',
+              isActive: true,
+              accessLevel: 'write',
+            },
+          ],
+        }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({ client, onUpdated: updatedSpy })
+    await flushUi()
+
+    const select = container!.querySelector('[data-sheet-permission-candidate="member-group:3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c"] .meta-sheet-perm__select') as HTMLSelectElement
+    const optionValues = Array.from(select.options).map((option) => option.value)
+    expect(optionValues).toEqual(['read', 'write', 'admin'])
+    select.value = 'write'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(container!.querySelector('[data-sheet-permission-candidate="member-group:3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c"] .meta-sheet-perm__action--primary') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateSheetPermission).toHaveBeenCalledWith('sheet_orders', 'member-group', '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c', 'write')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+    expect(container!.querySelector('[data-sheet-permission-entry="member-group:3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c"]')).not.toBeNull()
   })
 })

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -363,6 +363,88 @@ describe('MetaSheetPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('shows subject override summaries and clears downstream overrides for a sheet subject', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+        { id: 'fld_owner', name: 'Owner', type: 'string', property: {}, order: 1, options: [] },
+      ],
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          visible: true,
+          readOnly: true,
+          isActive: true,
+        },
+        {
+          fieldId: 'fld_owner',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          visible: false,
+          readOnly: false,
+          isActive: true,
+        },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          permission: 'admin',
+          isActive: true,
+        },
+      ],
+    })
+    await flushUi()
+
+    const sheetRow = container!.querySelector('[data-sheet-permission-entry="member-group:group_north"]')!
+    expect(sheetRow.textContent).toContain('2 field overrides')
+    expect(sheetRow.textContent).toContain('1 view override')
+
+    ;(container!.querySelector('[data-sheet-permission-clear-overrides="member-group:group_north"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(1, 'sheet_orders', 'fld_title', 'member-group', 'group_north', { remove: true })
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(2, 'sheet_orders', 'fld_owner', 'member-group', 'group_north', { remove: true })
+    expect(client.updateViewPermission).toHaveBeenCalledWith('view_grid', 'member-group', 'group_north', 'none')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('applies a field template to all fields for a member-group subject', async () => {
     const updatedSpy = vi.fn()
     const client = {

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -224,6 +224,47 @@ describe('MetaSheetPermissionManager', () => {
     expect(container!.querySelector('[data-sheet-permission-entry="member-group:3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c"]')).not.toBeNull()
   })
 
+  it('surfaces inactive users in sheet entries and candidate results', async () => {
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_inactive',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'Morgan',
+            subtitle: 'morgan@example.com',
+            isActive: false,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_candidate_inactive',
+            label: 'Taylor',
+            subtitle: 'taylor@example.com',
+            isActive: false,
+            accessLevel: null,
+          },
+        ],
+      }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({ client })
+    await flushUi()
+
+    const inactiveEntry = container!.querySelector('[data-sheet-permission-entry="user:user_inactive"]')!
+    const inactiveCandidate = container!.querySelector('[data-sheet-permission-candidate="user:user_candidate_inactive"]')!
+    expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Inactive user')
+  })
+
   it('clears field defaults by removing overrides and shows orphan field overrides', async () => {
     const updatedSpy = vi.fn()
     const client = {

--- a/docs/development/multitable-acl-inactive-subject-visibility-development-20260418.md
+++ b/docs/development/multitable-acl-inactive-subject-visibility-development-20260418.md
@@ -1,0 +1,31 @@
+# Multitable ACL Inactive Subject Visibility Development 2026-04-18
+
+## Goal
+
+Surface inactive users directly inside the multitable ACL management UI so operators can distinguish live governance subjects from disabled identities without inspecting another admin page.
+
+## Scope
+
+- show `Inactive user` on sheet ACL rows and candidate results when the subject is a disabled user
+- show `Inactive user` on record ACL rows and candidate results for the same case
+- keep the slice frontend-only and reuse the existing `isActive` data already returned by the APIs
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Implementation Notes
+
+1. Added a lightweight `subjectIsInactive(...)` helper in both managers.
+2. Rendered an inline `Inactive user` lifecycle pill only when:
+   - `subjectType === 'user'`
+   - `isActive === false`
+3. Kept role and member-group rendering unchanged.
+4. Reused existing hydrated entry/candidate payloads instead of changing backend contracts.
+
+## Why This Slice
+
+Current multitable ACL APIs already hydrate `isActive`, but the management UI did not expose it. That created a governance blind spot: disabled users looked the same as active users in sheet and record permission surfaces, which made stale access review harder than necessary.

--- a/docs/development/multitable-acl-inactive-subject-visibility-verification-20260418.md
+++ b/docs/development/multitable-acl-inactive-subject-visibility-verification-20260418.md
@@ -1,0 +1,36 @@
+# Multitable ACL Inactive Subject Visibility Verification 2026-04-18
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`
+  - passed
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+  - `17/17 passed`
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Coverage of This Slice
+
+- inactive users are marked in sheet ACL current-access rows
+- inactive users are marked in sheet ACL candidate results
+- inactive users are marked in record ACL current-access rows
+- inactive users are marked in record ACL candidate results
+
+## Known Non-Blocking Noise
+
+- web build still prints the existing Vite dynamic-import warning
+- web build still prints the existing chunk-size warning
+
+## Deployment
+
+- none
+- frontend-only
+- no database migration

--- a/docs/development/multitable-field-view-acl-governance-development-20260418.md
+++ b/docs/development/multitable-field-view-acl-governance-development-20260418.md
@@ -1,0 +1,83 @@
+# Multitable Field And View ACL Governance Development
+
+## Summary
+- Built the next stacked slice on top of member-group ACL subjects by making field-level and view-level overrides administratively usable.
+- Hydrated field and view permission entries with real subject labels, subtitles, and active-state metadata.
+- Changed field-level `Default` back to true override removal instead of persisting an explicit default-shaped row.
+- Surfaced orphan field/view overrides when the subject no longer has sheet access, and added direct clear actions for those orphaned overrides.
+
+## Why This Slice
+- The member-group ACL subject slice made `platform_member_groups` valid multitable ACL subjects at the API layer.
+- Record governance was improved in the previous stacked slice, but field and view governance still had two operational gaps:
+  - administrators saw bare subject IDs instead of real labels
+  - `Default` kept storing an explicit override rather than clearing it
+- There was also no management path for orphan overrides that stayed behind after sheet access changed.
+
+## Runtime Changes
+
+### Backend Permission List Hydration
+- Extended `GET /api/multitable/sheets/:sheetId/field-permissions` to join:
+  - `users`
+  - `roles`
+  - `platform_member_groups`
+- Extended `GET /api/multitable/views/:viewId/permissions` with the same subject hydration pattern.
+- Both endpoints now return:
+  - `subjectLabel`
+  - `subjectSubtitle`
+  - `isActive`
+- File:
+  - `packages/core-backend/src/routes/univer-meta.ts`
+
+### Frontend Types And Client
+- Added hydrated subject metadata to:
+  - `MetaFieldPermissionEntry`
+  - `MetaViewPermissionEntry`
+- Updated client normalization for:
+  - field permission list responses
+  - view permission list responses
+- Widened `updateFieldPermission` so the client can send:
+  - `{ remove: true }`
+  - or a normal `{ visible, readOnly }` override
+- Files:
+  - `apps/web/src/multitable/types.ts`
+  - `apps/web/src/multitable/api/client.ts`
+
+### MetaSheetPermissionManager Governance Cleanup
+- Reworked the field and view tabs in `MetaSheetPermissionManager`:
+  - field rows now display hydrated subject labels from permission list payloads
+  - view rows now display hydrated subject labels from permission list payloads
+  - orphan field overrides now remain visible even if the subject no longer has sheet access
+  - orphan view overrides now remain visible even if the subject no longer has sheet access
+  - orphan rows expose an explicit `Clear` action
+- Added a small hint treatment for orphan rows:
+  - `No current sheet access`
+- File:
+  - `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+
+## Governance Semantics
+
+### Field `Default` Means No Override
+- Selecting `Default` now removes the field override instead of persisting:
+  - `visible: true`
+  - `readOnly: false`
+- This keeps the data model aligned with operator expectations:
+  - default = inherit sheet behavior
+  - hidden = explicit override
+  - read-only = explicit override
+
+### Orphan Overrides Stay Manageable
+- Field/view overrides may outlive the sheet grant that originally made the subject eligible.
+- Instead of hiding those rows, the UI now keeps them visible and clearable.
+- This avoids a common governance trap where stale overrides remain in the database but become inaccessible to administrators.
+
+## Test Updates
+- Frontend:
+  - `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- Backend:
+  - `packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts`
+
+## Out Of Scope
+- No new ACL subject type was introduced in this slice.
+- No record ACL behavior change beyond regression coverage.
+- No cell-level ACL.
+- No deployment or migration changes.

--- a/docs/development/multitable-field-view-acl-governance-verification-20260418.md
+++ b/docs/development/multitable-field-view-acl-governance-verification-20260418.md
@@ -1,0 +1,43 @@
+# Multitable Field And View ACL Governance Verification
+
+## Targeted Frontend Tests
+- Command:
+  - `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+- Result:
+  - `12/12` passed
+
+## Targeted Backend Integration
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts --watch=false`
+- Result:
+  - `38/38` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/core-backend build`
+- Result:
+  - passed
+
+- Command:
+  - `pnpm --filter @metasheet/web build`
+- Result:
+  - passed
+
+## Coverage Highlights
+- Verified field permission list responses hydrate member-group labels and subtitles.
+- Verified view permission list responses hydrate member-group labels and subtitles.
+- Verified selecting field `Default` removes the override through the client authoring call.
+- Verified orphan field overrides remain visible and can be cleared.
+- Verified orphan view overrides remain visible and can be cleared.
+- Re-ran record permission manager coverage to confirm this slice did not regress adjacent ACL governance UI.
+
+## Validation Scope
+- No deployment was performed.
+- No database migration was added or executed in this slice.
+- Validation stayed scoped to field/view governance UI behavior, supporting backend permission list APIs, adjacent record governance UI regression coverage, and local builds.
+
+## Known Non-Blocking Noise
+- Frontend Vitest may print:
+  - `WebSocket server error: Port is already in use`
+- Backend integration still prints one existing formula recalculation stderr line in a write-own test path, but the suite passes.
+- Web build still emits the existing Vite dynamic-import and chunk-size warnings.

--- a/docs/development/multitable-field-view-acl-template-governance-development-20260418.md
+++ b/docs/development/multitable-field-view-acl-template-governance-development-20260418.md
@@ -1,0 +1,50 @@
+# Multitable Field And View ACL Template Governance Development
+
+## Summary
+- Added subject-scoped bulk template actions to `MetaSheetPermissionManager` for field-level and view-level ACL governance.
+- Administrators can now take an existing sheet subject and apply one field permission template to every field in the sheet.
+- Administrators can also apply one view permission template to every view in the sheet.
+
+## Why This Slice
+- The previous stacked slices made field/view overrides manageable one row at a time.
+- The main remaining governance pain was operator throughput:
+  - many fields
+  - many views
+  - one subject at a time
+- This slice improves ACL administration without adding a new permission model or changing backend semantics.
+
+## Runtime Changes
+
+### Field Template Bulk Apply
+- In the field permissions tab, every current sheet subject now gets a bulk template row.
+- Available field template values:
+  - `Default`
+  - `Hidden`
+  - `Read-only`
+- Clicking `Apply to all fields` reuses the existing field-permission authoring API for every field on the active sheet.
+- `Default` uses `{ remove: true }`, so the bulk action clears overrides instead of persisting explicit default-shaped rows.
+
+### View Template Bulk Apply
+- In the view permissions tab, every current sheet subject now gets a bulk template row.
+- Available view template values:
+  - `None`
+  - `Read`
+  - `Write`
+  - `Admin`
+- Clicking `Apply to all views` reuses the existing view-permission authoring API for every view on the active sheet.
+
+### UI Notes
+- The template rows are scoped to current sheet subjects only.
+- No new subject discovery flow was added.
+- Existing one-by-one field/view editing remains unchanged.
+- Existing orphan override handling remains unchanged.
+
+## Files
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+## Out Of Scope
+- No backend API change
+- No migration
+- No new ACL subject type
+- No record-level bulk template flow in this slice

--- a/docs/development/multitable-field-view-acl-template-governance-verification-20260418.md
+++ b/docs/development/multitable-field-view-acl-template-governance-verification-20260418.md
@@ -1,0 +1,28 @@
+# Multitable Field And View ACL Template Governance Verification
+
+## Targeted Frontend Tests
+- Command:
+  - `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+- Result:
+  - `14/14` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/web build`
+- Result:
+  - passed
+
+## Coverage Highlights
+- Verified field template rows render for current sheet subjects.
+- Verified `Apply to all fields` fans out field-permission updates across every field for a member-group subject.
+- Verified view template rows render for current sheet subjects.
+- Verified `Apply to all views` fans out view-permission updates across every view for a member-group subject.
+- Re-ran record permission manager tests to confirm no regression in the adjacent ACL governance UI.
+
+## Validation Scope
+- No backend changes were made or tested in this slice.
+- No deployment was performed.
+- No migration was added or executed.
+
+## Known Non-Blocking Noise
+- Web build still emits the existing Vite dynamic-import and chunk-size warnings.

--- a/docs/development/multitable-member-group-acl-hardening-development-20260418.md
+++ b/docs/development/multitable-member-group-acl-hardening-development-20260418.md
@@ -1,0 +1,54 @@
+# Multitable Member-Group ACL Hardening Development
+
+## Summary
+- Hardened the main member-group ACL slice without widening scope beyond sheet permission support.
+- Fixed the migration so `spreadsheet_permissions` accepts `member-group`, matching the runtime authoring and enforcement behavior already present in `#902`.
+- Tightened `loadSheetPermissionScopeMap()` so it only degrades gracefully for known missing-table compatibility cases instead of swallowing all database failures.
+
+## Why This Slice
+- The member-group ACL subject slice already allowed `member-group` authoring and enforcement for sheet access.
+- The migration only widened subject constraints for:
+  - `meta_view_permissions`
+  - `field_permissions`
+  - `record_permissions`
+- It did **not** widen `spreadsheet_permissions`, which left the main sheet ACL table behind the runtime logic.
+- `sheet-capabilities.ts` also caught every error from scope loading and returned an empty map, which could silently hide real operational failures.
+
+## Runtime Changes
+
+### Migration Hardening
+- Updated:
+  - `packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts`
+- `up` now widens `spreadsheet_permissions_subject_type_check` to:
+  - `user`
+  - `role`
+  - `member-group`
+- `down` now:
+  - deletes `member-group` rows from `spreadsheet_permissions`
+  - restores the previous two-subject constraint
+
+### Sheet Capability Compatibility Hardening
+- Updated:
+  - `packages/core-backend/src/multitable/sheet-capabilities.ts`
+- Added table-specific undefined-table detection, matching the compatibility style already used in `univer-meta.ts`.
+- `loadSheetPermissionScopeMap()` now only returns an empty scope map when one of these tables is absent:
+  - `spreadsheet_permissions`
+  - `user_roles`
+  - `platform_member_group_members`
+- Other failures are now rethrown instead of being silently downgraded.
+
+## Test Coverage
+- Added:
+  - `packages/core-backend/tests/unit/multitable-member-group-acl-hardening.test.ts`
+
+The new unit coverage verifies:
+- member-group-only sheet grants still produce an effective scope
+- known missing-table compatibility errors still fail closed to an empty scope map
+- non-compatibility database failures are rethrown
+- the migration source now includes `spreadsheet_permissions` widening and rollback cleanup
+
+## Out Of Scope
+- No UI changes
+- No ACL semantic changes
+- No new subject types
+- No deployment or environment changes

--- a/docs/development/multitable-member-group-acl-hardening-verification-20260418.md
+++ b/docs/development/multitable-member-group-acl-hardening-verification-20260418.md
@@ -1,0 +1,35 @@
+# Multitable Member-Group ACL Hardening Verification
+
+## Targeted Unit Coverage
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-member-group-acl-hardening.test.ts --watch=false`
+- Result:
+  - `4/4` passed
+
+## Targeted Integration Regression
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts tests/integration/multitable-context.api.test.ts --watch=false`
+- Result:
+  - `52/52` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/core-backend build`
+- Result:
+  - passed
+
+## Validation Highlights
+- Verified member-group sheet grants still resolve into effective sheet capabilities.
+- Verified missing-table compatibility still returns an empty scope map for partial environments.
+- Verified unexpected DB failures are no longer swallowed by `sheet-capabilities.ts`.
+- Verified the main multitable sheet/context integration suite still passes after tightening the compatibility behavior.
+- Verified the widening migration now covers `spreadsheet_permissions`, matching the runtime sheet ACL subject model.
+
+## Validation Scope
+- No frontend changes were made or tested in this slice.
+- No deployment was performed.
+- No migration was executed against a live database in this slice.
+
+## Known Non-Blocking Noise
+- Backend integration still prints one existing formula recalculation stderr line in a write-own test path, but the suite passes.
+- The backend test runner still prints the existing Vite CJS deprecation notice before Vitest startup.

--- a/docs/development/multitable-member-group-acl-subject-development-20260418.md
+++ b/docs/development/multitable-member-group-acl-subject-development-20260418.md
@@ -1,0 +1,87 @@
+# Multitable Member Group ACL Subject Development
+
+## Summary
+- Added `member-group` as a new multitable permission subject so `platform_member_groups` can drive sheet, view, field, and record ACL assignment.
+- Kept the scope intentionally narrow to the existing multitable ACL layers:
+  - sheet
+  - view
+  - field
+  - record
+- Explicitly did not introduce generic cell-level ACL in this slice.
+
+## Why This Slice
+- DingTalk directory sync now projects selected departments into `platform_member_groups`.
+- The next lowest-risk ACL step is to let those member groups become first-class subjects in multitable permission assignment and enforcement.
+- This closes the path:
+  - DingTalk department
+  - projected member group
+  - multitable ACL subject
+
+## Runtime Changes
+
+### Frontend Types And Client
+- Updated multitable subject typing to allow `member-group`:
+  - `apps/web/src/multitable/types.ts`
+- Extended client normalization and request typing for `member-group` permission subjects:
+  - `apps/web/src/multitable/api/client.ts`
+
+### Frontend Permission Managers
+- Added member-group handling to sheet/view/field permission management UI:
+  - `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- Added member-group handling to record permission management UI:
+  - `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+
+### Backend ACL Enforcement And Authoring
+- Extended multitable ACL listing, candidate loading, effective-permission derivation, and authoring endpoints to accept `member-group`:
+  - `packages/core-backend/src/routes/univer-meta.ts`
+- Extended shared sheet capability narrowing to honor member-group grants:
+  - `packages/core-backend/src/multitable/sheet-capabilities.ts`
+
+### Migration
+- Added a migration to widen multitable permission subject-type constraints:
+  - `packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts`
+- The migration updates check constraints for:
+  - `meta_view_permissions`
+  - `field_permissions`
+  - `record_permissions`
+- `down` removes any `member-group` rows before restoring the previous two-subject constraint.
+
+## ACL Semantics
+- `member-group` behaves like a shared governance subject, not a direct-user override.
+- Effective permission precedence is:
+  - direct user
+  - member group
+  - role
+- `write-own` remains user-only and is rejected for non-user subjects.
+- Member-group candidates are sourced from:
+  - `platform_member_groups`
+  - `platform_member_group_members`
+
+## UI Semantics
+- Permission managers now show three subject families:
+  - people
+  - member groups
+  - roles
+- Member-group access choices follow role-style shared access:
+  - `read`
+  - `write`
+  - `admin`
+- They do not expose `write-own`.
+
+## Validation Rules
+- Authoring endpoints now validate that `member-group` subjects exist in `platform_member_groups`.
+- Effective ACL derivation safely falls back for environments that do not yet expose `platform_member_group_members`, matching the repository’s existing compatibility style for partial migration states.
+
+## Test Updates
+- Added frontend coverage:
+  - `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+  - `apps/web/tests/multitable-record-permission-manager.spec.ts`
+- Updated backend integration coverage:
+  - `packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts`
+  - `packages/core-backend/tests/integration/multitable-context.api.test.ts`
+
+## Out Of Scope
+- No generic cell-level ACL
+- No new multitable governance UI beyond the existing permission managers
+- No DingTalk sync or member-group projection changes
+- No deployment or environment changes

--- a/docs/development/multitable-member-group-acl-subject-verification-20260418.md
+++ b/docs/development/multitable-member-group-acl-subject-verification-20260418.md
@@ -1,0 +1,42 @@
+# Multitable Member Group ACL Subject Verification
+
+## Targeted Frontend Tests
+- Command:
+  - `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+- Result:
+  - `9/9` passed
+
+## Targeted Backend Integration
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-context.api.test.ts tests/integration/multitable-sheet-permissions.api.test.ts --watch=false`
+- Result:
+  - `49/49` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/core-backend build`
+- Result:
+  - passed
+
+- Command:
+  - `pnpm --filter @metasheet/web build`
+- Result:
+  - passed
+
+## Coverage Highlights
+- Verified sheet permission entries and candidates now include `member-group`.
+- Verified member-group candidates remain eligible even without direct user or role-level global multitable access.
+- Verified effective sheet access can be derived from member-group grants.
+- Verified sheet authoring endpoints accept `member-group` subjects.
+- Verified sheet and record permission managers expose member-group options in the frontend and submit the expected payloads.
+
+## Validation Scope
+- No deployment was performed.
+- No database migration was executed against a live environment.
+- Validation remained scoped to targeted frontend tests, backend integration tests, and local package builds.
+
+## Known Non-Blocking Noise
+- Frontend Vitest may print:
+  - `WebSocket server error: Port is already in use`
+- One existing backend integration path still prints a formula recalculation stderr line for unhandled mock SQL, but the test passes.
+- Web build still emits the existing chunk-size warning and dynamic import warning.

--- a/docs/development/multitable-orphan-bulk-cleanup-development-20260418.md
+++ b/docs/development/multitable-orphan-bulk-cleanup-development-20260418.md
@@ -1,0 +1,31 @@
+# Multitable Orphan Bulk Cleanup Development 2026-04-18
+
+## Goal
+
+Reduce repetitive cleanup work in the field/view permission managers by allowing operators to clear orphan overrides in bulk per field or per view.
+
+## Scope
+
+- add `Clear orphan overrides` for field groups when a field has multiple orphan overrides
+- add `Clear orphan overrides` for view groups when a view has multiple orphan overrides
+- keep the slice frontend-only and reuse existing field/view permission authoring APIs
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+## Implementation Notes
+
+1. Added grouped cleanup actions inside field/view section headers.
+2. Introduced small bulk-busy states so batch cleanup does not overlap with per-row writes.
+3. Implemented:
+   - `clearFieldOrphans(fieldId)`
+   - `clearViewOrphans(viewId)`
+4. Reused existing:
+   - `updateFieldPermission(..., { remove: true })`
+   - `updateViewPermission(..., 'none')`
+
+## Why This Slice
+
+`#904` made orphan overrides visible and individually clearable. `#907` then linked sheet subjects to downstream cleanup. The remaining operational gap was still obvious: a field or view with many orphan overrides required many repetitive clicks. This slice closes that cleanup loop without changing ACL semantics.

--- a/docs/development/multitable-orphan-bulk-cleanup-verification-20260418.md
+++ b/docs/development/multitable-orphan-bulk-cleanup-verification-20260418.md
@@ -1,0 +1,35 @@
+# Multitable Orphan Bulk Cleanup Verification 2026-04-18
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`
+  - passed
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+  - `19/19 passed`
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Coverage of This Slice
+
+- bulk-clear orphan field overrides for a field
+- bulk-clear orphan view overrides for a view
+- existing sheet subject cleanup and record manager tests remain green
+
+## Known Non-Blocking Noise
+
+- web build still prints the existing Vite dynamic-import warning
+- web build still prints the existing chunk-size warning
+
+## Deployment
+
+- none
+- frontend-only
+- no database migration

--- a/docs/development/multitable-record-acl-governance-development-20260418.md
+++ b/docs/development/multitable-record-acl-governance-development-20260418.md
@@ -1,0 +1,76 @@
+# Multitable Record ACL Governance Development
+
+## Summary
+- Built the next stacked slice on top of member-group ACL subjects by making record-level permission governance usable in the UI.
+- Replaced raw `subjectId` entry for record grants with searchable permission candidates sourced from existing multitable sheet subjects.
+- Hydrated record permission entries with human labels so current record grants show real people, member groups, and roles instead of bare IDs.
+
+## Why This Slice
+- The previous slice made `member-group` a valid multitable ACL subject.
+- Record-level governance was still awkward because administrators had to type opaque subject IDs by hand.
+- This slice makes row-level ACL practical for the same subject universe:
+  - people
+  - member groups
+  - roles
+
+## Runtime Changes
+
+### Frontend Types And Client
+- Extended `RecordPermissionEntry` to carry:
+  - `label`
+  - `subtitle`
+  - `isActive`
+- Added client-side normalization for hydrated record permission entries:
+  - `apps/web/src/multitable/types.ts`
+  - `apps/web/src/multitable/api/client.ts`
+
+### Record Permission Manager
+- Reworked `MetaRecordPermissionManager`:
+  - removed raw free-text `subjectId` grant flow
+  - added candidate search input
+  - loads grant candidates from:
+    - current sheet permission entries
+    - existing sheet permission candidates
+  - groups grant candidates into:
+    - people
+    - member groups
+    - roles
+  - filters out subjects that already have record-specific entries
+- Current record entries now render:
+  - hydrated label
+  - subtitle
+  - subject-type badge
+- File:
+  - `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+
+### Backend Record Permission Listing
+- Extended `GET /api/multitable/sheets/:sheetId/records/:recordId/permissions` to hydrate subjects via joins against:
+  - `users`
+  - `roles`
+  - `platform_member_groups`
+- The record permission list response now includes:
+  - `label`
+  - `subtitle`
+  - `isActive`
+- File:
+  - `packages/core-backend/src/routes/univer-meta.ts`
+
+## Governance Semantics
+- Record-level ACL still uses the existing access levels:
+  - `read`
+  - `write`
+  - `admin`
+- This slice does not widen access semantics; it only improves subject selection and current-entry visibility.
+- Candidate sourcing intentionally follows the existing sheet ACL governance universe instead of inventing a second subject directory for record permissions.
+
+## Test Updates
+- Frontend:
+  - `apps/web/tests/multitable-record-permission-manager.spec.ts`
+- Backend:
+  - `packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts`
+
+## Out Of Scope
+- No field/view permission UX redesign in this slice
+- No new member-group projection logic
+- No cell-level ACL
+- No deployment or migration changes

--- a/docs/development/multitable-record-acl-governance-verification-20260418.md
+++ b/docs/development/multitable-record-acl-governance-verification-20260418.md
@@ -1,0 +1,45 @@
+# Multitable Record ACL Governance Verification
+
+## Targeted Frontend Tests
+- Command:
+  - `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+- Result:
+  - `10/10` passed
+
+## Targeted Backend Integration
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts --watch=false`
+- Result:
+  - `36/36` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/core-backend build`
+- Result:
+  - passed
+
+- Command:
+  - `pnpm --filter @metasheet/web build`
+- Result:
+  - passed
+
+## Coverage Highlights
+- Verified record permission entries return hydrated member-group labels from the backend.
+- Verified record permission manager renders hydrated labels and no longer depends on raw typed subject IDs.
+- Verified record permission manager can grant:
+  - user subjects
+  - member-group subjects
+- Verified record candidate search combines:
+  - current sheet permission subjects
+  - eligible sheet permission candidates
+
+## Validation Scope
+- No deployment was performed.
+- No database migration was added or executed in this slice.
+- Validation stayed scoped to the record-governance UI path, its supporting backend integration path, and local builds.
+
+## Known Non-Blocking Noise
+- Frontend Vitest may print:
+  - `WebSocket server error: Port is already in use`
+- Backend integration still prints one existing formula recalculation stderr line in a write-own test path, but the suite passes.
+- Web build still emits the existing Vite dynamic-import and chunk-size warnings.

--- a/docs/development/multitable-sheet-acl-linkage-cleanup-development-20260418.md
+++ b/docs/development/multitable-sheet-acl-linkage-cleanup-development-20260418.md
@@ -1,0 +1,29 @@
+# Multitable Sheet ACL Linkage Cleanup Development 2026-04-18
+
+## Goal
+
+Close a governance gap in the sheet access manager: when a subject still has field/view overrides, surface that linkage directly on the sheet access row and allow one-click downstream cleanup without forcing operators to hunt through orphan rows later.
+
+## Scope
+
+- show per-subject downstream override counts on the sheet access list
+- add a `Clear overrides` action for subjects that still own field/view overrides
+- keep the slice frontend-only and reuse existing field/view authoring APIs
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+## Implementation Notes
+
+1. Added subject-level override counting derived from existing `fieldPermissionEntries` and `viewPermissionEntries`.
+2. Exposed a summary hint on each sheet access row when the subject still owns downstream overrides.
+3. Added a `Clear overrides` action that:
+   - removes matching field overrides via `updateFieldPermission(..., { remove: true })`
+   - clears matching view overrides via `updateViewPermission(..., 'none')`
+4. Reused `busySubjectKey` and existing status/error surfaces so the slice stays consistent with the rest of the manager.
+
+## Why This Slice
+
+`#904` made orphan field/view overrides visible and individually clearable. The remaining operational gap was still real: removing or refactoring a sheet subject could leave many lower-level overrides behind. This slice closes that last cleanup loop without inventing a new ACL model.

--- a/docs/development/multitable-sheet-acl-linkage-cleanup-verification-20260418.md
+++ b/docs/development/multitable-sheet-acl-linkage-cleanup-verification-20260418.md
@@ -1,0 +1,35 @@
+# Multitable Sheet ACL Linkage Cleanup Verification 2026-04-18
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`
+  - passed
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+  - `15/15 passed`
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Coverage of This Slice
+
+- sheet access rows show downstream override counts for linked subjects
+- operators can clear matching field and view overrides directly from the sheet access row
+- existing field/view template and record permission manager tests remain green
+
+## Known Non-Blocking Noise
+
+- web build still prints the existing Vite dynamic-import and chunk-size warnings
+- no new runtime or test failures were introduced by this slice
+
+## Deployment
+
+- none
+- no backend changes
+- no database migration

--- a/packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts
@@ -3,6 +3,16 @@ import { sql } from 'kysely'
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
+    ALTER TABLE spreadsheet_permissions
+    DROP CONSTRAINT IF EXISTS spreadsheet_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE spreadsheet_permissions
+    ADD CONSTRAINT spreadsheet_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role', 'member-group'))
+  `.execute(db)
+
+  await sql`
     ALTER TABLE meta_view_permissions
     DROP CONSTRAINT IF EXISTS meta_view_permissions_subject_type_check
   `.execute(db)
@@ -34,6 +44,20 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DELETE FROM spreadsheet_permissions
+    WHERE subject_type = 'member-group'
+  `.execute(db)
+  await sql`
+    ALTER TABLE spreadsheet_permissions
+    DROP CONSTRAINT IF EXISTS spreadsheet_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE spreadsheet_permissions
+    ADD CONSTRAINT spreadsheet_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role'))
+  `.execute(db)
+
   await sql`
     DELETE FROM meta_view_permissions
     WHERE subject_type = 'member-group'

--- a/packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts
@@ -1,0 +1,78 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE meta_view_permissions
+    DROP CONSTRAINT IF EXISTS meta_view_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE meta_view_permissions
+    ADD CONSTRAINT meta_view_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role', 'member-group'))
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE field_permissions
+    DROP CONSTRAINT IF EXISTS field_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE field_permissions
+    ADD CONSTRAINT field_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role', 'member-group'))
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE record_permissions
+    DROP CONSTRAINT IF EXISTS record_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE record_permissions
+    ADD CONSTRAINT record_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role', 'member-group'))
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DELETE FROM meta_view_permissions
+    WHERE subject_type = 'member-group'
+  `.execute(db)
+  await sql`
+    ALTER TABLE meta_view_permissions
+    DROP CONSTRAINT IF EXISTS meta_view_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE meta_view_permissions
+    ADD CONSTRAINT meta_view_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role'))
+  `.execute(db)
+
+  await sql`
+    DELETE FROM field_permissions
+    WHERE subject_type = 'member-group'
+  `.execute(db)
+  await sql`
+    ALTER TABLE field_permissions
+    DROP CONSTRAINT IF EXISTS field_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE field_permissions
+    ADD CONSTRAINT field_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role'))
+  `.execute(db)
+
+  await sql`
+    DELETE FROM record_permissions
+    WHERE subject_type = 'member-group'
+  `.execute(db)
+  await sql`
+    ALTER TABLE record_permissions
+    DROP CONSTRAINT IF EXISTS record_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE record_permissions
+    ADD CONSTRAINT record_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role'))
+  `.execute(db)
+}

--- a/packages/core-backend/src/multitable/sheet-capabilities.ts
+++ b/packages/core-backend/src/multitable/sheet-capabilities.ts
@@ -155,6 +155,15 @@ export async function loadSheetPermissionScopeMap(
          AND (
            (sp.subject_type = 'user' AND sp.subject_id = $1)
            OR (
+             sp.subject_type = 'member-group'
+             AND EXISTS (
+               SELECT 1
+               FROM platform_member_group_members pgm
+               WHERE pgm.user_id = $1
+                 AND pgm.group_id::text = sp.subject_id
+             )
+           )
+           OR (
              sp.subject_type = 'role'
              AND EXISTS (
                SELECT 1
@@ -166,20 +175,25 @@ export async function loadSheetPermissionScopeMap(
          )`,
       [userId, sheetIds],
     )
-    const grouped = new Map<string, { direct: string[]; role: string[] }>()
+    const grouped = new Map<string, { direct: string[]; memberGroup: string[]; role: string[] }>()
     for (const row of result.rows as Array<{ sheet_id: string; perm_code: string; subject_type?: string }>) {
       const sheetId = typeof row.sheet_id === 'string' ? row.sheet_id : ''
       const code = typeof row.perm_code === 'string' ? row.perm_code.trim() : ''
       if (!sheetId || !code) continue
-      const current = grouped.get(sheetId) ?? { direct: [], role: [] }
+      const current = grouped.get(sheetId) ?? { direct: [], memberGroup: [], role: [] }
       if (row.subject_type === 'user') current.direct.push(code)
+      else if (row.subject_type === 'member-group') current.memberGroup.push(code)
       else current.role.push(code)
       grouped.set(sheetId, current)
     }
     return new Map(
       Array.from(grouped.entries()).map(([sheetId, codes]) => [
         sheetId,
-        summarizeSheetPermissionCodes(codes.direct.length > 0 ? codes.direct : codes.role),
+        summarizeSheetPermissionCodes(
+          codes.direct.length > 0 ? codes.direct
+            : codes.memberGroup.length > 0 ? codes.memberGroup
+              : codes.role,
+        ),
       ]),
     )
   } catch {

--- a/packages/core-backend/src/multitable/sheet-capabilities.ts
+++ b/packages/core-backend/src/multitable/sheet-capabilities.ts
@@ -53,6 +53,13 @@ export type SheetPermissionScope = {
 
 export type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
 
+function isUndefinedTableError(err: unknown, tableName: string): boolean {
+  const code = typeof (err as any)?.code === 'string' ? (err as any).code : null
+  const message = typeof (err as any)?.message === 'string' ? (err as any).message : ''
+  if (code === '42P01') return message.includes(tableName)
+  return message.includes(`relation "${tableName}" does not exist`)
+}
+
 // ── Functions ───────────────────────────────────────────────────────
 
 export function hasPermission(permissions: string[], code: string): boolean {
@@ -196,8 +203,15 @@ export async function loadSheetPermissionScopeMap(
         ),
       ]),
     )
-  } catch {
-    return new Map()
+  } catch (err) {
+    if (
+      isUndefinedTableError(err, 'spreadsheet_permissions')
+      || isUndefinedTableError(err, 'user_roles')
+      || isUndefinedTableError(err, 'platform_member_group_members')
+    ) {
+      return new Map()
+    }
+    throw err
   }
 }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1442,7 +1442,7 @@ type SheetPermissionScope = {
   canAdmin: boolean
 }
 
-type MultitableSheetPermissionSubjectType = 'user' | 'role'
+type MultitableSheetPermissionSubjectType = 'user' | 'role' | 'member-group'
 type MultitableSheetAccessLevel = 'read' | 'write' | 'write-own' | 'admin'
 
 type MultitableSheetPermissionEntry = {
@@ -1523,7 +1523,7 @@ const CANONICAL_SHEET_PERMISSION_CODE_BY_ACCESS_LEVEL: Record<MultitableSheetAcc
 }
 
 function isSheetPermissionSubjectType(value: unknown): value is MultitableSheetPermissionSubjectType {
-  return value === 'user' || value === 'role'
+  return value === 'user' || value === 'role' || value === 'member-group'
 }
 
 async function resolveRequestAccess(req: Request): Promise<ResolvedRequestAccess> {
@@ -1616,7 +1616,9 @@ async function listSheetPermissionEntries(
         u.name AS user_name,
         u.email AS user_email,
         u.is_active AS user_is_active,
-        r.name AS role_name
+        r.name AS role_name,
+        g.name AS group_name,
+        g.description AS group_description
      FROM spreadsheet_permissions sp
      LEFT JOIN users u
        ON sp.subject_type = 'user'
@@ -1624,12 +1626,19 @@ async function listSheetPermissionEntries(
      LEFT JOIN roles r
        ON sp.subject_type = 'role'
       AND r.id = sp.subject_id
+     LEFT JOIN platform_member_groups g
+       ON sp.subject_type = 'member-group'
+      AND g.id::text = sp.subject_id
      WHERE sp.sheet_id = $1
-     GROUP BY sp.subject_type, sp.subject_id, u.name, u.email, u.is_active, r.name
+     GROUP BY sp.subject_type, sp.subject_id, u.name, u.email, u.is_active, r.name, g.name, g.description
      ORDER BY
-       CASE WHEN sp.subject_type = 'user' THEN 0 ELSE 1 END,
+       CASE
+         WHEN sp.subject_type = 'user' THEN 0
+         WHEN sp.subject_type = 'member-group' THEN 1
+         ELSE 2
+       END,
        CASE WHEN sp.subject_type = 'user' AND COALESCE(u.is_active, true) THEN 0 WHEN sp.subject_type = 'user' THEN 1 ELSE 0 END,
-       COALESCE(NULLIF(u.name, ''), NULLIF(u.email, ''), NULLIF(r.name, ''), sp.subject_id) ASC`,
+       COALESCE(NULLIF(u.name, ''), NULLIF(u.email, ''), NULLIF(g.name, ''), NULLIF(r.name, ''), sp.subject_id) ASC`,
     [sheetId],
   )
 
@@ -1641,6 +1650,8 @@ async function listSheetPermissionEntries(
     user_email?: string | null
     user_is_active?: boolean | null
     role_name?: string | null
+    group_name?: string | null
+    group_description?: string | null
   }>)
     .map((row) => {
       const subjectType = isSheetPermissionSubjectType(row.subject_type) ? row.subject_type : 'user'
@@ -1651,17 +1662,25 @@ async function listSheetPermissionEntries(
       const userName = typeof row.user_name === 'string' ? row.user_name.trim() : ''
       const userEmail = typeof row.user_email === 'string' ? row.user_email.trim() : ''
       const roleName = typeof row.role_name === 'string' ? row.role_name.trim() : ''
+      const groupName = typeof row.group_name === 'string' ? row.group_name.trim() : ''
+      const groupDescription = typeof row.group_description === 'string' ? row.group_description.trim() : ''
       return {
         subjectType,
         subjectId,
         accessLevel,
         permissions,
-        label: subjectType === 'user'
-          ? userName || userEmail || subjectId
-          : roleName || subjectId,
-        subtitle: subjectType === 'user'
-          ? (userEmail || (userName && userName !== subjectId ? subjectId : null))
-          : (roleName && roleName !== subjectId ? subjectId : 'Role'),
+        label:
+          subjectType === 'user'
+            ? (userName || userEmail || subjectId)
+            : subjectType === 'member-group'
+              ? (groupName || subjectId)
+              : (roleName || subjectId),
+        subtitle:
+          subjectType === 'user'
+            ? (userEmail || (userName && userName !== subjectId ? subjectId : null))
+            : subjectType === 'member-group'
+              ? (groupDescription || (groupName && groupName !== subjectId ? subjectId : 'Member group'))
+              : (roleName && roleName !== subjectId ? subjectId : 'Role'),
         isActive: subjectType === 'user' ? row.user_is_active !== false : true,
       } satisfies MultitableSheetPermissionEntry
     })
@@ -1684,6 +1703,9 @@ async function listSheetPermissionCandidates(
           u.email AS user_email,
           u.is_active AS user_is_active,
           NULL::text AS role_name,
+          NULL::text AS group_name,
+          NULL::text AS group_description,
+          NULL::integer AS member_count,
           COALESCE(
             ARRAY_AGG(sp.perm_code ORDER BY sp.perm_code) FILTER (WHERE sp.perm_code IS NOT NULL),
             ARRAY[]::text[]
@@ -1696,6 +1718,31 @@ async function listSheetPermissionCandidates(
         WHERE ($2 = '' OR u.id ILIKE $3 OR u.email ILIKE $3 OR COALESCE(u.name, '') ILIKE $3)
         GROUP BY u.id, u.name, u.email, u.is_active
       ),
+      member_group_candidates AS (
+        SELECT
+          'member-group'::text AS subject_type,
+          g.id::text AS subject_id,
+          NULL::text AS user_name,
+          NULL::text AS user_email,
+          true AS user_is_active,
+          NULL::text AS role_name,
+          g.name AS group_name,
+          g.description AS group_description,
+          COUNT(gm.user_id)::integer AS member_count,
+          COALESCE(
+            ARRAY_AGG(sp.perm_code ORDER BY sp.perm_code) FILTER (WHERE sp.perm_code IS NOT NULL),
+            ARRAY[]::text[]
+          ) AS permission_codes
+        FROM platform_member_groups g
+        LEFT JOIN platform_member_group_members gm
+          ON gm.group_id = g.id
+        LEFT JOIN spreadsheet_permissions sp
+          ON sp.sheet_id = $1
+         AND sp.subject_type = 'member-group'
+         AND sp.subject_id = g.id::text
+        WHERE ($2 = '' OR g.id::text ILIKE $3 OR COALESCE(g.name, '') ILIKE $3 OR COALESCE(g.description, '') ILIKE $3)
+        GROUP BY g.id, g.name, g.description
+      ),
       role_candidates AS (
         SELECT
           'role'::text AS subject_type,
@@ -1704,6 +1751,9 @@ async function listSheetPermissionCandidates(
           NULL::text AS user_email,
           true AS user_is_active,
           r.name AS role_name,
+          NULL::text AS group_name,
+          NULL::text AS group_description,
+          NULL::integer AS member_count,
           COALESCE(
             ARRAY_AGG(sp.perm_code ORDER BY sp.perm_code) FILTER (WHERE sp.perm_code IS NOT NULL),
             ARRAY[]::text[]
@@ -1720,12 +1770,18 @@ async function listSheetPermissionCandidates(
       FROM (
         SELECT * FROM user_candidates
         UNION ALL
+        SELECT * FROM member_group_candidates
+        UNION ALL
         SELECT * FROM role_candidates
       ) candidates
       ORDER BY
-        CASE WHEN subject_type = 'user' THEN 0 ELSE 1 END,
+        CASE
+          WHEN subject_type = 'user' THEN 0
+          WHEN subject_type = 'member-group' THEN 1
+          ELSE 2
+        END,
         CASE WHEN user_is_active THEN 0 ELSE 1 END,
-        COALESCE(NULLIF(user_name, ''), NULLIF(user_email, ''), NULLIF(role_name, ''), subject_id) ASC
+        COALESCE(NULLIF(user_name, ''), NULLIF(user_email, ''), NULLIF(group_name, ''), NULLIF(role_name, ''), subject_id) ASC
       LIMIT $4`,
     [sheetId, q, term, params.limit],
   )
@@ -1737,6 +1793,9 @@ async function listSheetPermissionCandidates(
     user_email?: string | null
     user_is_active?: boolean | null
     role_name?: string | null
+    group_name?: string | null
+    group_description?: string | null
+    member_count?: number | null
     permission_codes?: string[]
   }>)
     .map((row) => {
@@ -1745,15 +1804,24 @@ async function listSheetPermissionCandidates(
       const name = typeof row.user_name === 'string' ? row.user_name.trim() : ''
       const email = typeof row.user_email === 'string' ? row.user_email.trim() : ''
       const roleName = typeof row.role_name === 'string' ? row.role_name.trim() : ''
+      const groupName = typeof row.group_name === 'string' ? row.group_name.trim() : ''
+      const groupDescription = typeof row.group_description === 'string' ? row.group_description.trim() : ''
+      const memberCount = typeof row.member_count === 'number' ? row.member_count : null
       return {
         subjectType,
         subjectId,
-        label: subjectType === 'user'
-          ? (name || email || subjectId)
-          : (roleName || subjectId),
-        subtitle: subjectType === 'user'
-          ? (email || (name && name !== subjectId ? subjectId : null))
-          : (roleName && roleName !== subjectId ? subjectId : 'Role'),
+        label:
+          subjectType === 'user'
+            ? (name || email || subjectId)
+            : subjectType === 'member-group'
+              ? (groupName || subjectId)
+              : (roleName || subjectId),
+        subtitle:
+          subjectType === 'user'
+            ? (email || (name && name !== subjectId ? subjectId : null))
+            : subjectType === 'member-group'
+              ? (groupDescription || (memberCount != null ? `${memberCount} member${memberCount === 1 ? '' : 's'}` : 'Member group'))
+              : (roleName && roleName !== subjectId ? subjectId : 'Role'),
         isActive: subjectType === 'user' ? row.user_is_active !== false : true,
         accessLevel: deriveSheetAccessLevel(normalizePermissionCodes(row.permission_codes)),
       } satisfies MultitableSheetPermissionCandidate
@@ -1761,6 +1829,7 @@ async function listSheetPermissionCandidates(
 
   const eligibility = await Promise.all(
     candidates.map(async (candidate) => {
+      if (candidate.subjectType === 'member-group') return true
       if (candidate.subjectType === 'role') {
         if (candidate.subjectId === 'admin') return true
         const result = await query(
@@ -1798,6 +1867,15 @@ async function loadSheetPermissionScopeMap(
          AND (
            (sp.subject_type = 'user' AND sp.subject_id = $1)
            OR (
+             sp.subject_type = 'member-group'
+             AND EXISTS (
+               SELECT 1
+               FROM platform_member_group_members pgm
+               WHERE pgm.user_id = $1
+                 AND pgm.group_id::text = sp.subject_id
+             )
+           )
+           OR (
              sp.subject_type = 'role'
              AND EXISTS (
                SELECT 1
@@ -1809,24 +1887,33 @@ async function loadSheetPermissionScopeMap(
          )`,
       [userId, sheetIds],
     )
-    const grouped = new Map<string, { direct: string[]; role: string[] }>()
+    const grouped = new Map<string, { direct: string[]; memberGroup: string[]; role: string[] }>()
     for (const row of result.rows as Array<{ sheet_id: string; perm_code: string; subject_type?: string }>) {
       const sheetId = typeof row.sheet_id === 'string' ? row.sheet_id : ''
       const code = typeof row.perm_code === 'string' ? row.perm_code.trim() : ''
       if (!sheetId || !code) continue
-      const current = grouped.get(sheetId) ?? { direct: [], role: [] }
+      const current = grouped.get(sheetId) ?? { direct: [], memberGroup: [], role: [] }
       if (row.subject_type === 'user') current.direct.push(code)
+      else if (row.subject_type === 'member-group') current.memberGroup.push(code)
       else current.role.push(code)
       grouped.set(sheetId, current)
     }
     return new Map(
       Array.from(grouped.entries()).map(([sheetId, codes]) => [
         sheetId,
-        summarizeSheetPermissionCodes(codes.direct.length > 0 ? codes.direct : codes.role),
+        summarizeSheetPermissionCodes(
+          codes.direct.length > 0 ? codes.direct
+            : codes.memberGroup.length > 0 ? codes.memberGroup
+              : codes.role,
+        ),
       ]),
     )
   } catch (err) {
-    if (isUndefinedTableError(err, 'spreadsheet_permissions') || isUndefinedTableError(err, 'user_roles')) return new Map()
+    if (
+      isUndefinedTableError(err, 'spreadsheet_permissions')
+      || isUndefinedTableError(err, 'user_roles')
+      || isUndefinedTableError(err, 'platform_member_group_members')
+    ) return new Map()
     throw err
   }
 }
@@ -1850,6 +1937,13 @@ async function loadViewPermissionScopeMap(
          WHERE vp.view_id = ANY($2::text[])
            AND (
              (vp.subject_type = 'user' AND vp.subject_id = $1)
+             OR (
+               vp.subject_type = 'member-group'
+               AND EXISTS (
+                 SELECT 1 FROM platform_member_group_members pgm
+                 WHERE pgm.user_id = $1 AND pgm.group_id::text = vp.subject_id
+               )
+             )
              OR (
                vp.subject_type = 'role'
                AND EXISTS (
@@ -1888,7 +1982,11 @@ async function loadViewPermissionScopeMap(
       }),
     )
   } catch (err) {
-    if (isUndefinedTableError(err, 'meta_view_permissions') || isUndefinedTableError(err, 'user_roles')) return new Map()
+    if (
+      isUndefinedTableError(err, 'meta_view_permissions')
+      || isUndefinedTableError(err, 'user_roles')
+      || isUndefinedTableError(err, 'platform_member_group_members')
+    ) return new Map()
     throw err
   }
 }
@@ -1906,6 +2004,13 @@ async function loadFieldPermissionScopeMap(
        WHERE fp.sheet_id = $2
          AND (
            (fp.subject_type = 'user' AND fp.subject_id = $1)
+           OR (
+             fp.subject_type = 'member-group'
+             AND EXISTS (
+               SELECT 1 FROM platform_member_group_members pgm
+               WHERE pgm.user_id = $1 AND pgm.group_id::text = fp.subject_id
+             )
+           )
            OR (
              fp.subject_type = 'role'
              AND EXISTS (
@@ -1934,7 +2039,11 @@ async function loadFieldPermissionScopeMap(
     }
     return scopes
   } catch (err) {
-    if (isUndefinedTableError(err, 'field_permissions') || isUndefinedTableError(err, 'user_roles')) return new Map()
+    if (
+      isUndefinedTableError(err, 'field_permissions')
+      || isUndefinedTableError(err, 'user_roles')
+      || isUndefinedTableError(err, 'platform_member_group_members')
+    ) return new Map()
     throw err
   }
 }
@@ -1954,6 +2063,13 @@ async function loadRecordPermissionScopeMap(
          AND rp.record_id = ANY($3::text[])
          AND (
            (rp.subject_type = 'user' AND rp.subject_id = $1)
+           OR (
+             rp.subject_type = 'member-group'
+             AND EXISTS (
+               SELECT 1 FROM platform_member_group_members pgm
+               WHERE pgm.user_id = $1 AND pgm.group_id::text = rp.subject_id
+             )
+           )
            OR (
              rp.subject_type = 'role'
              AND EXISTS (
@@ -1982,7 +2098,11 @@ async function loadRecordPermissionScopeMap(
     }
     return scopes
   } catch (err) {
-    if (isUndefinedTableError(err, 'record_permissions') || isUndefinedTableError(err, 'user_roles')) return new Map()
+    if (
+      isUndefinedTableError(err, 'record_permissions')
+      || isUndefinedTableError(err, 'user_roles')
+      || isUndefinedTableError(err, 'platform_member_group_members')
+    ) return new Map()
     throw err
   }
 }
@@ -3647,7 +3767,7 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageSheetAccess) return sendForbidden(res)
 
-      if (subjectType === 'role' && parsed.data.accessLevel === 'write-own') {
+      if (subjectType !== 'user' && parsed.data.accessLevel === 'write-own') {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'write-own is only supported for direct user grants' } })
       }
 
@@ -3659,13 +3779,21 @@ export function univerMetaRouter(): Router {
         if (userResult.rows.length === 0) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `User not found: ${subjectId}` } })
         }
-      } else {
+      } else if (subjectType === 'role') {
         const roleResult = await pool.query(
           'SELECT id FROM roles WHERE id = $1',
           [subjectId],
         )
         if (roleResult.rows.length === 0) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Role not found: ${subjectId}` } })
+        }
+      } else {
+        const groupResult = await pool.query(
+          'SELECT id FROM platform_member_groups WHERE id::text = $1',
+          [subjectId],
+        )
+        if (groupResult.rows.length === 0) {
+          return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Member group not found: ${subjectId}` } })
         }
       }
 
@@ -3759,8 +3887,8 @@ export function univerMetaRouter(): Router {
     const viewId = typeof req.params.viewId === 'string' ? req.params.viewId.trim() : ''
     const subjectType = typeof req.params.subjectType === 'string' ? req.params.subjectType.trim() : ''
     const subjectId = typeof req.params.subjectId === 'string' ? req.params.subjectId.trim() : ''
-    if (!viewId || !subjectId || (subjectType !== 'user' && subjectType !== 'role')) {
-      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'viewId, subjectType (user|role), and subjectId are required' } })
+    if (!viewId || !subjectId || !isSheetPermissionSubjectType(subjectType)) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'viewId, subjectType (user|member-group|role), and subjectId are required' } })
     }
 
     const schema = z.object({
@@ -3786,10 +3914,15 @@ export function univerMetaRouter(): Router {
         if (userCheck.rows.length === 0) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `User not found: ${subjectId}` } })
         }
-      } else {
+      } else if (subjectType === 'role') {
         const roleCheck = await pool.query('SELECT id FROM roles WHERE id = $1', [subjectId])
         if (roleCheck.rows.length === 0) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Role not found: ${subjectId}` } })
+        }
+      } else {
+        const groupCheck = await pool.query('SELECT id FROM platform_member_groups WHERE id::text = $1', [subjectId])
+        if (groupCheck.rows.length === 0) {
+          return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Member group not found: ${subjectId}` } })
         }
       }
 
@@ -3864,8 +3997,8 @@ export function univerMetaRouter(): Router {
     const fieldId = typeof req.params.fieldId === 'string' ? req.params.fieldId.trim() : ''
     const subjectType = typeof req.params.subjectType === 'string' ? req.params.subjectType.trim() : ''
     const subjectId = typeof req.params.subjectId === 'string' ? req.params.subjectId.trim() : ''
-    if (!sheetId || !fieldId || !subjectId || (subjectType !== 'user' && subjectType !== 'role')) {
-      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, fieldId, subjectType (user|role), and subjectId are required' } })
+    if (!sheetId || !fieldId || !subjectId || !isSheetPermissionSubjectType(subjectType)) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, fieldId, subjectType (user|member-group|role), and subjectId are required' } })
     }
 
     const schema = z.object({
@@ -3897,10 +4030,15 @@ export function univerMetaRouter(): Router {
         if (userCheck.rows.length === 0) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `User not found: ${subjectId}` } })
         }
-      } else {
+      } else if (subjectType === 'role') {
         const roleCheck = await pool.query('SELECT id FROM roles WHERE id = $1', [subjectId])
         if (roleCheck.rows.length === 0) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Role not found: ${subjectId}` } })
+        }
+      } else {
+        const groupCheck = await pool.query('SELECT id FROM platform_member_groups WHERE id::text = $1', [subjectId])
+        if (groupCheck.rows.length === 0) {
+          return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Member group not found: ${subjectId}` } })
         }
       }
 
@@ -3989,7 +4127,7 @@ export function univerMetaRouter(): Router {
     }
 
     const schema = z.object({
-      subjectType: z.enum(['user', 'role']),
+      subjectType: z.enum(['user', 'role', 'member-group']),
       subjectId: z.string().min(1),
       accessLevel: z.enum(['read', 'write', 'admin']),
     })
@@ -4018,10 +4156,15 @@ export function univerMetaRouter(): Router {
         if (userCheck.rows.length === 0) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `User not found: ${subjectId}` } })
         }
-      } else {
+      } else if (subjectType === 'role') {
         const roleCheck = await pool.query('SELECT id FROM roles WHERE id = $1', [subjectId])
         if (roleCheck.rows.length === 0) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Role not found: ${subjectId}` } })
+        }
+      } else {
+        const groupCheck = await pool.query('SELECT id FROM platform_member_groups WHERE id::text = $1', [subjectId])
+        if (groupCheck.rows.length === 0) {
+          return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Member group not found: ${subjectId}` } })
         }
       }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3859,8 +3859,33 @@ export function univerMetaRouter(): Router {
       if (!capabilities.canManageViews) return sendForbidden(res)
 
       const result = await pool.query(
-        `SELECT id, view_id, subject_type, subject_id, permission, created_at, created_by
-         FROM meta_view_permissions WHERE view_id = $1 ORDER BY created_at ASC`,
+        `SELECT
+            vp.id,
+            vp.view_id,
+            vp.subject_type,
+            vp.subject_id,
+            vp.permission,
+            vp.created_at,
+            vp.created_by,
+            u.name AS user_name,
+            u.email AS user_email,
+            u.is_active AS user_is_active,
+            r.name AS role_name,
+            r.description AS role_description,
+            g.name AS group_name,
+            g.description AS group_description
+         FROM meta_view_permissions vp
+         LEFT JOIN users u
+           ON vp.subject_type = 'user'
+          AND u.id = vp.subject_id
+         LEFT JOIN roles r
+           ON vp.subject_type = 'role'
+          AND r.id::text = vp.subject_id
+         LEFT JOIN platform_member_groups g
+           ON vp.subject_type = 'member-group'
+          AND g.id::text = vp.subject_id
+         WHERE vp.view_id = $1
+         ORDER BY vp.created_at ASC`,
         [viewId],
       )
       const items = (result.rows as any[]).map((row) => ({
@@ -3868,6 +3893,19 @@ export function univerMetaRouter(): Router {
         viewId: String(row.view_id),
         subjectType: String(row.subject_type),
         subjectId: String(row.subject_id),
+        subjectLabel:
+          row.subject_type === 'user'
+            ? String(row.user_name ?? row.subject_id)
+            : row.subject_type === 'member-group'
+              ? String(row.group_name ?? row.subject_id)
+              : String(row.role_name ?? row.subject_id),
+        subjectSubtitle:
+          row.subject_type === 'user'
+            ? (typeof row.user_email === 'string' ? row.user_email : null)
+            : row.subject_type === 'member-group'
+              ? (typeof row.group_description === 'string' ? row.group_description : null)
+              : (typeof row.role_description === 'string' ? row.role_description : null),
+        isActive: row.subject_type === 'user' ? row.user_is_active !== false : true,
         permission: String(row.permission),
         createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at ?? ''),
       }))
@@ -3967,8 +4005,34 @@ export function univerMetaRouter(): Router {
       if (!capabilities.canManageFields) return sendForbidden(res)
 
       const result = await pool.query(
-        `SELECT id, sheet_id, field_id, subject_type, subject_id, visible, read_only, created_at
-         FROM field_permissions WHERE sheet_id = $1 ORDER BY field_id ASC, created_at ASC`,
+        `SELECT
+            fp.id,
+            fp.sheet_id,
+            fp.field_id,
+            fp.subject_type,
+            fp.subject_id,
+            fp.visible,
+            fp.read_only,
+            fp.created_at,
+            u.name AS user_name,
+            u.email AS user_email,
+            u.is_active AS user_is_active,
+            r.name AS role_name,
+            r.description AS role_description,
+            g.name AS group_name,
+            g.description AS group_description
+         FROM field_permissions fp
+         LEFT JOIN users u
+           ON fp.subject_type = 'user'
+          AND u.id = fp.subject_id
+         LEFT JOIN roles r
+           ON fp.subject_type = 'role'
+          AND r.id::text = fp.subject_id
+         LEFT JOIN platform_member_groups g
+           ON fp.subject_type = 'member-group'
+          AND g.id::text = fp.subject_id
+         WHERE fp.sheet_id = $1
+         ORDER BY fp.field_id ASC, fp.created_at ASC`,
         [sheetId],
       )
       const items = (result.rows as any[]).map((row) => ({
@@ -3977,6 +4041,19 @@ export function univerMetaRouter(): Router {
         fieldId: String(row.field_id),
         subjectType: String(row.subject_type),
         subjectId: String(row.subject_id),
+        subjectLabel:
+          row.subject_type === 'user'
+            ? String(row.user_name ?? row.subject_id)
+            : row.subject_type === 'member-group'
+              ? String(row.group_name ?? row.subject_id)
+              : String(row.role_name ?? row.subject_id),
+        subjectSubtitle:
+          row.subject_type === 'user'
+            ? (typeof row.user_email === 'string' ? row.user_email : null)
+            : row.subject_type === 'member-group'
+              ? (typeof row.group_description === 'string' ? row.group_description : null)
+              : (typeof row.role_description === 'string' ? row.role_description : null),
+        isActive: row.subject_type === 'user' ? row.user_is_active !== false : true,
         visible: row.visible !== false,
         readOnly: row.read_only === true,
       }))

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -4094,8 +4094,34 @@ export function univerMetaRouter(): Router {
       }
 
       const result = await pool.query(
-        `SELECT id, sheet_id, record_id, subject_type, subject_id, access_level, created_at, created_by
-         FROM record_permissions WHERE sheet_id = $1 AND record_id = $2 ORDER BY created_at ASC`,
+        `SELECT
+            rp.id,
+            rp.sheet_id,
+            rp.record_id,
+            rp.subject_type,
+            rp.subject_id,
+            rp.access_level,
+            rp.created_at,
+            rp.created_by,
+            u.name AS user_name,
+            u.email AS user_email,
+            u.is_active AS user_is_active,
+            r.name AS role_name,
+            r.description AS role_description,
+            g.name AS group_name,
+            g.description AS group_description
+         FROM record_permissions rp
+         LEFT JOIN users u
+           ON rp.subject_type = 'user'
+          AND u.id = rp.subject_id
+         LEFT JOIN roles r
+           ON rp.subject_type = 'role'
+          AND r.id::text = rp.subject_id
+         LEFT JOIN platform_member_groups g
+           ON rp.subject_type = 'member-group'
+          AND g.id::text = rp.subject_id
+         WHERE rp.sheet_id = $1 AND rp.record_id = $2
+         ORDER BY rp.created_at ASC`,
         [sheetId, recordId],
       )
       const items = (result.rows as any[]).map((row) => ({
@@ -4105,6 +4131,19 @@ export function univerMetaRouter(): Router {
         subjectType: String(row.subject_type),
         subjectId: String(row.subject_id),
         accessLevel: String(row.access_level),
+        label:
+          row.subject_type === 'user'
+            ? String(row.user_name ?? row.subject_id)
+            : row.subject_type === 'member-group'
+              ? String(row.group_name ?? row.subject_id)
+              : String(row.role_name ?? row.subject_id),
+        subtitle:
+          row.subject_type === 'user'
+            ? (typeof row.user_email === 'string' ? row.user_email : null)
+            : row.subject_type === 'member-group'
+              ? (typeof row.group_description === 'string' ? row.group_description : null)
+              : (typeof row.role_description === 'string' ? row.role_description : null),
+        isActive: row.subject_type === 'user' ? row.user_is_active !== false : true,
         createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at ?? ''),
       }))
       return res.json({ ok: true, data: { items } })

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -14,6 +14,15 @@ function createMockPool(queryHandler: QueryHandler) {
     if (sql.includes('FROM spreadsheet_permissions')) {
       return { rows: [], rowCount: 0 }
     }
+    if (sql.includes('FROM meta_view_permissions')) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes('FROM field_permissions')) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes('FROM record_permissions')) {
+      return { rows: [], rowCount: 0 }
+    }
     return queryHandler(sql, params)
   })
   const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
@@ -150,6 +159,7 @@ describe('Multitable context API', () => {
       canManageViews: false,
       canComment: true,
       canManageAutomation: true,
+      canExport: true,
     })
     expect(response.body.data.capabilityOrigin).toEqual({
       source: 'global-rbac',
@@ -331,6 +341,7 @@ describe('Multitable context API', () => {
       canManageViews: true,
       canComment: true,
       canManageAutomation: true,
+      canExport: true,
     })
     expect(response.body.data.viewPermissions).toEqual({
       view_grid: {

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -10,7 +10,12 @@ type QueryResult = {
 type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
 
 function createMockPool(queryHandler: QueryHandler) {
-  const query = vi.fn(async (sql: string, params?: unknown[]) => queryHandler(sql, params))
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM meta_view_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM field_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM record_permissions')) return { rows: [], rowCount: 0 }
+    return queryHandler(sql, params)
+  })
   const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
   return { query, transaction }
 }
@@ -130,6 +135,7 @@ describe('Multitable sheet-scoped permissions API', () => {
       canManageViews: false,
       canComment: true,
       canManageAutomation: false,
+      canExport: true,
     })
     expect(contextResponse.body.data.viewPermissions).toEqual({
       view_grid: {
@@ -1357,6 +1363,13 @@ describe('Multitable sheet-scoped permissions API', () => {
                 user_is_active: true,
               },
               {
+                subject_type: 'member-group',
+                subject_id: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+                permission_codes: ['spreadsheet:write'],
+                group_name: 'North Region',
+                group_description: 'Regional operations team',
+              },
+              {
                 subject_type: 'role',
                 subject_id: 'role_ops_writer',
                 permission_codes: ['spreadsheet:admin'],
@@ -1376,6 +1389,15 @@ describe('Multitable sheet-scoped permissions API', () => {
                 user_email: 'alpha@example.com',
                 user_is_active: true,
                 permission_codes: ['spreadsheet:read'],
+              },
+              {
+                subject_type: 'member-group',
+                subject_id: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+                group_name: 'North Region',
+                group_description: 'Regional operations team',
+                member_count: 12,
+                user_is_active: true,
+                permission_codes: ['spreadsheet:write'],
               },
               {
                 subject_type: 'role',
@@ -1410,6 +1432,15 @@ describe('Multitable sheet-scoped permissions API', () => {
         isActive: true,
       },
       {
+        subjectType: 'member-group',
+        subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+        accessLevel: 'write',
+        permissions: ['spreadsheet:write'],
+        label: 'North Region',
+        subtitle: 'Regional operations team',
+        isActive: true,
+      },
+      {
         subjectType: 'role',
         subjectId: 'role_ops_writer',
         accessLevel: 'admin',
@@ -1436,6 +1467,14 @@ describe('Multitable sheet-scoped permissions API', () => {
           accessLevel: 'read',
         },
         {
+          subjectType: 'member-group',
+          subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+          label: 'North Region',
+          subtitle: 'Regional operations team',
+          isActive: true,
+          accessLevel: 'write',
+        },
+        {
           subjectType: 'role',
           subjectId: 'role_ops_writer',
           label: 'Ops Writers',
@@ -1444,7 +1483,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           accessLevel: 'admin',
         },
       ],
-      total: 2,
+      total: 3,
       limit: 20,
       query: '',
     })
@@ -1514,6 +1553,69 @@ describe('Multitable sheet-scoped permissions API', () => {
     })
   })
 
+  test('derives effective sheet access from member-group grants', async () => {
+    const { app } = await createApp({
+      tokenPerms: [],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('FROM meta_sheets s') && sql.includes('LEFT JOIN meta_bases')) {
+          expect(params).toEqual(['sheet_ops'])
+          return {
+            rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: 'Ops records' }],
+          }
+        }
+        if (sql.includes('FROM meta_bases') && sql.includes('WHERE id = $1')) {
+          expect(params).toEqual(['base_ops'])
+          return {
+            rows: [{ id: 'base_ops', name: 'Ops Base', icon: 'table', color: '#1677ff', owner_id: 'owner_1', workspace_id: 'workspace_1' }],
+          }
+        }
+        if (sql.includes('FROM meta_sheets') && sql.includes('WHERE base_id = $1')) {
+          expect(params).toEqual(['base_ops'])
+          return {
+            rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: 'Ops records' }],
+          }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return {
+            rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:write', subject_type: 'member-group' }],
+          }
+        }
+        if (sql.includes('FROM meta_views') && sql.includes('WHERE sheet_id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return {
+            rows: [{ id: 'view_grid', sheet_id: 'sheet_ops', name: 'Grid', type: 'grid', filter_info: {}, sort_info: {}, group_info: {}, hidden_field_ids: [], config: {} }],
+          }
+        }
+        if (sql.includes('SELECT id, name, type, property, \"order\" FROM meta_fields WHERE sheet_id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return {
+            rows: [{ id: 'fld_name', name: 'Name', type: 'string', property: {}, order: 1 }],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/context')
+      .query({ sheetId: 'sheet_ops' })
+      .expect(200)
+
+    expect(response.body.data.capabilities).toMatchObject({
+      canRead: true,
+      canCreateRecord: true,
+      canEditRecord: true,
+      canDeleteRecord: true,
+      canManageFields: true,
+      canManageViews: true,
+    })
+    expect(response.body.data.capabilityOrigin).toEqual({
+      source: 'sheet-grant',
+      hasSheetAssignments: true,
+    })
+  })
+
   test('filters permission candidates that lack global multitable access', async () => {
     const { app } = await createApp({
       tokenPerms: ['multitable:read'],
@@ -1548,6 +1650,15 @@ describe('Multitable sheet-scoped permissions API', () => {
                 user_email: 'scope@example.com',
                 user_is_active: true,
                 permission_codes: ['spreadsheet:read'],
+              },
+              {
+                subject_type: 'member-group',
+                subject_id: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+                group_name: 'North Region',
+                group_description: null,
+                member_count: 12,
+                user_is_active: true,
+                permission_codes: [],
               },
               {
                 subject_type: 'role',
@@ -1590,6 +1701,14 @@ describe('Multitable sheet-scoped permissions API', () => {
           accessLevel: null,
         },
         {
+          subjectType: 'member-group',
+          subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+          label: 'North Region',
+          subtitle: '12 members',
+          isActive: true,
+          accessLevel: null,
+        },
+        {
           subjectType: 'role',
           subjectId: 'role_allowed',
           label: 'Allowed Role',
@@ -1598,7 +1717,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           accessLevel: null,
         },
       ],
-      total: 2,
+      total: 3,
       limit: 20,
       query: '',
     })
@@ -1684,6 +1803,90 @@ describe('Multitable sheet-scoped permissions API', () => {
         permissions: ['spreadsheet:write-own'],
         label: 'Target User',
         subtitle: 'target@example.com',
+        isActive: true,
+      },
+    })
+  })
+
+  test('sets sheet permission access levels for member groups through the authoring endpoint', async () => {
+    const deleteCalls: Array<unknown[] | undefined> = []
+    const insertCalls: Array<unknown[] | undefined> = []
+
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('SELECT id FROM platform_member_groups WHERE id::text = $1')) {
+          expect(params).toEqual(['3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c'])
+          return { rows: [{ id: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c' }] }
+        }
+        if (sql.includes('DELETE FROM spreadsheet_permissions') && sql.includes('subject_type = $2')) {
+          deleteCalls.push(params)
+          return { rows: [], rowCount: 2 }
+        }
+        if (sql.includes('INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code)')) {
+          insertCalls.push(params)
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('FROM spreadsheet_permissions sp') && sql.includes('GROUP BY sp.subject_type, sp.subject_id')) {
+          expect(params).toEqual(['sheet_ops'])
+          return {
+            rows: [{
+              subject_type: 'member-group',
+              subject_id: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+              permission_codes: ['spreadsheet:write'],
+              group_name: 'North Region',
+              group_description: 'Regional operations team',
+            }],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .put('/api/multitable/sheets/sheet_ops/permissions/member-group/3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c')
+      .send({ accessLevel: 'write' })
+      .expect(200)
+
+    expect(deleteCalls).toEqual([[
+      'sheet_ops',
+      'member-group',
+      '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+      [
+        'spreadsheet:read',
+        'spreadsheet:write',
+        'spreadsheet:write-own',
+        'spreadsheet:admin',
+        'spreadsheets:read',
+        'spreadsheets:write',
+        'spreadsheets:write-own',
+        'spreadsheets:admin',
+        'multitable:read',
+        'multitable:write',
+        'multitable:write-own',
+        'multitable:admin',
+      ],
+    ]])
+    expect(insertCalls).toEqual([['sheet_ops', null, 'member-group', '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c', 'spreadsheet:write']])
+    expect(response.body.data).toEqual({
+      subjectType: 'member-group',
+      subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+      accessLevel: 'write',
+      entry: {
+        subjectType: 'member-group',
+        subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+        accessLevel: 'write',
+        permissions: ['spreadsheet:write'],
+        label: 'North Region',
+        subtitle: 'Regional operations team',
         isActive: true,
       },
     })

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -11,8 +11,18 @@ type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<Q
 
 function createMockPool(queryHandler: QueryHandler) {
   const query = vi.fn(async (sql: string, params?: unknown[]) => {
-    if (sql.includes('FROM meta_view_permissions')) return { rows: [], rowCount: 0 }
-    if (sql.includes('FROM field_permissions')) return { rows: [], rowCount: 0 }
+    if (
+      sql.includes('FROM meta_view_permissions')
+      && !(sql.includes('FROM meta_view_permissions vp') && sql.includes('LEFT JOIN platform_member_groups g'))
+    ) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (
+      sql.includes('FROM field_permissions')
+      && !(sql.includes('FROM field_permissions fp') && sql.includes('LEFT JOIN platform_member_groups g'))
+    ) {
+      return { rows: [], rowCount: 0 }
+    }
     if (sql.includes('FROM record_permissions') && !sql.includes('FROM record_permissions rp')) return { rows: [], rowCount: 0 }
     return queryHandler(sql, params)
   })
@@ -2746,6 +2756,111 @@ describe('Multitable sheet-scoped permissions API', () => {
         subtitle: 'Regional operations team',
         isActive: true,
         createdAt: '2026-04-18T11:30:00.000Z',
+      },
+    ])
+  })
+
+  test('lists field permissions with hydrated member-group labels', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('FROM field_permissions fp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          expect(params).toEqual(['sheet_ops'])
+          return {
+            rows: [
+              {
+                id: 'field_perm_1',
+                sheet_id: 'sheet_ops',
+                field_id: 'fld_title',
+                subject_type: 'member-group',
+                subject_id: 'group_north',
+                visible: true,
+                read_only: true,
+                group_name: 'North Region',
+                group_description: 'Regional operations team',
+              },
+            ],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/field-permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([
+      {
+        id: 'field_perm_1',
+        sheetId: 'sheet_ops',
+        fieldId: 'fld_title',
+        subjectType: 'member-group',
+        subjectId: 'group_north',
+        subjectLabel: 'North Region',
+        subjectSubtitle: 'Regional operations team',
+        isActive: true,
+        visible: true,
+        readOnly: true,
+      },
+    ])
+  })
+
+  test('lists view permissions with hydrated member-group labels', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, sheet_id FROM meta_views WHERE id = $1')) {
+          expect(params).toEqual(['view_ops'])
+          return { rows: [{ id: 'view_ops', sheet_id: 'sheet_ops' }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('FROM meta_view_permissions vp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          expect(params).toEqual(['view_ops'])
+          return {
+            rows: [
+              {
+                id: 'view_perm_1',
+                view_id: 'view_ops',
+                subject_type: 'member-group',
+                subject_id: 'group_north',
+                permission: 'admin',
+                group_name: 'North Region',
+                group_description: 'Regional operations team',
+              },
+            ],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/views/view_ops/permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([
+      {
+        id: 'view_perm_1',
+        viewId: 'view_ops',
+        subjectType: 'member-group',
+        subjectId: 'group_north',
+        subjectLabel: 'North Region',
+        subjectSubtitle: 'Regional operations team',
+        isActive: true,
+        permission: 'admin',
+        createdAt: '',
       },
     ])
   })

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -13,7 +13,7 @@ function createMockPool(queryHandler: QueryHandler) {
   const query = vi.fn(async (sql: string, params?: unknown[]) => {
     if (sql.includes('FROM meta_view_permissions')) return { rows: [], rowCount: 0 }
     if (sql.includes('FROM field_permissions')) return { rows: [], rowCount: 0 }
-    if (sql.includes('FROM record_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM record_permissions') && !sql.includes('FROM record_permissions rp')) return { rows: [], rowCount: 0 }
     return queryHandler(sql, params)
   })
   const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
@@ -2688,6 +2688,64 @@ describe('Multitable sheet-scoped permissions API', () => {
         color: '#1677ff',
         ownerId: 'owner_1',
         workspaceId: 'workspace_1',
+      },
+    ])
+  })
+
+  test('lists record permissions with hydrated member-group labels', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('SELECT id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+          expect(params).toEqual(['record_1', 'sheet_ops'])
+          return { rows: [{ id: 'record_1' }] }
+        }
+        if (sql.includes('FROM record_permissions rp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          expect(params).toEqual(['sheet_ops', 'record_1'])
+          return {
+            rows: [
+              {
+                id: 'perm_group',
+                sheet_id: 'sheet_ops',
+                record_id: 'record_1',
+                subject_type: 'member-group',
+                subject_id: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+                access_level: 'write',
+                created_at: new Date('2026-04-18T11:30:00.000Z'),
+                group_name: 'North Region',
+                group_description: 'Regional operations team',
+              },
+            ],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/records/record_1/permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([
+      {
+        id: 'perm_group',
+        sheetId: 'sheet_ops',
+        recordId: 'record_1',
+        subjectType: 'member-group',
+        subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+        accessLevel: 'write',
+        label: 'North Region',
+        subtitle: 'Regional operations team',
+        isActive: true,
+        createdAt: '2026-04-18T11:30:00.000Z',
       },
     ])
   })

--- a/packages/core-backend/tests/unit/multitable-member-group-acl-hardening.test.ts
+++ b/packages/core-backend/tests/unit/multitable-member-group-acl-hardening.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+describe('multitable member-group ACL hardening', () => {
+  it('returns member-group sheet scope when only member-group grants exist', async () => {
+    const { loadSheetPermissionScopeMap } = await import('../../src/multitable/sheet-capabilities')
+
+    const scopeMap = await loadSheetPermissionScopeMap(
+      async () => ({
+        rows: [
+          { sheet_id: 'sheet_ops', perm_code: 'spreadsheet:read', subject_type: 'member-group' },
+          { sheet_id: 'sheet_ops', perm_code: 'spreadsheet:write', subject_type: 'member-group' },
+        ],
+      }),
+      ['sheet_ops'],
+      'user_ops_1',
+    )
+
+    expect(scopeMap.get('sheet_ops')).toEqual({
+      hasAssignments: true,
+      canRead: true,
+      canWrite: true,
+      canWriteOwn: false,
+      canAdmin: false,
+    })
+  })
+
+  it('returns empty scope map for known missing-table compatibility cases', async () => {
+    const { loadSheetPermissionScopeMap } = await import('../../src/multitable/sheet-capabilities')
+
+    const scopeMap = await loadSheetPermissionScopeMap(
+      async () => {
+        const error = new Error('relation "platform_member_group_members" does not exist') as Error & { code: string }
+        error.code = '42P01'
+        throw error
+      },
+      ['sheet_ops'],
+      'user_ops_1',
+    )
+
+    expect(scopeMap.size).toBe(0)
+  })
+
+  it('rethrows non-compatibility database errors from sheet scope loading', async () => {
+    const { loadSheetPermissionScopeMap } = await import('../../src/multitable/sheet-capabilities')
+
+    const failure = new Error('permission denied for table spreadsheet_permissions')
+
+    await expect(
+      loadSheetPermissionScopeMap(
+        async () => {
+          throw failure
+        },
+        ['sheet_ops'],
+        'user_ops_1',
+      ),
+    ).rejects.toBe(failure)
+  })
+
+  it('widens spreadsheet permission subject constraints in the member-group migration', async () => {
+    const currentFile = fileURLToPath(import.meta.url)
+    const migrationPath = path.resolve(
+      path.dirname(currentFile),
+      '../../src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts',
+    )
+
+    const source = await readFile(migrationPath, 'utf8')
+
+    expect(source).toContain('ALTER TABLE spreadsheet_permissions')
+    expect(source).toContain("CHECK (subject_type IN ('user', 'role', 'member-group'))")
+    expect(source).toContain("DELETE FROM spreadsheet_permissions")
+    expect(source).toContain("CHECK (subject_type IN ('user', 'role'))")
+  })
+})


### PR DESCRIPTION
## What changed

This PR adds `platform_member_groups` as a first-class multitable ACL subject.

It extends multitable permission authoring and enforcement so `member-group` can be used for:

- sheet permissions
- view permissions
- field permissions
- record permissions

This is the first code slice that closes the path:

- DingTalk department
- projected platform member group
- multitable ACL subject

## Scope

Included:
- frontend multitable typing and client support for `member-group`
- sheet/view/field permission manager support for member groups
- record permission manager support for member groups
- backend ACL listing, candidate loading, effective permission derivation, and authoring support for `member-group`
- migration to widen subject-type constraints for multitable permission tables
- targeted frontend and backend integration coverage
- development and verification MDs

Not included:
- generic cell-level ACL
- new DingTalk sync or member-group projection logic
- deployment changes

## Verification

Ran:

```bash
pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-context.api.test.ts tests/integration/multitable-sheet-permissions.api.test.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
```

Results:
- frontend tests: `9/9` passed
- backend integration tests: `49/49` passed
- backend build: passed
- web build: passed

## Notes

- `write-own` remains user-only and is rejected for non-user subjects.
- Effective multitable grant precedence stays:
  - direct user
  - member group
  - role
- Partial environments that do not yet expose `platform_member_group_members` continue to fail closed without crashing, matching the existing compatibility style in this area.
