### PR TITLE
feat(dingtalk): add notification message presets

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -73,6 +73,12 @@
           </template>
 
           <template v-if="draft.actionType === 'send_dingtalk_group_message'">
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Message preset</span>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-form" @click="applyGroupPreset('form_request')">Form request</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-internal" @click="applyGroupPreset('internal_process')">Internal processing</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-both" @click="applyGroupPreset('form_and_process')">Form + processing</button>
+            </div>
             <label class="meta-automation__label">DingTalk group</label>
             <select v-model="draft.dingtalkDestinationId" class="meta-automation__select" data-automation-field="dingtalkDestinationId">
               <option value="">-- select DingTalk group --</option>
@@ -109,6 +115,12 @@
           </template>
 
           <template v-if="draft.actionType === 'send_dingtalk_person_message'">
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Message preset</span>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-form" @click="applyPersonPreset('form_request')">Form request</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-internal" @click="applyPersonPreset('internal_process')">Internal processing</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-both" @click="applyPersonPreset('form_and_process')">Form + processing</button>
+            </div>
             <label class="meta-automation__label">Search and add users</label>
             <input
               v-model="dingtalkPersonUserSearch"
@@ -305,6 +317,7 @@ import MetaAutomationRuleEditor from './MetaAutomationRuleEditor.vue'
 import MetaAutomationLogViewer from './MetaAutomationLogViewer.vue'
 import MetaAutomationGroupDeliveryViewer from './MetaAutomationGroupDeliveryViewer.vue'
 import MetaAutomationPersonDeliveryViewer from './MetaAutomationPersonDeliveryViewer.vue'
+import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
 
 const props = defineProps<{
   visible: boolean
@@ -452,6 +465,40 @@ function removeDingTalkPersonRecipient(userId: string) {
   draft.value.dingtalkPersonUserIds = parseUserIdsText(draft.value.dingtalkPersonUserIds)
     .filter((id) => id !== userId)
     .join(', ')
+}
+
+function applyGroupPreset(preset: DingTalkNotificationPreset) {
+  const next = applyDingTalkNotificationPreset(
+    {
+      titleTemplate: draft.value.dingtalkTitleTemplate,
+      bodyTemplate: draft.value.dingtalkBodyTemplate,
+      publicFormViewId: draft.value.publicFormViewId,
+      internalViewId: draft.value.internalViewId,
+    },
+    preset,
+    props.views ?? [],
+  )
+  draft.value.dingtalkTitleTemplate = next.titleTemplate ?? ''
+  draft.value.dingtalkBodyTemplate = next.bodyTemplate ?? ''
+  draft.value.publicFormViewId = next.publicFormViewId ?? ''
+  draft.value.internalViewId = next.internalViewId ?? ''
+}
+
+function applyPersonPreset(preset: DingTalkNotificationPreset) {
+  const next = applyDingTalkNotificationPreset(
+    {
+      titleTemplate: draft.value.dingtalkPersonTitleTemplate,
+      bodyTemplate: draft.value.dingtalkPersonBodyTemplate,
+      publicFormViewId: draft.value.dingtalkPersonPublicFormViewId,
+      internalViewId: draft.value.dingtalkPersonInternalViewId,
+    },
+    preset,
+    props.views ?? [],
+  )
+  draft.value.dingtalkPersonTitleTemplate = next.titleTemplate ?? ''
+  draft.value.dingtalkPersonBodyTemplate = next.bodyTemplate ?? ''
+  draft.value.dingtalkPersonPublicFormViewId = next.publicFormViewId ?? ''
+  draft.value.dingtalkPersonInternalViewId = next.internalViewId ?? ''
 }
 
 // --- Rule editor + log viewer state ---
@@ -845,6 +892,20 @@ watch(
 
 .meta-automation__recipient-list--selected {
   margin-bottom: 4px;
+}
+
+.meta-automation__preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.meta-automation__preset-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
 }
 
 .meta-automation__recipient-option,

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -94,6 +94,19 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkTitleTemplate"
             />
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`group-title-${token.key}`"
+                @click="appendGroupTemplateToken('title', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Body template</label>
             <textarea
               v-model="draft.dingtalkBodyTemplate"
@@ -102,6 +115,19 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkBodyTemplate"
             ></textarea>
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`group-body-${token.key}`"
+                @click="appendGroupTemplateToken('body', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Public form view (optional)</label>
             <select v-model="draft.publicFormViewId" class="meta-automation__select" data-automation-field="publicFormViewId">
               <option value="">-- no public form link --</option>
@@ -176,6 +202,19 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkPersonTitleTemplate"
             />
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`person-title-${token.key}`"
+                @click="appendPersonTemplateToken('title', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Body template</label>
             <textarea
               v-model="draft.dingtalkPersonBodyTemplate"
@@ -184,6 +223,19 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkPersonBodyTemplate"
             ></textarea>
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`person-body-${token.key}`"
+                @click="appendPersonTemplateToken('body', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Public form view (optional)</label>
             <select v-model="draft.dingtalkPersonPublicFormViewId" class="meta-automation__select" data-automation-field="dingtalkPersonPublicFormViewId">
               <option value="">-- no public form link --</option>
@@ -318,6 +370,11 @@ import MetaAutomationLogViewer from './MetaAutomationLogViewer.vue'
 import MetaAutomationGroupDeliveryViewer from './MetaAutomationGroupDeliveryViewer.vue'
 import MetaAutomationPersonDeliveryViewer from './MetaAutomationPersonDeliveryViewer.vue'
 import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
+import {
+  appendTemplateToken,
+  DINGTALK_BODY_TEMPLATE_TOKENS,
+  DINGTALK_TITLE_TEMPLATE_TOKENS,
+} from '../utils/dingtalkNotificationTemplateTokens'
 
 const props = defineProps<{
   visible: boolean
@@ -499,6 +556,22 @@ function applyPersonPreset(preset: DingTalkNotificationPreset) {
   draft.value.dingtalkPersonBodyTemplate = next.bodyTemplate ?? ''
   draft.value.dingtalkPersonPublicFormViewId = next.publicFormViewId ?? ''
   draft.value.dingtalkPersonInternalViewId = next.internalViewId ?? ''
+}
+
+function appendGroupTemplateToken(field: 'title' | 'body', token: string) {
+  if (field === 'title') {
+    draft.value.dingtalkTitleTemplate = appendTemplateToken(draft.value.dingtalkTitleTemplate, token)
+    return
+  }
+  draft.value.dingtalkBodyTemplate = appendTemplateToken(draft.value.dingtalkBodyTemplate, token, true)
+}
+
+function appendPersonTemplateToken(field: 'title' | 'body', token: string) {
+  if (field === 'title') {
+    draft.value.dingtalkPersonTitleTemplate = appendTemplateToken(draft.value.dingtalkPersonTitleTemplate, token)
+    return
+  }
+  draft.value.dingtalkPersonBodyTemplate = appendTemplateToken(draft.value.dingtalkPersonBodyTemplate, token, true)
 }
 
 // --- Rule editor + log viewer state ---

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -187,6 +187,12 @@
 
             <!-- send_dingtalk_group_message config -->
             <div v-if="action.type === 'send_dingtalk_group_message'" class="meta-rule-editor__action-config">
+              <div class="meta-rule-editor__preset-row">
+                <span class="meta-rule-editor__preset-label">Message preset</span>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetForm" @click="applyGroupPreset(action, 'form_request')">Form request</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetInternal" @click="applyGroupPreset(action, 'internal_process')">Internal processing</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetBoth" @click="applyGroupPreset(action, 'form_and_process')">Form + processing</button>
+              </div>
               <label class="meta-rule-editor__label">DingTalk group</label>
               <select
                 v-model="action.config.destinationId"
@@ -237,6 +243,12 @@
 
             <!-- send_dingtalk_person_message config -->
             <div v-if="action.type === 'send_dingtalk_person_message'" class="meta-rule-editor__action-config">
+              <div class="meta-rule-editor__preset-row">
+                <span class="meta-rule-editor__preset-label">Message preset</span>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetForm" @click="applyPersonPreset(action, 'form_request')">Form request</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetInternal" @click="applyPersonPreset(action, 'internal_process')">Internal processing</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetBoth" @click="applyPersonPreset(action, 'form_and_process')">Form + processing</button>
+              </div>
               <label class="meta-rule-editor__label">Search and add users</label>
               <input
                 v-model="action.config.userIdsSearch"
@@ -364,6 +376,7 @@ import type {
   MetaCommentMentionSuggestion,
   MetaView,
 } from '../types'
+import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
 
 interface FieldPair {
   fieldId: string
@@ -623,6 +636,38 @@ function removePersonRecipient(action: DraftAction, userId: string) {
   action.config.userIdsText = parseUserIdsText(action.config.userIdsText)
     .filter((id) => id !== userId)
     .join(', ')
+}
+
+function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
+  action.config = {
+    ...action.config,
+    ...applyDingTalkNotificationPreset(
+      {
+        titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate : '',
+        bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate : '',
+        publicFormViewId: typeof action.config.publicFormViewId === 'string' ? action.config.publicFormViewId : '',
+        internalViewId: typeof action.config.internalViewId === 'string' ? action.config.internalViewId : '',
+      },
+      preset,
+      props.views ?? [],
+    ),
+  }
+}
+
+function applyPersonPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
+  action.config = {
+    ...action.config,
+    ...applyDingTalkNotificationPreset(
+      {
+        titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate : '',
+        bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate : '',
+        publicFormViewId: typeof action.config.publicFormViewId === 'string' ? action.config.publicFormViewId : '',
+        internalViewId: typeof action.config.internalViewId === 'string' ? action.config.internalViewId : '',
+      },
+      preset,
+      props.views ?? [],
+    ),
+  }
 }
 
 function defaultConfigForActionType(type: AutomationActionType): DraftActionConfig {
@@ -885,6 +930,19 @@ function onTestRun() {
   flex-direction: column;
   gap: 6px;
   padding-left: 20px;
+}
+
+.meta-rule-editor__preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.meta-rule-editor__preset-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
 }
 
 .meta-rule-editor__recipient-list {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -213,6 +213,19 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkTitleTemplate"
               />
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`groupTitleToken-${token.key}`"
+                  @click="appendGroupTemplateToken(action, 'titleTemplate', token.value)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Body template</label>
               <textarea
                 v-model="action.config.bodyTemplate"
@@ -221,6 +234,19 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkBodyTemplate"
               ></textarea>
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`groupBodyToken-${token.key}`"
+                  @click="appendGroupTemplateToken(action, 'bodyTemplate', token.value, true)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Public form view (optional)</label>
               <select
                 v-model="action.config.publicFormViewId"
@@ -304,6 +330,19 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkPersonTitleTemplate"
               />
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`personTitleToken-${token.key}`"
+                  @click="appendPersonTemplateToken(action, 'titleTemplate', token.value)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Body template</label>
               <textarea
                 v-model="action.config.bodyTemplate"
@@ -312,6 +351,19 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkPersonBodyTemplate"
               ></textarea>
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`personBodyToken-${token.key}`"
+                  @click="appendPersonTemplateToken(action, 'bodyTemplate', token.value, true)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Public form view (optional)</label>
               <select
                 v-model="action.config.publicFormViewId"
@@ -377,6 +429,11 @@ import type {
   MetaView,
 } from '../types'
 import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
+import {
+  appendTemplateToken,
+  DINGTALK_BODY_TEMPLATE_TOKENS,
+  DINGTALK_TITLE_TEMPLATE_TOKENS,
+} from '../utils/dingtalkNotificationTemplateTokens'
 
 interface FieldPair {
   fieldId: string
@@ -670,6 +727,26 @@ function applyPersonPreset(action: DraftAction, preset: DingTalkNotificationPres
   }
 }
 
+function appendGroupTemplateToken(
+  action: DraftAction,
+  field: 'titleTemplate' | 'bodyTemplate',
+  token: string,
+  multiline = false,
+) {
+  const current = typeof action.config[field] === 'string' ? action.config[field] : ''
+  action.config[field] = appendTemplateToken(current, token, multiline)
+}
+
+function appendPersonTemplateToken(
+  action: DraftAction,
+  field: 'titleTemplate' | 'bodyTemplate',
+  token: string,
+  multiline = false,
+) {
+  const current = typeof action.config[field] === 'string' ? action.config[field] : ''
+  action.config[field] = appendTemplateToken(current, token, multiline)
+}
+
 function defaultConfigForActionType(type: AutomationActionType): DraftActionConfig {
   switch (type) {
     case 'update_record':
@@ -937,6 +1014,14 @@ function onTestRun() {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+}
+
+.meta-rule-editor__token-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 12px;
 }
 
 .meta-rule-editor__preset-label {

--- a/apps/web/src/multitable/utils/dingtalkNotificationPresets.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationPresets.ts
@@ -1,0 +1,63 @@
+import type { MetaView } from '../types'
+
+export type DingTalkNotificationPreset = 'form_request' | 'internal_process' | 'form_and_process'
+
+export interface DingTalkNotificationPresetConfig {
+  titleTemplate?: string
+  bodyTemplate?: string
+  publicFormViewId?: string
+  internalViewId?: string
+}
+
+function normalizeId(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function pickDefaultFormViewId(views: MetaView[], currentViewId?: string): string {
+  const current = normalizeId(currentViewId)
+  if (current && views.some((view) => view.id === current && view.type === 'form')) return current
+  return views.find((view) => view.type === 'form')?.id ?? ''
+}
+
+function pickDefaultInternalViewId(views: MetaView[], currentViewId?: string): string {
+  const current = normalizeId(currentViewId)
+  if (current && views.some((view) => view.id === current)) return current
+  return views.find((view) => view.type !== 'form')?.id ?? views[0]?.id ?? ''
+}
+
+export function applyDingTalkNotificationPreset(
+  config: DingTalkNotificationPresetConfig,
+  preset: DingTalkNotificationPreset,
+  views: MetaView[],
+): DingTalkNotificationPresetConfig {
+  const formViewId = pickDefaultFormViewId(views, config.publicFormViewId)
+  const internalViewId = pickDefaultInternalViewId(views, config.internalViewId)
+
+  if (preset === 'form_request') {
+    return {
+      ...config,
+      titleTemplate: '{{recordId}} 待填写',
+      bodyTemplate: '请完成本次表单填写。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+      publicFormViewId: formViewId,
+      internalViewId: '',
+    }
+  }
+
+  if (preset === 'internal_process') {
+    return {
+      ...config,
+      titleTemplate: '{{recordId}} 待处理',
+      bodyTemplate: '请查看并处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+      publicFormViewId: '',
+      internalViewId,
+    }
+  }
+
+  return {
+    ...config,
+    titleTemplate: '{{recordId}} 待填写并处理',
+    bodyTemplate: '请先填写所需信息，并由有权限成员继续处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+    publicFormViewId: formViewId,
+    internalViewId,
+  }
+}

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts
@@ -1,0 +1,23 @@
+export interface DingTalkNotificationTemplateToken {
+  key: string
+  label: string
+  value: string
+}
+
+export const DINGTALK_TITLE_TEMPLATE_TOKENS: DingTalkNotificationTemplateToken[] = [
+  { key: 'recordId', label: 'Record ID', value: '{{recordId}}' },
+  { key: 'sheetId', label: 'Sheet ID', value: '{{sheetId}}' },
+  { key: 'actorId', label: 'Actor ID', value: '{{actorId}}' },
+]
+
+export const DINGTALK_BODY_TEMPLATE_TOKENS: DingTalkNotificationTemplateToken[] = [
+  ...DINGTALK_TITLE_TEMPLATE_TOKENS,
+  { key: 'recordField', label: 'Record field', value: '{{record.xxx}}' },
+]
+
+export function appendTemplateToken(currentValue: string, token: string, multiline = false): string {
+  if (!currentValue.trim()) return token
+  if (currentValue.endsWith(token)) return currentValue
+  if (/\s$/.test(currentValue)) return `${currentValue}${token}`
+  return multiline ? `${currentValue}\n${token}` : `${currentValue} ${token}`
+}

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -472,4 +472,67 @@ describe('MetaAutomationManager', () => {
     expect(delivery?.textContent).toContain('Ops Group')
     expect(delivery?.textContent).toContain('Ticket rec_1 pending')
   })
+
+  it('applies DingTalk group presets in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const presetBtn = container.querySelector('[data-automation-preset="group-form"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
+    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLSelectElement
+
+    expect(titleInput.value).toBe('{{recordId}} 待填写')
+    expect(bodyInput.value).toContain('请完成本次表单填写')
+    expect(publicFormSelect.value).toBe('view_form')
+    expect(internalViewSelect.value).toBe('')
+  })
+
+  it('applies DingTalk person presets in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const presetBtn = container.querySelector('[data-automation-preset="person-both"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    const internalViewSelect = container.querySelector('[data-automation-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+
+    expect(userIdsInput.value).toBe('user_1')
+    expect(titleInput.value).toBe('{{recordId}} 待填写并处理')
+    expect(bodyInput.value).toContain('请先填写所需信息')
+    expect(publicFormSelect.value).toBe('view_form')
+    expect(internalViewSelect.value).toBe('view_grid')
+  })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -535,4 +535,28 @@ describe('MetaAutomationManager', () => {
     expect(publicFormSelect.value).toBe('view_form')
     expect(internalViewSelect.value).toBe('view_grid')
   })
+
+  it('inserts DingTalk template tokens in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-token="person-title-recordId"]') as HTMLButtonElement).click()
+    ;(container.querySelector('[data-automation-token="person-body-recordField"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    expect(titleInput.value).toBe('{{recordId}}')
+    expect(bodyInput.value).toBe('{{record.xxx}}')
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -391,4 +391,71 @@ describe('MetaAutomationRuleEditor', () => {
     expect(payload.actionConfig.userIds).toEqual(['user_1'])
     expect(client.listCommentMentionSuggestions).toHaveBeenCalledTimes(1)
   })
+
+  it('applies DingTalk group message presets', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const presetBtn = container.querySelector('[data-field="groupPresetBoth"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
+    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLSelectElement
+
+    expect(titleInput.value).toBe('{{recordId}} 待填写并处理')
+    expect(bodyInput.value).toContain('请先填写所需信息')
+    expect(publicFormSelect.value).toBe('view_form')
+    expect(internalViewSelect.value).toBe('view_grid')
+  })
+
+  it('applies DingTalk person message presets without touching recipients', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1'
+    userIdsInput.dispatchEvent(new Event('input'))
+
+    const presetBtn = container.querySelector('[data-field="personPresetInternal"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+
+    expect(userIdsInput.value).toBe('user_1')
+    expect(titleInput.value).toBe('{{recordId}} 待处理')
+    expect(bodyInput.value).toContain('请查看并处理该记录')
+    expect(publicFormSelect.value).toBe('')
+    expect(internalViewSelect.value).toBe('view_grid')
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -458,4 +458,30 @@ describe('MetaAutomationRuleEditor', () => {
     expect(publicFormSelect.value).toBe('')
     expect(internalViewSelect.value).toBe('view_grid')
   })
+
+  it('inserts DingTalk template tokens in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-field="groupTitleToken-recordId"]') as HTMLButtonElement).click()
+    ;(container.querySelector('[data-field="groupBodyToken-recordField"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    expect(titleInput.value).toBe('{{recordId}}')
+    expect(bodyInput.value).toBe('{{record.xxx}}')
+  })
 })

--- a/docs/development/dingtalk-notify-template-governance-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-governance-development-20260420.md
@@ -1,0 +1,92 @@
+# DingTalk Notification Template Governance Development
+
+Date: 2026-04-20
+
+## Goal
+
+Reduce authoring friction for DingTalk notification automations by adding one-click message presets for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+The presets standardize the common cases:
+
+- form request
+- internal processing
+- form + processing
+
+## Scope
+
+Frontend-only governance enhancement:
+
+- add a shared preset helper
+- expose preset buttons in the rule editor
+- expose the same preset buttons in the inline automation manager create form
+- preserve existing recipient and action payload structure
+
+No backend API or migration changes were needed.
+
+## Implementation
+
+### Shared preset helper
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationPresets.ts`
+
+This helper centralizes:
+
+- preset ids and labels
+- default title/body templates
+- default public form view selection
+- default internal view selection
+
+It applies presets without changing unrelated action fields.
+
+### Rule editor
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Added preset buttons for both DingTalk message actions:
+
+- group message presets
+- person message presets
+
+The preset buttons populate:
+
+- `titleTemplate`
+- `bodyTemplate`
+- `publicFormViewId`
+- `internalViewId`
+
+For person messages, recipient ids remain unchanged.
+
+### Inline automation manager
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+The inline create flow now supports the same presets so the quick-create path and full editor stay aligned.
+
+### Test coverage
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies:
+
+- group preset application in the rule editor
+- person preset application in the rule editor
+- group preset application in the inline create form
+- person preset application in the inline create form
+- recipient ids are preserved for person-message presets
+
+## Notes
+
+- This change is deliberately scoped to authoring ergonomics.
+- It does not alter delivery semantics, ACL behavior, or runtime execution.

--- a/docs/development/dingtalk-notify-template-governance-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-governance-verification-20260420.md
@@ -1,0 +1,33 @@
+# DingTalk Notification Template Governance Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `27 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- group preset buttons populate DingTalk group message templates correctly
+- person preset buttons populate DingTalk person message templates correctly
+- person recipient ids remain intact after applying presets
+- inline automation creation and full rule editor stay behaviorally aligned
+- default public/internal views are filled according to preset intent
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.

--- a/docs/development/dingtalk-notify-template-token-assist-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-token-assist-development-20260420.md
@@ -1,0 +1,68 @@
+# DingTalk Notification Template Token Assist Development
+
+Date: 2026-04-20
+
+## Goal
+
+Reduce template authoring mistakes for DingTalk notification actions by exposing a small, shared token reference and one-click token insertion in both automation authoring surfaces.
+
+## Scope
+
+Frontend-only authoring enhancement for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Surfaces covered:
+
+- `MetaAutomationRuleEditor`
+- `MetaAutomationManager`
+
+## Implementation
+
+### Shared token helper
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts`
+
+The helper defines:
+
+- title-safe tokens
+- body tokens
+- append behavior with sensible spacing/newline handling
+
+### Rule editor
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Added token rows under:
+
+- group title/body template fields
+- person title/body template fields
+
+Each button appends a supported token into the current template field without overwriting the existing value.
+
+### Inline automation manager
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Added the same token assist behavior to the inline create/edit form so quick authoring stays aligned with the full rule editor.
+
+### Tests
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies token insertion in both surfaces.
+
+## Notes
+
+- This change does not alter runtime payloads or backend execution.
+- It is intentionally scoped to authoring guidance and template consistency.

--- a/docs/development/dingtalk-notify-template-token-assist-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-token-assist-verification-20260420.md
@@ -1,0 +1,33 @@
+# DingTalk Notification Template Token Assist Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `29 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- rule editor exposes token buttons for DingTalk group and person message templates
+- inline automation manager exposes the same token buttons
+- title token insertion appends inline text correctly
+- body token insertion appends multiline text correctly
+- no backend API or migration changes were required
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.


### PR DESCRIPTION
## What changed
- add shared DingTalk notification message presets for common form/process flows
- expose preset buttons in the multitable automation rule editor and inline automation manager
- keep person-recipient ids intact while filling title/body/public/internal link defaults
- add focused frontend coverage plus development and verification notes

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build