### PR TITLE
feat(dingtalk): add template syntax warnings

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -94,6 +94,13 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkTitleTemplate"
             />
+            <div
+              v-for="warning in templateSyntaxWarnings(draft.dingtalkTitleTemplate)"
+              :key="`draft-group-title-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">Template tokens</span>
               <button
@@ -115,6 +122,13 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkBodyTemplate"
             ></textarea>
+            <div
+              v-for="warning in templateSyntaxWarnings(draft.dingtalkBodyTemplate)"
+              :key="`draft-group-body-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">Template tokens</span>
               <button
@@ -210,6 +224,13 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkPersonTitleTemplate"
             />
+            <div
+              v-for="warning in templateSyntaxWarnings(draft.dingtalkPersonTitleTemplate)"
+              :key="`draft-person-title-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">Template tokens</span>
               <button
@@ -231,6 +252,13 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkPersonBodyTemplate"
             ></textarea>
+            <div
+              v-for="warning in templateSyntaxWarnings(draft.dingtalkPersonBodyTemplate)"
+              :key="`draft-person-body-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">Template tokens</span>
               <button
@@ -391,6 +419,7 @@ import {
   DINGTALK_BODY_TEMPLATE_TOKENS,
   DINGTALK_TITLE_TEMPLATE_TOKENS,
 } from '../utils/dingtalkNotificationTemplateTokens'
+import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
 
 const props = defineProps<{
   visible: boolean
@@ -558,6 +587,10 @@ const dingTalkPersonRecipientSummary = computed(() => {
   if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
   return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
 })
+
+function templateSyntaxWarnings(value: string) {
+  return listDingTalkTemplateSyntaxWarnings(value)
+}
 
 function applyGroupPreset(preset: DingTalkNotificationPreset) {
   const next = applyDingTalkNotificationPreset(
@@ -978,6 +1011,10 @@ watch(
 
 .meta-automation__hint--error {
   color: #b91c1c;
+}
+
+.meta-automation__hint--warning {
+  color: #b45309;
 }
 
 .meta-automation__input,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -213,6 +213,13 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkTitleTemplate"
               />
+              <div
+                v-for="warning in templateSyntaxWarnings(action.config.titleTemplate)"
+                :key="`group-title-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">Template tokens</span>
                 <button
@@ -234,6 +241,13 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkBodyTemplate"
               ></textarea>
+              <div
+                v-for="warning in templateSyntaxWarnings(action.config.bodyTemplate)"
+                :key="`group-body-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">Template tokens</span>
                 <button
@@ -338,6 +352,13 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkPersonTitleTemplate"
               />
+              <div
+                v-for="warning in templateSyntaxWarnings(action.config.titleTemplate)"
+                :key="`person-title-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">Template tokens</span>
                 <button
@@ -359,6 +380,13 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkPersonBodyTemplate"
               ></textarea>
+              <div
+                v-for="warning in templateSyntaxWarnings(action.config.bodyTemplate)"
+                :key="`person-body-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">Template tokens</span>
                 <button
@@ -450,6 +478,7 @@ import {
   DINGTALK_BODY_TEMPLATE_TOKENS,
   DINGTALK_TITLE_TEMPLATE_TOKENS,
 } from '../utils/dingtalkNotificationTemplateTokens'
+import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
 
 interface FieldPair {
   fieldId: string
@@ -733,6 +762,10 @@ function personRecipientSummary(action: DraftAction) {
   return selected.map((item) => item.label).join(', ')
 }
 
+function templateSyntaxWarnings(value: unknown) {
+  return typeof value === 'string' ? listDingTalkTemplateSyntaxWarnings(value) : []
+}
+
 function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
   action.config = {
     ...action.config,
@@ -974,6 +1007,8 @@ function onTestRun() {
 .meta-rule-editor__label { font-size: 12px; font-weight: 600; color: #475569; margin-top: 4px; }
 
 .meta-rule-editor__hint--error { color: #b91c1c; }
+
+.meta-rule-editor__hint--warning { color: #b45309; }
 
 .meta-rule-editor__input,
 .meta-rule-editor__select,

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
@@ -1,0 +1,31 @@
+const VALID_TEMPLATE_PATH = /^[A-Za-z0-9_.]+$/
+
+export function listDingTalkTemplateSyntaxWarnings(template: string): string[] {
+  const warnings: string[] = []
+  const seen = new Set<string>()
+
+  function push(message: string) {
+    if (seen.has(message)) return
+    seen.add(message)
+    warnings.push(message)
+  }
+
+  for (const match of template.matchAll(/\{\{([^{}]*)\}\}/g)) {
+    const raw = match[0]
+    const inner = match[1].trim()
+    if (!inner) {
+      push('Empty placeholder {{ }} is not supported.')
+      continue
+    }
+    if (!VALID_TEMPLATE_PATH.test(inner)) {
+      push(`Unsupported placeholder syntax ${raw}. Use letters, numbers, "_" and dot paths such as {{recordId}} or {{record.xxx}}.`)
+    }
+  }
+
+  const stripped = template.replace(/\{\{[^{}]*\}\}/g, '')
+  if (stripped.includes('{{') || stripped.includes('}}')) {
+    push('Unclosed placeholder braces detected. Use complete forms like {{recordId}}.')
+  }
+
+  return warnings
+}

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -594,4 +594,26 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })
+
+  it('shows DingTalk template syntax warnings in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = '{{recordId'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Unclosed placeholder braces detected')
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -521,4 +521,28 @@ describe('MetaAutomationRuleEditor', () => {
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })
+
+  it('shows DingTalk template syntax warnings in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = '{{record-id}}'
+    titleInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Unsupported placeholder syntax {{record-id}}')
+  })
 })

--- a/docs/development/dingtalk-notify-template-lint-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-lint-development-20260420.md
@@ -1,0 +1,67 @@
+# DingTalk Notification Template Lint Development
+
+Date: 2026-04-20
+
+## Goal
+
+Add authoring-time syntax warnings for DingTalk notification templates so invalid placeholder forms are caught before a rule is saved or tested.
+
+## Scope
+
+Frontend-only governance enhancement for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Surfaces covered:
+
+- `MetaAutomationRuleEditor`
+- `MetaAutomationManager`
+
+## Implementation
+
+### Shared lint helper
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts`
+
+The helper flags two classes of authoring issues:
+
+- unsupported placeholder syntax inside `{{ ... }}`
+- unclosed placeholder braces
+
+It intentionally does not try to reject arbitrary dot paths such as `{{record.anyField}}`, because runtime rendering accepts dotted lookup paths.
+
+### Rule editor warnings
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Warnings now render under DingTalk title/body fields for both group and person notification actions.
+
+### Inline automation manager warnings
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+The inline create/edit form shows the same warnings so the quick authoring path and full editor stay aligned.
+
+### Test coverage
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies:
+
+- invalid placeholder syntax warning in the rule editor
+- unclosed placeholder warning in the inline manager
+
+## Notes
+
+- This slice does not change backend rendering behavior.
+- It adds guidance only; valid templates continue to work unchanged.

--- a/docs/development/dingtalk-notify-template-lint-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-lint-verification-20260420.md
@@ -1,0 +1,44 @@
+# DingTalk Notification Template Lint Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `33 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- invalid placeholder syntax such as `{{record-id}}` surfaces a warning in the full rule editor
+- unclosed placeholder braces such as `{{recordId` surface a warning in the inline automation manager
+- valid template authoring flows remain intact
+- both surfaces still build cleanly after the lint helper is introduced
+
+## Runtime Alignment
+
+Runtime template rendering in `packages/core-backend/src/multitable/automation-executor.ts` accepts dotted placeholder paths via:
+
+- `{{recordId}}`
+- `{{sheetId}}`
+- `{{actorId}}`
+- `{{record.xxx}}`
+- and other `{{path.with.dots}}` forms that resolve through object lookup
+
+The frontend lint therefore only warns on malformed syntax, not on arbitrary dotted lookup paths.
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.


### PR DESCRIPTION
## What changed
- add shared DingTalk notification template syntax linting
- warn on malformed placeholders and unclosed braces in both the full rule editor and the inline automation manager
- keep runtime rendering behavior unchanged and only add authoring-time guidance
- add focused frontend coverage plus development and verification notes

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build