### PR TITLE
feat(dingtalk): add rendered notification examples

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -155,8 +155,10 @@
             <div class="meta-automation__preview" data-automation-summary="group">
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Group:</strong> {{ dingTalkGroupName(draft.dingtalkDestinationId) }}</div>
-              <div><strong>Title:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
-              <div class="meta-automation__preview-body"><strong>Body:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
+              <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
+              <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
+              <div><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, 'No rendered title') }}</div>
+              <div class="meta-automation__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, 'No rendered body') }}</div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
             </div>
@@ -285,8 +287,10 @@
             <div class="meta-automation__preview" data-automation-summary="person">
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
-              <div><strong>Title:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
-              <div class="meta-automation__preview-body"><strong>Body:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
+              <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
+              <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
+              <div><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, 'No rendered title') }}</div>
+              <div class="meta-automation__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, 'No rendered body') }}</div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
             </div>
@@ -420,6 +424,7 @@ import {
   DINGTALK_TITLE_TEMPLATE_TOKENS,
 } from '../utils/dingtalkNotificationTemplateTokens'
 import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
+import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemplateExample'
 
 const props = defineProps<{
   visible: boolean
@@ -581,6 +586,13 @@ function viewSummaryName(viewId: string, fallback: string) {
 
 function templatePreviewText(value: string, fallback: string) {
   return value.trim() ? value.trim() : fallback
+}
+
+function renderedTemplateExample(value: string, fallback: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return fallback
+  const rendered = renderDingTalkTemplateExample(trimmed).trim()
+  return rendered || fallback
 }
 
 const dingTalkPersonRecipientSummary = computed(() => {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -282,8 +282,10 @@
               <div class="meta-rule-editor__preview" data-field="groupMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Group:</strong> {{ dingTalkGroupName(action.config.destinationId) }}</div>
-                <div><strong>Title:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Body:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
@@ -421,8 +423,10 @@
               <div class="meta-rule-editor__preview" data-field="personMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
-                <div><strong>Title:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Body:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
@@ -479,6 +483,7 @@ import {
   DINGTALK_TITLE_TEMPLATE_TOKENS,
 } from '../utils/dingtalkNotificationTemplateTokens'
 import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
+import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemplateExample'
 
 interface FieldPair {
   fieldId: string
@@ -754,6 +759,12 @@ function viewSummaryName(viewId: unknown, fallback: string) {
 
 function templatePreviewText(value: unknown, fallback: string) {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function renderedTemplateExample(value: unknown, fallback: string) {
+  if (typeof value !== 'string' || !value.trim()) return fallback
+  const rendered = renderDingTalkTemplateExample(value).trim()
+  return rendered || fallback
 }
 
 function personRecipientSummary(action: DraftAction) {

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts
@@ -1,0 +1,41 @@
+function lookupTemplateValue(path: string, data: Record<string, unknown>): unknown {
+  const segments = path.split('.').filter(Boolean)
+  let current: unknown = data
+  for (const segment of segments) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function renderTemplateValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return ''
+  }
+}
+
+const EXAMPLE_TEMPLATE_DATA: Record<string, unknown> = {
+  sheetId: 'sheet_demo_001',
+  recordId: 'record_demo_001',
+  actorId: 'user_demo_001',
+  record: {
+    title: '示例申请单',
+    status: '待处理',
+    owner: '示例负责人',
+    name: '示例联系人',
+    email: 'demo@example.com',
+    mobile: '13900001234',
+    xxx: '示例字段值',
+  },
+}
+
+export function renderDingTalkTemplateExample(template: string): string {
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key: string) =>
+    renderTemplateValue(lookupTemplateValue(key, EXAMPLE_TEMPLATE_DATA)),
+  )
+}

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -591,6 +591,8 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('user_1')
     expect(summary?.textContent).toContain('Need action {{recordId}}')
     expect(summary?.textContent).toContain('Handle {{record.xxx}}')
+    expect(summary?.textContent).toContain('Need action record_demo_001')
+    expect(summary?.textContent).toContain('Handle 示例字段值')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -518,6 +518,8 @@ describe('MetaAutomationRuleEditor', () => {
     expect(summary?.textContent).toContain('Ops Group')
     expect(summary?.textContent).toContain('Ticket {{recordId}}')
     expect(summary?.textContent).toContain('Please fill {{record.xxx}}')
+    expect(summary?.textContent).toContain('Ticket record_demo_001')
+    expect(summary?.textContent).toContain('Please fill 示例字段值')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })

--- a/docs/development/dingtalk-notify-template-example-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-example-development-20260420.md
@@ -1,0 +1,67 @@
+# DingTalk Notify Template Example Development 2026-04-20
+
+## Goal
+
+Add a rendered-example layer to DingTalk notification authoring so admins can see not only the raw title/body templates, but also a sample rendered result before saving the rule.
+
+## Scope
+
+- Frontend only
+- No backend API changes
+- No runtime protocol changes
+- No database migrations
+
+## Changes
+
+### Shared example renderer
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts`
+
+This utility provides:
+
+- sample data for common notification tokens
+- a simple renderer for `{{recordId}}`, `{{sheetId}}`, `{{actorId}}`, and `{{record.xxx}}` token paths
+
+### Rule editor summary
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Changes:
+
+- summary labels now distinguish `Title template` and `Body template`
+- summary cards now also show:
+  - `Rendered title`
+  - `Rendered body`
+- applies to both:
+  - `send_dingtalk_group_message`
+  - `send_dingtalk_person_message`
+
+### Inline automation manager summary
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Changes:
+
+- inline create/edit summaries now match the full rule editor
+- rendered example output is visible for both group and person DingTalk message actions
+
+### Test coverage
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New assertions verify that rendered example text appears alongside the raw template.
+
+## Notes
+
+- This slice intentionally keeps the summary read-only.
+- The rendered preview uses static sample values so authoring remains deterministic.
+- No existing recipient selection behavior changed.

--- a/docs/development/dingtalk-notify-template-example-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-example-verification-20260420.md
@@ -1,0 +1,34 @@
+# DingTalk Notify Template Example Verification 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+claude -p "Reply only with OK."
+```
+
+## Results
+
+- Frontend tests: `33 passed`
+- Web build: `passed`
+- Claude Code CLI availability check: `OK`
+
+## Verified Behavior
+
+- DingTalk group message summaries show:
+  - raw title/body templates
+  - rendered title/body examples
+- DingTalk person message summaries show:
+  - raw title/body templates
+  - rendered title/body examples
+- Rendered examples resolve sample token data such as:
+  - `{{recordId}} -> record_demo_001`
+  - `{{record.xxx}} -> 示例字段值`
+
+## Non-Goals Confirmed
+
+- No backend changes
+- No migration changes
+- No remote deployment


### PR DESCRIPTION
## Summary\n- add a shared DingTalk template example renderer for common tokens\n- show raw templates plus rendered title/body examples in both notification authoring surfaces\n- cover the new summary output in rule editor and automation manager tests\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false\n- pnpm --filter @metasheet/web build\n- claude -p "Reply only with OK."