### PR TITLE
feat(multitable): explain inactive candidate grant blocks

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -113,6 +113,12 @@
                 >
                   Inactive user
                 </span>
+                <span
+                  v-if="candidateGrantBlocked(candidate)"
+                  class="meta-record-perm__hint"
+                >
+                  Grant blocked
+                </span>
               </div>
               <span class="meta-record-perm__subject" data-subject-type="user">User</span>
               <select

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -143,6 +143,12 @@
                   >
                     Inactive user
                   </span>
+                  <span
+                    v-if="candidateGrantBlocked(candidate)"
+                    class="meta-sheet-perm__hint"
+                  >
+                    Grant blocked
+                  </span>
                 </div>
                 <span class="meta-sheet-perm__subject" data-subject-type="user">Person</span>
                 <select

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -230,6 +230,7 @@ describe('MetaRecordPermissionManager', () => {
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveEntry.textContent).toContain('Cleanup only')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Grant blocked')
     expect((inactiveEntry.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-record-perm__action') as HTMLButtonElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-record-perm__action--danger') as HTMLButtonElement).disabled).toBe(false)

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -272,6 +272,7 @@ describe('MetaSheetPermissionManager', () => {
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveEntry.textContent).toContain('Cleanup only')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Grant blocked')
     expect((inactiveEntry.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-sheet-perm__action') as HTMLButtonElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-sheet-perm__action--danger') as HTMLButtonElement).disabled).toBe(false)

--- a/docs/development/multitable-inactive-candidate-hint-development-20260418.md
+++ b/docs/development/multitable-inactive-candidate-hint-development-20260418.md
@@ -1,0 +1,51 @@
+## Background
+
+The previous inactive-candidate guard already blocked new ACL grants to inactive user candidates in both sheet and record ACL managers. The disabled controls were safe, but the candidate rows still only showed `Inactive user`, which did not explicitly explain why the primary action was unavailable.
+
+## Goal
+
+Make the blocked state self-explanatory on inactive candidate rows by showing an explicit `Grant blocked` hint.
+
+## Scope
+
+- `MetaSheetPermissionManager`
+- `MetaRecordPermissionManager`
+- focused frontend regression coverage
+
+## Implementation
+
+### 1. Add blocked-grant hints to inactive sheet candidates
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- reused the existing `candidateGrantBlocked(candidate)` helper
+- added a `Grant blocked` hint beside the existing `Inactive user` lifecycle badge on inactive candidate rows
+
+### 2. Add blocked-grant hints to inactive record candidates
+
+In `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`:
+
+- mirrored the same `Grant blocked` hint on inactive candidate rows
+
+### 3. Extend regression coverage
+
+Updated:
+
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+The inactive candidate assertions now verify the new explanatory hint in both managers.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Risk Notes
+
+- frontend-only explanatory UX change
+- no backend semantic change
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-candidate-hint-verification-20260418.md
+++ b/docs/development/multitable-inactive-candidate-hint-verification-20260418.md
@@ -1,0 +1,31 @@
+## Verification Scope
+
+Verified that inactive ACL candidate rows now explicitly explain why new grants are unavailable.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `20/20 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive sheet candidate rows show `Inactive user`
+- inactive sheet candidate rows show `Grant blocked`
+- inactive record candidate rows show `Inactive user`
+- inactive record candidate rows show `Grant blocked`
+- existing disabled-grant behavior continues to pass
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added


### PR DESCRIPTION
## Summary
- add explicit grant-blocked hints to inactive sheet ACL candidate rows
- add the same grant-blocked hints to inactive record ACL candidate rows
- keep ACL semantics unchanged while making disabled grant state self-explanatory

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build