### PR TITLE
fix(collab): YjsRecordBridge re-registers observer when Y.Doc is recreated (P1)

### DIFF
--- a/docs/operations/yjs-bridge-stale-observer-fix-20260420.md
+++ b/docs/operations/yjs-bridge-stale-observer-fix-20260420.md
@@ -1,0 +1,139 @@
+# Yjs Bridge — Stale Observer Fix (Development & Fix Report)
+
+Date: 2026-04-20
+Branch: `codex/yjs-bridge-stale-observer-fix-20260420`
+Priority: P1 (blocks every second-and-later subscription to a record)
+
+## 1. How the bug surfaced
+
+During the 2026-04-20 internal rollout trial (see
+`docs/operations/yjs-node-client-validation-20260420.md`):
+
+- **Run 1 (cold doc)**: Node.js Yjs client edited a Y.Text field → backend
+  bridge flushed once → `meta_records` reflected the edit ✅
+- **Run 2 (warm doc, immediately after Run 1)**: same client code, same
+  record. Y.Doc was still in-memory on server. Client inserted a new value.
+  Bridge `flushSuccessCount` went 1 → 2, but `meta_records` was unchanged ❌
+
+Today's rerun (after the doc idled out and was recreated) made the pattern
+worse: flush count didn't even increment. Edits were silently dropped.
+
+## 2. Root cause
+
+`packages/core-backend/src/collab/yjs-record-bridge.ts` — the `observe()`
+method used to early-return if it had seen the `recordId` before:
+
+```ts
+observe(recordId: string, doc: Y.Doc): void {
+  if (this.observedDocs.has(recordId)) return  // ← stale-observer bug
+  // ... register observeDeep on doc.getMap('fields') ...
+}
+```
+
+The `YjsSyncService` destroys idle Y.Doc instances every 60s. When the next
+client subscribes, `getOrCreateDoc(recordId)` allocates a **fresh Y.Doc**.
+The WebSocket adapter dutifully calls `bridge.observe(recordId, newDoc)` —
+but the bridge sees the cached `recordId` key, returns early, and never
+registers `observeDeep` on the new Y.Doc.
+
+Result: edits on the recreated doc had no observer → `scheduleFlush` never
+ran → bridge never called `RecordWriteService.patchRecords()` → DB untouched.
+
+The `flushSuccessCount: 1 → 2` in Run 2 came from the previous, still-alive
+observer finally flushing pending writes from earlier activity; the new
+edit never made it into the flush.
+
+## 3. Fix
+
+Change the observer tracking to key by `{ doc, cleanup }` instead of just
+the cleanup closure, and treat a different Y.Doc instance as a signal to
+tear down the stale observer and re-register on the new one.
+
+```ts
+private observedDocs = new Map<string, { doc: Y.Doc; cleanup: () => void }>()
+
+observe(recordId: string, doc: Y.Doc): void {
+  const existing = this.observedDocs.get(recordId)
+  if (existing && existing.doc === doc) return  // idempotent for same doc
+  if (existing) {
+    try { existing.cleanup() } catch { /* stale doc already destroyed */ }
+    this.observedDocs.delete(recordId)
+  }
+  // ... register observeDeep on the NEW doc.getMap('fields') ...
+  this.observedDocs.set(recordId, { doc, cleanup: () => fields.unobserveDeep(handler) })
+}
+```
+
+Behavior:
+- Same Y.Doc handed in twice → no-op (idempotent)
+- Different Y.Doc for same recordId → tear down stale, re-register fresh
+- Y.Doc destroyed then recreated by syncService → next subscribe re-observes correctly
+
+## 4. Regression tests
+
+Added in `packages/core-backend/tests/unit/yjs-poc.test.ts`:
+
+### Test 1 — re-register on Y.Doc change
+
+Simulates idle release + resubscribe:
+1. observe(rec1, doc1) → edit doc1 → assert 1 flush
+2. doc1.destroy() (no unobserve call — matches sync-service behavior)
+3. observe(rec1, doc2) (fresh Y.Doc for same record)
+4. edit doc2 → **assert 2nd flush** (before fix: 0 flushes here)
+
+### Test 2 — idempotent on same Y.Doc
+
+Calls `observe(rec1, doc)` three times with the same instance, then edits.
+Expects **1 flush**, not 3 — confirms we don't double-register.
+
+Both tests pass.
+
+## 5. Verification
+
+```bash
+$ npx vitest run tests/unit/yjs-poc.test.ts --watch=false
+Test Files  1 passed (1)
+     Tests  27 passed (27)  ← was 25 before, +2 regression
+```
+
+### Validating on real staging (TODO post-merge)
+
+Rerun `scripts/ops/yjs-client-validation/yjs-node-client.mjs` against
+`http://142.171.239.56:8081` twice in a row with the same record. Expected:
+
+- Run A (cold): all 4 checks green
+- Run B (warm): all 4 checks green (previously: DB-reflects-edit ❌)
+
+## 6. Why tests didn't catch this earlier
+
+The existing `YjsRecordBridge` tests create a bridge + doc + observe + edit
+in a single test function, i.e. they never exercise the "destroy and
+recreate the doc" path. The real production flow does this routinely via
+idle cleanup every 60s. The test matrix was missing a lifecycle dimension.
+
+The new regression tests close that gap.
+
+## 7. Scope of impact
+
+This bug means any user who edits a record more than once across an idle
+gap (or any second user who arrives after a doc was cleaned up) got
+**silently dropped edits**. Not a corruption bug — just a "nothing happens"
+bug. Combined with the fact that the frontend editor isn't wired yet, this
+had zero real user impact so far. But it would have been the first thing
+users hit once the frontend did land.
+
+## 8. Files changed
+
+- `packages/core-backend/src/collab/yjs-record-bridge.ts` (fix + JSDoc)
+- `packages/core-backend/tests/unit/yjs-poc.test.ts` (+2 regression tests)
+- `docs/operations/yjs-bridge-stale-observer-fix-20260420.md` (this file)
+
+## 9. Non-goals
+
+- Did not touch `YjsSyncService` — the sync service correctly destroys idle
+  docs and correctly creates fresh ones. The defect was solely in the
+  bridge not reacting to doc recreation.
+- Did not change the idle threshold (60s) — that is a tuning parameter.
+- Did not add an explicit "doc destroyed" callback from sync service to
+  bridge. The simpler invariant "observe() must be idempotent per Y.Doc
+  identity" is sufficient and doesn't add inter-service coupling.

--- a/packages/core-backend/src/collab/yjs-record-bridge.ts
+++ b/packages/core-backend/src/collab/yjs-record-bridge.ts
@@ -40,7 +40,18 @@ interface PendingWrite {
  */
 export class YjsRecordBridge {
   private pendingWrites = new Map<string, PendingWrite>()
-  private observedDocs = new Map<string, () => void>()
+  /**
+   * Tracks per-record observer state. Keyed by recordId. Value holds the
+   * current Y.Doc ref and the cleanup closure for that observer.
+   *
+   * We key by recordId AND validate the Y.Doc identity on every observe()
+   * call. The sync service may destroy and recreate Y.Doc instances across
+   * idle-release cycles; if the incoming doc is a different instance than
+   * the one we previously hooked, we must tear down the stale observer and
+   * re-register on the new doc. Without this, edits on the recreated doc
+   * have no observer and silently fail to flush.
+   */
+  private observedDocs = new Map<string, { doc: Y.Doc; cleanup: () => void }>()
   private _flushSuccessCount = 0
   private _flushFailureCount = 0
 
@@ -66,7 +77,17 @@ export class YjsRecordBridge {
    * Call this after YjsSyncService.getOrCreateDoc().
    */
   observe(recordId: string, doc: Y.Doc): void {
-    if (this.observedDocs.has(recordId)) return
+    // If we already observe this record and the caller is handing us the
+    // SAME Y.Doc instance, nothing to do — the existing observer is live.
+    const existing = this.observedDocs.get(recordId)
+    if (existing && existing.doc === doc) return
+
+    // Doc identity changed (recreated after idle release). Clean up the
+    // stale observer binding first so we don't leak / double-observe.
+    if (existing) {
+      try { existing.cleanup() } catch { /* ignore */ }
+      this.observedDocs.delete(recordId)
+    }
 
     const fields = doc.getMap('fields')
 
@@ -109,8 +130,11 @@ export class YjsRecordBridge {
 
     fields.observeDeep(handler)
 
-    this.observedDocs.set(recordId, () => {
-      fields.unobserveDeep(handler)
+    this.observedDocs.set(recordId, {
+      doc,
+      cleanup: () => {
+        fields.unobserveDeep(handler)
+      },
     })
   }
 
@@ -118,9 +142,9 @@ export class YjsRecordBridge {
    * Stop observing a record doc.
    */
   unobserve(recordId: string): void {
-    const cleanup = this.observedDocs.get(recordId)
-    if (cleanup) {
-      cleanup()
+    const entry = this.observedDocs.get(recordId)
+    if (entry) {
+      entry.cleanup()
       this.observedDocs.delete(recordId)
     }
     // Flush any pending writes immediately

--- a/packages/core-backend/tests/unit/yjs-poc.test.ts
+++ b/packages/core-backend/tests/unit/yjs-poc.test.ts
@@ -655,3 +655,115 @@ describe('YjsRecordBridge multi-actor', () => {
     doc.destroy()
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════
+// Regression: YjsRecordBridge re-observes when Y.Doc is recreated
+// ═══════════════════════════════════════════════════════════════════
+// This reproduces the Run 2 bug from yjs-node-client-validation-20260420.md:
+// after a Y.Doc is destroyed by idle cleanup and recreated on next subscribe,
+// bridge.observe() used to early-return because observedDocs still had the
+// recordId entry, leaving the new doc unobserved → edits silently skipped.
+describe('YjsRecordBridge doc lifecycle', () => {
+  it('re-registers observer when Y.Doc instance changes for the same record', async () => {
+    const { YjsRecordBridge } = await import('../../src/collab/yjs-record-bridge')
+
+    const mockPatch = vi.fn().mockResolvedValue({ updated: [] })
+    const mockGetInput = vi.fn().mockImplementation(
+      async (recordId: string, patch: Record<string, unknown>, pAid: string, allAids: string[]) => ({
+        sheetId: 'sheet1',
+        changesByRecord: new Map([[recordId, Object.entries(patch).map(([fieldId, value]) => ({ fieldId, value }))]]),
+        actorId: pAid,
+        fields: [],
+        visiblePropertyFields: [],
+        visiblePropertyFieldIds: new Set<string>(),
+        attachmentFields: [],
+        fieldById: new Map([['fld_name', { type: 'string', readOnly: false, hidden: false }]]),
+        capabilities: { canEditRecord: true } as any,
+        access: { userId: pAid, permissions: [], isAdminRole: false },
+      }),
+    )
+
+    const bridge = new YjsRecordBridge(
+      {} as any,
+      { patchRecords: mockPatch } as any,
+      mockGetInput,
+      { mergeWindowMs: 20, maxDelayMs: 100 },
+    )
+
+    // First doc: simulates first subscribe cycle
+    const doc1 = new Y.Doc()
+    const text1 = new Y.Text()
+    doc1.getMap('fields').set('fld_name', text1)
+    bridge.observe('rec1', doc1)
+    text1.insert(0, 'first')
+    await new Promise((r) => setTimeout(r, 60))
+    expect(mockPatch).toHaveBeenCalledTimes(1)
+
+    // Simulate cleanup: destroy doc1 (but don't call unobserve — matches
+    // real sync-service behavior where idle cleanup nukes the Y.Doc without
+    // notifying the bridge).
+    doc1.destroy()
+
+    // Second doc: simulates resubscribe after idle release. Fresh Y.Doc,
+    // fresh Y.Text. Previous bug: observe() early-returned and this edit
+    // never reached the bridge.
+    const doc2 = new Y.Doc()
+    const text2 = new Y.Text()
+    doc2.getMap('fields').set('fld_name', text2)
+    bridge.observe('rec1', doc2)
+    text2.insert(0, 'second')
+    await new Promise((r) => setTimeout(r, 60))
+
+    // With the fix: observer is re-registered on doc2, so this edit flushes.
+    expect(mockPatch).toHaveBeenCalledTimes(2)
+    expect(mockGetInput).toHaveBeenLastCalledWith('rec1', { fld_name: 'second' }, 'unknown', ['unknown'])
+
+    bridge.destroy()
+    doc2.destroy()
+  })
+
+  it('does not re-register when observe() is called with the same Y.Doc', async () => {
+    const { YjsRecordBridge } = await import('../../src/collab/yjs-record-bridge')
+
+    const mockPatch = vi.fn().mockResolvedValue({ updated: [] })
+    const mockGetInput = vi.fn().mockImplementation(
+      async (recordId: string, patch: Record<string, unknown>, pAid: string) => ({
+        sheetId: 'sheet1',
+        changesByRecord: new Map([[recordId, [{ fieldId: 'fld_name', value: (patch as any).fld_name }]]]),
+        actorId: pAid,
+        fields: [],
+        visiblePropertyFields: [],
+        visiblePropertyFieldIds: new Set<string>(),
+        attachmentFields: [],
+        fieldById: new Map([['fld_name', { type: 'string', readOnly: false, hidden: false }]]),
+        capabilities: { canEditRecord: true } as any,
+        access: { userId: pAid, permissions: [], isAdminRole: false },
+      }),
+    )
+
+    const bridge = new YjsRecordBridge(
+      {} as any,
+      { patchRecords: mockPatch } as any,
+      mockGetInput,
+      { mergeWindowMs: 20, maxDelayMs: 100 },
+    )
+
+    const doc = new Y.Doc()
+    const text = new Y.Text()
+    doc.getMap('fields').set('fld_name', text)
+
+    bridge.observe('rec1', doc)
+    bridge.observe('rec1', doc) // idempotent second call — same doc instance
+    bridge.observe('rec1', doc)
+
+    text.insert(0, 'hello')
+    await new Promise((r) => setTimeout(r, 60))
+
+    // Expected: ONE flush (not 3). If observer was registered 3 times we'd
+    // see 3 flushes.
+    expect(mockPatch).toHaveBeenCalledTimes(1)
+
+    bridge.destroy()
+    doc.destroy()
+  })
+})


### PR DESCRIPTION
## Summary

P1 fix for the Run 2 bug surfaced in #937. Bridge observer was sticky to the first Y.Doc instance for a given record — after idle cleanup destroyed the doc and sync service created a fresh one, subsequent Y.Text edits silently failed to flush.

## The Bug

```ts
observe(recordId, doc) {
  if (this.observedDocs.has(recordId)) return  // ← ignores the NEW doc
  // ... observeDeep on stale reference never reached ...
}
```

Symptoms from staging (`http://142.171.239.56:8081`):
- Run A/B: `flushSuccessCount` did not increment after `Y.Text.insert`
- `meta_records` title stayed on previous value
- No error logged — just silent no-op

## The Fix

`observedDocs: Map<recordId, { doc, cleanup }>`. When `observe()` receives a **different Y.Doc** for the same recordId, clean up the stale observer and re-register on the new doc. Same-doc calls remain idempotent.

## Tests

2 new regression cases in `yjs-poc.test.ts`:
- `re-registers observer when Y.Doc instance changes for the same record` — reproduces Run 2
- `does not re-register when observe() is called with the same Y.Doc` — guards against double-observe

`27/27` unit tests pass.

## Non-goals

- `YjsSyncService` unchanged — the fix belongs in the bridge (per-observer invariant, not inter-service coupling)
- Idle threshold (60s) unchanged — tuning parameter, not a fix
- No behavior change for frontend editor (still not wired to `/yjs` — that's a separate product decision)

## Validation path

- [x] Unit tests 27/27
- [ ] Rerun Node.js Yjs client against staging after deploy → expect Run A + Run B both green

## Artifacts

- `docs/operations/yjs-bridge-stale-observer-fix-20260420.md` — full dev/fix report with repro sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)