### PR TITLE
feat(multitable): link sheet subjects to downstream acl cleanup

### DIFF
--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -44,6 +44,12 @@
               <div class="meta-sheet-perm__identity">
                 <strong>{{ entry.label }}</strong>
                 <span>{{ entry.subtitle || entry.subjectId }}</span>
+                <span
+                  v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
+                  class="meta-sheet-perm__hint meta-sheet-perm__hint--inline"
+                >
+                  {{ subjectOverrideSummaryLabel(entry.subjectType, entry.subjectId) }}
+                </span>
               </div>
               <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
               <span class="meta-sheet-perm__badge" :data-access-level="entry.accessLevel">{{ accessLevelLabel(entry.accessLevel) }}</span>
@@ -68,6 +74,16 @@
                 @click="applyEntry(entry.subjectType, entry.subjectId)"
               >
                 Save
+              </button>
+              <button
+                v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
+                class="meta-sheet-perm__action"
+                type="button"
+                :data-sheet-permission-clear-overrides="subjectKey(entry.subjectType, entry.subjectId)"
+                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId)"
+                @click="clearSubjectOverrides(entry.subjectType, entry.subjectId)"
+              >
+                Clear overrides
               </button>
               <button
                 class="meta-sheet-perm__action meta-sheet-perm__action--danger"
@@ -777,6 +793,22 @@ const peopleCandidates = computed(() => availableCandidates.value.filter((candid
 const memberGroupCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'member-group'))
 const roleCandidates = computed(() => availableCandidates.value.filter((candidate) => candidate.subjectType === 'role'))
 const activeSheetSubjectKeys = computed(() => new Set(entries.value.map((entry) => subjectKey(entry.subjectType, entry.subjectId))))
+const subjectOverrideCounts = computed<Record<string, { fieldCount: number; viewCount: number }>>(() => {
+  const counts: Record<string, { fieldCount: number; viewCount: number }> = {}
+  for (const entry of props.fieldPermissionEntries) {
+    const key = subjectKey(entry.subjectType, entry.subjectId)
+    const current = counts[key] ?? { fieldCount: 0, viewCount: 0 }
+    current.fieldCount += 1
+    counts[key] = current
+  }
+  for (const entry of props.viewPermissionEntries) {
+    const key = subjectKey(entry.subjectType, entry.subjectId)
+    const current = counts[key] ?? { fieldCount: 0, viewCount: 0 }
+    current.viewCount += 1
+    counts[key] = current
+  }
+  return counts
+})
 const fieldPermissionOrphans = computed(() =>
   props.fieldPermissionEntries.filter((entry) => !activeSheetSubjectKeys.value.has(subjectKey(entry.subjectType, entry.subjectId))),
 )
@@ -799,6 +831,23 @@ const viewPermissionOrphansByView = computed<Record<string, MetaViewPermissionEn
 })
 const hasFieldOrphans = computed(() => fieldPermissionOrphans.value.length > 0)
 const hasViewOrphans = computed(() => viewPermissionOrphans.value.length > 0)
+
+function subjectOverrideCountsFor(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
+  return subjectOverrideCounts.value[subjectKey(subjectType, subjectId)] ?? { fieldCount: 0, viewCount: 0 }
+}
+
+function hasSubjectOverrides(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
+  const counts = subjectOverrideCountsFor(subjectType, subjectId)
+  return counts.fieldCount > 0 || counts.viewCount > 0
+}
+
+function subjectOverrideSummaryLabel(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
+  const counts = subjectOverrideCountsFor(subjectType, subjectId)
+  const parts: string[] = []
+  if (counts.fieldCount > 0) parts.push(`${counts.fieldCount} field override${counts.fieldCount === 1 ? '' : 's'}`)
+  if (counts.viewCount > 0) parts.push(`${counts.viewCount} view override${counts.viewCount === 1 ? '' : 's'}`)
+  return parts.join(' · ')
+}
 
 function accessLevelLabel(accessLevel: MetaSheetPermissionAccessLevel) {
   return ACCESS_LEVEL_OPTIONS.find((option) => option.value === accessLevel)?.label ?? accessLevel
@@ -939,6 +988,36 @@ async function removeEntry(subjectType: MetaSheetPermissionSubjectType, subjectI
 async function grantCandidate(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   const key = subjectKey(subjectType, subjectId)
   await updateSubjectAccess(subjectType, subjectId, candidateDrafts.value[key] ?? 'read', 'Sheet access override saved')
+}
+
+async function clearSubjectOverrides(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
+  const key = subjectKey(subjectType, subjectId)
+  const fieldOverrides = props.fieldPermissionEntries.filter(
+    (entry) => entry.subjectType === subjectType && entry.subjectId === subjectId,
+  )
+  const viewOverrides = props.viewPermissionEntries.filter(
+    (entry) => entry.subjectType === subjectType && entry.subjectId === subjectId,
+  )
+  if (!fieldOverrides.length && !viewOverrides.length) return
+
+  busySubjectKey.value = key
+  clearMessages()
+  try {
+    await Promise.all([
+      ...fieldOverrides.map((entry) =>
+        props.client.updateFieldPermission(props.sheetId, entry.fieldId, subjectType, subjectId, { remove: true }),
+      ),
+      ...viewOverrides.map((entry) =>
+        props.client.updateViewPermission(entry.viewId, subjectType, subjectId, 'none'),
+      ),
+    ])
+    status.value = `Cleared ${subjectOverrideSummaryLabel(subjectType, subjectId)}`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear subject overrides'
+  } finally {
+    busySubjectKey.value = null
+  }
 }
 
 watch(
@@ -1163,6 +1242,10 @@ onBeforeUnmount(() => {
   color: #64748b;
   font-size: 12px;
   font-weight: 500;
+}
+
+.meta-sheet-perm__hint--inline {
+  margin-top: 2px;
 }
 
 .meta-sheet-perm__subject {

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -363,6 +363,88 @@ describe('MetaSheetPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('shows subject override summaries and clears downstream overrides for a sheet subject', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'write',
+            permissions: ['spreadsheet:write'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+        { id: 'fld_owner', name: 'Owner', type: 'string', property: {}, order: 1, options: [] },
+      ],
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          visible: true,
+          readOnly: true,
+          isActive: true,
+        },
+        {
+          fieldId: 'fld_owner',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          visible: false,
+          readOnly: false,
+          isActive: true,
+        },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          permission: 'admin',
+          isActive: true,
+        },
+      ],
+    })
+    await flushUi()
+
+    const sheetRow = container!.querySelector('[data-sheet-permission-entry="member-group:group_north"]')!
+    expect(sheetRow.textContent).toContain('2 field overrides')
+    expect(sheetRow.textContent).toContain('1 view override')
+
+    ;(container!.querySelector('[data-sheet-permission-clear-overrides="member-group:group_north"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(1, 'sheet_orders', 'fld_title', 'member-group', 'group_north', { remove: true })
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(2, 'sheet_orders', 'fld_owner', 'member-group', 'group_north', { remove: true })
+    expect(client.updateViewPermission).toHaveBeenCalledWith('view_grid', 'member-group', 'group_north', 'none')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('applies a field template to all fields for a member-group subject', async () => {
     const updatedSpy = vi.fn()
     const client = {

--- a/docs/development/multitable-sheet-acl-linkage-cleanup-development-20260418.md
+++ b/docs/development/multitable-sheet-acl-linkage-cleanup-development-20260418.md
@@ -1,0 +1,29 @@
+# Multitable Sheet ACL Linkage Cleanup Development 2026-04-18
+
+## Goal
+
+Close a governance gap in the sheet access manager: when a subject still has field/view overrides, surface that linkage directly on the sheet access row and allow one-click downstream cleanup without forcing operators to hunt through orphan rows later.
+
+## Scope
+
+- show per-subject downstream override counts on the sheet access list
+- add a `Clear overrides` action for subjects that still own field/view overrides
+- keep the slice frontend-only and reuse existing field/view authoring APIs
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+## Implementation Notes
+
+1. Added subject-level override counting derived from existing `fieldPermissionEntries` and `viewPermissionEntries`.
+2. Exposed a summary hint on each sheet access row when the subject still owns downstream overrides.
+3. Added a `Clear overrides` action that:
+   - removes matching field overrides via `updateFieldPermission(..., { remove: true })`
+   - clears matching view overrides via `updateViewPermission(..., 'none')`
+4. Reused `busySubjectKey` and existing status/error surfaces so the slice stays consistent with the rest of the manager.
+
+## Why This Slice
+
+`#904` made orphan field/view overrides visible and individually clearable. The remaining operational gap was still real: removing or refactoring a sheet subject could leave many lower-level overrides behind. This slice closes that last cleanup loop without inventing a new ACL model.

--- a/docs/development/multitable-sheet-acl-linkage-cleanup-verification-20260418.md
+++ b/docs/development/multitable-sheet-acl-linkage-cleanup-verification-20260418.md
@@ -1,0 +1,35 @@
+# Multitable Sheet ACL Linkage Cleanup Verification 2026-04-18
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`
+  - passed
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+  - `15/15 passed`
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Coverage of This Slice
+
+- sheet access rows show downstream override counts for linked subjects
+- operators can clear matching field and view overrides directly from the sheet access row
+- existing field/view template and record permission manager tests remain green
+
+## Known Non-Blocking Noise
+
+- web build still prints the existing Vite dynamic-import and chunk-size warnings
+- no new runtime or test failures were introduced by this slice
+
+## Deployment
+
+- none
+- no backend changes
+- no database migration


### PR DESCRIPTION
## Summary\n- show downstream field/view override counts on sheet access rows\n- add a one-click clear-overrides action for sheet subjects\n- document the development and verification for this governance cleanup slice\n\n## Verification\n- pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false\n- pnpm --filter @metasheet/web build