### PR TITLE
feat(auth): support no-email DingTalk user admission

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -48,11 +48,11 @@
       <div class="directory-admin__account-grid">
         <div>
           <strong>本地用户</strong>
-          <div>{{ manualAdmissionResult.userName || manualAdmissionResult.email || manualAdmissionResult.userId }}</div>
+          <div>{{ manualAdmissionResult.userName || manualAdmissionResult.email || manualAdmissionResult.username || manualAdmissionResult.mobile || manualAdmissionResult.userId }}</div>
         </div>
         <div>
-          <strong>邮箱</strong>
-          <div>{{ manualAdmissionResult.email }}</div>
+          <strong>登录账号</strong>
+          <div>{{ manualAdmissionResult.email || manualAdmissionResult.username || manualAdmissionResult.mobile || manualAdmissionResult.userId }}</div>
         </div>
         <div>
           <strong>用户 ID</strong>
@@ -438,7 +438,7 @@
               </div>
             </div>
             <p class="directory-admin__hint">
-              本地用户：{{ item.account.localUser ? (item.account.localUser.email || item.account.localUser.id) : '未绑定' }} ·
+              本地用户：{{ item.account.localUser ? describeLocalUserIdentifier(item.account.localUser) : '未绑定' }} ·
               外部用户：{{ item.account.externalUserId }} ·
               部门：{{ item.account.departmentPaths.join('，') || '未分配部门' }}
             </p>
@@ -453,7 +453,7 @@
             </div>
             <div v-if="item.kind === 'pending_binding'" class="directory-admin__form-grid directory-admin__form-grid--account">
               <label class="directory-admin__field">
-                <span>绑定到本地用户 ID / 邮箱</span>
+                <span>绑定到本地用户 ID / 邮箱 / 用户名 / 手机号</span>
                 <input
                   :value="readBindingDraft(item.account)"
                   class="directory-admin__input"
@@ -480,8 +480,8 @@
                 type="button"
                 @click="applyRecommendedLocalUser(item.account.id, recommendation)"
               >
-                <strong>{{ recommendation.localUser.name || recommendation.localUser.email || recommendation.localUser.id }}</strong>
-                <span>{{ recommendation.localUser.email || recommendation.localUser.id }}</span>
+                <strong>{{ describeLocalUserLabel(recommendation.localUser) }}</strong>
+                <span>{{ describeLocalUserIdentifier(recommendation.localUser) }}</span>
                 <small>{{ readRecommendationReasonLabel(recommendation.reasons) }}</small>
               </button>
             </div>
@@ -493,8 +493,8 @@
                 type="button"
                 @click="chooseLocalUser(item.account.id, user)"
               >
-                <strong>{{ user.name || user.email }}</strong>
-                <span>{{ user.email }}</span>
+                <strong>{{ describeLocalUserLabel(user) }}</strong>
+                <span>{{ describeLocalUserIdentifier(user) }}</span>
                 <small>{{ user.id }} · {{ user.role }} · {{ user.is_active ? 'active' : 'inactive' }}</small>
               </button>
             </div>
@@ -533,13 +533,23 @@
                   />
                 </label>
                 <label class="directory-admin__field">
-                  <span>邮箱</span>
+                  <span>邮箱（可选）</span>
                   <input
                     :value="readManualAdmissionDraft(item.account).email"
                     class="directory-admin__input"
                     type="email"
                     placeholder="例如 alpha@example.com"
                     @input="onManualAdmissionDraftInput(item.account.id, 'email', $event)"
+                  />
+                </label>
+                <label class="directory-admin__field">
+                  <span>用户名（可选）</span>
+                  <input
+                    :value="readManualAdmissionDraft(item.account).username"
+                    class="directory-admin__input"
+                    type="text"
+                    placeholder="例如 liqing"
+                    @input="onManualAdmissionDraftInput(item.account.id, 'username', $event)"
                   />
                 </label>
                 <label class="directory-admin__field">
@@ -553,7 +563,7 @@
                   />
                 </label>
               </div>
-              <p class="directory-admin__hint">创建成功后会保留邀请信息；若后续绑定失败，目录卡片会自动选中新建用户，便于继续重试。</p>
+              <p class="directory-admin__hint">姓名必填；邮箱、用户名、手机号至少填写一项。无邮箱用户会走临时密码 + 首登强制改密。</p>
             </div>
             <div class="directory-admin__actions">
               <button
@@ -900,7 +910,7 @@
               <div>
                 <strong>{{ account.name }}</strong>
                 <p class="directory-admin__hint">
-                  {{ account.localUser ? `本地用户：${account.localUser.email || account.localUser.id}` : '未绑定本地用户' }}
+                  {{ account.localUser ? `本地用户：${describeLocalUserIdentifier(account.localUser)}` : '未绑定本地用户' }}
                 </p>
               </div>
               <div class="directory-admin__chips">
@@ -936,7 +946,7 @@
 
             <div class="directory-admin__form-grid directory-admin__form-grid--account">
               <label class="directory-admin__field">
-                <span>绑定到本地用户 ID / 邮箱</span>
+                <span>绑定到本地用户 ID / 邮箱 / 用户名 / 手机号</span>
                 <input
                   :value="readBindingDraft(account)"
                   class="directory-admin__input"
@@ -995,8 +1005,8 @@
                 type="button"
                 @click="chooseLocalUser(account.id, user)"
               >
-                <strong>{{ user.name || user.email }}</strong>
-                <span>{{ user.email }}</span>
+                <strong>{{ describeLocalUserLabel(user) }}</strong>
+                <span>{{ describeLocalUserIdentifier(user) }}</span>
                 <small>{{ user.id }} · {{ user.role }} · {{ user.is_active ? 'active' : 'inactive' }}</small>
               </button>
             </div>
@@ -1257,6 +1267,7 @@ type DirectoryAccount = {
   localUser: {
     id: string
     email: string | null
+    username?: string | null
     name: string | null
   } | null
   departmentPaths: string[]
@@ -1264,7 +1275,8 @@ type DirectoryAccount = {
 
 type LocalUserOption = {
   id: string
-  email: string
+  email: string | null
+  username?: string | null
   name: string | null
   mobile?: string | null
   role: string
@@ -1272,6 +1284,7 @@ type LocalUserOption = {
 }
 
 type OnboardingPacket = {
+  accountLabel?: string
   acceptInviteUrl?: string
   inviteMessage?: string
 }
@@ -1279,6 +1292,7 @@ type OnboardingPacket = {
 type ManualAdmissionDraft = {
   name: string
   email: string
+  username: string
   mobile: string
 }
 
@@ -1288,7 +1302,8 @@ type ManualAdmissionResult = {
   integrationId: string
   userId: string
   userName: string
-  email: string
+  email: string | null
+  username: string | null
   mobile: string
   temporaryPassword: string
   onboarding: OnboardingPacket | null
@@ -1871,7 +1886,7 @@ async function loadIntegrations() {
 }
 
 function readBindingDraft(account: DirectoryAccount): string {
-  return bindingDrafts[account.id] ?? account.localUser?.email ?? account.localUser?.id ?? ''
+  return bindingDrafts[account.id] ?? describeLocalUserIdentifier(account.localUser) ?? ''
 }
 
 function readBindingDraftByAccountId(accountId: string): string {
@@ -1942,7 +1957,13 @@ function updateBindingDraft(accountId: string, value: string) {
   const selectedUser = selectedBindingUsers[accountId]
   if (!selectedUser) return
   const normalizedValue = value.trim()
-  if (normalizedValue !== selectedUser.id && normalizedValue !== (selectedUser.email || '')) {
+  const selectedIdentifiers = new Set([
+    selectedUser.id,
+    selectedUser.email || '',
+    selectedUser.username || '',
+    selectedUser.mobile || '',
+  ].filter((item) => item.trim().length > 0))
+  if (!selectedIdentifiers.has(normalizedValue)) {
     delete selectedBindingUsers[accountId]
     delete mobileOverrideConfirmations[accountId]
     delete mobileConflictHints[accountId]
@@ -2003,7 +2024,7 @@ async function searchLocalUsers(accountId: string) {
 }
 
 function chooseLocalUser(accountId: string, user: LocalUserOption) {
-  updateBindingDraft(accountId, user.email || user.id)
+  updateBindingDraft(accountId, describeLocalUserIdentifier(user))
   selectedBindingUsers[accountId] = user
   delete mobileOverrideConfirmations[accountId]
   delete mobileConflictHints[accountId]
@@ -2011,7 +2032,7 @@ function chooseLocalUser(accountId: string, user: LocalUserOption) {
 }
 
 function applyRecommendedLocalUser(accountId: string, recommendation: DirectoryBindingRecommendation) {
-  updateBindingDraft(accountId, recommendation.localUser.email || recommendation.localUser.id)
+  updateBindingDraft(accountId, describeLocalUserIdentifier(recommendation.localUser))
   selectedBindingUsers[accountId] = recommendation.localUser
   delete mobileOverrideConfirmations[accountId]
   delete mobileConflictHints[accountId]
@@ -2117,6 +2138,7 @@ function buildManualAdmissionDraft(account: DirectoryAccount): ManualAdmissionDr
   return {
     name: account.name?.trim() || '',
     email: account.email?.trim() || '',
+    username: '',
     mobile: account.mobile?.trim() || '',
   }
 }
@@ -2143,6 +2165,7 @@ function onManualAdmissionDraftInput(accountId: string, field: keyof ManualAdmis
   const current = manualAdmissionDrafts[accountId] ?? {
     name: '',
     email: '',
+    username: '',
     mobile: '',
   }
   manualAdmissionDrafts[accountId] = {
@@ -2153,7 +2176,18 @@ function onManualAdmissionDraftInput(accountId: string, field: keyof ManualAdmis
 
 function canSubmitManualAdmission(item: DirectoryReviewItem): boolean {
   const draft = readManualAdmissionDraft(item.account)
-  return draft.name.trim().length > 0 && draft.email.trim().length > 0
+  return draft.name.trim().length > 0
+    && (draft.email.trim().length > 0 || draft.username.trim().length > 0 || draft.mobile.trim().length > 0)
+}
+
+function describeLocalUserIdentifier(user: Pick<LocalUserOption, 'id' | 'email' | 'username' | 'mobile'> | null | undefined): string {
+  if (!user) return ''
+  return user.email || user.username || user.mobile || user.id
+}
+
+function describeLocalUserLabel(user: Pick<LocalUserOption, 'id' | 'email' | 'username' | 'mobile' | 'name'> | null | undefined): string {
+  if (!user) return ''
+  return user.name || describeLocalUserIdentifier(user)
 }
 
 function clearManualAdmissionResult(): void {
@@ -2168,7 +2202,8 @@ function readCreatedLocalUserOption(data: Record<string, unknown>, fallback: Man
   }
   return {
     id,
-    email: typeof user?.email === 'string' && user.email.trim().length > 0 ? user.email : fallback.email,
+    email: typeof user?.email === 'string' && user.email.trim().length > 0 ? user.email : (fallback.email || null),
+    username: typeof user?.username === 'string' && user.username.trim().length > 0 ? user.username : (fallback.username || null),
     name: typeof user?.name === 'string' && user.name.trim().length > 0 ? user.name : fallback.name,
     mobile: typeof user?.mobile === 'string' && user.mobile.trim().length > 0 ? user.mobile : null,
     role: typeof user?.role === 'string' && user.role.trim().length > 0 ? user.role : 'user',
@@ -2657,7 +2692,7 @@ async function bindAccount(account: DirectoryAccount) {
     const boundAccount = body?.data?.account as DirectoryAccount | undefined
     if (boundAccount) {
       accounts.value = accounts.value.map((item) => (item.id === boundAccount.id ? boundAccount : item))
-      bindingDrafts[account.id] = boundAccount.localUser?.email || boundAccount.localUser?.id || readBindingDraft(account)
+      bindingDrafts[account.id] = describeLocalUserIdentifier(boundAccount.localUser) || readBindingDraft(account)
     }
 
     setStatus(`目录成员 ${account.name} 已绑定到本地用户`)
@@ -3007,11 +3042,12 @@ async function createAndBindReviewUser(item: DirectoryReviewItem) {
   const nextDraft: ManualAdmissionDraft = {
     name: draft.name.trim(),
     email: draft.email.trim(),
+    username: draft.username.trim(),
     mobile: draft.mobile.trim(),
   }
   manualAdmissionDrafts[item.account.id] = nextDraft
-  if (!nextDraft.name || !nextDraft.email) {
-    setStatus(`待处理成员 ${item.account.name} 的姓名和邮箱不能为空`, 'error')
+  if (!nextDraft.name || (!nextDraft.email && !nextDraft.username && !nextDraft.mobile)) {
+    setStatus(`待处理成员 ${item.account.name} 的姓名必填，且邮箱、用户名、手机号至少填写一项`, 'error')
     return
   }
 
@@ -3021,7 +3057,8 @@ async function createAndBindReviewUser(item: DirectoryReviewItem) {
       method: 'POST',
       body: JSON.stringify({
         name: nextDraft.name,
-        email: nextDraft.email,
+        email: nextDraft.email || undefined,
+        username: nextDraft.username || undefined,
         mobile: nextDraft.mobile || undefined,
         enableDingTalkGrant: readGrantToggle(item.account.id),
       }),
@@ -3037,7 +3074,7 @@ async function createAndBindReviewUser(item: DirectoryReviewItem) {
       ? data.onboarding as OnboardingPacket
       : null
 
-    updateBindingDraft(item.account.id, createdUser.email || createdUser.id)
+    updateBindingDraft(item.account.id, describeLocalUserIdentifier(createdUser))
     selectedBindingUsers[item.account.id] = createdUser
     clearBindingSearch(item.account.id)
     delete mobileOverrideConfirmations[item.account.id]
@@ -3051,7 +3088,8 @@ async function createAndBindReviewUser(item: DirectoryReviewItem) {
       integrationId: item.account.integrationId,
       userId: createdUser.id,
       userName: createdUser.name || nextDraft.name,
-      email: createdUser.email || nextDraft.email,
+      email: createdUser.email || nextDraft.email || null,
+      username: createdUser.username || nextDraft.username || null,
       mobile: createdUser.mobile || nextDraft.mobile,
       temporaryPassword,
       onboarding,

--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -86,6 +86,60 @@
       </pre>
     </article>
 
+    <article v-if="autoAdmissionOnboardingPackets.length > 0" class="directory-admin__progress-card">
+      <div class="directory-admin__section-head">
+        <div>
+          <h2>本次自动准入临时凭据</h2>
+          <p class="directory-admin__hint">以下无邮箱目录成员已自动创建本地用户，请通过安全渠道下发登录账号与临时密码。</p>
+        </div>
+        <div class="directory-admin__actions">
+          <button class="directory-admin__button directory-admin__button--secondary" type="button" @click="clearAutoAdmissionOnboardingPackets()">
+            关闭结果
+          </button>
+        </div>
+      </div>
+
+      <article
+        v-for="packet in autoAdmissionOnboardingPackets"
+        :key="packet.userId"
+        class="directory-admin__review-admission"
+      >
+        <div class="directory-admin__account-grid">
+          <div>
+            <strong>本地用户</strong>
+            <div>{{ packet.name || packet.email || packet.username || packet.mobile || packet.userId }}</div>
+          </div>
+          <div>
+            <strong>登录账号</strong>
+            <div>{{ packet.email || packet.username || packet.mobile || packet.userId }}</div>
+          </div>
+          <div>
+            <strong>用户 ID</strong>
+            <div>{{ packet.userId }}</div>
+          </div>
+          <div>
+            <strong>手机号</strong>
+            <div>{{ packet.mobile || '未填写' }}</div>
+          </div>
+        </div>
+        <p class="directory-admin__status">
+          临时密码：{{ packet.temporaryPassword }}
+        </p>
+        <p v-if="packet.onboarding?.acceptInviteUrl" class="directory-admin__hint">
+          邀请链接：
+          <a :href="packet.onboarding.acceptInviteUrl" target="_blank" rel="noreferrer">
+            {{ packet.onboarding.acceptInviteUrl }}
+          </a>
+        </p>
+        <p v-else class="directory-admin__hint">
+          该账号未生成邀请链接，请直接分发登录账号和临时密码。
+        </p>
+        <pre v-if="packet.onboarding?.inviteMessage" class="directory-admin__invite">
+{{ packet.onboarding.inviteMessage }}
+        </pre>
+      </article>
+    </article>
+
     <div class="directory-admin__layout">
       <aside class="directory-admin__panel directory-admin__panel--list">
         <div class="directory-admin__section-head">
@@ -1313,6 +1367,16 @@ type ManualAdmissionResult = {
   mobileBackfillError: string
 }
 
+type AutoAdmissionOnboardingPacket = {
+  userId: string
+  name: string
+  email: string | null
+  username: string | null
+  mobile: string | null
+  temporaryPassword: string
+  onboarding: OnboardingPacket | null
+}
+
 type InitialDirectoryNavigation = {
   integrationId: string
   accountId: string
@@ -1416,6 +1480,7 @@ const userSearchError = reactive<Record<string, string>>({})
 const manualAdmissionDrafts = reactive<Record<string, ManualAdmissionDraft>>({})
 const manualAdmissionExpanded = reactive<Record<string, boolean>>({})
 const manualAdmissionResult = ref<ManualAdmissionResult | null>(null)
+const autoAdmissionOnboardingPackets = ref<AutoAdmissionOnboardingPacket[]>([])
 const grantToggles = reactive<Record<string, boolean>>({})
 const selectedReviewIds = reactive<Record<string, boolean>>({})
 const reviewDisableDingTalkGrant = ref(true)
@@ -1695,6 +1760,7 @@ function resetDraft() {
   for (const key of Object.keys(userSearchError)) delete userSearchError[key]
   for (const key of Object.keys(grantToggles)) delete grantToggles[key]
   for (const key of Object.keys(selectedReviewIds)) delete selectedReviewIds[key]
+  autoAdmissionOnboardingPackets.value = []
   draft.name = ''
   draft.corpId = ''
   draft.appKey = ''
@@ -1775,6 +1841,7 @@ function readMemberGroupSyncLabel(integration: DirectoryIntegration): string {
 async function selectIntegration(integrationId: string): Promise<void> {
   selectedIntegrationId.value = integrationId
   testResult.value = null
+  clearAutoAdmissionOnboardingPackets()
   clearFocusedAccount()
   accountPage.value = 1
   accountTotal.value = 0
@@ -2194,6 +2261,10 @@ function clearManualAdmissionResult(): void {
   manualAdmissionResult.value = null
 }
 
+function clearAutoAdmissionOnboardingPackets(): void {
+  autoAdmissionOnboardingPackets.value = []
+}
+
 function readCreatedLocalUserOption(data: Record<string, unknown>, fallback: ManualAdmissionDraft): LocalUserOption {
   const user = data.user && typeof data.user === 'object' ? data.user as Record<string, unknown> : null
   const id = typeof user?.id === 'string' ? user.id.trim() : ''
@@ -2209,6 +2280,27 @@ function readCreatedLocalUserOption(data: Record<string, unknown>, fallback: Man
     role: typeof user?.role === 'string' && user.role.trim().length > 0 ? user.role : 'user',
     is_active: typeof user?.is_active === 'boolean' ? user.is_active : true,
   }
+}
+
+function readAutoAdmissionOnboardingPackets(data: Record<string, unknown> | undefined): AutoAdmissionOnboardingPacket[] {
+  const rawPackets = Array.isArray(data?.autoAdmissionOnboardingPackets) ? data.autoAdmissionOnboardingPackets : []
+  return rawPackets.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object') return []
+    const packet = entry as Record<string, unknown>
+    const userId = typeof packet.userId === 'string' ? packet.userId.trim() : ''
+    if (!userId) return []
+    return [{
+      userId,
+      name: typeof packet.name === 'string' ? packet.name : '',
+      email: typeof packet.email === 'string' && packet.email.trim().length > 0 ? packet.email : null,
+      username: typeof packet.username === 'string' && packet.username.trim().length > 0 ? packet.username : null,
+      mobile: typeof packet.mobile === 'string' && packet.mobile.trim().length > 0 ? packet.mobile : null,
+      temporaryPassword: typeof packet.temporaryPassword === 'string' ? packet.temporaryPassword : '',
+      onboarding: packet.onboarding && typeof packet.onboarding === 'object'
+        ? packet.onboarding as OnboardingPacket
+        : null,
+    }]
+  })
 }
 
 function buildPayload() {
@@ -2284,12 +2376,15 @@ async function syncIntegration() {
   if (!selectedIntegration.value) return
   busy.value = true
   try {
+    clearAutoAdmissionOnboardingPackets()
     const response = await apiFetch(`/api/admin/directory/integrations/${selectedIntegration.value.id}/sync`, {
       method: 'POST',
     })
     const body = await readJson(response)
     if (!response.ok) throw new Error(readApiError(body, '目录同步失败'))
+    autoAdmissionOnboardingPackets.value = readAutoAdmissionOnboardingPackets(body?.data as Record<string, unknown> | undefined)
     const autoAdmittedCount = Number(body?.data?.run?.stats?.autoAdmittedCount ?? 0)
+    const autoAdmittedNoEmailCount = Number(body?.data?.run?.stats?.autoAdmittedNoEmailCount ?? 0)
     const autoAdmissionSkippedMissingEmailCount = Number(body?.data?.run?.stats?.autoAdmissionSkippedMissingEmailCount ?? 0)
     const autoAdmissionExcludedCount = Number(body?.data?.run?.stats?.autoAdmissionExcludedCount ?? 0)
     const memberGroupsSyncedCount = Number(body?.data?.run?.stats?.memberGroupsSyncedCount ?? 0)
@@ -2299,6 +2394,7 @@ async function syncIntegration() {
     const memberGroupDefaultNamespaceAdmissionsCount = Number(body?.data?.run?.stats?.memberGroupDefaultNamespaceAdmissionsCount ?? 0)
     if (
       autoAdmittedCount > 0
+      || autoAdmittedNoEmailCount > 0
       || autoAdmissionSkippedMissingEmailCount > 0
       || autoAdmissionExcludedCount > 0
       || memberGroupsSyncedCount > 0
@@ -2306,6 +2402,7 @@ async function syncIntegration() {
     ) {
       const parts = ['目录同步已完成']
       if (autoAdmittedCount > 0) parts.push(`自动准入 ${autoAdmittedCount} 位成员`)
+      if (autoAdmittedNoEmailCount > 0) parts.push(`其中 ${autoAdmittedNoEmailCount} 位成员无邮箱，已生成平台登录账号和临时密码`)
       if (autoAdmissionSkippedMissingEmailCount > 0) parts.push(`${autoAdmissionSkippedMissingEmailCount} 位成员因缺少邮箱未自动创建`)
       if (autoAdmissionExcludedCount > 0) parts.push(`${autoAdmissionExcludedCount} 位成员命中排除部门，未自动创建`)
       if (memberGroupsSyncedCount > 0) {

--- a/apps/web/src/views/LoginView.vue
+++ b/apps/web/src/views/LoginView.vue
@@ -22,13 +22,13 @@
 
       <form class="login-form" @submit.prevent="onSubmit">
         <label class="login-field">
-          <span>{{ text.email }}</span>
+          <span>{{ text.identifier }}</span>
           <input
-            v-model="email"
-            type="email"
+            v-model="identifier"
+            type="text"
             autocomplete="username"
             required
-            :placeholder="text.emailPlaceholder"
+            :placeholder="text.identifierPlaceholder"
           />
         </label>
 
@@ -115,7 +115,7 @@ const { setToken, primeSession } = useAuth()
 const { locale, isZh, setLocale } = useLocale()
 const { loadProductFeatures, resolveHomePath } = useFeatureFlags()
 
-const email = ref('')
+const identifier = ref('')
 const password = ref('')
 const submitting = ref(false)
 const errorMessage = ref('')
@@ -129,10 +129,10 @@ const text = computed(() => {
     return {
       title: '登录 MetaSheet',
       subtitle: '输入账号密码后进入系统。',
-      email: '邮箱',
+      identifier: '账号',
       password: '密码',
       language: '语言',
-      emailPlaceholder: 'admin@metasheet.app',
+      identifierPlaceholder: '邮箱、手机号或用户名',
       passwordPlaceholder: '请输入密码',
       submit: '登录',
       submitting: '登录中...',
@@ -150,17 +150,17 @@ const text = computed(() => {
   return {
     title: 'Sign in to MetaSheet',
     subtitle: 'Use your account credentials to continue.',
-    email: 'Email',
+    identifier: 'Account',
     password: 'Password',
     language: 'Language',
-    emailPlaceholder: 'admin@metasheet.app',
+    identifierPlaceholder: 'Email, mobile, or username',
     passwordPlaceholder: 'Enter password',
     submit: 'Sign in',
     submitting: 'Signing in...',
     alternative: 'or',
     dingtalkSubmit: 'Continue with DingTalk',
     dingtalkSubmitting: 'Redirecting to DingTalk...',
-    failed: 'Sign-in failed. Check your email or password.',
+    failed: 'Sign-in failed. Check your account or password.',
     networkError: 'Sign-in failed. Please try again.',
     dingtalkUnavailable: 'DingTalk login is unavailable right now.',
     dingtalkMissingUrl: 'No DingTalk login URL was returned.',
@@ -246,7 +246,7 @@ async function onSubmit(): Promise<void> {
     const response = await apiFetch('/api/auth/login', {
       method: 'POST',
       body: JSON.stringify({
-        email: email.value.trim(),
+        identifier: identifier.value.trim(),
         password: password.value,
       }),
     })

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -15,7 +15,7 @@
           v-model.trim="search"
           class="user-admin__search"
           type="search"
-          placeholder="搜索邮箱、姓名或用户 ID"
+          placeholder="搜索邮箱、用户名、手机号、姓名或用户 ID"
           @keyup.enter="void loadUsers()"
         />
         <button class="user-admin__button" type="button" :disabled="loading" @click="void loadUsers()">
@@ -39,7 +39,9 @@
       </div>
       <div class="user-admin__create-grid">
         <input v-model.trim="createForm.name" class="user-admin__search" type="text" placeholder="姓名" />
-        <input v-model.trim="createForm.email" class="user-admin__search" type="email" placeholder="邮箱" />
+        <input v-model.trim="createForm.email" class="user-admin__search" type="email" placeholder="邮箱（可选）" />
+        <input v-model.trim="createForm.username" class="user-admin__search" type="text" placeholder="用户名（可选）" />
+        <input v-model.trim="createForm.mobile" class="user-admin__search" type="text" placeholder="手机号（可选）" />
         <input v-model.trim="createForm.password" class="user-admin__search" type="text" placeholder="可选：初始密码" />
         <select v-model="presetModeFilter" class="user-admin__select">
           <option value="">预设模式（全部）</option>
@@ -226,8 +228,8 @@
             <span>选择</span>
           </label>
           <button class="user-admin__user-body" type="button" @click="void selectUser(user.id)">
-            <strong>{{ user.name || user.email }}</strong>
-            <span>{{ user.email }}</span>
+            <strong>{{ user.name || formatManagedUserLabel(user) }}</strong>
+            <span>{{ formatManagedUserIdentifier(user) }}</span>
             <span class="user-admin__meta">{{ user.role }} · {{ user.is_active ? '启用' : '停用' }}</span>
             <div class="user-admin__row-badges">
               <span class="user-admin__row-badge" :class="{ 'user-admin__row-badge--success': user.is_active, 'user-admin__row-badge--danger': !user.is_active }">
@@ -257,8 +259,8 @@
         <template v-if="access">
           <div class="user-admin__detail-head">
             <div>
-              <h2>{{ access.user.name || access.user.email }}</h2>
-              <p>{{ access.user.email }}</p>
+              <h2>{{ access.user.name || formatManagedUserLabel(access.user) }}</h2>
+              <p>{{ formatManagedUserIdentifier(access.user) }}</p>
               <p v-if="access.user.mobile" class="user-admin__hint">手机号：{{ access.user.mobile }}</p>
             </div>
             <div class="user-admin__badges">
@@ -590,7 +592,8 @@ import { subscribeToLocationChanges } from '../utils/browserLocation'
 
 type ManagedUser = {
   id: string
-  email: string
+  email: string | null
+  username?: string | null
   name: string | null
   mobile?: string | null
   role: string
@@ -694,6 +697,8 @@ type NamespaceAdmission = {
 type CreateUserForm = {
   name: string
   email: string
+  username: string
+  mobile: string
   password: string
   presetId: string
   role: string
@@ -722,6 +727,7 @@ type OnboardingPacket = {
   loginUrl: string
   acceptInvitePath: string
   acceptInviteUrl: string
+  accountLabel: string
   welcomeTitle: string
   checklist: string[]
   inviteMessage: string
@@ -800,6 +806,8 @@ const appliedUserNavigationKey = ref('')
 const createForm = ref<CreateUserForm>({
   name: '',
   email: '',
+  username: '',
+  mobile: '',
   password: '',
   presetId: '',
   role: 'user',
@@ -845,6 +853,16 @@ const hasProfileDraftChanges = computed(() => {
   if (!access.value) return false
   return profileDraftName.value !== (access.value.user.name || '') || profileDraftMobile.value !== (access.value.user.mobile || '')
 })
+
+function formatManagedUserIdentifier(user: ManagedUser | null | undefined): string {
+  if (!user) return ''
+  return user.email || user.username || user.mobile || user.id
+}
+
+function formatManagedUserLabel(user: ManagedUser | null | undefined): string {
+  if (!user) return ''
+  return user.name || formatManagedUserIdentifier(user)
+}
 const namespaceOptions = computed(() => {
   const namespaces: string[] = []
   const append = (namespace: string): void => {
@@ -1211,7 +1229,7 @@ async function selectUser(userId: string): Promise<void> {
     const navigationKey = buildUserNavigationKey(userNavigation.value)
     if (userNavigation.value.userId === userId && appliedUserNavigationKey.value !== navigationKey) {
       if (userNavigation.value.source === 'directory-sync') {
-        setStatus(`已从目录同步定位到用户 ${access.value.user.name || access.value.user.email}`)
+        setStatus(`已从目录同步定位到用户 ${formatManagedUserLabel(access.value.user)}`)
       }
       appliedUserNavigationKey.value = navigationKey
     }
@@ -1432,6 +1450,8 @@ async function createUser(): Promise<void> {
       body: JSON.stringify({
         name: createForm.value.name,
         email: createForm.value.email,
+        username: createForm.value.username || undefined,
+        mobile: createForm.value.mobile || undefined,
         password: createForm.value.password || undefined,
         presetId: createForm.value.presetId || undefined,
         role: createForm.value.role || undefined,
@@ -1455,6 +1475,8 @@ async function createUser(): Promise<void> {
     createForm.value = {
       name: '',
       email: '',
+      username: '',
+      mobile: '',
       password: '',
       presetId: '',
       role: 'user',

--- a/apps/web/tests/LoginView.spec.ts
+++ b/apps/web/tests/LoginView.spec.ts
@@ -130,17 +130,17 @@ describe('LoginView', () => {
     app.mount(container)
     await flushUi()
 
-    const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement | null
+    const identifierInput = container.querySelector('input[autocomplete="username"]') as HTMLInputElement | null
     const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement | null
     const submitButton = container.querySelector('button[type="submit"]') as HTMLButtonElement | null
 
-    expect(emailInput).not.toBeNull()
+    expect(identifierInput).not.toBeNull()
     expect(passwordInput).not.toBeNull()
     expect(submitButton).not.toBeNull()
 
-    if (emailInput) {
-      emailInput.value = 'admin@example.com'
-      emailInput.dispatchEvent(new Event('input', { bubbles: true }))
+    if (identifierInput) {
+      identifierInput.value = 'admin@example.com'
+      identifierInput.dispatchEvent(new Event('input', { bubbles: true }))
     }
     if (passwordInput) {
       passwordInput.value = 'secret'
@@ -156,7 +156,16 @@ describe('LoginView', () => {
       '/api/auth/dingtalk/launch?probe=1',
       expect.objectContaining({ method: 'GET', suppressUnauthorizedRedirect: true }),
     )
-    expect(mocks.apiFetch).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({ method: 'POST' }))
+    expect(mocks.apiFetch).toHaveBeenCalledWith(
+      '/api/auth/login',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          identifier: 'admin@example.com',
+          password: 'secret',
+        }),
+      }),
+    )
     expect(window.localStorage.getItem('auth_token')).toBe('login-token')
     expect(window.localStorage.getItem('user_roles')).toBe(JSON.stringify(['admin']))
     expect(window.localStorage.getItem('user_permissions')).toBe(JSON.stringify(['attendance:read']))
@@ -223,12 +232,12 @@ describe('LoginView', () => {
     app.mount(container)
     await flushUi()
 
-    const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement | null
+    const identifierInput = container.querySelector('input[autocomplete="username"]') as HTMLInputElement | null
     const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement | null
     const submitButton = container.querySelector('button[type="submit"]') as HTMLButtonElement | null
 
-    emailInput!.value = 'forced@example.com'
-    emailInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    identifierInput!.value = 'forced@example.com'
+    identifierInput!.dispatchEvent(new Event('input', { bubbles: true }))
     passwordInput!.value = 'TempPass9A'
     passwordInput!.dispatchEvent(new Event('input', { bubbles: true }))
 

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -398,6 +398,7 @@ describe('DirectoryManagementView', () => {
             status: 'completed',
             stats: {
               autoAdmittedCount: 2,
+              autoAdmittedNoEmailCount: 1,
               autoAdmissionExcludedCount: 1,
               memberGroupsSyncedCount: 2,
               memberGroupsCreatedCount: 1,
@@ -406,6 +407,21 @@ describe('DirectoryManagementView', () => {
               memberGroupDefaultNamespaceAdmissionsCount: 6,
             },
           },
+          autoAdmissionOnboardingPackets: [
+            {
+              userId: 'user-no-email-1',
+              name: '林岚',
+              email: null,
+              username: 'dt_linlan_12345678',
+              mobile: '13900001234',
+              temporaryPassword: 'Tmp-NoEmail-123',
+              onboarding: {
+                accountLabel: 'dt_linlan_12345678',
+                acceptInviteUrl: '',
+                inviteMessage: '账号：dt_linlan_12345678\n临时密码：Tmp-NoEmail-123',
+              },
+            },
+          ],
         },
       }))
       .mockResolvedValueOnce(createJsonResponse({
@@ -439,6 +455,7 @@ describe('DirectoryManagementView', () => {
                 pendingCount: 3,
                 linkedCount: 89,
                 autoAdmittedCount: 2,
+                autoAdmittedNoEmailCount: 1,
                 autoAdmissionExcludedCount: 1,
                 memberGroupsSyncedCount: 2,
                 memberGroupsCreatedCount: 1,
@@ -533,7 +550,11 @@ describe('DirectoryManagementView', () => {
     expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/alerts?page=1&pageSize=20&filter=all')
     expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/review-items?page=1&pageSize=100&filter=all')
     expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/accounts?page=1&pageSize=25')
-    expect(container?.textContent).toContain('目录同步已完成，自动准入 2 位成员，1 位成员命中排除部门，未自动创建，同步 2 个成员组（新建 1 个），为 3 位成员补齐默认治理（角色新增 4 项，插件开通新增 6 项）')
+    expect(container?.textContent).toContain('目录同步已完成，自动准入 2 位成员，其中 1 位成员无邮箱，已生成平台登录账号和临时密码，1 位成员命中排除部门，未自动创建，同步 2 个成员组（新建 1 个），为 3 位成员补齐默认治理（角色新增 4 项，插件开通新增 6 项）')
+    expect(container?.textContent).toContain('本次自动准入临时凭据')
+    expect(container?.textContent).toContain('dt_linlan_12345678')
+    expect(container?.textContent).toContain('Tmp-NoEmail-123')
+    expect(container?.textContent).toContain('该账号未生成邀请链接，请直接分发登录账号和临时密码。')
     expect(container?.textContent).toContain('账号 99')
   })
 

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -876,6 +876,150 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('已创建本地用户并完成绑定')
   })
 
+  it('supports no-email manual admission with username/mobile and shows temporary-password onboarding', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-manual-no-email',
+              name: '林岚',
+              email: null,
+              mobile: '13900004567',
+            }),
+            flags: {
+              missingUnionId: false,
+              missingOpenId: true,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未匹配到本地用户',
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          id: 'account-manual-no-email',
+          name: '林岚',
+          email: null,
+          mobile: '13900004567',
+        })], { total: 1 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          user: {
+            id: 'user-created-no-email',
+            email: null,
+            username: 'linlan',
+            name: '林岚',
+            mobile: '13900004567',
+            role: 'user',
+            is_active: true,
+          },
+          roles: [],
+          permissions: [],
+          isAdmin: false,
+          temporaryPassword: 'Temp#654321',
+          onboarding: {
+            accountLabel: 'linlan',
+            acceptInviteUrl: '',
+            inviteMessage: '账号：linlan',
+          },
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          id: 'account-manual-no-email',
+          name: '林岚',
+          email: null,
+          mobile: '13900004567',
+          linkStatus: 'linked',
+          matchStrategy: 'manual_admin',
+          localUser: {
+            id: 'user-created-no-email',
+            email: null,
+            username: 'linlan',
+            name: '林岚',
+          },
+        })], { total: 1 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const toggleButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('手动创建用户'))
+    expect(toggleButton).toBeTruthy()
+    toggleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    const inputs = Array.from(container!.querySelectorAll('.directory-admin__review-item input'))
+    const usernameInput = inputs.find((input) => input.getAttribute('placeholder') === '例如 liqing') as HTMLInputElement | undefined
+    if (!usernameInput) throw new Error('Username input not found')
+    usernameInput.value = 'linlan'
+    usernameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    const createAndBindButton = Array.from(container!.querySelectorAll('.directory-admin__review-item button')).find((button) => button.textContent?.includes('创建用户并绑定'))
+    expect(createAndBindButton).toBeTruthy()
+    createAndBindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(12)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/account-manual-no-email/admit-user',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: '林岚',
+          username: 'linlan',
+          mobile: '13900004567',
+          enableDingTalkGrant: true,
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('最近创建并绑定结果')
+    expect(container?.textContent).toContain('新用户临时密码：Temp#654321')
+    expect(container?.textContent).toContain('账号：linlan')
+    expect(container?.textContent).toContain('登录账号')
+    expect(container?.textContent).toContain('linlan')
+    expect(container?.textContent).not.toContain('https://example.com/invite/abc')
+  })
+
   it('focuses a reviewed account and quick-binds it from the accounts banner', async () => {
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -92,7 +92,8 @@ function registerRouterLink(app: App<Element>, withHref = false): void {
 
 type UserFixture = {
   id: string
-  email: string
+  email: string | null
+  username?: string | null
   name: string
   mobile: string | null
   role: string
@@ -113,6 +114,7 @@ function createApiState(): UserFixture[] {
     {
       id: 'user-1',
       email: 'alpha@example.com',
+      username: 'alpha',
       name: 'Alpha',
       mobile: null,
       role: 'user',
@@ -132,6 +134,7 @@ function createApiState(): UserFixture[] {
     {
       id: 'user-2',
       email: 'bravo@example.com',
+      username: 'bravo',
       name: 'Bravo',
       mobile: null,
       role: 'user',
@@ -151,6 +154,7 @@ function createApiState(): UserFixture[] {
     {
       id: 'user-3',
       email: 'charlie@example.com',
+      username: 'charlie',
       name: 'Charlie',
       mobile: null,
       role: 'user',
@@ -170,6 +174,7 @@ function createApiState(): UserFixture[] {
     {
       id: 'user-4',
       email: 'delta@example.com',
+      username: 'delta',
       name: 'Delta',
       mobile: '13800000004',
       role: 'admin',
@@ -206,7 +211,7 @@ function createApiImplementation(
     const pathname = url.pathname
     const query = url.searchParams.get('q')?.trim().toLowerCase() || ''
     const filteredUsers = query
-      ? state.filter((user) => [user.name, user.email, user.id, user.role, user.mobile || ''].some((field) => field.toLowerCase().includes(query)))
+      ? state.filter((user) => [user.name, user.email || '', user.username || '', user.id, user.role, user.mobile || ''].some((field) => field.toLowerCase().includes(query)))
       : state
 
     const findUserById = (userId: string) => state.find((user) => user.id === userId) || state[0]
@@ -214,6 +219,7 @@ function createApiImplementation(
     const buildUserPayload = (user: UserFixture) => ({
       id: user.id,
       email: user.email,
+      username: user.username ?? null,
       name: user.name,
       mobile: user.mobile,
       role: user.role,
@@ -323,6 +329,44 @@ function createApiImplementation(
       return createJsonResponse({
         ok: true,
         data: { items: [] },
+      })
+    }
+
+    if (pathname === '/api/admin/users' && (init?.method || 'GET').toUpperCase() === 'POST') {
+      const rawBody = typeof init?.body === 'string' ? init.body : ''
+      const parsed = rawBody ? JSON.parse(rawBody) as {
+        name?: unknown
+        email?: unknown
+        username?: unknown
+        mobile?: unknown
+      } : {}
+      const newUser: UserFixture = {
+        id: 'user-created',
+        email: typeof parsed.email === 'string' && parsed.email.trim().length > 0 ? parsed.email.trim() : null,
+        username: typeof parsed.username === 'string' && parsed.username.trim().length > 0 ? parsed.username.trim() : null,
+        name: typeof parsed.name === 'string' && parsed.name.trim().length > 0 ? parsed.name.trim() : '新用户',
+        mobile: typeof parsed.mobile === 'string' && parsed.mobile.trim().length > 0 ? parsed.mobile.trim() : null,
+        role: 'user',
+        is_active: true,
+        grantEnabled: false,
+        directoryLinked: false,
+        namespaceAdmissions: [],
+      }
+      state.unshift(newUser)
+      return createJsonResponse({
+        ok: true,
+        data: {
+          user: buildUserPayload(newUser),
+          roles: [],
+          permissions: [],
+          isAdmin: false,
+          temporaryPassword: 'Temp#123456',
+          onboarding: {
+            accountLabel: newUser.username || newUser.mobile || newUser.id,
+            acceptInviteUrl: '',
+            inviteMessage: `账号：${newUser.username || newUser.mobile || newUser.id}`,
+          },
+        },
       })
     }
 
@@ -817,6 +861,48 @@ describe('UserManagementView', () => {
 
     expect(container?.textContent).not.toContain('用户手机号已被其他操作更新为')
     expect(container?.textContent).not.toContain('用户资料已更新')
+  })
+
+  it('creates a no-email user with username/mobile and surfaces temporary-password onboarding', async () => {
+    app = createApp(UserManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi(20)
+
+    const inputs = Array.from(container!.querySelectorAll('.user-admin__panel--create input'))
+    const nameInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '姓名') as HTMLInputElement | undefined
+    const usernameInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '用户名（可选）') as HTMLInputElement | undefined
+    const mobileInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '手机号（可选）') as HTMLInputElement | undefined
+    if (!nameInput || !usernameInput || !mobileInput) {
+      throw new Error('Create-user form inputs not found')
+    }
+
+    nameInput.value = '林岚'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    usernameInput.value = 'linlan'
+    usernameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    mobileInput.value = '13900001234'
+    mobileInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    findButtonByText(container!, '创建用户').click()
+    await waitForCondition(() => apiFetchMock.mock.calls.some((args) => String(args[0]) === '/api/admin/users' && (args[1] as RequestInit | undefined)?.method === 'POST'))
+    await flushUi(8)
+
+    const createCall = apiFetchMock.mock.calls.find((args) => String(args[0]) === '/api/admin/users' && (args[1] as RequestInit | undefined)?.method === 'POST')
+    if (!createCall) throw new Error('Create-user request not found')
+    expect(JSON.parse(String((createCall[1] as RequestInit | undefined)?.body))).toEqual({
+      name: '林岚',
+      email: '',
+      username: 'linlan',
+      mobile: '13900001234',
+      role: 'user',
+      isActive: true,
+    })
+    expect(container?.textContent).toContain('用户已创建')
+    expect(container?.textContent).toContain('新用户临时密码：Temp#123456')
+    expect(container?.textContent).toContain('账号：linlan')
+    expect(container?.textContent).not.toContain('首次设置密码链接：')
   })
 
   it('can auto-focus a user from directory query params', async () => {

--- a/docs/development/dingtalk-no-email-admission-rollforward-development-20260420.md
+++ b/docs/development/dingtalk-no-email-admission-rollforward-development-20260420.md
@@ -1,0 +1,94 @@
+# DingTalk No-Email Admission Rollforward Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-no-email-admission-20260420`
+
+## Goal
+
+Allow administrators to create and bind a local user from a DingTalk-synced directory account even when the account has no email address, instead of forcing a fake email or skipping the user.
+
+## Why this change
+
+Current `main` still required `users.email` at every layer:
+
+- database schema: `users.email TEXT NOT NULL UNIQUE`
+- admin user creation: `email and name are required`
+- directory manual admission: `name and email are required`
+- directory auto-admission: skipped in-scope DingTalk accounts without email
+
+That made DingTalk onboarding incomplete for real enterprise accounts that only had DingTalk identity and mobile.
+
+## Approach
+
+Reused the previously validated no-email closure implementation from the historical `codex/no-email-user-closure-20260418` line and rolled it forward onto current `main`, instead of re-implementing the same account-model change from scratch.
+
+Cherry-picked commits:
+
+- `91d3b2bf4` `feat(auth): support no-email user admission and login identifiers`
+- `11c7555b8` `feat(directory): return no-email auto-admission onboarding packets`
+
+## Main changes
+
+### 1. User model
+
+- Added migration `zzzz20260418170000_allow_no_email_users_and_add_username.ts`
+- `users.email` can now be null
+- added `users.username`
+- added unique index on `lower(username)` when username is not null
+
+### 2. Auth and login
+
+- login now accepts a generic `identifier`
+- identifier may resolve by:
+  - email
+  - username
+  - mobile
+- no-email users can still sign in through DingTalk, and can also use username/mobile when provisioned that way
+
+### 3. Admin user creation
+
+- admin-side create-user flow no longer requires email
+- requires:
+  - `name`
+  - and at least one of `email | username | mobile`
+- skips invite issuance when there is no email
+- returns temporary-password onboarding metadata for no-email users
+
+### 4. Directory manual admission
+
+- `/api/admin/directory/accounts/:accountId/admit-user` now supports no-email local-user creation
+- manual admission requires:
+  - `name`
+  - and at least one of `email | username | mobile`
+- generated onboarding is email-aware:
+  - email path: invite + email onboarding
+  - no-email path: temporary password + account label
+
+### 5. Directory auto-admission
+
+- in-scope DingTalk accounts without email are no longer just dead ends
+- deterministic username generation was added
+- auto-admission response now includes onboarding packets for no-email users
+
+### 6. Frontend admin flows
+
+- `DirectoryManagementView` manual-admission form supports no-email creation
+- `UserManagementView` create-user flow supports no-email creation
+- `LoginView` now uses a generic account identifier
+
+## Key files
+
+- `packages/core-backend/src/db/migrations/zzzz20260418170000_allow_no_email_users_and_add_username.ts`
+- `packages/core-backend/src/auth/AuthService.ts`
+- `packages/core-backend/src/routes/auth.ts`
+- `packages/core-backend/src/routes/admin-users.ts`
+- `packages/core-backend/src/routes/admin-directory.ts`
+- `packages/core-backend/src/directory/directory-sync.ts`
+- `apps/web/src/views/LoginView.vue`
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/src/views/DirectoryManagementView.vue`
+
+## Notes
+
+- This rollforward intentionally reused already tested work rather than designing a second incompatible no-email model.
+- The scope is broader than only directory manual admission because the schema change (`users.email` nullable) needs auth and admin user creation to stay coherent.

--- a/docs/development/dingtalk-no-email-admission-rollforward-verification-20260420.md
+++ b/docs/development/dingtalk-no-email-admission-rollforward-verification-20260420.md
@@ -1,0 +1,70 @@
+# DingTalk No-Email Admission Rollforward Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-no-email-admission-20260420`
+
+## Commands run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/AuthService.test.ts \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts \
+  tests/unit/directory-sync-auto-admission.test.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  tests/directoryManagementView.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- backend tests: `137 passed`
+- frontend tests: `49 passed`
+- backend build: passed
+- web build: passed
+
+## Verified behaviors
+
+### Backend
+
+- admin user creation accepts no-email users when username or mobile is provided
+- directory manual admission accepts no-email users when username or mobile is provided
+- directory auto-admission builds deterministic usernames for no-email users
+- no-email onboarding skips invite issuance and returns temporary-password metadata
+- auth login accepts generic identifiers
+- username login works
+- ambiguous mobile login is rejected safely
+
+### Frontend
+
+- login page uses a generic account identifier
+- user management create-user flow supports no-email provisioning
+- directory management manual-admission flow supports no-email create-and-bind
+- directory management UI surfaces no-email auto-admission onboarding packets
+
+## Non-blocking noise
+
+- frontend Vitest printed `WebSocket server error: Port is already in use`
+- web build still printed the existing chunk-size warning
+
+Neither issue blocked the test or build result.
+
+## Additional check
+
+Claude Code CLI was invoked successfully in read-only mode during this rollforward:
+
+```bash
+claude -p "In one short sentence, describe the safest user-facing summary for enabling no-email DingTalk directory admission."
+```
+
+The CLI completed successfully and was used only for wording assistance, not for direct code generation.

--- a/docs/development/no-email-auto-admission-packets-development-20260419.md
+++ b/docs/development/no-email-auto-admission-packets-development-20260419.md
@@ -1,0 +1,95 @@
+# 无邮箱自动准入临时凭据开发说明 2026-04-19
+
+## 目标
+
+在“无邮箱用户闭环”基础上继续补齐自动准入场景：
+
+- 钉钉目录同步命中的无邮箱成员，也允许自动创建本地账号
+- 同步完成后，后端直接返回一组 onboarding packet
+- 管理员可在目录同步页查看账号、临时密码和引导文案，并通过安全渠道下发
+
+本轮不引入新的消息通道，不直接发短信或钉钉消息，只负责把凭据包安全地返回给管理员。
+
+## 方案
+
+### 后端自动准入
+
+- 保持现有白名单/排除部门判断不变
+- 当成员命中自动准入且没有邮箱时：
+  - 生成稳定的平台用户名
+  - 生成临时密码
+  - 创建本地用户
+  - 强制首登改密
+  - 绑定 DingTalk identity 和 directory link
+  - 返回 onboarding packet
+
+### 用户名生成
+
+- 新增 `buildDirectoryAutoAdmissionUsername()`
+- 输入使用目录账号的稳定字段：
+  - `external_user_id`
+  - `union_id`
+  - `open_id`
+  - `account.id`
+- 输出形如：
+  - `dt_<stable-source>_<short-account-id>`
+
+目标是：
+
+- 尽量可读
+- 重跑同步时稳定
+- 不依赖邮箱
+
+### 返回包
+
+新增 `DirectoryAutoAdmissionOnboardingPacket`：
+
+- `userId`
+- `name`
+- `email`
+- `username`
+- `mobile`
+- `temporaryPassword`
+- `onboarding`
+
+这组数据跟随 `/api/admin/directory/integrations/:integrationId/sync` 的响应一起返回。
+
+## 核心改动
+
+### 后端
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+  - 新增 `DirectoryAutoAdmissionOnboardingPacket`
+  - 新增 `buildDirectoryAutoAdmissionUsername()`
+  - `syncDirectoryIntegration()` 返回值扩展为：
+    - `integration`
+    - `run`
+    - `autoAdmissionOnboardingPackets`
+  - 自动准入逻辑不再把“缺邮箱”直接视为硬阻塞
+  - 无邮箱自动准入成功后：
+    - `autoAdmittedCount += 1`
+    - `autoAdmittedNoEmailCount += 1`
+    - 记录 onboarding packet
+  - 有邮箱自动准入仍走 invite token / invite ledger
+
+### 前端
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+  - 新增 `autoAdmissionOnboardingPackets` 状态
+  - 手动同步成功后解析 `autoAdmissionOnboardingPackets`
+  - 新增“本次自动准入临时凭据”结果卡
+  - 同步状态文案新增：
+    - `其中 X 位成员无邮箱，已生成平台登录账号和临时密码`
+  - 切换集成或重新同步时会清掉旧的自动准入凭据结果
+
+## 范围外
+
+- 自动给无邮箱用户发送短信
+- 自动给无邮箱用户发送钉钉消息
+- 自动为无邮箱用户生成邀请链接
+- 新的账号通知渠道治理
+
+## 部署影响
+
+- 本轮没有新增数据库迁移
+- 本轮没有远端部署

--- a/docs/development/no-email-auto-admission-packets-verification-20260419.md
+++ b/docs/development/no-email-auto-admission-packets-verification-20260419.md
@@ -1,0 +1,78 @@
+# 无邮箱自动准入临时凭据验证说明 2026-04-19
+
+## 验证范围
+
+- 无邮箱自动准入用户名生成逻辑
+- 目录同步路由透传 onboarding packet
+- 目录同步页展示无邮箱自动准入临时凭据
+- 前后端构建通过
+
+## 执行命令
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/directory-sync-auto-admission.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/directoryManagementView.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## 结果
+
+### 后端测试
+
+- `directory-sync-auto-admission.test.ts`
+- `admin-directory-routes.test.ts`
+- `directory-sync-bind-account.test.ts`
+
+结果：
+
+- `3 files passed`
+- `32 tests passed`
+
+新增覆盖点：
+
+- 无邮箱自动准入用户名稳定生成
+- sync 路由返回 `autoAdmissionOnboardingPackets`
+
+### 前端测试
+
+- `directoryManagementView.spec.ts`
+
+结果：
+
+- `1 file passed`
+- `33 tests passed`
+
+新增覆盖点：
+
+- 手动同步完成后显示“本次自动准入临时凭据”
+- 无邮箱自动准入结果展示：
+  - 登录账号
+  - 临时密码
+  - 无邀请链接提示
+
+### 构建
+
+- `pnpm --filter @metasheet/core-backend build`：通过
+- `pnpm --filter @metasheet/web build`：通过
+
+## 备注
+
+- 前端测试环境仍会打印既有噪音：
+  - `WebSocket server error: Port is already in use`
+- 前端构建仍会打印既有 Vite chunk-size warning
+- 后端单测启动时仍会打印既有 `DATABASE_URL not set` warning
+- 以上均不影响本轮结论
+
+## 部署内容
+
+- 本轮没有远端部署
+- 本轮没有新增数据库迁移

--- a/docs/development/no-email-user-closure-development-20260418.md
+++ b/docs/development/no-email-user-closure-development-20260418.md
@@ -1,0 +1,100 @@
+# 无邮箱用户闭环开发说明 2026-04-18
+
+## 目标
+
+补齐“没有邮箱的本地用户”闭环，覆盖以下链路：
+
+- 管理员手动创建用户
+- 钉钉目录手动准入创建用户并绑定
+- 登录页使用统一账号标识登录
+- 无邮箱用户依赖临时密码登录，并在首次交互后强制改密
+
+本轮不改变自动准入的默认策略。自动准入仍然要求邮箱，因为当前没有安全、自动的临时密码分发通道。
+
+## 方案
+
+### 账号标识
+
+- `users.email` 改为可空
+- 新增 `users.username`
+- 登录支持统一 `identifier`
+  - 邮箱
+  - 用户名
+  - 手机号
+
+### 创建与准入
+
+- `/api/admin/users`
+  - `email` 改为可选
+  - 新增 `username`
+  - 保持 `mobile` 可选
+  - 约束改为：`name` 必填，且 `email / username / mobile` 至少一项存在
+- `/api/admin/directory/accounts/:accountId/admit-user`
+  - 同样支持无邮箱准入
+  - 创建用户后仍会绑定 DingTalk identity / directory link
+  - 无邮箱时不生成 invite token，不写 invite ledger
+
+### Onboarding
+
+- onboarding packet 新增 `accountLabel`
+- 邀请文案不再强依赖邮箱
+- 无邮箱用户场景下：
+  - 有临时密码
+  - 无邀请链接
+  - 由管理员线下分发初始凭据
+
+## 核心改动
+
+### 后端
+
+- `packages/core-backend/src/db/types.ts`
+  - `users.email` 变为 `string | null`
+  - 新增 `users.username`
+- `packages/core-backend/src/db/migrations/zzzz20260418170000_allow_no_email_users_and_add_username.ts`
+  - 放开 `users.email` 的非空约束
+  - 新增 `username`
+  - 新增 `lower(username)` 唯一索引
+- `packages/core-backend/src/auth/AuthService.ts`
+  - 登录改为 `getUserByIdentifier()`
+  - 支持邮箱 / 用户名 / 手机号
+- `packages/core-backend/src/routes/auth.ts`
+  - `/login` 接收 `identifier`
+  - 登录限流也按 `identifier` 计数
+- `packages/core-backend/src/routes/admin-users.ts`
+  - 手动创建用户支持无邮箱
+  - 新增用户名校验与唯一性校验
+  - 无邮箱用户跳过 invite token / invite ledger
+- `packages/core-backend/src/routes/admin-directory.ts`
+  - 目录手动准入路由透传 `username`
+- `packages/core-backend/src/directory/directory-sync.ts`
+  - 目录手动准入服务支持无邮箱创建
+  - 本地用户匹配支持用户名 / 手机号
+  - 目录账户摘要、推荐绑定、已链接用户摘要补齐 `username`
+- `packages/core-backend/src/auth/access-presets.ts`
+  - onboarding packet 新增 `accountLabel`
+
+### 前端
+
+- `apps/web/src/views/LoginView.vue`
+  - 登录页输入改为统一账号标识
+- `apps/web/src/views/UserManagementView.vue`
+  - 创建用户表单新增 `username`
+  - `email` 改为可选
+  - 列表与详情优先显示 `email -> username -> mobile -> id`
+- `apps/web/src/views/DirectoryManagementView.vue`
+  - 手动准入表单新增 `username`
+  - 校验改为“姓名必填 + 至少一个账号标识”
+  - 结果面板支持显示无邮箱用户的登录账号
+
+## 范围外
+
+- 自动准入的“无邮箱自动建人”
+- 邀请链接之外的新通知通道
+- 手机号验证码登录
+- 工号单独登录策略
+
+## 部署影响
+
+- 需要执行数据库迁移：
+  - `zzzz20260418170000_allow_no_email_users_and_add_username.ts`
+- 本轮未做远端部署

--- a/docs/development/no-email-user-closure-verification-20260418.md
+++ b/docs/development/no-email-user-closure-verification-20260418.md
@@ -1,0 +1,82 @@
+# 无邮箱用户闭环验证说明 2026-04-18
+
+## 验证范围
+
+- 登录支持 `identifier`
+- 管理员可创建无邮箱用户
+- 目录手动准入可创建无邮箱用户并绑定
+- onboarding 文案在无邮箱场景不再依赖 invite link
+- 前后端构建通过
+
+## 执行命令
+
+```bash
+pnpm install --frozen-lockfile
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/AuthService.test.ts \
+  tests/unit/auth-login-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/LoginView.spec.ts \
+  tests/userManagementView.spec.ts \
+  tests/directoryManagementView.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## 结果
+
+### 后端测试
+
+- `AuthService.test.ts`
+- `auth-login-routes.test.ts`
+- `admin-users-routes.test.ts`
+- `admin-directory-routes.test.ts`
+- `directory-sync-bind-account.test.ts`
+
+结果：
+
+- `5 files passed`
+- `132 tests passed`
+
+### 前端测试
+
+- `LoginView.spec.ts`
+- `userManagementView.spec.ts`
+- `directoryManagementView.spec.ts`
+
+结果：
+
+- `3 files passed`
+- `49 tests passed`
+
+新增覆盖点：
+
+- 登录页提交 `identifier`
+- 用户管理页无邮箱创建用户
+- 目录治理页无邮箱手动准入创建并绑定
+
+### 构建
+
+- `pnpm --filter @metasheet/core-backend build`：通过
+- `pnpm --filter @metasheet/web build`：通过
+
+## 备注
+
+- 前端测试环境仍会打印既有噪音：
+  - `WebSocket server error: Port is already in use`
+- 前端构建仍会打印既有 Vite chunk-size warning
+- 以上均不影响本轮结论
+
+## 部署内容
+
+- 本轮未做远端部署
+- 本轮新增数据库迁移：
+  - `zzzz20260418170000_allow_no_email_users_and_add_username.ts`

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -17,8 +17,10 @@ import { createUserSession, isUserSessionActive } from './session-registry'
 
 export interface User {
   id: string
-  email: string
+  email: string | null
+  username?: string | null
   name: string
+  mobile?: string | null
   role: string
   permissions: string[]
   tenantId?: string
@@ -214,7 +216,7 @@ export class AuthService {
   createToken(user: User, options: { sid?: string } = {}): string {
     const payload: Omit<TokenPayload, 'iat' | 'exp'> = {
       userId: user.id,
-      email: user.email,
+      email: user.email ?? '',
       role: user.role,
       ...(typeof user.tenantId === 'string' && user.tenantId.trim().length > 0 ? { tenantId: user.tenantId.trim() } : {}),
       ...(typeof options.sid === 'string' && options.sid.trim().length > 0 ? { sid: options.sid.trim() } : {}),
@@ -243,12 +245,12 @@ export class AuthService {
    * 用户登录
    */
   async login(
-    email: string,
+    identifier: string,
     password: string,
     options: { ipAddress?: string | null; userAgent?: string | null; tenantId?: string | null } = {},
   ): Promise<{ user: User; token: string } | null> {
     try {
-      const user = await this.getUserByEmail(email)
+      const user = await this.getUserByIdentifier(identifier)
       if (!user) {
         return null
       }
@@ -346,7 +348,7 @@ export class AuthService {
       try {
         const pool = poolManager.get()
         const result = await pool.query(
-          'SELECT id, email, name, role, permissions, password_hash, is_active, must_change_password, created_at, updated_at FROM users WHERE id = $1',
+          'SELECT id, email, username, mobile, name, role, permissions, password_hash, is_active, must_change_password, created_at, updated_at FROM users WHERE id = $1',
           [userId]
         )
 
@@ -356,6 +358,8 @@ export class AuthService {
           return {
             id: row.id,
             email: row.email,
+            username: row.username ?? null,
+            mobile: row.mobile ?? null,
             name: row.name,
             role: resolved.role,
             permissions: resolved.permissions,
@@ -375,7 +379,9 @@ export class AuthService {
         return {
           id: userId,
           email: 'dev@metasheet.com',
+          username: 'dev-user',
           name: 'Development User',
+          mobile: null,
           role: 'admin',
           permissions: ['*:*'],
           is_active: true,
@@ -393,17 +399,50 @@ export class AuthService {
     }
   }
 
-  /**
-   * 通过邮箱获取用户
-   */
   private async getUserByEmail(email: string): Promise<(User & { password_hash: string }) | null> {
+    return this.getUserByIdentifier(email)
+  }
+
+  /**
+   * 通过邮箱、用户名或手机号获取用户
+   */
+  private async getUserByIdentifier(identifier: string): Promise<(User & { password_hash: string }) | null> {
     try {
+      const trimmedIdentifier = identifier.trim()
+      if (!trimmedIdentifier) return null
+
+      const normalizedEmail = trimmedIdentifier.toLowerCase()
+      const normalizedUsername = trimmedIdentifier.toLowerCase()
+      const normalizedMobile = trimmedIdentifier.replace(/\s+/g, '')
+
       try {
         const pool = poolManager.get()
         const result = await pool.query(
-          'SELECT id, email, name, role, permissions, password_hash, is_active, must_change_password, created_at, updated_at FROM users WHERE email = $1',
-          [email]
+          `SELECT id, email, username, mobile, name, role, permissions, password_hash, is_active, must_change_password, created_at, updated_at
+           FROM users
+           WHERE lower(COALESCE(email, '')) = $1
+              OR lower(COALESCE(username, '')) = $2
+              OR regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g') = $3
+           ORDER BY
+             CASE
+               WHEN lower(COALESCE(email, '')) = $1 THEN 0
+               WHEN lower(COALESCE(username, '')) = $2 THEN 1
+               WHEN regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g') = $3 THEN 2
+               ELSE 3
+             END ASC,
+             created_at ASC
+           LIMIT 2`,
+          [normalizedEmail, normalizedUsername, normalizedMobile]
         )
+
+        const emailMatches = result.rows.filter((row) => typeof row.email === 'string' && row.email.toLowerCase() === normalizedEmail)
+        const usernameMatches = result.rows.filter((row) => typeof row.username === 'string' && row.username.toLowerCase() === normalizedUsername)
+        if (emailMatches.length > 1 || usernameMatches.length > 1) {
+          return null
+        }
+        if (result.rows.length > 1 && emailMatches.length === 0 && usernameMatches.length === 0) {
+          return null
+        }
 
         if (result.rows.length > 0) {
           const row = result.rows[0] as UserRow
@@ -411,6 +450,8 @@ export class AuthService {
           return {
             id: row.id,
             email: row.email,
+            username: row.username ?? null,
+            mobile: row.mobile ?? null,
             name: row.name,
             role: resolved.role,
             permissions: resolved.permissions,
@@ -426,7 +467,7 @@ export class AuthService {
       }
       return null
     } catch (error) {
-      this.logger.error('Get user by email error', error instanceof Error ? error : undefined)
+      this.logger.error('Get user by identifier error', error instanceof Error ? error : undefined)
       return null
     }
   }

--- a/packages/core-backend/src/auth/access-presets.ts
+++ b/packages/core-backend/src/auth/access-presets.ts
@@ -21,6 +21,7 @@ export interface OnboardingPacket {
   loginUrl: string
   acceptInvitePath: string
   acceptInviteUrl: string
+  accountLabel: string
   welcomeTitle: string
   checklist: string[]
   inviteMessage: string
@@ -117,7 +118,8 @@ function resolvePublicAppBase(): string {
 }
 
 export function buildOnboardingPacket(options: {
-  email: string
+  email?: string | null
+  accountLabel?: string | null
   temporaryPassword?: string | null
   preset: AccessPresetDefinition | null
   inviteToken?: string | null
@@ -133,13 +135,14 @@ export function buildOnboardingPacket(options: {
     : ''
   const welcomeTitle = options.preset?.welcomeTitle || 'MetaSheet 新用户引导'
   const checklist = options.preset?.checklist || ['登录后确认首页入口与权限范围']
+  const accountLabel = (options.accountLabel || options.email || '由管理员单独告知').trim()
   const passwordLine = options.temporaryPassword
     ? `临时密码：${options.temporaryPassword}`
     : '初始密码：由管理员单独告知'
 
   const inviteMessage = [
     `${welcomeTitle}`,
-    `账号：${options.email}`,
+    `账号：${accountLabel}`,
     passwordLine,
     ...(acceptInviteUrl ? [`首次设置密码：${acceptInviteUrl}`] : []),
     `登录地址：${loginUrl}`,
@@ -158,6 +161,7 @@ export function buildOnboardingPacket(options: {
     loginUrl,
     acceptInvitePath,
     acceptInviteUrl,
+    accountLabel,
     welcomeTitle,
     checklist,
     inviteMessage,

--- a/packages/core-backend/src/db/migrations/zzzz20260418170000_allow_no_email_users_and_add_username.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260418170000_allow_no_email_users_and_add_username.ts
@@ -1,0 +1,42 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE users
+    ALTER COLUMN email DROP NOT NULL
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS username TEXT
+  `.execute(db)
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS users_username_lower_unique_idx
+    ON users (lower(username))
+    WHERE username IS NOT NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE users
+    SET email = COALESCE(email, id || '@migration-revert.local')
+    WHERE email IS NULL
+  `.execute(db)
+
+  await sql`
+    DROP INDEX IF EXISTS users_username_lower_unique_idx
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE users
+    DROP COLUMN IF EXISTS username
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE users
+    ALTER COLUMN email SET NOT NULL
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -707,8 +707,10 @@ export interface MetaWidgetsTable {
 
 export interface UsersTable {
   id: Generated<string>
-  email: string
+  email: string | null
+  username: string | null
   name: string | null
+  mobile: string | null
   password_hash: string
   must_change_password: boolean
   role: string

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -141,6 +141,7 @@ type ExternalIdentityRow = {
 type LocalUserRow = {
   id: string
   email?: string | null
+  username?: string | null
   mobile?: string | null
 }
 
@@ -165,6 +166,7 @@ type DirectoryIntegrationAccountRow = {
   link_updated_at: string | null
   local_user_id: string | null
   local_user_email: string | null
+  local_user_username: string | null
   local_user_name: string | null
   department_paths: string[] | null
 }
@@ -178,7 +180,9 @@ type DirectoryReviewItemRow = DirectoryIntegrationAccountRow & {
 
 type DirectoryBindingUserRow = {
   id: string
-  email: string
+  email: string | null
+  username: string | null
+  mobile: string | null
   name: string | null
   role: string
   is_active: boolean
@@ -223,6 +227,7 @@ type DirectoryBindingTargetAccountRow = {
 type DirectoryAccountLinkedUserRow = {
   local_user_id: string | null
   local_user_email: string | null
+  local_user_username: string | null
   local_user_name: string | null
 }
 
@@ -411,7 +416,8 @@ export type DirectoryBindingRecommendationStatusCode =
 export type DirectoryBindingRecommendation = {
   localUser: {
     id: string
-    email: string
+    email: string | null
+    username: string | null
     name: string | null
     mobile: string | null
     role: string
@@ -463,6 +469,7 @@ export type DirectoryIntegrationAccountSummary = {
   localUser: {
     id: string
     email: string | null
+    username: string | null
     name: string | null
   } | null
   departmentPaths: string[]
@@ -497,7 +504,8 @@ export type DirectoryAccountMutationResult = {
 export type DirectoryAccountManualAdmissionInput = {
   adminUserId: string
   name: string
-  email: string
+  email?: string
+  username?: string
   mobile?: string | null
   enableDingTalkGrant?: boolean
   password?: string
@@ -506,14 +514,15 @@ export type DirectoryAccountManualAdmissionInput = {
 export type DirectoryAccountManualAdmissionResult = DirectoryAccountMutationResult & {
   user: {
     id: string
-    email: string
+    email: string | null
+    username: string | null
     name: string
     mobile: string | null
     role: string
     is_active: boolean
   }
   temporaryPassword?: string
-  inviteToken: string
+  inviteToken: string | null
   onboarding: ReturnType<typeof buildOnboardingPacket>
 }
 
@@ -570,6 +579,29 @@ function sanitizeDirectoryAdmissionMobile(value: unknown): string | null {
   const text = normalizeText(value).replace(/\s+/g, '')
   if (!text) return null
   return text.slice(0, 32)
+}
+
+function sanitizeDirectoryAdmissionUsername(value: unknown): string | null {
+  const text = normalizeText(value).toLowerCase()
+  if (!text) return null
+  return text.slice(0, 64)
+}
+
+function validateDirectoryAdmissionUsername(username: string | null): string | null {
+  if (!username) return null
+  if (!/^(?=.*[a-z])[a-z0-9._-]{3,64}$/.test(username)) {
+    return 'Username must be 3-64 characters and include at least one letter. Only lowercase letters, numbers, dot, underscore, and dash are allowed'
+  }
+  return null
+}
+
+function resolveDirectoryAdmissionAccountLabel(options: {
+  email?: string | null
+  username?: string | null
+  mobile?: string | null
+  userId?: string | null
+}): string {
+  return options.email || options.username || options.mobile || options.userId || '由管理员单独告知'
 }
 
 function generateDirectoryAdmissionTemporaryPassword(): string {
@@ -976,6 +1008,7 @@ function summarizeDirectoryAccount(row: DirectoryIntegrationAccountRow): Directo
       ? {
         id: row.local_user_id,
         email: row.local_user_email,
+        username: row.local_user_username,
         name: row.local_user_name,
       }
       : null,
@@ -1252,6 +1285,7 @@ async function loadDirectoryReviewRecommendations(
         localUser: {
           id: user.id,
           email: user.email,
+          username: user.username ?? null,
           name: user.name,
           mobile: user.mobile,
           role: user.role,
@@ -2046,6 +2080,7 @@ export async function syncDirectoryIntegration(
                     adminUserId: triggeredBy,
                     name: cleanName,
                     email: cleanEmail,
+                    username: null,
                     mobile: cleanMobile,
                     passwordHash,
                     mustChangePassword: true,
@@ -2533,6 +2568,7 @@ export async function listDirectoryReviewItems(
           l.updated_at AS link_updated_at,
           u.id AS local_user_id,
           u.email AS local_user_email,
+          u.username AS local_user_username,
           u.name AS local_user_name,
           COALESCE(array_remove(array_agg(DISTINCT d.full_path), NULL), ARRAY[]::text[]) AS department_paths,
           CASE
@@ -2558,7 +2594,7 @@ export async function listDirectoryReviewItems(
          a.integration_id, a.provider, a.corp_id, a.id, a.external_user_id, a.union_id, a.open_id, a.external_key,
          a.name, a.email, a.mobile, a.is_active, a.updated_at,
          l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
-         u.id, u.email, u.name
+         u.id, u.email, u.username, u.name
        ORDER BY
          CASE
            WHEN COALESCE(a.union_id, '') = '' AND COALESCE(a.open_id, '') = '' THEN 0
@@ -2611,6 +2647,7 @@ export async function getDirectoryReviewItem(
         l.updated_at AS link_updated_at,
         u.id AS local_user_id,
         u.email AS local_user_email,
+        u.username AS local_user_username,
         u.name AS local_user_name,
         COALESCE(array_remove(array_agg(DISTINCT d.full_path), NULL), ARRAY[]::text[]) AS department_paths,
         CASE
@@ -2636,7 +2673,7 @@ export async function getDirectoryReviewItem(
        a.integration_id, a.provider, a.corp_id, a.id, a.external_user_id, a.union_id, a.open_id, a.external_key,
        a.name, a.email, a.mobile, a.is_active, a.updated_at,
        l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
-       u.id, u.email, u.name`,
+       u.id, u.email, u.username, u.name`,
     [normalizedAccountId],
   )
 
@@ -2692,7 +2729,7 @@ async function applyDirectoryAccountBindInTransaction(
     normalizedAdminUserId: string
     enableDingTalkGrant: boolean
     account: DirectoryBindingTargetAccountRow
-    localUser: Pick<DirectoryBindingUserRow, 'id' | 'email' | 'name'>
+    localUser: Pick<DirectoryBindingUserRow, 'id' | 'email' | 'username' | 'name'>
   },
 ): Promise<void> {
   const { normalizedAccountId, normalizedAdminUserId, enableDingTalkGrant, account, localUser } = options
@@ -2837,7 +2874,8 @@ async function createDirectoryAdmittedUserInTransaction(
     account: DirectoryBindingTargetAccountRow
     adminUserId: string
     name: string
-    email: string
+    email: string | null
+    username: string | null
     mobile: string | null
     passwordHash: string
     mustChangePassword: boolean
@@ -2845,25 +2883,60 @@ async function createDirectoryAdmittedUserInTransaction(
   },
 ): Promise<{ userId: string }> {
   const userId = crypto.randomUUID()
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(options.email)) {
+  if (options.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(options.email)) {
     throw new Error('Invalid email format')
   }
+  const usernameValidationError = validateDirectoryAdmissionUsername(options.username)
+  if (usernameValidationError) {
+    throw new Error(usernameValidationError)
+  }
+  if (!options.email && !options.username && !options.mobile) {
+    throw new Error('At least one account identifier (email, username, or mobile) is required')
+  }
 
-  const existingUserResult = await client.query(
-    `SELECT id
-     FROM users
-     WHERE email = $1
-     LIMIT 1`,
-    [options.email],
-  )
-  if (existingUserResult.rows.length > 0) {
-    throw new Error('User with this email already exists')
+  if (options.email) {
+    const existingUserResult = await client.query(
+      `SELECT id
+       FROM users
+       WHERE email = $1
+       LIMIT 1`,
+      [options.email],
+    )
+    if (existingUserResult.rows.length > 0) {
+      throw new Error('User with this email already exists')
+    }
+  }
+
+  if (options.username) {
+    const existingUsernameResult = await client.query(
+      `SELECT id
+       FROM users
+       WHERE lower(username) = lower($1)
+       LIMIT 1`,
+      [options.username],
+    )
+    if (existingUsernameResult.rows.length > 0) {
+      throw new Error('User with this username already exists')
+    }
+  }
+
+  if (options.mobile) {
+    const existingMobileResult = await client.query(
+      `SELECT id
+       FROM users
+       WHERE mobile = $1
+       LIMIT 1`,
+      [options.mobile],
+    )
+    if (existingMobileResult.rows.length > 0) {
+      throw new Error('User with this mobile already exists')
+    }
   }
 
   await client.query(
-    `INSERT INTO users (id, email, name, mobile, password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, 'user', $7::jsonb, TRUE, FALSE, NOW(), NOW())`,
-    [userId, options.email, options.name, options.mobile, options.passwordHash, options.mustChangePassword, JSON.stringify([])],
+    `INSERT INTO users (id, email, username, name, mobile, password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'user', $8::jsonb, TRUE, FALSE, NOW(), NOW())`,
+    [userId, options.email, options.username, options.name, options.mobile, options.passwordHash, options.mustChangePassword, JSON.stringify([])],
   )
 
   await applyDirectoryAccountBindInTransaction(client, {
@@ -2874,6 +2947,7 @@ async function createDirectoryAdmittedUserInTransaction(
     localUser: {
       id: userId,
       email: options.email,
+      username: options.username,
       name: options.name,
     },
   })
@@ -3129,6 +3203,7 @@ export async function getDirectoryAccountSummary(accountId: string): Promise<Dir
         l.updated_at AS link_updated_at,
         u.id AS local_user_id,
         u.email AS local_user_email,
+        u.username AS local_user_username,
         u.name AS local_user_name,
         COALESCE(array_remove(array_agg(DISTINCT d.full_path), NULL), ARRAY[]::text[]) AS department_paths
      FROM directory_accounts a
@@ -3141,7 +3216,7 @@ export async function getDirectoryAccountSummary(accountId: string): Promise<Dir
        a.integration_id, a.provider, a.corp_id, a.id, a.external_user_id, a.union_id, a.open_id, a.external_key,
        a.name, a.email, a.mobile, a.is_active, a.updated_at,
        l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
-       u.id, u.email, u.name`,
+       u.id, u.email, u.username, u.name`,
     [normalizedAccountId],
   )
 
@@ -3156,12 +3231,24 @@ async function resolveDirectoryBindingUser(localUserRef: string): Promise<Direct
   const result = await query<DirectoryBindingUserRow>(
     `SELECT id,
             email,
+            username,
+            mobile,
             name,
             COALESCE(role, 'user') AS role,
             COALESCE(is_active, TRUE) AS is_active
      FROM users
-     WHERE id = $1 OR LOWER(email) = LOWER($1)
-     ORDER BY CASE WHEN id = $1 THEN 0 ELSE 1 END
+     WHERE id = $1
+        OR LOWER(COALESCE(email, '')) = LOWER($1)
+        OR LOWER(COALESCE(username, '')) = LOWER($1)
+        OR regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g') = regexp_replace($1, '\\s+', '', 'g')
+     ORDER BY
+       CASE
+         WHEN id = $1 THEN 0
+         WHEN LOWER(COALESCE(email, '')) = LOWER($1) THEN 1
+         WHEN LOWER(COALESCE(username, '')) = LOWER($1) THEN 2
+         WHEN regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g') = regexp_replace($1, '\\s+', '', 'g') THEN 3
+         ELSE 4
+       END
      LIMIT 1`,
     [ref],
   )
@@ -3184,6 +3271,7 @@ async function loadDirectoryLinkedUser(directoryAccountId: string): Promise<Dire
   const result = await query<DirectoryAccountLinkedUserRow>(
     `SELECT l.local_user_id,
             u.email AS local_user_email,
+            u.username AS local_user_username,
             u.name AS local_user_name
      FROM directory_account_links l
      LEFT JOIN users u ON u.id = l.local_user_id
@@ -3256,6 +3344,7 @@ export async function listDirectoryIntegrationAccounts(
           l.updated_at AS link_updated_at,
           u.id AS local_user_id,
           u.email AS local_user_email,
+          u.username AS local_user_username,
           u.name AS local_user_name,
           COALESCE(array_remove(array_agg(DISTINCT d.full_path), NULL), ARRAY[]::text[]) AS department_paths
        FROM directory_accounts a
@@ -3268,7 +3357,7 @@ export async function listDirectoryIntegrationAccounts(
          a.integration_id, a.provider, a.corp_id, a.id, a.external_user_id, a.union_id, a.open_id, a.external_key,
          a.name, a.email, a.mobile, a.is_active, a.updated_at,
          l.link_status, l.match_strategy, l.reviewed_by, l.review_note, l.updated_at,
-         u.id, u.email, u.name
+         u.id, u.email, u.username, u.name
        ORDER BY a.is_active DESC, a.name ASC, a.external_user_id ASC
        LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
       listValues,
@@ -3342,15 +3431,20 @@ export async function admitDirectoryAccountUser(
   const normalizedAdminUserId = normalizeText(input.adminUserId)
   const cleanName = sanitizeDirectoryAdmissionName(input.name)
   const cleanEmail = sanitizeDirectoryAdmissionEmail(input.email)
+  const cleanUsername = sanitizeDirectoryAdmissionUsername(input.username)
   const cleanMobile = sanitizeDirectoryAdmissionMobile(input.mobile)
   const requestedPassword = normalizeText(input.password)
   const enableDingTalkGrant = input.enableDingTalkGrant !== false
 
   if (!normalizedAccountId) throw new Error('directoryAccountId is required')
   if (!normalizedAdminUserId) throw new Error('adminUserId is required')
-  if (!cleanName || !cleanEmail) throw new Error('name and email are required')
+  if (!cleanName || (!cleanEmail && !cleanUsername && !cleanMobile)) {
+    throw new Error('name and at least one account identifier (email, username, or mobile) are required')
+  }
   if (cleanName.length < 2 || cleanName.length > 100) throw new Error('Name must be between 2 and 100 characters')
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(cleanEmail)) throw new Error('Invalid email format')
+  if (cleanEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(cleanEmail)) throw new Error('Invalid email format')
+  const usernameValidationError = validateDirectoryAdmissionUsername(cleanUsername)
+  if (usernameValidationError) throw new Error(usernameValidationError)
 
   const generatedPassword = requestedPassword || generateDirectoryAdmissionTemporaryPassword()
   const mustChangePassword = requestedPassword.length === 0
@@ -3377,7 +3471,8 @@ export async function admitDirectoryAccountUser(
       account,
       adminUserId: normalizedAdminUserId,
       name: cleanName,
-      email: cleanEmail,
+      email: cleanEmail || null,
+      username: cleanUsername,
       mobile: cleanMobile,
       passwordHash,
       mustChangePassword,
@@ -3386,21 +3481,25 @@ export async function admitDirectoryAccountUser(
     userId = created.userId
   })
 
-  const resolvedInviteToken = issueInviteToken({
-    userId,
-    email: cleanEmail,
-    presetId: null,
-  })
+  const resolvedInviteToken = cleanEmail
+    ? issueInviteToken({
+      userId,
+      email: cleanEmail,
+      presetId: null,
+    })
+    : null
 
-  await recordInvite({
-    userId,
-    email: cleanEmail,
-    presetId: null,
-    productMode: 'platform',
-    roleId: null,
-    invitedBy: normalizedAdminUserId,
-    inviteToken: resolvedInviteToken,
-  })
+  if (cleanEmail && resolvedInviteToken) {
+    await recordInvite({
+      userId,
+      email: cleanEmail,
+      presetId: null,
+      productMode: 'platform',
+      roleId: null,
+      invitedBy: normalizedAdminUserId,
+      inviteToken: resolvedInviteToken,
+    })
+  }
 
   const summary = await getDirectoryAccountSummary(normalizedAccountId)
   if (!summary) {
@@ -3418,7 +3517,8 @@ export async function admitDirectoryAccountUser(
       : null,
     user: {
       id: userId,
-      email: cleanEmail,
+      email: cleanEmail || null,
+      username: cleanUsername,
       name: cleanName,
       mobile: cleanMobile,
       role: 'user',
@@ -3427,7 +3527,13 @@ export async function admitDirectoryAccountUser(
     temporaryPassword: requestedPassword.length === 0 ? generatedPassword : undefined,
     inviteToken: resolvedInviteToken,
     onboarding: buildOnboardingPacket({
-      email: cleanEmail,
+      email: cleanEmail || null,
+      accountLabel: resolveDirectoryAdmissionAccountLabel({
+        email: cleanEmail || null,
+        username: cleanUsername,
+        mobile: cleanMobile,
+        userId,
+      }),
       temporaryPassword: requestedPassword.length === 0 ? generatedPassword : null,
       preset: null,
       inviteToken: resolvedInviteToken,

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -526,6 +526,16 @@ export type DirectoryAccountManualAdmissionResult = DirectoryAccountMutationResu
   onboarding: ReturnType<typeof buildOnboardingPacket>
 }
 
+export type DirectoryAutoAdmissionOnboardingPacket = {
+  userId: string
+  name: string
+  email: string | null
+  username: string | null
+  mobile: string | null
+  temporaryPassword: string
+  onboarding: ReturnType<typeof buildOnboardingPacket>
+}
+
 export type DirectoryAutoAdmissionEligibility = {
   inScope: boolean
   missingEmail: boolean
@@ -602,6 +612,29 @@ function resolveDirectoryAdmissionAccountLabel(options: {
   userId?: string | null
 }): string {
   return options.email || options.username || options.mobile || options.userId || '由管理员单独告知'
+}
+
+export function buildDirectoryAutoAdmissionUsername(account: {
+  id: string
+  external_user_id: string
+  union_id: string | null
+  open_id: string | null
+}): string {
+  const stableSource = [
+    normalizeText(account.external_user_id),
+    normalizeText(account.union_id),
+    normalizeText(account.open_id),
+    normalizeText(account.id).replace(/-/g, ''),
+  ].find((value) => value.length > 0) || 'user'
+  const normalizedSource = stableSource
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+  const uniqueSuffix = normalizeText(account.id).replace(/-/g, '').slice(0, 8).toLowerCase() || 'account'
+  const username = `dt_${normalizedSource || 'user'}_${uniqueSuffix}`
+    .replace(/_+/g, '_')
+    .slice(0, 64)
+  return username.length >= 3 ? username : `dt_${uniqueSuffix}`
 }
 
 function generateDirectoryAdmissionTemporaryPassword(): string {
@@ -1828,7 +1861,11 @@ export async function syncDirectoryIntegration(
   integrationId: string,
   triggeredBy: string,
   triggerSource: 'manual' | 'scheduler' = 'manual',
-): Promise<{ integration: DirectoryIntegrationSummary; run: DirectorySyncRunSummary }> {
+): Promise<{
+  integration: DirectoryIntegrationSummary
+  run: DirectorySyncRunSummary
+  autoAdmissionOnboardingPackets: DirectoryAutoAdmissionOnboardingPacket[]
+}> {
   const governedUserIds = new Set<string>()
   const integration = await getIntegrationRow(integrationId)
   if (!integration) throw new Error('Directory integration not found')
@@ -1850,6 +1887,7 @@ export async function syncDirectoryIntegration(
     const users = await fetchAllUsers(config, departments)
     const syncTimestamp = new Date().toISOString()
     const autoAdmissionInvites: Array<{ userId: string; email: string; inviteToken: string }> = []
+    const autoAdmissionOnboardingPackets: DirectoryAutoAdmissionOnboardingPacket[] = []
 
     await transaction(async (client) => {
       for (const department of departments.values()) {
@@ -2012,6 +2050,7 @@ export async function syncDirectoryIntegration(
       let unmatchedCount = 0
       let autoAdmissionCandidateCount = 0
       let autoAdmittedCount = 0
+      let autoAdmittedNoEmailCount = 0
       let autoAdmissionSkippedMissingEmailCount = 0
       let autoAdmissionExcludedCount = 0
       let autoAdmissionFailedCount = 0
@@ -2056,10 +2095,18 @@ export async function syncDirectoryIntegration(
               if (autoAdmission.inScope) autoAdmissionCandidateCount += 1
               if (autoAdmission.excluded) autoAdmissionExcludedCount += 1
 
-              if (autoAdmission.inScope && !autoAdmission.missingEmail && directoryUser) {
+              if (autoAdmission.inScope && directoryUser) {
                 try {
                   const cleanName = sanitizeDirectoryAdmissionName(account.name)
-                  const cleanEmail = sanitizeDirectoryAdmissionEmail(account.email ?? '')
+                  const cleanEmail = account.email ? sanitizeDirectoryAdmissionEmail(account.email) : null
+                  const generatedUsername = cleanEmail
+                    ? null
+                    : buildDirectoryAutoAdmissionUsername({
+                        id: account.id,
+                        external_user_id: account.external_user_id,
+                        union_id: account.union_id,
+                        open_id: account.open_id,
+                      })
                   const cleanMobile = sanitizeDirectoryAdmissionMobile(account.mobile)
                   const generatedPassword = generateDirectoryAdmissionTemporaryPassword()
                   const passwordHash = await bcrypt.hash(generatedPassword, getBcryptSaltRounds())
@@ -2080,27 +2127,52 @@ export async function syncDirectoryIntegration(
                     adminUserId: triggeredBy,
                     name: cleanName,
                     email: cleanEmail,
-                    username: null,
+                    username: generatedUsername,
                     mobile: cleanMobile,
                     passwordHash,
                     mustChangePassword: true,
                     enableDingTalkGrant: true,
                   })
-                  const inviteToken = issueInviteToken({
-                    userId: created.userId,
-                    email: cleanEmail,
-                    presetId: null,
-                  })
-                  autoAdmissionInvites.push({
-                    userId: created.userId,
-                    email: cleanEmail,
-                    inviteToken,
-                  })
+                  let inviteToken: string | null = null
+                  if (cleanEmail) {
+                    inviteToken = issueInviteToken({
+                      userId: created.userId,
+                      email: cleanEmail,
+                      presetId: null,
+                    })
+                    autoAdmissionInvites.push({
+                      userId: created.userId,
+                      email: cleanEmail,
+                      inviteToken,
+                    })
+                  } else {
+                    autoAdmittedNoEmailCount += 1
+                    autoAdmissionOnboardingPackets.push({
+                      userId: created.userId,
+                      name: cleanName,
+                      email: cleanEmail,
+                      username: generatedUsername,
+                      mobile: cleanMobile,
+                      temporaryPassword: generatedPassword,
+                      onboarding: buildOnboardingPacket({
+                        email: cleanEmail,
+                        accountLabel: resolveDirectoryAdmissionAccountLabel({
+                          email: cleanEmail,
+                          username: generatedUsername,
+                          mobile: cleanMobile,
+                          userId: created.userId,
+                        }),
+                        temporaryPassword: generatedPassword,
+                        preset: null,
+                        inviteToken,
+                      }),
+                    })
+                  }
                   localUserId = created.userId
                   linkStatus = 'linked'
                   matchStrategy = 'auto_admit'
                   autoAdmittedCount += 1
-                  emailMap.set(cleanEmail.toLowerCase(), created.userId)
+                  if (cleanEmail) emailMap.set(cleanEmail.toLowerCase(), created.userId)
                   if (cleanMobile) mobileMap.set(cleanMobile, created.userId)
                   externalIdentityMap.set(account.external_key, created.userId)
                   const scopedOpenIdentityKey = buildScopedIdentityKey(account.corp_id, account.open_id)
@@ -2181,6 +2253,7 @@ export async function syncDirectoryIntegration(
         unmatchedCount,
         autoAdmissionCandidateCount,
         autoAdmittedCount,
+        autoAdmittedNoEmailCount,
         autoAdmissionSkippedMissingEmailCount,
         autoAdmissionExcludedCount,
         autoAdmissionFailedCount,
@@ -2245,6 +2318,7 @@ export async function syncDirectoryIntegration(
     return {
       integration: summarizeIntegration(updatedIntegration),
       run: summarizeRun(updatedRun.rows[0]),
+      autoAdmissionOnboardingPackets,
     }
   } catch (error) {
     const message = readErrorMessage(error, 'Directory sync failed')

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -365,10 +365,14 @@ export function adminDirectoryRouter(): Router {
     if (!adminUserId) return
 
     try {
+      const username = typeof req.body?.username === 'string' && req.body.username.trim().length > 0
+        ? req.body.username
+        : undefined
       const result = await admitDirectoryAccountUser(req.params.accountId, {
         adminUserId,
         name: typeof req.body?.name === 'string' ? req.body.name : '',
         email: typeof req.body?.email === 'string' ? req.body.email : '',
+        ...(username ? { username } : {}),
         mobile: typeof req.body?.mobile === 'string' ? req.body.mobile : null,
         password: typeof req.body?.password === 'string' ? req.body.password : '',
         enableDingTalkGrant: typeof req.body?.enableDingTalkGrant === 'boolean' ? req.body.enableDingTalkGrant : true,
@@ -387,6 +391,7 @@ export function adminDirectoryRouter(): Router {
             directoryAccountId: result.account.id,
             integrationId: result.account.integrationId,
             email: result.user.email,
+            username: result.user.username,
             name: result.user.name,
             mobile: result.user.mobile,
             generatedPassword: typeof result.temporaryPassword === 'string',
@@ -406,6 +411,7 @@ export function adminDirectoryRouter(): Router {
             previousLocalUserEmail: result.previousLocalUser?.email ?? null,
             localUserId: result.user.id,
             localUserEmail: result.user.email,
+            localUserUsername: result.user.username,
             externalUserId: result.account.externalUserId,
             corpId: result.account.corpId,
             mode: 'manual_admission',

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -29,7 +29,8 @@ import { jsonError, jsonOk, parsePagination } from '../util/response'
 
 type AdminUserProfile = {
   id: string
-  email: string
+  email: string | null
+  username: string | null
   name: string | null
   mobile: string | null
   role: string
@@ -236,6 +237,8 @@ type AuditRangeBoundaryMode = 'start' | 'end'
 
 type CreateUserRequestBody = {
   email?: string
+  username?: string
+  mobile?: string
   name?: string
   password?: string
   role?: string
@@ -282,7 +285,7 @@ async function ensurePlatformAdmin(req: Request, res: Response): Promise<string 
 
 async function fetchUserProfile(userId: string): Promise<AdminUserProfile | null> {
   const result = await query<AdminUserProfile>(
-    `SELECT id, email, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+    `SELECT id, email, username, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
      FROM users
      WHERE id = $1`,
     [userId],
@@ -357,6 +360,29 @@ function sanitizeMobile(mobile: string): string | null {
   const value = mobile.trim().replace(/\s+/g, '')
   if (!value) return null
   return value.slice(0, 32)
+}
+
+function sanitizeUsername(username: string): string | null {
+  const value = username.trim().toLowerCase()
+  if (!value) return null
+  return value.slice(0, 64)
+}
+
+function validateUsername(username: string | null): string | null {
+  if (!username) return null
+  if (!/^(?=.*[a-z])[a-z0-9._-]{3,64}$/.test(username)) {
+    return 'Username must be 3-64 characters and include at least one letter. Only lowercase letters, numbers, dot, underscore, and dash are allowed'
+  }
+  return null
+}
+
+function resolveUserAccountLabel(options: {
+  email?: string | null
+  username?: string | null
+  mobile?: string | null
+  userId?: string | null
+}): string {
+  return options.email || options.username || options.mobile || options.userId || '由管理员单独告知'
 }
 
 function parseAuditRangeBoundary(value: unknown, mode: AuditRangeBoundaryMode): string | null {
@@ -2148,10 +2174,10 @@ export function adminUsersRouter(): Router {
           Promise.resolve([]),
           (async () => {
             const term = q ? `%${q}%` : '%'
-            const where = q ? 'WHERE email ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR id ILIKE $1' : ''
+            const where = q ? 'WHERE COALESCE(email, \'\') ILIKE $1 OR COALESCE(username, \'\') ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR id ILIKE $1' : ''
             const countSql = `SELECT COUNT(*)::int AS c FROM users ${where}`
             const listSql = `
-              SELECT id, email, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+              SELECT id, email, username, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
               FROM users
               ${where}
               ORDER BY created_at DESC
@@ -2454,10 +2480,10 @@ export function adminUsersRouter(): Router {
       })
 
       const term = q ? `%${q}%` : '%'
-      const where = q ? 'WHERE email ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR id ILIKE $1' : ''
+      const where = q ? 'WHERE COALESCE(email, \'\') ILIKE $1 OR COALESCE(username, \'\') ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR id ILIKE $1' : ''
       const countSql = `SELECT COUNT(*)::int AS c FROM users ${where}`
       const listSql = `
-        SELECT id, email, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+        SELECT id, email, username, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
         FROM users
         ${where}
         ORDER BY created_at DESC
@@ -2474,7 +2500,7 @@ export function adminUsersRouter(): Router {
         // Deep-link target was not in the paginated window — fetch the single
         // row so the caller can focus it without a second round-trip.
         const pinned = await query<AdminUserProfile>(
-          `SELECT id, email, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+          `SELECT id, email, username, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
            FROM users
            WHERE id = $1`,
           [pinUserId],
@@ -2786,6 +2812,8 @@ export function adminUsersRouter(): Router {
     try {
       const body = (req.body || {}) as CreateUserRequestBody
       const cleanEmail = typeof body.email === 'string' ? sanitizeEmail(body.email) : ''
+      const cleanUsername = typeof body.username === 'string' ? sanitizeUsername(body.username) : null
+      const cleanMobile = typeof body.mobile === 'string' ? sanitizeMobile(body.mobile) : null
       const cleanName = typeof body.name === 'string' ? sanitizeName(body.name) : ''
       const preset = getAccessPreset(typeof body.presetId === 'string' ? body.presetId.trim() : '')
       const cleanRole = typeof body.role === 'string' && body.role.trim()
@@ -2800,13 +2828,18 @@ export function adminUsersRouter(): Router {
       const mustChangePassword = requestedPassword.length === 0
       const directPermissions = Array.from(new Set(preset?.permissions || []))
 
-      if (!cleanEmail || !cleanName) {
-        return jsonError(res, 400, 'USER_FIELDS_REQUIRED', 'email and name are required')
+      if (!cleanName || (!cleanEmail && !cleanUsername && !cleanMobile)) {
+        return jsonError(res, 400, 'USER_FIELDS_REQUIRED', 'name and at least one account identifier (email, username, or mobile) are required')
       }
 
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-      if (!emailRegex.test(cleanEmail)) {
+      if (cleanEmail && !emailRegex.test(cleanEmail)) {
         return jsonError(res, 400, 'INVALID_EMAIL', 'Invalid email format')
+      }
+
+      const usernameValidationError = validateUsername(cleanUsername)
+      if (usernameValidationError) {
+        return jsonError(res, 400, 'INVALID_USERNAME', usernameValidationError)
       }
 
       if (cleanName.length < 2 || cleanName.length > 100) {
@@ -2821,9 +2854,29 @@ export function adminUsersRouter(): Router {
         })
       }
 
-      const existing = await query<{ id: string }>('SELECT id FROM users WHERE email = $1', [cleanEmail])
-      if (existing.rows.length > 0) {
-        return jsonError(res, 409, 'USER_ALREADY_EXISTS', 'User with this email already exists')
+      if (cleanEmail) {
+        const existing = await query<{ id: string }>('SELECT id FROM users WHERE email = $1', [cleanEmail])
+        if (existing.rows.length > 0) {
+          return jsonError(res, 409, 'USER_ALREADY_EXISTS', 'User with this email already exists')
+        }
+      }
+      if (cleanUsername) {
+        const existingUsername = await query<{ id: string }>(
+          'SELECT id FROM users WHERE lower(username) = lower($1)',
+          [cleanUsername],
+        )
+        if (existingUsername.rows.length > 0) {
+          return jsonError(res, 409, 'USERNAME_ALREADY_EXISTS', 'User with this username already exists')
+        }
+      }
+      if (cleanMobile) {
+        const existingMobile = await query<{ id: string }>(
+          'SELECT id FROM users WHERE mobile = $1',
+          [cleanMobile],
+        )
+        if (existingMobile.rows.length > 0) {
+          return jsonError(res, 409, 'MOBILE_ALREADY_EXISTS', 'User with this mobile already exists')
+        }
       }
 
       if (roleId) {
@@ -2835,11 +2888,29 @@ export function adminUsersRouter(): Router {
 
       const userId = crypto.randomUUID()
       const passwordHash = await bcrypt.hash(password, getBcryptSaltRounds())
+      const accountLabel = resolveUserAccountLabel({
+        email: cleanEmail || null,
+        username: cleanUsername,
+        mobile: cleanMobile,
+        userId,
+      })
 
       await query(
-        `INSERT INTO users (id, email, name, password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, NOW(), NOW())`,
-        [userId, cleanEmail, cleanName, passwordHash, mustChangePassword, effectiveRole, JSON.stringify(directPermissions), isActive, effectiveRole === 'admin'],
+        `INSERT INTO users (id, email, username, name, mobile, password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, NOW(), NOW())`,
+        [
+          userId,
+          cleanEmail || null,
+          cleanUsername,
+          cleanName,
+          cleanMobile,
+          passwordHash,
+          mustChangePassword,
+          effectiveRole,
+          JSON.stringify(directPermissions),
+          isActive,
+          effectiveRole === 'admin',
+        ],
       )
 
       if (roleId) {
@@ -2871,6 +2942,9 @@ export function adminUsersRouter(): Router {
         resourceId: userId,
         meta: {
           email: cleanEmail,
+          username: cleanUsername,
+          mobile: cleanMobile,
+          accountLabel,
           name: cleanName,
           adminUserId,
           role: effectiveRole,
@@ -2888,20 +2962,24 @@ export function adminUsersRouter(): Router {
         return jsonError(res, 500, 'USER_CREATE_FAILED', 'User created but failed to load access snapshot')
       }
 
-      const inviteToken = issueInviteToken({
-        userId,
-        email: cleanEmail,
-        presetId: preset?.id || null,
-      })
-      await recordInvite({
-        userId,
-        email: cleanEmail,
-        presetId: preset?.id || null,
-        productMode: preset?.productMode || 'platform',
-        roleId: roleId || preset?.roleId || null,
-        invitedBy: adminUserId,
-        inviteToken,
-      })
+      const inviteToken = cleanEmail
+        ? issueInviteToken({
+          userId,
+          email: cleanEmail,
+          presetId: preset?.id || null,
+        })
+        : null
+      if (cleanEmail && inviteToken) {
+        await recordInvite({
+          userId,
+          email: cleanEmail,
+          presetId: preset?.id || null,
+          productMode: preset?.productMode || 'platform',
+          roleId: roleId || preset?.roleId || null,
+          invitedBy: adminUserId,
+          inviteToken,
+        })
+      }
 
       return jsonOk(res, {
         ...snapshot,
@@ -2909,7 +2987,8 @@ export function adminUsersRouter(): Router {
         temporaryPassword: requestedPassword.length === 0 ? password : undefined,
         inviteToken,
         onboarding: buildOnboardingPacket({
-          email: cleanEmail,
+          email: cleanEmail || null,
+          accountLabel,
           temporaryPassword: requestedPassword.length === 0 ? password : null,
           preset,
           inviteToken,

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -176,12 +176,18 @@ function resetRateLimit(key: string): void {
 // Rate limit middleware for login
 const loginRateLimiter = (req: Request, res: Response, next: NextFunction) => {
   const ip = getClientIP(req)
-  const email = req.body?.email?.toLowerCase() || ''
-  const key = `login:${ip}:${email}`
+  const identifier = sanitizeLoginIdentifier(
+    typeof req.body?.identifier === 'string'
+      ? req.body.identifier
+      : typeof req.body?.email === 'string'
+        ? req.body.email
+        : '',
+  ).toLowerCase()
+  const key = `login:${ip}:${identifier}`
 
   const result = checkRateLimit(key, MAX_LOGIN_ATTEMPTS)
   if (!result.allowed) {
-    logger.warn(`Rate limit exceeded for login: ${ip} / ${email}`)
+    logger.warn(`Rate limit exceeded for login: ${ip} / ${identifier}`)
     return res.status(429).json({
       success: false,
       error: 'Too many login attempts. Please try again later.',
@@ -213,6 +219,10 @@ const registerRateLimiter = (req: Request, res: Response, next: NextFunction) =>
 // ============================================
 function sanitizeEmail(email: string): string {
   return email.trim().toLowerCase().slice(0, 255)
+}
+
+function sanitizeLoginIdentifier(identifier: string): string {
+  return identifier.trim().slice(0, 255)
 }
 
 function sanitizeName(name: string): string {
@@ -441,37 +451,37 @@ authRouter.post('/login', loginRateLimiter, async (req: Request, res: Response) 
   const ip = getClientIP(req)
 
   try {
-    const { email, password } = req.body
+    const legacyEmail = typeof req.body?.email === 'string' ? req.body.email : ''
+    const rawIdentifier = typeof req.body?.identifier === 'string' ? req.body.identifier : legacyEmail
+    const password = typeof req.body?.password === 'string' ? req.body.password : ''
+    const identifier = sanitizeLoginIdentifier(rawIdentifier)
 
     // 验证请求参数
-    if (!email || !password) {
+    if (!identifier || !password) {
       return res.status(400).json({
         success: false,
-        error: 'Email and password are required'
+        error: 'Account identifier and password are required'
       })
     }
 
-    // Sanitize email
-    const cleanEmail = sanitizeEmail(email)
-
     // 尝试登录
-    const result = await authService.login(cleanEmail, password, {
+    const result = await authService.login(identifier, password, {
       ipAddress: ip,
       userAgent: req.headers['user-agent'] || null,
       tenantId: resolveRequestTenantId(req),
     })
 
     if (!result) {
-      logger.warn(`Failed login attempt for ${cleanEmail} from ${ip}`)
+      logger.warn(`Failed login attempt for ${identifier} from ${ip}`)
       return res.status(401).json({
         success: false,
-        error: 'Invalid email or password'
+        error: 'Invalid account or password'
       })
     }
 
     // Success - reset rate limit
-    resetRateLimit(`login:${ip}:${cleanEmail}`)
-    logger.info(`Successful login for ${cleanEmail} from ${ip}`)
+    resetRateLimit(`login:${ip}:${identifier.toLowerCase()}`)
+    logger.info(`Successful login for ${identifier} from ${ip}`)
 
     // 返回用户信息和token
     res.json({

--- a/packages/core-backend/tests/unit/AuthService.test.ts
+++ b/packages/core-backend/tests/unit/AuthService.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as bcrypt from 'bcryptjs'
 
 const jwtMocks = vi.hoisted(() => ({
   verify: vi.fn(),
@@ -391,6 +392,120 @@ describe('AuthService.register', () => {
       expect.stringContaining('INSERT INTO user_roles'),
       [expect.any(String), 'attendance_employee'],
     )
+  })
+})
+
+describe('AuthService.login', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.RBAC_TOKEN_TRUST = 'false'
+    jwtMocks.verify.mockReset()
+    jwtMocks.sign.mockReset()
+    jwtMocks.sign.mockReturnValue('signed-login-token')
+    poolMocks.query.mockReset()
+    poolMocks.query.mockResolvedValue({ rows: [] })
+    rbacMocks.isAdmin.mockReset()
+    rbacMocks.isAdmin.mockResolvedValue(false)
+    rbacMocks.listUserPermissions.mockReset()
+    rbacMocks.listUserPermissions.mockResolvedValue(['attendance:read'])
+    sessionMocks.createUserSession.mockReset()
+    sessionMocks.isUserSessionRevoked.mockReset()
+    sessionMocks.isUserSessionActive.mockReset()
+    secretManagerMocks.get.mockReset()
+    secretManagerMocks.get.mockReturnValue('unit-test-secret-abcdefghijklmnopqrstuvwxyz123456')
+  })
+
+  it('logs in with a username identifier', async () => {
+    const passwordHash = await bcrypt.hash('WelcomePass9A', 10)
+    poolMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: null,
+          username: 'liqing',
+          mobile: '13900001234',
+          name: '李青',
+          role: 'user',
+          permissions: ['attendance:read'],
+          password_hash: passwordHash,
+          is_active: true,
+          must_change_password: false,
+          created_at: new Date('2026-04-18T00:00:00.000Z'),
+          updated_at: new Date('2026-04-18T00:00:00.000Z'),
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+    jwtMocks.verify.mockReturnValue({
+      userId: 'user-1',
+      email: '',
+      role: 'user',
+      exp: Math.floor(new Date('2026-04-19T00:00:00.000Z').getTime() / 1000),
+      iat: Math.floor(new Date('2026-04-18T00:00:00.000Z').getTime() / 1000),
+      sid: 'session-1',
+    })
+
+    const auth = new AuthService()
+    const result = await auth.login('liqing', 'WelcomePass9A', {
+      ipAddress: '127.0.0.1',
+      userAgent: 'vitest',
+    })
+
+    expect(result?.user.username).toBe('liqing')
+    expect(result?.user.email).toBeNull()
+    expect(sessionMocks.createUserSession).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({
+        sessionId: expect.any(String),
+      }),
+    )
+    expect(poolMocks.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('lower(COALESCE(username'),
+      ['liqing', 'liqing', 'liqing'],
+    )
+  })
+
+  it('returns null when a mobile identifier matches multiple users', async () => {
+    const passwordHash = await bcrypt.hash('WelcomePass9A', 10)
+    poolMocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'user-1',
+          email: null,
+          username: 'liqing',
+          mobile: '13900001234',
+          name: '李青',
+          role: 'user',
+          permissions: ['attendance:read'],
+          password_hash: passwordHash,
+          is_active: true,
+          must_change_password: false,
+          created_at: new Date('2026-04-18T00:00:00.000Z'),
+          updated_at: new Date('2026-04-18T00:00:00.000Z'),
+        },
+        {
+          id: 'user-2',
+          email: null,
+          username: 'linlan',
+          mobile: '13900001234',
+          name: '林岚',
+          role: 'user',
+          permissions: ['attendance:read'],
+          password_hash: passwordHash,
+          is_active: true,
+          must_change_password: false,
+          created_at: new Date('2026-04-18T00:00:00.000Z'),
+          updated_at: new Date('2026-04-18T00:00:00.000Z'),
+        },
+      ],
+    })
+
+    const auth = new AuthService()
+    const result = await auth.login('13900001234', 'WelcomePass9A')
+
+    expect(result).toBeNull()
+    expect(sessionMocks.createUserSession).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -237,6 +237,21 @@ describe('adminDirectoryRouter', () => {
     directoryMocks.syncDirectoryIntegration.mockResolvedValue({
       integration: { id: 'dir-1', name: 'DingTalk CN' },
       run: { id: 'run-1', status: 'completed' },
+      autoAdmissionOnboardingPackets: [
+        {
+          userId: 'user-1',
+          name: '林岚',
+          email: null,
+          username: 'dt_linlan_12345678',
+          mobile: '13900001234',
+          temporaryPassword: 'Tmp-123',
+          onboarding: {
+            accountLabel: 'dt_linlan_12345678',
+            acceptInviteUrl: '',
+            inviteMessage: '账号：dt_linlan_12345678',
+          },
+        },
+      ],
     })
 
     const response = await invokeRoute('post', '/integrations/:integrationId/sync', {
@@ -251,6 +266,13 @@ describe('adminDirectoryRouter', () => {
       data: {
         integration: { id: 'dir-1' },
         run: { id: 'run-1', status: 'completed' },
+        autoAdmissionOnboardingPackets: [
+          {
+            userId: 'user-1',
+            username: 'dt_linlan_12345678',
+            temporaryPassword: 'Tmp-123',
+          },
+        ],
       },
     })
   })

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -668,6 +668,73 @@ describe('adminDirectoryRouter', () => {
     })
   })
 
+  it('supports manual admission without email when username or mobile is provided', async () => {
+    directoryMocks.admitDirectoryAccountUser.mockResolvedValue({
+      account: {
+        id: 'account-1',
+        integrationId: 'dir-1',
+        corpId: 'dingcorp',
+        externalUserId: '0447654442691174',
+        localUser: {
+          id: 'user-created',
+          email: null,
+          username: 'liqing',
+          name: '李青',
+        },
+      },
+      previousLocalUser: null,
+      user: {
+        id: 'user-created',
+        email: null,
+        username: 'liqing',
+        name: '李青',
+        mobile: '13900001234',
+        role: 'user',
+        is_active: true,
+      },
+      temporaryPassword: 'Temp#123456',
+      inviteToken: null,
+      onboarding: {
+        accountLabel: 'liqing',
+        acceptInviteUrl: '',
+        inviteMessage: '账号：liqing',
+      },
+    })
+
+    const response = await invokeRoute('post', '/accounts/:accountId/admit-user', {
+      params: { accountId: 'account-1' },
+      body: {
+        name: '李青',
+        username: 'liqing',
+        mobile: '13900001234',
+        enableDingTalkGrant: true,
+      },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.admitDirectoryAccountUser).toHaveBeenCalledWith('account-1', {
+      adminUserId: 'admin-1',
+      name: '李青',
+      email: '',
+      username: 'liqing',
+      mobile: '13900001234',
+      password: '',
+      enableDingTalkGrant: true,
+    })
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        user: {
+          id: 'user-created',
+          email: null,
+          username: 'liqing',
+        },
+        inviteToken: null,
+      },
+    })
+  })
+
   it('batch binds directory accounts', async () => {
     directoryMocks.batchBindDirectoryAccounts.mockResolvedValue([
       {

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -2495,6 +2495,51 @@ describe('admin-users routes', () => {
     expect((response.body as Record<string, any>).error.code).toBe('PASSWORD_POLICY_FAILED')
   })
 
+  it('creates a no-email user with username/mobile and skips invite issuance', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    bcryptMocks.hash.mockResolvedValue('hashed-temp-password')
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-no-email',
+          email: null,
+          username: 'liqing',
+          name: '李青',
+          mobile: '13900001234',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-04-18T00:00:00.000Z',
+          updated_at: '2026-04-18T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [],
+      })
+
+    const response = await invokeRoute('post', '/api/admin/users', {
+      body: {
+        name: '李青',
+        username: 'liqing',
+        mobile: '13900001234',
+        isActive: true,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect((response.body as Record<string, any>).data.user.email).toBeNull()
+    expect((response.body as Record<string, any>).data.user.username).toBe('liqing')
+    expect((response.body as Record<string, any>).data.temporaryPassword).toBeTruthy()
+    expect((response.body as Record<string, any>).data.inviteToken).toBeNull()
+    expect(String((response.body as Record<string, any>).data.onboarding.acceptInviteUrl || '')).toBe('')
+    expect(String((response.body as Record<string, any>).data.onboarding.inviteMessage)).toContain('账号：liqing')
+    expect(inviteMocks.issueInviteToken).not.toHaveBeenCalled()
+  })
+
   it('resets password and returns temporary password', async () => {
     rbacMocks.isAdmin.mockResolvedValue(true)
     bcryptMocks.hash.mockResolvedValue('hashed-temp-password')

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -262,6 +262,39 @@ describe('auth login routes', () => {
     })
   })
 
+  it('accepts a generic identifier payload for login', async () => {
+    authServiceMocks.login.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        email: null,
+        username: 'liqing',
+        mobile: '13900001234',
+        name: '李青',
+        role: 'user',
+        permissions: ['attendance:read'],
+        created_at: new Date('2026-03-13T00:00:00.000Z'),
+        updated_at: new Date('2026-03-13T00:00:00.000Z'),
+      },
+      token: 'jwt-login-token',
+    })
+
+    const response = await invokeRoute('post', '/login', {
+      body: {
+        identifier: 'liqing',
+        password: 'WelcomePass9A',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(authServiceMocks.login).toHaveBeenCalledWith(
+      'liqing',
+      'WelcomePass9A',
+      expect.objectContaining({
+        ipAddress: '127.0.0.1',
+      }),
+    )
+  })
+
   it('forwards x-tenant-id into the normal login flow', async () => {
     authServiceMocks.login.mockResolvedValue({
       user: {

--- a/packages/core-backend/tests/unit/directory-sync-auto-admission.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-auto-admission.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildDirectoryAutoAdmissionUsername,
   evaluateDirectoryAutoAdmissionEligibility,
   isDirectoryUserWithinAdmissionScope,
 } from '../../src/directory/directory-sync'
@@ -79,5 +80,14 @@ describe('directory auto admission scope', () => {
       inScope: true,
       missingEmail: true,
     })
+  })
+
+  it('builds a deterministic username for no-email auto-admission', () => {
+    expect(buildDirectoryAutoAdmissionUsername({
+      id: 'account-12345678-aaaa-bbbb-cccc-1234567890ab',
+      external_user_id: 'User.001',
+      union_id: null,
+      open_id: null,
+    })).toBe('dt_user_001_account1')
   })
 })

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -190,7 +190,7 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('creates a local user and binds it to a directory account in one server-side admission flow', async () => {
-    const clientQuery = vi.fn()
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -242,13 +242,6 @@ describe('bindDirectoryAccount', () => {
         }],
       })
 
-    clientQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-
     const result = await admitDirectoryAccountUser('account-admit-1', {
       adminUserId: 'admin-1',
       name: '李青',
@@ -296,6 +289,91 @@ describe('bindDirectoryAccount', () => {
       },
       inviteToken: 'invite-token-fixed',
     })
+  })
+
+  it('admits a no-email local user with username/mobile and skips invite issuance', async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-admit-2',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691188',
+          union_id: 'union-2',
+          open_id: 'open-2',
+          external_key: 'union-2',
+          name: '林岚',
+          email: null,
+          mobile: '13900004567',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_username: null,
+          local_user_name: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-admit-2',
+          external_user_id: '0447654442691188',
+          union_id: 'union-2',
+          open_id: 'open-2',
+          external_key: 'union-2',
+          account_name: '林岚',
+          account_email: null,
+          account_mobile: '13900004567',
+          account_is_active: true,
+          account_updated_at: '2026-04-11T08:00:00.000Z',
+          link_status: 'linked',
+          match_strategy: 'manual_admin',
+          reviewed_by: 'admin-1',
+          review_note: null,
+          link_updated_at: '2026-04-11T08:00:00.000Z',
+          local_user_id: 'user-created-2',
+          local_user_email: null,
+          local_user_username: 'linlan',
+          local_user_name: '林岚',
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+
+    const result = await admitDirectoryAccountUser('account-admit-2', {
+      adminUserId: 'admin-1',
+      name: '林岚',
+      username: 'linlan',
+      mobile: '13900004567',
+      enableDingTalkGrant: true,
+    })
+
+    const createUserCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('INSERT INTO users'))
+    const createdUserId = Array.isArray(createUserCall?.[1]) ? String(createUserCall?.[1]?.[0] || '') : ''
+    expect(createUserCall?.[1]).toEqual(expect.arrayContaining([
+      null,
+      'linlan',
+      '林岚',
+      '13900004567',
+      JSON.stringify([]),
+    ]))
+    expect(result).toMatchObject({
+      user: {
+        id: createdUserId,
+        email: null,
+        username: 'linlan',
+        mobile: '13900004567',
+      },
+      inviteToken: null,
+    })
+    expect(inviteLedgerMocks.recordInvite).not.toHaveBeenCalled()
+    expect(inviteTokenMocks.issueInviteToken).not.toHaveBeenCalled()
   })
 
   it('removes the bound identity, optionally disables grant, and resets the link on unbind', async () => {


### PR DESCRIPTION
## Summary
- allow `users.email` to be nullable and add optional `username`
- support no-email admin user creation and directory manual admission when username/mobile is present
- return onboarding packets for no-email directory auto-admission candidates

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/AuthService.test.ts tests/unit/auth-login-routes.test.ts tests/unit/admin-users-routes.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/directory-sync-auto-admission.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/LoginView.spec.ts tests/userManagementView.spec.ts tests/directoryManagementView.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
