### PR TITLE
feat(dingtalk): warn on unknown template paths

### DIFF
--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
@@ -1,4 +1,14 @@
 const VALID_TEMPLATE_PATH = /^[A-Za-z0-9_.]+$/
+const KNOWN_TEMPLATE_TOKENS = new Set(['recordId', 'sheetId', 'actorId'])
+
+function isKnownPlaceholderPath(path: string): boolean {
+  if (KNOWN_TEMPLATE_TOKENS.has(path)) return true
+  if (path.startsWith('record.')) {
+    const suffix = path.slice('record.'.length)
+    return suffix.length > 0 && !suffix.startsWith('.') && !suffix.endsWith('.') && !suffix.includes('..')
+  }
+  return false
+}
 
 export function listDingTalkTemplateSyntaxWarnings(template: string): string[] {
   const warnings: string[] = []
@@ -19,6 +29,10 @@ export function listDingTalkTemplateSyntaxWarnings(template: string): string[] {
     }
     if (!VALID_TEMPLATE_PATH.test(inner)) {
       push(`Unsupported placeholder syntax ${raw}. Use letters, numbers, "_" and dot paths such as {{recordId}} or {{record.xxx}}.`)
+      continue
+    }
+    if (!isKnownPlaceholderPath(inner)) {
+      push(`Unknown placeholder ${raw}. Use {{recordId}}, {{sheetId}}, {{actorId}}, or {{record.fieldName}}.`)
     }
   }
 

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -634,6 +634,28 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).toContain('Unclosed placeholder braces detected')
   })
 
+  it('shows DingTalk unknown placeholder warnings in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = '{{record}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Unknown placeholder {{record}}')
+  })
+
   it('copies rendered DingTalk person body example in the inline create form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -563,6 +563,30 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Unsupported placeholder syntax {{record-id}}')
   })
 
+  it('shows DingTalk unknown placeholder warnings in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = '{{recoredId}}'
+    titleInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Unknown placeholder {{recoredId}}')
+  })
+
   it('copies rendered DingTalk group body example in the rule editor', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/docs/development/dingtalk-notify-template-path-warnings-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-path-warnings-development-20260420.md
@@ -1,0 +1,56 @@
+# DingTalk Notify Template Path Warnings Development 2026-04-20
+
+## Goal
+
+Extend DingTalk notification template linting from syntax-only checks to path-aware checks so admins get warned when a placeholder is well-formed but still unknown or incomplete.
+
+## Scope
+
+- Frontend only
+- No backend/API changes
+- No migration changes
+
+## Changes
+
+### Path-aware linting
+
+Updated:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts`
+
+Added:
+
+- known token allow-list:
+  - `recordId`
+  - `sheetId`
+  - `actorId`
+- record path rule:
+  - allow `record.<fieldName>`
+  - reject incomplete or malformed paths such as `record`, `record.`, or `record..name`
+
+New warning shape:
+
+- `Unknown placeholder {{...}}. Use {{recordId}}, {{sheetId}}, {{actorId}}, or {{record.fieldName}}.`
+
+### Existing authoring surfaces
+
+No new UI surface was introduced. The new warning is surfaced through the existing warning areas in:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+### Tests
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+Added focused coverage for:
+
+- typo placeholder: `{{recoredId}}`
+- incomplete record path: `{{record}}`
+
+## Claude Code CLI
+
+This slice was selected after a read-only `claude -p` suggestion pass. The implementation itself remained local in the repo worktree.

--- a/docs/development/dingtalk-notify-template-path-warnings-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-path-warnings-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Notify Template Path Warnings Verification 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- Frontend tests: `37 passed`
+- Web build: `passed`
+
+## Verified Behavior
+
+- Syntax warnings still show for malformed placeholders such as `{{record-id}}`
+- Unknown-path warnings now show for valid-but-unsupported placeholders such as:
+  - `{{recoredId}}`
+  - `{{record}}`
+- Existing valid placeholders remain accepted:
+  - `{{recordId}}`
+  - `{{sheetId}}`
+  - `{{actorId}}`
+  - `{{record.xxx}}`
+
+## Deployment
+
+- No remote deployment
+- No migrations


### PR DESCRIPTION
## Summary
- extend DingTalk template linting from syntax-only warnings to unknown-path warnings
- warn on valid-looking but unsupported placeholders like {{recoredId}} and {{record}}
- cover both authoring surfaces with focused regression tests

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- claude -p "You are reviewing a stacked Vue-only authoring governance series for DingTalk notification templates. Recent slices already added presets, token assist, message summary preview, syntax warnings, rendered examples, and copy actions. Suggest the single next smallest high-value frontend-only improvement. Reply in exactly 3 lines: title, why, affected files/classes."
