### PR TITLE
feat(dingtalk): add direct person automation messaging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ JWT_EXPIRES_IN=2h
 # DINGTALK_CLIENT_ID=dingtalk-app-key
 # DINGTALK_CLIENT_SECRET=dingtalk-app-secret
 # DINGTALK_REDIRECT_URI=https://app.example.com/login/dingtalk/callback
+# DINGTALK_AGENT_ID=123456789
 # DINGTALK_CORP_ID=dingtalk-corp-id
 # DINGTALK_AUTH_AUTO_LINK_EMAIL=0
 # DINGTALK_AUTH_AUTO_PROVISION=0

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -58,6 +58,7 @@ import type {
   WebhookDelivery,
   DingTalkGroupDestination,
   DingTalkGroupDelivery,
+  DingTalkPersonDelivery,
   DingTalkGroupDestinationInput,
 } from '../types'
 import { apiFetch } from '../../utils/api'
@@ -1154,6 +1155,14 @@ export class MultitableApiClient {
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}/stats`,
     )
     return parseJson<AutomationStats>(res)
+  }
+
+  async getAutomationDingTalkPersonDeliveries(sheetId: string, ruleId: string, limit?: number): Promise<DingTalkPersonDelivery[]> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}/dingtalk-person-deliveries${qs({ limit })}`,
+    )
+    const data = await parseJson<{ deliveries: DingTalkPersonDelivery[] }>(res)
+    return Array.isArray(data?.deliveries) ? data.deliveries : []
   }
 
   // --- Charts ---

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -109,6 +109,45 @@
           </template>
 
           <template v-if="draft.actionType === 'send_dingtalk_person_message'">
+            <label class="meta-automation__label">Search and add users</label>
+            <input
+              v-model="dingtalkPersonUserSearch"
+              class="meta-automation__input"
+              type="text"
+              placeholder="Search by name, email, or userId"
+              data-automation-field="dingtalkPersonUserSearch"
+              @input="void loadDingTalkPersonSuggestions()"
+            />
+            <div v-if="dingtalkPersonUserSearchLoading" class="meta-automation__hint">Searching users…</div>
+            <div v-else-if="dingtalkPersonUserSearchError" class="meta-automation__hint meta-automation__hint--error">{{ dingtalkPersonUserSearchError }}</div>
+            <div v-else-if="availableDingTalkPersonSuggestions.length" class="meta-automation__recipient-list">
+              <button
+                v-for="candidate in availableDingTalkPersonSuggestions"
+                :key="candidate.id"
+                class="meta-automation__recipient-option"
+                type="button"
+                :data-automation-person-suggestion="candidate.id"
+                @click="addDingTalkPersonRecipient(candidate)"
+              >
+                <strong>{{ candidate.label }}</strong>
+                <span>{{ candidate.subtitle || candidate.id }}</span>
+              </button>
+            </div>
+            <div v-else-if="dingtalkPersonUserSearch.trim()" class="meta-automation__hint">No matching users</div>
+            <div v-if="selectedDingTalkPersonRecipients.length" class="meta-automation__recipient-list meta-automation__recipient-list--selected">
+              <button
+                v-for="recipient in selectedDingTalkPersonRecipients"
+                :key="recipient.id"
+                class="meta-automation__recipient-chip"
+                type="button"
+                :data-automation-person-recipient="recipient.id"
+                @click="removeDingTalkPersonRecipient(recipient.id)"
+              >
+                <strong>{{ recipient.label }}</strong>
+                <span>{{ recipient.subtitle || recipient.id }}</span>
+                <em>Remove</em>
+              </button>
+            </div>
             <label class="meta-automation__label">Local user IDs</label>
             <textarea
               v-model="draft.dingtalkPersonUserIds"
@@ -225,6 +264,7 @@ import type {
   AutomationActionType,
   AutomationStats,
   DingTalkGroupDestination,
+  MetaCommentMentionSuggestion,
   MetaView,
 } from '../types'
 import { useMultitableAutomations } from '../composables/useMultitableAutomations'
@@ -295,8 +335,90 @@ function emptyDraft(): DraftState {
 
 const draft = ref<DraftState>(emptyDraft())
 const dingTalkDestinations = ref<DingTalkGroupDestination[]>([])
+const dingtalkPersonUserSearch = ref('')
+const dingtalkPersonUserSearchLoading = ref(false)
+const dingtalkPersonUserSearchError = ref('')
+const dingtalkPersonUserSuggestions = ref<MetaCommentMentionSuggestion[]>([])
+const dingtalkPersonUserDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
+let dingtalkPersonSuggestionLoadId = 0
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
+
+function parseUserIdsText(value: string): string[] {
+  return value
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function rememberDingTalkPersonSuggestions(items: MetaCommentMentionSuggestion[]) {
+  const next = { ...dingtalkPersonUserDirectory.value }
+  for (const item of items) {
+    next[item.id] = { label: item.label, subtitle: item.subtitle }
+  }
+  dingtalkPersonUserDirectory.value = next
+}
+
+const selectedDingTalkPersonRecipients = computed(() =>
+  parseUserIdsText(draft.value.dingtalkPersonUserIds).map((id) => ({
+    id,
+    label: dingtalkPersonUserDirectory.value[id]?.label ?? id,
+    subtitle: dingtalkPersonUserDirectory.value[id]?.subtitle,
+  })),
+)
+
+const availableDingTalkPersonSuggestions = computed(() => {
+  const selected = new Set(parseUserIdsText(draft.value.dingtalkPersonUserIds))
+  return dingtalkPersonUserSuggestions.value.filter((candidate) => !selected.has(candidate.id))
+})
+
+async function loadDingTalkPersonSuggestions() {
+  const query = dingtalkPersonUserSearch.value.trim()
+  if (!props.client || !showForm.value || draft.value.actionType !== 'send_dingtalk_person_message' || !query) {
+    dingtalkPersonUserSuggestions.value = []
+    dingtalkPersonUserSearchError.value = ''
+    dingtalkPersonUserSearchLoading.value = false
+    return
+  }
+
+  const requestId = ++dingtalkPersonSuggestionLoadId
+  dingtalkPersonUserSearchLoading.value = true
+  dingtalkPersonUserSearchError.value = ''
+  try {
+    const response = await props.client.listCommentMentionSuggestions({
+      spreadsheetId: props.sheetId,
+      q: query,
+      limit: 8,
+    })
+    if (requestId !== dingtalkPersonSuggestionLoadId) return
+    rememberDingTalkPersonSuggestions(response.items)
+    dingtalkPersonUserSuggestions.value = response.items
+  } catch (error) {
+    if (requestId !== dingtalkPersonSuggestionLoadId) return
+    dingtalkPersonUserSuggestions.value = []
+    dingtalkPersonUserSearchError.value = error instanceof Error ? error.message : 'Failed to search users'
+  } finally {
+    if (requestId === dingtalkPersonSuggestionLoadId) {
+      dingtalkPersonUserSearchLoading.value = false
+    }
+  }
+}
+
+function addDingTalkPersonRecipient(candidate: MetaCommentMentionSuggestion) {
+  const ids = new Set(parseUserIdsText(draft.value.dingtalkPersonUserIds))
+  ids.add(candidate.id)
+  draft.value.dingtalkPersonUserIds = Array.from(ids).join(', ')
+  rememberDingTalkPersonSuggestions([candidate])
+  dingtalkPersonUserSearch.value = ''
+  dingtalkPersonUserSuggestions.value = []
+  dingtalkPersonUserSearchError.value = ''
+}
+
+function removeDingTalkPersonRecipient(userId: string) {
+  draft.value.dingtalkPersonUserIds = parseUserIdsText(draft.value.dingtalkPersonUserIds)
+    .filter((id) => id !== userId)
+    .join(', ')
+}
 
 // --- Rule editor + log viewer state ---
 const showRuleEditor = ref(false)
@@ -374,6 +496,9 @@ const canSave = computed(() => {
 function openCreateForm() {
   editingRuleId.value = null
   draft.value = emptyDraft()
+  dingtalkPersonUserSearch.value = ''
+  dingtalkPersonUserSuggestions.value = []
+  dingtalkPersonUserSearchError.value = ''
   showForm.value = true
 }
 
@@ -398,6 +523,9 @@ function openEditForm(rule: AutomationRule) {
     dingtalkPersonPublicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
     dingtalkPersonInternalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
   }
+  dingtalkPersonUserSearch.value = ''
+  dingtalkPersonUserSuggestions.value = []
+  dingtalkPersonUserSearchError.value = ''
   showForm.value = true
 }
 
@@ -405,6 +533,9 @@ function cancelForm() {
   showForm.value = false
   editingRuleId.value = null
   draft.value = emptyDraft()
+  dingtalkPersonUserSearch.value = ''
+  dingtalkPersonUserSuggestions.value = []
+  dingtalkPersonUserSearchError.value = ''
 }
 
 function buildTriggerConfig(): Record<string, unknown> {
@@ -637,6 +768,15 @@ watch(
   margin-top: 4px;
 }
 
+.meta-automation__hint {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.meta-automation__hint--error {
+  color: #b91c1c;
+}
+
 .meta-automation__input,
 .meta-automation__select {
   width: 100%;
@@ -647,6 +787,38 @@ watch(
   font-size: 13px;
   background: #fff;
   box-sizing: border-box;
+}
+
+.meta-automation__recipient-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.meta-automation__recipient-list--selected {
+  margin-bottom: 4px;
+}
+
+.meta-automation__recipient-option,
+.meta-automation__recipient-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  padding: 8px 10px;
+  cursor: pointer;
+  color: #0f172a;
+}
+
+.meta-automation__recipient-option span,
+.meta-automation__recipient-chip span,
+.meta-automation__recipient-chip em {
+  font-size: 12px;
+  color: #64748b;
+  font-style: normal;
 }
 
 .meta-automation__form-actions {

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -230,6 +230,15 @@
           <div class="meta-automation__card-actions">
             <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openRuleEditor(rule)">Edit</button>
             <button class="meta-automation__btn" type="button" data-automation-logs="true" @click="openLogViewer(rule)">View Logs</button>
+            <button
+              v-if="rule.actionType === 'send_dingtalk_person_message'"
+              class="meta-automation__btn"
+              type="button"
+              :data-automation-person-deliveries="rule.id"
+              @click="openPersonDeliveryViewer(rule)"
+            >
+              View Deliveries
+            </button>
             <button class="meta-automation__btn meta-automation__btn--danger" type="button" data-automation-delete="true" @click="onDelete(rule)">Delete</button>
           </div>
         </div>
@@ -253,6 +262,13 @@
       :client="client"
       @close="showLogViewer = false"
     />
+    <MetaAutomationPersonDeliveryViewer
+      :visible="showPersonDeliveryViewer"
+      :sheet-id="sheetId"
+      :rule-id="personDeliveryViewerRuleId"
+      :client="client"
+      @close="showPersonDeliveryViewer = false"
+    />
   </div>
 </template>
 
@@ -271,6 +287,7 @@ import { useMultitableAutomations } from '../composables/useMultitableAutomation
 import type { MultitableApiClient } from '../api/client'
 import MetaAutomationRuleEditor from './MetaAutomationRuleEditor.vue'
 import MetaAutomationLogViewer from './MetaAutomationLogViewer.vue'
+import MetaAutomationPersonDeliveryViewer from './MetaAutomationPersonDeliveryViewer.vue'
 
 const props = defineProps<{
   visible: boolean
@@ -425,6 +442,8 @@ const showRuleEditor = ref(false)
 const editingRule = ref<AutomationRule | null>(null)
 const showLogViewer = ref(false)
 const logViewerRuleId = ref('')
+const showPersonDeliveryViewer = ref(false)
+const personDeliveryViewerRuleId = ref('')
 const ruleStats = ref<Record<string, AutomationStats>>({})
 
 function openRuleEditor(rule?: AutomationRule) {
@@ -437,6 +456,11 @@ function openRuleEditor(rule?: AutomationRule) {
 function openLogViewer(rule: AutomationRule) {
   logViewerRuleId.value = rule.id
   showLogViewer.value = true
+}
+
+function openPersonDeliveryViewer(rule: AutomationRule) {
+  personDeliveryViewerRuleId.value = rule.id
+  showPersonDeliveryViewer.value = true
 }
 
 async function onRuleEditorSave(payload: Partial<AutomationRule>) {

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -42,6 +42,7 @@
             <option value="notify">Send notification</option>
             <option value="update_field">Update field value</option>
             <option value="send_dingtalk_group_message">Send DingTalk group message</option>
+            <option value="send_dingtalk_person_message">Send DingTalk person message</option>
           </select>
 
           <template v-if="draft.actionType === 'notify'">
@@ -102,6 +103,43 @@
             </select>
             <label class="meta-automation__label">Internal processing view (optional)</label>
             <select v-model="draft.internalViewId" class="meta-automation__select" data-automation-field="internalViewId">
+              <option value="">-- no internal link --</option>
+              <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
+            </select>
+          </template>
+
+          <template v-if="draft.actionType === 'send_dingtalk_person_message'">
+            <label class="meta-automation__label">Local user IDs</label>
+            <textarea
+              v-model="draft.dingtalkPersonUserIds"
+              class="meta-automation__input"
+              rows="3"
+              placeholder="使用逗号或换行分隔本地 userId"
+              data-automation-field="dingtalkPersonUserIds"
+            ></textarea>
+            <label class="meta-automation__label">Title template</label>
+            <input
+              v-model="draft.dingtalkPersonTitleTemplate"
+              class="meta-automation__input"
+              type="text"
+              placeholder="例如：{{record.title}} 待处理"
+              data-automation-field="dingtalkPersonTitleTemplate"
+            />
+            <label class="meta-automation__label">Body template</label>
+            <textarea
+              v-model="draft.dingtalkPersonBodyTemplate"
+              class="meta-automation__input"
+              rows="4"
+              placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+              data-automation-field="dingtalkPersonBodyTemplate"
+            ></textarea>
+            <label class="meta-automation__label">Public form view (optional)</label>
+            <select v-model="draft.dingtalkPersonPublicFormViewId" class="meta-automation__select" data-automation-field="dingtalkPersonPublicFormViewId">
+              <option value="">-- no public form link --</option>
+              <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
+            </select>
+            <label class="meta-automation__label">Internal processing view (optional)</label>
+            <select v-model="draft.dingtalkPersonInternalViewId" class="meta-automation__select" data-automation-field="dingtalkPersonInternalViewId">
               <option value="">-- no internal link --</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
@@ -226,6 +264,11 @@ interface DraftState {
   dingtalkBodyTemplate: string
   publicFormViewId: string
   internalViewId: string
+  dingtalkPersonUserIds: string
+  dingtalkPersonTitleTemplate: string
+  dingtalkPersonBodyTemplate: string
+  dingtalkPersonPublicFormViewId: string
+  dingtalkPersonInternalViewId: string
 }
 
 function emptyDraft(): DraftState {
@@ -242,6 +285,11 @@ function emptyDraft(): DraftState {
     dingtalkBodyTemplate: '',
     publicFormViewId: '',
     internalViewId: '',
+    dingtalkPersonUserIds: '',
+    dingtalkPersonTitleTemplate: '',
+    dingtalkPersonBodyTemplate: '',
+    dingtalkPersonPublicFormViewId: '',
+    dingtalkPersonInternalViewId: '',
   }
 }
 
@@ -315,6 +363,11 @@ const canSave = computed(() => {
     if (!draft.value.dingtalkTitleTemplate.trim()) return false
     if (!draft.value.dingtalkBodyTemplate.trim()) return false
   }
+  if (draft.value.actionType === 'send_dingtalk_person_message') {
+    if (!draft.value.dingtalkPersonUserIds.trim()) return false
+    if (!draft.value.dingtalkPersonTitleTemplate.trim()) return false
+    if (!draft.value.dingtalkPersonBodyTemplate.trim()) return false
+  }
   return true
 })
 
@@ -339,6 +392,11 @@ function openEditForm(rule: AutomationRule) {
     dingtalkBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
     publicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
     internalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
+    dingtalkPersonUserIds: Array.isArray(rule.actionConfig?.userIds) ? rule.actionConfig?.userIds.join(', ') : '',
+    dingtalkPersonTitleTemplate: (rule.actionConfig?.titleTemplate as string) ?? '',
+    dingtalkPersonBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
+    dingtalkPersonPublicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
+    dingtalkPersonInternalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
   }
   showForm.value = true
 }
@@ -370,6 +428,18 @@ function buildActionConfig(): Record<string, unknown> {
       bodyTemplate: draft.value.dingtalkBodyTemplate,
       publicFormViewId: draft.value.publicFormViewId || undefined,
       internalViewId: draft.value.internalViewId || undefined,
+    }
+  }
+  if (draft.value.actionType === 'send_dingtalk_person_message') {
+    return {
+      userIds: draft.value.dingtalkPersonUserIds
+        .split(/[\n,]+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+      titleTemplate: draft.value.dingtalkPersonTitleTemplate,
+      bodyTemplate: draft.value.dingtalkPersonBodyTemplate,
+      publicFormViewId: draft.value.dingtalkPersonPublicFormViewId || undefined,
+      internalViewId: draft.value.dingtalkPersonInternalViewId || undefined,
     }
   }
   return {}
@@ -445,6 +515,8 @@ function describeAction(rule: AutomationRule): string {
     }
     case 'send_dingtalk_group_message':
       return 'Send DingTalk group message'
+    case 'send_dingtalk_person_message':
+      return 'Send DingTalk person message'
     default:
       return String(rule.actionType)
   }

--- a/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
@@ -1,0 +1,270 @@
+<template>
+  <div v-if="visible" class="meta-person-delivery__overlay" @click.self="$emit('close')">
+    <div class="meta-person-delivery">
+      <div class="meta-person-delivery__header">
+        <h4 class="meta-person-delivery__title">DingTalk Person Deliveries</h4>
+        <button class="meta-person-delivery__close" type="button" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="meta-person-delivery__body">
+        <div class="meta-person-delivery__toolbar">
+          <select v-model="statusFilter" class="meta-person-delivery__select" data-field="statusFilter">
+            <option value="">All statuses</option>
+            <option value="success">Success</option>
+            <option value="failed">Failed</option>
+          </select>
+          <button class="meta-person-delivery__btn" type="button" data-action="refresh" @click="loadData">Refresh</button>
+        </div>
+
+        <div v-if="loading" class="meta-person-delivery__empty">Loading deliveries...</div>
+        <div v-else-if="filteredDeliveries.length === 0" class="meta-person-delivery__empty" data-empty="true">
+          No DingTalk person deliveries found.
+        </div>
+
+        <div
+          v-for="delivery in filteredDeliveries"
+          :key="delivery.id"
+          class="meta-person-delivery__item"
+          :data-person-delivery-id="delivery.id"
+        >
+          <div class="meta-person-delivery__summary">
+            <span class="meta-person-delivery__recipient">
+              {{ delivery.localUserLabel || delivery.localUserId }}
+              <em v-if="!delivery.localUserIsActive">Inactive user</em>
+            </span>
+            <span
+              class="meta-person-delivery__badge"
+              :class="delivery.success ? 'meta-person-delivery__badge--success' : 'meta-person-delivery__badge--failed'"
+              :data-status="delivery.success ? 'success' : 'failed'"
+            >
+              {{ delivery.success ? 'success' : 'failed' }}
+            </span>
+            <span class="meta-person-delivery__time">{{ formatTime(delivery.createdAt) }}</span>
+          </div>
+          <div v-if="delivery.localUserSubtitle || delivery.dingtalkUserId" class="meta-person-delivery__detail">
+            <span v-if="delivery.localUserSubtitle">{{ delivery.localUserSubtitle }}</span>
+            <span v-if="delivery.dingtalkUserId">DingTalk: {{ delivery.dingtalkUserId }}</span>
+          </div>
+          <div class="meta-person-delivery__subject">{{ delivery.subject }}</div>
+          <div v-if="!delivery.success && delivery.errorMessage" class="meta-person-delivery__error">{{ delivery.errorMessage }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { DingTalkPersonDelivery } from '../types'
+import type { MultitableApiClient } from '../api/client'
+
+const props = defineProps<{
+  visible: boolean
+  sheetId: string
+  ruleId: string
+  client?: MultitableApiClient
+}>()
+
+defineEmits<{
+  (e: 'close'): void
+}>()
+
+const loading = ref(false)
+const deliveries = ref<DingTalkPersonDelivery[]>([])
+const statusFilter = ref('')
+
+const filteredDeliveries = computed(() => {
+  if (!statusFilter.value) return deliveries.value
+  const expected = statusFilter.value === 'success'
+  return deliveries.value.filter((delivery) => delivery.success === expected)
+})
+
+function formatTime(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return ts
+  }
+}
+
+async function loadData() {
+  if (!props.client || !props.sheetId || !props.ruleId) return
+  loading.value = true
+  try {
+    deliveries.value = await props.client.getAutomationDingTalkPersonDeliveries(props.sheetId, props.ruleId, 50)
+  } catch {
+    deliveries.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (visible) {
+      statusFilter.value = ''
+      void loadData()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.meta-person-delivery__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.meta-person-delivery {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  width: 620px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-person-delivery__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-person-delivery__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.meta-person-delivery__close {
+  border: none;
+  background: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #64748b;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.meta-person-delivery__body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.meta-person-delivery__toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.meta-person-delivery__select {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.meta-person-delivery__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 14px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.meta-person-delivery__empty {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.meta-person-delivery__item {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-person-delivery__summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.meta-person-delivery__recipient {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.meta-person-delivery__recipient em {
+  margin-left: 8px;
+  font-style: normal;
+  font-size: 11px;
+  color: #b45309;
+}
+
+.meta-person-delivery__badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.meta-person-delivery__badge--success {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.meta-person-delivery__badge--failed {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.meta-person-delivery__time {
+  margin-left: auto;
+  color: #64748b;
+}
+
+.meta-person-delivery__detail {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: #475569;
+}
+
+.meta-person-delivery__subject {
+  color: #0f172a;
+  font-size: 13px;
+}
+
+.meta-person-delivery__error {
+  font-size: 12px;
+  color: #b91c1c;
+}
+</style>

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -130,6 +130,7 @@
                 <option value="send_webhook">Send webhook</option>
                 <option value="send_notification">Send notification</option>
                 <option value="send_dingtalk_group_message">Send DingTalk group message</option>
+                <option value="send_dingtalk_person_message">Send DingTalk person message</option>
                 <option value="lock_record">Lock record</option>
               </select>
               <div class="meta-rule-editor__action-btns">
@@ -234,6 +235,52 @@
               </select>
             </div>
 
+            <!-- send_dingtalk_person_message config -->
+            <div v-if="action.type === 'send_dingtalk_person_message'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__label">Local user IDs</label>
+              <textarea
+                v-model="action.config.userIdsText"
+                class="meta-rule-editor__textarea"
+                rows="3"
+                placeholder="使用逗号或换行分隔本地 userId"
+                data-field="dingtalkPersonUserIds"
+              ></textarea>
+              <label class="meta-rule-editor__label">Title template</label>
+              <input
+                v-model="action.config.titleTemplate"
+                class="meta-rule-editor__input"
+                type="text"
+                placeholder="例如：{{record.title}} 待处理"
+                data-field="dingtalkPersonTitleTemplate"
+              />
+              <label class="meta-rule-editor__label">Body template</label>
+              <textarea
+                v-model="action.config.bodyTemplate"
+                class="meta-rule-editor__textarea"
+                rows="4"
+                placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+                data-field="dingtalkPersonBodyTemplate"
+              ></textarea>
+              <label class="meta-rule-editor__label">Public form view (optional)</label>
+              <select
+                v-model="action.config.publicFormViewId"
+                class="meta-rule-editor__select"
+                data-field="dingtalkPersonPublicFormViewId"
+              >
+                <option value="">-- no public form link --</option>
+                <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
+              </select>
+              <label class="meta-rule-editor__label">Internal processing view (optional)</label>
+              <select
+                v-model="action.config.internalViewId"
+                class="meta-rule-editor__select"
+                data-field="dingtalkPersonInternalViewId"
+              >
+                <option value="">-- no internal link --</option>
+                <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
+              </select>
+            </div>
+
             <!-- lock_record config -->
             <div v-if="action.type === 'lock_record'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__toggle-label">
@@ -290,6 +337,7 @@ type DraftActionConfig = Record<string, unknown> & {
   url?: string
   method?: string
   userId?: string
+  userIdsText?: string
   message?: string
   destinationId?: string
   titleTemplate?: string
@@ -363,6 +411,18 @@ function emptyDraft(): Draft {
   }
 }
 
+function draftConfigFromAction(type: AutomationActionType, config: Record<string, unknown>): DraftActionConfig {
+  if (type === 'send_dingtalk_person_message') {
+    return {
+      ...config,
+      userIdsText: Array.isArray(config.userIds)
+        ? config.userIds.join(', ')
+        : '',
+    }
+  }
+  return { ...config }
+}
+
 function draftFromRule(rule: AutomationRule): Draft {
   return {
     name: rule.name,
@@ -372,8 +432,8 @@ function draftFromRule(rule: AutomationRule): Draft {
       ? { conjunction: rule.conditions.conjunction, conditions: rule.conditions.conditions.map((c) => ({ ...c })) }
       : { conjunction: 'AND', conditions: [] },
     actions: rule.actions && rule.actions.length
-      ? rule.actions.map((a) => ({ type: a.type, config: { ...a.config } }))
-      : [{ type: rule.actionType, config: { ...rule.actionConfig } }],
+      ? rule.actions.map((a) => ({ type: a.type, config: draftConfigFromAction(a.type, a.config) }))
+      : [{ type: rule.actionType, config: draftConfigFromAction(rule.actionType, rule.actionConfig) }],
   }
 }
 
@@ -412,6 +472,12 @@ const canSave = computed(() => {
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
       if (!destinationId || !titleTemplate || !bodyTemplate) return false
     }
+    if (action.type === 'send_dingtalk_person_message') {
+      const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
+      const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
+      const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
+      if (!userIdsText || !titleTemplate || !bodyTemplate) return false
+    }
   }
   return true
 })
@@ -442,6 +508,14 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
     case 'send_dingtalk_group_message':
       return {
         destinationId: '',
+        titleTemplate: '',
+        bodyTemplate: '',
+        publicFormViewId: '',
+        internalViewId: '',
+      }
+    case 'send_dingtalk_person_message':
+      return {
+        userIdsText: '',
         titleTemplate: '',
         bodyTemplate: '',
         publicFormViewId: '',
@@ -493,15 +567,40 @@ function buildPayload(): Partial<AutomationRule> {
   if (d.triggerType === 'schedule.cron' && cronPreset.value !== 'custom') {
     triggerConfig.cron = cronPreset.value
   }
+  const actions = d.actions.map((action) => {
+    if (action.type === 'send_dingtalk_person_message') {
+      const userIds = typeof action.config.userIdsText === 'string'
+        ? action.config.userIdsText
+          .split(/[\n,]+/)
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+        : []
+      return {
+        type: action.type,
+        config: {
+          userIds,
+          titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : '',
+          bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : '',
+          publicFormViewId: typeof action.config.publicFormViewId === 'string' && action.config.publicFormViewId.trim()
+            ? action.config.publicFormViewId.trim()
+            : undefined,
+          internalViewId: typeof action.config.internalViewId === 'string' && action.config.internalViewId.trim()
+            ? action.config.internalViewId.trim()
+            : undefined,
+        },
+      }
+    }
+    return { type: action.type, config: action.config }
+  })
   return {
     name: d.name.trim(),
     triggerType: d.triggerType,
     triggerConfig,
     trigger: { type: d.triggerType, config: triggerConfig },
     conditions: d.conditions.conditions.length > 0 ? d.conditions : undefined,
-    actions: d.actions.map((a) => ({ type: a.type, config: a.config })),
-    actionType: d.actions[0]?.type ?? 'update_record',
-    actionConfig: d.actions[0]?.config ?? {},
+    actions,
+    actionType: actions[0]?.type ?? 'update_record',
+    actionConfig: actions[0]?.config ?? {},
   }
 }
 

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -237,6 +237,45 @@
 
             <!-- send_dingtalk_person_message config -->
             <div v-if="action.type === 'send_dingtalk_person_message'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__label">Search and add users</label>
+              <input
+                v-model="action.config.userIdsSearch"
+                class="meta-rule-editor__input"
+                type="text"
+                placeholder="Search by name, email, or userId"
+                data-field="dingtalkPersonUserSearch"
+                @input="void loadPersonRecipientSuggestions(idx, action)"
+              />
+              <div v-if="personRecipientLoading[idx]" class="meta-rule-editor__hint">Searching users…</div>
+              <div v-else-if="personRecipientErrors[idx]" class="meta-rule-editor__hint meta-rule-editor__hint--error">{{ personRecipientErrors[idx] }}</div>
+              <div v-else-if="availablePersonRecipientSuggestions(idx, action).length" class="meta-rule-editor__recipient-list">
+                <button
+                  v-for="candidate in availablePersonRecipientSuggestions(idx, action)"
+                  :key="candidate.id"
+                  class="meta-rule-editor__recipient-option"
+                  type="button"
+                  :data-person-recipient-suggestion="candidate.id"
+                  @click="addPersonRecipient(action, candidate, idx)"
+                >
+                  <strong>{{ candidate.label }}</strong>
+                  <span>{{ candidate.subtitle || candidate.id }}</span>
+                </button>
+              </div>
+              <div v-else-if="typeof action.config.userIdsSearch === 'string' && action.config.userIdsSearch.trim()" class="meta-rule-editor__hint">No matching users</div>
+              <div v-if="selectedPersonRecipients(action).length" class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected">
+                <button
+                  v-for="recipient in selectedPersonRecipients(action)"
+                  :key="recipient.id"
+                  class="meta-rule-editor__recipient-chip"
+                  type="button"
+                  :data-person-recipient="recipient.id"
+                  @click="removePersonRecipient(action, recipient.id)"
+                >
+                  <strong>{{ recipient.label }}</strong>
+                  <span>{{ recipient.subtitle || recipient.id }}</span>
+                  <em>Remove</em>
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Local user IDs</label>
               <textarea
                 v-model="action.config.userIdsText"
@@ -322,6 +361,7 @@ import type {
   AutomationAction,
   AutomationCondition,
   DingTalkGroupDestination,
+  MetaCommentMentionSuggestion,
   MetaView,
 } from '../types'
 
@@ -338,6 +378,7 @@ type DraftActionConfig = Record<string, unknown> & {
   method?: string
   userId?: string
   userIdsText?: string
+  userIdsSearch?: string
   message?: string
   destinationId?: string
   titleTemplate?: string
@@ -380,6 +421,11 @@ const saving = ref(false)
 const cronPreset = ref('0 * * * *')
 const dingTalkDestinations = ref<DingTalkGroupDestination[]>([])
 const dingTalkDestinationsError = ref('')
+const personRecipientSuggestions = ref<Record<number, MetaCommentMentionSuggestion[]>>({})
+const personRecipientLoading = ref<Record<number, boolean>>({})
+const personRecipientErrors = ref<Record<number, string>>({})
+const personRecipientDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
+let personRecipientSuggestionLoadId = 0
 
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
@@ -418,6 +464,7 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
       userIdsText: Array.isArray(config.userIds)
         ? config.userIds.join(', ')
         : '',
+      userIdsSearch: '',
     }
   }
   return { ...config }
@@ -447,6 +494,9 @@ watch(
       error.value = ''
       saving.value = false
       dingTalkDestinationsError.value = ''
+      personRecipientSuggestions.value = {}
+      personRecipientLoading.value = {}
+      personRecipientErrors.value = {}
       if (props.client) {
         try {
           dingTalkDestinations.value = await props.client.listDingTalkGroups()
@@ -495,6 +545,86 @@ function addAction() {
   draft.value.actions.push({ type: 'update_record', config: defaultConfigForActionType('update_record') })
 }
 
+function parseUserIdsText(value: unknown): string[] {
+  if (typeof value !== 'string') return []
+  return value
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function rememberPersonRecipientSuggestions(items: MetaCommentMentionSuggestion[]) {
+  const next = { ...personRecipientDirectory.value }
+  for (const item of items) {
+    next[item.id] = { label: item.label, subtitle: item.subtitle }
+  }
+  personRecipientDirectory.value = next
+}
+
+function selectedPersonRecipients(action: DraftAction) {
+  return parseUserIdsText(action.config.userIdsText).map((id) => ({
+    id,
+    label: personRecipientDirectory.value[id]?.label ?? id,
+    subtitle: personRecipientDirectory.value[id]?.subtitle,
+  }))
+}
+
+function availablePersonRecipientSuggestions(idx: number, action: DraftAction) {
+  const selected = new Set(parseUserIdsText(action.config.userIdsText))
+  return (personRecipientSuggestions.value[idx] ?? []).filter((candidate) => !selected.has(candidate.id))
+}
+
+async function loadPersonRecipientSuggestions(idx: number, action: DraftAction) {
+  const query = typeof action.config.userIdsSearch === 'string' ? action.config.userIdsSearch.trim() : ''
+  if (!props.client || !query) {
+    personRecipientSuggestions.value = { ...personRecipientSuggestions.value, [idx]: [] }
+    personRecipientErrors.value = { ...personRecipientErrors.value, [idx]: '' }
+    personRecipientLoading.value = { ...personRecipientLoading.value, [idx]: false }
+    return
+  }
+
+  const requestId = ++personRecipientSuggestionLoadId
+  personRecipientLoading.value = { ...personRecipientLoading.value, [idx]: true }
+  personRecipientErrors.value = { ...personRecipientErrors.value, [idx]: '' }
+  try {
+    const response = await props.client.listCommentMentionSuggestions({
+      spreadsheetId: props.sheetId,
+      q: query,
+      limit: 8,
+    })
+    if (requestId !== personRecipientSuggestionLoadId) return
+    rememberPersonRecipientSuggestions(response.items)
+    personRecipientSuggestions.value = { ...personRecipientSuggestions.value, [idx]: response.items }
+  } catch (error) {
+    if (requestId !== personRecipientSuggestionLoadId) return
+    personRecipientSuggestions.value = { ...personRecipientSuggestions.value, [idx]: [] }
+    personRecipientErrors.value = {
+      ...personRecipientErrors.value,
+      [idx]: error instanceof Error ? error.message : 'Failed to search users',
+    }
+  } finally {
+    if (requestId === personRecipientSuggestionLoadId) {
+      personRecipientLoading.value = { ...personRecipientLoading.value, [idx]: false }
+    }
+  }
+}
+
+function addPersonRecipient(action: DraftAction, candidate: MetaCommentMentionSuggestion, idx: number) {
+  const ids = new Set(parseUserIdsText(action.config.userIdsText))
+  ids.add(candidate.id)
+  action.config.userIdsText = Array.from(ids).join(', ')
+  action.config.userIdsSearch = ''
+  rememberPersonRecipientSuggestions([candidate])
+  personRecipientSuggestions.value = { ...personRecipientSuggestions.value, [idx]: [] }
+  personRecipientErrors.value = { ...personRecipientErrors.value, [idx]: '' }
+}
+
+function removePersonRecipient(action: DraftAction, userId: string) {
+  action.config.userIdsText = parseUserIdsText(action.config.userIdsText)
+    .filter((id) => id !== userId)
+    .join(', ')
+}
+
 function defaultConfigForActionType(type: AutomationActionType): DraftActionConfig {
   switch (type) {
     case 'update_record':
@@ -516,6 +646,7 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
     case 'send_dingtalk_person_message':
       return {
         userIdsText: '',
+        userIdsSearch: '',
         titleTemplate: '',
         bodyTemplate: '',
         publicFormViewId: '',
@@ -682,6 +813,8 @@ function onTestRun() {
 
 .meta-rule-editor__label { font-size: 12px; font-weight: 600; color: #475569; margin-top: 4px; }
 
+.meta-rule-editor__hint--error { color: #b91c1c; }
+
 .meta-rule-editor__input,
 .meta-rule-editor__select,
 .meta-rule-editor__textarea {
@@ -752,6 +885,38 @@ function onTestRun() {
   flex-direction: column;
   gap: 6px;
   padding-left: 20px;
+}
+
+.meta-rule-editor__recipient-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.meta-rule-editor__recipient-list--selected {
+  margin-bottom: 4px;
+}
+
+.meta-rule-editor__recipient-option,
+.meta-rule-editor__recipient-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  padding: 8px 10px;
+  cursor: pointer;
+  color: #0f172a;
+}
+
+.meta-rule-editor__recipient-option span,
+.meta-rule-editor__recipient-chip span,
+.meta-rule-editor__recipient-chip em {
+  font-size: 12px;
+  color: #64748b;
+  font-style: normal;
 }
 
 .meta-rule-editor__toggle-label {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -821,6 +821,27 @@ export interface DingTalkGroupDelivery {
   deliveredAt?: string
 }
 
+export interface DingTalkPersonDelivery {
+  id: string
+  localUserId: string
+  dingtalkUserId?: string
+  sourceType: 'manual_test' | 'automation'
+  subject: string
+  content: string
+  success: boolean
+  httpStatus?: number
+  responseBody?: string
+  errorMessage?: string
+  automationRuleId?: string
+  recordId?: string
+  initiatedBy?: string
+  createdAt: string
+  deliveredAt?: string
+  localUserLabel?: string
+  localUserSubtitle?: string
+  localUserIsActive: boolean
+}
+
 // --- Field Validation ---
 export type FieldValidationRuleType = 'required' | 'minLength' | 'maxLength' | 'pattern' | 'min' | 'max' | 'enum'
 

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -586,6 +586,7 @@ export type AutomationActionType =
   | 'send_webhook'
   | 'send_notification'
   | 'send_dingtalk_group_message'
+  | 'send_dingtalk_person_message'
   | 'lock_record'
   // Legacy aliases
   | 'notify'

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -6,7 +6,7 @@ function flushPromises() {
 }
 import MetaAutomationManager from '../src/multitable/components/MetaAutomationManager.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
-import type { AutomationRule } from '../src/multitable/types'
+import type { AutomationRule, DingTalkPersonDelivery } from '../src/multitable/types'
 
 function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
   return {
@@ -25,6 +25,21 @@ function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
 function mockClient(rules: AutomationRule[] = []) {
   const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
   const noContent = () => new Response(null, { status: 204 })
+  const personDeliveries: DingTalkPersonDelivery[] = [
+    {
+      id: 'dpd_1',
+      localUserId: 'user_1',
+      dingtalkUserId: 'dt_1',
+      sourceType: 'automation',
+      subject: 'Ticket rec_1 ready',
+      content: 'Please review the latest changes.',
+      success: true,
+      createdAt: '2026-04-19T12:00:00.000Z',
+      localUserLabel: 'Lin Lan',
+      localUserSubtitle: 'lin@example.com',
+      localUserIsActive: true,
+    },
+  ]
 
   const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
     const method = init?.method ?? 'GET'
@@ -41,6 +56,9 @@ function mockClient(rules: AutomationRule[] = []) {
       })
     }
     if (method === 'GET' && url.includes('/automations')) {
+      if (url.includes('/dingtalk-person-deliveries')) {
+        return ok({ deliveries: personDeliveries })
+      }
       return ok({ rules })
     }
     if (method === 'POST' && url.includes('/automations')) {
@@ -388,5 +406,30 @@ describe('MetaAutomationManager', () => {
     const body = JSON.parse(postCalls[0][1]?.body as string)
     expect(body.actionConfig.userIds).toEqual(['user_1'])
     expect(client.listCommentMentionSuggestions).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens DingTalk person delivery viewer for person message rules', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        name: 'DingTalk person notify',
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: ['user_1'],
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deliveriesBtn = container.querySelector('[data-automation-person-deliveries="rule_1"]') as HTMLButtonElement
+    expect(deliveriesBtn).toBeTruthy()
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const delivery = document.querySelector('[data-person-delivery-id="dpd_1"]')
+    expect(delivery?.textContent).toContain('Lin Lan')
+    expect(delivery?.textContent).toContain('Ticket rec_1 ready')
   })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -55,7 +55,16 @@ function mockClient(rules: AutomationRule[] = []) {
     }
     return ok({})
   })
-  return { client: new MultitableApiClient({ fetchFn }), fetchFn }
+  const client = new MultitableApiClient({ fetchFn })
+  client.listCommentMentionSuggestions = vi.fn(async () => ({
+    items: [
+      { id: 'user_1', label: 'Lin Lan', subtitle: 'lin@example.com' },
+      { id: 'user_2', label: 'Zhao Ming', subtitle: 'zhao@example.com' },
+    ],
+    total: 2,
+    limit: 8,
+  }))
+  return { client, fetchFn }
 }
 
 function mount(props: Record<string, unknown>) {
@@ -328,5 +337,56 @@ describe('MetaAutomationManager', () => {
       publicFormViewId: 'view_form',
       internalViewId: 'view_grid',
     })
+  })
+
+  it('can search and add DingTalk person recipients before save', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk search notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const searchInput = container.querySelector('[data-automation-field="dingtalkPersonUserSearch"]') as HTMLInputElement
+    searchInput.value = 'lin'
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const suggestion = container.querySelector('[data-automation-person-suggestion="user_1"]') as HTMLButtonElement
+    expect(suggestion).toBeTruthy()
+    suggestion.click()
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    expect(userIdsInput.value).toBe('user_1')
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionConfig.userIds).toEqual(['user_1'])
+    expect(client.listCommentMentionSuggestions).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -273,4 +273,60 @@ describe('MetaAutomationManager', () => {
       internalViewId: 'view_grid',
     })
   })
+
+  it('creates DingTalk person automation via form', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk person notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1, user_2'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const internalViewSelect = container.querySelector('[data-automation-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+    internalViewSelect.value = 'view_grid'
+    internalViewSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionType).toBe('send_dingtalk_person_message')
+    expect(body.actionConfig).toEqual({
+      userIds: ['user_1', 'user_2'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please fill {{record.status}}',
+      publicFormViewId: 'view_form',
+      internalViewId: 'view_grid',
+    })
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -30,6 +30,14 @@ function mockClient() {
         createdAt: '2026-04-01T00:00:00Z',
       },
     ]),
+    listCommentMentionSuggestions: vi.fn(async () => ({
+      items: [
+        { id: 'user_1', label: 'Lin Lan', subtitle: 'lin@example.com' },
+        { id: 'user_2', label: 'Zhao Ming', subtitle: 'zhao@example.com' },
+      ],
+      total: 2,
+      limit: 8,
+    })),
   }
 }
 
@@ -327,5 +335,60 @@ describe('MetaAutomationRuleEditor', () => {
         internalViewId: 'view_grid',
       },
     })
+  })
+
+  it('can search and add DingTalk person recipients', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify search recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const searchInput = container.querySelector('[data-field="dingtalkPersonUserSearch"]') as HTMLInputElement
+    searchInput.value = 'lin'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const suggestion = container.querySelector('[data-person-recipient-suggestion="user_1"]') as HTMLButtonElement
+    expect(suggestion).toBeTruthy()
+    suggestion.click()
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    expect(userIdsInput.value).toBe('user_1')
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionConfig.userIds).toEqual(['user_1'])
+    expect(client.listCommentMentionSuggestions).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -257,4 +257,75 @@ describe('MetaAutomationRuleEditor', () => {
     })
     expect(client.listDingTalkGroups).toHaveBeenCalledTimes(1)
   })
+
+  it('emits DingTalk person action config with optional links', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify People'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1, user_2'
+    userIdsInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+
+    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+    internalViewSelect.value = 'view_grid'
+    internalViewSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionType).toBe('send_dingtalk_person_message')
+    expect(payload.actionConfig).toEqual({
+      userIds: ['user_1', 'user_2'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      publicFormViewId: 'view_form',
+      internalViewId: 'view_grid',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_dingtalk_person_message',
+      config: {
+        userIds: ['user_1', 'user_2'],
+        titleTemplate: 'Ticket {{recordId}}',
+        bodyTemplate: 'Please review {{record.status}}',
+        publicFormViewId: 'view_form',
+        internalViewId: 'view_grid',
+      },
+    })
+  })
 })

--- a/docs/development/dingtalk-person-delivery-history-development-20260419.md
+++ b/docs/development/dingtalk-person-delivery-history-development-20260419.md
@@ -1,0 +1,99 @@
+# DingTalk Person Delivery History Development
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-person-notify-20260419`
+- Scope: surface `send_dingtalk_person_message` delivery history in automation management
+
+## Goal
+
+Close the governance gap for direct DingTalk personal notifications:
+
+- keep recipient-level delivery records queryable by automation rule
+- expose those records in the multitable automation UI
+- do it without changing the existing automation payload or execution contract
+
+## Backend
+
+Added a focused query helper:
+
+- `packages/core-backend/src/multitable/dingtalk-person-delivery-service.ts`
+
+Behavior:
+
+- reads `dingtalk_person_deliveries` by `automation_rule_id`
+- joins `users` to surface:
+  - `localUserLabel`
+  - `localUserSubtitle`
+  - `localUserIsActive`
+- normalizes DB rows into API-facing camelCase fields
+- clamps `limit` to `1..200`
+
+Added a mounted API route in `univer-meta.ts`:
+
+- `GET /api/multitable/sheets/:sheetId/automations/:ruleId/dingtalk-person-deliveries`
+
+Guardrails:
+
+- requires `sheetId` and `ruleId`
+- reuses `resolveSheetCapabilities(...)`
+- requires `canManageAutomation`
+- verifies the target automation rule exists and belongs to the current sheet
+
+## Frontend
+
+Added a new viewer component:
+
+- `apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue`
+
+Behavior:
+
+- modal viewer for person delivery history
+- refresh action
+- success/failed filter
+- shows:
+  - local user label
+  - inactive user hint
+  - DingTalk user id
+  - subject
+  - error message when failed
+  - created time
+
+Integrated it into automation management:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Behavior:
+
+- rules with `actionType === 'send_dingtalk_person_message'` now show `View Deliveries`
+- button opens the new viewer bound to the selected rule
+
+Extended client/types:
+
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/api/client.ts`
+
+Added:
+
+- `DingTalkPersonDelivery`
+- `getAutomationDingTalkPersonDeliveries(sheetId, ruleId, limit?)`
+
+## Tests
+
+Added focused backend coverage:
+
+- `packages/core-backend/tests/unit/dingtalk-person-delivery-service.test.ts`
+
+Added focused frontend coverage:
+
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+Scenario covered:
+
+- open delivery viewer from a person-notify automation rule
+- load and render recipient delivery history
+
+## Notes
+
+- No migration changes in this slice
+- No remote deployment in this slice
+- Existing `plugins/**/node_modules` and `tools/cli/node_modules` workspace noise was intentionally left out of the code changes

--- a/docs/development/dingtalk-person-delivery-history-verification-20260419.md
+++ b/docs/development/dingtalk-person-delivery-history-verification-20260419.md
@@ -1,0 +1,49 @@
+# DingTalk Person Delivery History Verification
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-person-notify-20260419`
+- Scope: verification for person delivery history viewer and API
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-work-notification.test.ts tests/unit/dingtalk-person-delivery-service.test.ts tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- Backend unit tests: `100 passed`
+- Frontend tests: `22 passed`
+- Backend build: passed
+- Web build: passed
+
+## Verified Outcomes
+
+### Backend
+
+- person delivery rows are mapped into API-ready camelCase data
+- joined user metadata is exposed to the UI
+- automation-scoped delivery lookup is sheet-bounded
+- invalid or cross-sheet rule ids return `NOT_FOUND`
+
+### Frontend
+
+- `send_dingtalk_person_message` rules render a `View Deliveries` action
+- opening the viewer fetches delivery history for the selected rule
+- recipient label and subject render correctly
+- viewer remains read-only and does not alter automation authoring payloads
+
+## Non-blocking Noise
+
+- frontend vitest still prints the existing `WebSocket server error: Port is already in use`
+- web build still prints the existing Vite chunk-size warning
+
+Neither issue was introduced by this slice.
+
+## Deployment
+
+- No remote deployment performed
+- No database migration executed

--- a/docs/development/dingtalk-person-notify-automation-development-20260419.md
+++ b/docs/development/dingtalk-person-notify-automation-development-20260419.md
@@ -1,0 +1,148 @@
+# DingTalk Person Notification Automation Development
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-person-notify-20260419`
+- Scope: P1 first slice for direct DingTalk person messaging from multitable automation
+
+## Goal
+
+Deliver the first standard runtime path for sending DingTalk messages to specific linked users:
+
+- add `send_dingtalk_person_message` as a first-class automation action
+- allow automation authors to target local platform users by `userId`
+- resolve those users to linked DingTalk accounts at execution time
+- support the same optional `填写入口` and `处理入口` links already used by group messages
+- record per-recipient delivery history for audit and troubleshooting
+
+## Backend
+
+### Action model
+
+Updated:
+
+- `packages/core-backend/src/multitable/automation-actions.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+
+Changes:
+
+- added `send_dingtalk_person_message` to the automation action type set and route allowlists
+- defined config shape:
+  - `userIds`
+  - `titleTemplate`
+  - `bodyTemplate`
+  - `publicFormViewId?`
+  - `internalViewId?`
+
+### DingTalk client support
+
+Updated:
+
+- `packages/core-backend/src/integrations/dingtalk/client.ts`
+- `.env.example`
+
+Changes:
+
+- added `readDingTalkMessageConfig()` for org-app message credentials
+- added `sendDingTalkWorkNotification()` for direct DingTalk work notifications
+- added `DingTalkBusinessError` so application-level DingTalk failures can be surfaced with response payloads
+- made the client request path accept an injectable `fetchFn` so automation tests do not depend on global network
+- documented the required `DINGTALK_AGENT_ID`
+
+### Automation execution
+
+Updated:
+
+- `packages/core-backend/src/multitable/automation-executor.ts`
+
+Changes:
+
+- added `executeSendDingTalkPersonMessage()`
+- validates:
+  - at least one local `userId`
+  - non-empty title/body templates
+  - shared public form when `publicFormViewId` is set
+  - existing internal view when `internalViewId` is set
+- resolves local users through `directory_account_links` and active DingTalk `directory_accounts`
+- fails cleanly when a requested user is inactive or has no linked DingTalk account
+- renders the message body with optional:
+  - `填写入口` public form link
+  - `处理入口` internal multitable record link
+- batches direct DingTalk sends and records per-recipient delivery rows
+- preserves `httpStatus` and `responseBody` when DingTalk returns request or business errors
+
+### Persistence compatibility
+
+Updated:
+
+- `packages/core-backend/src/db/types.ts`
+
+Added migrations:
+
+- `packages/core-backend/src/db/migrations/zzzz20260419213000_add_dingtalk_person_message_automation_action.ts`
+- `packages/core-backend/src/db/migrations/zzzz20260419214000_create_dingtalk_person_deliveries.ts`
+
+Purpose:
+
+- allow `send_dingtalk_person_message` in `automation_rules`
+- persist recipient-level DingTalk person delivery history in `dingtalk_person_deliveries`
+
+## Frontend
+
+### Shared automation types
+
+Updated:
+
+- `apps/web/src/multitable/types.ts`
+
+Changes:
+
+- added `send_dingtalk_person_message` to the frontend automation action union
+
+### Rule editor + manager
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Changes:
+
+- added `Send DingTalk person message` to the action selector
+- introduced authoring fields for:
+  - local user IDs textarea
+  - title template
+  - body template
+  - optional public form view
+  - optional internal processing view
+- normalize comma/newline separated local user IDs into the backend config shape
+- keep legacy single-action and action-chain editing paths aligned with the new action type
+
+## Tests
+
+Updated backend coverage:
+
+- `packages/core-backend/tests/unit/dingtalk-work-notification.test.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+
+Covered:
+
+- work notification config requires `DINGTALK_AGENT_ID`
+- direct DingTalk notification payload includes `agent_id` and `userid_list`
+- successful automation send against linked DingTalk users
+- missing DingTalk link failure path
+
+Updated frontend coverage:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+Covered:
+
+- editor emits `send_dingtalk_person_message` with optional public/internal links
+- manager quick-create form can save the new action payload
+
+## Deployment
+
+- None
+- No remote deployment
+- Two new migrations were added but not applied anywhere in this slice

--- a/docs/development/dingtalk-person-notify-automation-verification-20260419.md
+++ b/docs/development/dingtalk-person-notify-automation-verification-20260419.md
@@ -1,0 +1,48 @@
+# DingTalk Person Notification Automation Verification
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-person-notify-20260419`
+- Scope: direct DingTalk person messaging for multitable automation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-work-notification.test.ts tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+### Backend
+
+- `tests/unit/dingtalk-work-notification.test.ts`
+- `tests/unit/automation-v1.test.ts`
+  - `99 passed`
+
+### Frontend
+
+- `tests/multitable-automation-rule-editor.spec.ts`
+- `tests/multitable-automation-manager.spec.ts`
+  - `19 passed`
+
+### Builds
+
+- `pnpm --filter @metasheet/core-backend build`
+  - passed
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Notes
+
+- Frontend Vitest may still print the existing `WebSocket server error: Port is already in use` noise; tests still pass.
+- Web build still prints the existing Vite chunk-size warning; build still passes.
+- This slice intentionally targets linked local users only; it does not add a standalone personal DingTalk destination management UI.
+- `pnpm install --frozen-lockfile` left `plugins/**/node_modules` and `tools/cli/node_modules` noise in the worktree; those generated files remain out of scope and were not added to this implementation.
+
+## Deployment
+
+- None
+- No remote deployment
+- No migration execution in this verification run

--- a/docs/development/dingtalk-person-notify-recipient-picker-development-20260419.md
+++ b/docs/development/dingtalk-person-notify-recipient-picker-development-20260419.md
@@ -1,0 +1,74 @@
+# DingTalk Person Notification Recipient Picker Development
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-person-notify-20260419`
+- Scope: authoring UX follow-up for direct DingTalk person automation messaging
+
+## Goal
+
+Remove the worst part of the MVP authoring flow: manually typing local `userId` values.
+
+This slice keeps the backend config shape unchanged, but adds a searchable recipient picker on top of the existing `userIds` field in both automation editors.
+
+## Approach
+
+Reused the existing multitable comment mention candidate search instead of adding a new backend user-search endpoint.
+
+Source:
+
+- `client.listCommentMentionSuggestions({ spreadsheetId, q, limit })`
+
+This keeps the change small:
+
+- no new API routes
+- no new persistence changes
+- no change to the saved action config
+
+## Frontend
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Changes:
+
+- added a `Search and add users` input for `send_dingtalk_person_message`
+- loads candidate users through the existing mention candidate API
+- shows selectable suggestion rows with:
+  - label
+  - subtitle
+  - stable `userId`
+- shows selected recipients as removable chips
+- keeps the existing `Local user IDs` textarea as the persistence source of truth
+- still allows manual entry, but makes normal authoring path use search/add instead of raw ID memorization
+
+## Compatibility
+
+- backend config remains:
+  - `userIds`
+  - `titleTemplate`
+  - `bodyTemplate`
+  - optional link view IDs
+- no migration changes
+- no runtime behavior changes
+- no API contract changes
+
+## Tests
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+Covered:
+
+- rule editor can search and add a DingTalk person recipient
+- quick-create manager form can search and add a DingTalk person recipient before save
+- saved payload still serializes to the same `userIds` array shape
+
+## Deployment
+
+- None
+- No remote deployment
+- No migration changes

--- a/docs/development/dingtalk-person-notify-recipient-picker-verification-20260419.md
+++ b/docs/development/dingtalk-person-notify-recipient-picker-verification-20260419.md
@@ -1,0 +1,37 @@
+# DingTalk Person Notification Recipient Picker Verification
+
+- Date: 2026-04-19
+- Branch: `codex/dingtalk-person-notify-20260419`
+- Scope: searchable recipient picker for `send_dingtalk_person_message`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+### Frontend
+
+- `tests/multitable-automation-rule-editor.spec.ts`
+- `tests/multitable-automation-manager.spec.ts`
+  - `21 passed`
+
+### Build
+
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Notes
+
+- This slice intentionally reuses `listCommentMentionSuggestions` and does not introduce a new user-search backend route.
+- The existing `Local user IDs` textarea remains in place so current payload shape and manual fallback are preserved.
+- Web build still prints the existing Vite chunk-size warning; build still passes.
+
+## Deployment
+
+- None
+- No remote deployment
+- No migration execution

--- a/packages/core-backend/src/db/migrations/zzzz20260419213000_add_dingtalk_person_message_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260419213000_add_dingtalk_person_message_automation_action.ts
@@ -1,0 +1,44 @@
+import { sql, type Kysely } from 'kysely'
+
+const ACTIONS = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+] as const
+
+function quotedActions(): string {
+  return ACTIONS.map((action) => `'${action}'`).join(', ')
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quotedActions()}))
+  `).execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (
+      'notify',
+      'update_field',
+      'update_record',
+      'create_record',
+      'send_webhook',
+      'send_notification',
+      'send_dingtalk_group_message',
+      'lock_record'
+    ))
+  `).execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260419214000_create_dingtalk_person_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260419214000_create_dingtalk_person_deliveries.ts
@@ -1,0 +1,39 @@
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS dingtalk_person_deliveries (
+      id TEXT PRIMARY KEY,
+      local_user_id TEXT NOT NULL,
+      dingtalk_user_id TEXT,
+      source_type TEXT NOT NULL,
+      subject TEXT NOT NULL,
+      content TEXT NOT NULL,
+      success BOOLEAN NOT NULL DEFAULT FALSE,
+      http_status INTEGER,
+      response_body TEXT,
+      error_message TEXT,
+      automation_rule_id TEXT,
+      record_id TEXT,
+      initiated_by TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      delivered_at TIMESTAMPTZ
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_person_deliveries_local_user
+    ON dingtalk_person_deliveries(local_user_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_person_deliveries_source_type
+    ON dingtalk_person_deliveries(source_type)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_person_deliveries_source_type`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_person_deliveries_local_user`.execute(db)
+  await sql`DROP TABLE IF EXISTS dingtalk_person_deliveries`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -114,6 +114,7 @@ export interface Database {
   multitable_webhook_deliveries: MultitableWebhookDeliveriesTable
   dingtalk_group_destinations: DingTalkGroupDestinationsTable
   dingtalk_group_deliveries: DingTalkGroupDeliveriesTable
+  dingtalk_person_deliveries: DingTalkPersonDeliveriesTable
 }
 
 export interface SnapshotsTable {
@@ -1316,6 +1317,24 @@ export interface DingTalkGroupDestinationsTable {
 export interface DingTalkGroupDeliveriesTable {
   id: string
   destination_id: string
+  source_type: string
+  subject: string
+  content: string
+  success: boolean
+  http_status: number | null
+  response_body: string | null
+  error_message: string | null
+  automation_rule_id: string | null
+  record_id: string | null
+  initiated_by: string | null
+  created_at: CreatedAt
+  delivered_at: NullableTimestamp
+}
+
+export interface DingTalkPersonDeliveriesTable {
+  id: string
+  local_user_id: string
+  dingtalk_user_id: string | null
   source_type: string
   subject: string
   content: string

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -31,6 +31,26 @@ export interface DingTalkDirectoryConfig {
   baseUrl?: string
 }
 
+export interface DingTalkMessageConfig extends DingTalkDirectoryConfig {
+  agentId: string
+}
+
+export interface DingTalkWorkNotificationInput {
+  userIds: string[]
+  title: string
+  content: string
+}
+
+export interface DingTalkWorkNotificationResult {
+  taskId?: string
+  requestId?: string
+  raw: Record<string, unknown>
+}
+
+interface DingTalkRequestOptions {
+  fetchFn?: typeof fetch
+}
+
 export interface DingTalkDepartment {
   id: string
   parentId: string | null
@@ -66,7 +86,7 @@ export interface DingTalkDirectoryUser {
   source: Record<string, unknown>
 }
 
-class DingTalkRequestError extends Error {
+export class DingTalkRequestError extends Error {
   statusCode: number
   responseBody: Record<string, unknown> | null
 
@@ -74,6 +94,16 @@ class DingTalkRequestError extends Error {
     super(message)
     this.name = 'DingTalkRequestError'
     this.statusCode = statusCode
+    this.responseBody = responseBody
+  }
+}
+
+export class DingTalkBusinessError extends Error {
+  responseBody: Record<string, unknown> | null
+
+  constructor(message: string, responseBody: Record<string, unknown> | null) {
+    super(message)
+    this.name = 'DingTalkBusinessError'
     this.responseBody = responseBody
   }
 }
@@ -118,8 +148,9 @@ async function requestDingTalkJson(
   input: string,
   init: RequestInit,
   fallbackError: string,
+  options?: DingTalkRequestOptions,
 ): Promise<Record<string, unknown>> {
-  const response = await fetch(input, init)
+  const response = await (options?.fetchFn ?? fetch)(input, init)
   const payload = await readJson(response)
 
   if (!response.ok) {
@@ -150,7 +181,7 @@ function readNestedPayload(payload: Record<string, unknown>, key = 'result'): Re
 function normalizeDingTalkApiPayload(payload: Record<string, unknown>, fallbackError: string): Record<string, unknown> {
   const errcode = readNumericField(payload, 'errcode', 'code')
   if (errcode !== null && errcode !== 0) {
-    throw new Error(normalizeErrorMessage(payload, fallbackError))
+    throw new DingTalkBusinessError(normalizeErrorMessage(payload, fallbackError), payload)
   }
   return payload
 }
@@ -167,11 +198,13 @@ async function requestDingTalkDirectoryJson(
   init: RequestInit,
   fallbackError: string,
   baseUrl?: string,
+  options?: DingTalkRequestOptions,
 ): Promise<Record<string, unknown>> {
   const payload = await requestDingTalkJson(
     `${normalizeDirectoryBaseUrl(baseUrl)}${path}`,
     init,
     fallbackError,
+    options,
   )
   return normalizeDingTalkApiPayload(payload, fallbackError)
 }
@@ -192,6 +225,24 @@ export function readDingTalkOauthConfig(): DingTalkOauthConfig {
     clientSecret,
     redirectUri,
     corpId,
+  }
+}
+
+export function readDingTalkMessageConfig(): DingTalkMessageConfig {
+  const appKey = readStringEnv('DINGTALK_APP_KEY', 'DINGTALK_CLIENT_ID')
+  const appSecret = readStringEnv('DINGTALK_APP_SECRET', 'DINGTALK_CLIENT_SECRET')
+  const agentId = readStringEnv('DINGTALK_AGENT_ID', 'DINGTALK_NOTIFY_AGENT_ID')
+  const baseUrl = readStringEnv('DINGTALK_BASE_URL') || undefined
+
+  if (!appKey) throw new Error('DINGTALK_APP_KEY or DINGTALK_CLIENT_ID is not configured')
+  if (!appSecret) throw new Error('DINGTALK_APP_SECRET or DINGTALK_CLIENT_SECRET is not configured')
+  if (!agentId) throw new Error('DINGTALK_AGENT_ID or DINGTALK_NOTIFY_AGENT_ID is not configured')
+
+  return {
+    appKey,
+    appSecret,
+    agentId,
+    baseUrl,
   }
 }
 
@@ -305,7 +356,10 @@ export async function fetchDingTalkCurrentUser(accessToken: string): Promise<Din
   }
 }
 
-export async function fetchDingTalkAppAccessToken(config: DingTalkDirectoryConfig): Promise<string> {
+export async function fetchDingTalkAppAccessToken(
+  config: DingTalkDirectoryConfig,
+  options?: DingTalkRequestOptions,
+): Promise<string> {
   const baseUrl = normalizeDirectoryBaseUrl(config.baseUrl)
   const payload = await requestDingTalkDirectoryJson(
     `/gettoken?appkey=${encodeURIComponent(config.appKey)}&appsecret=${encodeURIComponent(config.appSecret)}`,
@@ -317,6 +371,7 @@ export async function fetchDingTalkAppAccessToken(config: DingTalkDirectoryConfi
     },
     'Failed to obtain DingTalk app access token',
     baseUrl,
+    options,
   )
 
   const token = typeof payload.access_token === 'string'
@@ -483,4 +538,61 @@ export async function getDingTalkUserDetail(
   }
 }
 
-export { DingTalkRequestError }
+export async function sendDingTalkWorkNotification(
+  accessToken: string,
+  input: DingTalkWorkNotificationInput,
+  config: DingTalkMessageConfig = readDingTalkMessageConfig(),
+  options?: DingTalkRequestOptions,
+): Promise<DingTalkWorkNotificationResult> {
+  const userIds = Array.from(new Set(
+    input.userIds
+      .map((userId) => String(userId ?? '').trim())
+      .filter(Boolean),
+  ))
+  const title = input.title.trim()
+  const content = input.content.trim()
+
+  if (userIds.length === 0) throw new Error('At least one DingTalk userId is required')
+  if (!title) throw new Error('DingTalk title is required')
+  if (!content) throw new Error('DingTalk content is required')
+
+  const payload = await requestDingTalkDirectoryJson(
+    `/topapi/message/corpconversation/asyncsend_v2?access_token=${encodeURIComponent(accessToken)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agent_id: Number.isNaN(Number(config.agentId)) ? config.agentId : Number(config.agentId),
+        userid_list: userIds.join(','),
+        to_all_user: false,
+        msg: {
+          msgtype: 'markdown',
+          markdown: {
+            title,
+            text: `### ${title}\n\n${content}`,
+          },
+        },
+      }),
+    },
+    'Failed to send DingTalk work notification',
+    config.baseUrl,
+    options,
+  )
+
+  const result = readNestedPayload(payload)
+  const taskIdValue = payload.task_id ?? payload.taskId ?? result.task_id ?? result.taskId
+  const requestIdValue = payload.request_id ?? payload.requestId ?? result.request_id ?? result.requestId
+  return {
+    taskId:
+      typeof taskIdValue === 'number'
+        ? String(taskIdValue)
+        : typeof taskIdValue === 'string'
+          ? taskIdValue
+              : undefined,
+    requestId:
+      typeof requestIdValue === 'string'
+        ? requestIdValue
+          : undefined,
+    raw: payload,
+  }
+}

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -9,6 +9,7 @@ export type AutomationActionType =
   | 'send_webhook'
   | 'send_notification'
   | 'send_dingtalk_group_message'
+  | 'send_dingtalk_person_message'
   | 'lock_record'
 
 export const ALL_ACTION_TYPES: AutomationActionType[] = [
@@ -17,6 +18,7 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'send_webhook',
   'send_notification',
   'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
   'lock_record',
 ]
 
@@ -48,6 +50,15 @@ export interface SendNotificationConfig {
 /** Config shape for send_dingtalk_group_message */
 export interface SendDingTalkGroupMessageConfig {
   destinationId: string
+  titleTemplate: string
+  bodyTemplate: string
+  publicFormViewId?: string
+  internalViewId?: string
+}
+
+/** Config shape for send_dingtalk_person_message */
+export interface SendDingTalkPersonMessageConfig {
+  userIds: string[]
   titleTemplate: string
   bodyTemplate: string
   publicFormViewId?: string

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -5,6 +5,13 @@
 
 import { randomUUID } from 'crypto'
 import { Logger } from '../core/logger'
+import {
+  DingTalkBusinessError,
+  DingTalkRequestError,
+  fetchDingTalkAppAccessToken,
+  readDingTalkMessageConfig,
+  sendDingTalkWorkNotification,
+} from '../integrations/dingtalk/client'
 import type { EventBus } from '../integration/events/event-bus'
 import {
   buildDingTalkMarkdown,
@@ -15,6 +22,7 @@ import type {
   AutomationAction,
   AutomationActionType,
   SendDingTalkGroupMessageConfig,
+  SendDingTalkPersonMessageConfig,
 } from './automation-actions'
 import type { ConditionGroup } from './automation-conditions'
 import { evaluateConditions } from './automation-conditions'
@@ -24,6 +32,7 @@ const logger = new Logger('AutomationExecutor')
 
 const WEBHOOK_TIMEOUT_MS = 5_000
 const MAX_WEBHOOK_RETRIES = 2
+const DINGTALK_PERSON_BATCH_SIZE = 100
 
 function readJsonSafely(response: Response): Promise<unknown> {
   return response.json().catch(() => null)
@@ -54,6 +63,33 @@ function renderAutomationTemplate(template: string, data: Record<string, unknown
   return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key: string) =>
     renderTemplateValue(lookupTemplateValue(key, data)),
   )
+}
+
+function normalizeUserIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return Array.from(new Set(
+    value
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter(Boolean),
+  ))
+}
+
+function chunkItems<T>(items: T[], size: number): T[][] {
+  if (items.length === 0) return []
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+function stringifyResponseBody(payload: unknown, fallback: string | null = null): string | null {
+  if (payload === null || payload === undefined) return fallback
+  try {
+    return JSON.stringify(payload)
+  } catch {
+    return fallback
+  }
 }
 
 function parseViewConfig(raw: unknown): Record<string, unknown> | null {
@@ -139,6 +175,67 @@ async function recordDingTalkGroupDeliverySafely(
     logger.warn('Failed to persist DingTalk group delivery history', {
       error: error instanceof Error ? error.message : String(error),
       destinationId: input.destinationId,
+      sourceType: input.sourceType,
+    })
+  }
+}
+
+async function recordDingTalkPersonDelivery(
+  queryFn: AutomationDeps['queryFn'],
+  input: {
+    localUserId: string
+    dingtalkUserId?: string | null
+    sourceType: 'automation'
+    subject: string
+    content: string
+    success: boolean
+    httpStatus?: number | null
+    responseBody?: string | null
+    errorMessage?: string | null
+    automationRuleId?: string | null
+    recordId?: string | null
+    initiatedBy?: string | null
+  },
+): Promise<void> {
+  await queryFn(
+    `INSERT INTO dingtalk_person_deliveries (
+       id, local_user_id, dingtalk_user_id, source_type, subject, content, success,
+       http_status, response_body, error_message, automation_rule_id,
+       record_id, initiated_by, delivered_at
+     ) VALUES (
+       $1, $2, $3, $4, $5, $6, $7,
+       $8, $9, $10, $11,
+       $12, $13, $14
+     )`,
+    [
+      randomUUID(),
+      input.localUserId,
+      input.dingtalkUserId ?? null,
+      input.sourceType,
+      input.subject,
+      input.content,
+      input.success,
+      input.httpStatus ?? null,
+      input.responseBody ?? null,
+      input.errorMessage ?? null,
+      input.automationRuleId ?? null,
+      input.recordId ?? null,
+      input.initiatedBy ?? null,
+      input.success ? new Date().toISOString() : null,
+    ],
+  )
+}
+
+async function recordDingTalkPersonDeliverySafely(
+  queryFn: AutomationDeps['queryFn'],
+  input: Parameters<typeof recordDingTalkPersonDelivery>[1],
+): Promise<void> {
+  try {
+    await recordDingTalkPersonDelivery(queryFn, input)
+  } catch (error) {
+    logger.warn('Failed to persist DingTalk person delivery history', {
+      error: error instanceof Error ? error.message : String(error),
+      localUserId: input.localUserId,
       sourceType: input.sourceType,
     })
   }
@@ -289,6 +386,9 @@ export class AutomationExecutor {
             break
           case 'send_dingtalk_group_message':
             result = await this.executeSendDingTalkGroupMessage(action.config as unknown as SendDingTalkGroupMessageConfig, context)
+            break
+          case 'send_dingtalk_person_message':
+            result = await this.executeSendDingTalkPersonMessage(action.config as unknown as SendDingTalkPersonMessageConfig, context)
             break
           case 'lock_record':
             result = await this.executeLockRecord(action.config, context)
@@ -492,6 +592,233 @@ export class AutomationExecutor {
       }
     } catch (err) {
       return { actionType: 'send_notification', status: 'failed', error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  private async executeSendDingTalkPersonMessage(
+    config: SendDingTalkPersonMessageConfig,
+    context: ExecutionContext,
+  ): Promise<AutomationStepResult> {
+    const userIds = normalizeUserIds(config.userIds)
+    const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
+    const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
+    const publicFormViewId = typeof config.publicFormViewId === 'string' ? config.publicFormViewId.trim() : ''
+    const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
+
+    if (userIds.length === 0) {
+      return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'At least one local userId is required' }
+    }
+    if (!titleTemplate) {
+      return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'DingTalk title template is required' }
+    }
+    if (!bodyTemplate) {
+      return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'DingTalk body template is required' }
+    }
+
+    let baseUrl: string | null = null
+    const linkLines: string[] = []
+    if (publicFormViewId || internalViewId) {
+      baseUrl = resolveAutomationAppBaseUrl()
+      if (!baseUrl) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: 'PUBLIC_APP_URL or APP_BASE_URL is required for DingTalk automation links',
+        }
+      }
+    }
+
+    if (publicFormViewId && baseUrl) {
+      const publicViewResult = await this.deps.queryFn(
+        `SELECT id, sheet_id, config
+           FROM meta_views
+          WHERE id = $1 AND sheet_id = $2`,
+        [publicFormViewId, context.sheetId],
+      )
+      const publicView = (publicViewResult.rows[0] ?? null) as {
+        id: string
+        sheet_id: string
+        config: unknown
+      } | null
+      if (!publicView) {
+        return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'Public form view not found' }
+      }
+
+      const viewConfig = parseViewConfig(publicView.config)
+      const publicForm = viewConfig?.publicForm
+      const publicToken = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
+        ? typeof (publicForm as Record<string, unknown>).publicToken === 'string'
+          ? ((publicForm as Record<string, unknown>).publicToken as string).trim()
+          : ''
+        : ''
+      const enabled = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
+        ? (publicForm as Record<string, unknown>).enabled === true
+        : false
+
+      if (!enabled || !publicToken) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: 'Selected public form view is not shared',
+        }
+      }
+
+      linkLines.push(`- [填写入口](${buildAppLink(baseUrl, `/multitable/public-form/${context.sheetId}/${publicFormViewId}`, { publicToken })})`)
+    }
+
+    if (internalViewId && baseUrl) {
+      const internalViewResult = await this.deps.queryFn(
+        `SELECT id
+           FROM meta_views
+          WHERE id = $1 AND sheet_id = $2`,
+        [internalViewId, context.sheetId],
+      )
+      if (!internalViewResult.rows[0]) {
+        return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'Internal view not found' }
+      }
+      linkLines.push(`- [处理入口](${buildAppLink(baseUrl, `/multitable/${context.sheetId}/${internalViewId}`, { recordId: context.recordId })})`)
+    }
+
+    const templateData: Record<string, unknown> = {
+      sheetId: context.sheetId,
+      recordId: context.recordId,
+      actorId: context.actorId ?? '',
+      record: context.recordData,
+    }
+    const renderedTitle = renderAutomationTemplate(titleTemplate, templateData).trim()
+    const renderedBody = renderAutomationTemplate(bodyTemplate, templateData).trim()
+    const bodyWithLinks = [
+      renderedBody,
+      linkLines.length > 0 ? ['**快捷入口**', ...linkLines].join('\n') : '',
+    ].filter(Boolean).join('\n\n')
+
+    const recipientsResult = await this.deps.queryFn(
+      `SELECT u.id AS local_user_id,
+              u.is_active AS local_user_active,
+              linked.external_user_id AS dingtalk_user_id
+         FROM users u
+         LEFT JOIN LATERAL (
+           SELECT a.external_user_id
+             FROM directory_account_links l
+             JOIN directory_accounts a ON a.id = l.directory_account_id
+            WHERE l.local_user_id = u.id
+              AND l.link_status = 'linked'
+              AND a.provider = 'dingtalk'
+              AND a.is_active = TRUE
+            ORDER BY a.updated_at DESC
+            LIMIT 1
+         ) linked ON TRUE
+        WHERE u.id = ANY($1::text[])`,
+      [userIds],
+    )
+
+    const recipientMap = new Map<string, { localUserId: string; dingtalkUserId: string }>()
+    for (const row of recipientsResult.rows as Array<Record<string, unknown>>) {
+      const localUserId = typeof row.local_user_id === 'string' ? row.local_user_id.trim() : ''
+      const dingtalkUserId = typeof row.dingtalk_user_id === 'string' ? row.dingtalk_user_id.trim() : ''
+      const isActive = row.local_user_active === true
+      if (!localUserId || !isActive || !dingtalkUserId || recipientMap.has(localUserId)) continue
+      recipientMap.set(localUserId, { localUserId, dingtalkUserId })
+    }
+
+    const missingUserIds = userIds.filter((userId) => !recipientMap.has(userId))
+    if (missingUserIds.length > 0) {
+      await Promise.all(missingUserIds.map((userId) => recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
+        localUserId: userId,
+        sourceType: 'automation',
+        subject: renderedTitle,
+        content: bodyWithLinks,
+        success: false,
+        errorMessage: 'DingTalk account is not linked or user is inactive',
+        automationRuleId: context.ruleId,
+        recordId: context.recordId,
+        initiatedBy: context.actorId ?? null,
+      })))
+      return {
+        actionType: 'send_dingtalk_person_message',
+        status: 'failed',
+        error: `DingTalk account not linked for users: ${missingUserIds.join(', ')}`,
+      }
+    }
+
+    const resolvedRecipients = userIds
+      .map((userId) => recipientMap.get(userId))
+      .filter((entry): entry is { localUserId: string; dingtalkUserId: string } => Boolean(entry))
+    const batches = chunkItems(resolvedRecipients, DINGTALK_PERSON_BATCH_SIZE)
+
+    try {
+      const messageConfig = readDingTalkMessageConfig()
+      const accessToken = await fetchDingTalkAppAccessToken(messageConfig, { fetchFn: this.deps.fetchFn })
+      let responseCount = 0
+
+      for (const batch of batches) {
+        const result = await sendDingTalkWorkNotification(
+          accessToken,
+          {
+            userIds: batch.map((recipient) => recipient.dingtalkUserId),
+            title: renderedTitle,
+            content: bodyWithLinks,
+          },
+          messageConfig,
+          { fetchFn: this.deps.fetchFn },
+        )
+        const responseBody = stringifyResponseBody(result.raw)
+        responseCount += 1
+
+        await Promise.all(batch.map((recipient) => recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
+          localUserId: recipient.localUserId,
+          dingtalkUserId: recipient.dingtalkUserId,
+          sourceType: 'automation',
+          subject: renderedTitle,
+          content: bodyWithLinks,
+          success: true,
+          httpStatus: 200,
+          responseBody,
+          automationRuleId: context.ruleId,
+          recordId: context.recordId,
+          initiatedBy: context.actorId ?? null,
+        })))
+      }
+
+      return {
+        actionType: 'send_dingtalk_person_message',
+        status: 'success',
+        output: {
+          notifiedUsers: resolvedRecipients.length,
+          batchCount: batches.length,
+          linkCount: linkLines.length,
+          responseCount,
+        },
+      }
+    } catch (error) {
+      const httpStatus = error instanceof DingTalkRequestError ? error.statusCode : error instanceof DingTalkBusinessError ? 200 : null
+      const responseBody = error instanceof DingTalkRequestError
+        ? stringifyResponseBody(error.responseBody)
+        : error instanceof DingTalkBusinessError
+          ? stringifyResponseBody(error.responseBody)
+          : null
+      const errorMessage = error instanceof Error ? error.message : String(error)
+
+      await Promise.all(resolvedRecipients.map((recipient) => recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
+        localUserId: recipient.localUserId,
+        dingtalkUserId: recipient.dingtalkUserId,
+        sourceType: 'automation',
+        subject: renderedTitle,
+        content: bodyWithLinks,
+        success: false,
+        httpStatus,
+        responseBody,
+        errorMessage,
+        automationRuleId: context.ruleId,
+        recordId: context.recordId,
+        initiatedBy: context.actorId ?? null,
+      })))
+
+      return {
+        actionType: 'send_dingtalk_person_message',
+        status: 'failed',
+        error: errorMessage,
+      }
     }
   }
 

--- a/packages/core-backend/src/multitable/dingtalk-person-delivery-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-person-delivery-service.ts
@@ -1,0 +1,102 @@
+export interface DingTalkPersonDelivery {
+  id: string
+  localUserId: string
+  dingtalkUserId?: string
+  sourceType: string
+  subject: string
+  content: string
+  success: boolean
+  httpStatus?: number
+  responseBody?: string
+  errorMessage?: string
+  automationRuleId?: string
+  recordId?: string
+  initiatedBy?: string
+  createdAt: string
+  deliveredAt?: string
+  localUserLabel?: string
+  localUserSubtitle?: string
+  localUserIsActive: boolean
+}
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+type DeliveryRow = {
+  id: string
+  local_user_id: string
+  dingtalk_user_id: string | null
+  source_type: string
+  subject: string
+  content: string
+  success: boolean
+  http_status: number | null
+  response_body: string | null
+  error_message: string | null
+  automation_rule_id: string | null
+  record_id: string | null
+  initiated_by: string | null
+  created_at: string
+  delivered_at: string | null
+  local_user_name: string | null
+  local_user_email: string | null
+  local_user_is_active: boolean | null
+}
+
+function mapDeliveryRow(row: DeliveryRow): DingTalkPersonDelivery {
+  return {
+    id: row.id,
+    localUserId: row.local_user_id,
+    dingtalkUserId: row.dingtalk_user_id ?? undefined,
+    sourceType: row.source_type,
+    subject: row.subject,
+    content: row.content,
+    success: row.success,
+    httpStatus: row.http_status ?? undefined,
+    responseBody: row.response_body ?? undefined,
+    errorMessage: row.error_message ?? undefined,
+    automationRuleId: row.automation_rule_id ?? undefined,
+    recordId: row.record_id ?? undefined,
+    initiatedBy: row.initiated_by ?? undefined,
+    createdAt: row.created_at,
+    deliveredAt: row.delivered_at ?? undefined,
+    localUserLabel: row.local_user_name ?? undefined,
+    localUserSubtitle: row.local_user_email ?? undefined,
+    localUserIsActive: row.local_user_is_active ?? false,
+  }
+}
+
+export async function listAutomationDingTalkPersonDeliveries(
+  queryFn: QueryFn,
+  ruleId: string,
+  limit = 50,
+): Promise<DingTalkPersonDelivery[]> {
+  const normalizedLimit = Math.min(Math.max(limit, 1), 200)
+  const result = await queryFn(
+    `SELECT d.id,
+            d.local_user_id,
+            d.dingtalk_user_id,
+            d.source_type,
+            d.subject,
+            d.content,
+            d.success,
+            d.http_status,
+            d.response_body,
+            d.error_message,
+            d.automation_rule_id,
+            d.record_id,
+            d.initiated_by,
+            d.created_at,
+            d.delivered_at,
+            u.name AS local_user_name,
+            u.email AS local_user_email,
+            u.is_active AS local_user_is_active
+       FROM dingtalk_person_deliveries d
+       LEFT JOIN users u ON u.id = d.local_user_id
+      WHERE d.automation_rule_id = $1
+      ORDER BY d.created_at DESC
+      LIMIT $2`,
+    [ruleId, normalizedLimit],
+  )
+
+  return (result.rows as DeliveryRow[]).map(mapDeliveryRow)
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7626,7 +7626,7 @@ export function univerMetaRouter(): Router {
       const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
 
       const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
-      const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'send_dingtalk_group_message', 'lock_record'])
+      const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'send_dingtalk_group_message', 'send_dingtalk_person_message', 'lock_record'])
       if (!validTriggers.has(triggerType)) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid trigger_type: ${triggerType}` } })
       }
@@ -7702,7 +7702,7 @@ export function univerMetaRouter(): Router {
         updates.trigger_config = JSON.stringify(body.triggerConfig)
       }
       if (typeof body?.actionType === 'string') {
-        const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'send_dingtalk_group_message', 'lock_record'])
+        const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'send_dingtalk_group_message', 'send_dingtalk_person_message', 'lock_record'])
         if (!validActions.has(body.actionType)) {
           return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid action_type: ${body.actionType}` } })
         }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -32,6 +32,7 @@ import { validateRecord, getDefaultValidationRules } from '../multitable/field-v
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import { getAutomationServiceInstance } from '../multitable/automation-service'
+import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
   publishMultitableSheetRealtime as publishMultitableSheetRealtimeShared,
   setRealtimeCacheInvalidator,
@@ -7778,6 +7779,37 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] delete automation rule failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete automation rule' } })
+    }
+  })
+
+  router.get('/sheets/:sheetId/automations/:ruleId/dingtalk-person-deliveries', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId : ''
+    const ruleId = typeof req.params.ruleId === 'string' ? req.params.ruleId : ''
+    if (!sheetId || !ruleId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and ruleId are required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageAutomation) return sendForbidden(res)
+      const automationService = getAutomationServiceInstance()
+      if (!automationService) {
+        return res.status(503).json({ ok: false, error: { code: 'SERVICE_UNAVAILABLE', message: 'Automation service is not available' } })
+      }
+
+      const rule = await automationService.getRule(ruleId)
+      if (!rule || rule.sheet_id !== sheetId) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
+      }
+
+      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
+      const deliveries = await listAutomationDingTalkPersonDeliveries(pool.query.bind(pool), ruleId, limit)
+      return res.json({ ok: true, data: { deliveries } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list dingtalk person deliveries failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list DingTalk person deliveries' } })
     }
   })
 

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -305,6 +305,9 @@ describe('AutomationExecutor', () => {
   afterEach(() => {
     delete process.env.APP_BASE_URL
     delete process.env.PUBLIC_APP_URL
+    delete process.env.DINGTALK_APP_KEY
+    delete process.env.DINGTALK_APP_SECRET
+    delete process.env.DINGTALK_AGENT_ID
   })
 
   it('executes update_record action successfully', async () => {
@@ -551,6 +554,95 @@ describe('AutomationExecutor', () => {
     expect(result.status).toBe('failed')
     expect(result.steps[0].status).toBe('failed')
     expect(result.steps[0].error).toContain('destination not found')
+  })
+
+  it('executes send_dingtalk_person_message action successfully', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+    process.env.APP_BASE_URL = 'https://app.example.com'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'view_form', sheet_id: 'sheet_1', config: { publicForm: { enabled: true, publicToken: 'public-token' } } }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'view_grid' }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' },
+          { local_user_id: 'user_2', local_user_active: true, dingtalk_user_id: 'dt-user-2' },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1', 'user_2'],
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+          publicFormViewId: 'view_form',
+          internalViewId: 'view_grid',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(result.steps[0].actionType).toBe('send_dingtalk_person_message')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    const [, sendInit] = fetchFn.mock.calls[1] as [string, RequestInit]
+    const payload = JSON.parse(sendInit.body as string)
+    expect(payload.userid_list).toBe('dt-user-1,dt-user-2')
+    expect(payload.msg.markdown.text).toContain('/multitable/public-form/sheet_1/view_form?publicToken=public-token')
+    expect(payload.msg.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
+    const insertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
+    expect(insertCalls).toHaveLength(2)
+  })
+
+  it('fails send_dingtalk_person_message when a user has no linked DingTalk account', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' }],
+      })
+      .mockResolvedValue({ rows: [] })
+    deps = createMockDeps({ queryFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1', 'user_2'],
+          titleTemplate: 'Title',
+          bodyTemplate: 'Body',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, { recordId: 'r1', sheetId: 'sheet_1', actorId: 'user_1' })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('user_2')
+    const insertCall = queryFn.mock.calls.find((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
+    expect(insertCall?.[1]?.[1]).toBe('user_2')
   })
 
   it('fails send_notification with no userIds', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-person-delivery-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-person-delivery-service.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import { listAutomationDingTalkPersonDeliveries } from '../../src/multitable/dingtalk-person-delivery-service'
+
+describe('dingtalk person delivery service', () => {
+  it('lists and maps automation-scoped deliveries', async () => {
+    const queryFn = vi.fn(async () => ({
+      rows: [
+        {
+          id: 'dpd_1',
+          local_user_id: 'user_1',
+          dingtalk_user_id: 'dt_1',
+          source_type: 'automation',
+          subject: 'Ticket rec_1 ready',
+          content: 'Please review the latest changes.',
+          success: true,
+          http_status: 200,
+          response_body: '{"errcode":0}',
+          error_message: null,
+          automation_rule_id: 'rule_1',
+          record_id: 'rec_1',
+          initiated_by: 'user_2',
+          created_at: '2026-04-19T12:00:00.000Z',
+          delivered_at: '2026-04-19T12:00:01.000Z',
+          local_user_name: 'Lin Lan',
+          local_user_email: 'lin@example.com',
+          local_user_is_active: true,
+        },
+      ],
+    }))
+
+    const deliveries = await listAutomationDingTalkPersonDeliveries(queryFn, 'rule_1', 500)
+
+    expect(queryFn).toHaveBeenCalledWith(expect.stringContaining('FROM dingtalk_person_deliveries d'), ['rule_1', 200])
+    expect(deliveries).toEqual([
+      {
+        id: 'dpd_1',
+        localUserId: 'user_1',
+        dingtalkUserId: 'dt_1',
+        sourceType: 'automation',
+        subject: 'Ticket rec_1 ready',
+        content: 'Please review the latest changes.',
+        success: true,
+        httpStatus: 200,
+        responseBody: '{"errcode":0}',
+        errorMessage: undefined,
+        automationRuleId: 'rule_1',
+        recordId: 'rec_1',
+        initiatedBy: 'user_2',
+        createdAt: '2026-04-19T12:00:00.000Z',
+        deliveredAt: '2026-04-19T12:00:01.000Z',
+        localUserLabel: 'Lin Lan',
+        localUserSubtitle: 'lin@example.com',
+        localUserIsActive: true,
+      },
+    ])
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  readDingTalkMessageConfig,
+  sendDingTalkWorkNotification,
+} from '../../src/integrations/dingtalk/client'
+
+describe('dingtalk work notification client', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('requires an agent id when reading work notification config', () => {
+    vi.stubEnv('DINGTALK_APP_KEY', 'dt-app-key')
+    vi.stubEnv('DINGTALK_APP_SECRET', 'dt-app-secret')
+
+    expect(() => readDingTalkMessageConfig()).toThrow('DINGTALK_AGENT_ID or DINGTALK_NOTIFY_AGENT_ID is not configured')
+  })
+
+  it('sends work notifications to DingTalk user ids', async () => {
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({
+        errcode: 0,
+        errmsg: 'ok',
+        task_id: 778899,
+        request_id: 'req_1',
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await sendDingTalkWorkNotification(
+      'app-access-token',
+      {
+        userIds: ['dt-user-1', 'dt-user-2'],
+        title: 'Ticket rec_1 ready',
+        content: 'Please review the latest changes.',
+      },
+      {
+        appKey: 'dt-app-key',
+        appSecret: 'dt-app-secret',
+        agentId: '123456789',
+      },
+    )
+
+    expect(result.taskId).toBe('778899')
+    expect(result.requestId).toBe('req_1')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/topapi/message/corpconversation/asyncsend_v2?access_token=app-access-token')
+    const payload = JSON.parse(String(init.body))
+    expect(payload.agent_id).toBe(123456789)
+    expect(payload.userid_list).toBe('dt-user-1,dt-user-2')
+    expect(payload.msg.markdown.title).toBe('Ticket rec_1 ready')
+    expect(payload.msg.markdown.text).toContain('Please review the latest changes.')
+  })
+})


### PR DESCRIPTION
## What changed

This PR adds the first standard multitable automation action for sending DingTalk messages directly to linked users.

- adds `send_dingtalk_person_message` as a first-class automation action
- resolves local platform users to linked DingTalk accounts at runtime
- supports optional public form and internal record deep links in the same message
- persists recipient-level delivery history in `dingtalk_person_deliveries`
- adds frontend authoring support in both automation editors

## Backend

- `packages/core-backend/src/multitable/automation-actions.ts`
- `packages/core-backend/src/multitable/automation-executor.ts`
- `packages/core-backend/src/integrations/dingtalk/client.ts`
- `packages/core-backend/src/routes/univer-meta.ts`
- `packages/core-backend/src/db/types.ts`
- `packages/core-backend/src/db/migrations/zzzz20260419213000_add_dingtalk_person_message_automation_action.ts`
- `packages/core-backend/src/db/migrations/zzzz20260419214000_create_dingtalk_person_deliveries.ts`

## Frontend

- `apps/web/src/multitable/types.ts`
- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
- `apps/web/src/multitable/components/MetaAutomationManager.vue`

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-work-notification.test.ts tests/unit/automation-v1.test.ts --watch=false
pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
```

Results:

- backend: `99 passed`
- frontend: `19 passed`
- backend build: passed
- web build: passed

## Notes

- Added `DINGTALK_AGENT_ID` to `.env.example`
- Added development and verification notes:
  - `docs/development/dingtalk-person-notify-automation-development-20260419.md`
  - `docs/development/dingtalk-person-notify-automation-verification-20260419.md`
