### PR TITLE
feat(multitable): improve field and view acl governance

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -565,6 +565,8 @@ export class MultitableApiClient {
             subjectType: item.subjectType,
             subjectId: item.subjectId,
             subjectLabel: typeof item.subjectLabel === 'string' ? item.subjectLabel : undefined,
+            subjectSubtitle: typeof item.subjectSubtitle === 'string' || item.subjectSubtitle === null ? item.subjectSubtitle ?? null : null,
+            isActive: item.isActive !== false,
             visible: item.visible !== false,
             readOnly: item.readOnly === true,
           }))
@@ -577,7 +579,7 @@ export class MultitableApiClient {
     fieldId: string,
     subjectType: 'user' | 'role' | 'member-group',
     subjectId: string,
-    perm: { visible: boolean; readOnly: boolean },
+    perm: { visible?: boolean; readOnly?: boolean; remove?: boolean },
   ): Promise<{ fieldId: string; subjectType: string; subjectId: string; visible: boolean; readOnly: boolean }> {
     const res = await this.fetch(
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/field-permissions/${encodeURIComponent(fieldId)}/${encodeURIComponent(subjectType)}/${encodeURIComponent(subjectId)}`,
@@ -607,6 +609,8 @@ export class MultitableApiClient {
             subjectType: item.subjectType,
             subjectId: item.subjectId,
             subjectLabel: typeof item.subjectLabel === 'string' ? item.subjectLabel : undefined,
+            subjectSubtitle: typeof item.subjectSubtitle === 'string' || item.subjectSubtitle === null ? item.subjectSubtitle ?? null : null,
+            isActive: item.isActive !== false,
             permission: item.permission,
           }))
         : [],

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -221,7 +221,7 @@
               <strong>Field-level permissions</strong>
             </div>
             <div v-if="!fields.length" class="meta-sheet-perm__empty">No fields available.</div>
-            <div v-else-if="!entries.length" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure field permissions.</div>
+            <div v-else-if="!entries.length && !hasFieldOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure field permissions.</div>
             <template v-else>
               <div
                 v-for="field in fields"
@@ -267,6 +267,32 @@
                     Save
                   </button>
                 </div>
+                <div
+                  v-for="orphan in fieldPermissionOrphansByField[field.id] ?? []"
+                  :key="`fp-orphan-${field.id}-${subjectKey(orphan.subjectType, orphan.subjectId)}`"
+                  class="meta-sheet-perm__row meta-sheet-perm__row--field"
+                  :data-field-permission-orphan-row="`${field.id}:${subjectKey(orphan.subjectType, orphan.subjectId)}`"
+                >
+                  <div class="meta-sheet-perm__identity">
+                    <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
+                    <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  </div>
+                  <span
+                    class="meta-sheet-perm__badge"
+                    :data-access-level="fieldPermDraftLabel(field.id, orphan.subjectType, orphan.subjectId)"
+                  >
+                    {{ fieldPermDraftLabel(field.id, orphan.subjectType, orphan.subjectId) }}
+                  </span>
+                  <span class="meta-sheet-perm__hint">No current sheet access</span>
+                  <button
+                    class="meta-sheet-perm__action meta-sheet-perm__action--danger"
+                    type="button"
+                    :disabled="busyFieldPermKey === fieldPermKey(field.id, orphan.subjectType, orphan.subjectId)"
+                    @click="clearFieldPerm(field.id, orphan.subjectType, orphan.subjectId)"
+                  >
+                    Clear
+                  </button>
+                </div>
               </div>
             </template>
           </section>
@@ -279,7 +305,7 @@
               <strong>View-level permissions</strong>
             </div>
             <div v-if="!views.length" class="meta-sheet-perm__empty">No views available.</div>
-            <div v-else-if="!entries.length" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure view permissions.</div>
+            <div v-else-if="!entries.length && !hasViewOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure view permissions.</div>
             <template v-else>
               <div
                 v-for="view in views"
@@ -324,6 +350,32 @@
                     @click="applyViewPerm(view.id, entry.subjectType, entry.subjectId)"
                   >
                     Save
+                  </button>
+                </div>
+                <div
+                  v-for="orphan in viewPermissionOrphansByView[view.id] ?? []"
+                  :key="`vp-orphan-${view.id}-${subjectKey(orphan.subjectType, orphan.subjectId)}`"
+                  class="meta-sheet-perm__row meta-sheet-perm__row--field"
+                  :data-view-permission-orphan-row="`${view.id}:${subjectKey(orphan.subjectType, orphan.subjectId)}`"
+                >
+                  <div class="meta-sheet-perm__identity">
+                    <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
+                    <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  </div>
+                  <span
+                    class="meta-sheet-perm__badge"
+                    :data-access-level="viewPermDraftValue(view.id, orphan.subjectType, orphan.subjectId)"
+                  >
+                    {{ viewPermDisplayLabel(viewPermDraftValue(view.id, orphan.subjectType, orphan.subjectId)) }}
+                  </span>
+                  <span class="meta-sheet-perm__hint">No current sheet access</span>
+                  <button
+                    class="meta-sheet-perm__action meta-sheet-perm__action--danger"
+                    type="button"
+                    :disabled="busyViewPermKey === viewPermKey(view.id, orphan.subjectType, orphan.subjectId)"
+                    @click="clearViewPerm(view.id, orphan.subjectType, orphan.subjectId)"
+                  >
+                    Clear
                   </button>
                 </div>
               </div>
@@ -382,7 +434,7 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   (e: 'close'): void
   (e: 'updated'): void
-  (e: 'update-field-permission', fieldId: string, subjectType: string, subjectId: string, perm: { visible: boolean; readOnly: boolean }): void
+  (e: 'update-field-permission', fieldId: string, subjectType: string, subjectId: string, perm: { visible: boolean; readOnly: boolean } | { remove: true }): void
   (e: 'update-view-permission', viewId: string, subjectType: string, subjectId: string, permission: string): void
 }>()
 
@@ -456,22 +508,35 @@ function fieldPermFromDraftValue(val: string): { visible: boolean; readOnly: boo
 async function applyFieldPerm(fieldId: string, subjectType: string, subjectId: string) {
   const key = fieldPermKey(fieldId, subjectType, subjectId)
   const val = fieldPermDrafts.value[key] ?? resolveFieldPerm(fieldId, subjectType, subjectId)
-  const perm = fieldPermFromDraftValue(val)
   busyFieldPermKey.value = key
   clearMessages()
   try {
-    await props.client.updateFieldPermission(
-      props.sheetId,
-      fieldId,
-      subjectType as MetaSheetPermissionSubjectType,
-      subjectId,
-      perm,
-    )
-    status.value = 'Field permission updated'
-    emit('update-field-permission', fieldId, subjectType, subjectId, perm)
+    const isDefault = val === 'default'
+    const perm: { remove: true } | { visible: boolean; readOnly: boolean } = isDefault
+      ? { remove: true }
+      : fieldPermFromDraftValue(val)
+    await props.client.updateFieldPermission(props.sheetId, fieldId, subjectType as MetaSheetPermissionSubjectType, subjectId, perm)
+    status.value = isDefault ? 'Field permission cleared' : 'Field permission updated'
+    emit('update-field-permission', fieldId, subjectType, subjectId, isDefault ? { visible: true, readOnly: false } : perm)
     emit('updated')
   } catch (cause: any) {
     error.value = cause?.message ?? 'Failed to update field permission'
+  } finally {
+    busyFieldPermKey.value = null
+  }
+}
+
+async function clearFieldPerm(fieldId: string, subjectType: string, subjectId: string) {
+  const key = fieldPermKey(fieldId, subjectType, subjectId)
+  busyFieldPermKey.value = key
+  clearMessages()
+  try {
+    await props.client.updateFieldPermission(props.sheetId, fieldId, subjectType as MetaSheetPermissionSubjectType, subjectId, { remove: true })
+    status.value = 'Field permission cleared'
+    emit('update-field-permission', fieldId, subjectType, subjectId, { visible: true, readOnly: false })
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear field permission'
   } finally {
     busyFieldPermKey.value = null
   }
@@ -531,6 +596,22 @@ async function applyViewPerm(viewId: string, subjectType: string, subjectId: str
   }
 }
 
+async function clearViewPerm(viewId: string, subjectType: string, subjectId: string) {
+  const key = viewPermKey(viewId, subjectType, subjectId)
+  busyViewPermKey.value = key
+  clearMessages()
+  try {
+    await props.client.updateViewPermission(viewId, subjectType as MetaSheetPermissionSubjectType, subjectId, 'none')
+    status.value = 'View permission cleared'
+    emit('update-view-permission', viewId, subjectType, subjectId, 'none')
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear view permission'
+  } finally {
+    busyViewPermKey.value = null
+  }
+}
+
 // --- Sheet access helpers (existing) ---
 const availableCandidates = computed(() => {
   const activeSubjectKeys = new Set(entries.value.map((entry) => subjectKey(entry.subjectType, entry.subjectId)))
@@ -540,6 +621,29 @@ const availableCandidates = computed(() => {
 const peopleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'user'))
 const memberGroupCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'member-group'))
 const roleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'role'))
+const activeSheetSubjectKeys = computed(() => new Set(entries.value.map((entry) => subjectKey(entry.subjectType, entry.subjectId))))
+const fieldPermissionOrphans = computed(() =>
+  props.fieldPermissionEntries.filter((entry) => !activeSheetSubjectKeys.value.has(subjectKey(entry.subjectType, entry.subjectId))),
+)
+const viewPermissionOrphans = computed(() =>
+  props.viewPermissionEntries.filter((entry) => !activeSheetSubjectKeys.value.has(subjectKey(entry.subjectType, entry.subjectId))),
+)
+const fieldPermissionOrphansByField = computed<Record<string, MetaFieldPermissionEntry[]>>(() => {
+  const grouped: Record<string, MetaFieldPermissionEntry[]> = {}
+  for (const entry of fieldPermissionOrphans.value) {
+    ;(grouped[entry.fieldId] ??= []).push(entry)
+  }
+  return grouped
+})
+const viewPermissionOrphansByView = computed<Record<string, MetaViewPermissionEntry[]>>(() => {
+  const grouped: Record<string, MetaViewPermissionEntry[]> = {}
+  for (const entry of viewPermissionOrphans.value) {
+    ;(grouped[entry.viewId] ??= []).push(entry)
+  }
+  return grouped
+})
+const hasFieldOrphans = computed(() => fieldPermissionOrphans.value.length > 0)
+const hasViewOrphans = computed(() => viewPermissionOrphans.value.length > 0)
 
 function accessLevelLabel(accessLevel: MetaSheetPermissionAccessLevel) {
   return ACCESS_LEVEL_OPTIONS.find((option) => option.value === accessLevel)?.label ?? accessLevel
@@ -894,6 +998,12 @@ onBeforeUnmount(() => {
 .meta-sheet-perm__badge[data-access-level='Read-only'] {
   background: #fef3c7;
   color: #92400e;
+}
+
+.meta-sheet-perm__hint {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .meta-sheet-perm__subject {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -221,6 +221,8 @@ export interface MetaFieldPermissionEntry {
   subjectType: MetaSheetPermissionSubjectType
   subjectId: string
   subjectLabel?: string
+  subjectSubtitle?: string | null
+  isActive?: boolean
   visible: boolean
   readOnly: boolean
 }
@@ -230,6 +232,8 @@ export interface MetaViewPermissionEntry {
   subjectType: MetaSheetPermissionSubjectType
   subjectId: string
   subjectLabel?: string
+  subjectSubtitle?: string | null
+  isActive?: boolean
   permission: string
 }
 

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -17,8 +17,14 @@ function mountManager(props: {
     listSheetPermissions: ReturnType<typeof vi.fn>
     listSheetPermissionCandidates: ReturnType<typeof vi.fn>
     updateSheetPermission: ReturnType<typeof vi.fn>
+    updateFieldPermission?: ReturnType<typeof vi.fn>
+    updateViewPermission?: ReturnType<typeof vi.fn>
   }
   onUpdated?: () => void
+  fields?: Array<{ id: string; name: string; type: string; property?: Record<string, unknown>; order?: number; options?: unknown[] }>
+  views?: Array<{ id: string; name: string; type?: string; sheetId?: string }>
+  fieldPermissionEntries?: Array<any>
+  viewPermissionEntries?: Array<any>
 }) {
   container = document.createElement('div')
   document.body.appendChild(container)
@@ -26,6 +32,10 @@ function mountManager(props: {
     visible: true,
     sheetId: 'sheet_orders',
     client: props.client,
+    fields: props.fields ?? [],
+    views: props.views ?? [],
+    fieldPermissionEntries: props.fieldPermissionEntries ?? [],
+    viewPermissionEntries: props.viewPermissionEntries ?? [],
     onClose: () => {},
     onUpdated: props.onUpdated ?? (() => {}),
   })
@@ -73,6 +83,8 @@ describe('MetaSheetPermissionManager', () => {
         ],
       }),
       updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
     }
 
     mountManager({ client })
@@ -123,6 +135,8 @@ describe('MetaSheetPermissionManager', () => {
           ],
         }),
       updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
     }
 
     mountManager({ client, onUpdated: updatedSpy })
@@ -188,6 +202,8 @@ describe('MetaSheetPermissionManager', () => {
           ],
         }),
       updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
     }
 
     mountManager({ client, onUpdated: updatedSpy })
@@ -206,5 +222,144 @@ describe('MetaSheetPermissionManager', () => {
     expect(client.updateSheetPermission).toHaveBeenCalledWith('sheet_orders', 'member-group', '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c', 'write')
     expect(updatedSpy).toHaveBeenCalledTimes(1)
     expect(container!.querySelector('[data-sheet-permission-entry="member-group:3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c"]')).not.toBeNull()
+  })
+
+  it('clears field defaults by removing overrides and shows orphan field overrides', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_alex',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'Alex',
+            subtitle: 'alex@example.com',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'user',
+          subjectId: 'user_alex',
+          subjectLabel: 'Alex',
+          subjectSubtitle: 'alex@example.com',
+          visible: false,
+          readOnly: false,
+          isActive: true,
+        },
+        {
+          fieldId: 'fld_title',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          visible: true,
+          readOnly: true,
+          isActive: true,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    const activeRow = container!.querySelector('[data-field-permission-row="fld_title:user:user_alex"]')!
+    const activeSelect = activeRow.querySelector('select') as HTMLSelectElement
+    activeSelect.value = 'default'
+    activeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(activeRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenCalledWith('sheet_orders', 'fld_title', 'user', 'user_alex', { remove: true })
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+
+    const orphanRow = container!.querySelector('[data-field-permission-orphan-row="fld_title:member-group:group_north"]')!
+    expect(orphanRow.textContent).toContain('North Region')
+    expect(orphanRow.textContent).toContain('No current sheet access')
+
+    ;(orphanRow.querySelector('.meta-sheet-perm__action--danger') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenLastCalledWith('sheet_orders', 'fld_title', 'member-group', 'group_north', { remove: true })
+    expect(updatedSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows orphan view overrides and clears them', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_alex',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'Alex',
+            subtitle: 'alex@example.com',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          permission: 'admin',
+          isActive: true,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    const orphanRow = container!.querySelector('[data-view-permission-orphan-row="view_grid:member-group:group_north"]')!
+    expect(orphanRow.textContent).toContain('North Region')
+    expect(orphanRow.textContent).toContain('Admin')
+
+    ;(orphanRow.querySelector('.meta-sheet-perm__action--danger') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateViewPermission).toHaveBeenCalledWith('view_grid', 'member-group', 'group_north', 'none')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/docs/development/multitable-field-view-acl-governance-development-20260418.md
+++ b/docs/development/multitable-field-view-acl-governance-development-20260418.md
@@ -1,0 +1,83 @@
+# Multitable Field And View ACL Governance Development
+
+## Summary
+- Built the next stacked slice on top of member-group ACL subjects by making field-level and view-level overrides administratively usable.
+- Hydrated field and view permission entries with real subject labels, subtitles, and active-state metadata.
+- Changed field-level `Default` back to true override removal instead of persisting an explicit default-shaped row.
+- Surfaced orphan field/view overrides when the subject no longer has sheet access, and added direct clear actions for those orphaned overrides.
+
+## Why This Slice
+- The member-group ACL subject slice made `platform_member_groups` valid multitable ACL subjects at the API layer.
+- Record governance was improved in the previous stacked slice, but field and view governance still had two operational gaps:
+  - administrators saw bare subject IDs instead of real labels
+  - `Default` kept storing an explicit override rather than clearing it
+- There was also no management path for orphan overrides that stayed behind after sheet access changed.
+
+## Runtime Changes
+
+### Backend Permission List Hydration
+- Extended `GET /api/multitable/sheets/:sheetId/field-permissions` to join:
+  - `users`
+  - `roles`
+  - `platform_member_groups`
+- Extended `GET /api/multitable/views/:viewId/permissions` with the same subject hydration pattern.
+- Both endpoints now return:
+  - `subjectLabel`
+  - `subjectSubtitle`
+  - `isActive`
+- File:
+  - `packages/core-backend/src/routes/univer-meta.ts`
+
+### Frontend Types And Client
+- Added hydrated subject metadata to:
+  - `MetaFieldPermissionEntry`
+  - `MetaViewPermissionEntry`
+- Updated client normalization for:
+  - field permission list responses
+  - view permission list responses
+- Widened `updateFieldPermission` so the client can send:
+  - `{ remove: true }`
+  - or a normal `{ visible, readOnly }` override
+- Files:
+  - `apps/web/src/multitable/types.ts`
+  - `apps/web/src/multitable/api/client.ts`
+
+### MetaSheetPermissionManager Governance Cleanup
+- Reworked the field and view tabs in `MetaSheetPermissionManager`:
+  - field rows now display hydrated subject labels from permission list payloads
+  - view rows now display hydrated subject labels from permission list payloads
+  - orphan field overrides now remain visible even if the subject no longer has sheet access
+  - orphan view overrides now remain visible even if the subject no longer has sheet access
+  - orphan rows expose an explicit `Clear` action
+- Added a small hint treatment for orphan rows:
+  - `No current sheet access`
+- File:
+  - `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+
+## Governance Semantics
+
+### Field `Default` Means No Override
+- Selecting `Default` now removes the field override instead of persisting:
+  - `visible: true`
+  - `readOnly: false`
+- This keeps the data model aligned with operator expectations:
+  - default = inherit sheet behavior
+  - hidden = explicit override
+  - read-only = explicit override
+
+### Orphan Overrides Stay Manageable
+- Field/view overrides may outlive the sheet grant that originally made the subject eligible.
+- Instead of hiding those rows, the UI now keeps them visible and clearable.
+- This avoids a common governance trap where stale overrides remain in the database but become inaccessible to administrators.
+
+## Test Updates
+- Frontend:
+  - `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- Backend:
+  - `packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts`
+
+## Out Of Scope
+- No new ACL subject type was introduced in this slice.
+- No record ACL behavior change beyond regression coverage.
+- No cell-level ACL.
+- No deployment or migration changes.

--- a/docs/development/multitable-field-view-acl-governance-verification-20260418.md
+++ b/docs/development/multitable-field-view-acl-governance-verification-20260418.md
@@ -1,0 +1,43 @@
+# Multitable Field And View ACL Governance Verification
+
+## Targeted Frontend Tests
+- Command:
+  - `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+- Result:
+  - `12/12` passed
+
+## Targeted Backend Integration
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts --watch=false`
+- Result:
+  - `38/38` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/core-backend build`
+- Result:
+  - passed
+
+- Command:
+  - `pnpm --filter @metasheet/web build`
+- Result:
+  - passed
+
+## Coverage Highlights
+- Verified field permission list responses hydrate member-group labels and subtitles.
+- Verified view permission list responses hydrate member-group labels and subtitles.
+- Verified selecting field `Default` removes the override through the client authoring call.
+- Verified orphan field overrides remain visible and can be cleared.
+- Verified orphan view overrides remain visible and can be cleared.
+- Re-ran record permission manager coverage to confirm this slice did not regress adjacent ACL governance UI.
+
+## Validation Scope
+- No deployment was performed.
+- No database migration was added or executed in this slice.
+- Validation stayed scoped to field/view governance UI behavior, supporting backend permission list APIs, adjacent record governance UI regression coverage, and local builds.
+
+## Known Non-Blocking Noise
+- Frontend Vitest may print:
+  - `WebSocket server error: Port is already in use`
+- Backend integration still prints one existing formula recalculation stderr line in a write-own test path, but the suite passes.
+- Web build still emits the existing Vite dynamic-import and chunk-size warnings.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3859,8 +3859,33 @@ export function univerMetaRouter(): Router {
       if (!capabilities.canManageViews) return sendForbidden(res)
 
       const result = await pool.query(
-        `SELECT id, view_id, subject_type, subject_id, permission, created_at, created_by
-         FROM meta_view_permissions WHERE view_id = $1 ORDER BY created_at ASC`,
+        `SELECT
+            vp.id,
+            vp.view_id,
+            vp.subject_type,
+            vp.subject_id,
+            vp.permission,
+            vp.created_at,
+            vp.created_by,
+            u.name AS user_name,
+            u.email AS user_email,
+            u.is_active AS user_is_active,
+            r.name AS role_name,
+            r.description AS role_description,
+            g.name AS group_name,
+            g.description AS group_description
+         FROM meta_view_permissions vp
+         LEFT JOIN users u
+           ON vp.subject_type = 'user'
+          AND u.id = vp.subject_id
+         LEFT JOIN roles r
+           ON vp.subject_type = 'role'
+          AND r.id::text = vp.subject_id
+         LEFT JOIN platform_member_groups g
+           ON vp.subject_type = 'member-group'
+          AND g.id::text = vp.subject_id
+         WHERE vp.view_id = $1
+         ORDER BY vp.created_at ASC`,
         [viewId],
       )
       const items = (result.rows as any[]).map((row) => ({
@@ -3868,6 +3893,19 @@ export function univerMetaRouter(): Router {
         viewId: String(row.view_id),
         subjectType: String(row.subject_type),
         subjectId: String(row.subject_id),
+        subjectLabel:
+          row.subject_type === 'user'
+            ? String(row.user_name ?? row.subject_id)
+            : row.subject_type === 'member-group'
+              ? String(row.group_name ?? row.subject_id)
+              : String(row.role_name ?? row.subject_id),
+        subjectSubtitle:
+          row.subject_type === 'user'
+            ? (typeof row.user_email === 'string' ? row.user_email : null)
+            : row.subject_type === 'member-group'
+              ? (typeof row.group_description === 'string' ? row.group_description : null)
+              : (typeof row.role_description === 'string' ? row.role_description : null),
+        isActive: row.subject_type === 'user' ? row.user_is_active !== false : true,
         permission: String(row.permission),
         createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at ?? ''),
       }))
@@ -3967,8 +4005,34 @@ export function univerMetaRouter(): Router {
       if (!capabilities.canManageFields) return sendForbidden(res)
 
       const result = await pool.query(
-        `SELECT id, sheet_id, field_id, subject_type, subject_id, visible, read_only, created_at
-         FROM field_permissions WHERE sheet_id = $1 ORDER BY field_id ASC, created_at ASC`,
+        `SELECT
+            fp.id,
+            fp.sheet_id,
+            fp.field_id,
+            fp.subject_type,
+            fp.subject_id,
+            fp.visible,
+            fp.read_only,
+            fp.created_at,
+            u.name AS user_name,
+            u.email AS user_email,
+            u.is_active AS user_is_active,
+            r.name AS role_name,
+            r.description AS role_description,
+            g.name AS group_name,
+            g.description AS group_description
+         FROM field_permissions fp
+         LEFT JOIN users u
+           ON fp.subject_type = 'user'
+          AND u.id = fp.subject_id
+         LEFT JOIN roles r
+           ON fp.subject_type = 'role'
+          AND r.id::text = fp.subject_id
+         LEFT JOIN platform_member_groups g
+           ON fp.subject_type = 'member-group'
+          AND g.id::text = fp.subject_id
+         WHERE fp.sheet_id = $1
+         ORDER BY fp.field_id ASC, fp.created_at ASC`,
         [sheetId],
       )
       const items = (result.rows as any[]).map((row) => ({
@@ -3977,6 +4041,19 @@ export function univerMetaRouter(): Router {
         fieldId: String(row.field_id),
         subjectType: String(row.subject_type),
         subjectId: String(row.subject_id),
+        subjectLabel:
+          row.subject_type === 'user'
+            ? String(row.user_name ?? row.subject_id)
+            : row.subject_type === 'member-group'
+              ? String(row.group_name ?? row.subject_id)
+              : String(row.role_name ?? row.subject_id),
+        subjectSubtitle:
+          row.subject_type === 'user'
+            ? (typeof row.user_email === 'string' ? row.user_email : null)
+            : row.subject_type === 'member-group'
+              ? (typeof row.group_description === 'string' ? row.group_description : null)
+              : (typeof row.role_description === 'string' ? row.role_description : null),
+        isActive: row.subject_type === 'user' ? row.user_is_active !== false : true,
         visible: row.visible !== false,
         readOnly: row.read_only === true,
       }))

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -11,8 +11,18 @@ type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<Q
 
 function createMockPool(queryHandler: QueryHandler) {
   const query = vi.fn(async (sql: string, params?: unknown[]) => {
-    if (sql.includes('FROM meta_view_permissions')) return { rows: [], rowCount: 0 }
-    if (sql.includes('FROM field_permissions')) return { rows: [], rowCount: 0 }
+    if (
+      sql.includes('FROM meta_view_permissions')
+      && !(sql.includes('FROM meta_view_permissions vp') && sql.includes('LEFT JOIN platform_member_groups g'))
+    ) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (
+      sql.includes('FROM field_permissions')
+      && !(sql.includes('FROM field_permissions fp') && sql.includes('LEFT JOIN platform_member_groups g'))
+    ) {
+      return { rows: [], rowCount: 0 }
+    }
     if (sql.includes('FROM record_permissions') && !sql.includes('FROM record_permissions rp')) return { rows: [], rowCount: 0 }
     return queryHandler(sql, params)
   })
@@ -2746,6 +2756,111 @@ describe('Multitable sheet-scoped permissions API', () => {
         subtitle: 'Regional operations team',
         isActive: true,
         createdAt: '2026-04-18T11:30:00.000Z',
+      },
+    ])
+  })
+
+  test('lists field permissions with hydrated member-group labels', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('FROM field_permissions fp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          expect(params).toEqual(['sheet_ops'])
+          return {
+            rows: [
+              {
+                id: 'field_perm_1',
+                sheet_id: 'sheet_ops',
+                field_id: 'fld_title',
+                subject_type: 'member-group',
+                subject_id: 'group_north',
+                visible: true,
+                read_only: true,
+                group_name: 'North Region',
+                group_description: 'Regional operations team',
+              },
+            ],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/field-permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([
+      {
+        id: 'field_perm_1',
+        sheetId: 'sheet_ops',
+        fieldId: 'fld_title',
+        subjectType: 'member-group',
+        subjectId: 'group_north',
+        subjectLabel: 'North Region',
+        subjectSubtitle: 'Regional operations team',
+        isActive: true,
+        visible: true,
+        readOnly: true,
+      },
+    ])
+  })
+
+  test('lists view permissions with hydrated member-group labels', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, sheet_id FROM meta_views WHERE id = $1')) {
+          expect(params).toEqual(['view_ops'])
+          return { rows: [{ id: 'view_ops', sheet_id: 'sheet_ops' }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('FROM meta_view_permissions vp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          expect(params).toEqual(['view_ops'])
+          return {
+            rows: [
+              {
+                id: 'view_perm_1',
+                view_id: 'view_ops',
+                subject_type: 'member-group',
+                subject_id: 'group_north',
+                permission: 'admin',
+                group_name: 'North Region',
+                group_description: 'Regional operations team',
+              },
+            ],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/views/view_ops/permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([
+      {
+        id: 'view_perm_1',
+        viewId: 'view_ops',
+        subjectType: 'member-group',
+        subjectId: 'group_north',
+        subjectLabel: 'North Region',
+        subjectSubtitle: 'Regional operations team',
+        isActive: true,
+        permission: 'admin',
+        createdAt: '',
       },
     ])
   })


### PR DESCRIPTION
## What changed

This stacked slice makes field-level and view-level ACL governance practical on top of member-group ACL subjects.

- hydrates field/view permission entries with subject labels, subtitles, and active-state metadata
- makes field `Default` remove the override instead of persisting an explicit default-shaped row
- surfaces orphan field/view overrides when the subject no longer has sheet access
- adds direct clear actions for orphan field/view overrides in `MetaSheetPermissionManager`

## Files

- `apps/web/src/multitable/api/client.ts`
- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
- `apps/web/src/multitable/types.ts`
- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
- `packages/core-backend/src/routes/univer-meta.ts`
- `packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts`
- `docs/development/multitable-field-view-acl-governance-development-20260418.md`
- `docs/development/multitable-field-view-acl-governance-verification-20260418.md`

## Verification

```bash
pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
```

Results:

- frontend tests: `12/12 passed`
- backend integration: `38/38 passed`
- backend build: passed
- web build: passed

## Notes

- no deployment performed
- no migration added in this slice
- existing non-blocking noise remains:
  - frontend Vitest may print `WebSocket server error: Port is already in use`
  - backend integration still prints one existing formula recalculation stderr line in a write-own path
  - web build still emits existing Vite chunk-size warnings
