### PR TITLE
feat(dingtalk): share group destinations across sheet managers

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1146,7 +1146,7 @@ export class MultitableApiClient {
     return parseJson(res)
   }
 
-  async updateDingTalkGroup(id: string, input: Partial<DingTalkGroupDestinationInput>, sheetId?: string): Promise<DingTalkGroupDestination> {
+  async updateDingTalkGroup(id: string, input: Partial<Omit<DingTalkGroupDestinationInput, 'sheetId'>>, sheetId?: string): Promise<DingTalkGroupDestination> {
     const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}${qs(sheetId ? { sheetId } : {})}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1131,8 +1131,8 @@ export class MultitableApiClient {
   }
 
   // --- DingTalk Group Destinations ---
-  async listDingTalkGroups(): Promise<DingTalkGroupDestination[]> {
-    const res = await this.fetch('/api/multitable/dingtalk-groups')
+  async listDingTalkGroups(sheetId?: string): Promise<DingTalkGroupDestination[]> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups${qs(sheetId ? { sheetId } : {})}`)
     const data = await parseJson<{ destinations: DingTalkGroupDestination[] }>(res)
     return data.destinations ?? []
   }
@@ -1146,8 +1146,8 @@ export class MultitableApiClient {
     return parseJson(res)
   }
 
-  async updateDingTalkGroup(id: string, input: Partial<DingTalkGroupDestinationInput>): Promise<DingTalkGroupDestination> {
-    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}`, {
+  async updateDingTalkGroup(id: string, input: Partial<DingTalkGroupDestinationInput>, sheetId?: string): Promise<DingTalkGroupDestination> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}${qs(sheetId ? { sheetId } : {})}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),
@@ -1155,15 +1155,15 @@ export class MultitableApiClient {
     return parseJson(res)
   }
 
-  async deleteDingTalkGroup(id: string): Promise<void> {
-    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}`, {
+  async deleteDingTalkGroup(id: string, sheetId?: string): Promise<void> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}${qs(sheetId ? { sheetId } : {})}`, {
       method: 'DELETE',
     })
     return parseJson(res)
   }
 
-  async testDingTalkGroup(id: string, input?: { subject?: string; content?: string }): Promise<void> {
-    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}/test-send`, {
+  async testDingTalkGroup(id: string, input?: { subject?: string; content?: string }, sheetId?: string): Promise<void> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}/test-send${qs(sheetId ? { sheetId } : {})}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input ?? {}),
@@ -1171,8 +1171,8 @@ export class MultitableApiClient {
     return parseJson(res)
   }
 
-  async getDingTalkGroupDeliveries(id: string): Promise<DingTalkGroupDelivery[]> {
-    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}/deliveries`)
+  async getDingTalkGroupDeliveries(id: string, sheetId?: string): Promise<DingTalkGroupDelivery[]> {
+    const res = await this.fetch(`/api/multitable/dingtalk-groups/${encodeURIComponent(id)}/deliveries${qs(sheetId ? { sheetId } : {})}`)
     const data = await parseJson<{ deliveries: DingTalkGroupDelivery[] }>(res)
     return data.deliveries ?? []
   }

--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -249,6 +249,7 @@
             </div>
             <div class="meta-api-mgr__card-meta">
               <span>Webhook: {{ maskDingTalkWebhookUrl(group.webhookUrl) }}</span>
+              <span>{{ group.sheetId ? 'Shared with this sheet' : 'Private legacy group' }}</span>
               <span>Created: {{ formatDate(group.createdAt) }}</span>
               <span v-if="group.lastTestedAt">Last test: {{ formatDate(group.lastTestedAt) }}</span>
               <span v-if="group.lastTestStatus" :data-dingtalk-group-test-status="group.lastTestStatus">
@@ -329,6 +330,7 @@ import type { MultitableApiClient } from '../api/client'
 
 const props = defineProps<{
   visible: boolean
+  sheetId?: string
   client?: MultitableApiClient
 }>()
 
@@ -616,7 +618,7 @@ async function loadDingTalkGroups() {
   dingTalkGroupsLoading.value = true
   error.value = null
   try {
-    dingTalkGroups.value = await props.client.listDingTalkGroups()
+    dingTalkGroups.value = await props.client.listDingTalkGroups(props.sheetId)
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to load DingTalk groups'
   } finally {
@@ -661,9 +663,10 @@ async function onSaveDingTalkGroup() {
       webhookUrl: dingTalkGroupDraft.value.webhookUrl.trim(),
       secret: dingTalkGroupDraft.value.secret || undefined,
       enabled: dingTalkGroupDraft.value.enabled,
+      sheetId: props.sheetId,
     }
     if (editingDingTalkGroupId.value) {
-      await props.client.updateDingTalkGroup(editingDingTalkGroupId.value, input)
+      await props.client.updateDingTalkGroup(editingDingTalkGroupId.value, input, props.sheetId)
     } else {
       await props.client.createDingTalkGroup(input)
     }
@@ -681,7 +684,7 @@ async function onToggleDingTalkGroup(group: DingTalkGroupDestination) {
   busy.value = true
   error.value = null
   try {
-    await props.client.updateDingTalkGroup(group.id, { enabled: !group.enabled })
+    await props.client.updateDingTalkGroup(group.id, { enabled: !group.enabled }, props.sheetId)
     await loadDingTalkGroups()
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to toggle DingTalk group'
@@ -695,7 +698,7 @@ async function onTestDingTalkGroup(groupId: string) {
   busy.value = true
   error.value = null
   try {
-    await props.client.testDingTalkGroup(groupId)
+    await props.client.testDingTalkGroup(groupId, undefined, props.sheetId)
     await loadDingTalkGroups()
     if (dingTalkDeliveriesGroupId.value === groupId) {
       await loadDingTalkDeliveries(groupId)
@@ -715,7 +718,7 @@ async function loadDingTalkDeliveries(groupId: string) {
   dingTalkDeliveries.value = []
   error.value = null
   try {
-    const deliveries = await props.client.getDingTalkGroupDeliveries(groupId)
+    const deliveries = await props.client.getDingTalkGroupDeliveries(groupId, props.sheetId)
     if (requestToken !== dingTalkDeliveriesRequestToken || dingTalkDeliveriesGroupId.value !== groupId) {
       return
     }
@@ -749,7 +752,7 @@ async function onDeleteDingTalkGroup(groupId: string) {
   busy.value = true
   error.value = null
   try {
-    await props.client.deleteDingTalkGroup(groupId)
+    await props.client.deleteDingTalkGroup(groupId, props.sheetId)
     if (dingTalkDeliveriesGroupId.value === groupId) {
       dingTalkDeliveriesRequestToken += 1
       dingTalkDeliveriesGroupId.value = null

--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -658,17 +658,19 @@ async function onSaveDingTalkGroup() {
   busy.value = true
   error.value = null
   try {
-    const input = {
+    const createInput = {
       name: dingTalkGroupDraft.value.name.trim(),
       webhookUrl: dingTalkGroupDraft.value.webhookUrl.trim(),
       secret: dingTalkGroupDraft.value.secret || undefined,
       enabled: dingTalkGroupDraft.value.enabled,
-      sheetId: props.sheetId,
     }
     if (editingDingTalkGroupId.value) {
-      await props.client.updateDingTalkGroup(editingDingTalkGroupId.value, input, props.sheetId)
+      await props.client.updateDingTalkGroup(editingDingTalkGroupId.value, createInput, props.sheetId)
     } else {
-      await props.client.createDingTalkGroup(input)
+      await props.client.createDingTalkGroup({
+        ...createInput,
+        sheetId: props.sheetId,
+      })
     }
     cancelDingTalkGroupForm()
     await loadDingTalkGroups()

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -965,7 +965,7 @@ watch(
     if (v && props.sheetId) {
       if (props.client) {
         try {
-          dingTalkDestinations.value = await props.client.listDingTalkGroups()
+          dingTalkDestinations.value = await props.client.listDingTalkGroups(props.sheetId)
         } catch {
           dingTalkDestinations.value = []
         }

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -661,7 +661,7 @@ watch(
       personRecipientErrors.value = {}
       if (props.client) {
         try {
-          dingTalkDestinations.value = await props.client.listDingTalkGroups()
+          dingTalkDestinations.value = await props.client.listDingTalkGroups(props.sheetId)
         } catch (err) {
           dingTalkDestinations.value = []
           dingTalkDestinationsError.value = err instanceof Error ? err.message : 'Failed to load DingTalk groups'

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -797,6 +797,7 @@ export interface DingTalkGroupDestination {
   webhookUrl: string
   secret?: string
   enabled: boolean
+  sheetId?: string
   createdBy: string
   createdAt: string
   updatedAt?: string
@@ -810,6 +811,7 @@ export interface DingTalkGroupDestinationInput {
   webhookUrl: string
   secret?: string
   enabled?: boolean
+  sheetId?: string
 }
 
 export interface DingTalkGroupDelivery {

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -302,6 +302,7 @@
     />
     <MetaApiTokenManager
       :visible="showApiTokenManager"
+      :sheet-id="workbench.activeSheetId.value"
       :client="workbench.client"
       @close="showApiTokenManager = false"
     />

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -83,6 +83,7 @@ function fakeDingTalkGroup(overrides: Partial<DingTalkGroupDestination> = {}): D
     name: 'Ops DingTalk Group',
     webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
     enabled: true,
+    sheetId: 'sheet_1',
     createdBy: 'user_1',
     createdAt: '2026-04-01T00:00:00Z',
     updatedAt: '2026-04-01T00:00:00Z',
@@ -194,7 +195,7 @@ function mockClient(
 function mount(props: Record<string, unknown>) {
   const container = document.createElement('div')
   document.body.appendChild(container)
-  const app = createApp({ render: () => h(MetaApiTokenManager, props) })
+  const app = createApp({ render: () => h(MetaApiTokenManager, { sheetId: 'sheet_1', ...props }) })
   app.mount(container)
   return { container, app }
 }
@@ -404,7 +405,7 @@ describe('MetaApiTokenManager', () => {
   // ---- DingTalk group tests ----
 
   it('switches to DingTalk groups tab', async () => {
-    const { client } = mockClient([], [], [], [fakeDingTalkGroup()])
+    const { client, fetchFn } = mockClient([], [], [], [fakeDingTalkGroup()])
     mount({ visible: true, client })
     await flushPromises()
 
@@ -414,6 +415,7 @@ describe('MetaApiTokenManager', () => {
 
     const cards = document.querySelectorAll('[data-dingtalk-group-id]')
     expect(cards.length).toBe(1)
+    expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups?sheetId=sheet_1'))).toBe(true)
   })
 
   it('masks DingTalk webhook access token in card display', async () => {
@@ -463,6 +465,11 @@ describe('MetaApiTokenManager', () => {
       (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/dingtalk-groups') && !c[0].includes('/test-send'),
     )
     expect(createCalls.length).toBe(1)
+    expect(JSON.parse(createCalls[0][1]?.body as string)).toMatchObject({
+      name: 'Support group',
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+      sheetId: 'sheet_1',
+    })
   })
 
   it('tests a DingTalk group destination', async () => {
@@ -482,10 +489,11 @@ describe('MetaApiTokenManager', () => {
       (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/dingtalk-groups/') && c[0].includes('/test-send'),
     )
     expect(testSendCalls.length).toBe(1)
+    expect(testSendCalls[0][0]).toContain('sheetId=sheet_1')
   })
 
   it('views DingTalk group deliveries', async () => {
-    const { client } = mockClient([], [], [], [fakeDingTalkGroup()], [fakeDingTalkDelivery()])
+    const { client, fetchFn } = mockClient([], [], [], [fakeDingTalkGroup()], [fakeDingTalkDelivery()])
     mount({ visible: true, client })
     await flushPromises()
 
@@ -501,6 +509,7 @@ describe('MetaApiTokenManager', () => {
     expect(rows.length).toBe(1)
     expect(rows[0]?.textContent).toContain('Please fill incident details')
     expect(rows[0]?.textContent).toContain('Automation')
+    expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups/dt_1/deliveries?sheetId=sheet_1'))).toBe(true)
   })
 
   it('refreshes open DingTalk delivery history after test send', async () => {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -62,6 +62,7 @@ function mockClient(rules: AutomationRule[] = []) {
           name: 'Ops Group',
           webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test',
           enabled: true,
+          sheetId: 'sheet_1',
           createdBy: 'user_1',
           createdAt: '2026-04-01T00:00:00Z',
         }],
@@ -329,6 +330,7 @@ describe('MetaAutomationManager', () => {
       publicFormViewId: 'view_form',
       internalViewId: 'view_grid',
     })
+    expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups?sheetId=sheet_1'))).toBe(true)
   })
 
   it('creates DingTalk person automation via form', async () => {
@@ -464,7 +466,7 @@ describe('MetaAutomationManager', () => {
   })
 
   it('opens DingTalk group delivery viewer for group message rules', async () => {
-    const { client } = mockClient([
+    const { client, fetchFn } = mockClient([
       fakeRule({
         name: 'DingTalk group notify',
         actionType: 'send_dingtalk_group_message',
@@ -486,6 +488,7 @@ describe('MetaAutomationManager', () => {
     const delivery = document.querySelector('[data-group-delivery-id="dgd_1"]')
     expect(delivery?.textContent).toContain('Ops Group')
     expect(delivery?.textContent).toContain('Ticket rec_1 pending')
+    expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/dingtalk-group-deliveries'))).toBe(true)
   })
 
   it('applies DingTalk group presets in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -26,6 +26,7 @@ function mockClient() {
         name: 'Ops Group',
         webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test',
         enabled: true,
+        sheetId: 'sheet_1',
         createdBy: 'user_1',
         createdAt: '2026-04-01T00:00:00Z',
       },
@@ -279,6 +280,7 @@ describe('MetaAutomationRuleEditor', () => {
       },
     })
     expect(client.listDingTalkGroups).toHaveBeenCalledTimes(1)
+    expect(client.listDingTalkGroups).toHaveBeenCalledWith('sheet_1')
   })
 
   it('emits DingTalk person action config with optional links', async () => {

--- a/docs/development/dingtalk-group-destination-sharing-development-20260420.md
+++ b/docs/development/dingtalk-group-destination-sharing-development-20260420.md
@@ -1,0 +1,91 @@
+# DingTalk Group Destination Sharing Development
+
+## Date
+- 2026-04-20
+
+## Goal
+- Evolve DingTalk group destinations from creator-private entries into sheet-shared destinations so a table's automation managers can reuse the same group configuration without duplicating webhook setup.
+
+## Scope
+- Add nullable `sheet_id` scope to `dingtalk_group_destinations`
+- Preserve legacy private rows with owner fallback
+- Pass `sheetId` through multitable client and management surfaces
+- Gate shared destination access by sheet automation capability
+- Add focused frontend/backend regression coverage
+
+## Implementation
+
+### Schema
+- Added `packages/core-backend/src/db/migrations/zzzz20260420164500_add_sheet_scope_to_dingtalk_group_destinations.ts`
+  - adds nullable `sheet_id`
+  - adds `idx_dingtalk_group_destinations_sheet_id`
+- Updated `packages/core-backend/src/db/types.ts`
+  - `dingtalk_group_destinations.sheet_id: string | null`
+
+### Backend
+- Updated `packages/core-backend/src/multitable/dingtalk-group-destinations.ts`
+  - `DingTalkGroupDestination.sheetId?: string`
+  - `DingTalkGroupDestinationCreateInput.sheetId?: string`
+- Updated `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+  - persists `sheet_id` on create
+  - `listDestinations(userId, sheetId?)` returns:
+    - sheet-shared rows for the current sheet
+    - plus legacy private rows owned by the current user
+  - `updateDestination` / `deleteDestination` / `testSend` accept optional `sheetId`
+  - shared rows authorize by matching `sheet_id`
+  - legacy rows keep owner-only authorization
+- Updated `packages/core-backend/src/routes/api-tokens.ts`
+  - DingTalk group CRUD/test-send/deliveries accept `sheetId`
+  - added `requireSheetAutomationAccess(...)`
+  - shared access is guarded by `resolveSheetCapabilitiesForUser(...).canManageAutomation`
+
+### Frontend
+- Updated `apps/web/src/multitable/types.ts`
+  - group destination/input include `sheetId`
+- Updated `apps/web/src/multitable/api/client.ts`
+  - group destination list/update/delete/test-send/delivery APIs now carry `sheetId`
+- Updated `apps/web/src/multitable/views/MultitableWorkbench.vue`
+  - passes active `sheetId` into `MetaApiTokenManager`
+- Updated `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+  - reads/writes DingTalk groups in sheet scope
+  - marks rows as:
+    - `Shared with this sheet`
+    - `Private legacy group`
+- Updated `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+  - loads DingTalk destinations with current `sheetId`
+- Updated `apps/web/src/multitable/components/MetaAutomationManager.vue`
+  - loads DingTalk destinations with current `sheetId`
+
+### Tests
+- Updated `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+  - shared non-owner update/delete/test-send coverage
+  - sheet-scoped create/list coverage
+- Updated `apps/web/tests/multitable-api-token-manager.spec.ts`
+  - asserts sheet-scoped group CRUD/delivery URLs
+- Updated `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+  - asserts group destination fetch uses `sheetId`
+- Updated `apps/web/tests/multitable-automation-manager.spec.ts`
+  - asserts inline DingTalk group authoring/delivery viewer uses sheet-scoped APIs
+
+## Files Changed
+- `packages/core-backend/src/db/migrations/zzzz20260420164500_add_sheet_scope_to_dingtalk_group_destinations.ts`
+- `packages/core-backend/src/db/types.ts`
+- `packages/core-backend/src/multitable/dingtalk-group-destinations.ts`
+- `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+- `packages/core-backend/src/routes/api-tokens.ts`
+- `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Notes
+- This is intentionally incremental:
+  - new rows can be sheet-shared
+  - old rows stay private until admins recreate or migrate them
+- I also used `claude -p` in read-only mode to sanity-check the incremental scope choice; implementation and verification were completed directly in the repo.

--- a/docs/development/dingtalk-group-destination-sharing-review-hardening-development-20260420.md
+++ b/docs/development/dingtalk-group-destination-sharing-review-hardening-development-20260420.md
@@ -1,0 +1,29 @@
+# DingTalk Group Destination Sharing Review Hardening Development
+
+## Date
+- 2026-04-20
+
+## Goal
+- Address concrete review comments on `#936` without expanding the feature scope.
+
+## Changes
+
+### Backend
+- Updated `packages/core-backend/src/routes/api-tokens.ts`
+  - `CreateDingTalkGroupSchema` now includes optional `sheetId`
+  - create route reads `sheetId` from parsed `input` instead of raw `req.body`
+- Updated `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+  - `loadAuthorizedDestination()` now uses `row.sheet_id !== null`
+  - avoids implicit empty-string fallback behavior
+
+### Frontend
+- Updated `apps/web/src/multitable/api/client.ts`
+  - `updateDingTalkGroup(...)` now accepts `Partial<Omit<DingTalkGroupDestinationInput, 'sheetId'>>`
+  - `sheetId` remains request context via query string, not PATCH body payload
+- Updated `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+  - create still sends `sheetId` in body
+  - update no longer includes `sheetId` in body
+
+## Notes
+- This slice intentionally keeps create semantics unchanged while removing ambiguous body/query duplication from update flows.
+- No schema changes were added beyond the original `sheet_id` migration.

--- a/docs/development/dingtalk-group-destination-sharing-review-hardening-verification-20260420.md
+++ b/docs/development/dingtalk-group-destination-sharing-review-hardening-verification-20260420.md
@@ -1,0 +1,40 @@
+# DingTalk Group Destination Sharing Review Hardening Verification
+
+## Date
+- 2026-04-20
+
+## Environment
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-destination-sharing-20260420`
+- Branch: `codex/dingtalk-group-destination-sharing-20260420`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+- `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+  - `10 passed`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+  - passed
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+  - passed
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+  - combined frontend result: `56 passed`
+- `pnpm --filter @metasheet/core-backend build`
+  - passed
+- `pnpm --filter @metasheet/web build`
+  - passed
+
+## Non-blocking Output
+- Frontend Vitest still printed the existing `WebSocket server error: Port is already in use` warning.
+- Web build still emitted the existing chunk-size warnings.
+
+## Verification Summary
+- `sheetId` for create flows is now schema-backed instead of pulled from raw body.
+- PATCH DingTalk group updates no longer send redundant `sheetId` in the JSON body.
+- Shared destination authorization still works for same-sheet automation managers after the explicit null-check change.

--- a/docs/development/dingtalk-group-destination-sharing-verification-20260420.md
+++ b/docs/development/dingtalk-group-destination-sharing-verification-20260420.md
@@ -1,0 +1,51 @@
+# DingTalk Group Destination Sharing Verification
+
+## Date
+- 2026-04-20
+
+## Environment
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-group-destination-sharing-20260420`
+- Branch: `codex/dingtalk-group-destination-sharing-20260420`
+
+## Commands
+
+```bash
+claude -p "Reply with one short sentence only: for a per-user DingTalk group destination model evolving to sheet-shared access, is a nullable sheet_id with legacy owner fallback a safe incremental step?"
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+- `claude -p ...`
+  - returned: `Yes — a nullable sheet_id with legacy owner fallback is a safe incremental step...`
+- `pnpm install --frozen-lockfile`
+  - passed
+- `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+  - `10 passed`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+  - passed
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+  - passed
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+  - combined frontend result: `56 passed`
+- `pnpm --filter @metasheet/core-backend build`
+  - passed
+- `pnpm --filter @metasheet/web build`
+  - passed
+- `git diff --check`
+  - passed
+
+## Non-blocking Output
+- `apps/web` Vitest printed the existing `WebSocket server error: Port is already in use` warning.
+- `apps/web` build emitted the existing dynamic import / chunk-size warnings.
+- No new remote deployment was performed in this slice.
+
+## Verification Summary
+- New DingTalk group destinations can be created as sheet-shared rows.
+- Sheet automation managers can list and use shared destinations without being the original creator.
+- Legacy private destinations still remain available to their original creator.
+- Frontend management and automation authoring now scope DingTalk groups to the active sheet.

--- a/packages/core-backend/src/db/migrations/zzzz20260420164500_add_sheet_scope_to_dingtalk_group_destinations.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260420164500_add_sheet_scope_to_dingtalk_group_destinations.ts
@@ -1,0 +1,25 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE dingtalk_group_destinations
+    ADD COLUMN IF NOT EXISTS sheet_id text
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_group_destinations_sheet_id
+    ON dingtalk_group_destinations(sheet_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DROP INDEX IF EXISTS idx_dingtalk_group_destinations_sheet_id
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE dingtalk_group_destinations
+    DROP COLUMN IF EXISTS sheet_id
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1306,6 +1306,7 @@ export interface DingTalkGroupDestinationsTable {
   webhook_url: string
   secret: string | null
   enabled: boolean
+  sheet_id: string | null
   created_by: string
   created_at: CreatedAt
   updated_at: NullableTimestamp

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -202,7 +202,7 @@ export class DingTalkGroupDestinationService {
       .where('id', '=', id)
       .executeTakeFirst()
     if (!row) throw new Error('Destination not found')
-    if (row.sheet_id) {
+    if (row.sheet_id !== null) {
       if (!sheetId || row.sheet_id !== sheetId) throw new Error('Not authorized')
       return row
     }

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -20,29 +20,33 @@ import type {
 const logger = new Logger('DingTalkGroupDestinationService')
 const DINGTALK_REQUEST_TIMEOUT_MS = 5_000
 
-function generateId(): string {
-  return randomBytes(16).toString('hex')
-}
-
-function rowToDestination(row: {
+type DingTalkGroupDestinationRow = {
   id: string
   name: string
   webhook_url: string
   secret: string | null
   enabled: boolean
+  sheet_id: string | null
   created_by: string
   created_at: string | Date
   updated_at?: string | Date | null
   last_tested_at?: string | Date | null
   last_test_status?: string | null
   last_test_error?: string | null
-}): DingTalkGroupDestination {
+}
+
+function generateId(): string {
+  return randomBytes(16).toString('hex')
+}
+
+function rowToDestination(row: DingTalkGroupDestinationRow): DingTalkGroupDestination {
   return {
     id: row.id,
     name: row.name,
     webhookUrl: row.webhook_url,
     secret: row.secret ?? undefined,
     enabled: row.enabled,
+    sheetId: row.sheet_id ?? undefined,
     createdBy: row.created_by,
     createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
     updatedAt: row.updated_at ? (row.updated_at instanceof Date ? row.updated_at.toISOString() : row.updated_at) : undefined,
@@ -108,6 +112,7 @@ export class DingTalkGroupDestinationService {
   async createDestination(userId: string, input: DingTalkGroupDestinationCreateInput): Promise<DingTalkGroupDestination> {
     const name = input.name?.trim()
     const webhookUrl = input.webhookUrl?.trim()
+    const sheetId = typeof input.sheetId === 'string' && input.sheetId.trim() ? input.sheetId.trim() : null
     if (!name) throw new Error('Destination name is required')
     if (!webhookUrl) throw new Error('Webhook URL is required')
     try {
@@ -130,6 +135,7 @@ export class DingTalkGroupDestinationService {
       webhook_url: webhookUrl,
       secret: input.secret ?? null,
       enabled,
+      sheet_id: sheetId,
       created_by: userId,
       created_at: now,
     }).execute()
@@ -141,17 +147,29 @@ export class DingTalkGroupDestinationService {
       webhookUrl,
       secret: input.secret,
       enabled,
+      ...(sheetId ? { sheetId } : {}),
       createdBy: userId,
       createdAt: now,
     }
   }
 
-  async listDestinations(userId: string): Promise<DingTalkGroupDestination[]> {
-    const rows = await this.db.selectFrom('dingtalk_group_destinations')
-      .selectAll()
-      .where('created_by', '=', userId)
-      .orderBy('created_at', 'desc')
-      .execute()
+  async listDestinations(userId: string, sheetId?: string): Promise<DingTalkGroupDestination[]> {
+    const normalizedSheetId = typeof sheetId === 'string' && sheetId.trim() ? sheetId.trim() : ''
+    let builder = this.db.selectFrom('dingtalk_group_destinations').selectAll()
+    if (normalizedSheetId) {
+      builder = builder.where((eb) =>
+        eb.or([
+          eb('sheet_id', '=', normalizedSheetId),
+          eb.and([
+            eb('sheet_id', 'is', null),
+            eb('created_by', '=', userId),
+          ]),
+        ]),
+      )
+    } else {
+      builder = builder.where('created_by', '=', userId)
+    }
+    const rows = await builder.orderBy('created_at', 'desc').execute()
     return rows.map((row) => rowToDestination(row as Parameters<typeof rowToDestination>[0]))
   }
 
@@ -174,17 +192,31 @@ export class DingTalkGroupDestinationService {
     return rows.map((row) => rowToDelivery(row as Parameters<typeof rowToDelivery>[0]))
   }
 
-  async updateDestination(
+  private async loadAuthorizedDestination(
     id: string,
     userId: string,
-    input: DingTalkGroupDestinationUpdateInput,
-  ): Promise<DingTalkGroupDestination> {
+    sheetId?: string,
+  ): Promise<DingTalkGroupDestinationRow> {
     const row = await this.db.selectFrom('dingtalk_group_destinations')
       .selectAll()
       .where('id', '=', id)
       .executeTakeFirst()
     if (!row) throw new Error('Destination not found')
+    if (row.sheet_id) {
+      if (!sheetId || row.sheet_id !== sheetId) throw new Error('Not authorized')
+      return row
+    }
     if (row.created_by !== userId) throw new Error('Not authorized')
+    return row
+  }
+
+  async updateDestination(
+    id: string,
+    userId: string,
+    input: DingTalkGroupDestinationUpdateInput,
+    sheetId?: string,
+  ): Promise<DingTalkGroupDestination> {
+    await this.loadAuthorizedDestination(id, userId, sheetId)
 
     const updates: Record<string, unknown> = { updated_at: nowTimestamp() }
     if (input.name !== undefined) {
@@ -221,14 +253,8 @@ export class DingTalkGroupDestinationService {
     return rowToDestination(updated as Parameters<typeof rowToDestination>[0])
   }
 
-  async deleteDestination(id: string, userId: string): Promise<void> {
-    const row = await this.db.selectFrom('dingtalk_group_destinations')
-      .selectAll()
-      .where('id', '=', id)
-      .executeTakeFirst()
-    if (!row) throw new Error('Destination not found')
-    if (row.created_by !== userId) throw new Error('Not authorized')
-
+  async deleteDestination(id: string, userId: string, sheetId?: string): Promise<void> {
+    await this.loadAuthorizedDestination(id, userId, sheetId)
     await this.db.deleteFrom('dingtalk_group_destinations')
       .where('id', '=', id)
       .execute()
@@ -238,13 +264,9 @@ export class DingTalkGroupDestinationService {
     id: string,
     userId: string,
     input: DingTalkGroupTestSendInput,
+    sheetId?: string,
   ): Promise<{ ok: true }> {
-    const row = await this.db.selectFrom('dingtalk_group_destinations')
-      .selectAll()
-      .where('id', '=', id)
-      .executeTakeFirst()
-    if (!row) throw new Error('Destination not found')
-    if (row.created_by !== userId) throw new Error('Not authorized')
+    const row = await this.loadAuthorizedDestination(id, userId, sheetId)
 
     const subject = input.subject?.trim() || 'MetaSheet DingTalk group test'
     const content = input.content?.trim() || 'This is a standard DingTalk group destination test message.'

--- a/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
@@ -4,6 +4,7 @@ export interface DingTalkGroupDestination {
   webhookUrl: string
   secret?: string
   enabled: boolean
+  sheetId?: string
   createdBy: string
   createdAt: string
   updatedAt?: string
@@ -17,6 +18,7 @@ export interface DingTalkGroupDestinationCreateInput {
   webhookUrl: string
   secret?: string
   enabled?: boolean
+  sheetId?: string
 }
 
 export interface DingTalkGroupDestinationUpdateInput {

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -7,10 +7,12 @@ import { Router } from 'express'
 import { z } from 'zod'
 import { db } from '../db/db'
 import { Logger } from '../core/logger'
+import { query } from '../db/pg'
 import { authenticate } from '../middleware/auth'
 import { ApiTokenService } from '../multitable/api-token-service'
 import { ALL_API_TOKEN_SCOPES } from '../multitable/api-tokens'
 import { DingTalkGroupDestinationService } from '../multitable/dingtalk-group-destination-service'
+import { resolveSheetCapabilitiesForUser } from '../multitable/sheet-capabilities'
 import { WebhookService } from '../multitable/webhook-service'
 import { ALL_WEBHOOK_EVENT_TYPES } from '../multitable/webhooks'
 
@@ -70,6 +72,23 @@ const DingTalkGroupTestSendSchema = z.object({
   subject: z.string().min(1).max(100).optional(),
   content: z.string().min(1).max(4000).optional(),
 })
+
+function getSheetId(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+async function requireSheetAutomationAccess(res: Response, userId: string, sheetId: string): Promise<boolean> {
+  if (!sheetId) {
+    res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    return false
+  }
+  const { capabilities } = await resolveSheetCapabilitiesForUser(query, sheetId, userId)
+  if (!capabilities.canManageAutomation) {
+    res.status(403).json({ ok: false, error: { code: 'FORBIDDEN' } })
+    return false
+  }
+  return true
+}
 
 function getUserId(req: Request): string {
   const user = req.user as Record<string, unknown> | undefined
@@ -295,7 +314,9 @@ export function apiTokensRouter(): Router {
       res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
       return
     }
-    const destinations = await dingTalkGroupDestinationService.listDestinations(userId)
+    const sheetId = getSheetId(req.query.sheetId)
+    if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
+    const destinations = await dingTalkGroupDestinationService.listDestinations(userId, sheetId || undefined)
     res.json({ ok: true, data: { destinations } })
   })
 
@@ -307,11 +328,14 @@ export function apiTokensRouter(): Router {
     }
     try {
       const input = CreateDingTalkGroupSchema.parse(req.body)
+      const sheetId = getSheetId((req.body as Record<string, unknown> | undefined)?.sheetId)
+      if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
       const destination = await dingTalkGroupDestinationService.createDestination(userId, {
         name: input.name,
         webhookUrl: input.webhookUrl,
         secret: input.secret,
         enabled: input.enabled,
+        sheetId: sheetId || undefined,
       })
       res.status(201).json({ ok: true, data: destination })
     } catch (err) {
@@ -332,12 +356,14 @@ export function apiTokensRouter(): Router {
     }
     try {
       const input = UpdateDingTalkGroupSchema.parse(req.body)
+      const sheetId = getSheetId(req.query.sheetId)
+      if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
       const destination = await dingTalkGroupDestinationService.updateDestination(req.params.id, userId, {
         name: input.name,
         webhookUrl: input.webhookUrl,
         secret: input.secret,
         enabled: input.enabled,
-      })
+      }, sheetId || undefined)
       res.json({ ok: true, data: destination })
     } catch (err) {
       if (err instanceof z.ZodError) {
@@ -356,7 +382,9 @@ export function apiTokensRouter(): Router {
       return
     }
     try {
-      await dingTalkGroupDestinationService.deleteDestination(req.params.id, userId)
+      const sheetId = getSheetId(req.query.sheetId)
+      if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
+      await dingTalkGroupDestinationService.deleteDestination(req.params.id, userId, sheetId || undefined)
       res.status(204).end()
     } catch (err) {
       logger.error('Failed to delete DingTalk group destination', err instanceof Error ? err : undefined)
@@ -370,12 +398,14 @@ export function apiTokensRouter(): Router {
       res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED' } })
       return
     }
+    const sheetId = getSheetId(req.query.sheetId)
+    if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
     const destination = await dingTalkGroupDestinationService.getDestinationById(req.params.id)
     if (!destination) {
       res.status(404).json({ ok: false, error: { code: 'NOT_FOUND' } })
       return
     }
-    if (destination.createdBy !== userId) {
+    if (destination.sheetId ? destination.sheetId !== sheetId : destination.createdBy !== userId) {
       res.status(403).json({ ok: false, error: { code: 'FORBIDDEN' } })
       return
     }
@@ -392,7 +422,9 @@ export function apiTokensRouter(): Router {
     }
     try {
       const input = DingTalkGroupTestSendSchema.parse(req.body ?? {})
-      await dingTalkGroupDestinationService.testSend(req.params.id, userId, input)
+      const sheetId = getSheetId(req.query.sheetId)
+      if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
+      await dingTalkGroupDestinationService.testSend(req.params.id, userId, input, sheetId || undefined)
       res.status(204).end()
     } catch (err) {
       if (err instanceof z.ZodError) {

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -59,6 +59,7 @@ const CreateDingTalkGroupSchema = z.object({
   webhookUrl: z.string().url(),
   secret: z.string().optional(),
   enabled: z.boolean().optional(),
+  sheetId: z.string().optional(),
 })
 
 const UpdateDingTalkGroupSchema = z.object({
@@ -328,7 +329,7 @@ export function apiTokensRouter(): Router {
     }
     try {
       const input = CreateDingTalkGroupSchema.parse(req.body)
-      const sheetId = getSheetId((req.body as Record<string, unknown> | undefined)?.sheetId)
+      const sheetId = getSheetId(input.sheetId)
       if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
       const destination = await dingTalkGroupDestinationService.createDestination(userId, {
         name: input.name,

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -67,6 +67,7 @@ function destinationRow(overrides: Record<string, unknown> = {}) {
     webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
     secret: 'SEC123',
     enabled: true,
+    sheet_id: null,
     created_by: 'user_1',
     created_at: '2026-04-19T10:00:00.000Z',
     updated_at: '2026-04-19T10:10:00.000Z',
@@ -111,15 +112,40 @@ describe('DingTalkGroupDestinationService', () => {
       name: ' Ops DingTalk Group ',
       webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
       secret: 'SEC123',
+      sheetId: 'sheet_1',
     })
 
     expect(created.name).toBe('Ops DingTalk Group')
     expect(created.enabled).toBe(true)
+    expect(created.sheetId).toBe('sheet_1')
 
-    executeQueue.push([destinationRow()])
-    const listed = await service.listDestinations('user_1')
-    expect(listed).toHaveLength(1)
+    executeQueue.push([destinationRow({ sheet_id: 'sheet_1' }), destinationRow({ id: 'dt_legacy', sheet_id: null })])
+    const listed = await service.listDestinations('user_1', 'sheet_1')
+    expect(listed).toHaveLength(2)
     expect(listed[0].name).toBe('Ops DingTalk Group')
+    expect(listed[0].sheetId).toBe('sheet_1')
+  })
+
+  test('shared sheet destinations can be managed by non-owners on the same sheet', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeTakeFirstQueue.push(destinationRow({ sheet_id: 'sheet_1', created_by: 'owner_user' }))
+    executeTakeFirstQueue.push(destinationRow({
+      sheet_id: 'sheet_1',
+      created_by: 'owner_user',
+      name: 'Updated shared group',
+      enabled: false,
+    }))
+
+    const updated = await service.updateDestination('dt_1', 'user_2', {
+      name: 'Updated shared group',
+      enabled: false,
+    }, 'sheet_1')
+
+    expect(updated.name).toBe('Updated shared group')
+    expect(updated.sheetId).toBe('sheet_1')
+    expect(roots.updateTable).toHaveBeenCalledWith('dingtalk_group_destinations')
   })
 
   test('updates a destination', async () => {
@@ -168,6 +194,16 @@ describe('DingTalkGroupDestinationService', () => {
     expect(roots.deleteFrom).toHaveBeenCalledWith('dingtalk_group_destinations')
   })
 
+  test('deletes a shared destination when sheet access matches even for non-owner', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeTakeFirstQueue.push(destinationRow({ sheet_id: 'sheet_1', created_by: 'owner_user' }))
+    await service.deleteDestination('dt_1', 'user_2', 'sheet_1')
+
+    expect(roots.deleteFrom).toHaveBeenCalledWith('dingtalk_group_destinations')
+  })
+
   test('testSend marks success when DingTalk responds ok', async () => {
     const { db, roots } = createMockDb()
     const fetchFn = vi.fn(async () => new Response(
@@ -191,6 +227,19 @@ describe('DingTalkGroupDestinationService', () => {
     const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
     expect(setArg?.last_test_status).toBe('success')
     expect(setArg?.last_test_error).toBeNull()
+  })
+
+  test('testSend allows shared destination access for non-owner on the same sheet', async () => {
+    const { db } = createMockDb()
+    const fetchFn = vi.fn(async () => new Response(
+      JSON.stringify({ errcode: 0, errmsg: 'ok' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    const service = new DingTalkGroupDestinationService(db, fetchFn as typeof fetch)
+
+    executeTakeFirstQueue.push(destinationRow({ sheet_id: 'sheet_1', created_by: 'owner_user' }))
+    await expect(service.testSend('dt_1', 'user_2', {}, 'sheet_1')).resolves.toEqual({ ok: true })
+    expect(fetchFn).toHaveBeenCalledTimes(1)
   })
 
   test('testSend marks failure when DingTalk returns an error', async () => {


### PR DESCRIPTION
## Summary
- add nullable sheet scope to DingTalk group destinations with legacy owner fallback
- let sheet automation managers reuse shared group destinations across API Tokens and automation authoring
- cover shared access with focused frontend/backend regression tests and docs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build