### PR TITLE
feat(auth): close no-email user admission and login loop

### DIFF
--- a/docs/development/dingtalk-no-email-review-hardening-development-20260421.md
+++ b/docs/development/dingtalk-no-email-review-hardening-development-20260421.md
@@ -1,0 +1,34 @@
+# DingTalk No-Email Review Hardening Development 2026-04-21
+
+Branch: `codex/dingtalk-no-email-review-hardening-20260421`
+
+Base: `codex/no-email-user-closure-20260418` (`#916`)
+
+## Scope
+
+This is a stacked hardening slice for the no-email DingTalk user admission and login PR. It addresses the substantive review risks without expanding the user-facing feature surface.
+
+## Changes
+
+- Updated identifier login lookup in `AuthService.getUserByIdentifier()` to keep existing case-insensitive email/username and whitespace-normalized mobile semantics while removing `COALESCE(...)` from the indexed predicates.
+- Extended the no-email migration with expression indexes for `lower(email)` and whitespace-normalized `mobile`, in addition to the existing unique `lower(username)` index.
+- Changed manual directory binding by local user reference to query two candidates and fail closed with `Local user reference is ambiguous` when the highest matching identifier tier has duplicate rows.
+- Tightened login and manual directory binding so a single input matching different users across identifier types is ambiguous. Exact local user ID still wins for manual directory binding.
+- Added a shared unique-match helper for directory sync local-user matching so duplicate email/mobile matches are tracked as ambiguous instead of collapsed by `Map`.
+- Updated directory sync auto-matching to only select unique email/mobile matches. Ambiguous identifiers now leave the account unmatched for manual review and do not trigger auto-admission.
+
+## Review Notes
+
+- The generated no-email auto-admission username test remains unchanged. The current implementation uses the first 8 characters of the hyphen-stripped account id, so `account-12345678-...` resolves to suffix `account1`.
+- No frontend behavior changed in this slice.
+- No deployment was performed in this slice.
+- Follow-up review on `#969` asked for cross-field ambiguity handling; the branch now fails closed for that case and covers the explicit exact-ID exception.
+
+## Files Changed
+
+- `packages/core-backend/src/auth/AuthService.ts`
+- `packages/core-backend/src/db/migrations/zzzz20260418170000_allow_no_email_users_and_add_username.ts`
+- `packages/core-backend/src/directory/directory-sync.ts`
+- `packages/core-backend/tests/unit/AuthService.test.ts`
+- `packages/core-backend/tests/unit/directory-sync-auto-admission.test.ts`
+- `packages/core-backend/tests/unit/directory-sync-bind-account.test.ts`

--- a/docs/development/dingtalk-no-email-review-hardening-verification-20260421.md
+++ b/docs/development/dingtalk-no-email-review-hardening-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk No-Email Review Hardening Verification 2026-04-21
+
+Branch: `codex/dingtalk-no-email-review-hardening-20260421`
+
+Base: `codex/no-email-user-closure-20260418` (`#916`)
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/AuthService.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-auto-admission.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/AuthService.test.ts tests/unit/auth-login-routes.test.ts tests/unit/admin-users-routes.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-auto-admission.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/AuthService.test.ts tests/unit/directory-sync-bind-account.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/AuthService.test.ts tests/unit/auth-login-routes.test.ts tests/unit/admin-users-routes.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-auto-admission.test.ts --watch=false
+git diff --check
+git diff --cached --check
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`: passed. Standard ignored build-script warning was emitted.
+- Initial targeted test attempt before install failed because `vitest` was not present in the fresh worktree.
+- Targeted backend tests: passed, `3 passed`, `26 passed`.
+- Backend build: passed.
+- `#916` backend regression subset: passed, `6 passed`, `139 passed`.
+- Follow-up targeted backend tests after cross-field ambiguity fix: passed, `2 passed`, `23 passed`.
+- Follow-up backend build: passed.
+- Follow-up `#916` backend regression subset: passed, `6 passed`, `142 passed`.
+- `git diff --check`: passed.
+- `git diff --cached --check`: passed after staging the target source/test/doc files.
+
+## Coverage
+
+- Identifier login SQL no longer contains `COALESCE(email|username|mobile)` in indexed predicates.
+- Manual directory binding by duplicate mobile reference fails closed with an explicit ambiguity error.
+- Identifier login and manual directory binding fail closed when one input matches different users across email/username/mobile fields.
+- Manual directory binding still permits an exact local user ID match even when another user's email/username/mobile also equals that same string.
+- Directory sync local-user match map keeps only unique identifier matches and records duplicate keys as ambiguous.
+
+## Not Run
+
+- Frontend tests were not rerun because this slice did not change frontend code.
+- No remote deployment or database migration execution was performed from this worktree.

--- a/docs/development/no-email-user-closure-development-20260418.md
+++ b/docs/development/no-email-user-closure-development-20260418.md
@@ -98,3 +98,14 @@
 - 需要执行数据库迁移：
   - `zzzz20260418170000_allow_no_email_users_and_add_username.ts`
 - 本轮未做远端部署
+
+## Rebase 收口 - 2026-04-21
+
+- 将 PR #916 分支 rebase 到 `origin/main`，基线为 `d0b5883b4`。
+- 解决 `packages/core-backend/src/directory/directory-sync.ts` 与后续 DingTalk hardening 的重叠冲突。
+- 保留的合并语义：
+  - 无邮箱自动准入继续生成稳定 `dt_*` username。
+  - 手机号匹配继续使用 `normalizeMobileIdentifier()` 去空白后比较。
+  - 自动准入创建用户时传入 `generatedUsername`，避免无邮箱账号落成无登录标识。
+  - onboarding packet 保留 `accountLabel` 和临时密码信息。
+- `feat(directory): return no-email auto-admission onboarding packets` 在 rebase 时被 Git 判定为 patch contents already upstream，未重复应用。

--- a/docs/development/no-email-user-closure-package-development-20260419.md
+++ b/docs/development/no-email-user-closure-package-development-20260419.md
@@ -1,0 +1,96 @@
+# 无邮箱用户闭环总包开发说明 2026-04-19
+
+## 目标
+
+将“无邮箱用户闭环”收口成一个可合并切片，覆盖：
+
+- 平台管理员手动创建无邮箱用户
+- 钉钉目录手动准入创建无邮箱用户并绑定
+- 登录页支持统一账号标识登录
+- 无邮箱用户走临时密码 + 首登强制改密
+- 钉钉目录自动准入命中的无邮箱成员返回临时凭据包
+
+## 包含能力
+
+### 账号标识与登录
+
+- 登录页从 `email` 改为统一 `identifier`
+- 支持：
+  - 邮箱
+  - 用户名
+  - 手机号
+- 后端登录匹配新增 `getUserByIdentifier()`
+- 手机号冲突匹配保持保守：歧义时不自动登录
+
+### 用户创建
+
+- `users.email` 改为可空
+- 新增 `users.username`
+- 管理员创建用户时：
+  - `name` 必填
+  - `email / username / mobile` 至少一项存在
+- 无邮箱用户不再强依赖邀请链接
+
+### 钉钉手动准入
+
+- 目录治理页手动准入表单新增 `username`
+- 可创建无邮箱本地用户并立即绑定目录成员
+- 结果卡片显示：
+  - 登录账号
+  - 临时密码
+  - onboarding 文案
+
+### 钉钉自动准入
+
+- 白名单部门自动准入命中的无邮箱成员，不再直接跳过
+- 后端会：
+  - 自动生成稳定用户名
+  - 生成临时密码
+  - 创建本地用户
+  - 强制首登改密
+  - 返回 `autoAdmissionOnboardingPackets`
+- 前端同步完成后会展示“本次自动准入临时凭据”
+
+## 关键实现
+
+### 数据模型
+
+- `packages/core-backend/src/db/types.ts`
+- `packages/core-backend/src/db/migrations/zzzz20260418170000_allow_no_email_users_and_add_username.ts`
+
+### 登录与认证
+
+- `packages/core-backend/src/auth/AuthService.ts`
+- `packages/core-backend/src/routes/auth.ts`
+- `apps/web/src/views/LoginView.vue`
+
+### 用户管理
+
+- `packages/core-backend/src/routes/admin-users.ts`
+- `apps/web/src/views/UserManagementView.vue`
+
+### 钉钉目录治理
+
+- `packages/core-backend/src/routes/admin-directory.ts`
+- `packages/core-backend/src/directory/directory-sync.ts`
+- `apps/web/src/views/DirectoryManagementView.vue`
+
+## 风险控制
+
+- 有邮箱场景仍然走既有 invite token / invite ledger
+- 无邮箱场景只返回临时密码和 onboarding 文案，不伪造邀请链接
+- 自动准入用户名生成可重复、可预测，但仍经过用户名规则校验
+- 本轮不引入新通知通道，不自动发送短信/钉钉消息
+
+## 范围外
+
+- 手机验证码登录
+- 工号单独认证策略
+- 自动短信/钉钉消息下发初始凭据
+- 更细的账号恢复流程
+
+## 部署影响
+
+- 需要执行数据库迁移：
+  - `zzzz20260418170000_allow_no_email_users_and_add_username.ts`
+- 本轮未做远端部署

--- a/docs/development/no-email-user-closure-package-verification-20260419.md
+++ b/docs/development/no-email-user-closure-package-verification-20260419.md
@@ -1,0 +1,78 @@
+# 无邮箱用户闭环总包验证说明 2026-04-19
+
+## 验证范围
+
+- 登录支持统一账号标识
+- 管理员可创建无邮箱用户
+- 目录手动准入可创建无邮箱用户并绑定
+- 自动准入命中的无邮箱成员可返回临时凭据包
+- 目录同步页可展示自动准入临时凭据
+- 前后端构建通过
+
+## 执行命令
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/AuthService.test.ts \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts \
+  tests/unit/directory-sync-auto-admission.test.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  tests/directoryManagementView.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## 结果
+
+### 后端测试
+
+- `6 files passed`
+- `137 tests passed`
+
+覆盖重点：
+
+- identifier 登录
+- 无邮箱用户创建
+- 无邮箱目录手动准入
+- 无邮箱自动准入用户名生成
+- sync 路由返回 `autoAdmissionOnboardingPackets`
+
+### 前端测试
+
+- `3 files passed`
+- `49 tests passed`
+
+覆盖重点：
+
+- 登录页提交 `identifier`
+- 用户管理页无邮箱创建用户
+- 目录治理页无邮箱手动准入
+- 目录同步完成后展示自动准入临时凭据
+
+### 构建
+
+- `pnpm --filter @metasheet/core-backend build`：通过
+- `pnpm --filter @metasheet/web build`：通过
+
+## 备注
+
+- 前端测试环境仍会打印既有噪音：
+  - `WebSocket server error: Port is already in use`
+- 前端构建仍会打印既有 Vite chunk-size warning
+- 后端单测启动时仍会打印既有 `DATABASE_URL not set` warning
+- 以上均不影响本轮结论
+
+## 部署内容
+
+- 本轮没有远端部署
+- 本轮新增数据库迁移：
+  - `zzzz20260418170000_allow_no_email_users_and_add_username.ts`

--- a/docs/development/no-email-user-closure-verification-20260418.md
+++ b/docs/development/no-email-user-closure-verification-20260418.md
@@ -80,3 +80,49 @@ pnpm --filter @metasheet/web build
 - 本轮未做远端部署
 - 本轮新增数据库迁移：
   - `zzzz20260418170000_allow_no_email_users_and_add_username.ts`
+
+## Rebase 验证 - 2026-04-21
+
+### 基线
+
+- PR #916 分支 rebase 到 `origin/main`。
+- `directory-sync.ts` 冲突已解决。
+- `feat(directory): return no-email auto-admission onboarding packets` 在 rebase 中被判定为已上游等价存在，未重复应用。
+
+### 命令与结果
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/AuthService.test.ts \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts \
+  tests/unit/directory-sync-auto-admission.test.ts \
+  --watch=false
+```
+
+- 结果：`6 files passed`, `142 tests passed`
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  tests/directoryManagementView.spec.ts \
+  --watch=false
+```
+
+- 结果：`3 files passed`, `49 tests passed`
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+- 结果：全部通过
+
+### 备注
+
+- 新 `/tmp` worktree 初次运行测试时缺少 package-level `node_modules` 链接，出现过依赖解析失败；补临时 symlink 后重跑通过。
+- 前端 Vitest 仍打印既有 `WebSocket server error: Port is already in use`，不影响测试结论。

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -420,14 +420,14 @@ export class AuthService {
         const result = await pool.query(
           `SELECT id, email, username, mobile, name, role, permissions, password_hash, is_active, must_change_password, created_at, updated_at
            FROM users
-           WHERE lower(COALESCE(email, '')) = $1
-              OR lower(COALESCE(username, '')) = $2
-              OR regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g') = $3
+           WHERE lower(email) = $1
+              OR lower(username) = $2
+              OR regexp_replace(mobile, '\\s+', '', 'g') = $3
            ORDER BY
              CASE
-               WHEN lower(COALESCE(email, '')) = $1 THEN 0
-               WHEN lower(COALESCE(username, '')) = $2 THEN 1
-               WHEN regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g') = $3 THEN 2
+               WHEN lower(email) = $1 THEN 0
+               WHEN lower(username) = $2 THEN 1
+               WHEN regexp_replace(mobile, '\\s+', '', 'g') = $3 THEN 2
                ELSE 3
              END ASC,
              created_at ASC
@@ -435,12 +435,8 @@ export class AuthService {
           [normalizedEmail, normalizedUsername, normalizedMobile]
         )
 
-        const emailMatches = result.rows.filter((row) => typeof row.email === 'string' && row.email.toLowerCase() === normalizedEmail)
-        const usernameMatches = result.rows.filter((row) => typeof row.username === 'string' && row.username.toLowerCase() === normalizedUsername)
-        if (emailMatches.length > 1 || usernameMatches.length > 1) {
-          return null
-        }
-        if (result.rows.length > 1 && emailMatches.length === 0 && usernameMatches.length === 0) {
+        const distinctUserIds = new Set(result.rows.map((row) => row.id))
+        if (distinctUserIds.size > 1) {
           return null
         }
 

--- a/packages/core-backend/src/db/migrations/zzzz20260418170000_allow_no_email_users_and_add_username.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260418170000_allow_no_email_users_and_add_username.ts
@@ -17,6 +17,18 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     ON users (lower(username))
     WHERE username IS NOT NULL
   `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS users_email_lower_idx
+    ON users (lower(email))
+    WHERE email IS NOT NULL
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS users_mobile_nospace_idx
+    ON users (regexp_replace(mobile, '\\s+', '', 'g'))
+    WHERE mobile IS NOT NULL
+  `.execute(db)
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
@@ -24,6 +36,14 @@ export async function down(db: Kysely<unknown>): Promise<void> {
     UPDATE users
     SET email = COALESCE(email, id || '@migration-revert.local')
     WHERE email IS NULL
+  `.execute(db)
+
+  await sql`
+    DROP INDEX IF EXISTS users_mobile_nospace_idx
+  `.execute(db)
+
+  await sql`
+    DROP INDEX IF EXISTS users_email_lower_idx
   `.execute(db)
 
   await sql`

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -572,6 +572,10 @@ function normalizeText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
 }
 
+function normalizeMobileIdentifier(value: unknown): string {
+  return normalizeText(value).replace(/\s+/g, '')
+}
+
 function normalizeOptionalText(value: unknown): string | null {
   const text = normalizeText(value)
   return text.length > 0 ? text : null
@@ -586,7 +590,7 @@ function sanitizeDirectoryAdmissionName(value: string): string {
 }
 
 function sanitizeDirectoryAdmissionMobile(value: unknown): string | null {
-  const text = normalizeText(value).replace(/\s+/g, '')
+  const text = normalizeMobileIdentifier(value)
   if (!text) return null
   return text.slice(0, 32)
 }

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1780,6 +1780,31 @@ async function markSyncFailure(integrationId: string, runId: string, message: st
   }
 }
 
+export function buildUniqueLocalUserMatchMap(
+  rows: LocalUserRow[],
+  readKey: (row: LocalUserRow) => string,
+): { uniqueMap: Map<string, string>; ambiguousKeys: Set<string> } {
+  const idsByKey = new Map<string, Set<string>>()
+  for (const row of rows) {
+    const key = readKey(row)
+    if (!key) continue
+    const ids = idsByKey.get(key) ?? new Set<string>()
+    ids.add(row.id)
+    idsByKey.set(key, ids)
+  }
+
+  const uniqueMap = new Map<string, string>()
+  const ambiguousKeys = new Set<string>()
+  for (const [key, ids] of idsByKey.entries()) {
+    if (ids.size === 1) {
+      uniqueMap.set(key, Array.from(ids)[0])
+    } else {
+      ambiguousKeys.add(key)
+    }
+  }
+  return { uniqueMap, ambiguousKeys }
+}
+
 async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
   const externalKeys = Array.from(new Set(accounts.map((account) => account.external_key).filter(Boolean)))
   const unionIds = Array.from(new Set(
@@ -1799,7 +1824,7 @@ async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
   ))
   const mobiles = Array.from(new Set(
     accounts
-      .map((account) => normalizeText(account.mobile))
+      .map((account) => normalizeMobileIdentifier(account.mobile))
       .filter(Boolean),
   ))
 
@@ -1829,7 +1854,7 @@ async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
       ? query<LocalUserRow>(
         `SELECT id, mobile
          FROM users
-         WHERE mobile = ANY($1::text[])`,
+         WHERE regexp_replace(mobile, '\\s+', '', 'g') = ANY($1::text[])`,
         [mobiles],
       )
       : Promise.resolve({ rows: [] } as Awaited<ReturnType<typeof query<LocalUserRow>>>),
@@ -1844,20 +1869,23 @@ async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
     if (openKey) scopedOpenIdentityMap.set(openKey, row.local_user_id)
   }
 
+  const emailMatches = buildUniqueLocalUserMatchMap(
+    emailUsers.rows,
+    (row) => normalizeText(row.email).toLowerCase(),
+  )
+  const mobileMatches = buildUniqueLocalUserMatchMap(
+    mobileUsers.rows,
+    (row) => normalizeMobileIdentifier(row.mobile),
+  )
+
   return {
     externalIdentityMap: new Map(externalIdentities.rows.map((row) => [row.external_key, row.local_user_id])),
     scopedUnionIdentityMap,
     scopedOpenIdentityMap,
-    emailMap: new Map(
-      emailUsers.rows
-        .map((row) => [normalizeText(row.email).toLowerCase(), row.id] as const)
-        .filter(([email]) => email.length > 0),
-    ),
-    mobileMap: new Map(
-      mobileUsers.rows
-        .map((row) => [normalizeText(row.mobile), row.id] as const)
-        .filter(([mobile]) => mobile.length > 0),
-    ),
+    emailMap: emailMatches.uniqueMap,
+    mobileMap: mobileMatches.uniqueMap,
+    ambiguousEmailKeys: emailMatches.ambiguousKeys,
+    ambiguousMobileKeys: mobileMatches.ambiguousKeys,
   }
 }
 
@@ -2035,7 +2063,15 @@ export async function syncDirectoryIntegration(
         }
       }
 
-      const { externalIdentityMap, scopedUnionIdentityMap, scopedOpenIdentityMap, emailMap, mobileMap } = await loadMatchMaps(
+      const {
+        externalIdentityMap,
+        scopedUnionIdentityMap,
+        scopedOpenIdentityMap,
+        emailMap,
+        mobileMap,
+        ambiguousEmailKeys,
+        ambiguousMobileKeys,
+      } = await loadMatchMaps(
         Array.from(accountIdMap.values()),
       )
 
@@ -2077,8 +2113,12 @@ export async function syncDirectoryIntegration(
             linkStatus = 'linked'
             matchStrategy = 'external_identity'
           } else {
-            const emailUserId = normalizeText(account.email).toLowerCase() ? emailMap.get(normalizeText(account.email).toLowerCase()) : undefined
-            const mobileUserId = normalizeText(account.mobile) ? mobileMap.get(normalizeText(account.mobile)) : undefined
+            const emailKey = normalizeText(account.email).toLowerCase()
+            const mobileKey = normalizeMobileIdentifier(account.mobile)
+            const emailUserId = emailKey ? emailMap.get(emailKey) : undefined
+            const mobileUserId = mobileKey ? mobileMap.get(mobileKey) : undefined
+            const hasAmbiguousIdentifierMatch = (emailKey.length > 0 && ambiguousEmailKeys.has(emailKey))
+              || (mobileKey.length > 0 && ambiguousMobileKeys.has(mobileKey))
             if (emailUserId) {
               localUserId = emailUserId
               linkStatus = 'pending'
@@ -2087,6 +2127,10 @@ export async function syncDirectoryIntegration(
               localUserId = mobileUserId
               linkStatus = 'pending'
               matchStrategy = 'mobile'
+            } else if (hasAmbiguousIdentifierMatch) {
+              localUserId = null
+              linkStatus = 'unmatched'
+              matchStrategy = 'none'
             } else {
               const autoAdmission = evaluateDirectoryAutoAdmissionEligibility({
                 admissionMode: config.admissionMode,
@@ -2178,6 +2222,8 @@ export async function syncDirectoryIntegration(
                   autoAdmittedCount += 1
                   if (cleanEmail) emailMap.set(cleanEmail.toLowerCase(), created.userId)
                   if (cleanMobile) mobileMap.set(cleanMobile, created.userId)
+                  if (cleanEmail) ambiguousEmailKeys.delete(cleanEmail.toLowerCase())
+                  if (cleanMobile) ambiguousMobileKeys.delete(cleanMobile)
                   externalIdentityMap.set(account.external_key, created.userId)
                   const scopedOpenIdentityKey = buildScopedIdentityKey(account.corp_id, account.open_id)
                   if (scopedOpenIdentityKey) scopedOpenIdentityMap.set(scopedOpenIdentityKey, created.userId)
@@ -3305,6 +3351,8 @@ export async function getDirectoryAccountSummary(accountId: string): Promise<Dir
 async function resolveDirectoryBindingUser(localUserRef: string): Promise<DirectoryBindingUserRow | null> {
   const ref = normalizeText(localUserRef)
   if (!ref) return null
+  const normalizedRef = ref.toLowerCase()
+  const normalizedMobile = normalizeMobileIdentifier(ref)
 
   const result = await query<DirectoryBindingUserRow>(
     `SELECT id,
@@ -3316,22 +3364,38 @@ async function resolveDirectoryBindingUser(localUserRef: string): Promise<Direct
             COALESCE(is_active, TRUE) AS is_active
      FROM users
      WHERE id = $1
-        OR LOWER(COALESCE(email, '')) = LOWER($1)
-        OR LOWER(COALESCE(username, '')) = LOWER($1)
-        OR regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g') = regexp_replace($1, '\\s+', '', 'g')
+        OR LOWER(email) = $2
+        OR LOWER(username) = $2
+        OR regexp_replace(mobile, '\\s+', '', 'g') = $3
      ORDER BY
        CASE
          WHEN id = $1 THEN 0
-         WHEN LOWER(COALESCE(email, '')) = LOWER($1) THEN 1
-         WHEN LOWER(COALESCE(username, '')) = LOWER($1) THEN 2
-         WHEN regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g') = regexp_replace($1, '\\s+', '', 'g') THEN 3
+         WHEN LOWER(email) = $2 THEN 1
+         WHEN LOWER(username) = $2 THEN 2
+         WHEN regexp_replace(mobile, '\\s+', '', 'g') = $3 THEN 3
          ELSE 4
        END
-     LIMIT 1`,
-    [ref],
+     LIMIT 2`,
+    [ref, normalizedRef, normalizedMobile],
   )
 
-  return result.rows[0] ?? null
+  const idMatch = result.rows.find((row) => row.id === ref)
+  if (idMatch) return idMatch
+
+  const distinctUserIds = new Set(result.rows.map((row) => row.id))
+  if (distinctUserIds.size > 1) throw new Error('Local user reference is ambiguous')
+
+  const emailMatches = result.rows.filter((row) => typeof row.email === 'string' && row.email.toLowerCase() === normalizedRef)
+  if (emailMatches.length > 1) throw new Error('Local user reference is ambiguous')
+  if (emailMatches.length === 1) return emailMatches[0]
+
+  const usernameMatches = result.rows.filter((row) => typeof row.username === 'string' && row.username.toLowerCase() === normalizedRef)
+  if (usernameMatches.length > 1) throw new Error('Local user reference is ambiguous')
+  if (usernameMatches.length === 1) return usernameMatches[0]
+
+  const mobileMatches = result.rows.filter((row) => typeof row.mobile === 'string' && normalizeMobileIdentifier(row.mobile) === normalizedMobile)
+  if (mobileMatches.length > 1) throw new Error('Local user reference is ambiguous')
+  return mobileMatches[0] ?? null
 }
 
 async function loadDirectoryBindingTargetAccount(directoryAccountId: string): Promise<DirectoryBindingTargetAccountRow | null> {

--- a/packages/core-backend/tests/unit/AuthService.test.ts
+++ b/packages/core-backend/tests/unit/AuthService.test.ts
@@ -461,9 +461,13 @@ describe('AuthService.login', () => {
     )
     expect(poolMocks.query).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('lower(COALESCE(username'),
+      expect.stringContaining('lower(username) = $2'),
       ['liqing', 'liqing', 'liqing'],
     )
+    const loginSql = String(poolMocks.query.mock.calls[0]?.[0] ?? '')
+    expect(loginSql).not.toContain('COALESCE(email')
+    expect(loginSql).not.toContain('COALESCE(username')
+    expect(loginSql).not.toContain('COALESCE(mobile')
   })
 
   it('returns null when a mobile identifier matches multiple users', async () => {
@@ -503,6 +507,48 @@ describe('AuthService.login', () => {
 
     const auth = new AuthService()
     const result = await auth.login('13900001234', 'WelcomePass9A')
+
+    expect(result).toBeNull()
+    expect(sessionMocks.createUserSession).not.toHaveBeenCalled()
+  })
+
+  it('returns null when one identifier matches different users across account fields', async () => {
+    const passwordHash = await bcrypt.hash('WelcomePass9A', 10)
+    poolMocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'user-1',
+          email: 'shared@example.com',
+          username: 'liqing',
+          mobile: '13900001234',
+          name: '李青',
+          role: 'user',
+          permissions: ['attendance:read'],
+          password_hash: passwordHash,
+          is_active: true,
+          must_change_password: false,
+          created_at: new Date('2026-04-18T00:00:00.000Z'),
+          updated_at: new Date('2026-04-18T00:00:00.000Z'),
+        },
+        {
+          id: 'user-2',
+          email: null,
+          username: 'shared@example.com',
+          mobile: '13900004567',
+          name: '林岚',
+          role: 'user',
+          permissions: ['attendance:read'],
+          password_hash: passwordHash,
+          is_active: true,
+          must_change_password: false,
+          created_at: new Date('2026-04-18T00:00:00.000Z'),
+          updated_at: new Date('2026-04-18T00:00:00.000Z'),
+        },
+      ],
+    })
+
+    const auth = new AuthService()
+    const result = await auth.login('shared@example.com', 'WelcomePass9A')
 
     expect(result).toBeNull()
     expect(sessionMocks.createUserSession).not.toHaveBeenCalled()

--- a/packages/core-backend/tests/unit/directory-sync-auto-admission.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-auto-admission.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildDirectoryAutoAdmissionUsername,
+  buildUniqueLocalUserMatchMap,
   evaluateDirectoryAutoAdmissionEligibility,
   isDirectoryUserWithinAdmissionScope,
 } from '../../src/directory/directory-sync'
@@ -89,5 +90,20 @@ describe('directory auto admission scope', () => {
       union_id: null,
       open_id: null,
     })).toBe('dt_user_001_account1')
+  })
+
+  it('keeps only unique local-user identifier matches', () => {
+    const result = buildUniqueLocalUserMatchMap([
+      { id: 'user-1', mobile: '13900001234' },
+      { id: 'user-2', mobile: '13900001234' },
+      { id: 'user-3', mobile: '13900004567' },
+    ], (row) => row.mobile || '')
+
+    expect(result.uniqueMap).toEqual(new Map([
+      ['13900004567', 'user-3'],
+    ]))
+    expect(result.ambiguousKeys).toEqual(new Set([
+      '13900001234',
+    ]))
   })
 })

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -189,6 +189,211 @@ describe('bindDirectoryAccount', () => {
     expect(pgMocks.transaction).not.toHaveBeenCalled()
   })
 
+  it('fails closed when a mobile binding reference matches multiple local users', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: '13900001234',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'user-1',
+            email: null,
+            username: 'liqing',
+            mobile: '13900001234',
+            name: '李青',
+            role: 'user',
+            is_active: true,
+          },
+          {
+            id: 'user-2',
+            email: null,
+            username: 'linlan',
+            mobile: '139 0000 1234',
+            name: '林岚',
+            role: 'user',
+            is_active: true,
+          },
+        ],
+      })
+
+    await expect(bindDirectoryAccount('account-1', {
+      localUserRef: '139 0000 1234',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: true,
+    })).rejects.toThrow('Local user reference is ambiguous')
+
+    expect(pgMocks.query).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('LIMIT 2'),
+      ['139 0000 1234', '139 0000 1234', '13900001234'],
+    )
+    expect(pgMocks.transaction).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a binding reference matches different users across account fields', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: '13900001234',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'user-1',
+            email: 'shared@example.com',
+            username: 'liqing',
+            mobile: '13900001234',
+            name: '李青',
+            role: 'user',
+            is_active: true,
+          },
+          {
+            id: 'user-2',
+            email: null,
+            username: 'shared@example.com',
+            mobile: '13900004567',
+            name: '林岚',
+            role: 'user',
+            is_active: true,
+          },
+        ],
+      })
+
+    await expect(bindDirectoryAccount('account-1', {
+      localUserRef: 'shared@example.com',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: true,
+    })).rejects.toThrow('Local user reference is ambiguous')
+
+    expect(pgMocks.transaction).not.toHaveBeenCalled()
+  })
+
+  it('prefers an exact local user id over cross-field identifier ambiguity', async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: '13900001234',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'user-1',
+            email: 'alpha@example.com',
+            username: 'alpha',
+            mobile: '13900001234',
+            name: 'Alpha',
+            role: 'user',
+            is_active: true,
+          },
+          {
+            id: 'user-2',
+            email: 'user-1',
+            username: 'user-1',
+            mobile: '13900004567',
+            name: 'Shadow',
+            role: 'user',
+            is_active: true,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '林岚',
+          account_email: null,
+          account_mobile: '13900001234',
+          account_is_active: true,
+          account_updated_at: '2026-04-11T08:00:00.000Z',
+          link_status: 'linked',
+          match_strategy: 'manual_admin',
+          reviewed_by: 'admin-1',
+          review_note: null,
+          link_updated_at: '2026-04-11T08:00:00.000Z',
+          local_user_id: 'user-1',
+          local_user_email: 'alpha@example.com',
+          local_user_name: 'Alpha',
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+
+    const result = await bindDirectoryAccount('account-1', {
+      localUserRef: 'user-1',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: true,
+    })
+
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO directory_account_links'),
+      ['account-1', 'user-1', 'admin-1'],
+    )
+    expect(result.account.localUser?.id).toBe('user-1')
+  })
+
   it('creates a local user and binds it to a directory account in one server-side admission flow', async () => {
     const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))


### PR DESCRIPTION
## What changed

This PR closes the no-email user admission and login loop across auth, admin user management, and DingTalk directory governance.

It adds:
- generic account identifier login (`email / username / mobile`)
- optional email for admin-created users
- no-email directory manual admission and bind
- no-email directory auto-admission onboarding packets
- frontend result handling for temporary-password distribution

## User-facing behavior

- Login now accepts a generic identifier instead of email-only.
- Admins can create a local user without email, as long as at least one identifier exists (`email`, `username`, or `mobile`).
- DingTalk directory manual admission can create and bind no-email users.
- White-listed DingTalk auto-admission no longer hard-skips users just because email is missing.
- When auto-admitting a no-email user, directory sync now returns onboarding packets with:
  - login account
  - temporary password
  - onboarding message
- Directory management shows a dedicated sync result card for those no-email auto-admitted users.

## Backend changes

- `users.email` becomes nullable
- `users.username` added with uniqueness enforcement
- auth login resolves by identifier (`email / username / mobile`)
- admin create-user route supports no-email users
- directory manual admission supports no-email users
- directory auto-admission supports no-email users by generating:
  - deterministic username
  - temporary password
  - onboarding packet

## Frontend changes

- login form label/submit payload uses `identifier`
- user management create-user flow supports optional email + username/mobile
- directory management manual admission supports username
- sync result UI surfaces no-email auto-admission credential packets

## Verification

Ran:

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/AuthService.test.ts \
  tests/unit/auth-login-routes.test.ts \
  tests/unit/admin-users-routes.test.ts \
  tests/unit/admin-directory-routes.test.ts \
  tests/unit/directory-sync-bind-account.test.ts \
  tests/unit/directory-sync-auto-admission.test.ts \
  --watch=false

pnpm --filter @metasheet/web exec vitest run \
  tests/LoginView.spec.ts \
  tests/userManagementView.spec.ts \
  tests/directoryManagementView.spec.ts \
  --watch=false

pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
```

Results:
- backend tests: `137 passed`
- frontend tests: `49 passed`
- backend build: passed
- web build: passed

## Notes

- This PR includes migration:
  - `zzzz20260418170000_allow_no_email_users_and_add_username.ts`
- No remote deployment was performed in this branch.
