### PR TITLE
feat(multitable): add field and view acl templates

### DIFF
--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -223,6 +223,41 @@
             <div v-if="!fields.length" class="meta-sheet-perm__empty">No fields available.</div>
             <div v-else-if="!entries.length && !hasFieldOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure field permissions.</div>
             <template v-else>
+              <div v-if="entries.length" class="meta-sheet-perm__section">
+                <div class="meta-sheet-perm__section-header">
+                  <strong>Bulk apply to all fields</strong>
+                </div>
+                <div
+                  v-for="entry in entries"
+                  :key="`fp-template-${subjectKey(entry.subjectType, entry.subjectId)}`"
+                  class="meta-sheet-perm__row meta-sheet-perm__row--template"
+                  :data-field-permission-template="subjectKey(entry.subjectType, entry.subjectId)"
+                >
+                  <div class="meta-sheet-perm__identity">
+                    <strong>{{ entry.label }}</strong>
+                    <span>{{ entry.subtitle || entry.subjectId }}</span>
+                  </div>
+                  <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                  <select
+                    :value="fieldTemplateDraftValue(entry.subjectType, entry.subjectId)"
+                    class="meta-sheet-perm__select"
+                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    @change="setFieldTemplateDraft(entry.subjectType, entry.subjectId, $event)"
+                  >
+                    <option value="default">Default</option>
+                    <option value="hidden">Hidden</option>
+                    <option value="readonly">Read-only</option>
+                  </select>
+                  <button
+                    class="meta-sheet-perm__action meta-sheet-perm__action--primary"
+                    type="button"
+                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    @click="applyFieldTemplate(entry.subjectType, entry.subjectId)"
+                  >
+                    Apply to all fields
+                  </button>
+                </div>
+              </div>
               <div
                 v-for="field in fields"
                 :key="field.id"
@@ -307,6 +342,42 @@
             <div v-if="!views.length" class="meta-sheet-perm__empty">No views available.</div>
             <div v-else-if="!entries.length && !hasViewOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure view permissions.</div>
             <template v-else>
+              <div v-if="entries.length" class="meta-sheet-perm__section">
+                <div class="meta-sheet-perm__section-header">
+                  <strong>Bulk apply to all views</strong>
+                </div>
+                <div
+                  v-for="entry in entries"
+                  :key="`vp-template-${subjectKey(entry.subjectType, entry.subjectId)}`"
+                  class="meta-sheet-perm__row meta-sheet-perm__row--template"
+                  :data-view-permission-template="subjectKey(entry.subjectType, entry.subjectId)"
+                >
+                  <div class="meta-sheet-perm__identity">
+                    <strong>{{ entry.label }}</strong>
+                    <span>{{ entry.subtitle || entry.subjectId }}</span>
+                  </div>
+                  <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                  <select
+                    :value="viewTemplateDraftValue(entry.subjectType, entry.subjectId)"
+                    class="meta-sheet-perm__select"
+                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    @change="setViewTemplateDraft(entry.subjectType, entry.subjectId, $event)"
+                  >
+                    <option value="none">None</option>
+                    <option value="read">Read</option>
+                    <option value="write">Write</option>
+                    <option value="admin">Admin</option>
+                  </select>
+                  <button
+                    class="meta-sheet-perm__action meta-sheet-perm__action--primary"
+                    type="button"
+                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    @click="applyViewTemplate(entry.subjectType, entry.subjectId)"
+                  >
+                    Apply to all views
+                  </button>
+                </div>
+              </div>
               <div
                 v-for="view in views"
                 :key="view.id"
@@ -455,10 +526,14 @@ let searchTimer: number | null = null
 // Field permission drafts
 const fieldPermDrafts = ref<Record<string, string>>({})
 const busyFieldPermKey = ref<string | null>(null)
+const fieldTemplateDrafts = ref<Record<string, string>>({})
+const busyFieldTemplateKey = ref<string | null>(null)
 
 // View permission drafts
 const viewPermDrafts = ref<Record<string, string>>({})
 const busyViewPermKey = ref<string | null>(null)
+const viewTemplateDrafts = ref<Record<string, string>>({})
+const busyViewTemplateKey = ref<string | null>(null)
 
 function subjectKey(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   return `${subjectType}:${subjectId}`
@@ -491,11 +566,22 @@ function fieldPermDraftLabel(fieldId: string, subjectType: string, subjectId: st
   return 'Default'
 }
 
+function fieldTemplateDraftValue(subjectType: string, subjectId: string): string {
+  return fieldTemplateDrafts.value[subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)] ?? 'default'
+}
+
 function setFieldPermDraft(fieldId: string, subjectType: string, subjectId: string, event: Event) {
   const key = fieldPermKey(fieldId, subjectType, subjectId)
   fieldPermDrafts.value = {
     ...fieldPermDrafts.value,
     [key]: (event.target as HTMLSelectElement).value,
+  }
+}
+
+function setFieldTemplateDraft(subjectType: string, subjectId: string, event: Event) {
+  fieldTemplateDrafts.value = {
+    ...fieldTemplateDrafts.value,
+    [subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)]: (event.target as HTMLSelectElement).value,
   }
 }
 
@@ -542,6 +628,38 @@ async function clearFieldPerm(fieldId: string, subjectType: string, subjectId: s
   }
 }
 
+async function applyFieldTemplate(subjectType: string, subjectId: string) {
+  if (!props.fields.length) return
+  const key = subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)
+  const draft = fieldTemplateDraftValue(subjectType, subjectId)
+  const perm: { remove: true } | { visible: boolean; readOnly: boolean } = draft === 'default'
+    ? { remove: true }
+    : fieldPermFromDraftValue(draft)
+  busyFieldTemplateKey.value = key
+  clearMessages()
+  try {
+    await Promise.all(
+      props.fields.map((field) =>
+        props.client.updateFieldPermission(
+          props.sheetId,
+          field.id,
+          subjectType as MetaSheetPermissionSubjectType,
+          subjectId,
+          perm,
+        ),
+      ),
+    )
+    status.value = draft === 'default'
+      ? `Cleared field permission overrides on ${props.fields.length} fields`
+      : `Applied field permission to ${props.fields.length} fields`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to apply field permission template'
+  } finally {
+    busyFieldTemplateKey.value = null
+  }
+}
+
 // --- View permission helpers ---
 function viewPermKey(viewId: string, subjectType: string, subjectId: string) {
   return `${viewId}:${subjectType}:${subjectId}`
@@ -559,6 +677,10 @@ function viewPermDraftValue(viewId: string, subjectType: string, subjectId: stri
   return viewPermDrafts.value[key] ?? resolveViewPerm(viewId, subjectType, subjectId)
 }
 
+function viewTemplateDraftValue(subjectType: string, subjectId: string): string {
+  return viewTemplateDrafts.value[subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)] ?? 'read'
+}
+
 function viewPermDisplayLabel(val: string): string {
   if (val === 'read') return 'Read'
   if (val === 'write') return 'Write'
@@ -571,6 +693,13 @@ function setViewPermDraft(viewId: string, subjectType: string, subjectId: string
   viewPermDrafts.value = {
     ...viewPermDrafts.value,
     [key]: (event.target as HTMLSelectElement).value,
+  }
+}
+
+function setViewTemplateDraft(subjectType: string, subjectId: string, event: Event) {
+  viewTemplateDrafts.value = {
+    ...viewTemplateDrafts.value,
+    [subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)]: (event.target as HTMLSelectElement).value,
   }
 }
 
@@ -609,6 +738,32 @@ async function clearViewPerm(viewId: string, subjectType: string, subjectId: str
     error.value = cause?.message ?? 'Failed to clear view permission'
   } finally {
     busyViewPermKey.value = null
+  }
+}
+
+async function applyViewTemplate(subjectType: string, subjectId: string) {
+  if (!props.views.length) return
+  const key = subjectKey(subjectType as MetaSheetPermissionSubjectType, subjectId)
+  const permission = viewTemplateDraftValue(subjectType, subjectId)
+  busyViewTemplateKey.value = key
+  clearMessages()
+  try {
+    await Promise.all(
+      props.views.map((view) =>
+        props.client.updateViewPermission(
+          view.id,
+          subjectType as MetaSheetPermissionSubjectType,
+          subjectId,
+          permission,
+        ),
+      ),
+    )
+    status.value = `Applied view permission to ${props.views.length} views`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to apply view permission template'
+  } finally {
+    busyViewTemplateKey.value = null
   }
 }
 
@@ -924,6 +1079,10 @@ onBeforeUnmount(() => {
   grid-template-columns: minmax(0, 1fr) 100px 120px auto;
 }
 
+.meta-sheet-perm__row--template {
+  grid-template-columns: minmax(0, 1fr) 100px 140px auto;
+}
+
 .meta-sheet-perm__field-group {
   display: flex;
   flex-direction: column;
@@ -1093,6 +1252,10 @@ onBeforeUnmount(() => {
   }
 
   .meta-sheet-perm__row--field {
+    grid-template-columns: 1fr;
+  }
+
+  .meta-sheet-perm__row--template {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -362,4 +362,108 @@ describe('MetaSheetPermissionManager', () => {
     expect(client.updateViewPermission).toHaveBeenCalledWith('view_grid', 'member-group', 'group_north', 'none')
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('applies a field template to all fields for a member-group subject', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+        { id: 'fld_owner', name: 'Owner', type: 'string', property: {}, order: 1, options: [] },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    const templateRow = container!.querySelector('[data-field-permission-template="member-group:group_north"]')!
+    const select = templateRow.querySelector('select') as HTMLSelectElement
+    select.value = 'readonly'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(templateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(1, 'sheet_orders', 'fld_title', 'member-group', 'group_north', { visible: true, readOnly: true })
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(2, 'sheet_orders', 'fld_owner', 'member-group', 'group_north', { visible: true, readOnly: true })
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies a view template to all views for a member-group subject', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+        { id: 'view_board', name: 'Board View', type: 'board', sheetId: 'sheet_orders' },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    const templateRow = container!.querySelector('[data-view-permission-template="member-group:group_north"]')!
+    const select = templateRow.querySelector('select') as HTMLSelectElement
+    select.value = 'admin'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(templateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateViewPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateViewPermission).toHaveBeenNthCalledWith(1, 'view_grid', 'member-group', 'group_north', 'admin')
+    expect(client.updateViewPermission).toHaveBeenNthCalledWith(2, 'view_board', 'member-group', 'group_north', 'admin')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/docs/development/multitable-field-view-acl-template-governance-development-20260418.md
+++ b/docs/development/multitable-field-view-acl-template-governance-development-20260418.md
@@ -1,0 +1,50 @@
+# Multitable Field And View ACL Template Governance Development
+
+## Summary
+- Added subject-scoped bulk template actions to `MetaSheetPermissionManager` for field-level and view-level ACL governance.
+- Administrators can now take an existing sheet subject and apply one field permission template to every field in the sheet.
+- Administrators can also apply one view permission template to every view in the sheet.
+
+## Why This Slice
+- The previous stacked slices made field/view overrides manageable one row at a time.
+- The main remaining governance pain was operator throughput:
+  - many fields
+  - many views
+  - one subject at a time
+- This slice improves ACL administration without adding a new permission model or changing backend semantics.
+
+## Runtime Changes
+
+### Field Template Bulk Apply
+- In the field permissions tab, every current sheet subject now gets a bulk template row.
+- Available field template values:
+  - `Default`
+  - `Hidden`
+  - `Read-only`
+- Clicking `Apply to all fields` reuses the existing field-permission authoring API for every field on the active sheet.
+- `Default` uses `{ remove: true }`, so the bulk action clears overrides instead of persisting explicit default-shaped rows.
+
+### View Template Bulk Apply
+- In the view permissions tab, every current sheet subject now gets a bulk template row.
+- Available view template values:
+  - `None`
+  - `Read`
+  - `Write`
+  - `Admin`
+- Clicking `Apply to all views` reuses the existing view-permission authoring API for every view on the active sheet.
+
+### UI Notes
+- The template rows are scoped to current sheet subjects only.
+- No new subject discovery flow was added.
+- Existing one-by-one field/view editing remains unchanged.
+- Existing orphan override handling remains unchanged.
+
+## Files
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+## Out Of Scope
+- No backend API change
+- No migration
+- No new ACL subject type
+- No record-level bulk template flow in this slice

--- a/docs/development/multitable-field-view-acl-template-governance-verification-20260418.md
+++ b/docs/development/multitable-field-view-acl-template-governance-verification-20260418.md
@@ -1,0 +1,28 @@
+# Multitable Field And View ACL Template Governance Verification
+
+## Targeted Frontend Tests
+- Command:
+  - `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+- Result:
+  - `14/14` passed
+
+## Build
+- Command:
+  - `pnpm --filter @metasheet/web build`
+- Result:
+  - passed
+
+## Coverage Highlights
+- Verified field template rows render for current sheet subjects.
+- Verified `Apply to all fields` fans out field-permission updates across every field for a member-group subject.
+- Verified view template rows render for current sheet subjects.
+- Verified `Apply to all views` fans out view-permission updates across every view for a member-group subject.
+- Re-ran record permission manager tests to confirm no regression in the adjacent ACL governance UI.
+
+## Validation Scope
+- No backend changes were made or tested in this slice.
+- No deployment was performed.
+- No migration was added or executed.
+
+## Known Non-Blocking Noise
+- Web build still emits the existing Vite dynamic-import and chunk-size warnings.


### PR DESCRIPTION
## What changed

This stacked slice adds subject-scoped bulk templates for field-level and view-level ACL governance.

- current sheet subjects can now apply one field permission template to every field in the sheet
- current sheet subjects can now apply one view permission template to every view in the sheet
- this reuses the existing field/view permission authoring APIs and does not introduce a new permission model

## Files

- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
- `docs/development/multitable-field-view-acl-template-governance-development-20260418.md`
- `docs/development/multitable-field-view-acl-template-governance-verification-20260418.md`

## Verification

```bash
pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
pnpm --filter @metasheet/web build
```

Results:

- frontend tests: `14/14 passed`
- web build: passed

## Notes

- no backend changes
- no migration
- no deployment performed
- existing Vite build warnings remain unchanged
