### PR TITLE
feat(forms): add dingtalk-protected public forms

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -721,7 +721,10 @@ export class MultitableApiClient {
 
   // --- Form context ---
   async loadFormContext(params: { sheetId?: string; viewId?: string; recordId?: string; publicToken?: string }): Promise<MetaFormContext> {
-    const res = await this.fetch(`/api/multitable/form-context${qs(params)}`)
+    const path = `/api/multitable/form-context${qs(params)}`
+    const res = params.publicToken && this.fetch === apiFetch
+      ? await apiFetch(path, { suppressUnauthorizedRedirect: true })
+      : await this.fetch(path)
     return parseJson(res)
   }
 
@@ -757,11 +760,15 @@ export class MultitableApiClient {
 
   // --- Form submit ---
   async submitForm(viewId: string, input: FormSubmitInput): Promise<FormSubmitResult> {
-    const res = await this.fetch(`/api/multitable/views/${viewId}/submit${qs({ publicToken: input.publicToken })}`, {
+    const path = `/api/multitable/views/${viewId}/submit${qs({ publicToken: input.publicToken })}`
+    const requestInit: RequestInit = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),
-    })
+    }
+    const res = input.publicToken && this.fetch === apiFetch
+      ? await apiFetch(path, { ...requestInit, suppressUnauthorizedRedirect: true })
+      : await this.fetch(path, requestInit)
     return parseJson(res)
   }
 

--- a/apps/web/src/multitable/components/MetaFormShareManager.vue
+++ b/apps/web/src/multitable/components/MetaFormShareManager.vue
@@ -32,6 +32,23 @@
 
           <!-- Link + actions (only when enabled) -->
           <template v-if="config?.enabled && config.publicToken">
+            <div class="meta-form-share__auth-section">
+              <label class="meta-form-share__label" for="meta-form-share-access-mode">Access mode</label>
+              <select
+                id="meta-form-share-access-mode"
+                class="meta-form-share__input"
+                :value="config.accessMode"
+                data-form-share-access-mode="true"
+                :disabled="busy"
+                @change="onAccessModeChange"
+              >
+                <option value="public">Anyone with the link</option>
+                <option value="dingtalk">Bound DingTalk users only</option>
+                <option value="dingtalk_granted">DingTalk-authorized users only</option>
+              </select>
+              <p class="meta-form-share__hint">{{ accessModeHint }}</p>
+            </div>
+
             <div class="meta-form-share__link-section">
               <label class="meta-form-share__label">Public link</label>
               <div class="meta-form-share__link-row">
@@ -145,6 +162,16 @@ const expiryDateValue = computed(() => {
   if (!config.value?.expiresAt) return ''
   return config.value.expiresAt.substring(0, 10)
 })
+const accessModeHint = computed(() => {
+  switch (config.value?.accessMode) {
+    case 'dingtalk':
+      return 'The form opens only after DingTalk sign-in, and the user must already be bound to a local account.'
+    case 'dingtalk_granted':
+      return 'The form opens only for DingTalk-bound users whose DingTalk grant is enabled by an administrator.'
+    default:
+      return 'Anyone who has the link can open and submit this form.'
+  }
+})
 
 async function loadConfig() {
   if (!props.client) return
@@ -170,6 +197,24 @@ async function onToggleEnabled() {
     emit('updated')
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to update'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onAccessModeChange(event: Event) {
+  if (!props.client || busy.value) return
+  const select = event.target as HTMLSelectElement | null
+  if (!select) return
+  busy.value = true
+  error.value = null
+  try {
+    config.value = await props.client.updateFormShareConfig(props.sheetId, props.viewId, {
+      accessMode: select.value as FormShareConfig['accessMode'],
+    })
+    emit('updated')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to update access mode'
   } finally {
     busy.value = false
   }
@@ -365,6 +410,7 @@ watch(
   color: #475569;
 }
 
+.meta-form-share__auth-section,
 .meta-form-share__link-section,
 .meta-form-share__expiry-section {
   display: flex;
@@ -413,5 +459,12 @@ watch(
   border-color: #2563eb;
   background: #2563eb;
   color: #fff;
+}
+
+.meta-form-share__hint {
+  margin: 0;
+  font-size: 12px;
+  color: #64748b;
+  line-height: 1.5;
 }
 </style>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -728,11 +728,13 @@ export interface FormShareConfig {
   publicToken: string | null
   expiresAt: string | null
   status: 'active' | 'expired' | 'disabled'
+  accessMode: 'public' | 'dingtalk' | 'dingtalk_granted'
 }
 
 export interface FormShareConfigUpdate {
   enabled?: boolean
   expiresAt?: string | null
+  accessMode?: 'public' | 'dingtalk' | 'dingtalk_granted'
 }
 
 // --- API Tokens ---

--- a/apps/web/src/views/PublicMultitableFormView.vue
+++ b/apps/web/src/views/PublicMultitableFormView.vue
@@ -7,7 +7,9 @@
         <p v-if="subtitle" class="public-multitable-form__subtitle">{{ subtitle }}</p>
       </header>
 
-      <div v-if="loading" class="public-multitable-form__state">Loading form…</div>
+      <div v-if="loading || redirectingToDingTalk" class="public-multitable-form__state">
+        {{ redirectingToDingTalk ? redirectingMessage : 'Loading form…' }}
+      </div>
       <div v-else-if="loadError" class="public-multitable-form__state public-multitable-form__state--error">
         {{ loadError }}
       </div>
@@ -45,6 +47,7 @@ import { computed, ref, watch } from 'vue'
 import type { FormSubmitResult, MetaFormContext } from '../multitable/types'
 import { multitableClient } from '../multitable/api/client'
 import MetaFormView from '../multitable/components/MetaFormView.vue'
+import { apiFetch } from '../utils/api'
 
 const props = defineProps<{
   sheetId?: string
@@ -61,6 +64,7 @@ const fieldErrors = ref<Record<string, string> | null>(null)
 const submitted = ref(false)
 const submissionResult = ref<FormSubmitResult | null>(null)
 const formKey = ref(0)
+const redirectingToDingTalk = ref(false)
 
 const title = computed(() => context.value?.view?.name || context.value?.sheet?.name || 'Public multitable form')
 const subtitle = computed(() => {
@@ -74,6 +78,7 @@ const submissionMessage = computed(() => {
     ? 'Your response has been updated successfully.'
     : 'Your response has been submitted successfully.'
 })
+const redirectingMessage = computed(() => 'Redirecting to DingTalk sign-in…')
 
 async function loadForm(): Promise<void> {
   loading.value = true
@@ -82,6 +87,7 @@ async function loadForm(): Promise<void> {
   fieldErrors.value = null
   submitted.value = false
   submissionResult.value = null
+  redirectingToDingTalk.value = false
   try {
     const publicToken = props.publicToken?.trim()
     if (!publicToken) {
@@ -96,10 +102,16 @@ async function loadForm(): Promise<void> {
       publicToken,
     })
   } catch (error) {
+    if (isDingTalkAuthRequired(error)) {
+      const launched = await launchDingTalkSignIn()
+      if (launched) return
+    }
     context.value = null
-    loadError.value = readErrorMessage(error, 'Failed to load public form')
+    loadError.value = readPublicFormErrorMessage(error, 'Failed to load public form')
   } finally {
-    loading.value = false
+    if (!redirectingToDingTalk.value) {
+      loading.value = false
+    }
   }
 }
 
@@ -124,7 +136,11 @@ async function onSubmit(data: Record<string, unknown>): Promise<void> {
     submissionResult.value = result
     submitted.value = true
   } catch (error) {
-    submitError.value = readErrorMessage(error, 'Failed to submit public form')
+    if (isDingTalkAuthRequired(error)) {
+      const launched = await launchDingTalkSignIn()
+      if (launched) return
+    }
+    submitError.value = readPublicFormErrorMessage(error, 'Failed to submit public form')
     fieldErrors.value = readFieldErrors(error)
   } finally {
     submitting.value = false
@@ -142,6 +158,61 @@ function resetForm(): void {
 function readErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error && error.message.trim()) return error.message
   return fallback
+}
+
+function readErrorCode(error: unknown): string {
+  return error instanceof Error && typeof (error as Error & { code?: unknown }).code === 'string'
+    ? String((error as Error & { code?: unknown }).code)
+    : ''
+}
+
+function isDingTalkAuthRequired(error: unknown): boolean {
+  return readErrorCode(error) === 'DINGTALK_AUTH_REQUIRED'
+}
+
+function readPublicFormErrorMessage(error: unknown, fallback: string): string {
+  const code = readErrorCode(error)
+  if (code === 'DINGTALK_BIND_REQUIRED') {
+    return 'This form only accepts users with a bound DingTalk account.'
+  }
+  if (code === 'DINGTALK_GRANT_REQUIRED') {
+    return 'This form only accepts DingTalk-authorized users.'
+  }
+  return readErrorMessage(error, fallback)
+}
+
+function currentPublicFormRedirect(): string {
+  if (typeof window === 'undefined') return '/login'
+  const path = `${window.location.pathname || ''}${window.location.search || ''}${window.location.hash || ''}`.trim()
+  return path || '/login'
+}
+
+async function launchDingTalkSignIn(): Promise<boolean> {
+  redirectingToDingTalk.value = true
+  loadError.value = null
+  try {
+    const response = await apiFetch(
+      `/api/auth/dingtalk/launch?redirect=${encodeURIComponent(currentPublicFormRedirect())}`,
+      { suppressUnauthorizedRedirect: true },
+    )
+    const payload = await response.json().catch(() => null)
+    if (!response.ok || !payload?.success || typeof payload?.data?.url !== 'string' || payload.data.url.trim().length === 0) {
+      throw new Error(readErrorMessage(payload, 'Failed to start DingTalk sign-in'))
+    }
+    if (typeof window !== 'undefined' && typeof window.location?.assign === 'function') {
+      window.location.assign(payload.data.url)
+      return true
+    }
+    if (typeof window !== 'undefined') {
+      window.location.href = payload.data.url
+      return true
+    }
+    return false
+  } catch (error) {
+    redirectingToDingTalk.value = false
+    loadError.value = readErrorMessage(error, 'Failed to start DingTalk sign-in')
+    return false
+  }
 }
 
 function readFieldErrors(error: unknown): Record<string, string> | null {

--- a/apps/web/tests/multitable-form-share-manager.spec.ts
+++ b/apps/web/tests/multitable-form-share-manager.spec.ts
@@ -17,6 +17,7 @@ function fakeConfig(overrides: Record<string, unknown> = {}) {
     publicToken: 'tok_abc123',
     expiresAt: null,
     status: 'active',
+    accessMode: 'public',
     ...overrides,
   }
 }
@@ -154,5 +155,24 @@ describe('MetaFormShareManager', () => {
     expect(patchCalls.length).toBe(1)
     const body = JSON.parse(patchCalls[0][1].body as string)
     expect(body.enabled).toBe(false)
+  })
+
+  it('updates access mode', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const select = document.querySelector('[data-form-share-access-mode]') as HTMLSelectElement
+    expect(select).toBeTruthy()
+    select.value = 'dingtalk_granted'
+    select.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const patchCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'PATCH' && c[0].includes('/form-share'),
+    )
+    expect(patchCalls.length).toBeGreaterThan(0)
+    const body = JSON.parse(String(patchCalls.at(-1)?.[1]?.body ?? '{}'))
+    expect(body.accessMode).toBe('dingtalk_granted')
   })
 })

--- a/apps/web/tests/public-multitable-form.spec.ts
+++ b/apps/web/tests/public-multitable-form.spec.ts
@@ -10,12 +10,17 @@ async function flushUi(cycles = 4): Promise<void> {
 
 const loadFormContextSpy = vi.fn()
 const submitFormSpy = vi.fn()
+const apiFetchSpy = vi.fn()
 
 vi.mock('../src/multitable/api/client', () => ({
   multitableClient: {
     loadFormContext: (...args: any[]) => loadFormContextSpy(...args),
     submitForm: (...args: any[]) => submitFormSpy(...args),
   },
+}))
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: any[]) => apiFetchSpy(...args),
 }))
 
 vi.mock('../src/multitable/components/MetaFormView.vue', () => ({
@@ -52,6 +57,7 @@ describe('PublicMultitableFormView', () => {
     container = null
     loadFormContextSpy.mockReset()
     submitFormSpy.mockReset()
+    apiFetchSpy.mockReset()
   })
 
   it('loads form context anonymously and submits with the public token', async () => {
@@ -122,5 +128,43 @@ describe('PublicMultitableFormView', () => {
     }))
     expect(container.textContent).toContain('Submission received')
     expect(container.textContent).toContain('Your response has been submitted successfully.')
+  })
+
+  it('launches DingTalk sign-in when the form requires authenticated DingTalk access', async () => {
+    loadFormContextSpy.mockRejectedValue(Object.assign(new Error('DingTalk sign-in is required for this form'), {
+      code: 'DINGTALK_AUTH_REQUIRED',
+    }))
+    apiFetchSpy.mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      data: { url: 'https://login.dingtalk.com/oauth2/auth?demo=1' },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+
+    const { default: PublicMultitableFormView } = await import('../src/views/PublicMultitableFormView.vue')
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const Root = defineComponent({
+      render() {
+        return h(PublicMultitableFormView, {
+          sheetId: 'sheet_orders',
+          viewId: 'view_form',
+          publicToken: 'pub_123',
+        })
+      },
+    })
+
+    app = createApp(Root)
+    app.mount(container)
+    await flushUi()
+
+    expect(apiFetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/auth/dingtalk/launch?redirect='),
+      expect.objectContaining({ suppressUnauthorizedRedirect: true }),
+    )
+    expect(container.textContent).toContain('Redirecting to DingTalk sign-in…')
   })
 })

--- a/docs/development/dingtalk-protected-public-form-development-20260420.md
+++ b/docs/development/dingtalk-protected-public-form-development-20260420.md
@@ -1,0 +1,111 @@
+# DingTalk Protected Public Form Development
+
+- Date: 2026-04-20
+- Branch: `codex/dingtalk-protected-public-form-20260420`
+- Base: `codex/public-form-auth-hotfix-20260420` (`#931`)
+
+## Goal
+
+Extend the existing anonymous public-form flow so form sharing can be configured in three modes:
+
+- `public`: anyone with a valid public token can submit
+- `dingtalk`: the visitor must authenticate and have a bound DingTalk identity
+- `dingtalk_granted`: the visitor must authenticate, have a bound DingTalk identity, and hold an enabled DingTalk auth grant
+
+## Backend changes
+
+### Optional auth hydration on public-form routes
+
+- Added `optionalJwtAuthMiddleware(...)` in [packages/core-backend/src/auth/jwt-middleware.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/packages/core-backend/src/auth/jwt-middleware.ts:1)
+- Refactored token verification into shared `hydrateAuthenticatedUser(...)`
+- Updated [packages/core-backend/src/index.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/packages/core-backend/src/index.ts:1) so public-form auth bypass still skips required JWT, but now hydrates `req.user` when a bearer token is present
+
+### Public form access modes
+
+- Added `PublicFormAccessMode` support in [packages/core-backend/src/routes/univer-meta.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/packages/core-backend/src/routes/univer-meta.ts:1)
+- Added `normalizePublicFormAccessMode(...)`
+- Added DingTalk access evaluation:
+  - `loadDingTalkPublicFormAccessState(...)`
+  - `evaluateProtectedPublicFormAccess(...)`
+- Protected mode checks use:
+  - `user_external_identities`
+  - `directory_account_links + directory_accounts`
+  - `user_external_auth_grants`
+
+### Form share config endpoints
+
+Added:
+
+- `GET /api/multitable/sheets/:sheetId/views/:viewId/form-share`
+- `PATCH /api/multitable/sheets/:sheetId/views/:viewId/form-share`
+- `POST /api/multitable/sheets/:sheetId/views/:viewId/form-share/regenerate`
+
+These now expose and update:
+
+- `enabled`
+- `publicToken`
+- `expiresAt`
+- `status`
+- `accessMode`
+
+### Protected public-form runtime behavior
+
+Updated:
+
+- `GET /api/multitable/form-context`
+- `POST /api/multitable/views/:viewId/submit`
+
+Behavior:
+
+- `DINGTALK_AUTH_REQUIRED` when the user must sign in
+- `DINGTALK_BIND_REQUIRED` when the signed-in user lacks a bound DingTalk identity
+- `DINGTALK_GRANT_REQUIRED` when the signed-in user lacks an enabled DingTalk grant
+
+Protected public forms still use the existing create-only public-form capability model. When the visitor is authenticated and passes the gate, record creation now uses the authenticated actor instead of always writing `created_by = null`.
+
+## Frontend changes
+
+### Form share management
+
+Updated [apps/web/src/multitable/components/MetaFormShareManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/apps/web/src/multitable/components/MetaFormShareManager.vue:1):
+
+- added access-mode selector
+- added mode hints
+- patched config via `PATCH /form-share`
+
+Supported authoring modes:
+
+- `Anyone with the link`
+- `Bound DingTalk users only`
+- `Authorized DingTalk users only`
+
+### Public form page
+
+Updated [apps/web/src/views/PublicMultitableFormView.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/apps/web/src/views/PublicMultitableFormView.vue:1):
+
+- when the backend returns `DINGTALK_AUTH_REQUIRED`, it launches DingTalk sign-in automatically
+- after launch success, the browser redirects back to the same public-form URL
+- `DINGTALK_BIND_REQUIRED` and `DINGTALK_GRANT_REQUIRED` now render explicit user-facing messages
+
+### Client/API typing
+
+Updated:
+
+- [apps/web/src/multitable/types.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/apps/web/src/multitable/types.ts:1)
+- [apps/web/src/multitable/api/client.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/apps/web/src/multitable/api/client.ts:1)
+
+Public-form requests now suppress the global unauthorized redirect so the public-form page can handle DingTalk auth bootstrap itself.
+
+## Tests updated
+
+- [packages/core-backend/tests/unit/jwt-middleware.test.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/packages/core-backend/tests/unit/jwt-middleware.test.ts:1)
+- [packages/core-backend/tests/integration/public-form-flow.test.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/packages/core-backend/tests/integration/public-form-flow.test.ts:1)
+- [apps/web/tests/public-multitable-form.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/apps/web/tests/public-multitable-form.spec.ts:1)
+- [apps/web/tests/multitable-form-share-manager.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-protected-public-form-20260420/apps/web/tests/multitable-form-share-manager.spec.ts:1)
+
+## Claude Code CLI
+
+This branch also recorded a read-only `claude -p` check during implementation:
+
+> Add two protected submission modes on top of the existing anonymous public form: one that auto-identifies DingTalk-bound users, and one that gates access via a DingTalk-granted token.
+

--- a/docs/development/dingtalk-protected-public-form-verification-20260420.md
+++ b/docs/development/dingtalk-protected-public-form-verification-20260420.md
@@ -1,0 +1,71 @@
+# DingTalk Protected Public Form Verification
+
+- Date: 2026-04-20
+- Branch: `codex/dingtalk-protected-public-form-20260420`
+
+## Commands run
+
+### Backend targeted tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/jwt-middleware.test.ts tests/integration/public-form-flow.test.ts tests/integration/multitable-record-form.api.test.ts --watch=false
+```
+
+Result:
+
+- `24 passed`
+
+### Frontend targeted tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/public-multitable-form.spec.ts tests/multitable-form-share-manager.spec.ts --watch=false
+```
+
+Result:
+
+- `12 passed`
+
+Notes:
+
+- jsdom prints `Not implemented: navigation to another Document` when the DingTalk sign-in launch path attempts browser navigation
+- the test still passes and asserts the redirect bootstrap state instead of trying to fully emulate browser navigation
+
+### Backend build
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+- passed
+
+### Frontend build
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+- passed
+
+Notes:
+
+- existing Vite chunk-size warnings remain
+- existing dynamic import warning for `WorkflowDesigner.vue` remains
+
+## Verified behavior
+
+- public form sharing can now be authored in `public`, `dingtalk`, and `dingtalk_granted` modes
+- public-form routes no longer require JWT, but now optionally hydrate the signed-in user when present
+- anonymous access to DingTalk-protected forms triggers DingTalk sign-in bootstrap
+- bound signed-in users can load `dingtalk` forms
+- bound-but-not-granted users are rejected from `dingtalk_granted` forms
+- form-share config endpoints expose and update `accessMode`
+
+## Not included
+
+- no new database migration
+- no remote deployment in this branch yet
+- local `plugins/**/node_modules` and `tools/cli/node_modules` noise was not included in the feature scope

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -67,32 +67,38 @@ function isPasswordChangeWhitelisted(path: string): boolean {
   return PASSWORD_CHANGE_WHITELIST.some((prefix) => path.startsWith(prefix))
 }
 
-export async function jwtAuthMiddleware(req: Request, res: Response, next: NextFunction) {
+function resolveBearerToken(req: Request): string | undefined {
+  const auth = req.headers['authorization'] || ''
+  return auth.startsWith('Bearer ') ? auth.slice(7) : undefined
+}
+
+async function hydrateAuthenticatedUser(req: Request, token: string): Promise<
+  | { ok: true }
+  | { ok: false; statusCode: number; body: { ok: false; error: { code: string; message: string } }; metricReason?: string }
+> {
   try {
-    const auth = req.headers['authorization'] || ''
-    const token = auth.startsWith('Bearer ') ? auth.slice(7) : undefined
-
-    if (!token) {
-      metrics.jwtAuthFail.inc({ reason: 'missing_token' })
-      metrics.authFailures.inc()
-      return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Missing Bearer token' } })
-    }
-
     const user = await authService.verifyToken(token)
     if (!user) {
-      metrics.jwtAuthFail.inc({ reason: 'invalid_token' })
-      metrics.authFailures.inc()
-      return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Invalid token' } })
+      return {
+        ok: false,
+        statusCode: 401,
+        body: { ok: false, error: { code: 'UNAUTHORIZED', message: 'Invalid token' } },
+        metricReason: 'invalid_token',
+      }
     }
 
     if (user.must_change_password === true && !isPasswordChangeWhitelisted(req.path || req.originalUrl || '')) {
-      return res.status(403).json({
+      return {
         ok: false,
-        error: {
-          code: 'PASSWORD_CHANGE_REQUIRED',
-          message: 'Password change required',
+        statusCode: 403,
+        body: {
+          ok: false,
+          error: {
+            code: 'PASSWORD_CHANGE_REQUIRED',
+            message: 'Password change required',
+          },
         },
-      })
+      }
     }
 
     const headerTenantId = extractTenantFromHeaders(req.headers as Record<string, unknown> | undefined)
@@ -101,11 +107,55 @@ export async function jwtAuthMiddleware(req: Request, res: Response, next: NextF
     }
 
     req.user = user as Express.Request['user']
-    return next()
+    return { ok: true }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error && err.name === 'TokenExpiredError' ? 'expired_token' : 'invalid_token'
-    metrics.jwtAuthFail.inc({ reason: errorMessage })
-    metrics.authFailures.inc()
-    return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Invalid token' } })
+    return {
+      ok: false,
+      statusCode: 401,
+      body: { ok: false, error: { code: 'UNAUTHORIZED', message: 'Invalid token' } },
+      metricReason: errorMessage,
+    }
   }
+}
+
+type HydratedAuthResult = Awaited<ReturnType<typeof hydrateAuthenticatedUser>>
+
+function isHydrateFailure(result: HydratedAuthResult): result is Extract<HydratedAuthResult, { ok: false }> {
+  return result.ok === false
+}
+
+export async function optionalJwtAuthMiddleware(req: Request, res: Response, next: NextFunction) {
+  const token = resolveBearerToken(req)
+  if (!token) return next()
+
+  const result = await hydrateAuthenticatedUser(req, token)
+  if (isHydrateFailure(result)) {
+    if (result.metricReason) {
+      metrics.jwtAuthFail.inc({ reason: result.metricReason })
+      metrics.authFailures.inc()
+    }
+    return res.status(result.statusCode).json(result.body)
+  }
+  return next()
+}
+
+export async function jwtAuthMiddleware(req: Request, res: Response, next: NextFunction) {
+  const token = resolveBearerToken(req)
+
+  if (!token) {
+    metrics.jwtAuthFail.inc({ reason: 'missing_token' })
+    metrics.authFailures.inc()
+    return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Missing Bearer token' } })
+  }
+
+  const result = await hydrateAuthenticatedUser(req, token)
+  if (isHydrateFailure(result)) {
+    if (result.metricReason) {
+      metrics.jwtAuthFail.inc({ reason: result.metricReason })
+      metrics.authFailures.inc()
+    }
+    return res.status(result.statusCode).json(result.body)
+  }
+  return next()
 }

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -35,7 +35,7 @@ import { poolManager } from './integration/db/connection-pool'
 import { eventBus } from './integration/events/event-bus'
 import { initializeEventBusService } from './integration/events/event-bus-service'
 import { messageBus } from './integration/messaging/message-bus'
-import { jwtAuthMiddleware, isPublicFormAuthBypass, isWhitelisted } from './auth/jwt-middleware'
+import { jwtAuthMiddleware, optionalJwtAuthMiddleware, isPublicFormAuthBypass, isWhitelisted } from './auth/jwt-middleware'
 import { authService } from './auth/AuthService'
 import { cache } from './cache-init'
 import {
@@ -745,7 +745,7 @@ export class MetaSheetServer {
     // 全局 JWT 保护 `/api/**`（白名单在中间件内判定）
     this.app.use((req: Request, res: Response, next: NextFunction) => {
       if (isWhitelisted(req.path)) return next()
-      if (isPublicFormAuthBypass(req)) return next()
+      if (isPublicFormAuthBypass(req)) return optionalJwtAuthMiddleware(req, res, next)
       if (req.path.startsWith('/api/')) return jwtAuthMiddleware(req, res, next)
       return next()
     })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -250,11 +250,22 @@ type PeopleSheetPreset = {
   fieldProperty: Record<string, unknown>
 }
 
+type PublicFormAccessMode = 'public' | 'dingtalk' | 'dingtalk_granted'
+
 type PublicFormConfig = {
   enabled?: boolean
   publicToken?: string
   expiresAt?: unknown
   expiresOn?: unknown
+  accessMode?: unknown
+}
+
+type PublicFormShareConfigResponse = {
+  enabled: boolean
+  publicToken: string | null
+  expiresAt: string | null
+  status: 'active' | 'expired' | 'disabled'
+  accessMode: PublicFormAccessMode
 }
 
 type DashboardChartType = 'bar' | 'line' | 'pie'
@@ -331,6 +342,16 @@ function parsePublicFormExpiryMs(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+function normalizePublicFormAccessMode(value: unknown): PublicFormAccessMode {
+  if (value === 'dingtalk') return 'dingtalk'
+  if (value === 'dingtalk_granted') return 'dingtalk_granted'
+  return 'public'
+}
+
+function buildPublicFormToken(): string {
+  return buildId('pub')
+}
+
 function isPublicFormAccessAllowed(view: UniverMetaViewConfig | null | undefined, publicToken: string): boolean {
   if (!view || !publicToken) return false
   const publicForm = getPublicFormConfig(view)
@@ -340,6 +361,110 @@ function isPublicFormAccessAllowed(view: UniverMetaViewConfig | null | undefined
   const expiryMs = parsePublicFormExpiryMs(publicForm.expiresAt ?? publicForm.expiresOn)
   if (expiryMs !== null && Date.now() >= expiryMs) return false
   return true
+}
+
+function serializePublicFormShareConfig(view: UniverMetaViewConfig | null | undefined): PublicFormShareConfigResponse {
+  const publicForm = getPublicFormConfig(view)
+  const enabled = publicForm?.enabled === true
+  const publicToken = typeof publicForm?.publicToken === 'string' && publicForm.publicToken.trim().length > 0
+    ? publicForm.publicToken.trim()
+    : null
+  const expiryMs = parsePublicFormExpiryMs(publicForm?.expiresAt ?? publicForm?.expiresOn)
+  const expiresAt = expiryMs === null ? null : new Date(expiryMs).toISOString()
+  const status = !enabled || !publicToken ? 'disabled' : expiryMs !== null && Date.now() >= expiryMs ? 'expired' : 'active'
+  return {
+    enabled,
+    publicToken,
+    expiresAt,
+    status,
+    accessMode: normalizePublicFormAccessMode(publicForm?.accessMode),
+  }
+}
+
+async function loadDingTalkPublicFormAccessState(query: QueryFn, userId: string): Promise<{
+  hasBinding: boolean
+  grantEnabled: boolean
+}> {
+  const [identityResult, linkResult, grantResult] = await Promise.all([
+    query(
+      `SELECT 1
+       FROM user_external_identities
+       WHERE provider = $1 AND local_user_id = $2
+       LIMIT 1`,
+      ['dingtalk', userId],
+    ),
+    query(
+      `SELECT 1
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE l.local_user_id = $1
+         AND l.link_status = 'linked'
+         AND a.provider = $2
+       LIMIT 1`,
+      [userId, 'dingtalk'],
+    ),
+    query(
+      `SELECT enabled
+       FROM user_external_auth_grants
+       WHERE provider = $1 AND local_user_id = $2
+       LIMIT 1`,
+      ['dingtalk', userId],
+    ),
+  ])
+
+  const hasBinding = identityResult.rows.length > 0 || linkResult.rows.length > 0
+  const grantRow = grantResult.rows[0] as { enabled?: boolean } | undefined
+  const grantEnabled = grantRow?.enabled === true
+
+  return {
+    hasBinding,
+    grantEnabled,
+  }
+}
+
+async function evaluateProtectedPublicFormAccess(
+  query: QueryFn,
+  req: Request,
+  view: UniverMetaViewConfig | null | undefined,
+): Promise<
+  | { allowed: true; accessMode: PublicFormAccessMode }
+  | { allowed: false; statusCode: number; code: string; message: string }
+> {
+  const accessMode = normalizePublicFormAccessMode(getPublicFormConfig(view)?.accessMode)
+  if (accessMode === 'public') {
+    return { allowed: true, accessMode }
+  }
+
+  const userId = req.user?.id?.toString() ?? req.user?.sub?.toString() ?? req.user?.userId?.toString() ?? ''
+  if (!userId) {
+    return {
+      allowed: false,
+      statusCode: 401,
+      code: 'DINGTALK_AUTH_REQUIRED',
+      message: 'DingTalk sign-in is required for this form',
+    }
+  }
+
+  const dingtalkAccess = await loadDingTalkPublicFormAccessState(query, userId)
+  if (!dingtalkAccess.hasBinding) {
+    return {
+      allowed: false,
+      statusCode: 403,
+      code: 'DINGTALK_BIND_REQUIRED',
+      message: 'A bound DingTalk account is required for this form',
+    }
+  }
+
+  if (accessMode === 'dingtalk_granted' && !dingtalkAccess.grantEnabled) {
+    return {
+      allowed: false,
+      statusCode: 403,
+      code: 'DINGTALK_GRANT_REQUIRED',
+      message: 'A DingTalk-authorized account is required for this form',
+    }
+  }
+
+  return { allowed: true, accessMode }
 }
 
 function appendQueryParam(path: string, key: string, value: string): string {
@@ -5039,6 +5164,220 @@ export function univerMetaRouter(): Router {
     }
   })
 
+  router.get('/sheets/:sheetId/views/:viewId/form-share', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const viewId = typeof req.params.viewId === 'string' ? req.params.viewId.trim() : ''
+    if (!sheetId || !viewId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and viewId are required' } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      const current = await pool.query(
+        'SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1',
+        [viewId],
+      )
+      if (current.rows.length === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
+      }
+
+      const row: any = current.rows[0]
+      if (String(row.sheet_id) !== sheetId) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View ${viewId} does not belong to sheet ${sheetId}` } })
+      }
+
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageViews) return sendForbidden(res)
+
+      const view: UniverMetaViewConfig = {
+        id: viewId,
+        sheetId,
+        name: String(row.name),
+        type: String(row.type ?? 'grid'),
+        filterInfo: normalizeJson(row.filter_info),
+        sortInfo: normalizeJson(row.sort_info),
+        groupInfo: normalizeJson(row.group_info),
+        hiddenFieldIds: normalizeJsonArray(row.hidden_field_ids),
+        config: normalizeJson(row.config),
+      }
+
+      return res.json({ ok: true, data: serializePublicFormShareConfig(view) })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] get form share config failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load form share config' } })
+    }
+  })
+
+  router.patch('/sheets/:sheetId/views/:viewId/form-share', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const viewId = typeof req.params.viewId === 'string' ? req.params.viewId.trim() : ''
+    if (!sheetId || !viewId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and viewId are required' } })
+    }
+
+    const schema = z.object({
+      enabled: z.boolean().optional(),
+      expiresAt: z.string().datetime().nullable().optional(),
+      accessMode: z.enum(['public', 'dingtalk', 'dingtalk_granted']).optional(),
+    })
+
+    const parsed = schema.safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      const current = await pool.query(
+        'SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1',
+        [viewId],
+      )
+      if (current.rows.length === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
+      }
+
+      const row: any = current.rows[0]
+      if (String(row.sheet_id) !== sheetId) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View ${viewId} does not belong to sheet ${sheetId}` } })
+      }
+
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageViews) return sendForbidden(res)
+
+      const nextConfig = normalizeJson(row.config)
+      const existingPublicForm = getPublicFormConfig({
+        id: viewId,
+        sheetId,
+        name: String(row.name),
+        type: String(row.type ?? 'grid'),
+        filterInfo: normalizeJson(row.filter_info),
+        sortInfo: normalizeJson(row.sort_info),
+        groupInfo: normalizeJson(row.group_info),
+        hiddenFieldIds: normalizeJsonArray(row.hidden_field_ids),
+        config: nextConfig,
+      })
+      const nextEnabled = parsed.data.enabled ?? (existingPublicForm?.enabled === true)
+      const nextPublicToken = (() => {
+        const existing = typeof existingPublicForm?.publicToken === 'string' ? existingPublicForm.publicToken.trim() : ''
+        if (existing) return existing
+        return nextEnabled ? buildPublicFormToken() : ''
+      })()
+      const nextPublicForm: PublicFormConfig = {
+        ...(existingPublicForm ?? {}),
+        enabled: nextEnabled,
+        publicToken: nextPublicToken || undefined,
+        ...(parsed.data.expiresAt !== undefined
+          ? (parsed.data.expiresAt ? { expiresAt: parsed.data.expiresAt } : { expiresAt: null })
+          : (existingPublicForm?.expiresAt ?? existingPublicForm?.expiresOn) !== undefined
+            ? { expiresAt: existingPublicForm?.expiresAt ?? existingPublicForm?.expiresOn }
+            : {}),
+        accessMode: parsed.data.accessMode ?? normalizePublicFormAccessMode(existingPublicForm?.accessMode),
+      }
+      nextConfig.publicForm = nextPublicForm as Record<string, unknown>
+
+      await pool.query(
+        `UPDATE meta_views
+         SET config = $2::jsonb
+         WHERE id = $1`,
+        [viewId, JSON.stringify(nextConfig)],
+      )
+
+      const view: UniverMetaViewConfig = {
+        id: viewId,
+        sheetId,
+        name: String(row.name),
+        type: String(row.type ?? 'grid'),
+        filterInfo: normalizeJson(row.filter_info),
+        sortInfo: normalizeJson(row.sort_info),
+        groupInfo: normalizeJson(row.group_info),
+        hiddenFieldIds: normalizeJsonArray(row.hidden_field_ids),
+        config: nextConfig,
+      }
+      metaViewConfigCache.set(viewId, view)
+      return res.json({ ok: true, data: serializePublicFormShareConfig(view) })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] update form share config failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update form share config' } })
+    }
+  })
+
+  router.post('/sheets/:sheetId/views/:viewId/form-share/regenerate', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const viewId = typeof req.params.viewId === 'string' ? req.params.viewId.trim() : ''
+    if (!sheetId || !viewId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and viewId are required' } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      const current = await pool.query(
+        'SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1',
+        [viewId],
+      )
+      if (current.rows.length === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
+      }
+
+      const row: any = current.rows[0]
+      if (String(row.sheet_id) !== sheetId) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View ${viewId} does not belong to sheet ${sheetId}` } })
+      }
+
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageViews) return sendForbidden(res)
+
+      const nextConfig = normalizeJson(row.config)
+      const existingPublicForm = getPublicFormConfig({
+        id: viewId,
+        sheetId,
+        name: String(row.name),
+        type: String(row.type ?? 'grid'),
+        filterInfo: normalizeJson(row.filter_info),
+        sortInfo: normalizeJson(row.sort_info),
+        groupInfo: normalizeJson(row.group_info),
+        hiddenFieldIds: normalizeJsonArray(row.hidden_field_ids),
+        config: nextConfig,
+      })
+      const nextPublicToken = buildPublicFormToken()
+      nextConfig.publicForm = {
+        ...(existingPublicForm ?? {}),
+        enabled: existingPublicForm?.enabled === true,
+        publicToken: nextPublicToken,
+        accessMode: normalizePublicFormAccessMode(existingPublicForm?.accessMode),
+      } as Record<string, unknown>
+
+      await pool.query(
+        `UPDATE meta_views
+         SET config = $2::jsonb
+         WHERE id = $1`,
+        [viewId, JSON.stringify(nextConfig)],
+      )
+
+      const view: UniverMetaViewConfig = {
+        id: viewId,
+        sheetId,
+        name: String(row.name),
+        type: String(row.type ?? 'grid'),
+        filterInfo: normalizeJson(row.filter_info),
+        sortInfo: normalizeJson(row.sort_info),
+        groupInfo: normalizeJson(row.group_info),
+        hiddenFieldIds: normalizeJsonArray(row.hidden_field_ids),
+        config: nextConfig,
+      }
+      metaViewConfigCache.set(viewId, view)
+      return res.json({ ok: true, data: { publicToken: serializePublicFormShareConfig(view).publicToken } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] regenerate form share token failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to regenerate form share token' } })
+    }
+  })
+
   router.delete('/views/:viewId', async (req: Request, res: Response) => {
     const viewId = req.params.viewId
     if (!viewId || typeof viewId !== 'string') {
@@ -5584,21 +5923,34 @@ export function univerMetaRouter(): Router {
       const sheetId = resolved.sheetId
       const { access, capabilities, capabilityOrigin, sheetScope } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
       const publicAccessAllowed = isPublicFormAccessAllowed(resolved.view, publicTokenParam)
+      const protectedPublicAccess = publicAccessAllowed
+        ? await evaluateProtectedPublicFormAccess(pool.query.bind(pool), req, resolved.view)
+        : null
+      if (protectedPublicAccess?.allowed === false) {
+        return res.status(protectedPublicAccess.statusCode).json({
+          ok: false,
+          error: {
+            code: protectedPublicAccess.code,
+            message: protectedPublicAccess.message,
+          },
+        })
+      }
+      const effectivePublicAccessAllowed = publicAccessAllowed && (!protectedPublicAccess || protectedPublicAccess.allowed)
       if (!access.userId && !publicAccessAllowed) {
         return res.status(401).json({ error: 'Authentication required' })
       }
-      if (!publicAccessAllowed && !capabilities.canRead) return sendForbidden(res)
+      if (!effectivePublicAccessAllowed && !capabilities.canRead) return sendForbidden(res)
       const sheet = await loadSheetRow(pool.query.bind(pool), sheetId)
       if (!sheet) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
       }
 
       const fields = await loadFieldsForSheet(pool.query.bind(pool), sheetId)
-      const effectiveCapabilities = publicAccessAllowed ? PUBLIC_FORM_CAPABILITIES : capabilities
-      const effectiveCapabilityOrigin = publicAccessAllowed ? undefined : capabilityOrigin
-      const effectiveSheetScope = publicAccessAllowed ? undefined : sheetScope
-      const effectiveAccess = publicAccessAllowed ? { userId: '', permissions: [], isAdminRole: false } : access
-      if (publicAccessAllowed && recordIdParam) {
+      const effectiveCapabilities = effectivePublicAccessAllowed ? PUBLIC_FORM_CAPABILITIES : capabilities
+      const effectiveCapabilityOrigin = effectivePublicAccessAllowed ? undefined : capabilityOrigin
+      const effectiveSheetScope = effectivePublicAccessAllowed ? undefined : sheetScope
+      const effectiveAccess = effectivePublicAccessAllowed ? { userId: '', permissions: [], isAdminRole: false } : access
+      if (effectivePublicAccessAllowed && recordIdParam) {
         return res.status(400).json({
           ok: false,
           error: { code: 'VALIDATION_ERROR', message: 'Public forms do not support loading an existing record' },
@@ -5666,7 +6018,7 @@ export function univerMetaRouter(): Router {
           mode: 'form',
           readOnly: !effectiveCapabilities.canCreateRecord,
           submitPath: resolved.view
-            ? (publicAccessAllowed && publicTokenParam
+            ? (effectivePublicAccessAllowed && publicTokenParam
               ? buildPublicFormSubmitPath(resolved.view.id, publicTokenParam)
               : `/api/multitable/views/${resolved.view.id}/submit`)
             : '/api/multitable/records',
@@ -5742,13 +6094,26 @@ export function univerMetaRouter(): Router {
           ? req.query.publicToken.trim()
           : ''
       const publicAccessAllowed = isPublicFormAccessAllowed(view, publicTokenParam)
+      const protectedPublicAccess = publicAccessAllowed
+        ? await evaluateProtectedPublicFormAccess(pool.query.bind(pool), req, view)
+        : null
+      if (protectedPublicAccess?.allowed === false) {
+        return res.status(protectedPublicAccess.statusCode).json({
+          ok: false,
+          error: {
+            code: protectedPublicAccess.code,
+            message: protectedPublicAccess.message,
+          },
+        })
+      }
+      const effectivePublicAccessAllowed = publicAccessAllowed && (!protectedPublicAccess || protectedPublicAccess.allowed)
       if (!access.userId && !publicAccessAllowed) {
         return res.status(401).json({ error: 'Authentication required' })
       }
-      const effectiveCapabilities = publicAccessAllowed ? PUBLIC_FORM_CAPABILITIES : capabilities
-      const effectiveSheetScope = publicAccessAllowed ? undefined : sheetScope
-      const effectiveAccess = publicAccessAllowed ? { userId: '', permissions: [], isAdminRole: false } : access
-      if (publicAccessAllowed && parsed.data.recordId) {
+      const effectiveCapabilities = effectivePublicAccessAllowed ? PUBLIC_FORM_CAPABILITIES : capabilities
+      const effectiveSheetScope = effectivePublicAccessAllowed ? undefined : sheetScope
+      const effectiveAccess = effectivePublicAccessAllowed ? { userId: '', permissions: [], isAdminRole: false } : access
+      if (effectivePublicAccessAllowed && parsed.data.recordId) {
         return res.status(400).json({
           ok: false,
           error: { code: 'VALIDATION_ERROR', message: 'Public forms do not support updating an existing record' },
@@ -5965,7 +6330,12 @@ export function univerMetaRouter(): Router {
           `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
            VALUES ($1, $2, $3::jsonb, 1, $4)
            RETURNING id, version`,
-          [resultRecordId, view.sheetId, JSON.stringify(patch), publicAccessAllowed ? null : getRequestActorId(req)],
+          [
+            resultRecordId,
+            view.sheetId,
+            JSON.stringify(patch),
+            effectivePublicAccessAllowed && !access.userId ? null : getRequestActorId(req),
+          ],
         )
         resultRecordId = String((insertRes as any).rows[0]?.id ?? resultRecordId)
         nextVersion = Number((insertRes as any).rows[0]?.version ?? 1)

--- a/packages/core-backend/tests/integration/public-form-flow.test.ts
+++ b/packages/core-backend/tests/integration/public-form-flow.test.ts
@@ -20,7 +20,7 @@ const INVALID_TOKEN = 'wrong-token-nope'
 const TEST_VIEW_ID = 'view_pub_1'
 const TEST_SHEET_ID = 'sheet_pub_1'
 
-function makeViewRow(token: string, enabled = true, expiresAt?: number) {
+function makeViewRow(token: string, enabled = true, expiresAt?: number, accessMode: 'public' | 'dingtalk' | 'dingtalk_granted' = 'public') {
   return {
     id: TEST_VIEW_ID,
     sheetId: TEST_SHEET_ID,
@@ -32,6 +32,7 @@ function makeViewRow(token: string, enabled = true, expiresAt?: number) {
         enabled,
         publicToken: token,
         ...(expiresAt !== undefined ? { expiresAt } : {}),
+        accessMode,
       },
     }),
     hiddenFieldIds: [],
@@ -55,8 +56,17 @@ function makeFieldRows() {
   ]
 }
 
-function buildQueryHandler(viewToken: string, opts: { enabled?: boolean; expiresAt?: number } = {}): QueryHandler {
-  const view = makeViewRow(viewToken, opts.enabled ?? true, opts.expiresAt)
+function buildQueryHandler(
+  viewToken: string,
+  opts: {
+    enabled?: boolean
+    expiresAt?: number
+    accessMode?: 'public' | 'dingtalk' | 'dingtalk_granted'
+    hasDingTalkBinding?: boolean
+    hasDingTalkGrant?: boolean
+  } = {},
+): QueryHandler {
+  const view = makeViewRow(viewToken, opts.enabled ?? true, opts.expiresAt, opts.accessMode ?? 'public')
   const sheet = makeSheetRow()
   const fields = makeFieldRows()
   return (sql: string, params?: unknown[]) => {
@@ -77,6 +87,15 @@ function buildQueryHandler(viewToken: string, opts: { enabled?: boolean; expires
         rows: [{ id: 'rec_new_1', version: 1, data: JSON.stringify({ fld_1: 'Alice', fld_2: 'alice@test.com' }) }],
         rowCount: 1,
       }
+    }
+    if (sql.includes('FROM user_external_identities')) {
+      return { rows: opts.hasDingTalkBinding ? [{ local_user_id: params?.[1] }] : [], rowCount: opts.hasDingTalkBinding ? 1 : 0 }
+    }
+    if (sql.includes('FROM directory_account_links')) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes('FROM user_external_auth_grants')) {
+      return { rows: opts.hasDingTalkGrant ? [{ enabled: true }] : [], rowCount: opts.hasDingTalkGrant ? 1 : 0 }
     }
     return { rows: [], rowCount: 0 }
   }
@@ -196,6 +215,99 @@ describe('Public form flow', () => {
     // The important thing is it's not 401/403.
     expect(res.status).not.toBe(401)
     expect(res.status).not.toBe(403)
+  })
+
+  test('dingtalk-protected form redirects anonymous access to sign-in', async () => {
+    const { app } = await createApp({
+      queryHandler: buildQueryHandler(VALID_TOKEN, { accessMode: 'dingtalk' }),
+      user: null,
+    })
+
+    const res = await request(app)
+      .get(`/api/multitable/form-context?viewId=${TEST_VIEW_ID}&publicToken=${VALID_TOKEN}`)
+
+    expect(res.status).toBe(401)
+    expect(res.body.error?.code).toBe('DINGTALK_AUTH_REQUIRED')
+  })
+
+  test('dingtalk-protected form allows a bound signed-in user', async () => {
+    const { app } = await createApp({
+      queryHandler: buildQueryHandler(VALID_TOKEN, { accessMode: 'dingtalk', hasDingTalkBinding: true }),
+      user: { id: 'user_bound' },
+    })
+
+    const res = await request(app)
+      .get(`/api/multitable/form-context?viewId=${TEST_VIEW_ID}&publicToken=${VALID_TOKEN}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+
+  test('dingtalk-granted form rejects a bound user without grant', async () => {
+    const { app } = await createApp({
+      queryHandler: buildQueryHandler(VALID_TOKEN, {
+        accessMode: 'dingtalk_granted',
+        hasDingTalkBinding: true,
+        hasDingTalkGrant: false,
+      }),
+      user: { id: 'user_bound' },
+    })
+
+    const res = await request(app)
+      .get(`/api/multitable/form-context?viewId=${TEST_VIEW_ID}&publicToken=${VALID_TOKEN}`)
+
+    expect(res.status).toBe(403)
+    expect(res.body.error?.code).toBe('DINGTALK_GRANT_REQUIRED')
+  })
+
+  test('form share config routes expose and update protected access mode', async () => {
+    let storedConfig = {
+      publicForm: {
+        enabled: true,
+        publicToken: VALID_TOKEN,
+        accessMode: 'public',
+      },
+    }
+    const { app } = await createApp({
+      user: { id: 'admin_1', perms: ['multitable:write', 'multitable:share'] },
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1')) {
+          expect(params).toEqual([TEST_VIEW_ID])
+          return {
+            rows: [{
+              id: TEST_VIEW_ID,
+              sheet_id: TEST_SHEET_ID,
+              name: 'Public Form View',
+              type: 'form',
+              filter_info: {},
+              sort_info: {},
+              group_info: {},
+              hidden_field_ids: [],
+              config: storedConfig,
+            }],
+          }
+        }
+        if (sql.includes('UPDATE meta_views') && sql.includes('SET config = $2::jsonb')) {
+          storedConfig = JSON.parse(String(params?.[1] ?? '{}'))
+          return { rows: [], rowCount: 1 }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const getResponse = await request(app)
+      .get(`/api/multitable/sheets/${TEST_SHEET_ID}/views/${TEST_VIEW_ID}/form-share`)
+      .expect(200)
+
+    expect(getResponse.body.data.accessMode).toBe('public')
+
+    const patchResponse = await request(app)
+      .patch(`/api/multitable/sheets/${TEST_SHEET_ID}/views/${TEST_VIEW_ID}/form-share`)
+      .send({ accessMode: 'dingtalk_granted' })
+      .expect(200)
+
+    expect(patchResponse.body.data.accessMode).toBe('dingtalk_granted')
+    expect(storedConfig.publicForm.accessMode).toBe('dingtalk_granted')
   })
 
   test('rate limit exceeded -> 429 with Retry-After header', async () => {

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../src/metrics/metrics', () => ({
   metrics: metricsMocks,
 }))
 
-import { isPublicFormAuthBypass, isWhitelisted, jwtAuthMiddleware } from '../../src/auth/jwt-middleware'
+import { isPublicFormAuthBypass, isWhitelisted, jwtAuthMiddleware, optionalJwtAuthMiddleware } from '../../src/auth/jwt-middleware'
 
 describe('jwt auth whitelist', () => {
   it('allows DingTalk launch without a bearer token', () => {
@@ -197,6 +197,53 @@ describe('jwt auth middleware', () => {
 
     await jwtAuthMiddleware(req, res, next)
 
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('optionally hydrates the user on public form routes when a bearer token is present', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-4',
+      email: 'bound@example.com',
+      name: 'Bound User',
+      role: 'user',
+      permissions: ['multitable:read'],
+      created_at: new Date('2026-04-20T00:00:00.000Z'),
+      updated_at: new Date('2026-04-20T00:00:00.000Z'),
+    })
+
+    const req = {
+      path: '/api/multitable/form-context',
+      headers: {
+        authorization: 'Bearer optional-token',
+      },
+    } as unknown as Request
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response
+    const next = vi.fn() as NextFunction
+
+    await optionalJwtAuthMiddleware(req, res, next)
+
+    expect(req.user).toMatchObject({ id: 'user-4' })
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('optional public form auth bypass does not fail when no bearer token is present', async () => {
+    authServiceMocks.verifyToken.mockReset()
+    const req = {
+      path: '/api/multitable/form-context',
+      headers: {},
+    } as unknown as Request
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response
+    const next = vi.fn() as NextFunction
+
+    await optionalJwtAuthMiddleware(req, res, next)
+
+    expect(authServiceMocks.verifyToken).not.toHaveBeenCalled()
     expect(next).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- add protected public form access modes for DingTalk-bound and DingTalk-granted users
- optionally hydrate signed-in users on public form routes and bootstrap DingTalk sign-in from the public form page
- add form-share access mode management, tests, and development/verification docs

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/jwt-middleware.test.ts tests/integration/public-form-flow.test.ts tests/integration/multitable-record-form.api.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/public-multitable-form.spec.ts tests/multitable-form-share-manager.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build