### PR TITLE
feat(dingtalk): add rendered example copy actions

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -157,8 +157,28 @@
               <div><strong>Group:</strong> {{ dingTalkGroupName(draft.dingtalkDestinationId) }}</div>
               <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
               <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
-              <div><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, 'No rendered title') }}</div>
-              <div class="meta-automation__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, 'No rendered body') }}</div>
+              <div class="meta-automation__preview-line">
+                <span><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, 'No rendered title') }}</span>
+                <button
+                  class="meta-automation__copy-btn"
+                  type="button"
+                  data-automation-copy="group-rendered-title"
+                  @click="copyPreviewText('group-title', renderedTemplateExample(draft.dingtalkTitleTemplate, ''))"
+                >
+                  {{ copiedPreviewKey === 'group-title' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
+              <div class="meta-automation__preview-line meta-automation__preview-body">
+                <span><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, 'No rendered body') }}</span>
+                <button
+                  class="meta-automation__copy-btn"
+                  type="button"
+                  data-automation-copy="group-rendered-body"
+                  @click="copyPreviewText('group-body', renderedTemplateExample(draft.dingtalkBodyTemplate, ''))"
+                >
+                  {{ copiedPreviewKey === 'group-body' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
             </div>
@@ -289,8 +309,28 @@
               <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
               <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
               <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
-              <div><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, 'No rendered title') }}</div>
-              <div class="meta-automation__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, 'No rendered body') }}</div>
+              <div class="meta-automation__preview-line">
+                <span><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, 'No rendered title') }}</span>
+                <button
+                  class="meta-automation__copy-btn"
+                  type="button"
+                  data-automation-copy="person-rendered-title"
+                  @click="copyPreviewText('person-title', renderedTemplateExample(draft.dingtalkPersonTitleTemplate, ''))"
+                >
+                  {{ copiedPreviewKey === 'person-title' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
+              <div class="meta-automation__preview-line meta-automation__preview-body">
+                <span><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, 'No rendered body') }}</span>
+                <button
+                  class="meta-automation__copy-btn"
+                  type="button"
+                  data-automation-copy="person-rendered-body"
+                  @click="copyPreviewText('person-body', renderedTemplateExample(draft.dingtalkPersonBodyTemplate, ''))"
+                >
+                  {{ copiedPreviewKey === 'person-body' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
             </div>
@@ -401,7 +441,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import type {
   AutomationRule,
   AutomationTriggerType,
@@ -494,7 +534,9 @@ const dingtalkPersonUserSearchLoading = ref(false)
 const dingtalkPersonUserSearchError = ref('')
 const dingtalkPersonUserSuggestions = ref<MetaCommentMentionSuggestion[]>([])
 const dingtalkPersonUserDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
+const copiedPreviewKey = ref('')
 let dingtalkPersonSuggestionLoadId = 0
+let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
 
@@ -595,6 +637,18 @@ function renderedTemplateExample(value: string, fallback: string) {
   return rendered || fallback
 }
 
+function copyPreviewText(key: string, text: string) {
+  const trimmed = text.trim()
+  if (!trimmed || !navigator.clipboard?.writeText) return
+  void navigator.clipboard.writeText(trimmed).then(() => {
+    copiedPreviewKey.value = key
+    if (copiedPreviewResetTimer) window.clearTimeout(copiedPreviewResetTimer)
+    copiedPreviewResetTimer = window.setTimeout(() => {
+      if (copiedPreviewKey.value === key) copiedPreviewKey.value = ''
+    }, 1500)
+  }).catch(() => {})
+}
+
 const dingTalkPersonRecipientSummary = computed(() => {
   if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
   return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
@@ -603,6 +657,10 @@ const dingTalkPersonRecipientSummary = computed(() => {
 function templateSyntaxWarnings(value: string) {
   return listDingTalkTemplateSyntaxWarnings(value)
 }
+
+onBeforeUnmount(() => {
+  if (copiedPreviewResetTimer) window.clearTimeout(copiedPreviewResetTimer)
+})
 
 function applyGroupPreset(preset: DingTalkNotificationPreset) {
   const next = applyDingTalkNotificationPreset(
@@ -1082,8 +1140,26 @@ watch(
   color: #1e3a8a;
 }
 
+.meta-automation__preview-line {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .meta-automation__preview-body {
   white-space: pre-wrap;
+}
+
+.meta-automation__copy-btn {
+  flex-shrink: 0;
+  border: 1px solid #bfdbfe;
+  background: #fff;
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
 }
 
 .meta-automation__recipient-option,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -284,8 +284,28 @@
                 <div><strong>Group:</strong> {{ dingTalkGroupName(action.config.destinationId) }}</div>
                 <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
                 <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
-                <div><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</div>
+                <div class="meta-rule-editor__preview-line">
+                  <span><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</span>
+                  <button
+                    class="meta-rule-editor__copy-btn"
+                    type="button"
+                    :data-field="`groupRenderedTitleCopy-${idx}`"
+                    @click="copyPreviewText(`group-title-${idx}`, renderedTemplateExample(action.config.titleTemplate, ''))"
+                  >
+                    {{ copiedPreviewKey === `group-title-${idx}` ? 'Copied' : 'Copy' }}
+                  </button>
+                </div>
+                <div class="meta-rule-editor__preview-line meta-rule-editor__preview-body">
+                  <span><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</span>
+                  <button
+                    class="meta-rule-editor__copy-btn"
+                    type="button"
+                    :data-field="`groupRenderedBodyCopy-${idx}`"
+                    @click="copyPreviewText(`group-body-${idx}`, renderedTemplateExample(action.config.bodyTemplate, ''))"
+                  >
+                    {{ copiedPreviewKey === `group-body-${idx}` ? 'Copied' : 'Copy' }}
+                  </button>
+                </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
@@ -425,8 +445,28 @@
                 <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
                 <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
                 <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
-                <div><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</div>
+                <div class="meta-rule-editor__preview-line">
+                  <span><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</span>
+                  <button
+                    class="meta-rule-editor__copy-btn"
+                    type="button"
+                    :data-field="`personRenderedTitleCopy-${idx}`"
+                    @click="copyPreviewText(`person-title-${idx}`, renderedTemplateExample(action.config.titleTemplate, ''))"
+                  >
+                    {{ copiedPreviewKey === `person-title-${idx}` ? 'Copied' : 'Copy' }}
+                  </button>
+                </div>
+                <div class="meta-rule-editor__preview-line meta-rule-editor__preview-body">
+                  <span><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</span>
+                  <button
+                    class="meta-rule-editor__copy-btn"
+                    type="button"
+                    :data-field="`personRenderedBodyCopy-${idx}`"
+                    @click="copyPreviewText(`person-body-${idx}`, renderedTemplateExample(action.config.bodyTemplate, ''))"
+                  >
+                    {{ copiedPreviewKey === `person-body-${idx}` ? 'Copied' : 'Copy' }}
+                  </button>
+                </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
@@ -463,7 +503,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import type { MultitableApiClient } from '../api/client'
 import type {
   AutomationRule,
@@ -545,7 +585,9 @@ const personRecipientSuggestions = ref<Record<number, MetaCommentMentionSuggesti
 const personRecipientLoading = ref<Record<number, boolean>>({})
 const personRecipientErrors = ref<Record<number, string>>({})
 const personRecipientDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
+const copiedPreviewKey = ref('')
 let personRecipientSuggestionLoadId = 0
+let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
@@ -767,6 +809,18 @@ function renderedTemplateExample(value: unknown, fallback: string) {
   return rendered || fallback
 }
 
+function copyPreviewText(key: string, text: string) {
+  const trimmed = text.trim()
+  if (!trimmed || !navigator.clipboard?.writeText) return
+  void navigator.clipboard.writeText(trimmed).then(() => {
+    copiedPreviewKey.value = key
+    if (copiedPreviewResetTimer) window.clearTimeout(copiedPreviewResetTimer)
+    copiedPreviewResetTimer = window.setTimeout(() => {
+      if (copiedPreviewKey.value === key) copiedPreviewKey.value = ''
+    }, 1500)
+  }).catch(() => {})
+}
+
 function personRecipientSummary(action: DraftAction) {
   const selected = selectedPersonRecipients(action)
   if (!selected.length) return 'No recipients selected'
@@ -776,6 +830,10 @@ function personRecipientSummary(action: DraftAction) {
 function templateSyntaxWarnings(value: unknown) {
   return typeof value === 'string' ? listDingTalkTemplateSyntaxWarnings(value) : []
 }
+
+onBeforeUnmount(() => {
+  if (copiedPreviewResetTimer) window.clearTimeout(copiedPreviewResetTimer)
+})
 
 function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
   action.config = {
@@ -1131,8 +1189,26 @@ function onTestRun() {
   color: #1e3a8a;
 }
 
+.meta-rule-editor__preview-line {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .meta-rule-editor__preview-body {
   white-space: pre-wrap;
+}
+
+.meta-rule-editor__copy-btn {
+  flex-shrink: 0;
+  border: 1px solid #bfdbfe;
+  background: #fff;
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
 }
 
 .meta-rule-editor__recipient-list {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 
 function flushPromises() {
@@ -119,9 +119,24 @@ const views = [
 ]
 
 describe('MetaAutomationManager', () => {
+  const originalClipboard = navigator.clipboard
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
   afterEach(() => {
     document.body.innerHTML = ''
     vi.restoreAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    })
   })
 
   it('renders rule list when visible', async () => {
@@ -617,5 +632,32 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Unclosed placeholder braces detected')
+  })
+
+  it('copies rendered DingTalk person body example in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Handle {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-copy="person-rendered-body"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(navigator.clipboard?.writeText).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(navigator.clipboard!.writeText).mock.calls[0]?.[0]).toBe('Handle 示例字段值')
+    expect(container.textContent).toContain('Copied')
   })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 
 function flushPromises() {
@@ -65,9 +65,24 @@ function mount(props: Record<string, unknown>) {
 }
 
 describe('MetaAutomationRuleEditor', () => {
+  const originalClipboard = navigator.clipboard
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
   afterEach(() => {
     document.body.innerHTML = ''
     vi.restoreAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    })
   })
 
   it('renders trigger type selector when visible', async () => {
@@ -546,5 +561,34 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Unsupported placeholder syntax {{record-id}}')
+  })
+
+  it('copies rendered DingTalk group body example in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-field="groupRenderedBodyCopy-0"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(navigator.clipboard?.writeText).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(navigator.clipboard!.writeText).mock.calls[0]?.[0]).toBe('Please fill 示例字段值')
+    expect(container.textContent).toContain('Copied')
   })
 })

--- a/docs/development/dingtalk-notify-template-copy-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-copy-development-20260420.md
@@ -1,0 +1,55 @@
+# DingTalk Notify Template Copy Development 2026-04-20
+
+## Goal
+
+Add one-click copy actions for rendered DingTalk notification examples so admins can quickly reuse the rendered title/body text while authoring automation rules.
+
+## Scope
+
+- Frontend only
+- No backend/API changes
+- No migration changes
+
+## Changes
+
+### Rule editor
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Changes:
+
+- rendered title/body lines now include `Copy` actions
+- copy buttons switch to `Copied` after successful clipboard writes
+- applies to:
+  - `send_dingtalk_group_message`
+  - `send_dingtalk_person_message`
+
+### Inline automation manager
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Changes:
+
+- inline rendered examples now include the same `Copy` action pattern
+- copy state is local to the current authoring surface
+
+### Styling
+
+Added small preview-line and copy-button styles to keep rendered examples readable while preserving the existing summary card layout.
+
+### Tests
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies clipboard writes for rendered DingTalk examples in both authoring surfaces.
+
+## Claude Code CLI
+
+Used `claude -p` as a read-only assist to choose the next smallest high-value frontend-only slice. The implementation itself remained local in this repo worktree.

--- a/docs/development/dingtalk-notify-template-copy-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-copy-verification-20260420.md
@@ -1,0 +1,26 @@
+# DingTalk Notify Template Copy Verification 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- Frontend tests: `35 passed`
+- Web build: `passed`
+
+## Verified Behavior
+
+- Rule editor rendered DingTalk examples expose `Copy` buttons
+- Inline automation manager rendered DingTalk examples expose `Copy` buttons
+- Clipboard writes use rendered example text, not the raw template
+- Success state changes button text from `Copy` to `Copied`
+
+## Deployment
+
+- No remote deployment
+- No migrations


### PR DESCRIPTION
## Summary
- add copy actions for rendered DingTalk title/body examples in both authoring surfaces
- keep copy state local and switch actions to Copied on successful clipboard writes
- cover clipboard behavior in rule editor and automation manager tests

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- claude -p "You are reviewing a Vue notification authoring flow with recent governance slices: presets, token insert assist, message summary preview, syntax warnings, and rendered template examples. Suggest the single next smallest high-value frontend-only authoring improvement. Reply with 3 lines max: 1) title, 2) why, 3) affected surfaces."
