### PR TITLE
feat(multitable): explain inactive acl cleanup state

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -37,6 +37,12 @@
                 >
                   Inactive user
                 </span>
+                <span
+                  v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                  class="meta-record-perm__hint"
+                >
+                  Cleanup only
+                </span>
               </div>
             <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeLabel(entry.subjectType) }}</span>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
@@ -570,6 +576,12 @@ watch(
   color: #b91c1c;
   font-size: 11px;
   font-weight: 600;
+}
+
+.meta-record-perm__hint {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .meta-record-perm__subject {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -52,6 +52,12 @@
                   Inactive user
                 </span>
                 <span
+                  v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                  class="meta-sheet-perm__hint"
+                >
+                  Cleanup only
+                </span>
+                <span
                   v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
                   class="meta-sheet-perm__hint meta-sheet-perm__hint--inline"
                 >
@@ -273,6 +279,12 @@
                     >
                       Inactive user
                     </span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__hint"
+                    >
+                      Cleanup only
+                    </span>
                   </div>
                   <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   <select
@@ -331,6 +343,12 @@
                       data-lifecycle="inactive"
                     >
                       Inactive user
+                    </span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__hint"
+                    >
+                      Cleanup only
                     </span>
                   </div>
                   <span
@@ -425,6 +443,12 @@
                     >
                       Inactive user
                     </span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__hint"
+                    >
+                      Cleanup only
+                    </span>
                   </div>
                   <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   <select
@@ -484,6 +508,12 @@
                       data-lifecycle="inactive"
                     >
                       Inactive user
+                    </span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__hint"
+                    >
+                      Cleanup only
                     </span>
                   </div>
                   <span

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -228,6 +228,7 @@ describe('MetaRecordPermissionManager', () => {
     const inactiveEntry = container!.querySelector('[data-record-permission-entry="perm_inactive"]')!
     const inactiveCandidate = container!.querySelector('[data-record-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveEntry.textContent).toContain('Cleanup only')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
     expect((inactiveEntry.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-record-perm__action') as HTMLButtonElement).disabled).toBe(true)

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -270,6 +270,7 @@ describe('MetaSheetPermissionManager', () => {
     const inactiveEntry = container!.querySelector('[data-sheet-permission-entry="user:user_inactive"]')!
     const inactiveCandidate = container!.querySelector('[data-sheet-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveEntry.textContent).toContain('Cleanup only')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
     expect((inactiveEntry.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-sheet-perm__action') as HTMLButtonElement).disabled).toBe(true)
@@ -285,7 +286,9 @@ describe('MetaSheetPermissionManager', () => {
     const fieldTemplateRow = container!.querySelector('[data-field-permission-template="user:user_inactive"]')!
     const fieldRow = container!.querySelector('[data-field-permission-row="fld_title:user:user_inactive"]')!
     expect(fieldTemplateRow.textContent).toContain('Inactive user')
+    expect(fieldTemplateRow.textContent).toContain('Cleanup only')
     expect(fieldRow.textContent).toContain('Inactive user')
+    expect(fieldRow.textContent).toContain('Cleanup only')
     expect((fieldTemplateRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((fieldTemplateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
     expect((fieldRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
@@ -298,7 +301,9 @@ describe('MetaSheetPermissionManager', () => {
     const viewTemplateRow = container!.querySelector('[data-view-permission-template="user:user_inactive"]')!
     const viewRow = container!.querySelector('[data-view-permission-row="view_grid:user:user_inactive"]')!
     expect(viewTemplateRow.textContent).toContain('Inactive user')
+    expect(viewTemplateRow.textContent).toContain('Cleanup only')
     expect(viewRow.textContent).toContain('Inactive user')
+    expect(viewRow.textContent).toContain('Cleanup only')
     expect((viewTemplateRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((viewTemplateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
     expect((viewRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)

--- a/docs/development/multitable-inactive-cleanup-hint-development-20260418.md
+++ b/docs/development/multitable-inactive-cleanup-hint-development-20260418.md
@@ -1,0 +1,63 @@
+## Background
+
+The previous slices already made inactive-user ACL rows cleanup-only:
+
+- candidate rows cannot issue new grants
+- current sheet and record rows cannot be mutated further
+- field/view template and override rows for inactive users cannot be saved
+
+That behavior was safe, but the UI still mostly communicated it only through disabled controls plus the `Inactive user` lifecycle badge.
+
+## Goal
+
+Make the cleanup-only state explicit wherever inactive-user ACL entries remain visible for governance cleanup.
+
+## Scope
+
+- `MetaSheetPermissionManager`
+- `MetaRecordPermissionManager`
+- focused frontend regression coverage
+
+## Implementation
+
+### 1. Add explicit cleanup-only hints to inactive sheet ACL rows
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- added `Cleanup only` hints to inactive current sheet ACL rows
+- added the same hint to inactive field template rows
+- added the same hint to inactive field override rows
+- added the same hint to inactive view template rows
+- added the same hint to inactive view override rows
+
+This keeps the existing disabled behavior but makes the intent obvious.
+
+### 2. Add explicit cleanup-only hints to inactive record ACL rows
+
+In `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`:
+
+- added `Cleanup only` to inactive current record ACL rows
+- added a small `meta-record-perm__hint` style for the explanatory label
+
+### 3. Extend regression coverage
+
+Updated:
+
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+The inactive-user tests now assert the presence of `Cleanup only` on current inactive entries and downstream inactive sheet rows.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Risk Notes
+
+- frontend-only explanatory UX change
+- no backend semantic change
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-cleanup-hint-verification-20260418.md
+++ b/docs/development/multitable-inactive-cleanup-hint-verification-20260418.md
@@ -1,0 +1,32 @@
+## Verification Scope
+
+Verified that inactive-user ACL entries now clearly display `Cleanup only` anywhere governance is limited to removal/cleanup.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `20/20 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive current sheet ACL rows show `Cleanup only`
+- inactive current record ACL rows show `Cleanup only`
+- inactive field template rows show `Cleanup only`
+- inactive field override rows show `Cleanup only`
+- inactive view template rows show `Cleanup only`
+- inactive view override rows show `Cleanup only`
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added


### PR DESCRIPTION
## Summary
- add explicit cleanup-only hints to inactive current sheet and record ACL rows
- add the same cleanup-only hints to inactive field/view template and override rows
- keep ACL semantics unchanged while making disabled governance state self-explanatory

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build