### PR TITLE
feat(dingtalk): add rule-level group delivery viewer

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1165,6 +1165,14 @@ export class MultitableApiClient {
     return Array.isArray(data?.deliveries) ? data.deliveries : []
   }
 
+  async getAutomationDingTalkGroupDeliveries(sheetId: string, ruleId: string, limit?: number): Promise<DingTalkGroupDelivery[]> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}/dingtalk-group-deliveries${qs({ limit })}`,
+    )
+    const data = await parseJson<{ deliveries: DingTalkGroupDelivery[] }>(res)
+    return Array.isArray(data?.deliveries) ? data.deliveries : []
+  }
+
   // --- Charts ---
   async listCharts(sheetId: string): Promise<ChartConfig[]> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts`)

--- a/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
@@ -1,0 +1,248 @@
+<template>
+  <div v-if="visible" class="meta-group-delivery__overlay" @click.self="$emit('close')">
+    <div class="meta-group-delivery">
+      <div class="meta-group-delivery__header">
+        <h4 class="meta-group-delivery__title">DingTalk Group Deliveries</h4>
+        <button class="meta-group-delivery__close" type="button" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="meta-group-delivery__body">
+        <div class="meta-group-delivery__toolbar">
+          <select v-model="statusFilter" class="meta-group-delivery__select" data-field="statusFilter">
+            <option value="">All statuses</option>
+            <option value="success">Success</option>
+            <option value="failed">Failed</option>
+          </select>
+          <button class="meta-group-delivery__btn" type="button" data-action="refresh" @click="loadData">Refresh</button>
+        </div>
+
+        <div v-if="loading" class="meta-group-delivery__empty">Loading deliveries...</div>
+        <div v-else-if="filteredDeliveries.length === 0" class="meta-group-delivery__empty" data-empty="true">
+          No DingTalk group deliveries found.
+        </div>
+
+        <div
+          v-for="delivery in filteredDeliveries"
+          :key="delivery.id"
+          class="meta-group-delivery__item"
+          :data-group-delivery-id="delivery.id"
+        >
+          <div class="meta-group-delivery__summary">
+            <span class="meta-group-delivery__destination">{{ delivery.destinationName || delivery.destinationId }}</span>
+            <span
+              class="meta-group-delivery__badge"
+              :class="delivery.success ? 'meta-group-delivery__badge--success' : 'meta-group-delivery__badge--failed'"
+              :data-status="delivery.success ? 'success' : 'failed'"
+            >
+              {{ delivery.success ? 'success' : 'failed' }}
+            </span>
+            <span class="meta-group-delivery__time">{{ formatTime(delivery.createdAt) }}</span>
+          </div>
+          <div class="meta-group-delivery__subject">{{ delivery.subject }}</div>
+          <div v-if="!delivery.success && delivery.errorMessage" class="meta-group-delivery__error">{{ delivery.errorMessage }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { DingTalkGroupDelivery } from '../types'
+import type { MultitableApiClient } from '../api/client'
+
+const props = defineProps<{
+  visible: boolean
+  sheetId: string
+  ruleId: string
+  client?: MultitableApiClient
+}>()
+
+defineEmits<{
+  (e: 'close'): void
+}>()
+
+const loading = ref(false)
+const deliveries = ref<DingTalkGroupDelivery[]>([])
+const statusFilter = ref('')
+
+const filteredDeliveries = computed(() => {
+  if (!statusFilter.value) return deliveries.value
+  const expected = statusFilter.value === 'success'
+  return deliveries.value.filter((delivery) => delivery.success === expected)
+})
+
+function formatTime(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return ts
+  }
+}
+
+async function loadData() {
+  if (!props.client || !props.sheetId || !props.ruleId) return
+  loading.value = true
+  try {
+    deliveries.value = await props.client.getAutomationDingTalkGroupDeliveries(props.sheetId, props.ruleId, 50)
+  } catch {
+    deliveries.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (visible) {
+      statusFilter.value = ''
+      void loadData()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.meta-group-delivery__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.meta-group-delivery {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  width: 620px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-group-delivery__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.meta-group-delivery__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.meta-group-delivery__close {
+  border: none;
+  background: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #64748b;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.meta-group-delivery__body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.meta-group-delivery__toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.meta-group-delivery__select {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.meta-group-delivery__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 14px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.meta-group-delivery__empty {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.meta-group-delivery__item {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-group-delivery__summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.meta-group-delivery__destination {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.meta-group-delivery__badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.meta-group-delivery__badge--success {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.meta-group-delivery__badge--failed {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.meta-group-delivery__time {
+  margin-left: auto;
+  color: #64748b;
+}
+
+.meta-group-delivery__subject {
+  font-size: 13px;
+  color: #334155;
+}
+
+.meta-group-delivery__error {
+  color: #dc2626;
+  font-size: 12px;
+}
+</style>

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -231,6 +231,15 @@
             <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openRuleEditor(rule)">Edit</button>
             <button class="meta-automation__btn" type="button" data-automation-logs="true" @click="openLogViewer(rule)">View Logs</button>
             <button
+              v-if="rule.actionType === 'send_dingtalk_group_message'"
+              class="meta-automation__btn"
+              type="button"
+              :data-automation-group-deliveries="rule.id"
+              @click="openGroupDeliveryViewer(rule)"
+            >
+              View Deliveries
+            </button>
+            <button
               v-if="rule.actionType === 'send_dingtalk_person_message'"
               class="meta-automation__btn"
               type="button"
@@ -269,6 +278,13 @@
       :client="client"
       @close="showPersonDeliveryViewer = false"
     />
+    <MetaAutomationGroupDeliveryViewer
+      :visible="showGroupDeliveryViewer"
+      :sheet-id="sheetId"
+      :rule-id="groupDeliveryViewerRuleId"
+      :client="client"
+      @close="showGroupDeliveryViewer = false"
+    />
   </div>
 </template>
 
@@ -287,6 +303,7 @@ import { useMultitableAutomations } from '../composables/useMultitableAutomation
 import type { MultitableApiClient } from '../api/client'
 import MetaAutomationRuleEditor from './MetaAutomationRuleEditor.vue'
 import MetaAutomationLogViewer from './MetaAutomationLogViewer.vue'
+import MetaAutomationGroupDeliveryViewer from './MetaAutomationGroupDeliveryViewer.vue'
 import MetaAutomationPersonDeliveryViewer from './MetaAutomationPersonDeliveryViewer.vue'
 
 const props = defineProps<{
@@ -442,6 +459,8 @@ const showRuleEditor = ref(false)
 const editingRule = ref<AutomationRule | null>(null)
 const showLogViewer = ref(false)
 const logViewerRuleId = ref('')
+const showGroupDeliveryViewer = ref(false)
+const groupDeliveryViewerRuleId = ref('')
 const showPersonDeliveryViewer = ref(false)
 const personDeliveryViewerRuleId = ref('')
 const ruleStats = ref<Record<string, AutomationStats>>({})
@@ -456,6 +475,11 @@ function openRuleEditor(rule?: AutomationRule) {
 function openLogViewer(rule: AutomationRule) {
   logViewerRuleId.value = rule.id
   showLogViewer.value = true
+}
+
+function openGroupDeliveryViewer(rule: AutomationRule) {
+  groupDeliveryViewerRuleId.value = rule.id
+  showGroupDeliveryViewer.value = true
 }
 
 function openPersonDeliveryViewer(rule: AutomationRule) {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -807,6 +807,7 @@ export interface DingTalkGroupDestinationInput {
 export interface DingTalkGroupDelivery {
   id: string
   destinationId: string
+  destinationName?: string
   sourceType: 'manual_test' | 'automation'
   subject: string
   content: string

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -6,7 +6,7 @@ function flushPromises() {
 }
 import MetaAutomationManager from '../src/multitable/components/MetaAutomationManager.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
-import type { AutomationRule, DingTalkPersonDelivery } from '../src/multitable/types'
+import type { AutomationRule, DingTalkGroupDelivery, DingTalkPersonDelivery } from '../src/multitable/types'
 
 function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
   return {
@@ -40,6 +40,18 @@ function mockClient(rules: AutomationRule[] = []) {
       localUserIsActive: true,
     },
   ]
+  const groupDeliveries: DingTalkGroupDelivery[] = [
+    {
+      id: 'dgd_1',
+      destinationId: 'dt_1',
+      destinationName: 'Ops Group',
+      sourceType: 'automation',
+      subject: 'Ticket rec_1 pending',
+      content: 'Please process the latest update.',
+      success: true,
+      createdAt: '2026-04-19T12:00:00.000Z',
+    },
+  ]
 
   const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
     const method = init?.method ?? 'GET'
@@ -56,6 +68,9 @@ function mockClient(rules: AutomationRule[] = []) {
       })
     }
     if (method === 'GET' && url.includes('/automations')) {
+      if (url.includes('/dingtalk-group-deliveries')) {
+        return ok({ deliveries: groupDeliveries })
+      }
       if (url.includes('/dingtalk-person-deliveries')) {
         return ok({ deliveries: personDeliveries })
       }
@@ -431,5 +446,30 @@ describe('MetaAutomationManager', () => {
     const delivery = document.querySelector('[data-person-delivery-id="dpd_1"]')
     expect(delivery?.textContent).toContain('Lin Lan')
     expect(delivery?.textContent).toContain('Ticket rec_1 ready')
+  })
+
+  it('opens DingTalk group delivery viewer for group message rules', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        name: 'DingTalk group notify',
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deliveriesBtn = container.querySelector('[data-automation-group-deliveries="rule_1"]') as HTMLButtonElement
+    expect(deliveriesBtn).toBeTruthy()
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const delivery = document.querySelector('[data-group-delivery-id="dgd_1"]')
+    expect(delivery?.textContent).toContain('Ops Group')
+    expect(delivery?.textContent).toContain('Ticket rec_1 pending')
   })
 })

--- a/docs/development/dingtalk-group-rule-deliveries-development-20260420.md
+++ b/docs/development/dingtalk-group-rule-deliveries-development-20260420.md
@@ -1,0 +1,58 @@
+# DingTalk Group Rule Deliveries Development
+
+## Date
+- 2026-04-20
+
+## Goal
+- Add rule-level DingTalk group delivery visibility to multitable automation management so `send_dingtalk_group_message` matches the existing person-delivery governance path.
+
+## Scope
+- Backend automation-scoped group delivery query service and route
+- Frontend API/client/types for automation-scoped group deliveries
+- Automation Manager group delivery viewer and button wiring
+- Focused frontend/backend regression coverage
+
+## Implementation
+
+### Backend
+- Added `packages/core-backend/src/multitable/dingtalk-group-delivery-service.ts`
+  - `listAutomationDingTalkGroupDeliveries(queryFn, ruleId, limit)`
+  - joins `dingtalk_group_deliveries` with `dingtalk_group_destinations`
+  - returns `destinationName` alongside the existing delivery payload
+  - clamps `limit` to `1..200`
+- Updated `packages/core-backend/src/routes/univer-meta.ts`
+  - added `GET /api/multitable/sheets/:sheetId/automations/:ruleId/dingtalk-group-deliveries`
+  - reuses sheet capability guard and automation ownership check
+
+### Frontend
+- Extended `apps/web/src/multitable/types.ts`
+  - `DingTalkGroupDelivery.destinationName?: string`
+- Extended `apps/web/src/multitable/api/client.ts`
+  - `getAutomationDingTalkGroupDeliveries(sheetId, ruleId, limit?)`
+- Added `apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue`
+  - status filter
+  - refresh action
+  - grouped delivery list with destination, status, created time, subject, and error message
+- Updated `apps/web/src/multitable/components/MetaAutomationManager.vue`
+  - added `View Deliveries` button for `send_dingtalk_group_message`
+  - added group delivery overlay state and viewer mounting
+
+### Tests
+- Added `packages/core-backend/tests/unit/dingtalk-group-delivery-service.test.ts`
+- Updated `apps/web/tests/multitable-automation-manager.spec.ts`
+  - mocked `/dingtalk-group-deliveries`
+  - added group delivery viewer regression
+
+## Files Changed
+- `packages/core-backend/src/multitable/dingtalk-group-delivery-service.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/unit/dingtalk-group-delivery-service.test.ts`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Notes
+- No schema change was required because group delivery rows already store `automation_rule_id`.
+- This change intentionally mirrors the existing person-delivery viewer instead of introducing another destination-level entry point.

--- a/docs/development/dingtalk-group-rule-deliveries-verification-20260420.md
+++ b/docs/development/dingtalk-group-rule-deliveries-verification-20260420.md
@@ -1,0 +1,43 @@
+# DingTalk Group Rule Deliveries Verification
+
+## Date
+- 2026-04-20
+
+## Environment
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-rule-deliveries-20260420`
+- Branch: `codex/dingtalk-group-rule-deliveries-20260420`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-delivery-service.test.ts tests/unit/dingtalk-person-delivery-service.test.ts tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+- `pnpm install --frozen-lockfile`
+  - passed
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+  - `12 passed`
+- `packages/core-backend/tests/unit/dingtalk-group-delivery-service.test.ts`
+  - passed
+- `packages/core-backend/tests/unit/dingtalk-person-delivery-service.test.ts`
+  - passed
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+  - combined backend result: `99 passed`
+- `pnpm --filter @metasheet/core-backend build`
+  - passed
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Non-blocking Output
+- `vite` emitted the existing dynamic import / chunk-size warnings during `apps/web` build.
+- No new migration was introduced.
+
+## Verification Summary
+- Group automation rules now expose `View Deliveries` in the same management surface as person-message rules.
+- Rule-level group deliveries resolve destination name and render subject/status history correctly.
+- Backend route/service and frontend manager wiring compile and pass focused regression coverage.

--- a/packages/core-backend/src/multitable/dingtalk-group-delivery-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-delivery-service.ts
@@ -1,0 +1,90 @@
+export interface DingTalkGroupDelivery {
+  id: string
+  destinationId: string
+  destinationName?: string
+  sourceType: string
+  subject: string
+  content: string
+  success: boolean
+  httpStatus?: number
+  responseBody?: string
+  errorMessage?: string
+  automationRuleId?: string
+  recordId?: string
+  initiatedBy?: string
+  createdAt: string
+  deliveredAt?: string
+}
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+type DeliveryRow = {
+  id: string
+  destination_id: string
+  destination_name: string | null
+  source_type: string
+  subject: string
+  content: string
+  success: boolean
+  http_status: number | null
+  response_body: string | null
+  error_message: string | null
+  automation_rule_id: string | null
+  record_id: string | null
+  initiated_by: string | null
+  created_at: string
+  delivered_at: string | null
+}
+
+function mapDeliveryRow(row: DeliveryRow): DingTalkGroupDelivery {
+  return {
+    id: row.id,
+    destinationId: row.destination_id,
+    destinationName: row.destination_name ?? undefined,
+    sourceType: row.source_type,
+    subject: row.subject,
+    content: row.content,
+    success: row.success,
+    httpStatus: row.http_status ?? undefined,
+    responseBody: row.response_body ?? undefined,
+    errorMessage: row.error_message ?? undefined,
+    automationRuleId: row.automation_rule_id ?? undefined,
+    recordId: row.record_id ?? undefined,
+    initiatedBy: row.initiated_by ?? undefined,
+    createdAt: row.created_at,
+    deliveredAt: row.delivered_at ?? undefined,
+  }
+}
+
+export async function listAutomationDingTalkGroupDeliveries(
+  queryFn: QueryFn,
+  ruleId: string,
+  limit = 50,
+): Promise<DingTalkGroupDelivery[]> {
+  const normalizedLimit = Math.min(Math.max(limit, 1), 200)
+  const result = await queryFn(
+    `SELECT d.id,
+            d.destination_id,
+            g.name AS destination_name,
+            d.source_type,
+            d.subject,
+            d.content,
+            d.success,
+            d.http_status,
+            d.response_body,
+            d.error_message,
+            d.automation_rule_id,
+            d.record_id,
+            d.initiated_by,
+            d.created_at,
+            d.delivered_at
+       FROM dingtalk_group_deliveries d
+       LEFT JOIN dingtalk_group_destinations g ON g.id = d.destination_id
+      WHERE d.automation_rule_id = $1
+      ORDER BY d.created_at DESC
+      LIMIT $2`,
+    [ruleId, normalizedLimit],
+  )
+
+  return (result.rows as DeliveryRow[]).map(mapDeliveryRow)
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -32,6 +32,7 @@ import { validateRecord, getDefaultValidationRules } from '../multitable/field-v
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import { getAutomationServiceInstance } from '../multitable/automation-service'
+import { listAutomationDingTalkGroupDeliveries } from '../multitable/dingtalk-group-delivery-service'
 import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
   publishMultitableSheetRealtime as publishMultitableSheetRealtimeShared,
@@ -7810,6 +7811,37 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] list dingtalk person deliveries failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list DingTalk person deliveries' } })
+    }
+  })
+
+  router.get('/sheets/:sheetId/automations/:ruleId/dingtalk-group-deliveries', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId : ''
+    const ruleId = typeof req.params.ruleId === 'string' ? req.params.ruleId : ''
+    if (!sheetId || !ruleId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and ruleId are required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageAutomation) return sendForbidden(res)
+      const automationService = getAutomationServiceInstance()
+      if (!automationService) {
+        return res.status(503).json({ ok: false, error: { code: 'SERVICE_UNAVAILABLE', message: 'Automation service is not available' } })
+      }
+
+      const rule = await automationService.getRule(ruleId)
+      if (!rule || rule.sheet_id !== sheetId) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
+      }
+
+      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
+      const deliveries = await listAutomationDingTalkGroupDeliveries(pool.query.bind(pool), ruleId, limit)
+      return res.json({ ok: true, data: { deliveries } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list dingtalk group deliveries failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list DingTalk group deliveries' } })
     }
   })
 

--- a/packages/core-backend/tests/unit/dingtalk-group-delivery-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-delivery-service.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { listAutomationDingTalkGroupDeliveries } from '../../src/multitable/dingtalk-group-delivery-service'
+
+describe('dingtalk group delivery service', () => {
+  it('lists and maps automation-scoped deliveries', async () => {
+    const queryFn = vi.fn(async () => ({
+      rows: [
+        {
+          id: 'dgd_1',
+          destination_id: 'group_1',
+          destination_name: 'Ops Group',
+          source_type: 'automation',
+          subject: 'Ticket rec_1 ready',
+          content: 'Please review the latest changes.',
+          success: true,
+          http_status: 200,
+          response_body: '{"errcode":0}',
+          error_message: null,
+          automation_rule_id: 'rule_1',
+          record_id: 'rec_1',
+          initiated_by: 'user_2',
+          created_at: '2026-04-20T08:00:00.000Z',
+          delivered_at: '2026-04-20T08:00:01.000Z',
+        },
+      ],
+    }))
+
+    const deliveries = await listAutomationDingTalkGroupDeliveries(queryFn, 'rule_1', 500)
+
+    expect(queryFn).toHaveBeenCalledWith(expect.stringContaining('FROM dingtalk_group_deliveries d'), ['rule_1', 200])
+    expect(deliveries).toEqual([
+      {
+        id: 'dgd_1',
+        destinationId: 'group_1',
+        destinationName: 'Ops Group',
+        sourceType: 'automation',
+        subject: 'Ticket rec_1 ready',
+        content: 'Please review the latest changes.',
+        success: true,
+        httpStatus: 200,
+        responseBody: '{"errcode":0}',
+        errorMessage: undefined,
+        automationRuleId: 'rule_1',
+        recordId: 'rec_1',
+        initiatedBy: 'user_2',
+        createdAt: '2026-04-20T08:00:00.000Z',
+        deliveredAt: '2026-04-20T08:00:01.000Z',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## What changed
- add automation-scoped DingTalk group delivery query service and route
- add a dedicated group delivery viewer in multitable automation management
- show `View Deliveries` for `send_dingtalk_group_message` rules, matching the existing person-delivery path
- return `destinationName` with rule-level group deliveries for clearer governance

## Verification
```bash
pnpm install --frozen-lockfile
pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-delivery-service.test.ts tests/unit/dingtalk-person-delivery-service.test.ts tests/unit/automation-v1.test.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
```

Results:
- frontend: `12 passed`
- backend: `99 passed`
- backend build: passed
- web build: passed
