### PR TITLE
feat(multitable): bulk-clear orphan acl overrides

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -26,11 +26,18 @@
             :key="entry.id"
             class="meta-record-perm__row"
             :data-record-permission-entry="entry.id"
-          >
-            <div class="meta-record-perm__identity">
-              <strong>{{ entry.label }}</strong>
-              <span>{{ entry.subtitle || entry.subjectId }}</span>
-            </div>
+            >
+              <div class="meta-record-perm__identity">
+                <strong>{{ entry.label }}</strong>
+                <span>{{ entry.subtitle || entry.subjectId }}</span>
+                <span
+                  v-if="subjectIsInactive(entry.subjectType, entry.isActive)"
+                  class="meta-record-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
+              </div>
             <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeLabel(entry.subjectType) }}</span>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
               {{ accessLevelLabel(entryDrafts[entry.id] ?? entry.accessLevel) }}
@@ -93,6 +100,13 @@
               <div class="meta-record-perm__identity">
                 <strong>{{ candidate.label }}</strong>
                 <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                <span
+                  v-if="subjectIsInactive(candidate.subjectType, candidate.isActive)"
+                  class="meta-record-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
               </div>
               <span class="meta-record-perm__subject" data-subject-type="user">User</span>
               <select
@@ -231,6 +245,10 @@ function subjectTypeLabel(subjectType: string): string {
   if (subjectType === 'role') return 'Role'
   if (subjectType === 'member-group') return 'Member group'
   return 'User'
+}
+
+function subjectIsInactive(subjectType: string, isActive: boolean) {
+  return subjectType === 'user' && isActive === false
 }
 
 function requestClose() {
@@ -532,6 +550,18 @@ watch(
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.meta-record-perm__lifecycle {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .meta-record-perm__subject {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -45,6 +45,13 @@
                 <strong>{{ entry.label }}</strong>
                 <span>{{ entry.subtitle || entry.subjectId }}</span>
                 <span
+                  v-if="subjectIsInactive(entry.subjectType, entry.isActive)"
+                  class="meta-sheet-perm__lifecycle"
+                  data-lifecycle="inactive"
+                >
+                  Inactive user
+                </span>
+                <span
                   v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
                   class="meta-sheet-perm__hint meta-sheet-perm__hint--inline"
                 >
@@ -123,6 +130,13 @@
                 <div class="meta-sheet-perm__identity">
                   <strong>{{ candidate.label }}</strong>
                   <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                  <span
+                    v-if="subjectIsInactive(candidate.subjectType, candidate.isActive)"
+                    class="meta-sheet-perm__lifecycle"
+                    data-lifecycle="inactive"
+                  >
+                    Inactive user
+                  </span>
                 </div>
                 <span class="meta-sheet-perm__subject" data-subject-type="user">Person</span>
                 <select
@@ -863,6 +877,10 @@ function subjectTypeBadgeLabel(subjectType: MetaSheetPermissionSubjectType) {
   return 'Person'
 }
 
+function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+  return subjectType === 'user' && isActive === false
+}
+
 function requestClose() {
   emit('close')
 }
@@ -1194,6 +1212,18 @@ onBeforeUnmount(() => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.meta-sheet-perm__lifecycle {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .meta-sheet-perm__badge {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -295,7 +295,19 @@
               >
                 <div class="meta-sheet-perm__section-header">
                   <strong>{{ field.name }}</strong>
-                  <span class="meta-sheet-perm__badge">{{ field.type }}</span>
+                  <div class="meta-sheet-perm__section-actions">
+                    <span class="meta-sheet-perm__badge">{{ field.type }}</span>
+                    <button
+                      v-if="(fieldPermissionOrphansByField[field.id]?.length ?? 0) > 1"
+                      class="meta-sheet-perm__action meta-sheet-perm__action--danger"
+                      type="button"
+                      :data-field-permission-clear-orphans="field.id"
+                      :disabled="busyFieldOrphanBulkKey === field.id"
+                      @click="clearFieldOrphans(field.id)"
+                    >
+                      Clear orphan overrides
+                    </button>
+                  </div>
                 </div>
                 <div
                   v-for="entry in entries"
@@ -415,7 +427,19 @@
               >
                 <div class="meta-sheet-perm__section-header">
                   <strong>{{ view.name }}</strong>
-                  <span class="meta-sheet-perm__badge">{{ view.type }}</span>
+                  <div class="meta-sheet-perm__section-actions">
+                    <span class="meta-sheet-perm__badge">{{ view.type }}</span>
+                    <button
+                      v-if="(viewPermissionOrphansByView[view.id]?.length ?? 0) > 1"
+                      class="meta-sheet-perm__action meta-sheet-perm__action--danger"
+                      type="button"
+                      :data-view-permission-clear-orphans="view.id"
+                      :disabled="busyViewOrphanBulkKey === view.id"
+                      @click="clearViewOrphans(view.id)"
+                    >
+                      Clear orphan overrides
+                    </button>
+                  </div>
                 </div>
                 <div
                   v-for="entry in entries"
@@ -558,12 +582,14 @@ const fieldPermDrafts = ref<Record<string, string>>({})
 const busyFieldPermKey = ref<string | null>(null)
 const fieldTemplateDrafts = ref<Record<string, string>>({})
 const busyFieldTemplateKey = ref<string | null>(null)
+const busyFieldOrphanBulkKey = ref<string | null>(null)
 
 // View permission drafts
 const viewPermDrafts = ref<Record<string, string>>({})
 const busyViewPermKey = ref<string | null>(null)
 const viewTemplateDrafts = ref<Record<string, string>>({})
 const busyViewTemplateKey = ref<string | null>(null)
+const busyViewOrphanBulkKey = ref<string | null>(null)
 
 function subjectKey(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   return `${subjectType}:${subjectId}`
@@ -655,6 +681,26 @@ async function clearFieldPerm(fieldId: string, subjectType: string, subjectId: s
     error.value = cause?.message ?? 'Failed to clear field permission'
   } finally {
     busyFieldPermKey.value = null
+  }
+}
+
+async function clearFieldOrphans(fieldId: string) {
+  const orphans = fieldPermissionOrphansByField.value[fieldId] ?? []
+  if (!orphans.length) return
+  busyFieldOrphanBulkKey.value = fieldId
+  clearMessages()
+  try {
+    await Promise.all(
+      orphans.map((entry) =>
+        props.client.updateFieldPermission(props.sheetId, fieldId, entry.subjectType, entry.subjectId, { remove: true }),
+      ),
+    )
+    status.value = `Cleared ${orphans.length} orphan field override${orphans.length === 1 ? '' : 's'}`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear orphan field overrides'
+  } finally {
+    busyFieldOrphanBulkKey.value = null
   }
 }
 
@@ -768,6 +814,26 @@ async function clearViewPerm(viewId: string, subjectType: string, subjectId: str
     error.value = cause?.message ?? 'Failed to clear view permission'
   } finally {
     busyViewPermKey.value = null
+  }
+}
+
+async function clearViewOrphans(viewId: string) {
+  const orphans = viewPermissionOrphansByView.value[viewId] ?? []
+  if (!orphans.length) return
+  busyViewOrphanBulkKey.value = viewId
+  clearMessages()
+  try {
+    await Promise.all(
+      orphans.map((entry) =>
+        props.client.updateViewPermission(viewId, entry.subjectType, entry.subjectId, 'none'),
+      ),
+    )
+    status.value = `Cleared ${orphans.length} orphan view override${orphans.length === 1 ? '' : 's'}`
+    emit('updated')
+  } catch (cause: any) {
+    error.value = cause?.message ?? 'Failed to clear orphan view overrides'
+  } finally {
+    busyViewOrphanBulkKey.value = null
   }
 }
 
@@ -1159,6 +1225,14 @@ onBeforeUnmount(() => {
   align-items: center;
   justify-content: space-between;
   color: #0f172a;
+}
+
+.meta-sheet-perm__section-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .meta-sheet-perm__row {

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -192,6 +192,45 @@ describe('MetaRecordPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('surfaces inactive users in current record access and candidate results', async () => {
+    const client = makeClient({
+      listRecordPermissions: vi.fn().mockResolvedValue([
+        {
+          id: 'perm_inactive',
+          sheetId: 'sheet_1',
+          recordId: 'record_1',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          accessLevel: 'read',
+          label: 'Morgan',
+          subtitle: 'morgan@example.com',
+          isActive: false,
+        },
+      ]),
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_candidate_inactive',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'Taylor',
+            subtitle: 'taylor@example.com',
+            isActive: false,
+          },
+        ],
+      }),
+    })
+
+    mountManager({ client })
+    await flushUi()
+
+    const inactiveEntry = container!.querySelector('[data-record-permission-entry="perm_inactive"]')!
+    const inactiveCandidate = container!.querySelector('[data-record-permission-candidate="user:user_candidate_inactive"]')!
+    expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Inactive user')
+  })
+
   it('searches across sheet subjects and global candidates when granting record access', async () => {
     const client = makeClient({
       listSheetPermissions: vi.fn().mockResolvedValue({

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -404,6 +404,114 @@ describe('MetaSheetPermissionManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('clears all orphan field overrides for a field in one action', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({ items: [] }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          visible: true,
+          readOnly: true,
+          isActive: true,
+        },
+        {
+          fieldId: 'fld_title',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          subjectLabel: 'Morgan',
+          subjectSubtitle: 'morgan@example.com',
+          visible: false,
+          readOnly: false,
+          isActive: false,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    ;(container!.querySelector('[data-field-permission-clear-orphans="fld_title"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateFieldPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(1, 'sheet_orders', 'fld_title', 'member-group', 'group_north', { remove: true })
+    expect(client.updateFieldPermission).toHaveBeenNthCalledWith(2, 'sheet_orders', 'fld_title', 'user', 'user_inactive', { remove: true })
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears all orphan view overrides for a view in one action', async () => {
+    const updatedSpy = vi.fn()
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({ items: [] }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      onUpdated: updatedSpy,
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'member-group',
+          subjectId: 'group_north',
+          subjectLabel: 'North Region',
+          subjectSubtitle: 'Regional operations',
+          permission: 'admin',
+          isActive: true,
+        },
+        {
+          viewId: 'view_grid',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          subjectLabel: 'Morgan',
+          subjectSubtitle: 'morgan@example.com',
+          permission: 'read',
+          isActive: false,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    ;(container!.querySelector('[data-view-permission-clear-orphans="view_grid"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(client.updateViewPermission).toHaveBeenCalledTimes(2)
+    expect(client.updateViewPermission).toHaveBeenNthCalledWith(1, 'view_grid', 'member-group', 'group_north', 'none')
+    expect(client.updateViewPermission).toHaveBeenNthCalledWith(2, 'view_grid', 'user', 'user_inactive', 'none')
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('shows subject override summaries and clears downstream overrides for a sheet subject', async () => {
     const updatedSpy = vi.fn()
     const client = {

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -224,6 +224,47 @@ describe('MetaSheetPermissionManager', () => {
     expect(container!.querySelector('[data-sheet-permission-entry="member-group:3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c"]')).not.toBeNull()
   })
 
+  it('surfaces inactive users in sheet entries and candidate results', async () => {
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_inactive',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'Morgan',
+            subtitle: 'morgan@example.com',
+            isActive: false,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_candidate_inactive',
+            label: 'Taylor',
+            subtitle: 'taylor@example.com',
+            isActive: false,
+            accessLevel: null,
+          },
+        ],
+      }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({ client })
+    await flushUi()
+
+    const inactiveEntry = container!.querySelector('[data-sheet-permission-entry="user:user_inactive"]')!
+    const inactiveCandidate = container!.querySelector('[data-sheet-permission-candidate="user:user_candidate_inactive"]')!
+    expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Inactive user')
+  })
+
   it('clears field defaults by removing overrides and shows orphan field overrides', async () => {
     const updatedSpy = vi.fn()
     const client = {

--- a/docs/development/multitable-acl-inactive-subject-visibility-development-20260418.md
+++ b/docs/development/multitable-acl-inactive-subject-visibility-development-20260418.md
@@ -1,0 +1,31 @@
+# Multitable ACL Inactive Subject Visibility Development 2026-04-18
+
+## Goal
+
+Surface inactive users directly inside the multitable ACL management UI so operators can distinguish live governance subjects from disabled identities without inspecting another admin page.
+
+## Scope
+
+- show `Inactive user` on sheet ACL rows and candidate results when the subject is a disabled user
+- show `Inactive user` on record ACL rows and candidate results for the same case
+- keep the slice frontend-only and reuse the existing `isActive` data already returned by the APIs
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Implementation Notes
+
+1. Added a lightweight `subjectIsInactive(...)` helper in both managers.
+2. Rendered an inline `Inactive user` lifecycle pill only when:
+   - `subjectType === 'user'`
+   - `isActive === false`
+3. Kept role and member-group rendering unchanged.
+4. Reused existing hydrated entry/candidate payloads instead of changing backend contracts.
+
+## Why This Slice
+
+Current multitable ACL APIs already hydrate `isActive`, but the management UI did not expose it. That created a governance blind spot: disabled users looked the same as active users in sheet and record permission surfaces, which made stale access review harder than necessary.

--- a/docs/development/multitable-acl-inactive-subject-visibility-verification-20260418.md
+++ b/docs/development/multitable-acl-inactive-subject-visibility-verification-20260418.md
@@ -1,0 +1,36 @@
+# Multitable ACL Inactive Subject Visibility Verification 2026-04-18
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`
+  - passed
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+  - `17/17 passed`
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Coverage of This Slice
+
+- inactive users are marked in sheet ACL current-access rows
+- inactive users are marked in sheet ACL candidate results
+- inactive users are marked in record ACL current-access rows
+- inactive users are marked in record ACL candidate results
+
+## Known Non-Blocking Noise
+
+- web build still prints the existing Vite dynamic-import warning
+- web build still prints the existing chunk-size warning
+
+## Deployment
+
+- none
+- frontend-only
+- no database migration

--- a/docs/development/multitable-orphan-bulk-cleanup-development-20260418.md
+++ b/docs/development/multitable-orphan-bulk-cleanup-development-20260418.md
@@ -1,0 +1,31 @@
+# Multitable Orphan Bulk Cleanup Development 2026-04-18
+
+## Goal
+
+Reduce repetitive cleanup work in the field/view permission managers by allowing operators to clear orphan overrides in bulk per field or per view.
+
+## Scope
+
+- add `Clear orphan overrides` for field groups when a field has multiple orphan overrides
+- add `Clear orphan overrides` for view groups when a view has multiple orphan overrides
+- keep the slice frontend-only and reuse existing field/view permission authoring APIs
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+## Implementation Notes
+
+1. Added grouped cleanup actions inside field/view section headers.
+2. Introduced small bulk-busy states so batch cleanup does not overlap with per-row writes.
+3. Implemented:
+   - `clearFieldOrphans(fieldId)`
+   - `clearViewOrphans(viewId)`
+4. Reused existing:
+   - `updateFieldPermission(..., { remove: true })`
+   - `updateViewPermission(..., 'none')`
+
+## Why This Slice
+
+`#904` made orphan overrides visible and individually clearable. `#907` then linked sheet subjects to downstream cleanup. The remaining operational gap was still obvious: a field or view with many orphan overrides required many repetitive clicks. This slice closes that cleanup loop without changing ACL semantics.

--- a/docs/development/multitable-orphan-bulk-cleanup-verification-20260418.md
+++ b/docs/development/multitable-orphan-bulk-cleanup-verification-20260418.md
@@ -1,0 +1,35 @@
+# Multitable Orphan Bulk Cleanup Verification 2026-04-18
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`
+  - passed
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false`
+  - `19/19 passed`
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Coverage of This Slice
+
+- bulk-clear orphan field overrides for a field
+- bulk-clear orphan view overrides for a view
+- existing sheet subject cleanup and record manager tests remain green
+
+## Known Non-Blocking Noise
+
+- web build still prints the existing Vite dynamic-import warning
+- web build still prints the existing chunk-size warning
+
+## Deployment
+
+- none
+- frontend-only
+- no database migration


### PR DESCRIPTION
## Summary
- add field-level bulk orphan override cleanup
- add view-level bulk orphan override cleanup
- document the development and verification for this governance cleanup slice

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build