### PR TITLE
feat(dingtalk): package notification template governance

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -73,6 +73,12 @@
           </template>
 
           <template v-if="draft.actionType === 'send_dingtalk_group_message'">
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Message preset</span>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-form" @click="applyGroupPreset('form_request')">Form request</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-internal" @click="applyGroupPreset('internal_process')">Internal processing</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-both" @click="applyGroupPreset('form_and_process')">Form + processing</button>
+            </div>
             <label class="meta-automation__label">DingTalk group</label>
             <select v-model="draft.dingtalkDestinationId" class="meta-automation__select" data-automation-field="dingtalkDestinationId">
               <option value="">-- select DingTalk group --</option>
@@ -109,6 +115,12 @@
           </template>
 
           <template v-if="draft.actionType === 'send_dingtalk_person_message'">
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Message preset</span>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-form" @click="applyPersonPreset('form_request')">Form request</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-internal" @click="applyPersonPreset('internal_process')">Internal processing</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-both" @click="applyPersonPreset('form_and_process')">Form + processing</button>
+            </div>
             <label class="meta-automation__label">Search and add users</label>
             <input
               v-model="dingtalkPersonUserSearch"
@@ -305,6 +317,7 @@ import MetaAutomationRuleEditor from './MetaAutomationRuleEditor.vue'
 import MetaAutomationLogViewer from './MetaAutomationLogViewer.vue'
 import MetaAutomationGroupDeliveryViewer from './MetaAutomationGroupDeliveryViewer.vue'
 import MetaAutomationPersonDeliveryViewer from './MetaAutomationPersonDeliveryViewer.vue'
+import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
 
 const props = defineProps<{
   visible: boolean
@@ -452,6 +465,40 @@ function removeDingTalkPersonRecipient(userId: string) {
   draft.value.dingtalkPersonUserIds = parseUserIdsText(draft.value.dingtalkPersonUserIds)
     .filter((id) => id !== userId)
     .join(', ')
+}
+
+function applyGroupPreset(preset: DingTalkNotificationPreset) {
+  const next = applyDingTalkNotificationPreset(
+    {
+      titleTemplate: draft.value.dingtalkTitleTemplate,
+      bodyTemplate: draft.value.dingtalkBodyTemplate,
+      publicFormViewId: draft.value.publicFormViewId,
+      internalViewId: draft.value.internalViewId,
+    },
+    preset,
+    props.views ?? [],
+  )
+  draft.value.dingtalkTitleTemplate = next.titleTemplate ?? ''
+  draft.value.dingtalkBodyTemplate = next.bodyTemplate ?? ''
+  draft.value.publicFormViewId = next.publicFormViewId ?? ''
+  draft.value.internalViewId = next.internalViewId ?? ''
+}
+
+function applyPersonPreset(preset: DingTalkNotificationPreset) {
+  const next = applyDingTalkNotificationPreset(
+    {
+      titleTemplate: draft.value.dingtalkPersonTitleTemplate,
+      bodyTemplate: draft.value.dingtalkPersonBodyTemplate,
+      publicFormViewId: draft.value.dingtalkPersonPublicFormViewId,
+      internalViewId: draft.value.dingtalkPersonInternalViewId,
+    },
+    preset,
+    props.views ?? [],
+  )
+  draft.value.dingtalkPersonTitleTemplate = next.titleTemplate ?? ''
+  draft.value.dingtalkPersonBodyTemplate = next.bodyTemplate ?? ''
+  draft.value.dingtalkPersonPublicFormViewId = next.publicFormViewId ?? ''
+  draft.value.dingtalkPersonInternalViewId = next.internalViewId ?? ''
 }
 
 // --- Rule editor + log viewer state ---
@@ -845,6 +892,20 @@ watch(
 
 .meta-automation__recipient-list--selected {
   margin-bottom: 4px;
+}
+
+.meta-automation__preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.meta-automation__preset-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
 }
 
 .meta-automation__recipient-option,

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -94,6 +94,13 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkTitleTemplate"
             />
+            <div
+              v-for="warning in templateSyntaxWarnings(draft.dingtalkTitleTemplate)"
+              :key="`draft-group-title-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">Template tokens</span>
               <button
@@ -115,6 +122,13 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkBodyTemplate"
             ></textarea>
+            <div
+              v-for="warning in templateSyntaxWarnings(draft.dingtalkBodyTemplate)"
+              :key="`draft-group-body-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">Template tokens</span>
               <button
@@ -210,6 +224,13 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkPersonTitleTemplate"
             />
+            <div
+              v-for="warning in templateSyntaxWarnings(draft.dingtalkPersonTitleTemplate)"
+              :key="`draft-person-title-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">Template tokens</span>
               <button
@@ -231,6 +252,13 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkPersonBodyTemplate"
             ></textarea>
+            <div
+              v-for="warning in templateSyntaxWarnings(draft.dingtalkPersonBodyTemplate)"
+              :key="`draft-person-body-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">Template tokens</span>
               <button
@@ -391,6 +419,7 @@ import {
   DINGTALK_BODY_TEMPLATE_TOKENS,
   DINGTALK_TITLE_TEMPLATE_TOKENS,
 } from '../utils/dingtalkNotificationTemplateTokens'
+import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
 
 const props = defineProps<{
   visible: boolean
@@ -558,6 +587,10 @@ const dingTalkPersonRecipientSummary = computed(() => {
   if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
   return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
 })
+
+function templateSyntaxWarnings(value: string) {
+  return listDingTalkTemplateSyntaxWarnings(value)
+}
 
 function applyGroupPreset(preset: DingTalkNotificationPreset) {
   const next = applyDingTalkNotificationPreset(
@@ -978,6 +1011,10 @@ watch(
 
 .meta-automation__hint--error {
   color: #b91c1c;
+}
+
+.meta-automation__hint--warning {
+  color: #b45309;
 }
 
 .meta-automation__input,

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -157,8 +157,28 @@
               <div><strong>Group:</strong> {{ dingTalkGroupName(draft.dingtalkDestinationId) }}</div>
               <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
               <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
-              <div><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, 'No rendered title') }}</div>
-              <div class="meta-automation__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, 'No rendered body') }}</div>
+              <div class="meta-automation__preview-line">
+                <span><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, 'No rendered title') }}</span>
+                <button
+                  class="meta-automation__copy-btn"
+                  type="button"
+                  data-automation-copy="group-rendered-title"
+                  @click="copyPreviewText('group-title', renderedTemplateExample(draft.dingtalkTitleTemplate, ''))"
+                >
+                  {{ copiedPreviewKey === 'group-title' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
+              <div class="meta-automation__preview-line meta-automation__preview-body">
+                <span><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, 'No rendered body') }}</span>
+                <button
+                  class="meta-automation__copy-btn"
+                  type="button"
+                  data-automation-copy="group-rendered-body"
+                  @click="copyPreviewText('group-body', renderedTemplateExample(draft.dingtalkBodyTemplate, ''))"
+                >
+                  {{ copiedPreviewKey === 'group-body' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
             </div>
@@ -289,8 +309,28 @@
               <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
               <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
               <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
-              <div><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, 'No rendered title') }}</div>
-              <div class="meta-automation__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, 'No rendered body') }}</div>
+              <div class="meta-automation__preview-line">
+                <span><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, 'No rendered title') }}</span>
+                <button
+                  class="meta-automation__copy-btn"
+                  type="button"
+                  data-automation-copy="person-rendered-title"
+                  @click="copyPreviewText('person-title', renderedTemplateExample(draft.dingtalkPersonTitleTemplate, ''))"
+                >
+                  {{ copiedPreviewKey === 'person-title' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
+              <div class="meta-automation__preview-line meta-automation__preview-body">
+                <span><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, 'No rendered body') }}</span>
+                <button
+                  class="meta-automation__copy-btn"
+                  type="button"
+                  data-automation-copy="person-rendered-body"
+                  @click="copyPreviewText('person-body', renderedTemplateExample(draft.dingtalkPersonBodyTemplate, ''))"
+                >
+                  {{ copiedPreviewKey === 'person-body' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
             </div>
@@ -401,7 +441,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import type {
   AutomationRule,
   AutomationTriggerType,
@@ -494,7 +534,9 @@ const dingtalkPersonUserSearchLoading = ref(false)
 const dingtalkPersonUserSearchError = ref('')
 const dingtalkPersonUserSuggestions = ref<MetaCommentMentionSuggestion[]>([])
 const dingtalkPersonUserDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
+const copiedPreviewKey = ref('')
 let dingtalkPersonSuggestionLoadId = 0
+let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
 
@@ -595,6 +637,18 @@ function renderedTemplateExample(value: string, fallback: string) {
   return rendered || fallback
 }
 
+function copyPreviewText(key: string, text: string) {
+  const trimmed = text.trim()
+  if (!trimmed || !navigator.clipboard?.writeText) return
+  void navigator.clipboard.writeText(trimmed).then(() => {
+    copiedPreviewKey.value = key
+    if (copiedPreviewResetTimer) window.clearTimeout(copiedPreviewResetTimer)
+    copiedPreviewResetTimer = window.setTimeout(() => {
+      if (copiedPreviewKey.value === key) copiedPreviewKey.value = ''
+    }, 1500)
+  }).catch(() => {})
+}
+
 const dingTalkPersonRecipientSummary = computed(() => {
   if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
   return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
@@ -603,6 +657,10 @@ const dingTalkPersonRecipientSummary = computed(() => {
 function templateSyntaxWarnings(value: string) {
   return listDingTalkTemplateSyntaxWarnings(value)
 }
+
+onBeforeUnmount(() => {
+  if (copiedPreviewResetTimer) window.clearTimeout(copiedPreviewResetTimer)
+})
 
 function applyGroupPreset(preset: DingTalkNotificationPreset) {
   const next = applyDingTalkNotificationPreset(
@@ -1082,8 +1140,26 @@ watch(
   color: #1e3a8a;
 }
 
+.meta-automation__preview-line {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .meta-automation__preview-body {
   white-space: pre-wrap;
+}
+
+.meta-automation__copy-btn {
+  flex-shrink: 0;
+  border: 1px solid #bfdbfe;
+  background: #fff;
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
 }
 
 .meta-automation__recipient-option,

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -94,6 +94,19 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkTitleTemplate"
             />
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`group-title-${token.key}`"
+                @click="appendGroupTemplateToken('title', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Body template</label>
             <textarea
               v-model="draft.dingtalkBodyTemplate"
@@ -102,6 +115,19 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkBodyTemplate"
             ></textarea>
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`group-body-${token.key}`"
+                @click="appendGroupTemplateToken('body', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Public form view (optional)</label>
             <select v-model="draft.publicFormViewId" class="meta-automation__select" data-automation-field="publicFormViewId">
               <option value="">-- no public form link --</option>
@@ -176,6 +202,19 @@
               placeholder="例如：{{record.title}} 待处理"
               data-automation-field="dingtalkPersonTitleTemplate"
             />
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`person-title-${token.key}`"
+                @click="appendPersonTemplateToken('title', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Body template</label>
             <textarea
               v-model="draft.dingtalkPersonBodyTemplate"
@@ -184,6 +223,19 @@
               placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
               data-automation-field="dingtalkPersonBodyTemplate"
             ></textarea>
+            <div class="meta-automation__preset-row">
+              <span class="meta-automation__preset-label">Template tokens</span>
+              <button
+                v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                :key="token.key"
+                class="meta-automation__btn"
+                type="button"
+                :data-automation-token="`person-body-${token.key}`"
+                @click="appendPersonTemplateToken('body', token.value)"
+              >
+                {{ token.label }}
+              </button>
+            </div>
             <label class="meta-automation__label">Public form view (optional)</label>
             <select v-model="draft.dingtalkPersonPublicFormViewId" class="meta-automation__select" data-automation-field="dingtalkPersonPublicFormViewId">
               <option value="">-- no public form link --</option>
@@ -318,6 +370,11 @@ import MetaAutomationLogViewer from './MetaAutomationLogViewer.vue'
 import MetaAutomationGroupDeliveryViewer from './MetaAutomationGroupDeliveryViewer.vue'
 import MetaAutomationPersonDeliveryViewer from './MetaAutomationPersonDeliveryViewer.vue'
 import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
+import {
+  appendTemplateToken,
+  DINGTALK_BODY_TEMPLATE_TOKENS,
+  DINGTALK_TITLE_TEMPLATE_TOKENS,
+} from '../utils/dingtalkNotificationTemplateTokens'
 
 const props = defineProps<{
   visible: boolean
@@ -499,6 +556,22 @@ function applyPersonPreset(preset: DingTalkNotificationPreset) {
   draft.value.dingtalkPersonBodyTemplate = next.bodyTemplate ?? ''
   draft.value.dingtalkPersonPublicFormViewId = next.publicFormViewId ?? ''
   draft.value.dingtalkPersonInternalViewId = next.internalViewId ?? ''
+}
+
+function appendGroupTemplateToken(field: 'title' | 'body', token: string) {
+  if (field === 'title') {
+    draft.value.dingtalkTitleTemplate = appendTemplateToken(draft.value.dingtalkTitleTemplate, token)
+    return
+  }
+  draft.value.dingtalkBodyTemplate = appendTemplateToken(draft.value.dingtalkBodyTemplate, token, true)
+}
+
+function appendPersonTemplateToken(field: 'title' | 'body', token: string) {
+  if (field === 'title') {
+    draft.value.dingtalkPersonTitleTemplate = appendTemplateToken(draft.value.dingtalkPersonTitleTemplate, token)
+    return
+  }
+  draft.value.dingtalkPersonBodyTemplate = appendTemplateToken(draft.value.dingtalkPersonBodyTemplate, token, true)
 }
 
 // --- Rule editor + log viewer state ---

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -138,6 +138,14 @@
               <option value="">-- no internal link --</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
+            <div class="meta-automation__preview" data-automation-summary="group">
+              <div class="meta-automation__preview-title">Message summary</div>
+              <div><strong>Group:</strong> {{ dingTalkGroupName(draft.dingtalkDestinationId) }}</div>
+              <div><strong>Title:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
+              <div class="meta-automation__preview-body"><strong>Body:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
+              <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
+              <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
+            </div>
           </template>
 
           <template v-if="draft.actionType === 'send_dingtalk_person_message'">
@@ -246,6 +254,14 @@
               <option value="">-- no internal link --</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
+            <div class="meta-automation__preview" data-automation-summary="person">
+              <div class="meta-automation__preview-title">Message summary</div>
+              <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
+              <div><strong>Title:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
+              <div class="meta-automation__preview-body"><strong>Body:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
+              <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
+              <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
+            </div>
           </template>
 
           <div class="meta-automation__form-actions">
@@ -523,6 +539,25 @@ function removeDingTalkPersonRecipient(userId: string) {
     .filter((id) => id !== userId)
     .join(', ')
 }
+
+function dingTalkGroupName(destinationId: string) {
+  if (!destinationId) return 'No group selected'
+  return dingTalkDestinations.value.find((item) => item.id === destinationId)?.name ?? destinationId
+}
+
+function viewSummaryName(viewId: string, fallback: string) {
+  if (!viewId) return fallback
+  return (props.views ?? []).find((view) => view.id === viewId)?.name ?? viewId
+}
+
+function templatePreviewText(value: string, fallback: string) {
+  return value.trim() ? value.trim() : fallback
+}
+
+const dingTalkPersonRecipientSummary = computed(() => {
+  if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
+  return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
+})
 
 function applyGroupPreset(preset: DingTalkNotificationPreset) {
   const next = applyDingTalkNotificationPreset(
@@ -979,6 +1014,27 @@ watch(
   font-size: 12px;
   font-weight: 600;
   color: #475569;
+}
+
+.meta-automation__preview {
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.meta-automation__preview-title {
+  font-weight: 700;
+  color: #1e3a8a;
+}
+
+.meta-automation__preview-body {
+  white-space: pre-wrap;
 }
 
 .meta-automation__recipient-option,

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -155,8 +155,10 @@
             <div class="meta-automation__preview" data-automation-summary="group">
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Group:</strong> {{ dingTalkGroupName(draft.dingtalkDestinationId) }}</div>
-              <div><strong>Title:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
-              <div class="meta-automation__preview-body"><strong>Body:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
+              <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
+              <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
+              <div><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, 'No rendered title') }}</div>
+              <div class="meta-automation__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, 'No rendered body') }}</div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
             </div>
@@ -285,8 +287,10 @@
             <div class="meta-automation__preview" data-automation-summary="person">
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
-              <div><strong>Title:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
-              <div class="meta-automation__preview-body"><strong>Body:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
+              <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
+              <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
+              <div><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, 'No rendered title') }}</div>
+              <div class="meta-automation__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, 'No rendered body') }}</div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
             </div>
@@ -420,6 +424,7 @@ import {
   DINGTALK_TITLE_TEMPLATE_TOKENS,
 } from '../utils/dingtalkNotificationTemplateTokens'
 import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
+import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemplateExample'
 
 const props = defineProps<{
   visible: boolean
@@ -581,6 +586,13 @@ function viewSummaryName(viewId: string, fallback: string) {
 
 function templatePreviewText(value: string, fallback: string) {
   return value.trim() ? value.trim() : fallback
+}
+
+function renderedTemplateExample(value: string, fallback: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return fallback
+  const rendered = renderDingTalkTemplateExample(trimmed).trim()
+  return rendered || fallback
 }
 
 const dingTalkPersonRecipientSummary = computed(() => {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -282,8 +282,10 @@
               <div class="meta-rule-editor__preview" data-field="groupMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Group:</strong> {{ dingTalkGroupName(action.config.destinationId) }}</div>
-                <div><strong>Title:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Body:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
@@ -421,8 +423,10 @@
               <div class="meta-rule-editor__preview" data-field="personMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
-                <div><strong>Title:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Body:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
@@ -479,6 +483,7 @@ import {
   DINGTALK_TITLE_TEMPLATE_TOKENS,
 } from '../utils/dingtalkNotificationTemplateTokens'
 import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
+import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemplateExample'
 
 interface FieldPair {
   fieldId: string
@@ -754,6 +759,12 @@ function viewSummaryName(viewId: unknown, fallback: string) {
 
 function templatePreviewText(value: unknown, fallback: string) {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function renderedTemplateExample(value: unknown, fallback: string) {
+  if (typeof value !== 'string' || !value.trim()) return fallback
+  const rendered = renderDingTalkTemplateExample(value).trim()
+  return rendered || fallback
 }
 
 function personRecipientSummary(action: DraftAction) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -284,8 +284,28 @@
                 <div><strong>Group:</strong> {{ dingTalkGroupName(action.config.destinationId) }}</div>
                 <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
                 <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
-                <div><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</div>
+                <div class="meta-rule-editor__preview-line">
+                  <span><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</span>
+                  <button
+                    class="meta-rule-editor__copy-btn"
+                    type="button"
+                    :data-field="`groupRenderedTitleCopy-${idx}`"
+                    @click="copyPreviewText(`group-title-${idx}`, renderedTemplateExample(action.config.titleTemplate, ''))"
+                  >
+                    {{ copiedPreviewKey === `group-title-${idx}` ? 'Copied' : 'Copy' }}
+                  </button>
+                </div>
+                <div class="meta-rule-editor__preview-line meta-rule-editor__preview-body">
+                  <span><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</span>
+                  <button
+                    class="meta-rule-editor__copy-btn"
+                    type="button"
+                    :data-field="`groupRenderedBodyCopy-${idx}`"
+                    @click="copyPreviewText(`group-body-${idx}`, renderedTemplateExample(action.config.bodyTemplate, ''))"
+                  >
+                    {{ copiedPreviewKey === `group-body-${idx}` ? 'Copied' : 'Copy' }}
+                  </button>
+                </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
@@ -425,8 +445,28 @@
                 <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
                 <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
                 <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
-                <div><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</div>
+                <div class="meta-rule-editor__preview-line">
+                  <span><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</span>
+                  <button
+                    class="meta-rule-editor__copy-btn"
+                    type="button"
+                    :data-field="`personRenderedTitleCopy-${idx}`"
+                    @click="copyPreviewText(`person-title-${idx}`, renderedTemplateExample(action.config.titleTemplate, ''))"
+                  >
+                    {{ copiedPreviewKey === `person-title-${idx}` ? 'Copied' : 'Copy' }}
+                  </button>
+                </div>
+                <div class="meta-rule-editor__preview-line meta-rule-editor__preview-body">
+                  <span><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</span>
+                  <button
+                    class="meta-rule-editor__copy-btn"
+                    type="button"
+                    :data-field="`personRenderedBodyCopy-${idx}`"
+                    @click="copyPreviewText(`person-body-${idx}`, renderedTemplateExample(action.config.bodyTemplate, ''))"
+                  >
+                    {{ copiedPreviewKey === `person-body-${idx}` ? 'Copied' : 'Copy' }}
+                  </button>
+                </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
@@ -463,7 +503,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import type { MultitableApiClient } from '../api/client'
 import type {
   AutomationRule,
@@ -545,7 +585,9 @@ const personRecipientSuggestions = ref<Record<number, MetaCommentMentionSuggesti
 const personRecipientLoading = ref<Record<number, boolean>>({})
 const personRecipientErrors = ref<Record<number, string>>({})
 const personRecipientDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
+const copiedPreviewKey = ref('')
 let personRecipientSuggestionLoadId = 0
+let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
@@ -767,6 +809,18 @@ function renderedTemplateExample(value: unknown, fallback: string) {
   return rendered || fallback
 }
 
+function copyPreviewText(key: string, text: string) {
+  const trimmed = text.trim()
+  if (!trimmed || !navigator.clipboard?.writeText) return
+  void navigator.clipboard.writeText(trimmed).then(() => {
+    copiedPreviewKey.value = key
+    if (copiedPreviewResetTimer) window.clearTimeout(copiedPreviewResetTimer)
+    copiedPreviewResetTimer = window.setTimeout(() => {
+      if (copiedPreviewKey.value === key) copiedPreviewKey.value = ''
+    }, 1500)
+  }).catch(() => {})
+}
+
 function personRecipientSummary(action: DraftAction) {
   const selected = selectedPersonRecipients(action)
   if (!selected.length) return 'No recipients selected'
@@ -776,6 +830,10 @@ function personRecipientSummary(action: DraftAction) {
 function templateSyntaxWarnings(value: unknown) {
   return typeof value === 'string' ? listDingTalkTemplateSyntaxWarnings(value) : []
 }
+
+onBeforeUnmount(() => {
+  if (copiedPreviewResetTimer) window.clearTimeout(copiedPreviewResetTimer)
+})
 
 function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
   action.config = {
@@ -1131,8 +1189,26 @@ function onTestRun() {
   color: #1e3a8a;
 }
 
+.meta-rule-editor__preview-line {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .meta-rule-editor__preview-body {
   white-space: pre-wrap;
+}
+
+.meta-rule-editor__copy-btn {
+  flex-shrink: 0;
+  border: 1px solid #bfdbfe;
+  background: #fff;
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
 }
 
 .meta-rule-editor__recipient-list {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -187,6 +187,12 @@
 
             <!-- send_dingtalk_group_message config -->
             <div v-if="action.type === 'send_dingtalk_group_message'" class="meta-rule-editor__action-config">
+              <div class="meta-rule-editor__preset-row">
+                <span class="meta-rule-editor__preset-label">Message preset</span>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetForm" @click="applyGroupPreset(action, 'form_request')">Form request</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetInternal" @click="applyGroupPreset(action, 'internal_process')">Internal processing</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetBoth" @click="applyGroupPreset(action, 'form_and_process')">Form + processing</button>
+              </div>
               <label class="meta-rule-editor__label">DingTalk group</label>
               <select
                 v-model="action.config.destinationId"
@@ -237,6 +243,12 @@
 
             <!-- send_dingtalk_person_message config -->
             <div v-if="action.type === 'send_dingtalk_person_message'" class="meta-rule-editor__action-config">
+              <div class="meta-rule-editor__preset-row">
+                <span class="meta-rule-editor__preset-label">Message preset</span>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetForm" @click="applyPersonPreset(action, 'form_request')">Form request</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetInternal" @click="applyPersonPreset(action, 'internal_process')">Internal processing</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetBoth" @click="applyPersonPreset(action, 'form_and_process')">Form + processing</button>
+              </div>
               <label class="meta-rule-editor__label">Search and add users</label>
               <input
                 v-model="action.config.userIdsSearch"
@@ -364,6 +376,7 @@ import type {
   MetaCommentMentionSuggestion,
   MetaView,
 } from '../types'
+import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
 
 interface FieldPair {
   fieldId: string
@@ -623,6 +636,38 @@ function removePersonRecipient(action: DraftAction, userId: string) {
   action.config.userIdsText = parseUserIdsText(action.config.userIdsText)
     .filter((id) => id !== userId)
     .join(', ')
+}
+
+function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
+  action.config = {
+    ...action.config,
+    ...applyDingTalkNotificationPreset(
+      {
+        titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate : '',
+        bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate : '',
+        publicFormViewId: typeof action.config.publicFormViewId === 'string' ? action.config.publicFormViewId : '',
+        internalViewId: typeof action.config.internalViewId === 'string' ? action.config.internalViewId : '',
+      },
+      preset,
+      props.views ?? [],
+    ),
+  }
+}
+
+function applyPersonPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
+  action.config = {
+    ...action.config,
+    ...applyDingTalkNotificationPreset(
+      {
+        titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate : '',
+        bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate : '',
+        publicFormViewId: typeof action.config.publicFormViewId === 'string' ? action.config.publicFormViewId : '',
+        internalViewId: typeof action.config.internalViewId === 'string' ? action.config.internalViewId : '',
+      },
+      preset,
+      props.views ?? [],
+    ),
+  }
 }
 
 function defaultConfigForActionType(type: AutomationActionType): DraftActionConfig {
@@ -885,6 +930,19 @@ function onTestRun() {
   flex-direction: column;
   gap: 6px;
   padding-left: 20px;
+}
+
+.meta-rule-editor__preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.meta-rule-editor__preset-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
 }
 
 .meta-rule-editor__recipient-list {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -213,6 +213,13 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkTitleTemplate"
               />
+              <div
+                v-for="warning in templateSyntaxWarnings(action.config.titleTemplate)"
+                :key="`group-title-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">Template tokens</span>
                 <button
@@ -234,6 +241,13 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkBodyTemplate"
               ></textarea>
+              <div
+                v-for="warning in templateSyntaxWarnings(action.config.bodyTemplate)"
+                :key="`group-body-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">Template tokens</span>
                 <button
@@ -338,6 +352,13 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkPersonTitleTemplate"
               />
+              <div
+                v-for="warning in templateSyntaxWarnings(action.config.titleTemplate)"
+                :key="`person-title-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">Template tokens</span>
                 <button
@@ -359,6 +380,13 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkPersonBodyTemplate"
               ></textarea>
+              <div
+                v-for="warning in templateSyntaxWarnings(action.config.bodyTemplate)"
+                :key="`person-body-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">Template tokens</span>
                 <button
@@ -450,6 +478,7 @@ import {
   DINGTALK_BODY_TEMPLATE_TOKENS,
   DINGTALK_TITLE_TEMPLATE_TOKENS,
 } from '../utils/dingtalkNotificationTemplateTokens'
+import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
 
 interface FieldPair {
   fieldId: string
@@ -733,6 +762,10 @@ function personRecipientSummary(action: DraftAction) {
   return selected.map((item) => item.label).join(', ')
 }
 
+function templateSyntaxWarnings(value: unknown) {
+  return typeof value === 'string' ? listDingTalkTemplateSyntaxWarnings(value) : []
+}
+
 function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
   action.config = {
     ...action.config,
@@ -974,6 +1007,8 @@ function onTestRun() {
 .meta-rule-editor__label { font-size: 12px; font-weight: 600; color: #475569; margin-top: 4px; }
 
 .meta-rule-editor__hint--error { color: #b91c1c; }
+
+.meta-rule-editor__hint--warning { color: #b45309; }
 
 .meta-rule-editor__input,
 .meta-rule-editor__select,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -265,6 +265,14 @@
                 <option value="">-- no internal link --</option>
                 <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
+              <div class="meta-rule-editor__preview" data-field="groupMessageSummary">
+                <div class="meta-rule-editor__preview-title">Message summary</div>
+                <div><strong>Group:</strong> {{ dingTalkGroupName(action.config.destinationId) }}</div>
+                <div><strong>Title:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Body:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
+                <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
+              </div>
             </div>
 
             <!-- send_dingtalk_person_message config -->
@@ -382,6 +390,14 @@
                 <option value="">-- no internal link --</option>
                 <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
+              <div class="meta-rule-editor__preview" data-field="personMessageSummary">
+                <div class="meta-rule-editor__preview-title">Message summary</div>
+                <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
+                <div><strong>Title:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>Body:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
+                <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
+              </div>
             </div>
 
             <!-- lock_record config -->
@@ -693,6 +709,28 @@ function removePersonRecipient(action: DraftAction, userId: string) {
   action.config.userIdsText = parseUserIdsText(action.config.userIdsText)
     .filter((id) => id !== userId)
     .join(', ')
+}
+
+function dingTalkGroupName(destinationId: unknown) {
+  const id = typeof destinationId === 'string' ? destinationId : ''
+  if (!id) return 'No group selected'
+  return dingTalkDestinations.value.find((item) => item.id === id)?.name ?? id
+}
+
+function viewSummaryName(viewId: unknown, fallback: string) {
+  const id = typeof viewId === 'string' ? viewId : ''
+  if (!id) return fallback
+  return (props.views ?? []).find((view) => view.id === id)?.name ?? id
+}
+
+function templatePreviewText(value: unknown, fallback: string) {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function personRecipientSummary(action: DraftAction) {
+  const selected = selectedPersonRecipients(action)
+  if (!selected.length) return 'No recipients selected'
+  return selected.map((item) => item.label).join(', ')
 }
 
 function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPreset) {
@@ -1028,6 +1066,27 @@ function onTestRun() {
   font-size: 12px;
   font-weight: 600;
   color: #475569;
+}
+
+.meta-rule-editor__preview {
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.meta-rule-editor__preview-title {
+  font-weight: 700;
+  color: #1e3a8a;
+}
+
+.meta-rule-editor__preview-body {
+  white-space: pre-wrap;
 }
 
 .meta-rule-editor__recipient-list {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -213,6 +213,19 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkTitleTemplate"
               />
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`groupTitleToken-${token.key}`"
+                  @click="appendGroupTemplateToken(action, 'titleTemplate', token.value)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Body template</label>
               <textarea
                 v-model="action.config.bodyTemplate"
@@ -221,6 +234,19 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkBodyTemplate"
               ></textarea>
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`groupBodyToken-${token.key}`"
+                  @click="appendGroupTemplateToken(action, 'bodyTemplate', token.value, true)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Public form view (optional)</label>
               <select
                 v-model="action.config.publicFormViewId"
@@ -304,6 +330,19 @@
                 placeholder="例如：{{record.title}} 待处理"
                 data-field="dingtalkPersonTitleTemplate"
               />
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`personTitleToken-${token.key}`"
+                  @click="appendPersonTemplateToken(action, 'titleTemplate', token.value)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Body template</label>
               <textarea
                 v-model="action.config.bodyTemplate"
@@ -312,6 +351,19 @@
                 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
                 data-field="dingtalkPersonBodyTemplate"
               ></textarea>
+              <div class="meta-rule-editor__token-row">
+                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <button
+                  v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
+                  :key="token.key"
+                  class="meta-rule-editor__btn"
+                  type="button"
+                  :data-field="`personBodyToken-${token.key}`"
+                  @click="appendPersonTemplateToken(action, 'bodyTemplate', token.value, true)"
+                >
+                  {{ token.label }}
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Public form view (optional)</label>
               <select
                 v-model="action.config.publicFormViewId"
@@ -377,6 +429,11 @@ import type {
   MetaView,
 } from '../types'
 import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
+import {
+  appendTemplateToken,
+  DINGTALK_BODY_TEMPLATE_TOKENS,
+  DINGTALK_TITLE_TEMPLATE_TOKENS,
+} from '../utils/dingtalkNotificationTemplateTokens'
 
 interface FieldPair {
   fieldId: string
@@ -670,6 +727,26 @@ function applyPersonPreset(action: DraftAction, preset: DingTalkNotificationPres
   }
 }
 
+function appendGroupTemplateToken(
+  action: DraftAction,
+  field: 'titleTemplate' | 'bodyTemplate',
+  token: string,
+  multiline = false,
+) {
+  const current = typeof action.config[field] === 'string' ? action.config[field] : ''
+  action.config[field] = appendTemplateToken(current, token, multiline)
+}
+
+function appendPersonTemplateToken(
+  action: DraftAction,
+  field: 'titleTemplate' | 'bodyTemplate',
+  token: string,
+  multiline = false,
+) {
+  const current = typeof action.config[field] === 'string' ? action.config[field] : ''
+  action.config[field] = appendTemplateToken(current, token, multiline)
+}
+
 function defaultConfigForActionType(type: AutomationActionType): DraftActionConfig {
   switch (type) {
     case 'update_record':
@@ -937,6 +1014,14 @@ function onTestRun() {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+}
+
+.meta-rule-editor__token-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 12px;
 }
 
 .meta-rule-editor__preset-label {

--- a/apps/web/src/multitable/utils/dingtalkNotificationPresets.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationPresets.ts
@@ -1,0 +1,63 @@
+import type { MetaView } from '../types'
+
+export type DingTalkNotificationPreset = 'form_request' | 'internal_process' | 'form_and_process'
+
+export interface DingTalkNotificationPresetConfig {
+  titleTemplate?: string
+  bodyTemplate?: string
+  publicFormViewId?: string
+  internalViewId?: string
+}
+
+function normalizeId(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function pickDefaultFormViewId(views: MetaView[], currentViewId?: string): string {
+  const current = normalizeId(currentViewId)
+  if (current && views.some((view) => view.id === current && view.type === 'form')) return current
+  return views.find((view) => view.type === 'form')?.id ?? ''
+}
+
+function pickDefaultInternalViewId(views: MetaView[], currentViewId?: string): string {
+  const current = normalizeId(currentViewId)
+  if (current && views.some((view) => view.id === current)) return current
+  return views.find((view) => view.type !== 'form')?.id ?? views[0]?.id ?? ''
+}
+
+export function applyDingTalkNotificationPreset(
+  config: DingTalkNotificationPresetConfig,
+  preset: DingTalkNotificationPreset,
+  views: MetaView[],
+): DingTalkNotificationPresetConfig {
+  const formViewId = pickDefaultFormViewId(views, config.publicFormViewId)
+  const internalViewId = pickDefaultInternalViewId(views, config.internalViewId)
+
+  if (preset === 'form_request') {
+    return {
+      ...config,
+      titleTemplate: '{{recordId}} 待填写',
+      bodyTemplate: '请完成本次表单填写。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+      publicFormViewId: formViewId,
+      internalViewId: '',
+    }
+  }
+
+  if (preset === 'internal_process') {
+    return {
+      ...config,
+      titleTemplate: '{{recordId}} 待处理',
+      bodyTemplate: '请查看并处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+      publicFormViewId: '',
+      internalViewId,
+    }
+  }
+
+  return {
+    ...config,
+    titleTemplate: '{{recordId}} 待填写并处理',
+    bodyTemplate: '请先填写所需信息，并由有权限成员继续处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+    publicFormViewId: formViewId,
+    internalViewId,
+  }
+}

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts
@@ -1,0 +1,41 @@
+function lookupTemplateValue(path: string, data: Record<string, unknown>): unknown {
+  const segments = path.split('.').filter(Boolean)
+  let current: unknown = data
+  for (const segment of segments) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function renderTemplateValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return ''
+  }
+}
+
+const EXAMPLE_TEMPLATE_DATA: Record<string, unknown> = {
+  sheetId: 'sheet_demo_001',
+  recordId: 'record_demo_001',
+  actorId: 'user_demo_001',
+  record: {
+    title: '示例申请单',
+    status: '待处理',
+    owner: '示例负责人',
+    name: '示例联系人',
+    email: 'demo@example.com',
+    mobile: '13900001234',
+    xxx: '示例字段值',
+  },
+}
+
+export function renderDingTalkTemplateExample(template: string): string {
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key: string) =>
+    renderTemplateValue(lookupTemplateValue(key, EXAMPLE_TEMPLATE_DATA)),
+  )
+}

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
@@ -1,4 +1,14 @@
 const VALID_TEMPLATE_PATH = /^[A-Za-z0-9_.]+$/
+const KNOWN_TEMPLATE_TOKENS = new Set(['recordId', 'sheetId', 'actorId'])
+
+function isKnownPlaceholderPath(path: string): boolean {
+  if (KNOWN_TEMPLATE_TOKENS.has(path)) return true
+  if (path.startsWith('record.')) {
+    const suffix = path.slice('record.'.length)
+    return suffix.length > 0 && !suffix.startsWith('.') && !suffix.endsWith('.') && !suffix.includes('..')
+  }
+  return false
+}
 
 export function listDingTalkTemplateSyntaxWarnings(template: string): string[] {
   const warnings: string[] = []
@@ -19,6 +29,10 @@ export function listDingTalkTemplateSyntaxWarnings(template: string): string[] {
     }
     if (!VALID_TEMPLATE_PATH.test(inner)) {
       push(`Unsupported placeholder syntax ${raw}. Use letters, numbers, "_" and dot paths such as {{recordId}} or {{record.xxx}}.`)
+      continue
+    }
+    if (!isKnownPlaceholderPath(inner)) {
+      push(`Unknown placeholder ${raw}. Use {{recordId}}, {{sheetId}}, {{actorId}}, or {{record.fieldName}}.`)
     }
   }
 

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
@@ -1,0 +1,31 @@
+const VALID_TEMPLATE_PATH = /^[A-Za-z0-9_.]+$/
+
+export function listDingTalkTemplateSyntaxWarnings(template: string): string[] {
+  const warnings: string[] = []
+  const seen = new Set<string>()
+
+  function push(message: string) {
+    if (seen.has(message)) return
+    seen.add(message)
+    warnings.push(message)
+  }
+
+  for (const match of template.matchAll(/\{\{([^{}]*)\}\}/g)) {
+    const raw = match[0]
+    const inner = match[1].trim()
+    if (!inner) {
+      push('Empty placeholder {{ }} is not supported.')
+      continue
+    }
+    if (!VALID_TEMPLATE_PATH.test(inner)) {
+      push(`Unsupported placeholder syntax ${raw}. Use letters, numbers, "_" and dot paths such as {{recordId}} or {{record.xxx}}.`)
+    }
+  }
+
+  const stripped = template.replace(/\{\{[^{}]*\}\}/g, '')
+  if (stripped.includes('{{') || stripped.includes('}}')) {
+    push('Unclosed placeholder braces detected. Use complete forms like {{recordId}}.')
+  }
+
+  return warnings
+}

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts
@@ -1,0 +1,23 @@
+export interface DingTalkNotificationTemplateToken {
+  key: string
+  label: string
+  value: string
+}
+
+export const DINGTALK_TITLE_TEMPLATE_TOKENS: DingTalkNotificationTemplateToken[] = [
+  { key: 'recordId', label: 'Record ID', value: '{{recordId}}' },
+  { key: 'sheetId', label: 'Sheet ID', value: '{{sheetId}}' },
+  { key: 'actorId', label: 'Actor ID', value: '{{actorId}}' },
+]
+
+export const DINGTALK_BODY_TEMPLATE_TOKENS: DingTalkNotificationTemplateToken[] = [
+  ...DINGTALK_TITLE_TEMPLATE_TOKENS,
+  { key: 'recordField', label: 'Record field', value: '{{record.xxx}}' },
+]
+
+export function appendTemplateToken(currentValue: string, token: string, multiline = false): string {
+  if (!currentValue.trim()) return token
+  if (currentValue.endsWith(token)) return currentValue
+  if (/\s$/.test(currentValue)) return `${currentValue}${token}`
+  return multiline ? `${currentValue}\n${token}` : `${currentValue} ${token}`
+}

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -472,4 +472,67 @@ describe('MetaAutomationManager', () => {
     expect(delivery?.textContent).toContain('Ops Group')
     expect(delivery?.textContent).toContain('Ticket rec_1 pending')
   })
+
+  it('applies DingTalk group presets in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const presetBtn = container.querySelector('[data-automation-preset="group-form"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
+    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLSelectElement
+
+    expect(titleInput.value).toBe('{{recordId}} 待填写')
+    expect(bodyInput.value).toContain('请完成本次表单填写')
+    expect(publicFormSelect.value).toBe('view_form')
+    expect(internalViewSelect.value).toBe('')
+  })
+
+  it('applies DingTalk person presets in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const presetBtn = container.querySelector('[data-automation-preset="person-both"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    const internalViewSelect = container.querySelector('[data-automation-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+
+    expect(userIdsInput.value).toBe('user_1')
+    expect(titleInput.value).toBe('{{recordId}} 待填写并处理')
+    expect(bodyInput.value).toContain('请先填写所需信息')
+    expect(publicFormSelect.value).toBe('view_form')
+    expect(internalViewSelect.value).toBe('view_grid')
+  })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 
 function flushPromises() {
@@ -119,9 +119,24 @@ const views = [
 ]
 
 describe('MetaAutomationManager', () => {
+  const originalClipboard = navigator.clipboard
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
   afterEach(() => {
     document.body.innerHTML = ''
     vi.restoreAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    })
   })
 
   it('renders rule list when visible', async () => {
@@ -617,5 +632,32 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Unclosed placeholder braces detected')
+  })
+
+  it('copies rendered DingTalk person body example in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Handle {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-copy="person-rendered-body"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(navigator.clipboard?.writeText).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(navigator.clipboard!.writeText).mock.calls[0]?.[0]).toBe('Handle 示例字段值')
+    expect(container.textContent).toContain('Copied')
   })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -559,4 +559,39 @@ describe('MetaAutomationManager', () => {
     expect(titleInput.value).toBe('{{recordId}}')
     expect(bodyInput.value).toBe('{{record.xxx}}')
   })
+
+  it('shows DingTalk person message summary in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Need action {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Handle {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(summary?.textContent).toContain('user_1')
+    expect(summary?.textContent).toContain('Need action {{recordId}}')
+    expect(summary?.textContent).toContain('Handle {{record.xxx}}')
+    expect(summary?.textContent).toContain('No public form link')
+    expect(summary?.textContent).toContain('No internal link')
+  })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -591,6 +591,8 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('user_1')
     expect(summary?.textContent).toContain('Need action {{recordId}}')
     expect(summary?.textContent).toContain('Handle {{record.xxx}}')
+    expect(summary?.textContent).toContain('Need action record_demo_001')
+    expect(summary?.textContent).toContain('Handle 示例字段值')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -535,4 +535,28 @@ describe('MetaAutomationManager', () => {
     expect(publicFormSelect.value).toBe('view_form')
     expect(internalViewSelect.value).toBe('view_grid')
   })
+
+  it('inserts DingTalk template tokens in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-token="person-title-recordId"]') as HTMLButtonElement).click()
+    ;(container.querySelector('[data-automation-token="person-body-recordField"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    expect(titleInput.value).toBe('{{recordId}}')
+    expect(bodyInput.value).toBe('{{record.xxx}}')
+  })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -594,4 +594,26 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })
+
+  it('shows DingTalk template syntax warnings in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = '{{recordId'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Unclosed placeholder braces detected')
+  })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -634,6 +634,28 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).toContain('Unclosed placeholder braces detected')
   })
 
+  it('shows DingTalk unknown placeholder warnings in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = '{{record}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Unknown placeholder {{record}}')
+  })
+
   it('copies rendered DingTalk person body example in the inline create form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -521,4 +521,28 @@ describe('MetaAutomationRuleEditor', () => {
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })
+
+  it('shows DingTalk template syntax warnings in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = '{{record-id}}'
+    titleInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Unsupported placeholder syntax {{record-id}}')
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -391,4 +391,71 @@ describe('MetaAutomationRuleEditor', () => {
     expect(payload.actionConfig.userIds).toEqual(['user_1'])
     expect(client.listCommentMentionSuggestions).toHaveBeenCalledTimes(1)
   })
+
+  it('applies DingTalk group message presets', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const presetBtn = container.querySelector('[data-field="groupPresetBoth"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
+    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLSelectElement
+
+    expect(titleInput.value).toBe('{{recordId}} 待填写并处理')
+    expect(bodyInput.value).toContain('请先填写所需信息')
+    expect(publicFormSelect.value).toBe('view_form')
+    expect(internalViewSelect.value).toBe('view_grid')
+  })
+
+  it('applies DingTalk person message presets without touching recipients', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1'
+    userIdsInput.dispatchEvent(new Event('input'))
+
+    const presetBtn = container.querySelector('[data-field="personPresetInternal"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+
+    expect(userIdsInput.value).toBe('user_1')
+    expect(titleInput.value).toBe('{{recordId}} 待处理')
+    expect(bodyInput.value).toContain('请查看并处理该记录')
+    expect(publicFormSelect.value).toBe('')
+    expect(internalViewSelect.value).toBe('view_grid')
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -563,6 +563,30 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Unsupported placeholder syntax {{record-id}}')
   })
 
+  it('shows DingTalk unknown placeholder warnings in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = '{{recoredId}}'
+    titleInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Unknown placeholder {{recoredId}}')
+  })
+
   it('copies rendered DingTalk group body example in the rule editor', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -458,4 +458,30 @@ describe('MetaAutomationRuleEditor', () => {
     expect(publicFormSelect.value).toBe('')
     expect(internalViewSelect.value).toBe('view_grid')
   })
+
+  it('inserts DingTalk template tokens in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-field="groupTitleToken-recordId"]') as HTMLButtonElement).click()
+    ;(container.querySelector('[data-field="groupBodyToken-recordField"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    expect(titleInput.value).toBe('{{recordId}}')
+    expect(bodyInput.value).toBe('{{record.xxx}}')
+  })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -518,6 +518,8 @@ describe('MetaAutomationRuleEditor', () => {
     expect(summary?.textContent).toContain('Ops Group')
     expect(summary?.textContent).toContain('Ticket {{recordId}}')
     expect(summary?.textContent).toContain('Please fill {{record.xxx}}')
+    expect(summary?.textContent).toContain('Ticket record_demo_001')
+    expect(summary?.textContent).toContain('Please fill 示例字段值')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 
 function flushPromises() {
@@ -65,9 +65,24 @@ function mount(props: Record<string, unknown>) {
 }
 
 describe('MetaAutomationRuleEditor', () => {
+  const originalClipboard = navigator.clipboard
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
   afterEach(() => {
     document.body.innerHTML = ''
     vi.restoreAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    })
   })
 
   it('renders trigger type selector when visible', async () => {
@@ -546,5 +561,34 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Unsupported placeholder syntax {{record-id}}')
+  })
+
+  it('copies rendered DingTalk group body example in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-field="groupRenderedBodyCopy-0"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(navigator.clipboard?.writeText).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(navigator.clipboard!.writeText).mock.calls[0]?.[0]).toBe('Please fill 示例字段值')
+    expect(container.textContent).toContain('Copied')
   })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -484,4 +484,41 @@ describe('MetaAutomationRuleEditor', () => {
     expect(titleInput.value).toBe('{{recordId}}')
     expect(bodyInput.value).toBe('{{record.xxx}}')
   })
+
+  it('shows DingTalk group message summary in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationId"]') as HTMLSelectElement
+    destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-field="groupMessageSummary"]')
+    expect(summary?.textContent).toContain('Ops Group')
+    expect(summary?.textContent).toContain('Ticket {{recordId}}')
+    expect(summary?.textContent).toContain('Please fill {{record.xxx}}')
+    expect(summary?.textContent).toContain('No public form link')
+    expect(summary?.textContent).toContain('No internal link')
+  })
 })

--- a/docs/development/dingtalk-notify-template-copy-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-copy-development-20260420.md
@@ -1,0 +1,55 @@
+# DingTalk Notify Template Copy Development 2026-04-20
+
+## Goal
+
+Add one-click copy actions for rendered DingTalk notification examples so admins can quickly reuse the rendered title/body text while authoring automation rules.
+
+## Scope
+
+- Frontend only
+- No backend/API changes
+- No migration changes
+
+## Changes
+
+### Rule editor
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Changes:
+
+- rendered title/body lines now include `Copy` actions
+- copy buttons switch to `Copied` after successful clipboard writes
+- applies to:
+  - `send_dingtalk_group_message`
+  - `send_dingtalk_person_message`
+
+### Inline automation manager
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Changes:
+
+- inline rendered examples now include the same `Copy` action pattern
+- copy state is local to the current authoring surface
+
+### Styling
+
+Added small preview-line and copy-button styles to keep rendered examples readable while preserving the existing summary card layout.
+
+### Tests
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies clipboard writes for rendered DingTalk examples in both authoring surfaces.
+
+## Claude Code CLI
+
+Used `claude -p` as a read-only assist to choose the next smallest high-value frontend-only slice. The implementation itself remained local in this repo worktree.

--- a/docs/development/dingtalk-notify-template-copy-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-copy-verification-20260420.md
@@ -1,0 +1,26 @@
+# DingTalk Notify Template Copy Verification 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- Frontend tests: `35 passed`
+- Web build: `passed`
+
+## Verified Behavior
+
+- Rule editor rendered DingTalk examples expose `Copy` buttons
+- Inline automation manager rendered DingTalk examples expose `Copy` buttons
+- Clipboard writes use rendered example text, not the raw template
+- Success state changes button text from `Copy` to `Copied`
+
+## Deployment
+
+- No remote deployment
+- No migrations

--- a/docs/development/dingtalk-notify-template-example-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-example-development-20260420.md
@@ -1,0 +1,67 @@
+# DingTalk Notify Template Example Development 2026-04-20
+
+## Goal
+
+Add a rendered-example layer to DingTalk notification authoring so admins can see not only the raw title/body templates, but also a sample rendered result before saving the rule.
+
+## Scope
+
+- Frontend only
+- No backend API changes
+- No runtime protocol changes
+- No database migrations
+
+## Changes
+
+### Shared example renderer
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts`
+
+This utility provides:
+
+- sample data for common notification tokens
+- a simple renderer for `{{recordId}}`, `{{sheetId}}`, `{{actorId}}`, and `{{record.xxx}}` token paths
+
+### Rule editor summary
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Changes:
+
+- summary labels now distinguish `Title template` and `Body template`
+- summary cards now also show:
+  - `Rendered title`
+  - `Rendered body`
+- applies to both:
+  - `send_dingtalk_group_message`
+  - `send_dingtalk_person_message`
+
+### Inline automation manager summary
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Changes:
+
+- inline create/edit summaries now match the full rule editor
+- rendered example output is visible for both group and person DingTalk message actions
+
+### Test coverage
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New assertions verify that rendered example text appears alongside the raw template.
+
+## Notes
+
+- This slice intentionally keeps the summary read-only.
+- The rendered preview uses static sample values so authoring remains deterministic.
+- No existing recipient selection behavior changed.

--- a/docs/development/dingtalk-notify-template-example-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-example-verification-20260420.md
@@ -1,0 +1,34 @@
+# DingTalk Notify Template Example Verification 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+claude -p "Reply only with OK."
+```
+
+## Results
+
+- Frontend tests: `33 passed`
+- Web build: `passed`
+- Claude Code CLI availability check: `OK`
+
+## Verified Behavior
+
+- DingTalk group message summaries show:
+  - raw title/body templates
+  - rendered title/body examples
+- DingTalk person message summaries show:
+  - raw title/body templates
+  - rendered title/body examples
+- Rendered examples resolve sample token data such as:
+  - `{{recordId}} -> record_demo_001`
+  - `{{record.xxx}} -> 示例字段值`
+
+## Non-Goals Confirmed
+
+- No backend changes
+- No migration changes
+- No remote deployment

--- a/docs/development/dingtalk-notify-template-governance-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-governance-development-20260420.md
@@ -1,0 +1,92 @@
+# DingTalk Notification Template Governance Development
+
+Date: 2026-04-20
+
+## Goal
+
+Reduce authoring friction for DingTalk notification automations by adding one-click message presets for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+The presets standardize the common cases:
+
+- form request
+- internal processing
+- form + processing
+
+## Scope
+
+Frontend-only governance enhancement:
+
+- add a shared preset helper
+- expose preset buttons in the rule editor
+- expose the same preset buttons in the inline automation manager create form
+- preserve existing recipient and action payload structure
+
+No backend API or migration changes were needed.
+
+## Implementation
+
+### Shared preset helper
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationPresets.ts`
+
+This helper centralizes:
+
+- preset ids and labels
+- default title/body templates
+- default public form view selection
+- default internal view selection
+
+It applies presets without changing unrelated action fields.
+
+### Rule editor
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Added preset buttons for both DingTalk message actions:
+
+- group message presets
+- person message presets
+
+The preset buttons populate:
+
+- `titleTemplate`
+- `bodyTemplate`
+- `publicFormViewId`
+- `internalViewId`
+
+For person messages, recipient ids remain unchanged.
+
+### Inline automation manager
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+The inline create flow now supports the same presets so the quick-create path and full editor stay aligned.
+
+### Test coverage
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies:
+
+- group preset application in the rule editor
+- person preset application in the rule editor
+- group preset application in the inline create form
+- person preset application in the inline create form
+- recipient ids are preserved for person-message presets
+
+## Notes
+
+- This change is deliberately scoped to authoring ergonomics.
+- It does not alter delivery semantics, ACL behavior, or runtime execution.

--- a/docs/development/dingtalk-notify-template-governance-package-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-governance-package-development-20260420.md
@@ -1,0 +1,45 @@
+# DingTalk Notify Template Governance Package Development 2026-04-20
+
+## Goal
+
+Package the DingTalk notification authoring governance stack into one `main`-based branch so the product can ship a coherent template-authoring experience instead of relying on a deep stacked PR chain.
+
+## Included Slices
+
+This package replays and bundles the following frontend-only governance work:
+
+1. Message presets
+2. Template token assist
+3. Message summary preview
+4. Template syntax warnings
+5. Rendered template examples
+6. Rendered example copy actions
+7. Unknown placeholder path warnings
+
+## Product Outcome
+
+After this package, both DingTalk actions:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+have authoring support for:
+
+- common scenario presets
+- token insertion
+- inline summary preview
+- rendered example preview
+- copy-to-clipboard from rendered examples
+- linting for malformed placeholders
+- linting for valid-looking but unknown placeholder paths
+
+## Scope
+
+- Frontend only
+- No backend/API changes
+- No migration changes
+- No remote deployment
+
+## Why Package It
+
+The underlying DingTalk notification capability is already in place. The remaining work on this line is primarily authoring quality. Packaging the governance slices into one `main`-based PR shortens review, merge, and deployment time for the final “send DingTalk message and open form” experience.

--- a/docs/development/dingtalk-notify-template-governance-package-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-governance-package-verification-20260420.md
@@ -1,0 +1,40 @@
+# DingTalk Notify Template Governance Package Verification 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- Frontend tests: `37 passed`
+- Web build: `passed`
+
+## Verified Package Behavior
+
+- DingTalk group message authoring supports:
+  - presets
+  - token insertion
+  - summary preview
+  - syntax warnings
+  - rendered examples
+  - copy actions
+  - unknown-path warnings
+
+- DingTalk person message authoring supports:
+  - presets
+  - recipient picker
+  - token insertion
+  - summary preview
+  - syntax warnings
+  - rendered examples
+  - copy actions
+  - unknown-path warnings
+
+## Deployment
+
+- No remote deployment
+- No migrations

--- a/docs/development/dingtalk-notify-template-governance-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-governance-verification-20260420.md
@@ -1,0 +1,33 @@
+# DingTalk Notification Template Governance Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `27 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- group preset buttons populate DingTalk group message templates correctly
+- person preset buttons populate DingTalk person message templates correctly
+- person recipient ids remain intact after applying presets
+- inline automation creation and full rule editor stay behaviorally aligned
+- default public/internal views are filled according to preset intent
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.

--- a/docs/development/dingtalk-notify-template-lint-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-lint-development-20260420.md
@@ -1,0 +1,67 @@
+# DingTalk Notification Template Lint Development
+
+Date: 2026-04-20
+
+## Goal
+
+Add authoring-time syntax warnings for DingTalk notification templates so invalid placeholder forms are caught before a rule is saved or tested.
+
+## Scope
+
+Frontend-only governance enhancement for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Surfaces covered:
+
+- `MetaAutomationRuleEditor`
+- `MetaAutomationManager`
+
+## Implementation
+
+### Shared lint helper
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts`
+
+The helper flags two classes of authoring issues:
+
+- unsupported placeholder syntax inside `{{ ... }}`
+- unclosed placeholder braces
+
+It intentionally does not try to reject arbitrary dot paths such as `{{record.anyField}}`, because runtime rendering accepts dotted lookup paths.
+
+### Rule editor warnings
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Warnings now render under DingTalk title/body fields for both group and person notification actions.
+
+### Inline automation manager warnings
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+The inline create/edit form shows the same warnings so the quick authoring path and full editor stay aligned.
+
+### Test coverage
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies:
+
+- invalid placeholder syntax warning in the rule editor
+- unclosed placeholder warning in the inline manager
+
+## Notes
+
+- This slice does not change backend rendering behavior.
+- It adds guidance only; valid templates continue to work unchanged.

--- a/docs/development/dingtalk-notify-template-lint-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-lint-verification-20260420.md
@@ -1,0 +1,44 @@
+# DingTalk Notification Template Lint Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `33 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- invalid placeholder syntax such as `{{record-id}}` surfaces a warning in the full rule editor
+- unclosed placeholder braces such as `{{recordId` surface a warning in the inline automation manager
+- valid template authoring flows remain intact
+- both surfaces still build cleanly after the lint helper is introduced
+
+## Runtime Alignment
+
+Runtime template rendering in `packages/core-backend/src/multitable/automation-executor.ts` accepts dotted placeholder paths via:
+
+- `{{recordId}}`
+- `{{sheetId}}`
+- `{{actorId}}`
+- `{{record.xxx}}`
+- and other `{{path.with.dots}}` forms that resolve through object lookup
+
+The frontend lint therefore only warns on malformed syntax, not on arbitrary dotted lookup paths.
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.

--- a/docs/development/dingtalk-notify-template-path-warnings-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-path-warnings-development-20260420.md
@@ -1,0 +1,56 @@
+# DingTalk Notify Template Path Warnings Development 2026-04-20
+
+## Goal
+
+Extend DingTalk notification template linting from syntax-only checks to path-aware checks so admins get warned when a placeholder is well-formed but still unknown or incomplete.
+
+## Scope
+
+- Frontend only
+- No backend/API changes
+- No migration changes
+
+## Changes
+
+### Path-aware linting
+
+Updated:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts`
+
+Added:
+
+- known token allow-list:
+  - `recordId`
+  - `sheetId`
+  - `actorId`
+- record path rule:
+  - allow `record.<fieldName>`
+  - reject incomplete or malformed paths such as `record`, `record.`, or `record..name`
+
+New warning shape:
+
+- `Unknown placeholder {{...}}. Use {{recordId}}, {{sheetId}}, {{actorId}}, or {{record.fieldName}}.`
+
+### Existing authoring surfaces
+
+No new UI surface was introduced. The new warning is surfaced through the existing warning areas in:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+### Tests
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+Added focused coverage for:
+
+- typo placeholder: `{{recoredId}}`
+- incomplete record path: `{{record}}`
+
+## Claude Code CLI
+
+This slice was selected after a read-only `claude -p` suggestion pass. The implementation itself remained local in the repo worktree.

--- a/docs/development/dingtalk-notify-template-path-warnings-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-path-warnings-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Notify Template Path Warnings Verification 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- Frontend tests: `37 passed`
+- Web build: `passed`
+
+## Verified Behavior
+
+- Syntax warnings still show for malformed placeholders such as `{{record-id}}`
+- Unknown-path warnings now show for valid-but-unsupported placeholders such as:
+  - `{{recoredId}}`
+  - `{{record}}`
+- Existing valid placeholders remain accepted:
+  - `{{recordId}}`
+  - `{{sheetId}}`
+  - `{{actorId}}`
+  - `{{record.xxx}}`
+
+## Deployment
+
+- No remote deployment
+- No migrations

--- a/docs/development/dingtalk-notify-template-preview-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-preview-development-20260420.md
@@ -1,0 +1,53 @@
+# DingTalk Notification Template Preview Development
+
+Date: 2026-04-20
+
+## Goal
+
+Make DingTalk notification authoring safer by showing a live message summary while the rule is being configured.
+
+## Scope
+
+Frontend-only enhancement for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Surfaces covered:
+
+- `MetaAutomationRuleEditor`
+- `MetaAutomationManager`
+
+## Implementation
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Added live summary cards that show:
+
+- destination group or selected recipients
+- current title template
+- current body template
+- public form link target
+- internal processing link target
+
+The preview is read-only and derives directly from the current draft state, so it does not change payload format or backend behavior.
+
+## Test coverage
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies:
+
+- group summary rendering in the full rule editor
+- person summary rendering in the inline automation manager
+
+## Notes
+
+- This is intentionally a governance/UX slice only.
+- No API, migration, or runtime execution changes were introduced.

--- a/docs/development/dingtalk-notify-template-preview-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-preview-verification-20260420.md
@@ -1,0 +1,32 @@
+# DingTalk Notification Template Preview Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `31 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- group message authoring shows live destination/title/body/link summary
+- person message authoring shows live recipient/title/body/link summary
+- summary cards update from draft state without changing the underlying authoring payload
+- both the full editor and inline manager remain build-clean
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.

--- a/docs/development/dingtalk-notify-template-token-assist-development-20260420.md
+++ b/docs/development/dingtalk-notify-template-token-assist-development-20260420.md
@@ -1,0 +1,68 @@
+# DingTalk Notification Template Token Assist Development
+
+Date: 2026-04-20
+
+## Goal
+
+Reduce template authoring mistakes for DingTalk notification actions by exposing a small, shared token reference and one-click token insertion in both automation authoring surfaces.
+
+## Scope
+
+Frontend-only authoring enhancement for:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Surfaces covered:
+
+- `MetaAutomationRuleEditor`
+- `MetaAutomationManager`
+
+## Implementation
+
+### Shared token helper
+
+Added:
+
+- `apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts`
+
+The helper defines:
+
+- title-safe tokens
+- body tokens
+- append behavior with sensible spacing/newline handling
+
+### Rule editor
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Added token rows under:
+
+- group title/body template fields
+- person title/body template fields
+
+Each button appends a supported token into the current template field without overwriting the existing value.
+
+### Inline automation manager
+
+Updated:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+Added the same token assist behavior to the inline create/edit form so quick authoring stays aligned with the full rule editor.
+
+### Tests
+
+Updated:
+
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+New coverage verifies token insertion in both surfaces.
+
+## Notes
+
+- This change does not alter runtime payloads or backend execution.
+- It is intentionally scoped to authoring guidance and template consistency.

--- a/docs/development/dingtalk-notify-template-token-assist-verification-20260420.md
+++ b/docs/development/dingtalk-notify-template-token-assist-verification-20260420.md
@@ -1,0 +1,33 @@
+# DingTalk Notification Template Token Assist Verification
+
+Date: 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts` + `multitable-automation-manager.spec.ts`: `29 passed`
+- `pnpm --filter @metasheet/web build`: passed
+
+## What Was Verified
+
+- rule editor exposes token buttons for DingTalk group and person message templates
+- inline automation manager exposes the same token buttons
+- title token insertion appends inline text correctly
+- body token insertion appends multiline text correctly
+- no backend API or migration changes were required
+
+## Known Non-Blocking Noise
+
+The frontend build still emits existing Vite warnings:
+
+- dynamic import warning for `WorkflowDesigner.vue`
+- chunk-size warnings
+
+These warnings predate this change and did not block build success.


### PR DESCRIPTION
## Summary
- package the DingTalk notification template governance stack onto a clean main-based branch
- include presets, token assist, preview, syntax warnings, rendered examples, copy actions, and unknown-path warnings
- keep the scope frontend-only with no migration or backend/runtime changes

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build
