### PR TITLE
fix(multitable): harden member-group sheet acl support

### DIFF
--- a/docs/development/multitable-member-group-acl-hardening-development-20260418.md
+++ b/docs/development/multitable-member-group-acl-hardening-development-20260418.md
@@ -1,0 +1,54 @@
+# Multitable Member-Group ACL Hardening Development
+
+## Summary
+- Hardened the main member-group ACL slice without widening scope beyond sheet permission support.
+- Fixed the migration so `spreadsheet_permissions` accepts `member-group`, matching the runtime authoring and enforcement behavior already present in `#902`.
+- Tightened `loadSheetPermissionScopeMap()` so it only degrades gracefully for known missing-table compatibility cases instead of swallowing all database failures.
+
+## Why This Slice
+- The member-group ACL subject slice already allowed `member-group` authoring and enforcement for sheet access.
+- The migration only widened subject constraints for:
+  - `meta_view_permissions`
+  - `field_permissions`
+  - `record_permissions`
+- It did **not** widen `spreadsheet_permissions`, which left the main sheet ACL table behind the runtime logic.
+- `sheet-capabilities.ts` also caught every error from scope loading and returned an empty map, which could silently hide real operational failures.
+
+## Runtime Changes
+
+### Migration Hardening
+- Updated:
+  - `packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts`
+- `up` now widens `spreadsheet_permissions_subject_type_check` to:
+  - `user`
+  - `role`
+  - `member-group`
+- `down` now:
+  - deletes `member-group` rows from `spreadsheet_permissions`
+  - restores the previous two-subject constraint
+
+### Sheet Capability Compatibility Hardening
+- Updated:
+  - `packages/core-backend/src/multitable/sheet-capabilities.ts`
+- Added table-specific undefined-table detection, matching the compatibility style already used in `univer-meta.ts`.
+- `loadSheetPermissionScopeMap()` now only returns an empty scope map when one of these tables is absent:
+  - `spreadsheet_permissions`
+  - `user_roles`
+  - `platform_member_group_members`
+- Other failures are now rethrown instead of being silently downgraded.
+
+## Test Coverage
+- Added:
+  - `packages/core-backend/tests/unit/multitable-member-group-acl-hardening.test.ts`
+
+The new unit coverage verifies:
+- member-group-only sheet grants still produce an effective scope
+- known missing-table compatibility errors still fail closed to an empty scope map
+- non-compatibility database failures are rethrown
+- the migration source now includes `spreadsheet_permissions` widening and rollback cleanup
+
+## Out Of Scope
+- No UI changes
+- No ACL semantic changes
+- No new subject types
+- No deployment or environment changes

--- a/docs/development/multitable-member-group-acl-hardening-verification-20260418.md
+++ b/docs/development/multitable-member-group-acl-hardening-verification-20260418.md
@@ -1,0 +1,35 @@
+# Multitable Member-Group ACL Hardening Verification
+
+## Targeted Unit Coverage
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-member-group-acl-hardening.test.ts --watch=false`
+- Result:
+  - `4/4` passed
+
+## Targeted Integration Regression
+- Command:
+  - `pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts tests/integration/multitable-context.api.test.ts --watch=false`
+- Result:
+  - `52/52` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/core-backend build`
+- Result:
+  - passed
+
+## Validation Highlights
+- Verified member-group sheet grants still resolve into effective sheet capabilities.
+- Verified missing-table compatibility still returns an empty scope map for partial environments.
+- Verified unexpected DB failures are no longer swallowed by `sheet-capabilities.ts`.
+- Verified the main multitable sheet/context integration suite still passes after tightening the compatibility behavior.
+- Verified the widening migration now covers `spreadsheet_permissions`, matching the runtime sheet ACL subject model.
+
+## Validation Scope
+- No frontend changes were made or tested in this slice.
+- No deployment was performed.
+- No migration was executed against a live database in this slice.
+
+## Known Non-Blocking Noise
+- Backend integration still prints one existing formula recalculation stderr line in a write-own test path, but the suite passes.
+- The backend test runner still prints the existing Vite CJS deprecation notice before Vitest startup.

--- a/packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts
@@ -3,6 +3,16 @@ import { sql } from 'kysely'
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
+    ALTER TABLE spreadsheet_permissions
+    DROP CONSTRAINT IF EXISTS spreadsheet_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE spreadsheet_permissions
+    ADD CONSTRAINT spreadsheet_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role', 'member-group'))
+  `.execute(db)
+
+  await sql`
     ALTER TABLE meta_view_permissions
     DROP CONSTRAINT IF EXISTS meta_view_permissions_subject_type_check
   `.execute(db)
@@ -34,6 +44,20 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DELETE FROM spreadsheet_permissions
+    WHERE subject_type = 'member-group'
+  `.execute(db)
+  await sql`
+    ALTER TABLE spreadsheet_permissions
+    DROP CONSTRAINT IF EXISTS spreadsheet_permissions_subject_type_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE spreadsheet_permissions
+    ADD CONSTRAINT spreadsheet_permissions_subject_type_check
+    CHECK (subject_type IN ('user', 'role'))
+  `.execute(db)
+
   await sql`
     DELETE FROM meta_view_permissions
     WHERE subject_type = 'member-group'

--- a/packages/core-backend/src/multitable/sheet-capabilities.ts
+++ b/packages/core-backend/src/multitable/sheet-capabilities.ts
@@ -53,6 +53,13 @@ export type SheetPermissionScope = {
 
 export type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
 
+function isUndefinedTableError(err: unknown, tableName: string): boolean {
+  const code = typeof (err as any)?.code === 'string' ? (err as any).code : null
+  const message = typeof (err as any)?.message === 'string' ? (err as any).message : ''
+  if (code === '42P01') return message.includes(tableName)
+  return message.includes(`relation "${tableName}" does not exist`)
+}
+
 // ── Functions ───────────────────────────────────────────────────────
 
 export function hasPermission(permissions: string[], code: string): boolean {
@@ -196,8 +203,15 @@ export async function loadSheetPermissionScopeMap(
         ),
       ]),
     )
-  } catch {
-    return new Map()
+  } catch (err) {
+    if (
+      isUndefinedTableError(err, 'spreadsheet_permissions')
+      || isUndefinedTableError(err, 'user_roles')
+      || isUndefinedTableError(err, 'platform_member_group_members')
+    ) {
+      return new Map()
+    }
+    throw err
   }
 }
 

--- a/packages/core-backend/tests/unit/multitable-member-group-acl-hardening.test.ts
+++ b/packages/core-backend/tests/unit/multitable-member-group-acl-hardening.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+describe('multitable member-group ACL hardening', () => {
+  it('returns member-group sheet scope when only member-group grants exist', async () => {
+    const { loadSheetPermissionScopeMap } = await import('../../src/multitable/sheet-capabilities')
+
+    const scopeMap = await loadSheetPermissionScopeMap(
+      async () => ({
+        rows: [
+          { sheet_id: 'sheet_ops', perm_code: 'spreadsheet:read', subject_type: 'member-group' },
+          { sheet_id: 'sheet_ops', perm_code: 'spreadsheet:write', subject_type: 'member-group' },
+        ],
+      }),
+      ['sheet_ops'],
+      'user_ops_1',
+    )
+
+    expect(scopeMap.get('sheet_ops')).toEqual({
+      hasAssignments: true,
+      canRead: true,
+      canWrite: true,
+      canWriteOwn: false,
+      canAdmin: false,
+    })
+  })
+
+  it('returns empty scope map for known missing-table compatibility cases', async () => {
+    const { loadSheetPermissionScopeMap } = await import('../../src/multitable/sheet-capabilities')
+
+    const scopeMap = await loadSheetPermissionScopeMap(
+      async () => {
+        const error = new Error('relation "platform_member_group_members" does not exist') as Error & { code: string }
+        error.code = '42P01'
+        throw error
+      },
+      ['sheet_ops'],
+      'user_ops_1',
+    )
+
+    expect(scopeMap.size).toBe(0)
+  })
+
+  it('rethrows non-compatibility database errors from sheet scope loading', async () => {
+    const { loadSheetPermissionScopeMap } = await import('../../src/multitable/sheet-capabilities')
+
+    const failure = new Error('permission denied for table spreadsheet_permissions')
+
+    await expect(
+      loadSheetPermissionScopeMap(
+        async () => {
+          throw failure
+        },
+        ['sheet_ops'],
+        'user_ops_1',
+      ),
+    ).rejects.toBe(failure)
+  })
+
+  it('widens spreadsheet permission subject constraints in the member-group migration', async () => {
+    const currentFile = fileURLToPath(import.meta.url)
+    const migrationPath = path.resolve(
+      path.dirname(currentFile),
+      '../../src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts',
+    )
+
+    const source = await readFile(migrationPath, 'utf8')
+
+    expect(source).toContain('ALTER TABLE spreadsheet_permissions')
+    expect(source).toContain("CHECK (subject_type IN ('user', 'role', 'member-group'))")
+    expect(source).toContain("DELETE FROM spreadsheet_permissions")
+    expect(source).toContain("CHECK (subject_type IN ('user', 'role'))")
+  })
+})


### PR DESCRIPTION
## What changed

This stacked hardening slice fixes two issues in the member-group multitable ACL mainline:

- widens `spreadsheet_permissions` to accept `member-group`, matching the already-supported runtime sheet ACL model
- narrows `loadSheetPermissionScopeMap()` compatibility handling so it only swallows known missing-table cases instead of all database failures

## Files

- `packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts`
- `packages/core-backend/src/multitable/sheet-capabilities.ts`
- `packages/core-backend/tests/unit/multitable-member-group-acl-hardening.test.ts`
- `docs/development/multitable-member-group-acl-hardening-development-20260418.md`
- `docs/development/multitable-member-group-acl-hardening-verification-20260418.md`

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-member-group-acl-hardening.test.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts tests/integration/multitable-context.api.test.ts --watch=false
pnpm --filter @metasheet/core-backend build
```

Results:

- unit: `4/4 passed`
- integration: `52/52 passed`
- backend build: passed

## Notes

- no frontend changes
- no deployment performed
- no live migration executed in this slice
- existing non-blocking noise remains in backend integration:
  - one formula recalculation stderr line in a write-own path
  - Vite CJS deprecation notice before Vitest startup
