### PR TITLE
feat(multitable): package inactive acl governance followups

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -45,7 +45,7 @@
             <select
               :value="entryDrafts[entry.id] ?? entry.accessLevel"
               class="meta-record-perm__select"
-              :disabled="busyKey === entry.id"
+              :disabled="busyKey === entry.id || subjectMutationBlocked(entry.subjectType, entry.isActive)"
               @change="setEntryDraft(entry.id, $event)"
             >
               <option value="read">Read</option>
@@ -55,7 +55,7 @@
             <button
               class="meta-record-perm__action"
               type="button"
-              :disabled="busyKey === entry.id || (entryDrafts[entry.id] ?? entry.accessLevel) === entry.accessLevel"
+              :disabled="busyKey === entry.id || subjectMutationBlocked(entry.subjectType, entry.isActive) || (entryDrafts[entry.id] ?? entry.accessLevel) === entry.accessLevel"
               @click="saveEntry(entry)"
             >
               Save
@@ -251,8 +251,12 @@ function subjectIsInactive(subjectType: string, isActive: boolean) {
   return subjectType === 'user' && isActive === false
 }
 
+function subjectMutationBlocked(subjectType: string, isActive: boolean) {
+  return subjectIsInactive(subjectType, isActive)
+}
+
 function candidateGrantBlocked(candidate: MetaSheetPermissionCandidate) {
-  return subjectIsInactive(candidate.subjectType, candidate.isActive)
+  return subjectMutationBlocked(candidate.subjectType, candidate.isActive)
 }
 
 function requestClose() {

--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -37,6 +37,12 @@
                 >
                   Inactive user
                 </span>
+                <span
+                  v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                  class="meta-record-perm__hint"
+                >
+                  Cleanup only
+                </span>
               </div>
             <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeLabel(entry.subjectType) }}</span>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
@@ -570,6 +576,12 @@ watch(
   color: #b91c1c;
   font-size: 11px;
   font-weight: 600;
+}
+
+.meta-record-perm__hint {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .meta-record-perm__subject {

--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -112,7 +112,7 @@
               <select
                 :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                 class="meta-record-perm__select"
-                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId) || candidateGrantBlocked(candidate)"
                 @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
               >
                 <option value="read">Read</option>
@@ -122,7 +122,7 @@
               <button
                 class="meta-record-perm__action meta-record-perm__action--primary"
                 type="button"
-                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId) || candidateGrantBlocked(candidate)"
                 @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
               >
                 Grant
@@ -249,6 +249,10 @@ function subjectTypeLabel(subjectType: string): string {
 
 function subjectIsInactive(subjectType: string, isActive: boolean) {
   return subjectType === 'user' && isActive === false
+}
+
+function candidateGrantBlocked(candidate: MetaSheetPermissionCandidate) {
+  return subjectIsInactive(candidate.subjectType, candidate.isActive)
 }
 
 function requestClose() {

--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -113,6 +113,12 @@
                 >
                   Inactive user
                 </span>
+                <span
+                  v-if="candidateGrantBlocked(candidate)"
+                  class="meta-record-perm__hint"
+                >
+                  Grant blocked
+                </span>
               </div>
               <span class="meta-record-perm__subject" data-subject-type="user">User</span>
               <select

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -52,6 +52,12 @@
                   Inactive user
                 </span>
                 <span
+                  v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                  class="meta-sheet-perm__hint"
+                >
+                  Cleanup only
+                </span>
+                <span
                   v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
                   class="meta-sheet-perm__hint meta-sheet-perm__hint--inline"
                 >
@@ -273,6 +279,12 @@
                     >
                       Inactive user
                     </span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__hint"
+                    >
+                      Cleanup only
+                    </span>
                   </div>
                   <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   <select
@@ -331,6 +343,12 @@
                       data-lifecycle="inactive"
                     >
                       Inactive user
+                    </span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__hint"
+                    >
+                      Cleanup only
                     </span>
                   </div>
                   <span
@@ -425,6 +443,12 @@
                     >
                       Inactive user
                     </span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__hint"
+                    >
+                      Cleanup only
+                    </span>
                   </div>
                   <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   <select
@@ -484,6 +508,12 @@
                       data-lifecycle="inactive"
                     >
                       Inactive user
+                    </span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__hint"
+                    >
+                      Cleanup only
                     </span>
                   </div>
                   <span

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -63,7 +63,7 @@
               <select
                 :value="entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel"
                 class="meta-sheet-perm__select"
-                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId)"
+                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                 @change="setEntryDraft(entry.subjectType, entry.subjectId, $event)"
               >
                 <option
@@ -77,7 +77,7 @@
               <button
                 class="meta-sheet-perm__action"
                 type="button"
-                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId) || (entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel) === entry.accessLevel"
+                :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive) || (entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel) === entry.accessLevel"
                 @click="applyEntry(entry.subjectType, entry.subjectId)"
               >
                 Save
@@ -266,12 +266,19 @@
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
                     <span>{{ entry.subtitle || entry.subjectId }}</span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__lifecycle"
+                      data-lifecycle="inactive"
+                    >
+                      Inactive user
+                    </span>
                   </div>
                   <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   <select
                     :value="fieldTemplateDraftValue(entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
-                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setFieldTemplateDraft(entry.subjectType, entry.subjectId, $event)"
                   >
                     <option value="default">Default</option>
@@ -281,7 +288,7 @@
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                     type="button"
-                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyFieldTemplate(entry.subjectType, entry.subjectId)"
                   >
                     Apply to all fields
@@ -318,6 +325,13 @@
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
                     <span>{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__lifecycle"
+                      data-lifecycle="inactive"
+                    >
+                      Inactive user
+                    </span>
                   </div>
                   <span
                     class="meta-sheet-perm__badge"
@@ -328,7 +342,7 @@
                   <select
                     :value="fieldPermDraftValue(field.id, entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
-                    :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId)"
+                    :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setFieldPermDraft(field.id, entry.subjectType, entry.subjectId, $event)"
                   >
                     <option value="default">Default</option>
@@ -338,7 +352,7 @@
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                     type="button"
-                    :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId)"
+                    :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyFieldPerm(field.id, entry.subjectType, entry.subjectId)"
                   >
                     Save
@@ -397,12 +411,19 @@
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
                     <span>{{ entry.subtitle || entry.subjectId }}</span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__lifecycle"
+                      data-lifecycle="inactive"
+                    >
+                      Inactive user
+                    </span>
                   </div>
                   <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
                   <select
                     :value="viewTemplateDraftValue(entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
-                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setViewTemplateDraft(entry.subjectType, entry.subjectId, $event)"
                   >
                     <option value="none">None</option>
@@ -413,7 +434,7 @@
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                     type="button"
-                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId)"
+                    :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyViewTemplate(entry.subjectType, entry.subjectId)"
                   >
                     Apply to all views
@@ -450,6 +471,13 @@
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
                     <span>{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                    <span
+                      v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
+                      class="meta-sheet-perm__lifecycle"
+                      data-lifecycle="inactive"
+                    >
+                      Inactive user
+                    </span>
                   </div>
                   <span
                     class="meta-sheet-perm__badge"
@@ -460,7 +488,7 @@
                   <select
                     :value="viewPermDraftValue(view.id, entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
-                    :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId)"
+                    :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setViewPermDraft(view.id, entry.subjectType, entry.subjectId, $event)"
                   >
                     <option value="none">None</option>
@@ -471,7 +499,7 @@
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                     type="button"
-                    :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId)"
+                    :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyViewPerm(view.id, entry.subjectType, entry.subjectId)"
                   >
                     Save
@@ -947,8 +975,12 @@ function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive
   return subjectType === 'user' && isActive === false
 }
 
+function subjectMutationBlocked(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+  return subjectIsInactive(subjectType, isActive)
+}
+
 function candidateGrantBlocked(candidate: MetaSheetPermissionCandidate) {
-  return subjectIsInactive(candidate.subjectType, candidate.isActive)
+  return subjectMutationBlocked(candidate.subjectType, candidate.isActive)
 }
 
 function requestClose() {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -142,7 +142,7 @@
                 <select
                   :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                   class="meta-sheet-perm__select"
-                  :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                  :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId) || candidateGrantBlocked(candidate)"
                   @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
                 >
                   <option
@@ -156,7 +156,7 @@
                 <button
                   class="meta-sheet-perm__action meta-sheet-perm__action--primary"
                   type="button"
-                  :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId)"
+                  :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId) || candidateGrantBlocked(candidate)"
                   @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
                 >
                   Apply
@@ -945,6 +945,10 @@ function subjectTypeBadgeLabel(subjectType: MetaSheetPermissionSubjectType) {
 
 function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
   return subjectType === 'user' && isActive === false
+}
+
+function candidateGrantBlocked(candidate: MetaSheetPermissionCandidate) {
+  return subjectIsInactive(candidate.subjectType, candidate.isActive)
 }
 
 function requestClose() {

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -143,6 +143,12 @@
                   >
                     Inactive user
                   </span>
+                  <span
+                    v-if="candidateGrantBlocked(candidate)"
+                    class="meta-sheet-perm__hint"
+                  >
+                    Grant blocked
+                  </span>
                 </div>
                 <span class="meta-sheet-perm__subject" data-subject-type="user">Person</span>
                 <select

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -364,10 +364,17 @@
                   class="meta-sheet-perm__row meta-sheet-perm__row--field"
                   :data-field-permission-orphan-row="`${field.id}:${subjectKey(orphan.subjectType, orphan.subjectId)}`"
                 >
-                  <div class="meta-sheet-perm__identity">
-                    <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
-                    <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
-                  </div>
+                <div class="meta-sheet-perm__identity">
+                  <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
+                  <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  <span
+                    v-if="subjectMutationBlocked(orphan.subjectType, orphan.isActive)"
+                    class="meta-sheet-perm__lifecycle"
+                    data-lifecycle="inactive"
+                  >
+                    Inactive user
+                  </span>
+                </div>
                   <span
                     class="meta-sheet-perm__badge"
                     :data-access-level="fieldPermDraftLabel(field.id, orphan.subjectType, orphan.subjectId)"
@@ -511,10 +518,17 @@
                   class="meta-sheet-perm__row meta-sheet-perm__row--field"
                   :data-view-permission-orphan-row="`${view.id}:${subjectKey(orphan.subjectType, orphan.subjectId)}`"
                 >
-                  <div class="meta-sheet-perm__identity">
-                    <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
-                    <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
-                  </div>
+                <div class="meta-sheet-perm__identity">
+                  <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
+                  <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  <span
+                    v-if="subjectMutationBlocked(orphan.subjectType, orphan.isActive)"
+                    class="meta-sheet-perm__lifecycle"
+                    data-lifecycle="inactive"
+                  >
+                    Inactive user
+                  </span>
+                </div>
                   <span
                     class="meta-sheet-perm__badge"
                     :data-access-level="viewPermDraftValue(view.id, orphan.subjectType, orphan.subjectId)"
@@ -971,11 +985,11 @@ function subjectTypeBadgeLabel(subjectType: MetaSheetPermissionSubjectType) {
   return 'Person'
 }
 
-function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean | undefined) {
   return subjectType === 'user' && isActive === false
 }
 
-function subjectMutationBlocked(subjectType: MetaSheetPermissionSubjectType, isActive: boolean) {
+function subjectMutationBlocked(subjectType: MetaSheetPermissionSubjectType, isActive: boolean | undefined) {
   return subjectIsInactive(subjectType, isActive)
 }
 

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -230,6 +230,7 @@ describe('MetaRecordPermissionManager', () => {
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveEntry.textContent).toContain('Cleanup only')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Grant blocked')
     expect((inactiveEntry.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-record-perm__action') as HTMLButtonElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-record-perm__action--danger') as HTMLButtonElement).disabled).toBe(false)

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -229,6 +229,9 @@ describe('MetaRecordPermissionManager', () => {
     const inactiveCandidate = container!.querySelector('[data-record-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect((inactiveEntry.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((inactiveEntry.querySelector('.meta-record-perm__action') as HTMLButtonElement).disabled).toBe(true)
+    expect((inactiveEntry.querySelector('.meta-record-perm__action--danger') as HTMLButtonElement).disabled).toBe(false)
     expect((inactiveCandidate.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveCandidate.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
   })

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -228,6 +228,7 @@ describe('MetaRecordPermissionManager', () => {
     const inactiveEntry = container!.querySelector('[data-record-permission-entry="perm_inactive"]')!
     const inactiveCandidate = container!.querySelector('[data-record-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveEntry.textContent).toContain('Cleanup only')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
     expect((inactiveEntry.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-record-perm__action') as HTMLButtonElement).disabled).toBe(true)

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -229,6 +229,8 @@ describe('MetaRecordPermissionManager', () => {
     const inactiveCandidate = container!.querySelector('[data-record-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect((inactiveCandidate.querySelector('.meta-record-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((inactiveCandidate.querySelector('.meta-record-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('searches across sheet subjects and global candidates when granting record access', async () => {

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -263,6 +263,8 @@ describe('MetaSheetPermissionManager', () => {
     const inactiveCandidate = container!.querySelector('[data-sheet-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect((inactiveCandidate.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((inactiveCandidate.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('clears field defaults by removing overrides and shows orphan field overrides', async () => {

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -270,6 +270,7 @@ describe('MetaSheetPermissionManager', () => {
     const inactiveEntry = container!.querySelector('[data-sheet-permission-entry="user:user_inactive"]')!
     const inactiveCandidate = container!.querySelector('[data-sheet-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
+    expect(inactiveEntry.textContent).toContain('Cleanup only')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
     expect((inactiveEntry.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-sheet-perm__action') as HTMLButtonElement).disabled).toBe(true)
@@ -285,7 +286,9 @@ describe('MetaSheetPermissionManager', () => {
     const fieldTemplateRow = container!.querySelector('[data-field-permission-template="user:user_inactive"]')!
     const fieldRow = container!.querySelector('[data-field-permission-row="fld_title:user:user_inactive"]')!
     expect(fieldTemplateRow.textContent).toContain('Inactive user')
+    expect(fieldTemplateRow.textContent).toContain('Cleanup only')
     expect(fieldRow.textContent).toContain('Inactive user')
+    expect(fieldRow.textContent).toContain('Cleanup only')
     expect((fieldTemplateRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((fieldTemplateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
     expect((fieldRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
@@ -298,7 +301,9 @@ describe('MetaSheetPermissionManager', () => {
     const viewTemplateRow = container!.querySelector('[data-view-permission-template="user:user_inactive"]')!
     const viewRow = container!.querySelector('[data-view-permission-row="view_grid:user:user_inactive"]')!
     expect(viewTemplateRow.textContent).toContain('Inactive user')
+    expect(viewTemplateRow.textContent).toContain('Cleanup only')
     expect(viewRow.textContent).toContain('Inactive user')
+    expect(viewRow.textContent).toContain('Cleanup only')
     expect((viewTemplateRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((viewTemplateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
     expect((viewRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -737,4 +737,69 @@ describe('MetaSheetPermissionManager', () => {
     expect(client.updateViewPermission).toHaveBeenNthCalledWith(2, 'view_board', 'member-group', 'group_north', 'admin')
     expect(updatedSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('surfaces inactive lifecycle badges on orphan field and view overrides', async () => {
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          subjectLabel: 'Morgan',
+          subjectSubtitle: 'morgan@example.com',
+          visible: false,
+          readOnly: false,
+          isActive: false,
+        },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          subjectLabel: 'Morgan',
+          subjectSubtitle: 'morgan@example.com',
+          permission: 'read',
+          isActive: false,
+        },
+      ],
+    })
+    await flushUi()
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    const fieldOrphanRow = container!.querySelector('[data-field-permission-orphan-row="fld_title:user:user_inactive"]')!
+    expect(fieldOrphanRow.textContent).toContain('Morgan')
+    expect(fieldOrphanRow.textContent).toContain('Inactive user')
+    expect(fieldOrphanRow.textContent).toContain('No current sheet access')
+
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    const viewOrphanRow = container!.querySelector('[data-view-permission-orphan-row="view_grid:user:user_inactive"]')!
+    expect(viewOrphanRow.textContent).toContain('Morgan')
+    expect(viewOrphanRow.textContent).toContain('Inactive user')
+    expect(viewOrphanRow.textContent).toContain('No current sheet access')
+  })
 })

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -272,6 +272,7 @@ describe('MetaSheetPermissionManager', () => {
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveEntry.textContent).toContain('Cleanup only')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect(inactiveCandidate.textContent).toContain('Grant blocked')
     expect((inactiveEntry.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-sheet-perm__action') as HTMLButtonElement).disabled).toBe(true)
     expect((inactiveEntry.querySelector('.meta-sheet-perm__action--danger') as HTMLButtonElement).disabled).toBe(false)

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -256,15 +256,53 @@ describe('MetaSheetPermissionManager', () => {
       updateViewPermission: vi.fn().mockResolvedValue({}),
     }
 
-    mountManager({ client })
+    mountManager({
+      client,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+    })
     await flushUi()
 
     const inactiveEntry = container!.querySelector('[data-sheet-permission-entry="user:user_inactive"]')!
     const inactiveCandidate = container!.querySelector('[data-sheet-permission-candidate="user:user_candidate_inactive"]')!
     expect(inactiveEntry.textContent).toContain('Inactive user')
     expect(inactiveCandidate.textContent).toContain('Inactive user')
+    expect((inactiveEntry.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((inactiveEntry.querySelector('.meta-sheet-perm__action') as HTMLButtonElement).disabled).toBe(true)
+    expect((inactiveEntry.querySelector('.meta-sheet-perm__action--danger') as HTMLButtonElement).disabled).toBe(false)
     expect((inactiveCandidate.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
     expect((inactiveCandidate.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    const fieldTab = tabs.find((tab) => tab.textContent?.includes('Field Permissions')) as HTMLElement
+    fieldTab.click()
+    await flushUi()
+
+    const fieldTemplateRow = container!.querySelector('[data-field-permission-template="user:user_inactive"]')!
+    const fieldRow = container!.querySelector('[data-field-permission-row="fld_title:user:user_inactive"]')!
+    expect(fieldTemplateRow.textContent).toContain('Inactive user')
+    expect(fieldRow.textContent).toContain('Inactive user')
+    expect((fieldTemplateRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((fieldTemplateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
+    expect((fieldRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((fieldRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
+
+    const viewTab = tabs.find((tab) => tab.textContent?.includes('View Permissions')) as HTMLElement
+    viewTab.click()
+    await flushUi()
+
+    const viewTemplateRow = container!.querySelector('[data-view-permission-template="user:user_inactive"]')!
+    const viewRow = container!.querySelector('[data-view-permission-row="view_grid:user:user_inactive"]')!
+    expect(viewTemplateRow.textContent).toContain('Inactive user')
+    expect(viewRow.textContent).toContain('Inactive user')
+    expect((viewTemplateRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((viewTemplateRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
+    expect((viewRow.querySelector('.meta-sheet-perm__select') as HTMLSelectElement).disabled).toBe(true)
+    expect((viewRow.querySelector('.meta-sheet-perm__action--primary') as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('clears field defaults by removing overrides and shows orphan field overrides', async () => {

--- a/docs/development/multitable-inactive-candidate-guard-development-20260418.md
+++ b/docs/development/multitable-inactive-candidate-guard-development-20260418.md
@@ -1,0 +1,55 @@
+## Background
+
+The multitable ACL governance UI already surfaced inactive users in sheet and record ACL entries so administrators could see stale grants. That visibility improvement still left one gap: inactive users remained grantable from the ACL candidate lists, which meant operators could accidentally issue fresh sheet or record access to disabled accounts.
+
+## Goal
+
+Keep inactive users visible in ACL candidate results for governance transparency, but block new grants from those inactive user rows.
+
+## Scope
+
+- Sheet ACL candidate rows in `MetaSheetPermissionManager`
+- Record ACL candidate rows in `MetaRecordPermissionManager`
+- Focused UI regression coverage for both managers
+
+## Implementation
+
+### 1. Block new grants to inactive sheet ACL candidates
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- reused the existing `subjectIsInactive(...)` helper
+- added `candidateGrantBlocked(candidate)`
+- disabled both the candidate access-level `<select>` and the `Apply` button when the candidate is an inactive user
+
+This preserves visibility while preventing new ACL authoring against disabled user identities.
+
+### 2. Block new grants to inactive record ACL candidates
+
+In `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`:
+
+- mirrored the same `candidateGrantBlocked(candidate)` behavior
+- disabled both the candidate access-level `<select>` and the `Grant` button for inactive user candidates
+
+### 3. Extend governance regression coverage
+
+Updated:
+
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+The existing inactive-subject visibility assertions now also verify that inactive user candidate rows are non-interactive for new grants.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Risk Notes
+
+- Frontend-only change
+- No backend semantic change
+- No migration
+- No deployment-step change

--- a/docs/development/multitable-inactive-candidate-guard-verification-20260418.md
+++ b/docs/development/multitable-inactive-candidate-guard-verification-20260418.md
@@ -1,0 +1,30 @@
+## Verification Scope
+
+Verified the inactive-candidate guard for multitable sheet and record ACL managers.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `19/19 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive users still render in sheet ACL entries and candidate results
+- inactive users still render in record ACL entries and candidate results
+- inactive user candidate rows now disable the access-level selector
+- inactive user candidate rows now disable the primary grant/apply action
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added

--- a/docs/development/multitable-inactive-candidate-hint-development-20260418.md
+++ b/docs/development/multitable-inactive-candidate-hint-development-20260418.md
@@ -1,0 +1,51 @@
+## Background
+
+The previous inactive-candidate guard already blocked new ACL grants to inactive user candidates in both sheet and record ACL managers. The disabled controls were safe, but the candidate rows still only showed `Inactive user`, which did not explicitly explain why the primary action was unavailable.
+
+## Goal
+
+Make the blocked state self-explanatory on inactive candidate rows by showing an explicit `Grant blocked` hint.
+
+## Scope
+
+- `MetaSheetPermissionManager`
+- `MetaRecordPermissionManager`
+- focused frontend regression coverage
+
+## Implementation
+
+### 1. Add blocked-grant hints to inactive sheet candidates
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- reused the existing `candidateGrantBlocked(candidate)` helper
+- added a `Grant blocked` hint beside the existing `Inactive user` lifecycle badge on inactive candidate rows
+
+### 2. Add blocked-grant hints to inactive record candidates
+
+In `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`:
+
+- mirrored the same `Grant blocked` hint on inactive candidate rows
+
+### 3. Extend regression coverage
+
+Updated:
+
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+The inactive candidate assertions now verify the new explanatory hint in both managers.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Risk Notes
+
+- frontend-only explanatory UX change
+- no backend semantic change
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-candidate-hint-verification-20260418.md
+++ b/docs/development/multitable-inactive-candidate-hint-verification-20260418.md
@@ -1,0 +1,31 @@
+## Verification Scope
+
+Verified that inactive ACL candidate rows now explicitly explain why new grants are unavailable.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `20/20 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive sheet candidate rows show `Inactive user`
+- inactive sheet candidate rows show `Grant blocked`
+- inactive record candidate rows show `Inactive user`
+- inactive record candidate rows show `Grant blocked`
+- existing disabled-grant behavior continues to pass
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added

--- a/docs/development/multitable-inactive-cleanup-hint-development-20260418.md
+++ b/docs/development/multitable-inactive-cleanup-hint-development-20260418.md
@@ -1,0 +1,63 @@
+## Background
+
+The previous slices already made inactive-user ACL rows cleanup-only:
+
+- candidate rows cannot issue new grants
+- current sheet and record rows cannot be mutated further
+- field/view template and override rows for inactive users cannot be saved
+
+That behavior was safe, but the UI still mostly communicated it only through disabled controls plus the `Inactive user` lifecycle badge.
+
+## Goal
+
+Make the cleanup-only state explicit wherever inactive-user ACL entries remain visible for governance cleanup.
+
+## Scope
+
+- `MetaSheetPermissionManager`
+- `MetaRecordPermissionManager`
+- focused frontend regression coverage
+
+## Implementation
+
+### 1. Add explicit cleanup-only hints to inactive sheet ACL rows
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- added `Cleanup only` hints to inactive current sheet ACL rows
+- added the same hint to inactive field template rows
+- added the same hint to inactive field override rows
+- added the same hint to inactive view template rows
+- added the same hint to inactive view override rows
+
+This keeps the existing disabled behavior but makes the intent obvious.
+
+### 2. Add explicit cleanup-only hints to inactive record ACL rows
+
+In `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`:
+
+- added `Cleanup only` to inactive current record ACL rows
+- added a small `meta-record-perm__hint` style for the explanatory label
+
+### 3. Extend regression coverage
+
+Updated:
+
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+The inactive-user tests now assert the presence of `Cleanup only` on current inactive entries and downstream inactive sheet rows.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Risk Notes
+
+- frontend-only explanatory UX change
+- no backend semantic change
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-cleanup-hint-verification-20260418.md
+++ b/docs/development/multitable-inactive-cleanup-hint-verification-20260418.md
@@ -1,0 +1,32 @@
+## Verification Scope
+
+Verified that inactive-user ACL entries now clearly display `Cleanup only` anywhere governance is limited to removal/cleanup.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `20/20 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive current sheet ACL rows show `Cleanup only`
+- inactive current record ACL rows show `Cleanup only`
+- inactive field template rows show `Cleanup only`
+- inactive field override rows show `Cleanup only`
+- inactive view template rows show `Cleanup only`
+- inactive view override rows show `Cleanup only`
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added

--- a/docs/development/multitable-inactive-entry-guard-development-20260418.md
+++ b/docs/development/multitable-inactive-entry-guard-development-20260418.md
@@ -1,0 +1,59 @@
+## Background
+
+The previous inactive-candidate guard blocked new ACL grants to inactive users from sheet and record candidate lists. One governance gap still remained: if an inactive user already had ACL entries, operators could still continue editing those existing sheet or record permissions, and in the sheet manager they could still author downstream field/view overrides and bulk templates for those inactive identities.
+
+## Goal
+
+Make inactive-user ACL entries cleanup-only:
+
+- keep inactive users visible
+- keep removal and override cleanup available
+- block further mutation of current sheet/record ACL levels
+- block new field/view overrides and bulk template application for inactive users
+
+## Scope
+
+- `MetaSheetPermissionManager`
+- `MetaRecordPermissionManager`
+- focused frontend regression coverage
+
+## Implementation
+
+### 1. Lock current sheet ACL entries for inactive users
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- added `subjectMutationBlocked(subjectType, isActive)`
+- disabled the current sheet-entry access `<select>` and `Save` button for inactive user rows
+- left `Remove` and `Clear overrides` available so cleanup still works
+
+### 2. Lock downstream field/view governance for inactive users
+
+In the same component:
+
+- disabled field bulk-template select/apply for inactive user subjects
+- disabled field row select/save for inactive user subjects
+- disabled view bulk-template select/apply for inactive user subjects
+- disabled view row select/save for inactive user subjects
+- surfaced `Inactive user` markers on those field/view rows so the disabled state has a visible explanation
+
+### 3. Lock current record ACL entries for inactive users
+
+In `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`:
+
+- disabled the current record-entry access `<select>` and `Save` button for inactive user rows
+- kept `Remove` available so stale grants can still be revoked
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+
+## Risk Notes
+
+- frontend-only governance hardening
+- no backend semantic change
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-entry-guard-verification-20260418.md
+++ b/docs/development/multitable-inactive-entry-guard-verification-20260418.md
@@ -1,0 +1,32 @@
+## Verification Scope
+
+Verified that inactive-user ACL entries are now cleanup-only across sheet, record, field, and view governance surfaces.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `19/19 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive sheet ACL entries remain visible
+- inactive record ACL entries remain visible
+- inactive sheet and record current-entry rows now disable mutation controls
+- inactive sheet field/view template rows now disable bulk-apply controls
+- inactive sheet field/view per-row overrides now disable save controls
+- inactive-user cleanup actions remain available through remove / clear paths
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added

--- a/docs/development/multitable-inactive-governance-followups-package-development-20260418.md
+++ b/docs/development/multitable-inactive-governance-followups-package-development-20260418.md
@@ -1,0 +1,61 @@
+## Background
+
+`#902` merged the main member-group ACL subject work into `main`, but the follow-up inactive-subject governance slices were still spread across stacked PRs:
+
+- `#910` inactive candidates cannot receive new grants
+- `#911` inactive current ACL entries become cleanup-only
+- `#912` inactive orphan field/view overrides become visibly identifiable
+- `#913` cleanup-only rows explicitly explain their state
+- `#914` inactive candidates explicitly explain blocked grants
+
+After `#902` merged, the fastest and cleanest way to continue was to promote these follow-up slices onto a fresh `main`-based branch instead of trying to preserve the old stacked chain.
+
+## Goal
+
+Package the inactive-subject governance follow-ups into one clean branch based on `main`, ready for a single PR and a single validation pass.
+
+## Scope
+
+- replay the five inactive-subject follow-up slices on top of `main`
+- preserve the per-slice development and verification notes
+- add one package-level record for the consolidation step
+
+## Implementation
+
+### 1. Promote the inactive-subject follow-ups onto `main`
+
+Created a new branch from `main` and replayed the following commits in order:
+
+- `f5fcef3bb` `fix(multitable): block acl grants to inactive candidates`
+- `4ee3e44d1` `fix(multitable): lock inactive acl entries to cleanup only`
+- `df3eaf7c1` `feat(multitable): surface inactive orphan acl subjects`
+- `7a5970d95` `feat(multitable): explain inactive acl cleanup state`
+- `e3c2b5de5` `feat(multitable): explain inactive candidate grant blocks`
+
+### 2. Keep the scope limited to inactive-subject governance
+
+No new ACL model was introduced in this package step. The promoted work is still limited to:
+
+- sheet ACL candidate rows
+- record ACL candidate rows
+- current sheet ACL rows
+- current record ACL rows
+- field/view template rows
+- field/view override rows
+- field/view orphan rows
+
+### 3. Preserve per-slice MD coverage
+
+The branch keeps all previously added slice-level development and verification docs so the packaged PR still has traceability for each step.
+
+## Files Added In This Packaging Step
+
+- `docs/development/multitable-inactive-governance-followups-package-development-20260418.md`
+- `docs/development/multitable-inactive-governance-followups-package-verification-20260418.md`
+
+## Risk Notes
+
+- no new runtime semantics beyond the previously verified slices
+- no backend changes
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-governance-followups-package-verification-20260418.md
+++ b/docs/development/multitable-inactive-governance-followups-package-verification-20260418.md
@@ -1,0 +1,36 @@
+## Verification Scope
+
+Verified the packaged inactive-subject governance follow-ups after replaying them onto the latest `main` that already includes `#902`.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts tests/integration/multitable-context.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+```
+
+## Results
+
+- frontend vitest: `20/20 passed`
+- frontend build: passed
+- backend integration: passed
+- backend build: passed
+
+## Assertions Covered
+
+- inactive candidates remain visible but cannot receive new grants
+- inactive current sheet and record ACL rows are cleanup-only
+- inactive field/view orphan overrides are visibly marked
+- inactive candidate and cleanup-only states are explicitly explained in the UI
+- existing member-group ACL integration coverage still passes on the new `main` base
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- Existing backend integration stderr noise from formula recalculation may still appear without failing tests
+- No remote deployment was performed
+- No database migration was added in this package step

--- a/docs/development/multitable-inactive-orphan-visibility-development-20260418.md
+++ b/docs/development/multitable-inactive-orphan-visibility-development-20260418.md
@@ -1,0 +1,56 @@
+## Background
+
+The sheet ACL governance UI already surfaces inactive users in:
+
+- current sheet ACL entries
+- current record ACL entries
+- eligible candidate rows
+- current field/view subject rows
+
+One visibility gap remained in the downstream cleanup path: orphan field/view overrides for inactive users only showed `No current sheet access`, which made them look the same as any generic orphaned override.
+
+## Goal
+
+Surface inactive lifecycle context on orphan field/view overrides so administrators can immediately tell when stale overrides belong to a disabled user account.
+
+## Scope
+
+- `MetaSheetPermissionManager`
+- focused frontend regression coverage
+
+## Implementation
+
+### 1. Add inactive lifecycle badges to orphan field overrides
+
+In `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`:
+
+- reused `subjectMutationBlocked(orphan.subjectType, orphan.isActive)`
+- added the existing `Inactive user` lifecycle badge to orphan field rows when the orphan subject is an inactive user
+
+### 2. Add inactive lifecycle badges to orphan view overrides
+
+In the same component:
+
+- mirrored the same lifecycle badge on orphan view rows
+
+This keeps the current cleanup flow unchanged while making the source of stale overrides easier to understand.
+
+### 3. Extend regression coverage
+
+Updated `apps/web/tests/multitable-sheet-permission-manager.spec.ts` with a focused test that verifies:
+
+- inactive orphan field overrides show `Inactive user`
+- inactive orphan view overrides show `Inactive user`
+- both still show `No current sheet access`
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+## Risk Notes
+
+- frontend-only visibility change
+- no backend semantic change
+- no migration
+- no deployment-step change

--- a/docs/development/multitable-inactive-orphan-visibility-verification-20260418.md
+++ b/docs/development/multitable-inactive-orphan-visibility-verification-20260418.md
@@ -1,0 +1,29 @@
+## Verification Scope
+
+Verified lifecycle visibility for inactive orphan field/view overrides in the sheet ACL governance UI.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `vitest`: `20/20 passed`
+- `web build`: passed
+
+## Assertions Covered
+
+- inactive orphan field overrides show both `Inactive user` and `No current sheet access`
+- inactive orphan view overrides show both `Inactive user` and `No current sheet access`
+- existing sheet/record inactive governance assertions continue to pass
+
+## Notes
+
+- Existing frontend test noise may still print `WebSocket server error: Port is already in use`
+- Existing Vite build warnings about chunk size / dynamic import remain unchanged
+- No remote deployment was performed
+- No database migration was added


### PR DESCRIPTION
## What changed

This PR packages the inactive-subject ACL governance follow-ups onto a clean `main`-based branch after `#902` merged.

It consolidates the follow-up work that was previously spread across stacked PRs:

- `#910` block new grants to inactive candidates
- `#911` lock inactive ACL entries to cleanup-only
- `#912` surface inactive orphan field/view ACL subjects
- `#913` explain inactive cleanup-only state
- `#914` explain inactive candidate grant blocks

## Scope

This PR does not change the member-group ACL model introduced by `#902`.
It only improves governance clarity and guardrails for inactive ACL subjects across:

- sheet ACL candidate rows
- record ACL candidate rows
- current sheet ACL rows
- current record ACL rows
- field/view template rows
- field/view override rows
- field/view orphan override rows

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @metasheet/web exec vitest run tests/multitable-sheet-permission-manager.spec.ts tests/multitable-record-permission-manager.spec.ts --watch=false
pnpm --filter @metasheet/web build
pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-sheet-permissions.api.test.ts tests/integration/multitable-context.api.test.ts --watch=false
pnpm --filter @metasheet/core-backend build
```

Results:

- frontend vitest: `20/20 passed`
- frontend build: passed
- backend integration: passed
- backend build: passed

## Notes

- No remote deployment in this PR
- No new migration in this PR
- Existing frontend/backend test stderr noise remains unchanged and non-blocking
- This PR supersedes the old stacked follow-up chain `#910-#914`
