### PR TITLE
feat(multitable): improve record acl governance

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -405,6 +405,47 @@ function normalizeSheetPermissionCandidates(
   }
 }
 
+function normalizeRecordPermissionEntry(
+  payload: Partial<RecordPermissionEntry> | null | undefined,
+): RecordPermissionEntry | null {
+  const subjectType =
+    payload?.subjectType === 'user' || payload?.subjectType === 'role' || payload?.subjectType === 'member-group'
+      ? payload.subjectType
+      : null
+  const id = typeof payload?.id === 'string' ? payload.id : ''
+  const sheetId = typeof payload?.sheetId === 'string' ? payload.sheetId : ''
+  const recordId = typeof payload?.recordId === 'string' ? payload.recordId : ''
+  const subjectId = typeof payload?.subjectId === 'string' ? payload.subjectId : ''
+  const accessLevel =
+    payload?.accessLevel === 'read' || payload?.accessLevel === 'write' || payload?.accessLevel === 'admin'
+      ? payload.accessLevel
+      : null
+  if (!id || !sheetId || !recordId || !subjectType || !subjectId || !accessLevel) return null
+  return {
+    id,
+    sheetId,
+    recordId,
+    subjectType,
+    subjectId,
+    accessLevel,
+    label: typeof payload?.label === 'string' ? payload.label : subjectId,
+    subtitle: typeof payload?.subtitle === 'string' || payload?.subtitle === null ? payload.subtitle ?? null : null,
+    isActive: payload?.isActive !== false,
+    createdAt: typeof payload?.createdAt === 'string' ? payload.createdAt : undefined,
+    createdBy: typeof payload?.createdBy === 'string' ? payload.createdBy : undefined,
+  }
+}
+
+function normalizeRecordPermissionEntries(
+  payload: { items?: Array<Partial<RecordPermissionEntry>> } | null | undefined,
+): RecordPermissionEntry[] {
+  return Array.isArray(payload?.items)
+    ? payload.items
+      .map((item) => normalizeRecordPermissionEntry(item))
+      .filter((item): item is RecordPermissionEntry => !!item)
+    : []
+}
+
 function normalizeCommentsParams(params: { containerId: string; targetId: string; targetFieldId?: string | null } | MetaCommentsScope) {
   if ('containerType' in params) {
     return {
@@ -755,8 +796,8 @@ export class MultitableApiClient {
   // --- Record permissions ---
   async listRecordPermissions(sheetId: string, recordId: string): Promise<RecordPermissionEntry[]> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/permissions`)
-    const data = await parseJson<{ permissions?: RecordPermissionEntry[] }>(res)
-    return Array.isArray(data?.permissions) ? data.permissions : []
+    const data = await parseJson<{ items?: Array<Partial<RecordPermissionEntry>> }>(res)
+    return normalizeRecordPermissionEntries(data)
   }
 
   async updateRecordPermission(

--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -19,7 +19,7 @@
             <strong>Current access</strong>
           </div>
           <div v-if="loading" class="meta-record-perm__empty">Loading permissions&#x2026;</div>
-          <div v-else-if="!entries.length" class="meta-record-perm__empty">No record-specific permissions yet.</div>
+        <div v-else-if="!entries.length" class="meta-record-perm__empty">No record-specific permissions yet.</div>
           <template v-else>
           <div
             v-for="entry in entries"
@@ -28,9 +28,10 @@
             :data-record-permission-entry="entry.id"
           >
             <div class="meta-record-perm__identity">
-              <strong>{{ entry.subjectId }}</strong>
-              <span>{{ subjectTypeLabel(entry.subjectType) }}</span>
+              <strong>{{ entry.label }}</strong>
+              <span>{{ entry.subtitle || entry.subjectId }}</span>
             </div>
+            <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeLabel(entry.subjectType) }}</span>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
               {{ accessLevelLabel(entryDrafts[entry.id] ?? entry.accessLevel) }}
             </span>
@@ -67,35 +68,123 @@
         <!-- Add permission -->
         <section class="meta-record-perm__section">
           <div class="meta-record-perm__section-header">
-            <strong>Add permission</strong>
+            <strong>Grant to people, member groups, or roles</strong>
           </div>
-          <div class="meta-record-perm__add-row" data-record-permission-add="true">
-            <select v-model="addSubjectType" class="meta-record-perm__select">
-              <option value="user">User</option>
-              <option value="role">Role</option>
-              <option value="member-group">Member group</option>
-            </select>
-            <input
-              v-model="addSubjectId"
-              class="meta-record-perm__input"
-              type="text"
-              placeholder="Subject ID"
-              data-record-permission-subject-input="true"
-            />
-            <select v-model="addAccessLevel" class="meta-record-perm__select">
-              <option value="read">Read</option>
-              <option value="write">Write</option>
-              <option value="admin">Admin</option>
-            </select>
-            <button
-              class="meta-record-perm__action meta-record-perm__action--primary"
-              type="button"
-              :disabled="!addSubjectId.trim() || busyKey === 'add'"
-              @click="grantNew"
+          <input
+            v-model="candidateSearch"
+            class="meta-record-perm__search"
+            type="search"
+            placeholder="Search people, member groups, or roles"
+            data-record-permission-search="true"
+          />
+          <div v-if="candidatesLoading" class="meta-record-perm__empty">Loading eligible people, member groups, and roles&#x2026;</div>
+          <div v-else-if="!availableCandidates.length" class="meta-record-perm__empty">No matching eligible people, member groups, or roles.</div>
+          <template v-else>
+            <div class="meta-record-perm__section-header">
+              <strong>People</strong>
+            </div>
+            <div v-if="!peopleCandidates.length" class="meta-record-perm__empty">No matching people.</div>
+            <div
+              v-for="candidate in peopleCandidates"
+              :key="`people-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
+              class="meta-record-perm__row"
+              :data-record-permission-candidate="subjectKey(candidate.subjectType, candidate.subjectId)"
             >
-              Grant
-            </button>
-          </div>
+              <div class="meta-record-perm__identity">
+                <strong>{{ candidate.label }}</strong>
+                <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+              </div>
+              <span class="meta-record-perm__subject" data-subject-type="user">User</span>
+              <select
+                :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
+                class="meta-record-perm__select"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
+              >
+                <option value="read">Read</option>
+                <option value="write">Write</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button
+                class="meta-record-perm__action meta-record-perm__action--primary"
+                type="button"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
+              >
+                Grant
+              </button>
+            </div>
+
+            <div class="meta-record-perm__section-header">
+              <strong>Member groups</strong>
+            </div>
+            <div v-if="!memberGroupCandidates.length" class="meta-record-perm__empty">No matching member groups.</div>
+            <div
+              v-for="candidate in memberGroupCandidates"
+              :key="`member-group-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
+              class="meta-record-perm__row"
+              :data-record-permission-candidate="subjectKey(candidate.subjectType, candidate.subjectId)"
+            >
+              <div class="meta-record-perm__identity">
+                <strong>{{ candidate.label }}</strong>
+                <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+              </div>
+              <span class="meta-record-perm__subject" data-subject-type="member-group">Member group</span>
+              <select
+                :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
+                class="meta-record-perm__select"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
+              >
+                <option value="read">Read</option>
+                <option value="write">Write</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button
+                class="meta-record-perm__action meta-record-perm__action--primary"
+                type="button"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
+              >
+                Grant
+              </button>
+            </div>
+
+            <div class="meta-record-perm__section-header">
+              <strong>Roles</strong>
+            </div>
+            <div v-if="!roleCandidates.length" class="meta-record-perm__empty">No matching roles.</div>
+            <div
+              v-for="candidate in roleCandidates"
+              :key="`role-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
+              class="meta-record-perm__row"
+              :data-record-permission-candidate="subjectKey(candidate.subjectType, candidate.subjectId)"
+            >
+              <div class="meta-record-perm__identity">
+                <strong>{{ candidate.label }}</strong>
+                <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+              </div>
+              <span class="meta-record-perm__subject" data-subject-type="role">Role</span>
+              <select
+                :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
+                class="meta-record-perm__select"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
+              >
+                <option value="read">Read</option>
+                <option value="write">Write</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button
+                class="meta-record-perm__action meta-record-perm__action--primary"
+                type="button"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
+              >
+                Grant
+              </button>
+            </div>
+          </template>
         </section>
       </div>
     </div>
@@ -103,9 +192,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { MultitableApiClient } from '../api/client'
-import type { RecordPermissionEntry, RecordPermissionAccessLevel } from '../types'
+import type { MetaSheetPermissionCandidate, MetaSheetPermissionEntry, RecordPermissionAccessLevel, RecordPermissionEntry } from '../types'
 
 const props = defineProps<{
   visible: boolean
@@ -125,10 +214,11 @@ const error = ref('')
 const busyKey = ref<string | null>(null)
 const status = ref('')
 const entryDrafts = ref<Record<string, RecordPermissionAccessLevel>>({})
-
-const addSubjectType = ref<'user' | 'role' | 'member-group'>('user')
-const addSubjectId = ref('')
-const addAccessLevel = ref<RecordPermissionAccessLevel>('read')
+const candidateSearch = ref('')
+const candidatesLoading = ref(false)
+const subjectCandidates = ref<MetaSheetPermissionCandidate[]>([])
+const candidateDrafts = ref<Record<string, RecordPermissionAccessLevel>>({})
+let candidateLoadVersion = 0
 
 function accessLevelLabel(level: string): string {
   if (level === 'read') return 'Read'
@@ -145,6 +235,10 @@ function subjectTypeLabel(subjectType: string): string {
 
 function requestClose() {
   emit('close')
+}
+
+function subjectKey(subjectType: string, subjectId: string) {
+  return `${subjectType}:${subjectId}`
 }
 
 function clearMessages() {
@@ -165,6 +259,41 @@ function syncEntryDrafts() {
   )
 }
 
+function matchesCandidateSearch(candidate: MetaSheetPermissionCandidate, query: string): boolean {
+  if (!query) return true
+  const haystack = `${candidate.label} ${candidate.subtitle ?? ''} ${candidate.subjectId}`.toLowerCase()
+  return haystack.includes(query)
+}
+
+function normalizeSheetEntryCandidate(entry: MetaSheetPermissionEntry): MetaSheetPermissionCandidate {
+  return {
+    subjectType: entry.subjectType,
+    subjectId: entry.subjectId,
+    label: entry.label,
+    subtitle: entry.subtitle ?? null,
+    isActive: entry.isActive,
+    accessLevel: entry.accessLevel,
+  }
+}
+
+const availableCandidates = computed(() => {
+  const activeSubjects = new Set(entries.value.map((entry) => subjectKey(entry.subjectType, entry.subjectId)))
+  return subjectCandidates.value.filter((candidate) => !activeSubjects.has(subjectKey(candidate.subjectType, candidate.subjectId)))
+})
+
+const peopleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'user'))
+const memberGroupCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'member-group'))
+const roleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'role'))
+
+function syncCandidateDrafts() {
+  const next: Record<string, RecordPermissionAccessLevel> = {}
+  for (const candidate of availableCandidates.value) {
+    const key = subjectKey(candidate.subjectType, candidate.subjectId)
+    next[key] = candidateDrafts.value[key] ?? candidate.accessLevel ?? 'read'
+  }
+  candidateDrafts.value = next
+}
+
 async function loadPermissions() {
   if (!props.sheetId || !props.recordId) {
     entries.value = []
@@ -179,6 +308,43 @@ async function loadPermissions() {
     error.value = cause?.message ?? 'Failed to load record permissions'
   } finally {
     loading.value = false
+  }
+}
+
+async function loadCandidates() {
+  if (!props.sheetId) {
+    subjectCandidates.value = []
+    return
+  }
+  const currentVersion = ++candidateLoadVersion
+  candidatesLoading.value = true
+  try {
+    const query = candidateSearch.value.trim().toLowerCase()
+    const [sheetEntries, candidatePage] = await Promise.all([
+      props.client.listSheetPermissions(props.sheetId),
+      props.client.listSheetPermissionCandidates(props.sheetId, { q: candidateSearch.value.trim() || undefined, limit: 20 }),
+    ])
+    if (currentVersion !== candidateLoadVersion) return
+
+    const combined = new Map<string, MetaSheetPermissionCandidate>()
+    for (const entry of sheetEntries.items.map((item) => normalizeSheetEntryCandidate(item))) {
+      if (!matchesCandidateSearch(entry, query)) continue
+      combined.set(subjectKey(entry.subjectType, entry.subjectId), entry)
+    }
+    for (const candidate of candidatePage.items) {
+      const key = subjectKey(candidate.subjectType, candidate.subjectId)
+      if (!matchesCandidateSearch(candidate, query) || combined.has(key)) continue
+      combined.set(key, candidate)
+    }
+    subjectCandidates.value = Array.from(combined.values())
+    syncCandidateDrafts()
+  } catch (cause: any) {
+    if (currentVersion !== candidateLoadVersion) return
+    error.value = cause?.message ?? 'Failed to load permission candidates'
+  } finally {
+    if (currentVersion === candidateLoadVersion) {
+      candidatesLoading.value = false
+    }
   }
 }
 
@@ -213,17 +379,28 @@ async function removeEntry(entry: RecordPermissionEntry) {
   }
 }
 
-async function grantNew() {
-  const subjectId = addSubjectId.value.trim()
-  if (!subjectId) return
-  busyKey.value = 'add'
+function setCandidateDraft(subjectType: string, subjectId: string, event: Event) {
+  const key = subjectKey(subjectType, subjectId)
+  candidateDrafts.value = {
+    ...candidateDrafts.value,
+    [key]: (event.target as HTMLSelectElement).value as RecordPermissionAccessLevel,
+  }
+}
+
+async function grantCandidate(subjectType: RecordPermissionEntry['subjectType'], subjectId: string) {
+  const key = subjectKey(subjectType, subjectId)
+  busyKey.value = key
   clearMessages()
   try {
-    await props.client.updateRecordPermission(props.sheetId, props.recordId, addSubjectType.value, subjectId, addAccessLevel.value)
-    await loadPermissions()
+    await props.client.updateRecordPermission(
+      props.sheetId,
+      props.recordId,
+      subjectType,
+      subjectId,
+      candidateDrafts.value[key] ?? 'read',
+    )
+    await Promise.all([loadPermissions(), loadCandidates()])
     status.value = 'Permission granted'
-    addSubjectId.value = ''
-    addAccessLevel.value = 'read'
     emit('updated')
   } catch (cause: any) {
     error.value = cause?.message ?? 'Failed to grant permission'
@@ -237,8 +414,17 @@ watch(
   ([visible, sheetId, recordId]) => {
     if (!visible || !sheetId || !recordId) return
     void loadPermissions()
+    void loadCandidates()
   },
   { immediate: true },
+)
+
+watch(
+  () => candidateSearch.value,
+  () => {
+    if (!props.visible || !props.sheetId) return
+    void loadCandidates()
+  },
 )
 </script>
 
@@ -312,22 +498,12 @@ watch(
   align-items: center;
   justify-content: space-between;
   color: #0f172a;
+  gap: 12px;
 }
 
 .meta-record-perm__row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 80px 120px auto auto;
-  gap: 10px;
-  align-items: center;
-  padding: 10px 12px;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  background: #f8fafc;
-}
-
-.meta-record-perm__add-row {
-  display: grid;
-  grid-template-columns: 100px minmax(0, 1fr) 120px auto;
   gap: 10px;
   align-items: center;
   padding: 10px 12px;
@@ -358,6 +534,28 @@ watch(
   text-overflow: ellipsis;
 }
 
+.meta-record-perm__subject {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.meta-record-perm__subject[data-subject-type='member-group'] {
+  background: #ecfeff;
+  color: #155e75;
+}
+
+.meta-record-perm__subject[data-subject-type='role'] {
+  background: #f5f3ff;
+  color: #6d28d9;
+}
+
 .meta-record-perm__badge {
   display: inline-flex;
   justify-content: center;
@@ -386,7 +584,7 @@ watch(
 }
 
 .meta-record-perm__select,
-.meta-record-perm__input {
+.meta-record-perm__search {
   width: 100%;
   min-width: 0;
   border: 1px solid #cbd5e1;
@@ -447,10 +645,6 @@ watch(
 
 @media (max-width: 640px) {
   .meta-record-perm__row {
-    grid-template-columns: 1fr;
-  }
-
-  .meta-record-perm__add-row {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -534,6 +534,9 @@ export interface RecordPermissionEntry {
   subjectType: RecordPermissionSubjectType
   subjectId: string
   accessLevel: RecordPermissionAccessLevel
+  label: string
+  subtitle?: string | null
+  isActive: boolean
   createdAt?: string
   createdBy?: string
 }

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -14,11 +14,15 @@ async function flushUi(cycles = 4) {
 
 function makeClient(overrides?: {
   listRecordPermissions?: ReturnType<typeof vi.fn>
+  listSheetPermissions?: ReturnType<typeof vi.fn>
+  listSheetPermissionCandidates?: ReturnType<typeof vi.fn>
   updateRecordPermission?: ReturnType<typeof vi.fn>
   deleteRecordPermission?: ReturnType<typeof vi.fn>
 }) {
   return {
     listRecordPermissions: overrides?.listRecordPermissions ?? vi.fn().mockResolvedValue([]),
+    listSheetPermissions: overrides?.listSheetPermissions ?? vi.fn().mockResolvedValue({ items: [] }),
+    listSheetPermissionCandidates: overrides?.listSheetPermissionCandidates ?? vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, query: '' }),
     updateRecordPermission: overrides?.updateRecordPermission ?? vi.fn().mockResolvedValue(undefined),
     deleteRecordPermission: overrides?.deleteRecordPermission ?? vi.fn().mockResolvedValue(undefined),
   }
@@ -61,6 +65,9 @@ describe('MetaRecordPermissionManager', () => {
           subjectType: 'user',
           subjectId: 'user_alice',
           accessLevel: 'write',
+          label: 'Alice',
+          subtitle: 'alice@example.com',
+          isActive: true,
           createdAt: '2026-01-01T00:00:00Z',
         },
         {
@@ -70,6 +77,9 @@ describe('MetaRecordPermissionManager', () => {
           subjectType: 'role',
           subjectId: 'role_ops',
           accessLevel: 'read',
+          label: 'Ops Reviewers',
+          subtitle: 'Operations review role',
+          isActive: true,
         },
       ]),
     })
@@ -80,11 +90,12 @@ describe('MetaRecordPermissionManager', () => {
     expect(client.listRecordPermissions).toHaveBeenCalledWith('sheet_1', 'record_1')
     expect(container!.querySelector('[data-record-permission-entry="perm_1"]')).not.toBeNull()
     expect(container!.querySelector('[data-record-permission-entry="perm_2"]')).not.toBeNull()
-    expect(container!.textContent).toContain('user_alice')
-    expect(container!.textContent).toContain('role_ops')
+    expect(container!.textContent).toContain('Alice')
+    expect(container!.textContent).toContain('alice@example.com')
+    expect(container!.textContent).toContain('Ops Reviewers')
   })
 
-  it('calls API on grant', async () => {
+  it('grants record access from sheet subjects without raw subject-id input', async () => {
     const client = makeClient({
       listRecordPermissions: vi.fn()
         .mockResolvedValueOnce([])
@@ -96,30 +107,37 @@ describe('MetaRecordPermissionManager', () => {
             subjectType: 'user',
             subjectId: 'user_bob',
             accessLevel: 'write',
+            label: 'Bob',
+            subtitle: 'bob@example.com',
+            isActive: true,
           },
         ]),
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_bob',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'Bob',
+            subtitle: 'bob@example.com',
+            isActive: true,
+          },
+        ],
+      }),
     })
     const updatedSpy = vi.fn()
 
     mountManager({ client, onUpdated: updatedSpy })
     await flushUi()
 
-    // Fill in the add form
-    const subjectInput = container!.querySelector('[data-record-permission-subject-input]') as HTMLInputElement
-    subjectInput.value = 'user_bob'
-    subjectInput.dispatchEvent(new Event('input', { bubbles: true }))
-    await flushUi()
-
-    // Change access level to write
-    const addRow = container!.querySelector('[data-record-permission-add]')!
-    const selects = addRow.querySelectorAll('select')
-    const accessSelect = selects[1] as HTMLSelectElement
+    const candidateRow = container!.querySelector('[data-record-permission-candidate="user:user_bob"]')!
+    const accessSelect = candidateRow.querySelector('select') as HTMLSelectElement
     accessSelect.value = 'write'
     accessSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushUi()
 
-    // Click grant
-    const grantBtn = addRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
+    const grantBtn = candidateRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
     grantBtn.click()
     await flushUi()
 
@@ -139,32 +157,84 @@ describe('MetaRecordPermissionManager', () => {
             subjectType: 'member-group',
             subjectId: '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d',
             accessLevel: 'read',
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
           },
         ]),
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
     })
     const updatedSpy = vi.fn()
 
     mountManager({ client, onUpdated: updatedSpy })
     await flushUi()
 
-    const addRow = container!.querySelector('[data-record-permission-add]')!
-    const selects = addRow.querySelectorAll('select')
-    const subjectTypeSelect = selects[0] as HTMLSelectElement
-    expect(Array.from(subjectTypeSelect.options).map((option) => option.value)).toEqual(['user', 'role', 'member-group'])
-    subjectTypeSelect.value = 'member-group'
-    subjectTypeSelect.dispatchEvent(new Event('change', { bubbles: true }))
-
-    const subjectInput = container!.querySelector('[data-record-permission-subject-input]') as HTMLInputElement
-    subjectInput.value = '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d'
-    subjectInput.dispatchEvent(new Event('input', { bubbles: true }))
-    await flushUi()
-
-    const grantBtn = addRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
+    const candidateRow = container!.querySelector('[data-record-permission-candidate="member-group:4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d"]')!
+    expect(candidateRow.textContent).toContain('North Region')
+    expect(candidateRow.textContent).toContain('Member group')
+    const grantBtn = candidateRow.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement
     grantBtn.click()
     await flushUi()
 
     expect(client.updateRecordPermission).toHaveBeenCalledWith('sheet_1', 'record_1', 'member-group', '4df0f2f2-8bc1-4d89-9c47-2746bde6bc4d', 'read')
     expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('searches across sheet subjects and global candidates when granting record access', async () => {
+    const client = makeClient({
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'role',
+            subjectId: 'role_ops',
+            label: 'Ops Reviewers',
+            subtitle: 'Operations review role',
+            isActive: true,
+            accessLevel: null,
+          },
+        ],
+        total: 1,
+        limit: 20,
+        query: 'north',
+      }),
+    })
+
+    mountManager({ client })
+    await flushUi()
+
+    const searchInput = container!.querySelector('[data-record-permission-search]') as HTMLInputElement
+    searchInput.value = 'north'
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    expect(client.listSheetPermissionCandidates).toHaveBeenLastCalledWith('sheet_1', { q: 'north', limit: 20 })
+    expect(container!.querySelector('[data-record-permission-candidate="member-group:group_north"]')).not.toBeNull()
+    expect(container!.querySelector('[data-record-permission-candidate="role:role_ops"]')).toBeNull()
   })
 
   it('calls API on revoke', async () => {

--- a/docs/development/multitable-record-acl-governance-development-20260418.md
+++ b/docs/development/multitable-record-acl-governance-development-20260418.md
@@ -1,0 +1,76 @@
+# Multitable Record ACL Governance Development
+
+## Summary
+- Built the next stacked slice on top of member-group ACL subjects by making record-level permission governance usable in the UI.
+- Replaced raw `subjectId` entry for record grants with searchable permission candidates sourced from existing multitable sheet subjects.
+- Hydrated record permission entries with human labels so current record grants show real people, member groups, and roles instead of bare IDs.
+
+## Why This Slice
+- The previous slice made `member-group` a valid multitable ACL subject.
+- Record-level governance was still awkward because administrators had to type opaque subject IDs by hand.
+- This slice makes row-level ACL practical for the same subject universe:
+  - people
+  - member groups
+  - roles
+
+## Runtime Changes
+
+### Frontend Types And Client
+- Extended `RecordPermissionEntry` to carry:
+  - `label`
+  - `subtitle`
+  - `isActive`
+- Added client-side normalization for hydrated record permission entries:
+  - `apps/web/src/multitable/types.ts`
+  - `apps/web/src/multitable/api/client.ts`
+
+### Record Permission Manager
+- Reworked `MetaRecordPermissionManager`:
+  - removed raw free-text `subjectId` grant flow
+  - added candidate search input
+  - loads grant candidates from:
+    - current sheet permission entries
+    - existing sheet permission candidates
+  - groups grant candidates into:
+    - people
+    - member groups
+    - roles
+  - filters out subjects that already have record-specific entries
+- Current record entries now render:
+  - hydrated label
+  - subtitle
+  - subject-type badge
+- File:
+  - `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+
+### Backend Record Permission Listing
+- Extended `GET /api/multitable/sheets/:sheetId/records/:recordId/permissions` to hydrate subjects via joins against:
+  - `users`
+  - `roles`
+  - `platform_member_groups`
+- The record permission list response now includes:
+  - `label`
+  - `subtitle`
+  - `isActive`
+- File:
+  - `packages/core-backend/src/routes/univer-meta.ts`
+
+## Governance Semantics
+- Record-level ACL still uses the existing access levels:
+  - `read`
+  - `write`
+  - `admin`
+- This slice does not widen access semantics; it only improves subject selection and current-entry visibility.
+- Candidate sourcing intentionally follows the existing sheet ACL governance universe instead of inventing a second subject directory for record permissions.
+
+## Test Updates
+- Frontend:
+  - `apps/web/tests/multitable-record-permission-manager.spec.ts`
+- Backend:
+  - `packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts`
+
+## Out Of Scope
+- No field/view permission UX redesign in this slice
+- No new member-group projection logic
+- No cell-level ACL
+- No deployment or migration changes

--- a/docs/development/multitable-record-acl-governance-verification-20260418.md
+++ b/docs/development/multitable-record-acl-governance-verification-20260418.md
@@ -1,0 +1,45 @@
+# Multitable Record ACL Governance Verification
+
+## Targeted Frontend Tests
+- Command:
+  - `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+- Result:
+  - `10/10` passed
+
+## Targeted Backend Integration
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts --watch=false`
+- Result:
+  - `36/36` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/core-backend build`
+- Result:
+  - passed
+
+- Command:
+  - `pnpm --filter @metasheet/web build`
+- Result:
+  - passed
+
+## Coverage Highlights
+- Verified record permission entries return hydrated member-group labels from the backend.
+- Verified record permission manager renders hydrated labels and no longer depends on raw typed subject IDs.
+- Verified record permission manager can grant:
+  - user subjects
+  - member-group subjects
+- Verified record candidate search combines:
+  - current sheet permission subjects
+  - eligible sheet permission candidates
+
+## Validation Scope
+- No deployment was performed.
+- No database migration was added or executed in this slice.
+- Validation stayed scoped to the record-governance UI path, its supporting backend integration path, and local builds.
+
+## Known Non-Blocking Noise
+- Frontend Vitest may print:
+  - `WebSocket server error: Port is already in use`
+- Backend integration still prints one existing formula recalculation stderr line in a write-own test path, but the suite passes.
+- Web build still emits the existing Vite dynamic-import and chunk-size warnings.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -4094,8 +4094,34 @@ export function univerMetaRouter(): Router {
       }
 
       const result = await pool.query(
-        `SELECT id, sheet_id, record_id, subject_type, subject_id, access_level, created_at, created_by
-         FROM record_permissions WHERE sheet_id = $1 AND record_id = $2 ORDER BY created_at ASC`,
+        `SELECT
+            rp.id,
+            rp.sheet_id,
+            rp.record_id,
+            rp.subject_type,
+            rp.subject_id,
+            rp.access_level,
+            rp.created_at,
+            rp.created_by,
+            u.name AS user_name,
+            u.email AS user_email,
+            u.is_active AS user_is_active,
+            r.name AS role_name,
+            r.description AS role_description,
+            g.name AS group_name,
+            g.description AS group_description
+         FROM record_permissions rp
+         LEFT JOIN users u
+           ON rp.subject_type = 'user'
+          AND u.id = rp.subject_id
+         LEFT JOIN roles r
+           ON rp.subject_type = 'role'
+          AND r.id::text = rp.subject_id
+         LEFT JOIN platform_member_groups g
+           ON rp.subject_type = 'member-group'
+          AND g.id::text = rp.subject_id
+         WHERE rp.sheet_id = $1 AND rp.record_id = $2
+         ORDER BY rp.created_at ASC`,
         [sheetId, recordId],
       )
       const items = (result.rows as any[]).map((row) => ({
@@ -4105,6 +4131,19 @@ export function univerMetaRouter(): Router {
         subjectType: String(row.subject_type),
         subjectId: String(row.subject_id),
         accessLevel: String(row.access_level),
+        label:
+          row.subject_type === 'user'
+            ? String(row.user_name ?? row.subject_id)
+            : row.subject_type === 'member-group'
+              ? String(row.group_name ?? row.subject_id)
+              : String(row.role_name ?? row.subject_id),
+        subtitle:
+          row.subject_type === 'user'
+            ? (typeof row.user_email === 'string' ? row.user_email : null)
+            : row.subject_type === 'member-group'
+              ? (typeof row.group_description === 'string' ? row.group_description : null)
+              : (typeof row.role_description === 'string' ? row.role_description : null),
+        isActive: row.subject_type === 'user' ? row.user_is_active !== false : true,
         createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at ?? ''),
       }))
       return res.json({ ok: true, data: { items } })

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -13,7 +13,7 @@ function createMockPool(queryHandler: QueryHandler) {
   const query = vi.fn(async (sql: string, params?: unknown[]) => {
     if (sql.includes('FROM meta_view_permissions')) return { rows: [], rowCount: 0 }
     if (sql.includes('FROM field_permissions')) return { rows: [], rowCount: 0 }
-    if (sql.includes('FROM record_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM record_permissions') && !sql.includes('FROM record_permissions rp')) return { rows: [], rowCount: 0 }
     return queryHandler(sql, params)
   })
   const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
@@ -2688,6 +2688,64 @@ describe('Multitable sheet-scoped permissions API', () => {
         color: '#1677ff',
         ownerId: 'owner_1',
         workspaceId: 'workspace_1',
+      },
+    ])
+  })
+
+  test('lists record permissions with hydrated member-group labels', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('SELECT id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+          expect(params).toEqual(['record_1', 'sheet_ops'])
+          return { rows: [{ id: 'record_1' }] }
+        }
+        if (sql.includes('FROM record_permissions rp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          expect(params).toEqual(['sheet_ops', 'record_1'])
+          return {
+            rows: [
+              {
+                id: 'perm_group',
+                sheet_id: 'sheet_ops',
+                record_id: 'record_1',
+                subject_type: 'member-group',
+                subject_id: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+                access_level: 'write',
+                created_at: new Date('2026-04-18T11:30:00.000Z'),
+                group_name: 'North Region',
+                group_description: 'Regional operations team',
+              },
+            ],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/records/record_1/permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([
+      {
+        id: 'perm_group',
+        sheetId: 'sheet_ops',
+        recordId: 'record_1',
+        subjectType: 'member-group',
+        subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+        accessLevel: 'write',
+        label: 'North Region',
+        subtitle: 'Regional operations team',
+        isActive: true,
+        createdAt: '2026-04-18T11:30:00.000Z',
       },
     ])
   })


### PR DESCRIPTION
## What changed

This stacked PR builds on #902 and makes record-level ACL governance usable once `member-group` becomes a valid multitable subject.

It does two things:

- hydrates record permission entries with human labels for users, roles, and member groups
- replaces raw `subjectId` entry in the record permission manager with searchable grant candidates sourced from the existing sheet permission subject universe

## Scope

Included:
- hydrated record permission entries (`label`, `subtitle`, `isActive`)
- record permission manager candidate search and grouped grant UX
- targeted frontend and backend tests
- development and verification MDs

Not included:
- field/view permission UX redesign
- new ACL subject types
- cell-level ACL
- deployment changes

## Verification

Ran:

```bash
pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
```

Results:
- frontend tests: `10/10` passed
- backend integration tests: `36/36` passed
- backend build: passed
- web build: passed
