### PR TITLE
feat(dingtalk): add template token assist

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -94,6 +94,19 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkTitleTemplate"
             />
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`group-title-${token.key}`"
+                @click="appendGroupTemplateToken('title', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Body template</label>
             <textarea
               v-model="draft.dingtalkBodyTemplate"
@@ -102,6 +115,19 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkBodyTemplate"
             ></textarea>
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`group-body-${token.key}`"
+                @click="appendGroupTemplateToken('body', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Public form view (optional)</label>
             <select v-model="draft.publicFormViewId" class="meta-automation__select" data-automation-field="publicFormViewId">
               <option value="">-- no public form link --</option>
@@ -176,6 +202,19 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkPersonTitleTemplate"
             />
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`person-title-${token.key}`"
+                @click="appendPersonTemplateToken('title', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Body template</label>
             <textarea
               v-model="draft.dingtalkPersonBodyTemplate"
@@ -184,6 +223,19 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkPersonBodyTemplate"
             ></textarea>
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`person-body-${token.key}`"
+                @click="appendPersonTemplateToken('body', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Public form view (optional)</label>
             <select v-model="draft.dingtalkPersonPublicFormViewId" class="meta-automation__select" data-automation-field="dingtalkPersonPublicFormViewId">
               <option value="">-- no public form link --</option>
@@ -318,6 +370,11 @@ import MetaAutomationLogViewer from './MetaAutomationLogViewer.vue'
 import MetaAutomationGroupDeliveryViewer from './MetaAutomationGroupDeliveryViewer.vue'
 import MetaAutomationPersonDeliveryViewer from './MetaAutomationPersonDeliveryViewer.vue'
 import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
+import {
+  appendTemplateToken,
+  DINGTALK_BODY_TEMPLATE_TOKENS,
+  DINGTALK_TITLE_TEMPLATE_TOKENS,
+} from '../utils/dingtalkNotificationTemplateTokens'
 
 const props = defineProps<{
   visible: boolean
@@ -499,6 +556,22 @@ function applyPersonPreset(preset: DingTalkNotificationPreset) {
   draft.value.dingtalkPersonBodyTemplate = next.bodyTemplate ?? ''
   draft.value.dingtalkPersonPublicFormViewId = next.publicFormViewId ?? ''
   draft.value.dingtalkPersonInternalViewId = next.internalViewId ?? ''
+}
+
+function appendGroupTemplateToken(field: 'title' | 'body', token: string) {
+  if (field === 'title') {
+    draft.value.dingtalkTitleTemplate = appendTemplateToken(draft.value.dingtalkTitleTemplate, token)
+    return
+  }
+  draft.value.dingtalkBodyTemplate = appendTemplateToken(draft.value.dingtalkBodyTemplate, token, true)
+}
+
+function appendPersonTemplateToken(field: 'title' | 'body', token: string) {
+  if (field === 'title') {
+    draft.value.dingtalkPersonTitleTemplate = appendTemplateToken(draft.value.dingtalkPersonTitleTemplate, token)
+    return
+  }
+  draft.value.dingtalkPersonBodyTemplate = appendTemplateToken(draft.value.dingtalkPersonBodyTemplate, token, true)
 }
 
 // --- Rule editor + log viewer state ---

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -213,6 +213,19 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkTitleTemplate"
               />
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`groupTitleToken-${token.key}`"
+                  @click="appendGroupTemplateToken(action, 'titleTemplate', token.value)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Body template</label>
               <textarea
                 v-model="action.config.bodyTemplate"
@@ -221,6 +234,19 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkBodyTemplate"
               ></textarea>
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`groupBodyToken-${token.key}`"
+                  @click="appendGroupTemplateToken(action, 'bodyTemplate', token.value, true)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Public form view (optional)</label>
               <select
                 v-model="action.config.publicFormViewId"
@@ -304,6 +330,19 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkPersonTitleTemplate"
               />
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`personTitleToken-${token.key}`"
+                  @click="appendPersonTemplateToken(action, 'titleTemplate', token.value)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Body template</label>
               <textarea
                 v-model="action.config.bodyTemplate"
@@ -312,6 +351,19 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkPersonBodyTemplate"
               ></textarea>
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`personBodyToken-${token.key}`"
+                  @click="appendPersonTemplateToken(action, 'bodyTemplate', token.value, true)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Public form view (optional)</label>
               <select
                 v-model="action.config.publicFormViewId"
@@ -377,6 +429,11 @@ import type {
   MetaView,
 } from '../types'
 import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
+import {
+  appendTemplateToken,
+  DINGTALK_BODY_TEMPLATE_TOKENS,
+  DINGTALK_TITLE_TEMPLATE_TOKENS,
+} from '../utils/dingtalkNotificationTemplateTokens'
 
 interface FieldPair {
   fieldId: string
@@ -670,6 +727,26 @@ function applyPersonPreset(action: DraftAction, preset: DingTalkNotificationPres
   }
 }
 
+function appendGroupTemplateToken(
+  action: DraftAction,
+  field: 'titleTemplate' | 'bodyTemplate',
+  token: string,
+  multiline = false,
+) {
+  const current = typeof action.config[field] === 'string' ? action.config[field] : ''
+  action.config[field] = appendTemplateToken(current, token, multiline)
+}
+
+function appendPersonTemplateToken(
+  action: DraftAction,
+  field: 'titleTemplate' | 'bodyTemplate',
+  token: string,
+  multiline = false,
+) {
+  const current = typeof action.config[field] === 'string' ? action.config[field] : ''
+  action.config[field] = appendTemplateToken(current, token, multiline)
+}
+
 function defaultConfigForActionType(type: AutomationActionType): DraftActionConfig {
   switch (type) {
     case 'update_record':
@@ -937,6 +1014,14 @@ function onTestRun() {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+}
+
+.meta-rule-editor__token-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 12px;
 }
 
 .meta-rule-editor__preset-label {

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts
@@ -1,0 +1,23 @@
+export interface DingTalkNotificationTemplateToken {
+  key: string
+  label: string
+  value: string
+}
+
+export const DINGTALK_TITLE_TEMPLATE_TOKENS: DingTalkNotificationTemplateToken[] = [
+  { key: 'recordId', label: 'Record ID', value: '{{recordId}}' },
+  { key: 'sheetId', label: 'Sheet ID', value: '{{sheetId}}' },
+  { key: 'actorId', label: 'Actor ID', value: '{{actorId}}' },
+]
+
+export const DINGTALK_BODY_TEMPLATE_TOKENS: DingTalkNotificationTemplateToken[] = [
+  ...DINGTALK_TITLE_TEMPLATE_TOKENS,
+  { key: 'recordField', label: 'Record field', value: '{{record.xxx}}' },
+]
+
+export function appendTemplateToken(currentValue: string, token: string, multiline = false): string {
+  if (!currentValue.trim()) return token
+  if (currentValue.endsWith(token)) return currentValue
+  if (/\s$/.test(currentValue)) return `${currentValue}${token}`
+  return multiline ? `${currentValue}\n${token}` : `${currentValue} ${token}`
+}

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -535,4 +535,28 @@ describe('MetaAutomationManager', () => {
     expect(publicFormSelect.value).toBe('view_form')
     expect(internalViewSelect.value).toBe('view_grid')
   })
+
+  it('inserts DingTalk template tokens in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-token="person-title-recordId"]') as HTMLButtonElement).click()
+    ;(container.querySelector('[data-automation-token="person-body-recordField"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    expect(titleInput.value).toBe('{{recordId}}')
+    expect(bodyInput.value).toBe('{{record.xxx}}')
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -458,4 +458,30 @@ describe('MetaAutomationRuleEditor', () => {
     expect(publicFormSelect.value).toBe('')
     expect(internalViewSelect.value).toBe('view_grid')
   })
+
+  it('inserts DingTalk template tokens in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-field="groupTitleToken-recordId"]') as HTMLButtonElement).click()
+    ;(container.querySelector('[data-field="groupBodyToken-recordField"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    expect(titleInput.value).toBe('{{recordId}}')
+    expect(bodyInput.value).toBe('{{record.xxx}}')
+  })
 })

--- a/docs/development/dingtalk-notify-template-token-assist-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-token-assist-development-20260420.md
@@ -1,0 +1,68 @@
+# DingTalk Notification Template Token Assist Development
+
+Date: 2026-04-20
+
+## Goal
+
+Reduce template authoring mistakes for DingTalk notification actions by exposing a small, shared token reference and one-click token insertion in both automation authoring surfaces.
+
+## Scope
+
+Frontend-only authoring enhancement for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Surfaces covered:
+
+- `MetaAutomationRuleEditor`
+- `MetaAutomationManager`
+
+## Implementation
+
+### Shared token helper
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts`
+
+The helper defines:
+
+- title-safe tokens
+- body tokens
+- append behavior with sensible spacing/newline handling
+
+### Rule editor
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Added token rows under:
+
+- group title/body template fields
+- person title/body template fields
+
+Each button appends a supported token into the current template field without overwriting the existing value.
+
+### Inline automation manager
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Added the same token assist behavior to the inline create/edit form so quick authoring stays aligned with the full rule editor.
+
+### Tests
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies token insertion in both surfaces.
+
+## Notes
+
+- This change does not alter runtime payloads or backend execution.
+- It is intentionally scoped to authoring guidance and template consistency.

--- a/docs/development/dingtalk-notify-template-token-assist-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-token-assist-verification-20260420.md
@@ -1,0 +1,33 @@
+# DingTalk Notification Template Token Assist Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `29 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- rule editor exposes token buttons for DingTalk group and person message templates
+- inline automation manager exposes the same token buttons
+- title token insertion appends inline text correctly
+- body token insertion appends multiline text correctly
+- no backend API or migration changes were required
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.


### PR DESCRIPTION
## What changed
- add shared DingTalk notification template token definitions and append behavior
- expose one-click token insertion for group/person message title and body templates
- cover both the full rule editor and the inline automation manager
- add focused frontend coverage plus development and verification notes

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build