### PR TITLE
feat(multitable): surface inactive acl subjects

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -26,11 +26,18 @@
             :key="entry.id"
             class="meta-record-perm__row"
             :data-record-permission-entry="entry.id"
-          >
-            <div class="meta-record-perm__identity">
-              <strong>{{ entry.label }}</strong>
-              <span>{{ entry.subtitle || entry.subjectId }}</span>
-            </div>
+            >
+              <div class="meta-record-perm__identity">
+                <strong>{{ entry.label }}</strong>
+                <span>{{ entry.subtitle || entry.subjectId }}</span>
+                <span
+                  v-if="subjectIsInactive(entry.subjectType, entry.isActive)"
+                  class="meta-record-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
+              </div>
             <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeLabel(entry.subjectType) }}</span>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
               {{ accessLevelLabel(entryDrafts[entry.id] ?? entry.accessLevel) }}
@@ -93,6 +100,13 @@
               <div class="meta-record-perm__identity">
                 <strong>{{ candidate.label }}</strong>
                 <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                <span
+                  v-if="subjectIsInactive(candidate.subjectType, candidate.isActive)"
+                  class="meta-record-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
               </div>
               <span class="meta-record-perm__subject" data-subject-type="user">User</span>
               <select
@@ -231,6 +245,10 @@ function subjectTypeLabel(subjectType: string): string {
   if (subjectType === 'role') return 'Role'
   if (subjectType === 'member-group') return 'Member group'
   return 'User'
+}
+
+function subjectIsInactive(subjectType: string, isActive: boolean) {
+  return subjectType === 'user' && isActive === false
 }
 
 function requestClose() {
@@ -532,6 +550,18 @@ watch(
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.meta-record-perm__lifecycle {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .meta-record-perm__subject {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -45,6 +45,13 @@
                 <strong>{{ entry.label }}</strong>
                 <span>{{ entry.subtitle || entry.subjectId }}</span>
                 <span
+                  v-if="subjectIsInactive(entry.subjectType, entry.isActive)"
+                  class="meta-sheet-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
+                <span
                   v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
                   class="meta-sheet-perm__hint meta-sheet-perm__hint--inline"
                 >
@@ -123,6 +130,13 @@
                 <div class="meta-sheet-perm__identity">
                   <strong>{{ candidate.label }}</strong>
                   <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                  <span
+                    v-if="subjectIsInactive(candidate.subjectType, candidate.isActive)"
+                    class="meta-sheet-perm__lifecycle"
+                    data-lifecycle="inactive"
+                  >
+                    Inactive user
+                  </span>
                 </div>
                 <span class="meta-sheet-perm__subject" data-subject-type="user">Person</span>
                 <select
@@ -863,6 +877,10 @@ function subjectTypeBadgeLabel(subjectType: MetaSheetPermissionSubjectType) {
   return 'Person'
 }
 
+function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+  return subjectType === 'user' && isActive === false
+}
+
 function requestClose() {
   emit('close')
 }
@@ -1194,6 +1212,18 @@ onBeforeUnmount(() => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.meta-sheet-perm__lifecycle {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .meta-sheet-perm__badge {

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -192,6 +192,45 @@ describe('MetaRecordPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('surfaces inactive users in current record access and candidate results', async () => {
+    const client = makeClient({
+      listRecordPermissions: vi.fn().mockResolvedValue([
+        {
+          id: 'perm_inactive',
+          sheetId: 'sheet_1',
+          recordId: 'record_1',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          accessLevel: 'read',
+          label: 'Morgan',
+          subtitle: 'morgan@example.com',
+          isActive: false,
+        },
+      ]),
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_candidate_inactive',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'Taylor',
+            subtitle: 'taylor@example.com',
+            isActive: false,
+          },
+        ],
+      }),
+    })
+
+    mountManager({ client })
+    await flushUi()
+
+    const inactiveEntry = container!.querySelector('[data-record-permission-entry="perm_inactive"]')!
+    const inactiveCandidate = container!.querySelector('[data-record-permission-candidate="user:user_candidate_inactive"]')!
+    expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Inactive user')
+  })
+
   it('searches across sheet subjects and global candidates when granting record access', async () => {
     const client = makeClient({
       listSheetPermissions: vi.fn().mockResolvedValue({

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -224,6 +224,47 @@ describe('MetaSheetPermissionManager', () => {
     expect(container!.querySelector('[data-sheet-permission-entry="member-group:3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c"]')).not.toBeNull()
   })
 
+  it('surfaces inactive users in sheet entries and candidate results', async () => {
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_inactive',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'Morgan',
+            subtitle: 'morgan@example.com',
+            isActive: false,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_candidate_inactive',
+            label: 'Taylor',
+            subtitle: 'taylor@example.com',
+            isActive: false,
+            accessLevel: null,
+          },
+        ],
+      }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({ client })
+    await flushUi()
+
+    const inactiveEntry = container!.querySelector('[data-sheet-permission-entry="user:user_inactive"]')!
+    const inactiveCandidate = container!.querySelector('[data-sheet-permission-candidate="user:user_candidate_inactive"]')!
+    expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Inactive user')
+  })
+
   it('clears field defaults by removing overrides and shows orphan field overrides', async () => {
     const updatedSpy = vi.fn()
     const client = {

--- a/docs/development/multitable-acl-inactive-subject-visibility-development-20260418.md
+++ b/docs/development/multitable-acl-inactive-subject-visibility-development-20260418.md
@@ -1,0 +1,31 @@
+# Multitable ACL Inactive Subject Visibility Development 2026-04-18
+
+## Goal
+
+Surface inactive users directly inside the multitable ACL management UI so operators can distinguish live governance subjects from disabled identities without inspecting another admin page.
+
+## Scope
+
+- show `Inactive user` on sheet ACL rows and candidate results when the subject is a disabled user
+- show `Inactive user` on record ACL rows and candidate results for the same case
+- keep the slice frontend-only and reuse the existing `isActive` data already returned by the APIs
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Implementation Notes
+
+1. Added a lightweight `subjectIsInactive(...)` helper in both managers.
+2. Rendered an inline `Inactive user` lifecycle pill only when:
+   - `subjectType === 'user'`
+   - `isActive === false`
+3. Kept role and member-group rendering unchanged.
+4. Reused existing hydrated entry/candidate payloads instead of changing backend contracts.
+
+## Why This Slice
+
+Current multitable ACL APIs already hydrate `isActive`, but the management UI did not expose it. That created a governance blind spot: disabled users looked the same as active users in sheet and record permission surfaces, which made stale access review harder than necessary.

--- a/docs/development/multitable-acl-inactive-subject-visibility-verification-20260418.md
+++ b/docs/development/multitable-acl-inactive-subject-visibility-verification-20260418.md
@@ -1,0 +1,36 @@
+# Multitable ACL Inactive Subject Visibility Verification 2026-04-18
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`
+  - passed
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+  - `17/17 passed`
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Coverage of This Slice
+
+- inactive users are marked in sheet ACL current-access rows
+- inactive users are marked in sheet ACL candidate results
+- inactive users are marked in record ACL current-access rows
+- inactive users are marked in record ACL candidate results
+
+## Known Non-Blocking Noise
+
+- web build still prints the existing Vite dynamic-import warning
+- web build still prints the existing chunk-size warning
+
+## Deployment
+
+- none
+- frontend-only
+- no database migration


### PR DESCRIPTION
## Summary
- surface inactive users in sheet ACL current-access and candidate rows
- surface inactive users in record ACL current-access and candidate rows
- document the development and verification for this governance visibility slice

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build