### PR TITLE
fix(multitable): lock inactive acl entries to cleanup only

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -45,7 +45,7 @@
             <select
               :value="entryDrafts[entry.id] ?? entry.accessLevel"
               class="meta-record-perm__select"
-              :disabled="busyKey === entry.id"
+              :disabled="busyKey === entry.id || subjectMutationBlocked(entry.subjectType, entry.isActive)"
               @change="setEntryDraft(entry.id, $event)"
             >
               <option value="read">Read</option>
@@ -55,7 +55,7 @@
             <button
               class="meta-record-perm__action"
               type="button"
-              :disabled="busyKey === entry.id || (entryDrafts[entry.id] ?? entry.accessLevel) === entry.accessLevel"
+              :disabled="busyKey === entry.id || subjectMutationBlocked(entry.subjectType, entry.isActive) || (entryDrafts[entry.id] ?? entry.accessLevel) === entry.accessLevel"
               @click="saveEntry(entry)"
             >
               Save
@@ -251,8 +251,12 @@ function subjectIsInactive(subjectType: string, isActive: boolean) {
   return subjectType === 'user' && isActive === false
 }
 
+function subjectMutationBlocked(subjectType: string, isActive: boolean) {
+  return subjectIsInactive(subjectType, isActive)
+}
+
 function candidateGrantBlocked(candidate: MetaSheetPermissionCandidate) {
-  return subjectIsInactive(candidate.subjectType, candidate.isActive)
+  return subjectMutationBlocked(candidate.subjectType, candidate.isActive)
 }
 
 function requestClose() {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -63,7 +63,7 @@
               <select
                 :value="entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel"
                 class="meta-sheet-perm__select"
-                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId)"
+                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                 @change="setEntryDraft(entry.subjectType, entry.subjectId, $event)"
               >
                 <option
@@ -77,7 +77,7 @@
               <button
                 class="meta-sheet-perm__action"
                 type="button"
-                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId) || (entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel) === entry.accessLevel"
+                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive) || (entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel) === entry.accessLevel"
                 @click="applyEntry(entry.subjectType, entry.subjectId)"
               >
                 Save
@@ -266,12 +266,19 @@
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
                     <span>{{ entry.subtitle || entry.subjectId }}</span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__lifecycle"
+                      data-lifecycle="inactive"
+                    >
+                      Inactive user
+                    </span>
                   </div>
                   <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   <select
                     :value="fieldTemplateDraftValue(entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
-                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setFieldTemplateDraft(entry.subjectType, entry.subjectId, $event)"
                   >
                     <option value="default">Default</option>
@@ -281,7 +288,7 @@
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                     type="button"
-                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyFieldTemplate(entry.subjectType, entry.subjectId)"
                   >
                     Apply to all fields
@@ -318,6 +325,13 @@
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
                     <span>{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__lifecycle"
+                      data-lifecycle="inactive"
+                    >
+                      Inactive user
+                    </span>
                   </div>
                   <span
                     class="meta-sheet-perm__badge"
@@ -328,7 +342,7 @@
                   <select
                     :value="fieldPermDraftValue(field.id, entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
-                    :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId)"
+                    :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setFieldPermDraft(field.id, entry.subjectType, entry.subjectId, $event)"
                   >
                     <option value="default">Default</option>
@@ -338,7 +352,7 @@
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                     type="button"
-                    :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId)"
+                    :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyFieldPerm(field.id, entry.subjectType, entry.subjectId)"
                   >
                     Save
@@ -397,12 +411,19 @@
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
                     <span>{{ entry.subtitle || entry.subjectId }}</span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__lifecycle"
+                      data-lifecycle="inactive"
+                    >
+                      Inactive user
+                    </span>
                   </div>
                   <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   <select
                     :value="viewTemplateDraftValue(entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
-                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setViewTemplateDraft(entry.subjectType, entry.subjectId, $event)"
                   >
                     <option value="none">None</option>
@@ -413,7 +434,7 @@
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                     type="button"
-                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyViewTemplate(entry.subjectType, entry.subjectId)"
                   >
                     Apply to all views
@@ -450,6 +471,13 @@
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
                     <span>{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__lifecycle"
+                      data-lifecycle="inactive"
+                    >
+                      Inactive user
+                    </span>
                   </div>
                   <span
                     class="meta-sheet-perm__badge"
@@ -460,7 +488,7 @@
                   <select
                     :value="viewPermDraftValue(view.id, entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
-                    :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId)"
+                    :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setViewPermDraft(view.id, entry.subjectType, entry.subjectId, $event)"
                   >
                     <option value="none">None</option>
@@ -471,7 +499,7 @@
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                     type="button"
-                    :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId)"
+                    :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyViewPerm(view.id, entry.subjectType, entry.subjectId)"
                   >
                     Save
@@ -947,8 +975,12 @@ function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive
   return subjectType === 'user' && isActive === false
 }
 
+function subjectMutationBlocked(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+  return subjectIsInactive(subjectType, isActive)
+}
+
 function candidateGrantBlocked(candidate: MetaSheetPermissionCandidate) {
-  return subjectIsInactive(candidate.subjectType, candidate.isActive)
+  return subjectMutationBlocked(candidate.subjectType, candidate.isActive)
 }
 
 function requestClose() {

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -229,6 +229,9 @@ describe('MetaRecordPermissionManager', () => {
     const inactiveCandidate = container!.querySelector('[data-record-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect((inactiveEntry.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((inactiveEntry.querySelector('.meta-record-perm__action') as HTMLButtonElement).disabled).toBe(true)
+    expect((inactiveEntry.querySelector('.meta-record-perm__action--danger') as HTMLButtonElement).disabled).toBe(false)
     expect((inactiveCandidate.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveCandidate.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
   })

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -256,15 +256,53 @@ describe('MetaSheetPermissionManager', () => {
       updateViewPermission: vi.fn().mockResolvedValue({}),
     }
 
-    mountManager({ client })
+    mountManager({
+      client,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+    })
     await flushUi()
 
     const inactiveEntry = container!.querySelector('[data-sheet-permission-entry="user:user_inactive"]')!
     const inactiveCandidate = container!.querySelector('[data-sheet-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect((inactiveEntry.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((inactiveEntry.querySelector('.meta-sheet-perm__action') as HTMLButtonElement).disabled).toBe(true)
+    expect((inactiveEntry.querySelector('.meta-sheet-perm__action--danger') as HTMLButtonElement).disabled).toBe(false)
     expect((inactiveCandidate.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveCandidate.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    const fieldTemplateRow = container!.querySelector('[data-field-permission-template="user:user_inactive"]')!
+    const fieldRow = container!.querySelector('[data-field-permission-row="fld_title:user:user_inactive"]')!
+    expect(fieldTemplateRow.textContent).toContain('Inactive user')
+    expect(fieldRow.textContent).toContain('Inactive user')
+    expect((fieldTemplateRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((fieldTemplateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
+    expect((fieldRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((fieldRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
+
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    const viewTemplateRow = container!.querySelector('[data-view-permission-template="user:user_inactive"]')!
+    const viewRow = container!.querySelector('[data-view-permission-row="view_grid:user:user_inactive"]')!
+    expect(viewTemplateRow.textContent).toContain('Inactive user')
+    expect(viewRow.textContent).toContain('Inactive user')
+    expect((viewTemplateRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((viewTemplateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
+    expect((viewRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((viewRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('clears field defaults by removing overrides and shows orphan field overrides', async () => {

--- a/docs/development/multitable-inactive-entry-guard-development-20260418.md
+++ b/docs/development/multitable-inactive-entry-guard-development-20260418.md
@@ -1,0 +1,59 @@
+## Background
+
+The previous inactive-candidate guard blocked new ACL grants to inactive users from sheet and record candidate lists. One governance gap still remained: if an inactive user already had ACL entries, operators could still continue editing those existing sheet or record permissions, and in the sheet manager they could still author downstream field/view overrides and bulk templates for those inactive identities.
+
+## Goal
+
+Make inactive-user ACL entries cleanup-only:
+
+- keep inactive users visible
+- keep removal and override cleanup available
+- block further mutation of current sheet/record ACL levels
+- block new field/view overrides and bulk template application for inactive users
+
+## Scope
+
+- `MetaSheetPermissionManager`
+- `MetaRecordPermissionManager`
+- focused frontend regression coverage
+
+## Implementation
+
+### 1. Lock current sheet ACL entries for inactive users
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- added `subjectMutationBlocked(subjectType, isActive)`
+- disabled the current sheet-entry access `<select>` and `Save` button for inactive user rows
+- left `Remove` and `Clear overrides` available so cleanup still works
+
+### 2. Lock downstream field/view governance for inactive users
+
+In the same component:
+
+- disabled field bulk-template select/apply for inactive user subjects
+- disabled field row select/save for inactive user subjects
+- disabled view bulk-template select/apply for inactive user subjects
+- disabled view row select/save for inactive user subjects
+- surfaced `Inactive user` markers on those field/view rows so the disabled state has a visible explanation
+
+### 3. Lock current record ACL entries for inactive users
+
+In `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`:
+
+- disabled the current record-entry access `<select>` and `Save` button for inactive user rows
+- kept `Remove` available so stale grants can still be revoked
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Risk Notes
+
+- frontend-only governance hardening
+- no backend semantic change
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-entry-guard-verification-20260418.md
+++ b/docs/development/multitable-inactive-entry-guard-verification-20260418.md
@@ -1,0 +1,32 @@
+## Verification Scope
+
+Verified that inactive-user ACL entries are now cleanup-only across sheet, record, field, and view governance surfaces.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `19/19 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive sheet ACL entries remain visible
+- inactive record ACL entries remain visible
+- inactive sheet and record current-entry rows now disable mutation controls
+- inactive sheet field/view template rows now disable bulk-apply controls
+- inactive sheet field/view per-row overrides now disable save controls
+- inactive-user cleanup actions remain available through remove / clear paths
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added


### PR DESCRIPTION
## Summary
- keep inactive sheet and record ACL entries visible but cleanup-only
- block field/view template and override authoring for inactive user sheet subjects
- record the development and verification for this governance hardening slice

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build