### PR TITLE
feat(dingtalk): add notification message preview

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -138,6 +138,14 @@
               <option value="">-- no internal link --</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
+            <div class="meta-automation__preview" data-automation-summary="group">
+              <div class="meta-automation__preview-title">Message summary</div>
+              <div><strong>Group:</strong> {{ dingTalkGroupName(draft.dingtalkDestinationId) }}</div>
+              <div><strong>Title:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
+              <div class="meta-automation__preview-body"><strong>Body:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
+              <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
+              <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
+            </div>
           </template>
 
           <template v-if="draft.actionType === 'send_dingtalk_person_message'">
@@ -246,6 +254,14 @@
               <option value="">-- no internal link --</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
+            <div class="meta-automation__preview" data-automation-summary="person">
+              <div class="meta-automation__preview-title">Message summary</div>
+              <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
+              <div><strong>Title:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
+              <div class="meta-automation__preview-body"><strong>Body:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
+              <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
+              <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
+            </div>
           </template>
 
           <div class="meta-automation__form-actions">
@@ -523,6 +539,25 @@ function removeDingTalkPersonRecipient(userId: string) {
     .filter((id) => id !== userId)
     .join(', ')
 }
+
+function dingTalkGroupName(destinationId: string) {
+  if (!destinationId) return 'No group selected'
+  return dingTalkDestinations.value.find((item) => item.id === destinationId)?.name ?? destinationId
+}
+
+function viewSummaryName(viewId: string, fallback: string) {
+  if (!viewId) return fallback
+  return (props.views ?? []).find((view) => view.id === viewId)?.name ?? viewId
+}
+
+function templatePreviewText(value: string, fallback: string) {
+  return value.trim() ? value.trim() : fallback
+}
+
+const dingTalkPersonRecipientSummary = computed(() => {
+  if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
+  return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
+})
 
 function applyGroupPreset(preset: DingTalkNotificationPreset) {
   const next = applyDingTalkNotificationPreset(
@@ -979,6 +1014,27 @@ watch(
   font-size: 12px;
   font-weight: 600;
   color: #475569;
+}
+
+.meta-automation__preview {
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.meta-automation__preview-title {
+  font-weight: 700;
+  color: #1e3a8a;
+}
+
+.meta-automation__preview-body {
+  white-space: pre-wrap;
 }
 
 .meta-automation__recipient-option,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -265,6 +265,14 @@
                 <option value="">-- no internal link --</option>
                 <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
+              <div class="meta-rule-editor__preview" data-field="groupMessageSummary">
+                <div class="meta-rule-editor__preview-title">Message summary</div>
+                <div><strong>Group:</strong> {{ dingTalkGroupName(action.config.destinationId) }}</div>
+                <div><strong>Title:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Body:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
+                <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
+              </div>
             </div>
 
             <!-- send_dingtalk_person_message config -->
@@ -382,6 +390,14 @@
                 <option value="">-- no internal link --</option>
                 <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
+              <div class="meta-rule-editor__preview" data-field="personMessageSummary">
+                <div class="meta-rule-editor__preview-title">Message summary</div>
+                <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
+                <div><strong>Title:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Body:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
+                <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
+              </div>
             </div>
 
             <!-- lock_record config -->
@@ -693,6 +709,28 @@ function removePersonRecipient(action: DraftAction, userId: string) {
   action.config.userIdsText = parseUserIdsText(action.config.userIdsText)
     .filter((id) => id !== userId)
     .join(', ')
+}
+
+function dingTalkGroupName(destinationId: unknown) {
+  const id = typeof destinationId === 'string' ? destinationId : ''
+  if (!id) return 'No group selected'
+  return dingTalkDestinations.value.find((item) => item.id === id)?.name ?? id
+}
+
+function viewSummaryName(viewId: unknown, fallback: string) {
+  const id = typeof viewId === 'string' ? viewId : ''
+  if (!id) return fallback
+  return (props.views ?? []).find((view) => view.id === id)?.name ?? id
+}
+
+function templatePreviewText(value: unknown, fallback: string) {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function personRecipientSummary(action: DraftAction) {
+  const selected = selectedPersonRecipients(action)
+  if (!selected.length) return 'No recipients selected'
+  return selected.map((item) => item.label).join(', ')
 }
 
 function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
@@ -1028,6 +1066,27 @@ function onTestRun() {
   font-size: 12px;
   font-weight: 600;
   color: #475569;
+}
+
+.meta-rule-editor__preview {
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.meta-rule-editor__preview-title {
+  font-weight: 700;
+  color: #1e3a8a;
+}
+
+.meta-rule-editor__preview-body {
+  white-space: pre-wrap;
 }
 
 .meta-rule-editor__recipient-list {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -559,4 +559,39 @@ describe('MetaAutomationManager', () => {
     expect(titleInput.value).toBe('{{recordId}}')
     expect(bodyInput.value).toBe('{{record.xxx}}')
   })
+
+  it('shows DingTalk person message summary in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Need action {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Handle {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(summary?.textContent).toContain('user_1')
+    expect(summary?.textContent).toContain('Need action {{recordId}}')
+    expect(summary?.textContent).toContain('Handle {{record.xxx}}')
+    expect(summary?.textContent).toContain('No public form link')
+    expect(summary?.textContent).toContain('No internal link')
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -484,4 +484,41 @@ describe('MetaAutomationRuleEditor', () => {
     expect(titleInput.value).toBe('{{recordId}}')
     expect(bodyInput.value).toBe('{{record.xxx}}')
   })
+
+  it('shows DingTalk group message summary in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationId"]') as HTMLSelectElement
+    destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-field="groupMessageSummary"]')
+    expect(summary?.textContent).toContain('Ops Group')
+    expect(summary?.textContent).toContain('Ticket {{recordId}}')
+    expect(summary?.textContent).toContain('Please fill {{record.xxx}}')
+    expect(summary?.textContent).toContain('No public form link')
+    expect(summary?.textContent).toContain('No internal link')
+  })
 })

--- a/docs/development/dingtalk-notify-template-preview-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-preview-development-20260420.md
@@ -1,0 +1,53 @@
+# DingTalk Notification Template Preview Development
+
+Date: 2026-04-20
+
+## Goal
+
+Make DingTalk notification authoring safer by showing a live message summary while the rule is being configured.
+
+## Scope
+
+Frontend-only enhancement for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Surfaces covered:
+
+- `MetaAutomationRuleEditor`
+- `MetaAutomationManager`
+
+## Implementation
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Added live summary cards that show:
+
+- destination group or selected recipients
+- current title template
+- current body template
+- public form link target
+- internal processing link target
+
+The preview is read-only and derives directly from the current draft state, so it does not change payload format or backend behavior.
+
+## Test coverage
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies:
+
+- group summary rendering in the full rule editor
+- person summary rendering in the inline automation manager
+
+## Notes
+
+- This is intentionally a governance/UX slice only.
+- No API, migration, or runtime execution changes were introduced.

--- a/docs/development/dingtalk-notify-template-preview-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-preview-verification-20260420.md
@@ -1,0 +1,32 @@
+# DingTalk Notification Template Preview Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `31 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- group message authoring shows live destination/title/body/link summary
+- person message authoring shows live recipient/title/body/link summary
+- summary cards update from draft state without changing the underlying authoring payload
+- both the full editor and inline manager remain build-clean
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.


### PR DESCRIPTION
## What changed
- add live DingTalk notification message summary cards in the full rule editor and inline automation manager
- surface destination or recipients, title/body template, and public/internal link targets while authoring
- keep runtime payloads unchanged and limit the change to governance UX
- add focused frontend coverage plus development and verification notes

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build