### PR TITLE
fix(db): load source sql migrations during dist deploys

### DIFF
--- a/docs/development/dingtalk-notify-deploy-development-20260419.md
+++ b/docs/development/dingtalk-notify-deploy-development-20260419.md
@@ -1,0 +1,67 @@
+# DingTalk Notify Deploy Development - 2026-04-19
+
+## Summary
+
+Deployed the DingTalk notification features from `#919` and `#920` to the remote host, then fixed a migration-provider gap that blocked production migrations from recognizing SQL files under `packages/core-backend/src/db/migrations`.
+
+## Problem Found During Deploy
+
+The remote database already contained later schema state, but `kysely_migration` was missing a block of historical entries. After ledger backfill, `migrate.js` still failed because:
+
+- `20250925_create_view_tables.sql`
+- `20250926_create_audit_tables.sql`
+
+were present in the image source tree at `/app/packages/core-backend/src/db/migrations`, but the runtime migration provider only searched:
+
+- `dist/src/db/migrations`
+- `dist/migrations`
+- `packages/core-backend/migrations`
+
+That made Kysely treat the existing ledger rows as corrupted.
+
+## Code Changes
+
+Updated `packages/core-backend/src/db/migration-provider.ts` to treat `../../../src/db/migrations` as a SQL-only candidate folder when running from `dist/src/db`.
+
+Key constraint:
+
+- the source-tree folder is added only for raw `.sql` discovery
+- it is not passed through `FileMigrationProvider`, so runtime does not try to import source `.ts` migrations
+
+Updated `packages/core-backend/tests/unit/migration-provider.test.ts` to cover the dist-runtime case where:
+
+- code migrations come from `dist/src/db/migrations`
+- SQL migrations come from `src/db/migrations`
+- legacy SQL migrations come from `packages/core-backend/migrations`
+
+## Remote Deployment Work
+
+1. Confirmed the remote host was already running the merged DingTalk notify mainline image from `453d16341...`.
+2. Compared local migration stems to remote `kysely_migration`.
+3. Backfilled 33 historical replay-debt migration names into `kysely_migration` without replaying old SQL.
+4. Built and pushed amd64 images from hotfix commit `8060c596970b59b0e2b6360297af1332b63db7f6`:
+   - `ghcr.io/zensgit/metasheet2-backend:8060c596970b59b0e2b6360297af1332b63db7f6`
+   - `ghcr.io/zensgit/metasheet2-web:8060c596970b59b0e2b6360297af1332b63db7f6`
+5. Updated remote `.env`:
+   - `IMAGE_TAG=8060c596970b59b0e2b6360297af1332b63db7f6`
+   - removed stale host-side `MIGRATION_EXCLUDE`
+6. Recreated `backend` and `web`.
+7. Ran `node packages/core-backend/dist/src/db/migrate.js`.
+8. Verified the five DingTalk notification migrations executed successfully.
+
+## Scope Deployed
+
+This deploy includes:
+
+- DingTalk group destination CRUD
+- `send_dingtalk_group_message`
+- DingTalk group delivery history
+- `send_dingtalk_person_message`
+- person recipient picker / delivery history support
+- migration-provider hotfix for source SQL migrations during dist runtime
+
+## Notes
+
+- The remote repo checkout on the host is still on the previously merged main commit `453d16341...`.
+- The running containers are now on hotfix image tag `8060c596970b59b0e2b6360297af1332b63db7f6`.
+- A follow-up PR is required so `main` matches the deployed runtime again.

--- a/docs/development/dingtalk-notify-deploy-verification-20260419.md
+++ b/docs/development/dingtalk-notify-deploy-verification-20260419.md
@@ -1,0 +1,131 @@
+# DingTalk Notify Deploy Verification - 2026-04-19
+
+## Local Validation
+
+Executed in `.worktrees/dingtalk-notify-deploy-20260419`:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/migrations.rollback.test.ts tests/unit/db.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+node -e "const {createCoreBackendMigrationProvider}=require('./packages/core-backend/dist/src/db/migration-provider.js'); (async()=>{ const runtimeDir=require('path').resolve('./packages/core-backend/dist/src/db'); const p=createCoreBackendMigrationProvider({runtimeDir}); const migrations=await p.getMigrations(); console.log('has20250925', Object.prototype.hasOwnProperty.call(migrations,'20250925_create_view_tables')); console.log('has20250926', Object.prototype.hasOwnProperty.call(migrations,'20250926_create_audit_tables')); })()"
+```
+
+Results:
+
+- unit tests: `21 passed`
+- backend build: `passed`
+- dist-runtime provider self-check:
+  - `has20250925 true`
+  - `has20250926 true`
+
+## Image Validation
+
+Built and pushed linux/amd64 manifests:
+
+```bash
+docker buildx build --platform linux/amd64 -f Dockerfile.backend -t ghcr.io/zensgit/metasheet2-backend:8060c596970b59b0e2b6360297af1332b63db7f6 --push <clean-exported-context>
+docker buildx build --platform linux/amd64 -f Dockerfile.frontend -t ghcr.io/zensgit/metasheet2-web:8060c596970b59b0e2b6360297af1332b63db7f6 --push <clean-exported-context>
+docker buildx imagetools inspect ghcr.io/zensgit/metasheet2-backend:8060c596970b59b0e2b6360297af1332b63db7f6
+docker buildx imagetools inspect ghcr.io/zensgit/metasheet2-web:8060c596970b59b0e2b6360297af1332b63db7f6
+```
+
+Results:
+
+- backend manifest present for `linux/amd64`
+- web manifest present for `linux/amd64`
+
+## Remote Migration Ledger Backfill
+
+Before backfill:
+
+- `kysely_migration` count: `103`
+
+Inserted 33 historical names into `kysely_migration` to reflect already-superseded schema debt and unblock current deploy.
+
+After backfill:
+
+- `kysely_migration` count: `136`
+
+## Remote Deployment
+
+Executed on `mainuser@142.171.239.56`:
+
+```bash
+docker compose -f docker-compose.app.yml pull backend web
+docker compose -f docker-compose.app.yml up -d --force-recreate backend web
+docker compose -f docker-compose.app.yml exec -T backend node packages/core-backend/dist/src/db/migrate.js
+```
+
+Migration results:
+
+- `zzzz20260419183000_create_dingtalk_group_destinations`
+- `zzzz20260419193000_add_dingtalk_group_message_automation_action`
+- `zzzz20260419203000_create_dingtalk_group_deliveries`
+- `zzzz20260419213000_add_dingtalk_person_message_automation_action`
+- `zzzz20260419214000_create_dingtalk_person_deliveries`
+
+All five executed successfully.
+
+## Remote Runtime Verification
+
+Running containers:
+
+- backend image: `ghcr.io/zensgit/metasheet2-backend:8060c596970b59b0e2b6360297af1332b63db7f6`
+- web image: `ghcr.io/zensgit/metasheet2-web:8060c596970b59b0e2b6360297af1332b63db7f6`
+
+Schema checks:
+
+```sql
+select table_name
+from information_schema.tables
+where table_schema='public'
+  and table_name in (
+    'dingtalk_group_destinations',
+    'dingtalk_group_deliveries',
+    'dingtalk_person_deliveries'
+  )
+order by table_name;
+```
+
+Result:
+
+- `dingtalk_group_destinations`
+- `dingtalk_group_deliveries`
+- `dingtalk_person_deliveries`
+
+Automation action registration check:
+
+```bash
+docker compose -f docker-compose.app.yml exec -T backend \
+  node -e "const mod=require('/app/packages/core-backend/dist/src/multitable/automation-actions.js'); console.log(JSON.stringify(mod.ALL_ACTION_TYPES));"
+```
+
+Result includes:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+HTTP sanity checks:
+
+```bash
+curl -s -o /dev/null -w 'web:%{http_code}\n' http://127.0.0.1:8081/
+curl -s -o /dev/null -w 'health:%{http_code}\n' http://127.0.0.1:8900/health
+```
+
+Results:
+
+- `web:200`
+- `health:200`
+
+`/health` payload included:
+
+- `status=ok`
+- `plugins=12`
+- `dbPool.total=1`
+
+## Deploy Content
+
+- Remote deploy performed: `yes`
+- Database migrations executed: `yes`
+- Runtime hotfix ahead of main: `yes`

--- a/packages/core-backend/src/db/migration-provider.ts
+++ b/packages/core-backend/src/db/migration-provider.ts
@@ -30,12 +30,24 @@ function isMissingDirectoryError(error: unknown): boolean {
   )
 }
 
-function getMigrationFolderCandidates(
+function getProviderFolderCandidates(
   runtimeDir: string,
   pathImpl: NodePathLike
 ): string[] {
   return dedupe([
     pathImpl.join(runtimeDir, 'migrations'),
+    pathImpl.resolve(runtimeDir, '../../migrations'),
+    pathImpl.resolve(runtimeDir, '../../../migrations'),
+  ])
+}
+
+function getSqlFolderCandidates(
+  runtimeDir: string,
+  pathImpl: NodePathLike
+): string[] {
+  return dedupe([
+    pathImpl.join(runtimeDir, 'migrations'),
+    pathImpl.resolve(runtimeDir, '../../../src/db/migrations'),
     pathImpl.resolve(runtimeDir, '../../migrations'),
     pathImpl.resolve(runtimeDir, '../../../migrations'),
   ])
@@ -127,7 +139,8 @@ export function createCoreBackendMigrationProvider(
   const fsImpl = options.fsImpl ?? fs
   const pathImpl = options.pathImpl ?? path
   const runtimeDir = options.runtimeDir ?? __dirname
-  const candidateFolders = getMigrationFolderCandidates(runtimeDir, pathImpl)
+  const providerFolders = getProviderFolderCandidates(runtimeDir, pathImpl)
+  const sqlFolders = getSqlFolderCandidates(runtimeDir, pathImpl)
   const excludedNames = getExcludedNames(
     options.excludedNames ??
       (process.env.MIGRATION_EXCLUDE || '')
@@ -140,7 +153,7 @@ export function createCoreBackendMigrationProvider(
     async getMigrations() {
       const migrations: Record<string, Migration> = {}
 
-      for (const folder of candidateFolders) {
+      for (const folder of providerFolders) {
         await addProviderMigrations(
           migrations,
           new FileMigrationProvider({
@@ -157,7 +170,7 @@ export function createCoreBackendMigrationProvider(
         })
       }
 
-      for (const folder of candidateFolders) {
+      for (const folder of sqlFolders) {
         await addSqlFileMigrations(migrations, folder, fsImpl, pathImpl)
       }
 

--- a/packages/core-backend/tests/unit/migration-provider.test.ts
+++ b/packages/core-backend/tests/unit/migration-provider.test.ts
@@ -62,11 +62,16 @@ describe('createCoreBackendMigrationProvider', () => {
     const projectRoot = await createTempProjectRoot()
     const runtimeDir = path.join(projectRoot, 'dist/src/db')
     const distMigrationsDir = path.join(runtimeDir, 'migrations')
+    const sourceSqlDir = path.join(projectRoot, 'src/db/migrations')
     const legacySqlDir = path.join(projectRoot, 'migrations')
 
     await writeFile(
       path.join(distMigrationsDir, '20260101000002_code.mjs'),
       'export async function up() {}\n'
+    )
+    await writeFile(
+      path.join(sourceSqlDir, '20250925_create_view_tables.sql'),
+      'create table if not exists views (id uuid primary key);'
     )
     await writeFile(
       path.join(legacySqlDir, '056_add_users_must_change_password.sql'),
@@ -78,6 +83,7 @@ describe('createCoreBackendMigrationProvider', () => {
 
     expect(Object.keys(migrations).sort()).toEqual([
       '056_add_users_must_change_password',
+      '20250925_create_view_tables',
       '20260101000002_code',
     ])
   })


### PR DESCRIPTION
## What changed

- load SQL migrations from `packages/core-backend/src/db/migrations` when runtime executes from `dist/src/db`
- keep that source-tree folder SQL-only so runtime does not try to import source `.ts` migrations
- add focused migration-provider coverage for the dist-runtime + source-SQL case
- record the DingTalk notify remote rollout and verification

## Why

The DingTalk notify rollout exposed a real deploy bug: production images contained
`20250925_create_view_tables.sql` and `20250926_create_audit_tables.sql` in the source tree, but the migration provider only searched `dist/...` and `packages/core-backend/migrations`. That made `migrate.js` treat valid ledger rows as corrupted.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/migrations.rollback.test.ts tests/unit/db.test.ts --watch=false
pnpm --filter @metasheet/core-backend build
```

Remote rollout verification is captured in:
- `docs/development/dingtalk-notify-deploy-development-20260419.md`
- `docs/development/dingtalk-notify-deploy-verification-20260419.md`
