### PR TITLE
feat(dingtalk): add standard group notification flow for multitable

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -56,6 +56,8 @@ import type {
   Webhook,
   WebhookCreateInput,
   WebhookDelivery,
+  DingTalkGroupDestination,
+  DingTalkGroupDestinationInput,
 } from '../types'
 import { apiFetch } from '../../utils/api'
 
@@ -1080,6 +1082,47 @@ export class MultitableApiClient {
     const res = await this.fetch(`/api/multitable/webhooks/${encodeURIComponent(id)}/deliveries`)
     const data = await parseJson<{ deliveries: WebhookDelivery[] }>(res)
     return data.deliveries ?? []
+  }
+
+  // --- DingTalk Group Destinations ---
+  async listDingTalkGroups(): Promise<DingTalkGroupDestination[]> {
+    const res = await this.fetch('/api/multitable/dingtalk-groups')
+    const data = await parseJson<{ destinations: DingTalkGroupDestination[] }>(res)
+    return data.destinations ?? []
+  }
+
+  async createDingTalkGroup(input: DingTalkGroupDestinationInput): Promise<DingTalkGroupDestination> {
+    const res = await this.fetch('/api/multitable/dingtalk-groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return parseJson(res)
+  }
+
+  async updateDingTalkGroup(id: string, input: Partial<DingTalkGroupDestinationInput>): Promise<DingTalkGroupDestination> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return parseJson(res)
+  }
+
+  async deleteDingTalkGroup(id: string): Promise<void> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    })
+    return parseJson(res)
+  }
+
+  async testDingTalkGroup(id: string, input?: { subject?: string; content?: string }): Promise<void> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}/test-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input ?? {}),
+    })
+    return parseJson(res)
   }
 
   // --- Automation V1: test / logs / stats ---

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -57,6 +57,7 @@ import type {
   WebhookCreateInput,
   WebhookDelivery,
   DingTalkGroupDestination,
+  DingTalkGroupDelivery,
   DingTalkGroupDestinationInput,
 } from '../types'
 import { apiFetch } from '../../utils/api'
@@ -1123,6 +1124,12 @@ export class MultitableApiClient {
       body: JSON.stringify(input ?? {}),
     })
     return parseJson(res)
+  }
+
+  async getDingTalkGroupDeliveries(id: string): Promise<DingTalkGroupDelivery[]> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}/deliveries`)
+    const data = await parseJson<{ deliveries: DingTalkGroupDelivery[] }>(res)
+    return data.deliveries ?? []
   }
 
   // --- Automation V1: test / logs / stats ---

--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -2,7 +2,7 @@
   <div v-if="visible" class="meta-api-mgr__overlay" @click.self="$emit('close')">
     <div class="meta-api-mgr">
       <div class="meta-api-mgr__header">
-        <h4 class="meta-api-mgr__title">API Tokens &amp; Webhooks</h4>
+        <h4 class="meta-api-mgr__title">API Tokens, Webhooks &amp; DingTalk Groups</h4>
         <button class="meta-api-mgr__close" type="button" @click="$emit('close')">&times;</button>
       </div>
 
@@ -24,6 +24,15 @@
           @click="activeTab = 'webhooks'"
         >
           Webhooks
+        </button>
+        <button
+          role="tab"
+          :aria-selected="activeTab === 'dingtalk-groups'"
+          class="meta-api-mgr__tab"
+          :class="{ 'meta-api-mgr__tab--active': activeTab === 'dingtalk-groups' }"
+          @click="activeTab = 'dingtalk-groups'"
+        >
+          DingTalk Groups
         </button>
       </div>
 
@@ -155,6 +164,116 @@
             </div>
           </div>
         </template>
+
+        <!-- ===== DINGTALK GROUPS TAB ===== -->
+        <template v-if="activeTab === 'dingtalk-groups'">
+          <section v-if="showDingTalkGroupForm" class="meta-api-mgr__form" data-dingtalk-group-form="true">
+            <div class="meta-api-mgr__form-title">
+              {{ editingDingTalkGroupId ? 'Edit DingTalk Group' : 'New DingTalk Group' }}
+            </div>
+            <label class="meta-api-mgr__label">Name</label>
+            <input
+              v-model="dingTalkGroupDraft.name"
+              class="meta-api-mgr__input"
+              type="text"
+              placeholder="Support group"
+              data-dingtalk-group-name="true"
+            />
+            <label class="meta-api-mgr__label">Webhook URL</label>
+            <input
+              v-model="dingTalkGroupDraft.webhookUrl"
+              class="meta-api-mgr__input"
+              type="url"
+              placeholder="https://oapi.dingtalk.com/robot/send?access_token=..."
+              data-dingtalk-group-webhook-url="true"
+            />
+            <label class="meta-api-mgr__label">Secret (optional)</label>
+            <input
+              v-model="dingTalkGroupDraft.secret"
+              class="meta-api-mgr__input"
+              type="text"
+              placeholder="SEC..."
+              data-dingtalk-group-secret="true"
+            />
+            <label class="meta-api-mgr__checkbox-label">
+              <input
+                v-model="dingTalkGroupDraft.enabled"
+                type="checkbox"
+                data-dingtalk-group-enabled="true"
+              />
+              Enabled
+            </label>
+            <div class="meta-api-mgr__form-actions">
+              <button
+                class="meta-api-mgr__btn meta-api-mgr__btn--primary"
+                type="button"
+                :disabled="!canSaveDingTalkGroup || busy"
+                data-dingtalk-group-save="true"
+                @click="onSaveDingTalkGroup"
+              >
+                {{ editingDingTalkGroupId ? 'Update' : 'Create' }}
+              </button>
+              <button class="meta-api-mgr__btn" type="button" @click="cancelDingTalkGroupForm">Cancel</button>
+            </div>
+          </section>
+
+          <button
+            v-if="!showDingTalkGroupForm"
+            class="meta-api-mgr__btn meta-api-mgr__btn--primary meta-api-mgr__btn-add"
+            type="button"
+            data-dingtalk-group-new="true"
+            @click="openDingTalkGroupForm"
+          >
+            + New DingTalk Group
+          </button>
+
+          <div v-if="dingTalkGroupsLoading" class="meta-api-mgr__empty">Loading DingTalk groups&#x2026;</div>
+          <div
+            v-else-if="!dingTalkGroups.length && !showDingTalkGroupForm"
+            class="meta-api-mgr__empty"
+            data-dingtalk-groups-empty="true"
+          >
+            No DingTalk groups yet.
+          </div>
+          <div
+            v-for="group in dingTalkGroups"
+            :key="group.id"
+            class="meta-api-mgr__card"
+            :data-dingtalk-group-id="group.id"
+          >
+            <div class="meta-api-mgr__card-header">
+              <strong class="meta-api-mgr__card-name">{{ group.name }}</strong>
+              <span class="meta-api-mgr__card-status" :data-dingtalk-group-status="group.enabled ? 'enabled' : 'disabled'">
+                {{ group.enabled ? 'Enabled' : 'Disabled' }}
+              </span>
+            </div>
+            <div class="meta-api-mgr__card-meta">
+              <span>Webhook: {{ group.webhookUrl }}</span>
+              <span>Created: {{ formatDate(group.createdAt) }}</span>
+              <span v-if="group.lastTestedAt">Last test: {{ formatDate(group.lastTestedAt) }}</span>
+              <span v-if="group.lastTestStatus" :data-dingtalk-group-test-status="group.lastTestStatus">
+                Test status: {{ group.lastTestStatus }}
+              </span>
+            </div>
+            <div v-if="group.lastTestError" class="meta-api-mgr__card-meta meta-api-mgr__card-failures">
+              <span>Last error: {{ group.lastTestError }}</span>
+            </div>
+            <div class="meta-api-mgr__card-actions">
+              <button class="meta-api-mgr__btn" type="button" data-dingtalk-group-edit="true" @click="openEditDingTalkGroup(group)">
+                Edit
+              </button>
+              <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-toggle="true" @click="onToggleDingTalkGroup(group)">
+                {{ group.enabled ? 'Disable' : 'Enable' }}
+              </button>
+              <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-test-send="true" @click="onTestDingTalkGroup(group.id)">
+                Test send
+              </button>
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-dingtalk-group-delete="true" @click="onDeleteDingTalkGroup(group.id)">
+                Delete
+              </button>
+            </div>
+          </div>
+        </template>
       </div>
     </div>
   </div>
@@ -162,7 +281,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import type { ApiToken, Webhook, WebhookDelivery } from '../types'
+import type { ApiToken, DingTalkGroupDestination, Webhook, WebhookDelivery } from '../types'
 import type { MultitableApiClient } from '../api/client'
 
 const props = defineProps<{
@@ -174,7 +293,7 @@ const emit = defineEmits<{
   (e: 'close'): void
 }>()
 
-const activeTab = ref<'tokens' | 'webhooks'>('tokens')
+const activeTab = ref<'tokens' | 'webhooks' | 'dingtalk-groups'>('tokens')
 const error = ref<string | null>(null)
 const busy = ref(false)
 
@@ -197,8 +316,24 @@ const availableEvents = ['record.created', 'record.updated', 'record.deleted', '
 const deliveriesWebhookId = ref<string | null>(null)
 const deliveries = ref<WebhookDelivery[]>([])
 
+// ---- DingTalk groups ----
+const dingTalkGroups = ref<DingTalkGroupDestination[]>([])
+const dingTalkGroupsLoading = ref(false)
+const showDingTalkGroupForm = ref(false)
+const editingDingTalkGroupId = ref<string | null>(null)
+const dingTalkGroupDraft = ref({
+  name: '',
+  webhookUrl: '',
+  secret: '',
+  enabled: true,
+})
+
 const canSaveWebhook = computed(() => {
   return webhookDraft.value.name.trim() && webhookDraft.value.url.startsWith('https://') && webhookDraft.value.events.length > 0
+})
+
+const canSaveDingTalkGroup = computed(() => {
+  return dingTalkGroupDraft.value.name.trim() && dingTalkGroupDraft.value.webhookUrl.trim().startsWith('https://')
 })
 
 function formatDate(iso: string): string {
@@ -411,6 +546,114 @@ async function onViewDeliveries(webhookId: string) {
   }
 }
 
+// ---- DingTalk group actions ----
+async function loadDingTalkGroups() {
+  if (!props.client) return
+  dingTalkGroupsLoading.value = true
+  error.value = null
+  try {
+    dingTalkGroups.value = await props.client.listDingTalkGroups()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load DingTalk groups'
+  } finally {
+    dingTalkGroupsLoading.value = false
+  }
+}
+
+function openDingTalkGroupForm() {
+  editingDingTalkGroupId.value = null
+  dingTalkGroupDraft.value = {
+    name: '',
+    webhookUrl: '',
+    secret: '',
+    enabled: true,
+  }
+  showDingTalkGroupForm.value = true
+}
+
+function openEditDingTalkGroup(group: DingTalkGroupDestination) {
+  editingDingTalkGroupId.value = group.id
+  dingTalkGroupDraft.value = {
+    name: group.name,
+    webhookUrl: group.webhookUrl,
+    secret: group.secret ?? '',
+    enabled: group.enabled,
+  }
+  showDingTalkGroupForm.value = true
+}
+
+function cancelDingTalkGroupForm() {
+  showDingTalkGroupForm.value = false
+  editingDingTalkGroupId.value = null
+}
+
+async function onSaveDingTalkGroup() {
+  if (!props.client || busy.value || !canSaveDingTalkGroup.value) return
+  busy.value = true
+  error.value = null
+  try {
+    const input = {
+      name: dingTalkGroupDraft.value.name.trim(),
+      webhookUrl: dingTalkGroupDraft.value.webhookUrl.trim(),
+      secret: dingTalkGroupDraft.value.secret || undefined,
+      enabled: dingTalkGroupDraft.value.enabled,
+    }
+    if (editingDingTalkGroupId.value) {
+      await props.client.updateDingTalkGroup(editingDingTalkGroupId.value, input)
+    } else {
+      await props.client.createDingTalkGroup(input)
+    }
+    cancelDingTalkGroupForm()
+    await loadDingTalkGroups()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to save DingTalk group'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onToggleDingTalkGroup(group: DingTalkGroupDestination) {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    await props.client.updateDingTalkGroup(group.id, { enabled: !group.enabled })
+    await loadDingTalkGroups()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to toggle DingTalk group'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onTestDingTalkGroup(groupId: string) {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    await props.client.testDingTalkGroup(groupId)
+    await loadDingTalkGroups()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to test DingTalk group'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onDeleteDingTalkGroup(groupId: string) {
+  if (!props.client || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    await props.client.deleteDingTalkGroup(groupId)
+    await loadDingTalkGroups()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to delete DingTalk group'
+  } finally {
+    busy.value = false
+  }
+}
+
 watch(
   () => props.visible,
   (v) => {
@@ -419,6 +662,7 @@ watch(
       newTokenPlaintext.value = null
       void loadTokens()
       void loadWebhooks()
+      void loadDingTalkGroups()
     }
   },
   { immediate: true },

--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -265,12 +265,49 @@
               <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-toggle="true" @click="onToggleDingTalkGroup(group)">
                 {{ group.enabled ? 'Disable' : 'Enable' }}
               </button>
+              <button class="meta-api-mgr__btn" type="button" data-dingtalk-group-deliveries="true" @click="onViewDingTalkDeliveries(group.id)">
+                Deliveries
+              </button>
               <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-test-send="true" @click="onTestDingTalkGroup(group.id)">
                 Test send
               </button>
               <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-dingtalk-group-delete="true" @click="onDeleteDingTalkGroup(group.id)">
                 Delete
               </button>
+            </div>
+
+            <div
+              v-if="dingTalkDeliveriesGroupId === group.id"
+              class="meta-api-mgr__deliveries"
+              data-dingtalk-deliveries="true"
+            >
+              <strong class="meta-api-mgr__label">Recent Deliveries</strong>
+              <div v-if="dingTalkDeliveriesLoading" class="meta-api-mgr__empty" data-dingtalk-deliveries-loading="true">
+                Loading DingTalk deliveries…
+              </div>
+              <div
+                v-else-if="!dingTalkDeliveries.length"
+                class="meta-api-mgr__empty"
+                data-dingtalk-deliveries-empty="true"
+              >
+                No DingTalk deliveries yet.
+              </div>
+              <template v-else>
+                <div
+                  v-for="delivery in dingTalkDeliveries"
+                  :key="delivery.id"
+                  class="meta-api-mgr__delivery-row"
+                  :data-dingtalk-delivery-id="delivery.id"
+                >
+                  <span :class="delivery.success ? 'meta-api-mgr__delivery--ok' : 'meta-api-mgr__delivery--fail'">
+                    {{ delivery.success ? 'OK' : 'FAIL' }}
+                  </span>
+                  <span>{{ delivery.sourceType === 'manual_test' ? 'Manual test' : 'Automation' }}</span>
+                  <span>{{ delivery.subject }}</span>
+                  <span>HTTP {{ delivery.httpStatus ?? '-' }}</span>
+                  <span>{{ formatDate(delivery.createdAt) }}</span>
+                </div>
+              </template>
             </div>
           </div>
         </template>
@@ -281,7 +318,13 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import type { ApiToken, DingTalkGroupDestination, Webhook, WebhookDelivery } from '../types'
+import type {
+  ApiToken,
+  DingTalkGroupDelivery,
+  DingTalkGroupDestination,
+  Webhook,
+  WebhookDelivery,
+} from '../types'
 import type { MultitableApiClient } from '../api/client'
 
 const props = defineProps<{
@@ -321,6 +364,10 @@ const dingTalkGroups = ref<DingTalkGroupDestination[]>([])
 const dingTalkGroupsLoading = ref(false)
 const showDingTalkGroupForm = ref(false)
 const editingDingTalkGroupId = ref<string | null>(null)
+const dingTalkDeliveriesGroupId = ref<string | null>(null)
+const dingTalkDeliveriesLoading = ref(false)
+const dingTalkDeliveries = ref<DingTalkGroupDelivery[]>([])
+let dingTalkDeliveriesRequestToken = 0
 const dingTalkGroupDraft = ref({
   name: '',
   webhookUrl: '',
@@ -633,11 +680,51 @@ async function onTestDingTalkGroup(groupId: string) {
   try {
     await props.client.testDingTalkGroup(groupId)
     await loadDingTalkGroups()
+    if (dingTalkDeliveriesGroupId.value === groupId) {
+      await loadDingTalkDeliveries(groupId)
+    }
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to test DingTalk group'
   } finally {
     busy.value = false
   }
+}
+
+async function loadDingTalkDeliveries(groupId: string) {
+  if (!props.client) return
+  const requestToken = ++dingTalkDeliveriesRequestToken
+  dingTalkDeliveriesGroupId.value = groupId
+  dingTalkDeliveriesLoading.value = true
+  dingTalkDeliveries.value = []
+  error.value = null
+  try {
+    const deliveries = await props.client.getDingTalkGroupDeliveries(groupId)
+    if (requestToken !== dingTalkDeliveriesRequestToken || dingTalkDeliveriesGroupId.value !== groupId) {
+      return
+    }
+    dingTalkDeliveries.value = deliveries
+  } catch (err) {
+    if (requestToken !== dingTalkDeliveriesRequestToken || dingTalkDeliveriesGroupId.value !== groupId) {
+      return
+    }
+    error.value = err instanceof Error ? err.message : 'Failed to load DingTalk deliveries'
+  } finally {
+    if (requestToken === dingTalkDeliveriesRequestToken && dingTalkDeliveriesGroupId.value === groupId) {
+      dingTalkDeliveriesLoading.value = false
+    }
+  }
+}
+
+async function onViewDingTalkDeliveries(groupId: string) {
+  if (!props.client) return
+  if (dingTalkDeliveriesGroupId.value === groupId) {
+    dingTalkDeliveriesRequestToken += 1
+    dingTalkDeliveriesGroupId.value = null
+    dingTalkDeliveriesLoading.value = false
+    dingTalkDeliveries.value = []
+    return
+  }
+  await loadDingTalkDeliveries(groupId)
 }
 
 async function onDeleteDingTalkGroup(groupId: string) {
@@ -646,6 +733,12 @@ async function onDeleteDingTalkGroup(groupId: string) {
   error.value = null
   try {
     await props.client.deleteDingTalkGroup(groupId)
+    if (dingTalkDeliveriesGroupId.value === groupId) {
+      dingTalkDeliveriesRequestToken += 1
+      dingTalkDeliveriesGroupId.value = null
+      dingTalkDeliveriesLoading.value = false
+      dingTalkDeliveries.value = []
+    }
     await loadDingTalkGroups()
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to delete DingTalk group'

--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -248,7 +248,7 @@
               </span>
             </div>
             <div class="meta-api-mgr__card-meta">
-              <span>Webhook: {{ group.webhookUrl }}</span>
+              <span>Webhook: {{ maskDingTalkWebhookUrl(group.webhookUrl) }}</span>
               <span>Created: {{ formatDate(group.createdAt) }}</span>
               <span v-if="group.lastTestedAt">Last test: {{ formatDate(group.lastTestedAt) }}</span>
               <span v-if="group.lastTestStatus" :data-dingtalk-group-test-status="group.lastTestStatus">
@@ -388,6 +388,23 @@ function formatDate(iso: string): string {
     return new Date(iso).toLocaleDateString()
   } catch {
     return iso
+  }
+}
+
+function maskDingTalkWebhookUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    for (const key of ['access_token', 'timestamp', 'sign']) {
+      if (parsed.searchParams.has(key)) {
+        parsed.searchParams.set(key, '***')
+      }
+    }
+    if (parsed.password) {
+      parsed.password = '***'
+    }
+    return parsed.toString()
+  } catch {
+    return String(url || '').replace(/([?&](?:access_token|timestamp|sign)=)[^&]+/gi, '$1***')
   }
 }
 

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -41,6 +41,7 @@
           <select v-model="draft.actionType" class="meta-automation__select" data-automation-field="actionType">
             <option value="notify">Send notification</option>
             <option value="update_field">Update field value</option>
+            <option value="send_dingtalk_group_message">Send DingTalk group message</option>
           </select>
 
           <template v-if="draft.actionType === 'notify'">
@@ -68,6 +69,42 @@
               placeholder="New value"
               data-automation-field="targetValue"
             />
+          </template>
+
+          <template v-if="draft.actionType === 'send_dingtalk_group_message'">
+            <label class="meta-automation__label">DingTalk group</label>
+            <select v-model="draft.dingtalkDestinationId" class="meta-automation__select" data-automation-field="dingtalkDestinationId">
+              <option value="">-- select DingTalk group --</option>
+              <option v-for="destination in dingTalkDestinations" :key="destination.id" :value="destination.id">
+                {{ destination.name }}
+              </option>
+            </select>
+            <label class="meta-automation__label">Title template</label>
+            <input
+              v-model="draft.dingtalkTitleTemplate"
+              class="meta-automation__input"
+              type="text"
+              placeholder="例如：{{record.title}} 待处理"
+              data-automation-field="dingtalkTitleTemplate"
+            />
+            <label class="meta-automation__label">Body template</label>
+            <textarea
+              v-model="draft.dingtalkBodyTemplate"
+              class="meta-automation__input"
+              rows="4"
+              placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+              data-automation-field="dingtalkBodyTemplate"
+            ></textarea>
+            <label class="meta-automation__label">Public form view (optional)</label>
+            <select v-model="draft.publicFormViewId" class="meta-automation__select" data-automation-field="publicFormViewId">
+              <option value="">-- no public form link --</option>
+              <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
+            </select>
+            <label class="meta-automation__label">Internal processing view (optional)</label>
+            <select v-model="draft.internalViewId" class="meta-automation__select" data-automation-field="internalViewId">
+              <option value="">-- no internal link --</option>
+              <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
+            </select>
           </template>
 
           <div class="meta-automation__form-actions">
@@ -126,6 +163,8 @@
       :sheet-id="sheetId"
       :rule="editingRule ?? undefined"
       :fields="fields"
+      :client="client"
+      :views="views"
       @close="showRuleEditor = false"
       @save="onRuleEditorSave"
       @test="onTestRule"
@@ -142,7 +181,14 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import type { AutomationRule, AutomationTriggerType, AutomationActionType, AutomationStats } from '../types'
+import type {
+  AutomationRule,
+  AutomationTriggerType,
+  AutomationActionType,
+  AutomationStats,
+  DingTalkGroupDestination,
+  MetaView,
+} from '../types'
 import { useMultitableAutomations } from '../composables/useMultitableAutomations'
 import type { MultitableApiClient } from '../api/client'
 import MetaAutomationRuleEditor from './MetaAutomationRuleEditor.vue'
@@ -153,6 +199,7 @@ const props = defineProps<{
   sheetId: string
   fields: Array<{ id: string; name: string; type: string }>
   client?: MultitableApiClient
+  views?: MetaView[]
 }>()
 
 const emit = defineEmits<{
@@ -174,6 +221,11 @@ interface DraftState {
   notifyMessage: string
   targetFieldId: string
   targetValue: string
+  dingtalkDestinationId: string
+  dingtalkTitleTemplate: string
+  dingtalkBodyTemplate: string
+  publicFormViewId: string
+  internalViewId: string
 }
 
 function emptyDraft(): DraftState {
@@ -185,10 +237,18 @@ function emptyDraft(): DraftState {
     notifyMessage: '',
     targetFieldId: '',
     targetValue: '',
+    dingtalkDestinationId: '',
+    dingtalkTitleTemplate: '',
+    dingtalkBodyTemplate: '',
+    publicFormViewId: '',
+    internalViewId: '',
   }
 }
 
 const draft = ref<DraftState>(emptyDraft())
+const dingTalkDestinations = ref<DingTalkGroupDestination[]>([])
+const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
+const internalViews = computed(() => props.views ?? [])
 
 // --- Rule editor + log viewer state ---
 const showRuleEditor = ref(false)
@@ -250,6 +310,11 @@ const canSave = computed(() => {
   if (draft.value.triggerType === 'field.changed' && !draft.value.triggerFieldId) return false
   if (draft.value.actionType === 'notify' && !draft.value.notifyMessage.trim()) return false
   if (draft.value.actionType === 'update_field' && (!draft.value.targetFieldId || !draft.value.targetValue.trim())) return false
+  if (draft.value.actionType === 'send_dingtalk_group_message') {
+    if (!draft.value.dingtalkDestinationId) return false
+    if (!draft.value.dingtalkTitleTemplate.trim()) return false
+    if (!draft.value.dingtalkBodyTemplate.trim()) return false
+  }
   return true
 })
 
@@ -269,6 +334,11 @@ function openEditForm(rule: AutomationRule) {
     notifyMessage: (rule.actionConfig?.message as string) ?? '',
     targetFieldId: (rule.actionConfig?.fieldId as string) ?? '',
     targetValue: (rule.actionConfig?.value as string) ?? '',
+    dingtalkDestinationId: (rule.actionConfig?.destinationId as string) ?? '',
+    dingtalkTitleTemplate: (rule.actionConfig?.titleTemplate as string) ?? '',
+    dingtalkBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
+    publicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
+    internalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
   }
   showForm.value = true
 }
@@ -292,6 +362,15 @@ function buildActionConfig(): Record<string, unknown> {
   }
   if (draft.value.actionType === 'update_field') {
     return { fieldId: draft.value.targetFieldId, value: draft.value.targetValue }
+  }
+  if (draft.value.actionType === 'send_dingtalk_group_message') {
+    return {
+      destinationId: draft.value.dingtalkDestinationId,
+      titleTemplate: draft.value.dingtalkTitleTemplate,
+      bodyTemplate: draft.value.dingtalkBodyTemplate,
+      publicFormViewId: draft.value.publicFormViewId || undefined,
+      internalViewId: draft.value.internalViewId || undefined,
+    }
   }
   return {}
 }
@@ -364,6 +443,8 @@ function describeAction(rule: AutomationRule): string {
       const fid = rule.actionConfig?.fieldId as string | undefined
       return fid ? `Update "${fieldNameById(fid)}"` : 'Update field value'
     }
+    case 'send_dingtalk_group_message':
+      return 'Send DingTalk group message'
     default:
       return String(rule.actionType)
   }
@@ -373,6 +454,13 @@ watch(
   () => props.visible,
   async (v) => {
     if (v && props.sheetId) {
+      if (props.client) {
+        try {
+          dingTalkDestinations.value = await props.client.listDingTalkGroups()
+        } catch {
+          dingTalkDestinations.value = []
+        }
+      }
       await loadRules(props.sheetId)
       cancelForm()
       void loadRuleStats()

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -124,11 +124,12 @@
           >
             <div class="meta-rule-editor__action-header">
               <span class="meta-rule-editor__action-num">{{ idx + 1 }}.</span>
-              <select v-model="action.type" class="meta-rule-editor__select">
+              <select v-model="action.type" class="meta-rule-editor__select" @change="onDraftActionTypeChange(action)">
                 <option value="update_record">Update record</option>
                 <option value="create_record">Create record</option>
                 <option value="send_webhook">Send webhook</option>
                 <option value="send_notification">Send notification</option>
+                <option value="send_dingtalk_group_message">Send DingTalk group message</option>
                 <option value="lock_record">Lock record</option>
               </select>
               <div class="meta-rule-editor__action-btns">
@@ -183,6 +184,56 @@
               <textarea v-model="action.config.message" class="meta-rule-editor__textarea" placeholder="Notification message" rows="3"></textarea>
             </div>
 
+            <!-- send_dingtalk_group_message config -->
+            <div v-if="action.type === 'send_dingtalk_group_message'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__label">DingTalk group</label>
+              <select
+                v-model="action.config.destinationId"
+                class="meta-rule-editor__select"
+                data-field="dingtalkDestinationId"
+              >
+                <option value="">-- select DingTalk group --</option>
+                <option v-for="destination in dingTalkDestinations" :key="destination.id" :value="destination.id">
+                  {{ destination.name }}
+                </option>
+              </select>
+              <div v-if="dingTalkDestinationsError" class="meta-rule-editor__hint">{{ dingTalkDestinationsError }}</div>
+              <label class="meta-rule-editor__label">Title template</label>
+              <input
+                v-model="action.config.titleTemplate"
+                class="meta-rule-editor__input"
+                type="text"
+                placeholder="例如：{{record.title}} 待处理"
+                data-field="dingtalkTitleTemplate"
+              />
+              <label class="meta-rule-editor__label">Body template</label>
+              <textarea
+                v-model="action.config.bodyTemplate"
+                class="meta-rule-editor__textarea"
+                rows="4"
+                placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+                data-field="dingtalkBodyTemplate"
+              ></textarea>
+              <label class="meta-rule-editor__label">Public form view (optional)</label>
+              <select
+                v-model="action.config.publicFormViewId"
+                class="meta-rule-editor__select"
+                data-field="publicFormViewId"
+              >
+                <option value="">-- no public form link --</option>
+                <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
+              </select>
+              <label class="meta-rule-editor__label">Internal processing view (optional)</label>
+              <select
+                v-model="action.config.internalViewId"
+                class="meta-rule-editor__select"
+                data-field="internalViewId"
+              >
+                <option value="">-- no internal link --</option>
+                <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
+              </select>
+            </div>
+
             <!-- lock_record config -->
             <div v-if="action.type === 'lock_record'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__toggle-label">
@@ -215,6 +266,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import type { MultitableApiClient } from '../api/client'
 import type {
   AutomationRule,
   AutomationTriggerType,
@@ -222,6 +274,8 @@ import type {
   ConditionOperator,
   AutomationAction,
   AutomationCondition,
+  DingTalkGroupDestination,
+  MetaView,
 } from '../types'
 
 interface FieldPair {
@@ -237,6 +291,11 @@ type DraftActionConfig = Record<string, unknown> & {
   method?: string
   userId?: string
   message?: string
+  destinationId?: string
+  titleTemplate?: string
+  bodyTemplate?: string
+  publicFormViewId?: string
+  internalViewId?: string
   locked?: boolean
 }
 
@@ -258,6 +317,8 @@ const props = defineProps<{
   rule?: AutomationRule
   visible: boolean
   fields: Array<{ id: string; name: string; type: string }>
+  client?: MultitableApiClient
+  views?: MetaView[]
 }>()
 
 const emit = defineEmits<{
@@ -269,6 +330,11 @@ const emit = defineEmits<{
 const error = ref('')
 const saving = ref(false)
 const cronPreset = ref('0 * * * *')
+const dingTalkDestinations = ref<DingTalkGroupDestination[]>([])
+const dingTalkDestinationsError = ref('')
+
+const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
+const internalViews = computed(() => props.views ?? [])
 
 const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
   { value: 'equals', label: 'Equals' },
@@ -293,7 +359,7 @@ function emptyDraft(): Draft {
     triggerType: 'record.created',
     triggerConfig: {},
     conditions: { conjunction: 'AND', conditions: [] },
-    actions: [{ type: 'update_record', config: { fieldUpdates: [] } }],
+    actions: [{ type: 'update_record', config: defaultConfigForActionType('update_record') }],
   }
 }
 
@@ -315,11 +381,22 @@ const draft = ref<Draft>(emptyDraft())
 
 watch(
   () => props.visible,
-  (v) => {
+  async (v) => {
     if (v) {
       draft.value = props.rule ? draftFromRule(props.rule) : emptyDraft()
       error.value = ''
       saving.value = false
+      dingTalkDestinationsError.value = ''
+      if (props.client) {
+        try {
+          dingTalkDestinations.value = await props.client.listDingTalkGroups()
+        } catch (err) {
+          dingTalkDestinations.value = []
+          dingTalkDestinationsError.value = err instanceof Error ? err.message : 'Failed to load DingTalk groups'
+        }
+      } else {
+        dingTalkDestinations.value = []
+      }
     }
   },
   { immediate: true },
@@ -328,6 +405,14 @@ watch(
 const canSave = computed(() => {
   if (!draft.value.name.trim()) return false
   if (draft.value.actions.length < 1) return false
+  for (const action of draft.value.actions) {
+    if (action.type === 'send_dingtalk_group_message') {
+      const destinationId = typeof action.config.destinationId === 'string' ? action.config.destinationId.trim() : ''
+      const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
+      const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
+      if (!destinationId || !titleTemplate || !bodyTemplate) return false
+    }
+  }
   return true
 })
 
@@ -341,7 +426,36 @@ function removeCondition(idx: number) {
 
 function addAction() {
   if (draft.value.actions.length >= 3) return
-  draft.value.actions.push({ type: 'update_record', config: { fieldUpdates: [] } })
+  draft.value.actions.push({ type: 'update_record', config: defaultConfigForActionType('update_record') })
+}
+
+function defaultConfigForActionType(type: AutomationActionType): DraftActionConfig {
+  switch (type) {
+    case 'update_record':
+      return { fieldUpdates: [] }
+    case 'create_record':
+      return { fieldValues: [] }
+    case 'send_webhook':
+      return { method: 'POST' }
+    case 'send_notification':
+      return { userId: '', message: '' }
+    case 'send_dingtalk_group_message':
+      return {
+        destinationId: '',
+        titleTemplate: '',
+        bodyTemplate: '',
+        publicFormViewId: '',
+        internalViewId: '',
+      }
+    case 'lock_record':
+      return { locked: true }
+    default:
+      return {}
+  }
+}
+
+function onDraftActionTypeChange(action: DraftAction) {
+  action.config = defaultConfigForActionType(action.type)
 }
 
 function removeAction(idx: number) {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -585,6 +585,7 @@ export type AutomationActionType =
   | 'create_record'
   | 'send_webhook'
   | 'send_notification'
+  | 'send_dingtalk_group_message'
   | 'lock_record'
   // Legacy aliases
   | 'notify'

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -780,6 +780,28 @@ export interface WebhookDelivery {
   timestamp: string
 }
 
+// --- DingTalk Group Destinations ---
+export interface DingTalkGroupDestination {
+  id: string
+  name: string
+  webhookUrl: string
+  secret?: string
+  enabled: boolean
+  createdBy: string
+  createdAt: string
+  updatedAt?: string
+  lastTestedAt?: string
+  lastTestStatus?: 'success' | 'failed'
+  lastTestError?: string
+}
+
+export interface DingTalkGroupDestinationInput {
+  name: string
+  webhookUrl: string
+  secret?: string
+  enabled?: boolean
+}
+
 // --- Field Validation ---
 export type FieldValidationRuleType = 'required' | 'minLength' | 'maxLength' | 'pattern' | 'min' | 'max' | 'enum'
 

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -803,6 +803,23 @@ export interface DingTalkGroupDestinationInput {
   enabled?: boolean
 }
 
+export interface DingTalkGroupDelivery {
+  id: string
+  destinationId: string
+  sourceType: 'manual_test' | 'automation'
+  subject: string
+  content: string
+  success: boolean
+  httpStatus?: number
+  responseBody?: string
+  errorMessage?: string
+  automationRuleId?: string
+  recordId?: string
+  initiatedBy?: string
+  createdAt: string
+  deliveredAt?: string
+}
+
 // --- Field Validation ---
 export type FieldValidationRuleType = 'required' | 'minLength' | 'maxLength' | 'pattern' | 'min' | 'max' | 'enum'
 

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -288,6 +288,7 @@
       :sheet-id="workbench.activeSheetId.value"
       :fields="grid.fields.value"
       :client="workbench.client"
+      :views="workbench.views.value"
       @close="showAutomationManager = false"
       @updated="showAutomationManager = false"
     />

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -10,7 +10,31 @@ async function flushPromises() {
 
 import MetaApiTokenManager from '../src/multitable/components/MetaApiTokenManager.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
-import type { ApiToken, DingTalkGroupDestination, Webhook, WebhookDelivery } from '../src/multitable/types'
+import type {
+  ApiToken,
+  DingTalkGroupDelivery,
+  DingTalkGroupDestination,
+  Webhook,
+  WebhookDelivery,
+} from '../src/multitable/types'
+
+function okResponse(body: unknown) {
+  return new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+}
+
+function noContentResponse() {
+  return new Response(null, { status: 204 })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
 
 function fakeToken(overrides: Partial<ApiToken> = {}): ApiToken {
   return {
@@ -69,59 +93,75 @@ function fakeDingTalkGroup(overrides: Partial<DingTalkGroupDestination> = {}): D
   }
 }
 
+function fakeDingTalkDelivery(overrides: Partial<DingTalkGroupDelivery> = {}): DingTalkGroupDelivery {
+  return {
+    id: 'dtd_1',
+    destinationId: 'dt_1',
+    sourceType: 'automation',
+    subject: 'Please fill incident details',
+    content: 'Body text',
+    success: true,
+    httpStatus: 200,
+    createdAt: '2026-04-01T02:00:00Z',
+    ...overrides,
+  }
+}
+
 function mockClient(
   tokens: ApiToken[] = [],
   webhooks: Webhook[] = [],
   deliveries: WebhookDelivery[] = [],
   dingTalkGroups: DingTalkGroupDestination[] = [],
+  dingTalkDeliveries: DingTalkGroupDelivery[] = [],
 ) {
-  const ok = (body: unknown) =>
-    new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
-  const noContent = () => new Response(null, { status: 204 })
+  let currentDingTalkDeliveries = [...dingTalkDeliveries]
 
   const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
     const method = init?.method ?? 'GET'
 
     // Tokens
     if (method === 'GET' && url.includes('/tokens') && !url.includes('/rotate')) {
-      return ok({ tokens })
+      return okResponse({ tokens })
     }
     if (method === 'POST' && url.includes('/tokens') && !url.includes('/rotate')) {
       const body = JSON.parse(init?.body as string)
-      return ok({ token: { id: 'tok_new', prefix: 'mst_new', ...body, createdAt: '2026-04-01', lastUsedAt: null, expiresAt: null }, plaintext: 'mst_plaintext_secret_123' })
+      return okResponse({ token: { id: 'tok_new', prefix: 'mst_new', ...body, createdAt: '2026-04-01', lastUsedAt: null, expiresAt: null }, plaintext: 'mst_plaintext_secret_123' })
     }
     if (method === 'DELETE' && url.includes('/tokens/')) {
-      return noContent()
+      return noContentResponse()
     }
     if (method === 'POST' && url.includes('/rotate')) {
-      return ok({ token: fakeToken({ id: 'tok_rotated', prefix: 'mst_rot' }), plaintext: 'mst_rotated_secret_456' })
+      return okResponse({ token: fakeToken({ id: 'tok_rotated', prefix: 'mst_rot' }), plaintext: 'mst_rotated_secret_456' })
     }
 
     // Webhooks
     if (method === 'GET' && url.includes('/webhooks') && !url.includes('/deliveries')) {
-      return ok({ webhooks })
+      return okResponse({ webhooks })
     }
     if (method === 'POST' && url.includes('/webhooks') && !url.includes('/deliveries')) {
       const body = JSON.parse(init?.body as string)
-      return ok({ id: 'wh_new', active: true, secret: null, failureCount: 0, createdAt: '2026-04-01', updatedAt: '2026-04-01', ...body })
+      return okResponse({ id: 'wh_new', active: true, secret: null, failureCount: 0, createdAt: '2026-04-01', updatedAt: '2026-04-01', ...body })
     }
     if (method === 'PATCH' && url.includes('/webhooks/')) {
-      return ok(webhooks[0] ?? {})
+      return okResponse(webhooks[0] ?? {})
     }
     if (method === 'DELETE' && url.includes('/webhooks/')) {
-      return noContent()
+      return noContentResponse()
     }
-    if (method === 'GET' && url.includes('/deliveries')) {
-      return ok({ deliveries })
+    if (method === 'GET' && url.includes('/webhooks/') && url.includes('/deliveries')) {
+      return okResponse({ deliveries })
     }
 
     // DingTalk groups
+    if (method === 'GET' && url.includes('/dingtalk-groups/') && url.includes('/deliveries')) {
+      return okResponse({ deliveries: currentDingTalkDeliveries })
+    }
     if (method === 'GET' && url.includes('/dingtalk-groups') && !url.includes('/test-send')) {
-      return ok({ destinations: dingTalkGroups })
+      return okResponse({ destinations: dingTalkGroups })
     }
     if (method === 'POST' && url.includes('/dingtalk-groups') && !url.includes('/test-send')) {
       const body = JSON.parse(init?.body as string)
-      return ok({
+      return okResponse({
         id: 'dt_new',
         createdBy: 'user_1',
         createdAt: '2026-04-01T00:00:00Z',
@@ -129,16 +169,24 @@ function mockClient(
       })
     }
     if (method === 'PATCH' && url.includes('/dingtalk-groups/')) {
-      return ok(dingTalkGroups[0] ?? {})
+      return okResponse(dingTalkGroups[0] ?? {})
     }
     if (method === 'DELETE' && url.includes('/dingtalk-groups/')) {
-      return noContent()
+      return noContentResponse()
     }
     if (method === 'POST' && url.includes('/dingtalk-groups/') && url.includes('/test-send')) {
-      return noContent()
+      currentDingTalkDeliveries = [
+        fakeDingTalkDelivery({
+          id: `dtd_${currentDingTalkDeliveries.length + 1}`,
+          sourceType: 'manual_test',
+          subject: 'MetaSheet DingTalk group test',
+        }),
+        ...currentDingTalkDeliveries,
+      ]
+      return noContentResponse()
     }
 
-    return ok({})
+    return okResponse({})
   })
   return { client: new MultitableApiClient({ fetchFn }), fetchFn }
 }
@@ -417,5 +465,116 @@ describe('MetaApiTokenManager', () => {
       (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/dingtalk-groups/') && c[0].includes('/test-send'),
     )
     expect(testSendCalls.length).toBe(1)
+  })
+
+  it('views DingTalk group deliveries', async () => {
+    const { client } = mockClient([], [], [], [fakeDingTalkGroup()], [fakeDingTalkDelivery()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const deliveriesBtn = document.querySelector('[data-dingtalk-group-deliveries]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const rows = document.querySelectorAll('[data-dingtalk-delivery-id]')
+    expect(rows.length).toBe(1)
+    expect(rows[0]?.textContent).toContain('Please fill incident details')
+    expect(rows[0]?.textContent).toContain('Automation')
+  })
+
+  it('refreshes open DingTalk delivery history after test send', async () => {
+    const { client } = mockClient([], [], [], [fakeDingTalkGroup()], [fakeDingTalkDelivery()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const deliveriesBtn = document.querySelector('[data-dingtalk-group-deliveries]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    let rows = document.querySelectorAll('[data-dingtalk-delivery-id]')
+    expect(rows.length).toBe(1)
+
+    const testSendBtn = document.querySelector('[data-dingtalk-group-test-send]') as HTMLButtonElement
+    testSendBtn.click()
+    await flushPromises()
+
+    rows = document.querySelectorAll('[data-dingtalk-delivery-id]')
+    expect(rows.length).toBe(2)
+    expect(rows[0]?.textContent).toContain('Manual test')
+    expect(rows[0]?.textContent).toContain('MetaSheet DingTalk group test')
+  })
+
+  it('shows an empty state for DingTalk delivery history', async () => {
+    const { client } = mockClient([], [], [], [fakeDingTalkGroup()], [])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const deliveriesBtn = document.querySelector('[data-dingtalk-group-deliveries]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    expect(document.querySelector('[data-dingtalk-deliveries-empty]')?.textContent).toContain('No DingTalk deliveries yet.')
+  })
+
+  it('ignores stale DingTalk delivery responses when switching groups', async () => {
+    const groupA = fakeDingTalkGroup({ id: 'dt_a', name: 'Group A' })
+    const groupB = fakeDingTalkGroup({ id: 'dt_b', name: 'Group B' })
+    const groupARequest = deferred<Response>()
+    const groupBRequest = deferred<Response>()
+
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && url.includes('/dingtalk-groups') && !url.includes('/deliveries') && !url.includes('/test-send')) {
+        return okResponse({ destinations: [groupA, groupB] })
+      }
+      if (method === 'GET' && url.includes('/dingtalk-groups/dt_a/deliveries')) {
+        return groupARequest.promise
+      }
+      if (method === 'GET' && url.includes('/dingtalk-groups/dt_b/deliveries')) {
+        return groupBRequest.promise
+      }
+      return okResponse({})
+    })
+
+    mount({ visible: true, client: new MultitableApiClient({ fetchFn }) })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const deliveriesButtons = document.querySelectorAll('[data-dingtalk-group-deliveries]')
+    ;(deliveriesButtons[0] as HTMLButtonElement).click()
+    await flushPromises()
+    ;(deliveriesButtons[1] as HTMLButtonElement).click()
+    await flushPromises()
+
+    groupBRequest.resolve(okResponse({
+      deliveries: [fakeDingTalkDelivery({ id: 'dtd_b', destinationId: 'dt_b', subject: 'Group B delivery' })],
+    }))
+    await flushPromises()
+
+    expect(document.querySelector('[data-dingtalk-deliveries]')?.textContent).toContain('Group B delivery')
+
+    groupARequest.resolve(okResponse({
+      deliveries: [fakeDingTalkDelivery({ id: 'dtd_a', destinationId: 'dt_a', subject: 'Group A delivery' })],
+    }))
+    await flushPromises()
+
+    const panelText = document.querySelector('[data-dingtalk-deliveries]')?.textContent ?? ''
+    expect(panelText).toContain('Group B delivery')
+    expect(panelText).not.toContain('Group A delivery')
   })
 })

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -416,6 +416,23 @@ describe('MetaApiTokenManager', () => {
     expect(cards.length).toBe(1)
   })
 
+  it('masks DingTalk webhook access token in card display', async () => {
+    const { client } = mockClient([], [], [], [fakeDingTalkGroup({
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=super-secret-token',
+    })])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const card = document.querySelector('[data-dingtalk-group-id]') as HTMLElement
+    const text = card.textContent ?? ''
+    expect(text).toContain('access_token=***')
+    expect(text).not.toContain('super-secret-token')
+  })
+
   it('creates a DingTalk group destination', async () => {
     const { client, fetchFn } = mockClient()
     mount({ visible: true, client })

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -10,7 +10,7 @@ async function flushPromises() {
 
 import MetaApiTokenManager from '../src/multitable/components/MetaApiTokenManager.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
-import type { ApiToken, Webhook, WebhookDelivery } from '../src/multitable/types'
+import type { ApiToken, DingTalkGroupDestination, Webhook, WebhookDelivery } from '../src/multitable/types'
 
 function fakeToken(overrides: Partial<ApiToken> = {}): ApiToken {
   return {
@@ -53,7 +53,28 @@ function fakeDelivery(overrides: Partial<WebhookDelivery> = {}): WebhookDelivery
   }
 }
 
-function mockClient(tokens: ApiToken[] = [], webhooks: Webhook[] = [], deliveries: WebhookDelivery[] = []) {
+function fakeDingTalkGroup(overrides: Partial<DingTalkGroupDestination> = {}): DingTalkGroupDestination {
+  return {
+    id: 'dt_1',
+    name: 'Ops DingTalk Group',
+    webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+    enabled: true,
+    createdBy: 'user_1',
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-04-01T00:00:00Z',
+    lastTestedAt: '2026-04-01T01:00:00Z',
+    lastTestStatus: 'success',
+    lastTestError: undefined,
+    ...overrides,
+  }
+}
+
+function mockClient(
+  tokens: ApiToken[] = [],
+  webhooks: Webhook[] = [],
+  deliveries: WebhookDelivery[] = [],
+  dingTalkGroups: DingTalkGroupDestination[] = [],
+) {
   const ok = (body: unknown) =>
     new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
   const noContent = () => new Response(null, { status: 204 })
@@ -92,6 +113,29 @@ function mockClient(tokens: ApiToken[] = [], webhooks: Webhook[] = [], deliverie
     }
     if (method === 'GET' && url.includes('/deliveries')) {
       return ok({ deliveries })
+    }
+
+    // DingTalk groups
+    if (method === 'GET' && url.includes('/dingtalk-groups') && !url.includes('/test-send')) {
+      return ok({ destinations: dingTalkGroups })
+    }
+    if (method === 'POST' && url.includes('/dingtalk-groups') && !url.includes('/test-send')) {
+      const body = JSON.parse(init?.body as string)
+      return ok({
+        id: 'dt_new',
+        createdBy: 'user_1',
+        createdAt: '2026-04-01T00:00:00Z',
+        ...body,
+      })
+    }
+    if (method === 'PATCH' && url.includes('/dingtalk-groups/')) {
+      return ok(dingTalkGroups[0] ?? {})
+    }
+    if (method === 'DELETE' && url.includes('/dingtalk-groups/')) {
+      return noContent()
+    }
+    if (method === 'POST' && url.includes('/dingtalk-groups/') && url.includes('/test-send')) {
+      return noContent()
     }
 
     return ok({})
@@ -307,5 +351,71 @@ describe('MetaApiTokenManager', () => {
 
     const deliveryRows = document.querySelectorAll('[data-delivery-id]')
     expect(deliveryRows.length).toBe(1)
+  })
+
+  // ---- DingTalk group tests ----
+
+  it('switches to DingTalk groups tab', async () => {
+    const { client } = mockClient([], [], [], [fakeDingTalkGroup()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const cards = document.querySelectorAll('[data-dingtalk-group-id]')
+    expect(cards.length).toBe(1)
+  })
+
+  it('creates a DingTalk group destination', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const newBtn = document.querySelector('[data-dingtalk-group-new]') as HTMLButtonElement
+    newBtn.click()
+    await flushPromises()
+
+    const nameInput = document.querySelector('[data-dingtalk-group-name]') as HTMLInputElement
+    nameInput.value = 'Support group'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const urlInput = document.querySelector('[data-dingtalk-group-webhook-url]') as HTMLInputElement
+    urlInput.value = 'https://oapi.dingtalk.com/robot/send?access_token=test-token'
+    urlInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = document.querySelector('[data-dingtalk-group-save]') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const createCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/dingtalk-groups') && !c[0].includes('/test-send'),
+    )
+    expect(createCalls.length).toBe(1)
+  })
+
+  it('tests a DingTalk group destination', async () => {
+    const { client, fetchFn } = mockClient([], [], [], [fakeDingTalkGroup()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const testSendBtn = document.querySelector('[data-dingtalk-group-test-send]') as HTMLButtonElement
+    testSendBtn.click()
+    await flushPromises()
+
+    const testSendCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/dingtalk-groups/') && c[0].includes('/test-send'),
+    )
+    expect(testSendCalls.length).toBe(1)
   })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -28,6 +28,18 @@ function mockClient(rules: AutomationRule[] = []) {
 
   const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
     const method = init?.method ?? 'GET'
+    if (method === 'GET' && url.includes('/dingtalk-groups')) {
+      return ok({
+        destinations: [{
+          id: 'dt_1',
+          name: 'Ops Group',
+          webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test',
+          enabled: true,
+          createdBy: 'user_1',
+          createdAt: '2026-04-01T00:00:00Z',
+        }],
+      })
+    }
     if (method === 'GET' && url.includes('/automations')) {
       return ok({ rules })
     }
@@ -59,6 +71,11 @@ const fields = [
   { id: 'fld_2', name: 'Name', type: 'string' },
 ]
 
+const views = [
+  { id: 'view_grid', sheetId: 'sheet_1', name: 'Grid', type: 'grid' },
+  { id: 'view_form', sheetId: 'sheet_1', name: 'Public Form', type: 'form' },
+]
+
 describe('MetaAutomationManager', () => {
   afterEach(() => {
     document.body.innerHTML = ''
@@ -67,7 +84,7 @@ describe('MetaAutomationManager', () => {
 
   it('renders rule list when visible', async () => {
     const { client } = mockClient([fakeRule()])
-    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
     await flushPromises()
 
     const cards = container.querySelectorAll('[data-automation-rule]')
@@ -77,7 +94,7 @@ describe('MetaAutomationManager', () => {
 
   it('shows empty state when no rules', async () => {
     const { client } = mockClient([])
-    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
     await flushPromises()
 
     const el = container.querySelector('[data-automation-empty]')
@@ -88,7 +105,7 @@ describe('MetaAutomationManager', () => {
   it('creates rule via form', async () => {
     const { client, fetchFn } = mockClient([])
     const updatedSpy = vi.fn()
-    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client, onUpdated: updatedSpy })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client, onUpdated: updatedSpy })
     await flushPromises()
 
     // Open form
@@ -123,7 +140,7 @@ describe('MetaAutomationManager', () => {
 
   it('toggles rule enabled/disabled', async () => {
     const { client, fetchFn } = mockClient([fakeRule()])
-    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
     await flushPromises()
 
     const toggle = container.querySelector('[data-automation-toggle]') as HTMLInputElement
@@ -139,7 +156,7 @@ describe('MetaAutomationManager', () => {
 
   it('deletes rule', async () => {
     const { client, fetchFn } = mockClient([fakeRule()])
-    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
     await flushPromises()
 
     const deleteBtn = container.querySelector('[data-automation-delete]') as HTMLButtonElement
@@ -153,7 +170,7 @@ describe('MetaAutomationManager', () => {
 
   it('shows field picker for field.changed trigger', async () => {
     const { client } = mockClient([])
-    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
     await flushPromises()
 
     // Open form
@@ -178,7 +195,7 @@ describe('MetaAutomationManager', () => {
 
   it('shows appropriate action config for each action type', async () => {
     const { client } = mockClient([])
-    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
     await flushPromises()
 
     // Open form
@@ -199,5 +216,61 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-automation-field="notifyMessage"]')).toBeNull()
     expect(container.querySelector('[data-automation-field="targetFieldId"]')).not.toBeNull()
     expect(container.querySelector('[data-automation-field="targetValue"]')).not.toBeNull()
+  })
+
+  it('creates DingTalk group automation via form', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationId"]') as HTMLSelectElement
+    destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLSelectElement
+    internalViewSelect.value = 'view_grid'
+    internalViewSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionType).toBe('send_dingtalk_group_message')
+    expect(body.actionConfig).toEqual({
+      destinationId: 'dt_1',
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please fill {{record.status}}',
+      publicFormViewId: 'view_form',
+      internalViewId: 'view_grid',
+    })
   })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -13,6 +13,26 @@ const fields = [
   { id: 'fld_2', name: 'Name', type: 'string' },
 ]
 
+const views = [
+  { id: 'view_grid', sheetId: 'sheet_1', name: 'Grid', type: 'grid' },
+  { id: 'view_form', sheetId: 'sheet_1', name: 'Public Form', type: 'form' },
+]
+
+function mockClient() {
+  return {
+    listDingTalkGroups: vi.fn(async () => [
+      {
+        id: 'dt_1',
+        name: 'Ops Group',
+        webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test',
+        enabled: true,
+        createdBy: 'user_1',
+        createdAt: '2026-04-01T00:00:00Z',
+      },
+    ]),
+  }
+}
+
 function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
   return {
     id: 'rule_1',
@@ -164,5 +184,77 @@ describe('MetaAutomationRuleEditor', () => {
 
     const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
     expect(triggerSelect.value).toBe('record.updated')
+  })
+
+  it('emits DingTalk group action config with optional links', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify DingTalk'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationId"]') as HTMLSelectElement
+    destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+
+    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLSelectElement
+    internalViewSelect.value = 'view_grid'
+    internalViewSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionType).toBe('send_dingtalk_group_message')
+    expect(payload.actionConfig).toEqual({
+      destinationId: 'dt_1',
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      publicFormViewId: 'view_form',
+      internalViewId: 'view_grid',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_dingtalk_group_message',
+      config: {
+        destinationId: 'dt_1',
+        titleTemplate: 'Ticket {{recordId}}',
+        bodyTemplate: 'Please review {{record.status}}',
+        publicFormViewId: 'view_form',
+        internalViewId: 'view_grid',
+      },
+    })
+    expect(client.listDingTalkGroups).toHaveBeenCalledTimes(1)
   })
 })

--- a/docs/development/dingtalk-group-automation-action-development-20260419.md
+++ b/docs/development/dingtalk-group-automation-action-development-20260419.md
@@ -1,0 +1,140 @@
+# DingTalk Group Automation Action Development
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-group-notify-standard-20260419`
+- Scope: P0 second slice for standard DingTalk group notification
+
+## Goal
+
+Deliver the first automation runtime action for the standard DingTalk group notification flow:
+
+- add `send_dingtalk_group_message` as a first-class automation action
+- let automation authors choose a DingTalk group destination
+- allow optional `public form` and `internal processing` links in the same message
+- keep internal link access behind existing ACL
+
+## Backend
+
+### Action model
+
+Updated:
+
+- `packages/core-backend/src/multitable/automation-actions.ts`
+
+Added:
+
+- `send_dingtalk_group_message` to the action type set
+- config shape:
+  - `destinationId`
+  - `titleTemplate`
+  - `bodyTemplate`
+  - `publicFormViewId?`
+  - `internalViewId?`
+
+### Action execution
+
+Updated:
+
+- `packages/core-backend/src/multitable/automation-executor.ts`
+
+Added runtime behavior:
+
+- resolve the target DingTalk group destination from `dingtalk_group_destinations`
+- validate required config before send
+- render `{{record.xxx}}`, `{{recordId}}`, `{{sheetId}}`, `{{actorId}}` placeholders
+- optionally append:
+  - `填写入口` public form link
+  - `处理入口` internal multitable record link
+- require `PUBLIC_APP_URL` or `APP_BASE_URL` only when links are requested
+- post a signed DingTalk robot markdown payload and validate the DingTalk response body
+
+### Route allowlists
+
+Updated:
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+
+Changes:
+
+- added `send_dingtalk_group_message` to automation create/update validation allowlists
+
+### Persistence compatibility
+
+Added migration:
+
+- `packages/core-backend/src/db/migrations/zzzz20260419193000_add_dingtalk_group_message_automation_action.ts`
+
+Purpose:
+
+- extend `automation_rules.action_type` constraint to allow `send_dingtalk_group_message`
+
+## Frontend
+
+### Shared automation types
+
+Updated:
+
+- `apps/web/src/multitable/types.ts`
+
+Changes:
+
+- added `send_dingtalk_group_message` to the frontend automation action union
+
+### Rule editor
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Changes:
+
+- added `Send DingTalk group message` to the action selector
+- loaded available DingTalk group destinations from the current multitable client
+- added editor fields for:
+  - destination
+  - title template
+  - body template
+  - optional public form view
+  - optional internal processing view
+- reset stale per-action config when the action type changes so old `fieldUpdates` / `fieldValues` state is not carried into the new action
+
+### Manager + workbench wiring
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+
+Changes:
+
+- quick-create automation form now also supports the DingTalk group action
+- manager passes `client` and `views` into the richer rule editor
+- workbench now threads `workbench.views.value` into the automation manager
+- rule list description now renders `Send DingTalk group message` instead of falling back to raw enum text
+
+## Tests
+
+Updated backend unit coverage:
+
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+
+Covered:
+
+- successful DingTalk group automation send
+- missing destination failure path
+
+Updated frontend component coverage:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+Covered:
+
+- editor emits the new DingTalk action config with optional links
+- manager quick-create form can save a DingTalk action payload
+
+## Deployment
+
+- None
+- No remote deployment
+- New migration was added but not applied anywhere in this slice

--- a/docs/development/dingtalk-group-automation-action-verification-20260419.md
+++ b/docs/development/dingtalk-group-automation-action-verification-20260419.md
@@ -1,0 +1,46 @@
+# DingTalk Group Automation Action Verification
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-group-notify-standard-20260419`
+- Scope: DingTalk group automation action + dual link authoring
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+### Backend
+
+- `tests/unit/automation-v1.test.ts`
+  - `93 passed`
+
+### Frontend
+
+- `tests/multitable-automation-rule-editor.spec.ts`
+- `tests/multitable-automation-manager.spec.ts`
+  - `17 passed`
+
+### Builds
+
+- `pnpm --filter @metasheet/core-backend build`
+  - passed
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Notes
+
+- Frontend Vitest may still print the existing `WebSocket server error: Port is already in use` noise; tests still pass.
+- Web build still prints the existing Vite chunk-size warning; build still passes.
+- `pnpm install --frozen-lockfile` from the previous slice left `plugins/**/node_modules` and `tools/cli/node_modules` noise in the worktree; those generated files remain out of scope and were not added to this implementation.
+
+## Deployment
+
+- None
+- No remote deployment
+- No migration execution in this verification run

--- a/docs/development/dingtalk-group-delivery-history-development-20260419.md
+++ b/docs/development/dingtalk-group-delivery-history-development-20260419.md
@@ -1,0 +1,116 @@
+# DingTalk Group Delivery History Development — 2026-04-19
+
+## Scope
+
+This slice adds delivery history and audit visibility for DingTalk group destinations used by multitable automation.
+
+The goal is to make both manual `test-send` attempts and automation-triggered DingTalk group messages inspectable in the same management UI, instead of relying only on the latest `last_test_*` health fields.
+
+## Backend Changes
+
+### Persistence
+
+Added a new table:
+
+- `dingtalk_group_deliveries`
+
+Migration:
+
+- `packages/core-backend/src/db/migrations/zzzz20260419203000_create_dingtalk_group_deliveries.ts`
+
+Stored attributes:
+
+- destination id
+- source type (`manual_test` or `automation`)
+- rendered subject/content
+- success/failure
+- HTTP status
+- raw response body
+- error message
+- automation rule id
+- record id
+- initiating user id
+- created / delivered timestamps
+
+### Service Layer
+
+Extended:
+
+- `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+- `packages/core-backend/src/multitable/dingtalk-group-destinations.ts`
+
+New behavior:
+
+- manual `testSend()` now writes a delivery row on both success and failure
+- delivery history persistence is now best-effort, so a delivery log insert failure does not turn a real DingTalk send into an application failure
+- DingTalk application-level failures (`HTTP 200` with non-zero `errcode`) now retain `httpStatus` and `responseBody` in the delivery record
+- destination list remains driven by `last_test_*`, but historical attempts are now queryable
+- added `listDeliveries()` for recent destination-level history
+
+### Automation Execution
+
+Extended:
+
+- `packages/core-backend/src/multitable/automation-executor.ts`
+
+New behavior:
+
+- `send_dingtalk_group_message` writes a delivery row for both success and failure
+- automation delivery logging is also best-effort and no longer blocks a successful DingTalk send
+- automation failure logs now keep parsed DingTalk response diagnostics when robot validation fails
+- automation delivery rows capture `automationRuleId`, `recordId`, and initiating actor where available
+
+### API
+
+Extended:
+
+- `packages/core-backend/src/routes/api-tokens.ts`
+
+New endpoint:
+
+- `GET /api/multitable/dingtalk-groups/:id/deliveries`
+
+Guardrails:
+
+- authenticated only
+- owner-only access
+- bounded `limit`
+
+## Frontend Changes
+
+Extended:
+
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+
+New behavior:
+
+- DingTalk group cards now expose a `Deliveries` action
+- inline history panel shows:
+  - success/failure
+  - source (`Manual test` / `Automation`)
+  - subject
+  - HTTP status
+  - timestamp
+- expanded delivery history now refreshes automatically after `Test send`
+- delivery history panel now has explicit loading and empty states
+- delivery history requests are guarded against stale async responses when switching between groups
+- deleting the currently expanded destination clears the active delivery panel state
+
+## Tests Updated
+
+Backend:
+
+- `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+
+Frontend:
+
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+
+## Notes
+
+- The frontend test failure encountered during implementation was caused by the generic webhook `/deliveries` mock intercepting the DingTalk destination deliveries request. The mock matcher was narrowed to `/webhooks/.../deliveries` so the DingTalk-specific branch can return its own history payload.
+- A backend TypeScript build issue surfaced because insert-time `delivered_at` was using `nowTimestamp()` (`RawBuilder<Date>`). That path now uses `sql\`CURRENT_TIMESTAMP\`` for insert compatibility with the table’s timestamp string column type.
+- Local `plugins/**/node_modules` and `tools/cli/node_modules` noise remains outside this slice and must not be committed.

--- a/docs/development/dingtalk-group-delivery-history-verification-20260419.md
+++ b/docs/development/dingtalk-group-delivery-history-verification-20260419.md
@@ -1,0 +1,58 @@
+# DingTalk Group Delivery History Verification — 2026-04-19
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-group-destination-service.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+### Backend unit tests
+
+- `tests/unit/automation-v1.test.ts`
+- `tests/unit/dingtalk-group-destination-service.test.ts`
+- Result: `102 passed`
+
+Coverage of interest:
+
+- manual test-send success/failure delivery recording
+- manual test-send keeps succeeding when delivery history persistence fails
+- delivery listing
+- automation DingTalk group action delivery persistence
+- automation preserves DingTalk application-error diagnostics
+- automation keeps succeeding when delivery history persistence fails
+
+### Frontend unit tests
+
+- `tests/multitable-api-token-manager.spec.ts`
+- Result: `18 passed`
+
+Coverage of interest:
+
+- DingTalk group delivery panel rendering
+- delivery row subject/source visibility
+- refresh after test-send
+- explicit empty state
+- stale async response protection when switching groups
+
+### Builds
+
+- `pnpm --filter @metasheet/core-backend build`: passed
+- `pnpm --filter @metasheet/web build`: passed
+
+## Non-blocking Noise
+
+- Frontend Vitest may print `WebSocket server error: Port is already in use`
+- Web build still prints existing Vite chunk-size / dynamic-import warnings
+
+Neither issue is introduced by this slice.
+
+## Deployment Impact
+
+- No remote deployment performed in this slice
+- New migration added but not executed remotely:
+  - `packages/core-backend/src/db/migrations/zzzz20260419203000_create_dingtalk_group_deliveries.ts`

--- a/docs/development/dingtalk-group-destination-crud-development-20260419.md
+++ b/docs/development/dingtalk-group-destination-crud-development-20260419.md
@@ -1,0 +1,155 @@
+# DingTalk Group Destination CRUD Development
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-group-notify-standard-20260419`
+- Scope: P0 first slice for standard DingTalk group notification
+
+## Goal
+
+Deliver the first runtime slice for the standard DingTalk group notification flow:
+
+- add DingTalk group destination CRUD
+- add manual `test send`
+- expose the management UI inside `MetaApiTokenManager`
+- fix the existing multitable token route mismatch by mounting the backend router and supporting the frontend's canonical `/api/multitable/tokens` path
+
+## Backend
+
+### Shared DingTalk robot helper
+
+Added reusable helper module:
+
+- `packages/core-backend/src/integrations/dingtalk/robot.ts`
+
+Included:
+
+- markdown payload builder
+- webhook signing helper
+- DingTalk response validation
+
+This removes duplicated DingTalk robot logic from `NotificationService` and lets group destination test-send use the same signing/response semantics.
+
+### Notification service reuse cleanup
+
+Updated:
+
+- `packages/core-backend/src/services/NotificationService.ts`
+
+Changes:
+
+- import shared DingTalk robot helpers
+- treat `DingTalkRobotResponseError` as non-retryable for notification delivery
+
+### New persistence model
+
+Added table type and migration for DingTalk group destinations:
+
+- `packages/core-backend/src/db/types.ts`
+- `packages/core-backend/src/db/migrations/zzzz20260419183000_create_dingtalk_group_destinations.ts`
+
+Table fields:
+
+- `id`
+- `name`
+- `webhook_url`
+- `secret`
+- `enabled`
+- `created_by`
+- `created_at`
+- `updated_at`
+- `last_tested_at`
+- `last_test_status`
+- `last_test_error`
+
+### Service layer
+
+Added:
+
+- `packages/core-backend/src/multitable/dingtalk-group-destinations.ts`
+- `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+
+Service responsibilities:
+
+- create/list/update/delete DingTalk group destinations
+- ownership enforcement
+- manual `testSend`
+- persist last test timestamp/status/error
+
+### Route layer
+
+Updated:
+
+- `packages/core-backend/src/routes/api-tokens.ts`
+- `packages/core-backend/src/index.ts`
+
+Changes:
+
+- mounted `apiTokensRouter()` in app runtime
+- kept legacy `/api/multitable/api-tokens` path
+- added canonical `/api/multitable/tokens` path expected by the frontend client
+- aligned token/webhook response envelopes with current `MultitableApiClient`
+- added DingTalk group endpoints:
+  - `GET /api/multitable/dingtalk-groups`
+  - `POST /api/multitable/dingtalk-groups`
+  - `PATCH /api/multitable/dingtalk-groups/:id`
+  - `DELETE /api/multitable/dingtalk-groups/:id`
+  - `POST /api/multitable/dingtalk-groups/:id/test-send`
+
+## Frontend
+
+### Types and client
+
+Updated:
+
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/api/client.ts`
+
+Added types and client methods for:
+
+- DingTalk group destination entity
+- create/update payload
+- list/create/update/delete/test-send client calls
+
+### Management UI
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+
+Changes:
+
+- preserved existing tab order for compatibility:
+  - `API Tokens`
+  - `Webhooks`
+  - `DingTalk Groups`
+- added DingTalk group create/edit form
+- added list state, enabled/disabled state, last test status/error display
+- added actions:
+  - create
+  - edit
+  - enable/disable
+  - manual test send
+  - delete
+
+## Tests
+
+Added backend unit coverage:
+
+- `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+
+Updated frontend component coverage:
+
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+
+Covered:
+
+- DingTalk groups tab render
+- create destination
+- manual test-send
+- existing token/webhook tab behavior remains intact
+
+## Deployment
+
+- None
+- No remote deployment
+- New migration was added but not applied anywhere in this slice

--- a/docs/development/dingtalk-group-destination-crud-verification-20260419.md
+++ b/docs/development/dingtalk-group-destination-crud-verification-20260419.md
@@ -1,0 +1,47 @@
+# DingTalk Group Destination CRUD Verification
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-group-notify-standard-20260419`
+- Scope: DingTalk group destination CRUD + test-send + multitable manager UI
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts tests/unit/api-token-webhook.test.ts --watch=false
+pnpm --filter @metasheet/web build
+pnpm --filter @metasheet/core-backend build
+```
+
+## Results
+
+### Frontend
+
+- `tests/multitable-api-token-manager.spec.ts`
+  - `14 passed`
+
+### Backend
+
+- `tests/unit/dingtalk-group-destination-service.test.ts`
+- `tests/unit/api-token-webhook.test.ts`
+  - `46 passed`
+
+### Builds
+
+- `pnpm --filter @metasheet/web build`
+  - passed
+- `pnpm --filter @metasheet/core-backend build`
+  - passed
+
+## Notes
+
+- Frontend Vitest still prints the existing `WebSocket server error: Port is already in use` noise; tests still pass.
+- Web build still prints the existing Vite chunk-size warning; build still passes.
+- `pnpm install --frozen-lockfile` produced local `plugins/**/node_modules` and `tools/cli/node_modules` noise in the worktree; those generated files are not part of the implementation scope.
+
+## Deployment
+
+- None
+- No remote deployment
+- No migration execution in this verification run

--- a/docs/development/dingtalk-group-notify-review-hardening-development-20260419.md
+++ b/docs/development/dingtalk-group-notify-review-hardening-development-20260419.md
@@ -1,0 +1,48 @@
+# DingTalk Group Notify Review Hardening Development — 2026-04-19
+
+## Scope
+
+This slice hardens PR `#919` against the first round of review feedback without expanding the P0 feature boundary.
+
+Addressed concerns:
+
+- DingTalk webhook access tokens should not be exposed in the destination list UI
+- DingTalk send paths should have explicit request timeout protection
+
+## Changes
+
+### UI masking
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+
+Behavior change:
+
+- DingTalk destination cards now show a masked webhook URL in read-only display
+- sensitive query keys such as `access_token`, `timestamp`, and `sign` are replaced with `***`
+
+Note:
+
+- Edit form behavior remains unchanged; this slice only hardens the passive list display
+
+### Request timeout protection
+
+Updated:
+
+- `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+
+Behavior change:
+
+- manual DingTalk `test-send` now uses `AbortController`
+- automation `send_dingtalk_group_message` now uses `AbortController`
+- both paths clear timeout handles in `finally`
+
+This aligns DingTalk sends with the repository’s existing webhook timeout pattern.
+
+## Tests Updated
+
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+- `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`

--- a/docs/development/dingtalk-group-notify-review-hardening-verification-20260419.md
+++ b/docs/development/dingtalk-group-notify-review-hardening-verification-20260419.md
@@ -1,0 +1,31 @@
+# DingTalk Group Notify Review Hardening Verification — 2026-04-19
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- frontend:
+  - `tests/multitable-api-token-manager.spec.ts`
+  - result: `19 passed`
+- backend:
+  - `tests/unit/dingtalk-group-destination-service.test.ts`
+  - `tests/unit/automation-v1.test.ts`
+  - result: `102 passed`
+- builds:
+  - `pnpm --filter @metasheet/core-backend build`
+  - `pnpm --filter @metasheet/web build`
+  - result: passed
+
+## Focus
+
+- DingTalk destination card display masks access tokens
+- DingTalk manual test-send passes an abort signal
+- DingTalk automation send passes an abort signal
+- builds remain green after timeout hardening

--- a/docs/development/dingtalk-group-notify-standard-design-20260419.md
+++ b/docs/development/dingtalk-group-notify-standard-design-20260419.md
@@ -1,0 +1,503 @@
+# DingTalk Group Notification Standard Feature Design
+
+Date: 2026-04-19
+
+## Objective
+
+Standardize the product flow:
+
+- `multitable trigger`
+- `send DingTalk group message`
+- `public form fill-in and/or internal record handling`
+
+The first production slice targets **group delivery** only.
+
+Direct personal DingTalk delivery is intentionally postponed to a later phase.
+
+## Product Principles
+
+### 1. Notification surface is not authorization surface
+
+Sending a message into a DingTalk group does **not** grant table access.
+
+- users with internal table permissions can open internal links
+- users without permissions must be blocked from internal table links
+
+### 2. Public form is not internal table access
+
+Public form links are only for **new submissions**.
+
+They must not allow:
+
+- browsing the internal table
+- opening arbitrary records
+- editing existing records
+
+### 3. Group first, personal DingTalk later
+
+The current standard feature should target:
+
+- DingTalk robot webhook based group messages
+
+The following should be phase 2:
+
+- DingTalk personal / enterprise work notifications
+
+because they require user-level DingTalk identity resolution and a different
+delivery mechanism than robot webhooks.
+
+## User Stories
+
+### Story A: Ask a group to fill a form
+
+When a record reaches a trigger condition, the system posts a DingTalk group
+message containing:
+
+- the trigger reason
+- key record summary fields
+- a public form link for new submissions
+
+Any recipient holding the valid public form link can submit a new response, but
+cannot access the internal table.
+
+### Story B: Ask internal operators to process a record
+
+When a record reaches a trigger condition, the system posts a DingTalk group
+message containing:
+
+- the trigger reason
+- key record summary fields
+- an internal deep link to the record
+
+Only users with existing ACL access can open the record and view or edit it.
+
+### Story C: Combined message
+
+For the most common operational flow, one message should contain both:
+
+- `填写入口` — public form link
+- `处理入口` — internal record deep link
+
+This lets external or broader recipients submit new information while internal
+operators process the record safely under ACL.
+
+## Current Codebase Baseline
+
+### DingTalk robot sending already exists
+
+The backend already supports DingTalk robot markdown messages with signing:
+
+- [NotificationService.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/src/services/NotificationService.ts:172)
+- [NotificationService.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/src/services/NotificationService.ts:324)
+
+Important current behavior:
+
+- it accepts only `webhook` / `group` recipients
+- it signs webhook URLs when a secret exists
+- it already validates DingTalk business-level responses
+
+### Multitable webhook management already exists
+
+The multitable API already supports webhook CRUD and delivery history:
+
+- [api-tokens.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/src/routes/api-tokens.ts:159)
+- [MetaApiTokenManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/multitable/components/MetaApiTokenManager.vue:92)
+
+This is useful as a reference for:
+
+- destination configuration UX
+- secret storage/update flows
+- delivery visibility
+
+### Public form links already exist
+
+Public multitable forms already have:
+
+- route contract:
+  - [types.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/router/types.ts:428)
+- link generation:
+  - [MetaFormShareManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/multitable/components/MetaFormShareManager.vue:139)
+- public submission audit:
+  - [univer-meta.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/src/routes/univer-meta.ts:6048)
+
+### Public forms are already create-only
+
+This is already enforced by integration tests:
+
+- [public-form-flow.test.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/tests/integration/public-form-flow.test.ts:246)
+
+This existing rule should remain unchanged.
+
+### Internal multitable deep links already exist
+
+The app already has internal multitable routes and record-scoped context:
+
+- [types.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/router/types.ts:428)
+- [MultitableWorkbench.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/multitable/views/MultitableWorkbench.vue:1043)
+
+This is enough to standardize:
+
+- sheet/view links
+- record deep links
+
+without inventing a second link system.
+
+## Standard Feature Scope
+
+### Phase 0
+
+Deliver a standard feature called:
+
+- `钉钉群通知`
+
+This feature must support:
+
+- multitable trigger conditions
+- DingTalk group destinations
+- templated message bodies
+- public form link inclusion
+- internal record link inclusion
+- delivery history and failure handling
+
+### Explicitly out of scope for phase 0
+
+- personal DingTalk direct messages
+- arbitrary external IM adapters
+- cell-level ACL
+- authorization bypass via message links
+
+## Standard Message Types
+
+### Type 1: Form request message
+
+Purpose:
+
+- ask a group to submit new information
+
+Payload contents:
+
+- title
+- trigger reason
+- key record summary
+- due time (optional)
+- public form link
+
+### Type 2: Internal action message
+
+Purpose:
+
+- ask internal operators to review, view, or edit a record
+
+Payload contents:
+
+- title
+- trigger reason
+- key record summary
+- assignee / status (optional)
+- internal record link
+
+### Type 3: Combined message
+
+Purpose:
+
+- one message for both broad collection and internal handling
+
+Payload contents:
+
+- title
+- trigger reason
+- summary
+- public form link
+- internal record link
+
+## Proposed Data Model
+
+### 1. DingTalk group destination
+
+Create a managed destination entity, for example:
+
+- `id`
+- `name`
+- `webhook_url`
+- `secret`
+- `enabled`
+- `scope_type`
+- `scope_id`
+- `created_by`
+- `created_at`
+- `updated_at`
+
+Recommended scope model:
+
+- `platform`
+- `organization`
+- `plugin_namespace`
+
+### 2. DingTalk message template
+
+- `id`
+- `name`
+- `type`
+  - `form_request`
+  - `record_action`
+  - `combined`
+- `title_template`
+- `body_template`
+- `enabled`
+
+### 3. Trigger binding
+
+- `id`
+- `sheet_id`
+- `view_id` nullable
+- `rule_name`
+- `trigger_type`
+- `trigger_config`
+- `destination_id`
+- `template_id`
+- `public_form_view_id` nullable
+- `include_internal_link`
+- `enabled`
+
+### 4. Delivery history
+
+Reuse the existing notification history model where practical, but for product
+clarity the standard feature should expose:
+
+- delivery status
+- failed reason
+- DingTalk response status
+- rendered title/body preview
+- destination used
+- trigger source record
+
+## Proposed Link Rules
+
+### Public fill-in link
+
+Format:
+
+- `/multitable/public-form/:sheetId/:viewId?publicToken=...`
+
+Rules:
+
+- can be opened by anyone holding the valid token
+- create-only
+- no internal table browsing
+- no editing existing records
+
+### Internal handling link
+
+Format:
+
+- `/multitable/:sheetId/:viewId`
+- `/multitable/:sheetId/:viewId?recordId=...`
+
+Rules:
+
+- can only be opened by authenticated users
+- access continues to respect existing sheet/view/field/record ACL
+- users without permission must be blocked
+
+## UI Plan
+
+### A. Destination management
+
+Add a dedicated management surface for DingTalk group destinations:
+
+- list destinations
+- create destination
+- update webhook/secret
+- enable / disable
+- test send
+- view delivery history
+
+Recommended entry point:
+
+- near existing multitable webhook / automation settings
+
+### B. Trigger configuration
+
+Extend multitable automation with a first-class action:
+
+- `send_dingtalk_group_message`
+
+instead of forcing users to model this manually as a raw generic webhook.
+
+Required fields:
+
+- destination
+- message type
+- template
+- include public form link
+- include internal link
+- fields to summarize
+
+### C. Message preview
+
+Operators should be able to preview:
+
+- title
+- body
+- resolved links
+
+before enabling the rule.
+
+## Backend Plan
+
+### Step 1: destination service
+
+Add a standard backend service and routes for DingTalk destinations.
+
+Suggested endpoints:
+
+- `GET /api/dingtalk-group-destinations`
+- `POST /api/dingtalk-group-destinations`
+- `PATCH /api/dingtalk-group-destinations/:id`
+- `POST /api/dingtalk-group-destinations/:id/test-send`
+- `GET /api/dingtalk-group-destinations/:id/deliveries`
+
+### Step 2: standard action adapter
+
+Add `send_dingtalk_group_message` into multitable automation execution.
+
+It should:
+
+- resolve destination
+- render title/body templates
+- resolve public form/internal links
+- call existing DingTalk notification sending logic
+- record delivery history
+
+### Step 3: template renderer
+
+Support variables such as:
+
+- table name
+- view name
+- record id
+- record title
+- operator name
+- status
+- due time
+- public form URL
+- internal URL
+
+### Step 4: delivery observability
+
+Expose:
+
+- success / failure counts
+- last delivery time
+- last failed reason
+- rendered preview for operators
+
+## Frontend Plan
+
+### Step 1: destination admin UI
+
+Create a focused UI for DingTalk group configuration.
+
+Minimum functions:
+
+- create
+- edit
+- enable/disable
+- test send
+- list deliveries
+
+### Step 2: automation editor integration
+
+In the multitable automation editor:
+
+- add action type `send_dingtalk_group_message`
+- show destination selector
+- show template selector or inline editor
+- toggle public/internal link inclusion
+
+### Step 3: link preview and safety hints
+
+Show two distinct hints:
+
+- `公开填写入口：任何持有 publicToken 的人可填写，但不能查看内部表格`
+- `内部处理入口：仅有权限的用户可打开`
+
+## Permission Boundaries
+
+### Must enforce
+
+- internal links do not bypass ACL
+- public form links do not expose internal table data
+- public form links remain create-only
+- message recipients do not equal authorized users
+
+### Must not do
+
+- auto-upgrade group recipients into internal viewers
+- treat DingTalk group membership as table permission
+- reuse public form links for record editing
+
+## Recommended Rollout Order
+
+### P0
+
+- destination configuration
+- test send
+- delivery history
+- standard action `send_dingtalk_group_message`
+- public form + internal link composition
+
+### P1
+
+- plugin/organization scoped destination governance
+- reusable template library
+- richer summary rendering
+
+### P2
+
+- personal DingTalk delivery
+- user-level recipient resolution from DingTalk identity
+
+## Detailed Development Task List
+
+### Backend
+
+1. Add DingTalk destination persistence model and CRUD routes.
+2. Add destination-level test send using existing signing logic.
+3. Add automation action type `send_dingtalk_group_message`.
+4. Add link resolver for:
+   - public form URL
+   - internal record URL
+5. Add templated rendering context.
+6. Add delivery history read API.
+7. Add audit logging.
+
+### Frontend
+
+1. Add DingTalk destination management page or settings module.
+2. Add destination test-send flow.
+3. Extend multitable automation editor with the new action type.
+4. Add public/internal link preview blocks.
+5. Add delivery history viewer.
+
+### Tests
+
+1. Destination CRUD route tests.
+2. DingTalk test-send unit tests.
+3. Automation execution tests for `send_dingtalk_group_message`.
+4. Public/internal link rendering tests.
+5. Frontend automation editor tests.
+6. Permission regression tests:
+   - no internal ACL bypass
+   - public forms remain create-only
+
+## Recommendation
+
+Ship this as a standard product capability in the following sequence:
+
+1. standardize DingTalk group destinations
+2. standardize group-message automation from multitable triggers
+3. standardize dual-link messages
+4. postpone personal DingTalk delivery to the next phase
+
+This gives the fastest business value with the least permission risk.

--- a/docs/development/dingtalk-group-notify-standard-development-20260419.md
+++ b/docs/development/dingtalk-group-notify-standard-development-20260419.md
@@ -1,0 +1,100 @@
+# DingTalk Group Notification Standard Development
+
+Date: 2026-04-19
+
+## Scope
+
+This slice does not implement runtime code yet.
+
+It formalizes the product and engineering plan for the standard feature:
+
+- `表格触发 -> 钉钉群消息 -> 表单填写 / 内部处理`
+
+## Why This Slice Was Needed
+
+The product requirement is now clear:
+
+- DingTalk group messaging should become a standard product capability
+- internal table links must continue to respect ACL
+- public form links should be used for broad fill-in flows
+- personal DingTalk messaging should come later
+
+Before implementation, the system needed one explicit design that ties together:
+
+- DingTalk robot delivery
+- multitable automation
+- public form links
+- internal deep links
+- permission boundaries
+
+## Work Performed
+
+Created the standard feature design document:
+
+- [dingtalk-group-notify-standard-design-20260419.md](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/docs/development/dingtalk-group-notify-standard-design-20260419.md:1)
+
+The document includes:
+
+- product principles
+- current codebase baseline
+- message types
+- proposed data model
+- link rules
+- UI plan
+- backend plan
+- frontend plan
+- permission boundaries
+- rollout order
+- detailed backend/frontend/test task list
+
+## Main Decisions
+
+### 1. Group delivery is phase 0
+
+The standard feature should first support:
+
+- DingTalk robot webhook based group delivery
+
+It should not start with personal DingTalk delivery because that needs a
+different recipient model and enterprise message channel.
+
+### 2. One message may contain two links
+
+The standard message can contain:
+
+- a public form link for new submissions
+- an internal deep link for authenticated handling
+
+These two links solve different business problems and must remain distinct.
+
+### 3. Notification does not grant access
+
+The design explicitly fixes this rule:
+
+- sending a link to a group never grants internal table access
+
+### 4. Public form remains create-only
+
+The design preserves the current public form invariant:
+
+- public forms do not expose internal table data
+- public forms do not edit existing records
+
+### 5. First-class automation action is preferred
+
+Instead of forcing users to handwire a generic webhook action, the plan
+recommends a standard action:
+
+- `send_dingtalk_group_message`
+
+This keeps the feature understandable and governable.
+
+## Delivery Recommendation
+
+Implementation should proceed in this order:
+
+1. DingTalk destination CRUD + test send
+2. standard multitable automation action
+3. dual-link message rendering
+4. delivery history / audit
+5. personal DingTalk later

--- a/docs/development/dingtalk-group-notify-standard-package-development-20260419.md
+++ b/docs/development/dingtalk-group-notify-standard-package-development-20260419.md
@@ -1,0 +1,105 @@
+# DingTalk Group Notify Standard P0 Package Development — 2026-04-19
+
+## Scope
+
+This package turns the previously separate DingTalk notification slices into one reviewable P0 feature line:
+
+- DingTalk group destination management
+- standard automation action `send_dingtalk_group_message`
+- public form link + internal record/view deep link support
+- delivery history and audit visibility
+
+This package intentionally stops at **group notification**. Direct DingTalk messaging to individual users remains out of scope.
+
+## Included Commits
+
+- `cf26ef3ec` `docs(dingtalk): define standard group notification flow`
+- `01928b4aa` `feat(dingtalk): add group destination management`
+- `af9c81816` `feat(dingtalk): add automation group message action`
+- `aeae067ca` `feat(dingtalk): add group delivery history and audit`
+
+## Functional Outcome
+
+### 1. DingTalk Group Destinations
+
+Added destination management for DingTalk robot webhooks:
+
+- create / update / enable / disable / delete
+- owner-scoped access
+- manual `test-send`
+
+Core pieces:
+
+- migration for `dingtalk_group_destinations`
+- backend destination service + routes
+- frontend `DingTalk Groups` tab in `MetaApiTokenManager`
+
+### 2. Standard Automation Action
+
+Added automation action:
+
+- `send_dingtalk_group_message`
+
+Supported configuration:
+
+- destination selection
+- title/body template
+- optional public form view link
+- optional internal multitable deep link
+
+Outcome:
+
+- one automation rule can notify a DingTalk group with both:
+  - a create-only public form entry point
+  - an internal processing link guarded by existing ACL
+
+### 3. Delivery History / Audit
+
+Added history persistence and visibility for both:
+
+- manual `test-send`
+- automation-triggered DingTalk group messages
+
+Delivery rows persist:
+
+- source type
+- rendered subject/content
+- success/failure
+- HTTP status
+- response body
+- error message
+- automation rule id
+- record id
+- initiating actor
+
+### 4. Hardening Included In P0
+
+This package also includes the following guardrails:
+
+- open delivery panel refreshes after `test-send`
+- delivery history has loading + empty states
+- stale async responses do not overwrite the currently selected destination
+- DingTalk application errors (`HTTP 200` with non-zero `errcode`) keep response diagnostics
+- delivery-history persistence is best-effort and does not convert a real send success into an application failure
+
+## Boundaries
+
+In scope:
+
+- DingTalk group robot destinations
+- multitable automation integration
+- delivery history / audit visibility
+
+Out of scope:
+
+- direct DingTalk personal messaging
+- remote deployment
+- production migration execution
+- organization-wide routing policies beyond per-destination selection
+
+## Related Slice Documents
+
+- `docs/development/dingtalk-group-notify-standard-design-20260419.md`
+- `docs/development/dingtalk-group-destination-crud-development-20260419.md`
+- `docs/development/dingtalk-group-automation-action-development-20260419.md`
+- `docs/development/dingtalk-group-delivery-history-development-20260419.md`

--- a/docs/development/dingtalk-group-notify-standard-package-verification-20260419.md
+++ b/docs/development/dingtalk-group-notify-standard-package-verification-20260419.md
@@ -1,0 +1,63 @@
+# DingTalk Group Notify Standard P0 Package Verification — 2026-04-19
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts tests/unit/api-token-webhook.test.ts tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+### Backend
+
+- `tests/unit/dingtalk-group-destination-service.test.ts`
+- `tests/unit/api-token-webhook.test.ts`
+- `tests/unit/automation-v1.test.ts`
+- Result: `143 passed`
+
+Covered areas:
+
+- destination CRUD + test-send
+- DingTalk robot signing / route integration surface already covered by API token webhook tests
+- automation action execution
+- delivery-history persistence
+- best-effort audit writes
+- DingTalk application error diagnostics
+
+### Frontend
+
+- `tests/multitable-api-token-manager.spec.ts`
+- `tests/multitable-automation-rule-editor.spec.ts`
+- `tests/multitable-automation-manager.spec.ts`
+- Result: `35 passed`
+
+Covered areas:
+
+- DingTalk group tab CRUD and test-send surface
+- delivery panel rendering / refresh / empty state / stale-request protection
+- automation editor configuration for DingTalk group action
+- automation manager rendering flow
+
+### Builds
+
+- `pnpm --filter @metasheet/core-backend build`: passed
+- `pnpm --filter @metasheet/web build`: passed
+
+## Non-blocking Noise
+
+- Frontend Vitest may print `WebSocket server error: Port is already in use`
+- Web build still prints existing Vite chunk-size / dynamic-import warnings
+- Backend test runs may print the existing Vite CJS deprecation warning
+
+These are pre-existing and not introduced by this package.
+
+## Deployment Impact
+
+- No remote deployment performed
+- New migrations exist in this package but were not executed remotely:
+  - `packages/core-backend/src/db/migrations/zzzz20260419183000_create_dingtalk_group_destinations.ts`
+  - `packages/core-backend/src/db/migrations/zzzz20260419193000_add_dingtalk_group_message_automation_action.ts`
+  - `packages/core-backend/src/db/migrations/zzzz20260419203000_create_dingtalk_group_deliveries.ts`

--- a/docs/development/dingtalk-group-notify-standard-verification-20260419.md
+++ b/docs/development/dingtalk-group-notify-standard-verification-20260419.md
@@ -1,0 +1,105 @@
+# DingTalk Group Notification Standard Verification
+
+Date: 2026-04-19
+
+## Verification Goal
+
+Verify that the proposed standard feature plan matches the current codebase and
+does not violate existing permission or public-form behavior.
+
+## Codebase Mapping Reviewed
+
+### DingTalk robot delivery baseline
+
+Reviewed:
+
+- [NotificationService.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/src/services/NotificationService.ts:172)
+- [NotificationService.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/src/services/NotificationService.ts:324)
+
+Confirmed:
+
+- DingTalk markdown payload building exists
+- webhook signing exists
+- DingTalk response validation exists
+- recipients are restricted to `webhook` / `group`
+
+### Multitable webhook management baseline
+
+Reviewed:
+
+- [api-tokens.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/src/routes/api-tokens.ts:159)
+- [MetaApiTokenManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/multitable/components/MetaApiTokenManager.vue:92)
+
+Confirmed:
+
+- CRUD for webhooks already exists
+- delivery history UI already exists
+- the destination-management proposal is grounded in existing product patterns
+
+### Public form baseline
+
+Reviewed:
+
+- [types.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/router/types.ts:428)
+- [MetaFormShareManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/multitable/components/MetaFormShareManager.vue:139)
+- [univer-meta.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/src/routes/univer-meta.ts:6048)
+- [public-form-flow.test.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/packages/core-backend/tests/integration/public-form-flow.test.ts:246)
+
+Confirmed:
+
+- public-form route contract already exists
+- share link generation already exists
+- submission audit logging already exists
+- public forms are already create-only and reject `recordId` updates
+
+### Internal multitable deep-link baseline
+
+Reviewed:
+
+- [types.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/router/types.ts:428)
+- [MultitableWorkbench.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/multitable/views/MultitableWorkbench.vue:1043)
+
+Confirmed:
+
+- internal multitable routes already exist
+- record-scoped context already exists
+- the design does not require inventing a parallel routing mechanism
+
+### Automation-editor baseline
+
+Reviewed:
+
+- [MetaAutomationRuleEditor.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-notify-standard-20260419/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue:127)
+
+Confirmed:
+
+- current automation UI already supports multiple standard actions
+- adding a first-class `send_dingtalk_group_message` action fits the current
+  architecture better than exposing only raw `send_webhook`
+
+## Verification Result
+
+The design is consistent with the current codebase:
+
+- no contradiction with existing DingTalk sending logic
+- no contradiction with existing public-form routing
+- no contradiction with current create-only public-form policy
+- no contradiction with existing multitable ACL behavior
+
+The proposed plan is therefore implementation-ready as a next development
+slice.
+
+## Commands Used
+
+```bash
+rg -n "public-form|MetaFormShareManager|MULTITABLE_PUBLIC_FORM|field 权限|record 权限|member-group acl|sheet permissions|record permissions" docs apps/web packages/core-backend -g '!**/node_modules/**'
+nl -ba packages/core-backend/src/services/NotificationService.ts | sed -n '168,390p'
+nl -ba packages/core-backend/src/routes/api-tokens.ts | sed -n '150,270p'
+nl -ba apps/web/src/multitable/components/MetaFormShareManager.vue | sed -n '130,170p'
+nl -ba packages/core-backend/tests/integration/public-form-flow.test.ts | sed -n '230,280p'
+nl -ba packages/core-backend/src/routes/univer-meta.ts | sed -n '6040,6065p'
+nl -ba apps/web/src/router/types.ts | sed -n '400,435p'
+nl -ba apps/web/src/multitable/views/MultitableWorkbench.vue | sed -n '1008,1056p'
+nl -ba apps/web/src/multitable/components/MetaAutomationRuleEditor.vue | sed -n '120,185p'
+nl -ba apps/web/src/multitable/components/MetaApiTokenManager.vue | sed -n '90,145p'
+```

--- a/packages/core-backend/src/db/migrations/zzzz20260419183000_create_dingtalk_group_destinations.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260419183000_create_dingtalk_group_destinations.ts
@@ -1,0 +1,36 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS dingtalk_group_destinations (
+      id text PRIMARY KEY,
+      name text NOT NULL,
+      webhook_url text NOT NULL,
+      secret text,
+      enabled boolean NOT NULL DEFAULT true,
+      created_by text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz,
+      last_tested_at timestamptz,
+      last_test_status text,
+      last_test_error text
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_group_destinations_created_by
+    ON dingtalk_group_destinations(created_by)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_group_destinations_enabled
+    ON dingtalk_group_destinations(enabled)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_group_destinations_enabled`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_group_destinations_created_by`.execute(db)
+  await sql`DROP TABLE IF EXISTS dingtalk_group_destinations`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260419193000_add_dingtalk_group_message_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260419193000_add_dingtalk_group_message_automation_action.ts
@@ -1,0 +1,37 @@
+import { sql, type Kysely } from 'kysely'
+
+function addConstraint(db: Kysely<unknown>, values: string[]) {
+  const quoted = values.map((value) => `'${value}'`).join(', ')
+  return sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quoted}))
+  `).execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await addConstraint(db, [
+    'notify',
+    'update_field',
+    'update_record',
+    'create_record',
+    'send_webhook',
+    'send_notification',
+    'send_dingtalk_group_message',
+    'lock_record',
+  ])
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await addConstraint(db, [
+    'notify',
+    'update_field',
+    'update_record',
+    'create_record',
+    'send_webhook',
+    'send_notification',
+    'lock_record',
+  ])
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260419203000_create_dingtalk_group_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260419203000_create_dingtalk_group_deliveries.ts
@@ -1,0 +1,38 @@
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS dingtalk_group_deliveries (
+      id TEXT PRIMARY KEY,
+      destination_id TEXT NOT NULL REFERENCES dingtalk_group_destinations(id) ON DELETE CASCADE,
+      source_type TEXT NOT NULL,
+      subject TEXT NOT NULL,
+      content TEXT NOT NULL,
+      success BOOLEAN NOT NULL DEFAULT FALSE,
+      http_status INTEGER,
+      response_body TEXT,
+      error_message TEXT,
+      automation_rule_id TEXT REFERENCES automation_rules(id) ON DELETE SET NULL,
+      record_id TEXT,
+      initiated_by TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      delivered_at TIMESTAMPTZ
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_group_deliveries_destination_id
+    ON dingtalk_group_deliveries(destination_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_group_deliveries_source_type
+    ON dingtalk_group_deliveries(source_type)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_group_deliveries_source_type`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_group_deliveries_destination_id`.execute(db)
+  await sql`DROP TABLE IF EXISTS dingtalk_group_deliveries`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -112,6 +112,7 @@ export interface Database {
   multitable_api_tokens: MultitableApiTokensTable
   multitable_webhooks: MultitableWebhooksTable
   multitable_webhook_deliveries: MultitableWebhookDeliveriesTable
+  dingtalk_group_destinations: DingTalkGroupDestinationsTable
 }
 
 export interface SnapshotsTable {
@@ -1295,4 +1296,18 @@ export interface MultitableWebhookDeliveriesTable {
   created_at: CreatedAt
   delivered_at: NullableTimestamp
   next_retry_at: NullableTimestamp
+}
+
+export interface DingTalkGroupDestinationsTable {
+  id: string
+  name: string
+  webhook_url: string
+  secret: string | null
+  enabled: boolean
+  created_by: string
+  created_at: CreatedAt
+  updated_at: NullableTimestamp
+  last_tested_at: NullableTimestamp
+  last_test_status: string | null
+  last_test_error: string | null
 }

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -113,6 +113,7 @@ export interface Database {
   multitable_webhooks: MultitableWebhooksTable
   multitable_webhook_deliveries: MultitableWebhookDeliveriesTable
   dingtalk_group_destinations: DingTalkGroupDestinationsTable
+  dingtalk_group_deliveries: DingTalkGroupDeliveriesTable
 }
 
 export interface SnapshotsTable {
@@ -1310,4 +1311,21 @@ export interface DingTalkGroupDestinationsTable {
   last_tested_at: NullableTimestamp
   last_test_status: string | null
   last_test_error: string | null
+}
+
+export interface DingTalkGroupDeliveriesTable {
+  id: string
+  destination_id: string
+  source_type: string
+  subject: string
+  content: string
+  success: boolean
+  http_status: number | null
+  response_body: string | null
+  error_message: string | null
+  automation_rule_id: string | null
+  record_id: string | null
+  initiated_by: string | null
+  created_at: CreatedAt
+  delivered_at: NullableTimestamp
 }

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -103,6 +103,7 @@ import workflowDesignerRouter from './routes/workflow-designer'
 import plmWorkbenchRouter from './routes/plm-workbench'
 import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
+import { apiTokensRouter } from './routes/api-tokens'
 import { SnapshotService } from './services/SnapshotService'
 import { MetricsStreamService } from './services/MetricsStreamService'
 import { notificationService } from './services/NotificationService'
@@ -859,6 +860,7 @@ export class MetaSheetServer {
 
     // Canonical multitable API used by the frontend and OpenAPI contracts.
     this.app.use('/api/multitable', univerMetaRouter())
+    this.app.use(apiTokensRouter())
     // Keep the legacy dev alias while existing tools/worktrees still reference it.
     if (process.env.NODE_ENV !== 'production') {
       this.app.use('/api/univer-meta', univerMetaRouter())

--- a/packages/core-backend/src/integrations/dingtalk/robot.ts
+++ b/packages/core-backend/src/integrations/dingtalk/robot.ts
@@ -1,0 +1,50 @@
+import { createHmac } from 'node:crypto'
+
+export interface DingTalkRobotPayload {
+  msgtype: 'markdown'
+  markdown: {
+    title: string
+    text: string
+  }
+}
+
+interface DingTalkRobotResponse {
+  errcode?: number
+  errmsg?: string
+}
+
+export class DingTalkRobotResponseError extends Error {}
+
+export function buildDingTalkMarkdown(subject: string, content: string): DingTalkRobotPayload {
+  const title = subject.trim() || 'MetaSheet Notification'
+  const body = content.trim() || title
+  return {
+    msgtype: 'markdown',
+    markdown: {
+      title,
+      text: `### ${title}\n\n${body}`,
+    },
+  }
+}
+
+export function buildSignedDingTalkWebhookUrl(baseUrl: string, secret?: string): string {
+  const normalizedSecret = typeof secret === 'string' ? secret.trim() : ''
+  if (!normalizedSecret) return baseUrl
+
+  const timestamp = Date.now()
+  const stringToSign = `${timestamp}\n${normalizedSecret}`
+  const sign = encodeURIComponent(createHmac('sha256', normalizedSecret).update(stringToSign).digest('base64'))
+  const separator = baseUrl.includes('?') ? '&' : '?'
+  return `${baseUrl}${separator}timestamp=${timestamp}&sign=${sign}`
+}
+
+export function validateDingTalkRobotResponse(payload: unknown): void {
+  const data = payload as DingTalkRobotResponse | null
+  if (!data || typeof data !== 'object') return
+  const errcode = typeof data.errcode === 'number' ? data.errcode : 0
+  if (errcode === 0) return
+  const errmsg = typeof data.errmsg === 'string' && data.errmsg.trim().length > 0
+    ? data.errmsg.trim()
+    : 'DingTalk robot request failed'
+  throw new DingTalkRobotResponseError(`DingTalk errcode ${errcode}: ${errmsg}`)
+}

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -8,6 +8,7 @@ export type AutomationActionType =
   | 'create_record'
   | 'send_webhook'
   | 'send_notification'
+  | 'send_dingtalk_group_message'
   | 'lock_record'
 
 export const ALL_ACTION_TYPES: AutomationActionType[] = [
@@ -15,6 +16,7 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'create_record',
   'send_webhook',
   'send_notification',
+  'send_dingtalk_group_message',
   'lock_record',
 ]
 
@@ -41,6 +43,15 @@ export interface SendWebhookConfig {
 export interface SendNotificationConfig {
   userIds: string[]
   message: string
+}
+
+/** Config shape for send_dingtalk_group_message */
+export interface SendDingTalkGroupMessageConfig {
+  destinationId: string
+  titleTemplate: string
+  bodyTemplate: string
+  publicFormViewId?: string
+  internalViewId?: string
 }
 
 /** Config shape for lock_record */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -640,17 +640,25 @@ export class AutomationExecutor {
     let responseBody: string | null = null
 
     try {
-      const response = await (this.deps.fetchFn ?? globalThis.fetch)(
-        buildSignedDingTalkWebhookUrl(destination.webhook_url, destination.secret ?? undefined),
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'User-Agent': 'MetaSheet-Automation-DingTalk/1.0',
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS)
+      let response: Response
+      try {
+        response = await (this.deps.fetchFn ?? globalThis.fetch)(
+          buildSignedDingTalkWebhookUrl(destination.webhook_url, destination.secret ?? undefined),
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'User-Agent': 'MetaSheet-Automation-DingTalk/1.0',
+            },
+            body: JSON.stringify(buildDingTalkMarkdown(renderedTitle, bodyWithLinks)),
+            signal: controller.signal,
           },
-          body: JSON.stringify(buildDingTalkMarkdown(renderedTitle, bodyWithLinks)),
-        },
-      )
+        )
+      } finally {
+        clearTimeout(timeout)
+      }
       const parsed = await readJsonSafely(response)
       responseStatus = response.status
       responseBody = parsed ? JSON.stringify(parsed) : response.statusText || null

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -85,6 +85,65 @@ function buildAppLink(baseUrl: string, path: string, search?: Record<string, str
   return url.toString()
 }
 
+async function recordDingTalkGroupDelivery(
+  queryFn: AutomationDeps['queryFn'],
+  input: {
+    destinationId: string
+    sourceType: 'automation' | 'manual_test'
+    subject: string
+    content: string
+    success: boolean
+    httpStatus?: number | null
+    responseBody?: string | null
+    errorMessage?: string | null
+    automationRuleId?: string | null
+    recordId?: string | null
+    initiatedBy?: string | null
+  },
+): Promise<void> {
+  await queryFn(
+    `INSERT INTO dingtalk_group_deliveries (
+       id, destination_id, source_type, subject, content, success,
+       http_status, response_body, error_message, automation_rule_id,
+       record_id, initiated_by, delivered_at
+     ) VALUES (
+       $1, $2, $3, $4, $5, $6,
+       $7, $8, $9, $10,
+       $11, $12, $13
+     )`,
+    [
+      randomUUID(),
+      input.destinationId,
+      input.sourceType,
+      input.subject,
+      input.content,
+      input.success,
+      input.httpStatus ?? null,
+      input.responseBody ?? null,
+      input.errorMessage ?? null,
+      input.automationRuleId ?? null,
+      input.recordId ?? null,
+      input.initiatedBy ?? null,
+      input.success ? new Date().toISOString() : null,
+    ],
+  )
+}
+
+async function recordDingTalkGroupDeliverySafely(
+  queryFn: AutomationDeps['queryFn'],
+  input: Parameters<typeof recordDingTalkGroupDelivery>[1],
+): Promise<void> {
+  try {
+    await recordDingTalkGroupDelivery(queryFn, input)
+  } catch (error) {
+    logger.warn('Failed to persist DingTalk group delivery history', {
+      error: error instanceof Error ? error.message : String(error),
+      destinationId: input.destinationId,
+      sourceType: input.sourceType,
+    })
+  }
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────
 
 export interface AutomationRule {
@@ -120,6 +179,7 @@ export interface AutomationStepResult {
 }
 
 export interface ExecutionContext {
+  ruleId: string
   sheetId: string
   recordId: string
   recordData: Record<string, unknown>
@@ -163,6 +223,7 @@ export class AutomationExecutor {
     // Build execution context from trigger event
     const payload = triggerEvent as Record<string, unknown>
     const context: ExecutionContext = {
+      ruleId: rule.id,
       sheetId: rule.sheetId,
       recordId: (payload?.recordId as string) ?? '',
       recordData: (payload?.data as Record<string, unknown>) ?? (payload?.changes as Record<string, unknown>) ?? {},
@@ -574,6 +635,9 @@ export class AutomationExecutor {
       renderedBody,
       linkLines.length > 0 ? ['**快捷入口**', ...linkLines].join('\n') : '',
     ].filter(Boolean).join('\n\n')
+    let deliveryRecorded = false
+    let responseStatus: number | null = null
+    let responseBody: string | null = null
 
     try {
       const response = await (this.deps.fetchFn ?? globalThis.fetch)(
@@ -588,14 +652,65 @@ export class AutomationExecutor {
         },
       )
       const parsed = await readJsonSafely(response)
+      responseStatus = response.status
+      responseBody = parsed ? JSON.stringify(parsed) : response.statusText || null
       if (!response.ok) {
+        deliveryRecorded = true
+        await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+          destinationId: destination.id,
+          sourceType: 'automation',
+          subject: renderedTitle,
+          content: bodyWithLinks,
+          success: false,
+          httpStatus: response.status,
+          responseBody,
+          errorMessage: `DingTalk request failed with HTTP ${response.status}`,
+          automationRuleId: context.ruleId,
+          recordId: context.recordId,
+          initiatedBy: context.actorId ?? null,
+        })
         return {
           actionType: 'send_dingtalk_group_message',
           status: 'failed',
           error: `DingTalk request failed with HTTP ${response.status}`,
         }
       }
-      validateDingTalkRobotResponse(parsed)
+      try {
+        validateDingTalkRobotResponse(parsed)
+      } catch (err) {
+        deliveryRecorded = true
+        await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+          destinationId: destination.id,
+          sourceType: 'automation',
+          subject: renderedTitle,
+          content: bodyWithLinks,
+          success: false,
+          httpStatus: response.status,
+          responseBody,
+          errorMessage: err instanceof Error ? err.message : String(err),
+          automationRuleId: context.ruleId,
+          recordId: context.recordId,
+          initiatedBy: context.actorId ?? null,
+        })
+        return {
+          actionType: 'send_dingtalk_group_message',
+          status: 'failed',
+          error: err instanceof Error ? err.message : String(err),
+        }
+      }
+      deliveryRecorded = true
+      await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+        destinationId: destination.id,
+        sourceType: 'automation',
+        subject: renderedTitle,
+        content: bodyWithLinks,
+        success: true,
+        httpStatus: response.status,
+        responseBody,
+        automationRuleId: context.ruleId,
+        recordId: context.recordId,
+        initiatedBy: context.actorId ?? null,
+      })
       return {
         actionType: 'send_dingtalk_group_message',
         status: 'success',
@@ -606,6 +721,21 @@ export class AutomationExecutor {
         },
       }
     } catch (err) {
+      if (!deliveryRecorded) {
+        await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+          destinationId: destination.id,
+          sourceType: 'automation',
+          subject: renderedTitle,
+          content: bodyWithLinks,
+          success: false,
+          httpStatus: responseStatus,
+          responseBody,
+          errorMessage: err instanceof Error ? err.message : String(err),
+          automationRuleId: context.ruleId,
+          recordId: context.recordId,
+          initiatedBy: context.actorId ?? null,
+        })
+      }
       return {
         actionType: 'send_dingtalk_group_message',
         status: 'failed',

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -6,7 +6,16 @@
 import { randomUUID } from 'crypto'
 import { Logger } from '../core/logger'
 import type { EventBus } from '../integration/events/event-bus'
-import type { AutomationAction, AutomationActionType } from './automation-actions'
+import {
+  buildDingTalkMarkdown,
+  buildSignedDingTalkWebhookUrl,
+  validateDingTalkRobotResponse,
+} from '../integrations/dingtalk/robot'
+import type {
+  AutomationAction,
+  AutomationActionType,
+  SendDingTalkGroupMessageConfig,
+} from './automation-actions'
 import type { ConditionGroup } from './automation-conditions'
 import { evaluateConditions } from './automation-conditions'
 import type { AutomationTrigger } from './automation-triggers'
@@ -15,6 +24,66 @@ const logger = new Logger('AutomationExecutor')
 
 const WEBHOOK_TIMEOUT_MS = 5_000
 const MAX_WEBHOOK_RETRIES = 2
+
+function readJsonSafely(response: Response): Promise<unknown> {
+  return response.json().catch(() => null)
+}
+
+function lookupTemplateValue(path: string, data: Record<string, unknown>): unknown {
+  const segments = path.split('.').filter(Boolean)
+  let current: unknown = data
+  for (const segment of segments) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function renderTemplateValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return ''
+  }
+}
+
+function renderAutomationTemplate(template: string, data: Record<string, unknown>): string {
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key: string) =>
+    renderTemplateValue(lookupTemplateValue(key, data)),
+  )
+}
+
+function parseViewConfig(raw: unknown): Record<string, unknown> | null {
+  if (!raw) return null
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : null
+    } catch {
+      return null
+    }
+  }
+  return typeof raw === 'object' && !Array.isArray(raw) ? raw as Record<string, unknown> : null
+}
+
+function resolveAutomationAppBaseUrl(): string | null {
+  const raw = process.env.PUBLIC_APP_URL?.trim() || process.env.APP_BASE_URL?.trim() || ''
+  if (!raw) return null
+  return raw.endsWith('/') ? raw : `${raw}/`
+}
+
+function buildAppLink(baseUrl: string, path: string, search?: Record<string, string>): string {
+  const url = new URL(path.replace(/^\//, ''), baseUrl)
+  for (const [key, value] of Object.entries(search ?? {})) {
+    url.searchParams.set(key, value)
+  }
+  return url.toString()
+}
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -156,6 +225,9 @@ export class AutomationExecutor {
             break
           case 'send_notification':
             result = await this.executeSendNotification(action.config, context)
+            break
+          case 'send_dingtalk_group_message':
+            result = await this.executeSendDingTalkGroupMessage(action.config as unknown as SendDingTalkGroupMessageConfig, context)
             break
           case 'lock_record':
             result = await this.executeLockRecord(action.config, context)
@@ -382,6 +454,163 @@ export class AutomationExecutor {
       }
     } catch (err) {
       return { actionType: 'lock_record', status: 'failed', error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  private async executeSendDingTalkGroupMessage(
+    config: SendDingTalkGroupMessageConfig,
+    context: ExecutionContext,
+  ): Promise<AutomationStepResult> {
+    const destinationId = typeof config.destinationId === 'string' ? config.destinationId.trim() : ''
+    const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
+    const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
+    const publicFormViewId = typeof config.publicFormViewId === 'string' ? config.publicFormViewId.trim() : ''
+    const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
+
+    if (!destinationId) {
+      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk destination is required' }
+    }
+    if (!titleTemplate) {
+      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk title template is required' }
+    }
+    if (!bodyTemplate) {
+      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk body template is required' }
+    }
+
+    const destinationResult = await this.deps.queryFn(
+      `SELECT id, name, webhook_url, secret, enabled
+         FROM dingtalk_group_destinations
+        WHERE id = $1`,
+      [destinationId],
+    )
+    const destination = (destinationResult.rows[0] ?? null) as {
+      id: string
+      name: string
+      webhook_url: string
+      secret: string | null
+      enabled: boolean
+    } | null
+
+    if (!destination) {
+      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk destination not found' }
+    }
+    if (destination.enabled !== true) {
+      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk destination is disabled' }
+    }
+
+    let baseUrl: string | null = null
+    const linkLines: string[] = []
+    if (publicFormViewId || internalViewId) {
+      baseUrl = resolveAutomationAppBaseUrl()
+      if (!baseUrl) {
+        return {
+          actionType: 'send_dingtalk_group_message',
+          status: 'failed',
+          error: 'PUBLIC_APP_URL or APP_BASE_URL is required for DingTalk automation links',
+        }
+      }
+    }
+
+    if (publicFormViewId && baseUrl) {
+      const publicViewResult = await this.deps.queryFn(
+        `SELECT id, sheet_id, config
+           FROM meta_views
+          WHERE id = $1 AND sheet_id = $2`,
+        [publicFormViewId, context.sheetId],
+      )
+      const publicView = (publicViewResult.rows[0] ?? null) as {
+        id: string
+        sheet_id: string
+        config: unknown
+      } | null
+      if (!publicView) {
+        return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'Public form view not found' }
+      }
+
+      const viewConfig = parseViewConfig(publicView.config)
+      const publicForm = viewConfig?.publicForm
+      const publicToken = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
+        ? typeof (publicForm as Record<string, unknown>).publicToken === 'string'
+          ? ((publicForm as Record<string, unknown>).publicToken as string).trim()
+          : ''
+        : ''
+      const enabled = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
+        ? (publicForm as Record<string, unknown>).enabled === true
+        : false
+
+      if (!enabled || !publicToken) {
+        return {
+          actionType: 'send_dingtalk_group_message',
+          status: 'failed',
+          error: 'Selected public form view is not shared',
+        }
+      }
+
+      linkLines.push(`- [填写入口](${buildAppLink(baseUrl, `/multitable/public-form/${context.sheetId}/${publicFormViewId}`, { publicToken })})`)
+    }
+
+    if (internalViewId && baseUrl) {
+      const internalViewResult = await this.deps.queryFn(
+        `SELECT id
+           FROM meta_views
+          WHERE id = $1 AND sheet_id = $2`,
+        [internalViewId, context.sheetId],
+      )
+      if (!internalViewResult.rows[0]) {
+        return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'Internal view not found' }
+      }
+      linkLines.push(`- [处理入口](${buildAppLink(baseUrl, `/multitable/${context.sheetId}/${internalViewId}`, { recordId: context.recordId })})`)
+    }
+
+    const templateData: Record<string, unknown> = {
+      sheetId: context.sheetId,
+      recordId: context.recordId,
+      actorId: context.actorId ?? '',
+      record: context.recordData,
+    }
+    const renderedTitle = renderAutomationTemplate(titleTemplate, templateData).trim()
+    const renderedBody = renderAutomationTemplate(bodyTemplate, templateData).trim()
+    const bodyWithLinks = [
+      renderedBody,
+      linkLines.length > 0 ? ['**快捷入口**', ...linkLines].join('\n') : '',
+    ].filter(Boolean).join('\n\n')
+
+    try {
+      const response = await (this.deps.fetchFn ?? globalThis.fetch)(
+        buildSignedDingTalkWebhookUrl(destination.webhook_url, destination.secret ?? undefined),
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'MetaSheet-Automation-DingTalk/1.0',
+          },
+          body: JSON.stringify(buildDingTalkMarkdown(renderedTitle, bodyWithLinks)),
+        },
+      )
+      const parsed = await readJsonSafely(response)
+      if (!response.ok) {
+        return {
+          actionType: 'send_dingtalk_group_message',
+          status: 'failed',
+          error: `DingTalk request failed with HTTP ${response.status}`,
+        }
+      }
+      validateDingTalkRobotResponse(parsed)
+      return {
+        actionType: 'send_dingtalk_group_message',
+        status: 'success',
+        output: {
+          destinationId: destination.id,
+          destinationName: destination.name,
+          linkCount: linkLines.length,
+        },
+      }
+    } catch (err) {
+      return {
+        actionType: 'send_dingtalk_group_message',
+        status: 'failed',
+        error: err instanceof Error ? err.message : String(err),
+      }
     }
   }
 }

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -18,6 +18,7 @@ import type {
 } from './dingtalk-group-destinations'
 
 const logger = new Logger('DingTalkGroupDestinationService')
+const DINGTALK_REQUEST_TIMEOUT_MS = 5_000
 
 function generateId(): string {
   return randomBytes(16).toString('hex')
@@ -254,14 +255,22 @@ export class DingTalkGroupDestinationService {
     let responseBody: string | null = null
 
     try {
-      const response = await this.fetchFn(signedUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'User-Agent': 'MetaSheet-DingTalk-Destination-Test/1.0',
-        },
-        body: JSON.stringify(payload),
-      })
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), DINGTALK_REQUEST_TIMEOUT_MS)
+      let response: Response
+      try {
+        response = await this.fetchFn(signedUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'MetaSheet-DingTalk-Destination-Test/1.0',
+          },
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        })
+      } finally {
+        clearTimeout(timeout)
+      }
 
       const parsed = await readJsonSafely(response)
       responseStatus = response.status

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto'
-import type { Kysely } from 'kysely'
+import { sql, type Kysely } from 'kysely'
 import { Logger } from '../core/logger'
 import type { Database } from '../db/types'
 import { nowTimestamp } from '../db/type-helpers'
@@ -10,6 +10,7 @@ import {
 } from '../integrations/dingtalk/robot'
 import { maskDingTalkWebhookUrl } from '../integrations/dingtalk/runtime-policy'
 import type {
+  DingTalkGroupDelivery,
   DingTalkGroupDestination,
   DingTalkGroupDestinationCreateInput,
   DingTalkGroupDestinationUpdateInput,
@@ -49,6 +50,40 @@ function rowToDestination(row: {
       ? row.last_test_status
       : undefined,
     lastTestError: row.last_test_error ?? undefined,
+  }
+}
+
+function rowToDelivery(row: {
+  id: string
+  destination_id: string
+  source_type: string
+  subject: string
+  content: string
+  success: boolean
+  http_status: number | null
+  response_body: string | null
+  error_message: string | null
+  automation_rule_id: string | null
+  record_id: string | null
+  initiated_by: string | null
+  created_at: string | Date
+  delivered_at?: string | Date | null
+}): DingTalkGroupDelivery {
+  return {
+    id: row.id,
+    destinationId: row.destination_id,
+    sourceType: row.source_type === 'manual_test' ? 'manual_test' : 'automation',
+    subject: row.subject,
+    content: row.content,
+    success: row.success,
+    httpStatus: row.http_status ?? undefined,
+    responseBody: row.response_body ?? undefined,
+    errorMessage: row.error_message ?? undefined,
+    automationRuleId: row.automation_rule_id ?? undefined,
+    recordId: row.record_id ?? undefined,
+    initiatedBy: row.initiated_by ?? undefined,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    deliveredAt: row.delivered_at ? (row.delivered_at instanceof Date ? row.delivered_at.toISOString() : row.delivered_at) : undefined,
   }
 }
 
@@ -128,6 +163,16 @@ export class DingTalkGroupDestinationService {
     return rowToDestination(row as Parameters<typeof rowToDestination>[0])
   }
 
+  async listDeliveries(id: string, limit = 50): Promise<DingTalkGroupDelivery[]> {
+    const rows = await this.db.selectFrom('dingtalk_group_deliveries')
+      .selectAll()
+      .where('destination_id', '=', id)
+      .orderBy('created_at', 'desc')
+      .limit(limit)
+      .execute()
+    return rows.map((row) => rowToDelivery(row as Parameters<typeof rowToDelivery>[0]))
+  }
+
   async updateDestination(
     id: string,
     userId: string,
@@ -204,6 +249,9 @@ export class DingTalkGroupDestinationService {
     const content = input.content?.trim() || 'This is a standard DingTalk group destination test message.'
     const payload = buildDingTalkMarkdown(subject, content)
     const signedUrl = buildSignedDingTalkWebhookUrl(row.webhook_url, row.secret ?? undefined)
+    let deliveryRecorded = false
+    let responseStatus: number | null = null
+    let responseBody: string | null = null
 
     try {
       const response = await this.fetchFn(signedUrl, {
@@ -216,10 +264,51 @@ export class DingTalkGroupDestinationService {
       })
 
       const parsed = await readJsonSafely(response)
+      responseStatus = response.status
+      responseBody = parsed ? JSON.stringify(parsed) : response.statusText || null
       if (!response.ok) {
+        deliveryRecorded = true
+        await this.recordDeliverySafely({
+          destinationId: id,
+          sourceType: 'manual_test',
+          subject,
+          content,
+          initiatedBy: userId,
+          success: false,
+          httpStatus: response.status,
+          responseBody,
+          errorMessage: `HTTP ${response.status}: ${response.statusText}`,
+        })
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }
-      validateDingTalkRobotResponse(parsed)
+      try {
+        validateDingTalkRobotResponse(parsed)
+      } catch (error) {
+        deliveryRecorded = true
+        await this.recordDeliverySafely({
+          destinationId: id,
+          sourceType: 'manual_test',
+          subject,
+          content,
+          initiatedBy: userId,
+          success: false,
+          httpStatus: response.status,
+          responseBody,
+          errorMessage: error instanceof Error ? error.message : 'DingTalk robot response validation failed',
+        })
+        throw error
+      }
+      deliveryRecorded = true
+      await this.recordDeliverySafely({
+        destinationId: id,
+        sourceType: 'manual_test',
+        subject,
+        content,
+        initiatedBy: userId,
+        success: true,
+        httpStatus: response.status,
+        responseBody,
+      })
 
       await this.db.updateTable('dingtalk_group_destinations')
         .set({
@@ -235,6 +324,19 @@ export class DingTalkGroupDestinationService {
       return { ok: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
+      if (!deliveryRecorded) {
+        await this.recordDeliverySafely({
+          destinationId: id,
+          sourceType: 'manual_test',
+          subject,
+          content,
+          initiatedBy: userId,
+          success: false,
+          httpStatus: responseStatus,
+          responseBody,
+          errorMessage: message,
+        })
+      }
       await this.db.updateTable('dingtalk_group_destinations')
         .set({
           updated_at: nowTimestamp(),
@@ -245,6 +347,48 @@ export class DingTalkGroupDestinationService {
         .where('id', '=', id)
         .execute()
       throw new Error(message)
+    }
+  }
+
+  private async recordDelivery(input: {
+    destinationId: string
+    sourceType: 'manual_test' | 'automation'
+    subject: string
+    content: string
+    initiatedBy?: string | null
+    automationRuleId?: string | null
+    recordId?: string | null
+    success: boolean
+    httpStatus?: number | null
+    responseBody?: string | null
+    errorMessage?: string | null
+  }): Promise<void> {
+    await this.db.insertInto('dingtalk_group_deliveries').values({
+      id: generateId(),
+      destination_id: input.destinationId,
+      source_type: input.sourceType,
+      subject: input.subject,
+      content: input.content,
+      success: input.success,
+      http_status: input.httpStatus ?? null,
+      response_body: input.responseBody ?? null,
+      error_message: input.errorMessage ?? null,
+      automation_rule_id: input.automationRuleId ?? null,
+      record_id: input.recordId ?? null,
+      initiated_by: input.initiatedBy ?? null,
+      delivered_at: input.success ? sql<string>`CURRENT_TIMESTAMP` : null,
+    }).execute()
+  }
+
+  private async recordDeliverySafely(input: Parameters<DingTalkGroupDestinationService['recordDelivery']>[0]): Promise<void> {
+    try {
+      await this.recordDelivery(input)
+    } catch (error) {
+      logger.warn('Failed to persist DingTalk group delivery history', {
+        error: error instanceof Error ? error.message : String(error),
+        destinationId: input.destinationId,
+        sourceType: input.sourceType,
+      })
     }
   }
 }

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -1,0 +1,250 @@
+import { randomBytes } from 'node:crypto'
+import type { Kysely } from 'kysely'
+import { Logger } from '../core/logger'
+import type { Database } from '../db/types'
+import { nowTimestamp } from '../db/type-helpers'
+import {
+  buildDingTalkMarkdown,
+  buildSignedDingTalkWebhookUrl,
+  validateDingTalkRobotResponse,
+} from '../integrations/dingtalk/robot'
+import { maskDingTalkWebhookUrl } from '../integrations/dingtalk/runtime-policy'
+import type {
+  DingTalkGroupDestination,
+  DingTalkGroupDestinationCreateInput,
+  DingTalkGroupDestinationUpdateInput,
+  DingTalkGroupTestSendInput,
+} from './dingtalk-group-destinations'
+
+const logger = new Logger('DingTalkGroupDestinationService')
+
+function generateId(): string {
+  return randomBytes(16).toString('hex')
+}
+
+function rowToDestination(row: {
+  id: string
+  name: string
+  webhook_url: string
+  secret: string | null
+  enabled: boolean
+  created_by: string
+  created_at: string | Date
+  updated_at?: string | Date | null
+  last_tested_at?: string | Date | null
+  last_test_status?: string | null
+  last_test_error?: string | null
+}): DingTalkGroupDestination {
+  return {
+    id: row.id,
+    name: row.name,
+    webhookUrl: row.webhook_url,
+    secret: row.secret ?? undefined,
+    enabled: row.enabled,
+    createdBy: row.created_by,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    updatedAt: row.updated_at ? (row.updated_at instanceof Date ? row.updated_at.toISOString() : row.updated_at) : undefined,
+    lastTestedAt: row.last_tested_at ? (row.last_tested_at instanceof Date ? row.last_tested_at.toISOString() : row.last_tested_at) : undefined,
+    lastTestStatus: row.last_test_status === 'success' || row.last_test_status === 'failed'
+      ? row.last_test_status
+      : undefined,
+    lastTestError: row.last_test_error ?? undefined,
+  }
+}
+
+async function readJsonSafely(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+export class DingTalkGroupDestinationService {
+  private db: Kysely<Database>
+  private fetchFn: typeof fetch
+
+  constructor(db: Kysely<Database>, fetchFn?: typeof fetch) {
+    this.db = db
+    this.fetchFn = fetchFn ?? globalThis.fetch
+  }
+
+  async createDestination(userId: string, input: DingTalkGroupDestinationCreateInput): Promise<DingTalkGroupDestination> {
+    const name = input.name?.trim()
+    const webhookUrl = input.webhookUrl?.trim()
+    if (!name) throw new Error('Destination name is required')
+    if (!webhookUrl) throw new Error('Webhook URL is required')
+    try {
+      const parsed = new URL(webhookUrl)
+      if (process.env.NODE_ENV === 'production' && parsed.protocol !== 'https:') {
+        throw new Error('Webhook URL must use HTTPS in production')
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('HTTPS')) throw error
+      throw new Error('Webhook URL is not a valid URL')
+    }
+
+    const id = generateId()
+    const enabled = input.enabled ?? true
+    const now = new Date().toISOString()
+
+    await this.db.insertInto('dingtalk_group_destinations').values({
+      id,
+      name,
+      webhook_url: webhookUrl,
+      secret: input.secret ?? null,
+      enabled,
+      created_by: userId,
+      created_at: now,
+    }).execute()
+
+    logger.info(`Created DingTalk group destination ${id} for ${userId}`)
+    return {
+      id,
+      name,
+      webhookUrl,
+      secret: input.secret,
+      enabled,
+      createdBy: userId,
+      createdAt: now,
+    }
+  }
+
+  async listDestinations(userId: string): Promise<DingTalkGroupDestination[]> {
+    const rows = await this.db.selectFrom('dingtalk_group_destinations')
+      .selectAll()
+      .where('created_by', '=', userId)
+      .orderBy('created_at', 'desc')
+      .execute()
+    return rows.map((row) => rowToDestination(row as Parameters<typeof rowToDestination>[0]))
+  }
+
+  async getDestinationById(id: string): Promise<DingTalkGroupDestination | undefined> {
+    const row = await this.db.selectFrom('dingtalk_group_destinations')
+      .selectAll()
+      .where('id', '=', id)
+      .executeTakeFirst()
+    if (!row) return undefined
+    return rowToDestination(row as Parameters<typeof rowToDestination>[0])
+  }
+
+  async updateDestination(
+    id: string,
+    userId: string,
+    input: DingTalkGroupDestinationUpdateInput,
+  ): Promise<DingTalkGroupDestination> {
+    const row = await this.db.selectFrom('dingtalk_group_destinations')
+      .selectAll()
+      .where('id', '=', id)
+      .executeTakeFirst()
+    if (!row) throw new Error('Destination not found')
+    if (row.created_by !== userId) throw new Error('Not authorized')
+
+    const updates: Record<string, unknown> = { updated_at: nowTimestamp() }
+    if (input.name !== undefined) {
+      const name = input.name.trim()
+      if (!name) throw new Error('Destination name is required')
+      updates.name = name
+    }
+    if (input.webhookUrl !== undefined) {
+      const webhookUrl = input.webhookUrl.trim()
+      if (!webhookUrl) throw new Error('Webhook URL is required')
+      try {
+        const parsed = new URL(webhookUrl)
+        if (process.env.NODE_ENV === 'production' && parsed.protocol !== 'https:') {
+          throw new Error('Webhook URL must use HTTPS in production')
+        }
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('HTTPS')) throw error
+        throw new Error('Webhook URL is not a valid URL')
+      }
+      updates.webhook_url = webhookUrl
+    }
+    if (input.secret !== undefined) updates.secret = input.secret || null
+    if (input.enabled !== undefined) updates.enabled = input.enabled
+
+    await this.db.updateTable('dingtalk_group_destinations')
+      .set(updates as never)
+      .where('id', '=', id)
+      .execute()
+
+    const updated = await this.db.selectFrom('dingtalk_group_destinations')
+      .selectAll()
+      .where('id', '=', id)
+      .executeTakeFirstOrThrow()
+    return rowToDestination(updated as Parameters<typeof rowToDestination>[0])
+  }
+
+  async deleteDestination(id: string, userId: string): Promise<void> {
+    const row = await this.db.selectFrom('dingtalk_group_destinations')
+      .selectAll()
+      .where('id', '=', id)
+      .executeTakeFirst()
+    if (!row) throw new Error('Destination not found')
+    if (row.created_by !== userId) throw new Error('Not authorized')
+
+    await this.db.deleteFrom('dingtalk_group_destinations')
+      .where('id', '=', id)
+      .execute()
+  }
+
+  async testSend(
+    id: string,
+    userId: string,
+    input: DingTalkGroupTestSendInput,
+  ): Promise<{ ok: true }> {
+    const row = await this.db.selectFrom('dingtalk_group_destinations')
+      .selectAll()
+      .where('id', '=', id)
+      .executeTakeFirst()
+    if (!row) throw new Error('Destination not found')
+    if (row.created_by !== userId) throw new Error('Not authorized')
+
+    const subject = input.subject?.trim() || 'MetaSheet DingTalk group test'
+    const content = input.content?.trim() || 'This is a standard DingTalk group destination test message.'
+    const payload = buildDingTalkMarkdown(subject, content)
+    const signedUrl = buildSignedDingTalkWebhookUrl(row.webhook_url, row.secret ?? undefined)
+
+    try {
+      const response = await this.fetchFn(signedUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'MetaSheet-DingTalk-Destination-Test/1.0',
+        },
+        body: JSON.stringify(payload),
+      })
+
+      const parsed = await readJsonSafely(response)
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      }
+      validateDingTalkRobotResponse(parsed)
+
+      await this.db.updateTable('dingtalk_group_destinations')
+        .set({
+          updated_at: nowTimestamp(),
+          last_tested_at: nowTimestamp(),
+          last_test_status: 'success',
+          last_test_error: null,
+        })
+        .where('id', '=', id)
+        .execute()
+
+      logger.info(`DingTalk group destination test sent to ${maskDingTalkWebhookUrl(row.webhook_url)}`)
+      return { ok: true }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      await this.db.updateTable('dingtalk_group_destinations')
+        .set({
+          updated_at: nowTimestamp(),
+          last_tested_at: nowTimestamp(),
+          last_test_status: 'failed',
+          last_test_error: message,
+        })
+        .where('id', '=', id)
+        .execute()
+      throw new Error(message)
+    }
+  }
+}

--- a/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
@@ -30,3 +30,20 @@ export interface DingTalkGroupTestSendInput {
   subject?: string
   content?: string
 }
+
+export interface DingTalkGroupDelivery {
+  id: string
+  destinationId: string
+  sourceType: 'manual_test' | 'automation'
+  subject: string
+  content: string
+  success: boolean
+  httpStatus?: number
+  responseBody?: string
+  errorMessage?: string
+  automationRuleId?: string
+  recordId?: string
+  initiatedBy?: string
+  createdAt: string
+  deliveredAt?: string
+}

--- a/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
@@ -1,0 +1,32 @@
+export interface DingTalkGroupDestination {
+  id: string
+  name: string
+  webhookUrl: string
+  secret?: string
+  enabled: boolean
+  createdBy: string
+  createdAt: string
+  updatedAt?: string
+  lastTestedAt?: string
+  lastTestStatus?: 'success' | 'failed'
+  lastTestError?: string
+}
+
+export interface DingTalkGroupDestinationCreateInput {
+  name: string
+  webhookUrl: string
+  secret?: string
+  enabled?: boolean
+}
+
+export interface DingTalkGroupDestinationUpdateInput {
+  name?: string
+  webhookUrl?: string
+  secret?: string
+  enabled?: boolean
+}
+
+export interface DingTalkGroupTestSendInput {
+  subject?: string
+  content?: string
+}

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -1,22 +1,34 @@
 /**
- * API Token & Webhook REST Routes
- * Provides CRUD endpoints for managing API tokens and webhooks.
+ * API Token, Webhook, and DingTalk group destination REST routes.
  */
 
 import type { Request, Response } from 'express'
 import { Router } from 'express'
 import { z } from 'zod'
+import { db } from '../db/db'
 import { Logger } from '../core/logger'
 import { authenticate } from '../middleware/auth'
 import { ApiTokenService } from '../multitable/api-token-service'
-import { WebhookService } from '../multitable/webhook-service'
-import { db } from '../db/db'
 import { ALL_API_TOKEN_SCOPES } from '../multitable/api-tokens'
+import { DingTalkGroupDestinationService } from '../multitable/dingtalk-group-destination-service'
+import { WebhookService } from '../multitable/webhook-service'
 import { ALL_WEBHOOK_EVENT_TYPES } from '../multitable/webhooks'
 
 const logger = new Logger('ApiTokenRoutes')
 
-// ─── Zod schemas ───────────────────────────────────────────────────────
+const apiTokenService = new ApiTokenService(db)
+const webhookService = new WebhookService(db)
+const dingTalkGroupDestinationService = new DingTalkGroupDestinationService(db)
+
+const tokenListPaths = ['/api/multitable/api-tokens', '/api/multitable/tokens']
+const tokenItemPaths = ['/api/multitable/api-tokens/:id', '/api/multitable/tokens/:id']
+const tokenRotatePaths = ['/api/multitable/api-tokens/:id/rotate', '/api/multitable/tokens/:id/rotate']
+const webhookPaths = ['/api/multitable/webhooks', '/api/multitable/webhooks/:id', '/api/multitable/webhooks/:id/deliveries']
+const dingTalkGroupPaths = [
+  '/api/multitable/dingtalk-groups',
+  '/api/multitable/dingtalk-groups/:id',
+  '/api/multitable/dingtalk-groups/:id/test-send',
+]
 
 const CreateTokenSchema = z.object({
   name: z.string().min(1).max(100),
@@ -28,23 +40,35 @@ const CreateWebhookSchema = z.object({
   name: z.string().min(1).max(100),
   url: z.string().url(),
   secret: z.string().optional(),
-  events: z
-    .array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]]))
-    .min(1),
+  events: z.array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]])).min(1),
 })
 
 const UpdateWebhookSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   url: z.string().url().optional(),
   secret: z.string().optional(),
-  events: z
-    .array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]]))
-    .min(1)
-    .optional(),
+  events: z.array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]])).min(1).optional(),
   active: z.boolean().optional(),
 })
 
-// ─── Helpers ───────────────────────────────────────────────────────────
+const CreateDingTalkGroupSchema = z.object({
+  name: z.string().min(1).max(100),
+  webhookUrl: z.string().url(),
+  secret: z.string().optional(),
+  enabled: z.boolean().optional(),
+})
+
+const UpdateDingTalkGroupSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  webhookUrl: z.string().url().optional(),
+  secret: z.string().optional(),
+  enabled: z.boolean().optional(),
+})
+
+const DingTalkGroupTestSendSchema = z.object({
+  subject: z.string().min(1).max(100).optional(),
+  content: z.string().min(1).max(4000).optional(),
+})
 
 function getUserId(req: Request): string {
   const user = req.user as Record<string, unknown> | undefined
@@ -59,35 +83,50 @@ function zodError(res: Response, err: z.ZodError): void {
   })
 }
 
-// ─── Router factory ────────────────────────────────────────────────────
+function serviceErrorResponse(res: Response, err: unknown, action: string): void {
+  const message = err instanceof Error ? err.message : 'Unknown error'
+  let status = 500
+  let code = `${action.toUpperCase()}_FAILED`
 
-const apiTokenService = new ApiTokenService(db)
-const webhookService = new WebhookService(db)
+  if (message === 'Destination not found' || message === 'Token not found' || message === 'Webhook not found') {
+    status = 404
+  } else if (message === 'Not authorized') {
+    status = 403
+    code = 'FORBIDDEN'
+  } else if (
+    message.includes('required')
+    || message.includes('valid URL')
+    || message.includes('HTTPS')
+    || message.includes('At least one scope')
+  ) {
+    status = 400
+  }
+
+  res.status(status).json({
+    ok: false,
+    error: { code, message },
+  })
+}
 
 export function apiTokensRouter(): Router {
   const router = Router()
 
-  // All routes require authentication
   router.use(
-    ['/api/multitable/api-tokens', '/api/multitable/webhooks'],
+    [...tokenListPaths, ...tokenItemPaths, ...tokenRotatePaths, ...webhookPaths, ...dingTalkGroupPaths],
     authenticate,
   )
 
-  // ── Token routes ──────────────────────────────────────────────────
-
-  // GET /api/multitable/api-tokens — list user's tokens
-  router.get('/api/multitable/api-tokens', async (req: Request, res: Response) => {
+  router.get(tokenListPaths, async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
       res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
       return
     }
     const tokens = await apiTokenService.listTokens(userId)
-    res.json({ ok: true, data: tokens })
+    res.json({ ok: true, data: { tokens } })
   })
 
-  // POST /api/multitable/api-tokens — create token
-  router.post('/api/multitable/api-tokens', async (req: Request, res: Response) => {
+  router.post(tokenListPaths, async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
       res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
@@ -100,22 +139,24 @@ export function apiTokensRouter(): Router {
         scopes: input.scopes as import('../multitable/api-tokens').ApiTokenScope[],
         expiresAt: input.expiresAt,
       })
-      res.status(201).json({ ok: true, data: result })
+      res.status(201).json({
+        ok: true,
+        data: {
+          token: result.token,
+          plaintext: result.plainTextToken,
+        },
+      })
     } catch (err) {
       if (err instanceof z.ZodError) {
         zodError(res, err)
         return
       }
       logger.error('Failed to create token', err instanceof Error ? err : undefined)
-      res.status(500).json({
-        ok: false,
-        error: { code: 'CREATE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
-      })
+      serviceErrorResponse(res, err, 'create')
     }
   })
 
-  // DELETE /api/multitable/api-tokens/:id — revoke token
-  router.delete('/api/multitable/api-tokens/:id', async (req: Request, res: Response) => {
+  router.delete(tokenItemPaths, async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
       res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
@@ -123,19 +164,14 @@ export function apiTokensRouter(): Router {
     }
     try {
       await apiTokenService.revokeToken(req.params.id, userId)
-      res.json({ ok: true })
+      res.status(204).end()
     } catch (err) {
       logger.error('Failed to revoke token', err instanceof Error ? err : undefined)
-      const status = (err instanceof Error && err.message === 'Token not found') ? 404 : 500
-      res.status(status).json({
-        ok: false,
-        error: { code: 'REVOKE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
-      })
+      serviceErrorResponse(res, err, 'revoke')
     }
   })
 
-  // POST /api/multitable/api-tokens/:id/rotate — rotate token
-  router.post('/api/multitable/api-tokens/:id/rotate', async (req: Request, res: Response) => {
+  router.post(tokenRotatePaths, async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
       res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
@@ -143,20 +179,19 @@ export function apiTokensRouter(): Router {
     }
     try {
       const result = await apiTokenService.rotateToken(req.params.id, userId)
-      res.json({ ok: true, data: result })
+      res.json({
+        ok: true,
+        data: {
+          token: result.token,
+          plaintext: result.plainTextToken,
+        },
+      })
     } catch (err) {
       logger.error('Failed to rotate token', err instanceof Error ? err : undefined)
-      const status = (err instanceof Error && err.message === 'Token not found') ? 404 : 500
-      res.status(status).json({
-        ok: false,
-        error: { code: 'ROTATE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
-      })
+      serviceErrorResponse(res, err, 'rotate')
     }
   })
 
-  // ── Webhook routes ────────────────────────────────────────────────
-
-  // GET /api/multitable/webhooks — list webhooks
   router.get('/api/multitable/webhooks', async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
@@ -164,10 +199,9 @@ export function apiTokensRouter(): Router {
       return
     }
     const webhooks = await webhookService.listWebhooks(userId)
-    res.json({ ok: true, data: webhooks })
+    res.json({ ok: true, data: { webhooks } })
   })
 
-  // POST /api/multitable/webhooks — create webhook
   router.post('/api/multitable/webhooks', async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
@@ -189,14 +223,10 @@ export function apiTokensRouter(): Router {
         return
       }
       logger.error('Failed to create webhook', err instanceof Error ? err : undefined)
-      res.status(400).json({
-        ok: false,
-        error: { code: 'CREATE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
-      })
+      serviceErrorResponse(res, err, 'create')
     }
   })
 
-  // PATCH /api/multitable/webhooks/:id — update webhook
   router.patch('/api/multitable/webhooks/:id', async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
@@ -219,15 +249,10 @@ export function apiTokensRouter(): Router {
         return
       }
       logger.error('Failed to update webhook', err instanceof Error ? err : undefined)
-      const status = (err instanceof Error && err.message === 'Webhook not found') ? 404 : 500
-      res.status(status).json({
-        ok: false,
-        error: { code: 'UPDATE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
-      })
+      serviceErrorResponse(res, err, 'update')
     }
   })
 
-  // DELETE /api/multitable/webhooks/:id — delete webhook
   router.delete('/api/multitable/webhooks/:id', async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
@@ -236,36 +261,126 @@ export function apiTokensRouter(): Router {
     }
     try {
       await webhookService.deleteWebhook(req.params.id, userId)
-      res.json({ ok: true })
+      res.status(204).end()
     } catch (err) {
       logger.error('Failed to delete webhook', err instanceof Error ? err : undefined)
-      const status = (err instanceof Error && err.message === 'Webhook not found') ? 404 : 500
-      res.status(status).json({
-        ok: false,
-        error: { code: 'DELETE_FAILED', message: err instanceof Error ? err.message : 'Unknown error' },
-      })
+      serviceErrorResponse(res, err, 'delete')
     }
   })
 
-  // GET /api/multitable/webhooks/:id/deliveries — list recent deliveries
   router.get('/api/multitable/webhooks/:id/deliveries', async (req: Request, res: Response) => {
     const userId = getUserId(req)
     if (!userId) {
       res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
       return
     }
-    const wh = await webhookService.getWebhookById(req.params.id)
-    if (!wh) {
+    const webhook = await webhookService.getWebhookById(req.params.id)
+    if (!webhook) {
       res.status(404).json({ ok: false, error: { code: 'NOT_FOUND' } })
       return
     }
-    if (wh.createdBy !== userId) {
+    if (webhook.createdBy !== userId) {
       res.status(403).json({ ok: false, error: { code: 'FORBIDDEN' } })
       return
     }
     const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
     const deliveries = await webhookService.listDeliveries(req.params.id, limit)
-    res.json({ ok: true, data: deliveries })
+    res.json({ ok: true, data: { deliveries } })
+  })
+
+  router.get('/api/multitable/dingtalk-groups', async (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    const destinations = await dingTalkGroupDestinationService.listDestinations(userId)
+    res.json({ ok: true, data: { destinations } })
+  })
+
+  router.post('/api/multitable/dingtalk-groups', async (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      const input = CreateDingTalkGroupSchema.parse(req.body)
+      const destination = await dingTalkGroupDestinationService.createDestination(userId, {
+        name: input.name,
+        webhookUrl: input.webhookUrl,
+        secret: input.secret,
+        enabled: input.enabled,
+      })
+      res.status(201).json({ ok: true, data: destination })
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        zodError(res, err)
+        return
+      }
+      logger.error('Failed to create DingTalk group destination', err instanceof Error ? err : undefined)
+      serviceErrorResponse(res, err, 'create')
+    }
+  })
+
+  router.patch('/api/multitable/dingtalk-groups/:id', async (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      const input = UpdateDingTalkGroupSchema.parse(req.body)
+      const destination = await dingTalkGroupDestinationService.updateDestination(req.params.id, userId, {
+        name: input.name,
+        webhookUrl: input.webhookUrl,
+        secret: input.secret,
+        enabled: input.enabled,
+      })
+      res.json({ ok: true, data: destination })
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        zodError(res, err)
+        return
+      }
+      logger.error('Failed to update DingTalk group destination', err instanceof Error ? err : undefined)
+      serviceErrorResponse(res, err, 'update')
+    }
+  })
+
+  router.delete('/api/multitable/dingtalk-groups/:id', async (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      await dingTalkGroupDestinationService.deleteDestination(req.params.id, userId)
+      res.status(204).end()
+    } catch (err) {
+      logger.error('Failed to delete DingTalk group destination', err instanceof Error ? err : undefined)
+      serviceErrorResponse(res, err, 'delete')
+    }
+  })
+
+  router.post('/api/multitable/dingtalk-groups/:id/test-send', async (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    try {
+      const input = DingTalkGroupTestSendSchema.parse(req.body ?? {})
+      await dingTalkGroupDestinationService.testSend(req.params.id, userId, input)
+      res.status(204).end()
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        zodError(res, err)
+        return
+      }
+      logger.error('Failed to test DingTalk group destination', err instanceof Error ? err : undefined)
+      serviceErrorResponse(res, err, 'test_send')
+    }
   })
 
   return router

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -27,6 +27,7 @@ const webhookPaths = ['/api/multitable/webhooks', '/api/multitable/webhooks/:id'
 const dingTalkGroupPaths = [
   '/api/multitable/dingtalk-groups',
   '/api/multitable/dingtalk-groups/:id',
+  '/api/multitable/dingtalk-groups/:id/deliveries',
   '/api/multitable/dingtalk-groups/:id/test-send',
 ]
 
@@ -361,6 +362,26 @@ export function apiTokensRouter(): Router {
       logger.error('Failed to delete DingTalk group destination', err instanceof Error ? err : undefined)
       serviceErrorResponse(res, err, 'delete')
     }
+  })
+
+  router.get('/api/multitable/dingtalk-groups/:id/deliveries', async (req: Request, res: Response) => {
+    const userId = getUserId(req)
+    if (!userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+      return
+    }
+    const destination = await dingTalkGroupDestinationService.getDestinationById(req.params.id)
+    if (!destination) {
+      res.status(404).json({ ok: false, error: { code: 'NOT_FOUND' } })
+      return
+    }
+    if (destination.createdBy !== userId) {
+      res.status(403).json({ ok: false, error: { code: 'FORBIDDEN' } })
+      return
+    }
+    const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
+    const deliveries = await dingTalkGroupDestinationService.listDeliveries(req.params.id, limit)
+    res.json({ ok: true, data: { deliveries } })
   })
 
   router.post('/api/multitable/dingtalk-groups/:id/test-send', async (req: Request, res: Response) => {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7626,7 +7626,7 @@ export function univerMetaRouter(): Router {
       const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
 
       const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
-      const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'lock_record'])
+      const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'send_dingtalk_group_message', 'lock_record'])
       if (!validTriggers.has(triggerType)) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid trigger_type: ${triggerType}` } })
       }
@@ -7702,7 +7702,7 @@ export function univerMetaRouter(): Router {
         updates.trigger_config = JSON.stringify(body.triggerConfig)
       }
       if (typeof body?.actionType === 'string') {
-        const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'lock_record'])
+        const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'send_dingtalk_group_message', 'lock_record'])
         if (!validActions.has(body.actionType)) {
           return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid action_type: ${body.actionType}` } })
         }

--- a/packages/core-backend/src/services/NotificationService.ts
+++ b/packages/core-backend/src/services/NotificationService.ts
@@ -3,7 +3,6 @@
  * 支持多渠道通知发送，模板管理，订阅管理
  */
 
-import { createHmac } from 'node:crypto'
 import { EventEmitter } from 'eventemitter3'
 import type {
   NotificationService,
@@ -21,6 +20,13 @@ import type {
 import { Logger } from '../core/logger'
 import { BackoffStrategy } from '../utils/BackoffStrategy'
 import { maskDingTalkWebhookUrl } from '../integrations/dingtalk/runtime-policy'
+import {
+  buildDingTalkMarkdown,
+  buildSignedDingTalkWebhookUrl,
+  type DingTalkRobotPayload,
+  DingTalkRobotResponseError,
+  validateDingTalkRobotResponse,
+} from '../integrations/dingtalk/robot'
 
 /**
  * Email notification payload
@@ -51,19 +57,6 @@ interface FeishuMessagePayload {
   data?: unknown
 }
 
-interface DingTalkRobotPayload {
-  msgtype: 'markdown'
-  markdown: {
-    title: string
-    text: string
-  }
-}
-
-interface DingTalkRobotResponse {
-  errcode?: number
-  errmsg?: string
-}
-
 function resolvePositiveInt(value: unknown, fallback: number, min = 1, max = Number.MAX_SAFE_INTEGER): number {
   const numeric = typeof value === 'number' ? value : Number(value)
   if (!Number.isFinite(numeric)) return fallback
@@ -86,17 +79,6 @@ async function readJsonSafely(response: Response): Promise<unknown> {
   } catch {
     return null
   }
-}
-
-function validateDingTalkRobotResponse(payload: unknown): void {
-  const data = payload as DingTalkRobotResponse | null
-  if (!data || typeof data !== 'object') return
-  const errcode = typeof data.errcode === 'number' ? data.errcode : 0
-  if (errcode === 0) return
-  const errmsg = typeof data.errmsg === 'string' && data.errmsg.trim().length > 0
-    ? data.errmsg.trim()
-    : 'DingTalk robot request failed'
-  throw new NonRetryableNotificationError(`DingTalk errcode ${errcode}: ${errmsg}`)
 }
 
 async function postJsonWithRetry(options: {
@@ -149,7 +131,7 @@ async function postJsonWithRetry(options: {
       return
     } catch (error) {
       lastError = error as Error
-      if (error instanceof NonRetryableNotificationError) {
+      if (error instanceof NonRetryableNotificationError || error instanceof DingTalkRobotResponseError) {
         throw error
       }
       if (attempt >= options.maxAttempts) break
@@ -167,29 +149,6 @@ async function postJsonWithRetry(options: {
   }
 
   throw lastError ?? new Error(`${options.context} failed`)
-}
-
-function buildDingTalkMarkdown(subject: string, content: string): DingTalkRobotPayload {
-  const title = subject.trim() || 'MetaSheet Notification'
-  const body = content.trim() || title
-  return {
-    msgtype: 'markdown',
-    markdown: {
-      title,
-      text: `### ${title}\n\n${body}`,
-    },
-  }
-}
-
-function buildSignedDingTalkWebhookUrl(baseUrl: string, secret?: string): string {
-  const normalizedSecret = typeof secret === 'string' ? secret.trim() : ''
-  if (!normalizedSecret) return baseUrl
-
-  const timestamp = Date.now()
-  const stringToSign = `${timestamp}\n${normalizedSecret}`
-  const sign = encodeURIComponent(createHmac('sha256', normalizedSecret).update(stringToSign).digest('base64'))
-  const separator = baseUrl.includes('?') ? '&' : '?'
-  return `${baseUrl}${separator}timestamp=${timestamp}&sign=${sign}`
 }
 
 /**

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -435,7 +435,7 @@ describe('AutomationExecutor', () => {
 
     expect(result.status).toBe('success')
     expect(result.steps[0].actionType).toBe('send_dingtalk_group_message')
-    expect(queryFn).toHaveBeenCalledTimes(3)
+    expect(queryFn).toHaveBeenCalledTimes(4)
     expect(fetchFn).toHaveBeenCalledTimes(1)
 
     const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
@@ -445,6 +445,89 @@ describe('AutomationExecutor', () => {
     expect(payload.markdown.text).toContain('Status: open')
     expect(payload.markdown.text).toContain('/multitable/public-form/sheet_1/view_form?publicToken=public-token')
     expect(payload.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
+    expect((queryFn.mock.calls[3]?.[0] as string) ?? '').toContain('INSERT INTO dingtalk_group_deliveries')
+  })
+
+  it('records DingTalk application error diagnostics for send_dingtalk_group_message', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 310000, errmsg: 'signature mismatch' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('signature mismatch')
+    const insertArgs = queryFn.mock.calls[1]?.[1] as unknown[] | undefined
+    expect(insertArgs?.[6]).toBe(200)
+    expect(insertArgs?.[7]).toContain('signature mismatch')
+    expect(insertArgs?.[8]).toContain('signature mismatch')
+  })
+
+  it('keeps send_dingtalk_group_message successful when delivery history persistence fails', async () => {
+    process.env.APP_BASE_URL = 'https://app.example.com'
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'view_form', sheet_id: 'sheet_1', config: { publicForm: { enabled: true, publicToken: 'public-token' } } }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'view_grid' }] })
+      .mockRejectedValueOnce(new Error('delivery history unavailable'))
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+          publicFormViewId: 'view_form',
+          internalViewId: 'view_grid',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(queryFn).toHaveBeenCalledTimes(4)
   })
 
   it('fails send_dingtalk_group_message when destination is missing', async () => {

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -440,6 +440,7 @@ describe('AutomationExecutor', () => {
 
     const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('https://oapi.dingtalk.com/robot/send?access_token=test')
+    expect(init.signal).toBeTruthy()
     const payload = JSON.parse(init.body as string)
     expect(payload.markdown.title).toBe('Record Incident ready')
     expect(payload.markdown.text).toContain('Status: open')

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -302,6 +302,11 @@ describe('AutomationExecutor', () => {
     executor = new AutomationExecutor(deps)
   })
 
+  afterEach(() => {
+    delete process.env.APP_BASE_URL
+    delete process.env.PUBLIC_APP_URL
+  })
+
   it('executes update_record action successfully', async () => {
     const rule = createMockRule({
       actions: [{ type: 'update_record', config: { fields: { status: 'done' } } }],
@@ -389,6 +394,79 @@ describe('AutomationExecutor', () => {
     const result = await executor.execute(rule, { recordId: 'r1', sheetId: 'sheet_1' })
     expect(result.status).toBe('success')
     expect(emitSpy).toHaveBeenCalledWith('automation.notification', expect.objectContaining({ userIds: ['u1', 'u2'] }))
+  })
+
+  it('executes send_dingtalk_group_message action successfully', async () => {
+    process.env.APP_BASE_URL = 'https://app.example.com'
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'view_form', sheet_id: 'sheet_1', config: { publicForm: { enabled: true, publicToken: 'public-token' } } }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'view_grid' }] })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+          publicFormViewId: 'view_form',
+          internalViewId: 'view_grid',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(result.steps[0].actionType).toBe('send_dingtalk_group_message')
+    expect(queryFn).toHaveBeenCalledTimes(3)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('https://oapi.dingtalk.com/robot/send?access_token=test')
+    const payload = JSON.parse(init.body as string)
+    expect(payload.markdown.title).toBe('Record Incident ready')
+    expect(payload.markdown.text).toContain('Status: open')
+    expect(payload.markdown.text).toContain('/multitable/public-form/sheet_1/view_form?publicToken=public-token')
+    expect(payload.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
+  })
+
+  it('fails send_dingtalk_group_message when destination is missing', async () => {
+    const queryFn = vi.fn(async () => ({ rows: [] }))
+    deps = createMockDeps({ queryFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_missing',
+          titleTemplate: 'Title',
+          bodyTemplate: 'Body',
+        },
+      }],
+    })
+
+    const result = await executor.execute(rule, { recordId: 'r1', sheetId: 'sheet_1' })
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].status).toBe('failed')
+    expect(result.steps[0].error).toContain('destination not found')
   })
 
   it('fails send_notification with no userIds', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -22,6 +22,7 @@ function makeChain(): MockChain {
     'select',
     'where',
     'orderBy',
+    'limit',
     'insertInto',
     'values',
     'updateTable',
@@ -76,6 +77,26 @@ function destinationRow(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function deliveryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'dtd_1',
+    destination_id: 'dt_1',
+    source_type: 'automation',
+    subject: 'Please fill incident details',
+    content: 'Body',
+    success: true,
+    http_status: 200,
+    response_body: '{"errcode":0,"errmsg":"ok"}',
+    error_message: null,
+    automation_rule_id: 'rule_1',
+    record_id: 'rec_1',
+    initiated_by: 'user_1',
+    created_at: '2026-04-19T10:30:00.000Z',
+    delivered_at: '2026-04-19T10:30:01.000Z',
+    ...overrides,
+  }
+}
+
 describe('DingTalkGroupDestinationService', () => {
   beforeEach(() => {
     executeQueue = []
@@ -123,6 +144,20 @@ describe('DingTalkGroupDestinationService', () => {
     expect(updated.webhookUrl).toContain('access_token=next')
   })
 
+  test('lists deliveries for a destination', async () => {
+    const { db } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeQueue.push([deliveryRow(), deliveryRow({ id: 'dtd_2', source_type: 'manual_test', success: false, error_message: 'signature mismatch' })])
+    const deliveries = await service.listDeliveries('dt_1', 20)
+
+    expect(deliveries).toHaveLength(2)
+    expect(deliveries[0].destinationId).toBe('dt_1')
+    expect(deliveries[0].subject).toBe('Please fill incident details')
+    expect(deliveries[1].sourceType).toBe('manual_test')
+    expect(deliveries[1].success).toBe(false)
+  })
+
   test('deletes a destination after ownership check', async () => {
     const { db, roots } = createMockDb()
     const service = new DingTalkGroupDestinationService(db, vi.fn())
@@ -145,6 +180,11 @@ describe('DingTalkGroupDestinationService', () => {
     await expect(service.testSend('dt_1', 'user_1', {})).resolves.toEqual({ ok: true })
 
     expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(roots.insertInto).toHaveBeenCalledWith('dingtalk_group_deliveries')
+    const insertChain = roots.insertInto.mock.results[0]?.value as MockChain | undefined
+    const deliveryValues = insertChain?.values?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(deliveryValues?.http_status).toBe(200)
+    expect(deliveryValues?.response_body).toContain('"errcode":0')
     const updateChain = roots.updateTable.mock.results[0]?.value as MockChain | undefined
     const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
     expect(setArg?.last_test_status).toBe('success')
@@ -162,9 +202,36 @@ describe('DingTalkGroupDestinationService', () => {
     executeTakeFirstQueue.push(destinationRow())
     await expect(service.testSend('dt_1', 'user_1', {})).rejects.toThrow('signature mismatch')
 
+    expect(roots.insertInto).toHaveBeenCalledWith('dingtalk_group_deliveries')
+    const insertChain = roots.insertInto.mock.results[0]?.value as MockChain | undefined
+    const deliveryValues = insertChain?.values?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(deliveryValues?.http_status).toBe(200)
+    expect(deliveryValues?.response_body).toContain('signature mismatch')
+    expect(deliveryValues?.error_message).toContain('signature mismatch')
     const updateChain = roots.updateTable.mock.results[0]?.value as MockChain | undefined
     const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
     expect(setArg?.last_test_status).toBe('failed')
     expect(setArg?.last_test_error).toMatch(/signature mismatch/)
+  })
+
+  test('testSend still succeeds when delivery history persistence fails', async () => {
+    const { db, roots } = createMockDb()
+    const fetchFn = vi.fn(async () => new Response(
+      JSON.stringify({ errcode: 0, errmsg: 'ok' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    const deliveryInsertChain = makeChain()
+    deliveryInsertChain.execute = vi.fn(async () => {
+      throw new Error('delivery history unavailable')
+    })
+    roots.insertInto.mockReturnValueOnce(deliveryInsertChain as never)
+    const service = new DingTalkGroupDestinationService(db, fetchFn as typeof fetch)
+
+    executeTakeFirstQueue.push(destinationRow())
+    await expect(service.testSend('dt_1', 'user_1', {})).resolves.toEqual({ ok: true })
+
+    const updateChain = roots.updateTable.mock.results[0]?.value as MockChain | undefined
+    const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(setArg?.last_test_status).toBe('success')
   })
 })

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Kysely } from 'kysely'
+import type { Database } from '../../src/db/types'
+import { DingTalkGroupDestinationService } from '../../src/multitable/dingtalk-group-destination-service'
+
+let executeQueue: unknown[]
+let executeTakeFirstQueue: unknown[]
+
+type MockChain = Record<string, unknown> & {
+  set?: ReturnType<typeof vi.fn>
+  execute?: ReturnType<typeof vi.fn>
+  executeTakeFirst?: ReturnType<typeof vi.fn>
+  executeTakeFirstOrThrow?: ReturnType<typeof vi.fn>
+}
+
+function makeChain(): MockChain {
+  const self: MockChain = {}
+  const chainFn = (..._args: unknown[]) => self
+  const methods = [
+    'selectFrom',
+    'selectAll',
+    'select',
+    'where',
+    'orderBy',
+    'insertInto',
+    'values',
+    'updateTable',
+    'set',
+    'deleteFrom',
+  ]
+  for (const method of methods) {
+    self[method] = vi.fn(chainFn)
+  }
+  self.execute = vi.fn(async () => executeQueue.shift() ?? [])
+  self.executeTakeFirst = vi.fn(async () => executeTakeFirstQueue.shift())
+  self.executeTakeFirstOrThrow = vi.fn(async () => {
+    const value = executeTakeFirstQueue.shift()
+    if (!value) throw new Error('no rows')
+    return value
+  })
+  return self
+}
+
+function createMockDb() {
+  const roots: Record<string, ReturnType<typeof vi.fn>> = {}
+  for (const method of ['selectFrom', 'insertInto', 'updateTable', 'deleteFrom']) {
+    roots[method] = vi.fn(() => makeChain())
+  }
+
+  const dbProxy = new Proxy(roots, {
+    get(target, prop) {
+      return target[prop as string]
+    },
+  })
+
+  return {
+    db: dbProxy as unknown as Kysely<Database>,
+    roots,
+  }
+}
+
+function destinationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'dt_1',
+    name: 'Ops DingTalk Group',
+    webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+    secret: 'SEC123',
+    enabled: true,
+    created_by: 'user_1',
+    created_at: '2026-04-19T10:00:00.000Z',
+    updated_at: '2026-04-19T10:10:00.000Z',
+    last_tested_at: null,
+    last_test_status: null,
+    last_test_error: null,
+    ...overrides,
+  }
+}
+
+describe('DingTalkGroupDestinationService', () => {
+  beforeEach(() => {
+    executeQueue = []
+    executeTakeFirstQueue = []
+  })
+
+  test('creates and lists destinations', async () => {
+    const { db } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    const created = await service.createDestination('user_1', {
+      name: ' Ops DingTalk Group ',
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+      secret: 'SEC123',
+    })
+
+    expect(created.name).toBe('Ops DingTalk Group')
+    expect(created.enabled).toBe(true)
+
+    executeQueue.push([destinationRow()])
+    const listed = await service.listDestinations('user_1')
+    expect(listed).toHaveLength(1)
+    expect(listed[0].name).toBe('Ops DingTalk Group')
+  })
+
+  test('updates a destination', async () => {
+    const { db } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeTakeFirstQueue.push(destinationRow())
+    executeTakeFirstQueue.push(destinationRow({
+      name: 'Updated group',
+      enabled: false,
+      webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=next',
+    }))
+
+    const updated = await service.updateDestination('dt_1', 'user_1', {
+      name: 'Updated group',
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=next',
+      enabled: false,
+    })
+
+    expect(updated.name).toBe('Updated group')
+    expect(updated.enabled).toBe(false)
+    expect(updated.webhookUrl).toContain('access_token=next')
+  })
+
+  test('deletes a destination after ownership check', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeTakeFirstQueue.push(destinationRow())
+    await service.deleteDestination('dt_1', 'user_1')
+
+    expect(roots.deleteFrom).toHaveBeenCalledWith('dingtalk_group_destinations')
+  })
+
+  test('testSend marks success when DingTalk responds ok', async () => {
+    const { db, roots } = createMockDb()
+    const fetchFn = vi.fn(async () => new Response(
+      JSON.stringify({ errcode: 0, errmsg: 'ok' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    const service = new DingTalkGroupDestinationService(db, fetchFn as typeof fetch)
+
+    executeTakeFirstQueue.push(destinationRow())
+    await expect(service.testSend('dt_1', 'user_1', {})).resolves.toEqual({ ok: true })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const updateChain = roots.updateTable.mock.results[0]?.value as MockChain | undefined
+    const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(setArg?.last_test_status).toBe('success')
+    expect(setArg?.last_test_error).toBeNull()
+  })
+
+  test('testSend marks failure when DingTalk returns an error', async () => {
+    const { db, roots } = createMockDb()
+    const fetchFn = vi.fn(async () => new Response(
+      JSON.stringify({ errcode: 310000, errmsg: 'signature mismatch' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    const service = new DingTalkGroupDestinationService(db, fetchFn as typeof fetch)
+
+    executeTakeFirstQueue.push(destinationRow())
+    await expect(service.testSend('dt_1', 'user_1', {})).rejects.toThrow('signature mismatch')
+
+    const updateChain = roots.updateTable.mock.results[0]?.value as MockChain | undefined
+    const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(setArg?.last_test_status).toBe('failed')
+    expect(setArg?.last_test_error).toMatch(/signature mismatch/)
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -180,6 +180,8 @@ describe('DingTalkGroupDestinationService', () => {
     await expect(service.testSend('dt_1', 'user_1', {})).resolves.toEqual({ ok: true })
 
     expect(fetchFn).toHaveBeenCalledTimes(1)
+    const fetchInit = fetchFn.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(fetchInit?.signal).toBeTruthy()
     expect(roots.insertInto).toHaveBeenCalledWith('dingtalk_group_deliveries')
     const insertChain = roots.insertInto.mock.results[0]?.value as MockChain | undefined
     const deliveryValues = insertChain?.values?.mock.calls[0]?.[0] as Record<string, unknown> | undefined


### PR DESCRIPTION
## What changed

This PR packages the DingTalk group notification P0 line for multitable:

- add DingTalk group destination management
- add standard automation action `send_dingtalk_group_message`
- support dual-link messages:
  - public form entry
  - internal multitable record/view deep link
- add delivery history and audit visibility for both manual test-send and automation sends

## Scope

Included:

- DingTalk group destination CRUD / enable / disable / delete / test-send
- automation editor and execution support for `send_dingtalk_group_message`
- delivery history persistence via `dingtalk_group_deliveries`
- frontend delivery history panel in `MetaApiTokenManager`
- package docs and verification notes

Not included:

- direct DingTalk personal messaging
- remote deployment
- production migration execution

## Hardening in this PR

- open delivery history refreshes after `Test send`
- delivery history has explicit loading and empty states
- stale async delivery responses do not override the currently selected group
- DingTalk application-level failures (`HTTP 200` with non-zero `errcode`) keep `httpStatus` and `responseBody`
- delivery-history persistence is best-effort and does not turn a real send success into an application failure

## Migrations

This PR adds:

- `zzzz20260419183000_create_dingtalk_group_destinations.ts`
- `zzzz20260419193000_add_dingtalk_group_message_automation_action.ts`
- `zzzz20260419203000_create_dingtalk_group_deliveries.ts`

## Verification

Ran:

```bash
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts tests/unit/api-token-webhook.test.ts tests/unit/automation-v1.test.ts --watch=false
pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
```

Results:

- backend: `143 passed`
- frontend: `35 passed`
- backend build: passed
- web build: passed

## Docs

Package docs:

- `docs/development/dingtalk-group-notify-standard-package-development-20260419.md`
- `docs/development/dingtalk-group-notify-standard-package-verification-20260419.md`
