### PR TITLE
feat(multitable): surface inactive orphan acl subjects

### DIFF
--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -364,10 +364,17 @@
                   class="meta-sheet-perm__row meta-sheet-perm__row--field"
                   :data-field-permission-orphan-row="`${field.id}:${subjectKey(orphan.subjectType, orphan.subjectId)}`"
                 >
-                  <div class="meta-sheet-perm__identity">
-                    <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
-                    <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
-                  </div>
+                <div class="meta-sheet-perm__identity">
+                  <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
+                  <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  <span
+                    v-if="subjectMutationBlocked(orphan.subjectType, orphan.isActive)"
+                    class="meta-sheet-perm__lifecycle"
+                    data-lifecycle="inactive"
+                  >
+                    Inactive user
+                  </span>
+                </div>
                   <span
                     class="meta-sheet-perm__badge"
                     :data-access-level="fieldPermDraftLabel(field.id, orphan.subjectType, orphan.subjectId)"
@@ -511,10 +518,17 @@
                   class="meta-sheet-perm__row meta-sheet-perm__row--field"
                   :data-view-permission-orphan-row="`${view.id}:${subjectKey(orphan.subjectType, orphan.subjectId)}`"
                 >
-                  <div class="meta-sheet-perm__identity">
-                    <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
-                    <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
-                  </div>
+                <div class="meta-sheet-perm__identity">
+                  <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
+                  <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  <span
+                    v-if="subjectMutationBlocked(orphan.subjectType, orphan.isActive)"
+                    class="meta-sheet-perm__lifecycle"
+                    data-lifecycle="inactive"
+                  >
+                    Inactive user
+                  </span>
+                </div>
                   <span
                     class="meta-sheet-perm__badge"
                     :data-access-level="viewPermDraftValue(view.id, orphan.subjectType, orphan.subjectId)"
@@ -971,11 +985,11 @@ function subjectTypeBadgeLabel(subjectType: MetaSheetPermissionSubjectType) {
   return 'Person'
 }
 
-function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean | undefined) {
   return subjectType === 'user' && isActive === false
 }
 
-function subjectMutationBlocked(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+function subjectMutationBlocked(subjectType: MetaSheetPermissionSubjectType, isActive: boolean | undefined) {
   return subjectIsInactive(subjectType, isActive)
 }
 

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -737,4 +737,69 @@ describe('MetaSheetPermissionManager', () => {
     expect(client.updateViewPermission).toHaveBeenNthCalledWith(2, 'view_board', 'member-group', 'group_north', 'admin')
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('surfaces inactive lifecycle badges on orphan field and view overrides', async () => {
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          subjectLabel: 'Morgan',
+          subjectSubtitle: 'morgan@example.com',
+          visible: false,
+          readOnly: false,
+          isActive: false,
+        },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          subjectLabel: 'Morgan',
+          subjectSubtitle: 'morgan@example.com',
+          permission: 'read',
+          isActive: false,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    const fieldOrphanRow = container!.querySelector('[data-field-permission-orphan-row="fld_title:user:user_inactive"]')!
+    expect(fieldOrphanRow.textContent).toContain('Morgan')
+    expect(fieldOrphanRow.textContent).toContain('Inactive user')
+    expect(fieldOrphanRow.textContent).toContain('No current sheet access')
+
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    const viewOrphanRow = container!.querySelector('[data-view-permission-orphan-row="view_grid:user:user_inactive"]')!
+    expect(viewOrphanRow.textContent).toContain('Morgan')
+    expect(viewOrphanRow.textContent).toContain('Inactive user')
+    expect(viewOrphanRow.textContent).toContain('No current sheet access')
+  })
 })

--- a/docs/development/multitable-inactive-orphan-visibility-development-20260418.md
+++ b/docs/development/multitable-inactive-orphan-visibility-development-20260418.md
@@ -1,0 +1,56 @@
+## Background
+
+The sheet ACL governance UI already surfaces inactive users in:
+
+- current sheet ACL entries
+- current record ACL entries
+- eligible candidate rows
+- current field/view subject rows
+
+One visibility gap remained in the downstream cleanup path: orphan field/view overrides for inactive users only showed `No current sheet access`, which made them look the same as any generic orphaned override.
+
+## Goal
+
+Surface inactive lifecycle context on orphan field/view overrides so administrators can immediately tell when stale overrides belong to a disabled user account.
+
+## Scope
+
+- `MetaSheetPermissionManager`
+- focused frontend regression coverage
+
+## Implementation
+
+### 1. Add inactive lifecycle badges to orphan field overrides
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- reused `subjectMutationBlocked(orphan.subjectType, orphan.isActive)`
+- added the existing `Inactive user` lifecycle badge to orphan field rows when the orphan subject is an inactive user
+
+### 2. Add inactive lifecycle badges to orphan view overrides
+
+In the same component:
+
+- mirrored the same lifecycle badge on orphan view rows
+
+This keeps the current cleanup flow unchanged while making the source of stale overrides easier to understand.
+
+### 3. Extend regression coverage
+
+Updated `apps/web/tests/multitable-sheet-permission-manager.spec.ts` with a focused test that verifies:
+
+- inactive orphan field overrides show `Inactive user`
+- inactive orphan view overrides show `Inactive user`
+- both still show `No current sheet access`
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+## Risk Notes
+
+- frontend-only visibility change
+- no backend semantic change
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-orphan-visibility-verification-20260418.md
+++ b/docs/development/multitable-inactive-orphan-visibility-verification-20260418.md
@@ -1,0 +1,29 @@
+## Verification Scope
+
+Verified lifecycle visibility for inactive orphan field/view overrides in the sheet ACL governance UI.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `20/20 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive orphan field overrides show both `Inactive user` and `No current sheet access`
+- inactive orphan view overrides show both `Inactive user` and `No current sheet access`
+- existing sheet/record inactive governance assertions continue to pass
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added


### PR DESCRIPTION
## Summary
- show inactive lifecycle badges on orphan field ACL rows
- show inactive lifecycle badges on orphan view ACL rows
- keep existing orphan cleanup flow unchanged while clarifying disabled identities

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build