### PR TITLE
feat(collab): POC preflight checklist + Yjs validation as npm script & CI workflow

### DIFF
--- a/.github/workflows/yjs-staging-validation.yml
+++ b/.github/workflows/yjs-staging-validation.yml
@@ -1,0 +1,97 @@
+name: Yjs Staging Validation
+
+# Manual-dispatch only. Hits a live staging server with an admin token.
+# Never runs on push / PR — would require secrets + a running /yjs namespace.
+# Use this to verify the Yjs stack end-to-end against staging after a
+# backend/infra change, or as a periodic health check.
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Yjs base URL (backend, not reverse-proxy)'
+        required: true
+        default: 'http://142.171.239.56:8081'
+      record_id:
+        description: 'Record ID with a fld_pilot_title text field to edit'
+        required: true
+      field_id:
+        description: 'Field ID to edit (must be text type)'
+        required: false
+        default: 'fld_pilot_title'
+      run_twice:
+        description: 'Run twice to validate warm-doc path (catches stale-observer class bugs)'
+        required: false
+        default: 'true'
+
+jobs:
+  validate:
+    name: Yjs End-to-End Validation
+    runs-on: ubuntu-latest
+    # The admin token must be set as a repository or environment secret.
+    # Set up via: gh secret set YJS_ADMIN_TOKEN --body '<jwt>'
+    env:
+      YJS_BASE_URL: ${{ inputs.base_url }}
+      YJS_TOKEN: ${{ secrets.YJS_ADMIN_TOKEN }}
+      RECORD_ID: ${{ inputs.record_id }}
+      FIELD_ID: ${{ inputs.field_id }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install deps (core-backend only)
+        working-directory: packages/core-backend
+        run: pnpm install --frozen-lockfile --filter @metasheet/core-backend...
+
+      - name: Sanity — is Yjs even enabled?
+        run: |
+          if [ -z "$YJS_TOKEN" ]; then
+            echo "::error::YJS_ADMIN_TOKEN secret is not set"
+            exit 1
+          fi
+          # Use repo's pinned status script so alerts + formatting stay consistent.
+          node scripts/ops/check-yjs-rollout-status.mjs \
+            --base-url "$YJS_BASE_URL" \
+            --token "$YJS_TOKEN"
+
+      - name: Run A — cold start validation
+        id: run_a
+        working-directory: packages/core-backend
+        run: |
+          node scripts/ops/yjs-node-client.mjs 2>&1 | tee run-a.log
+          # Script exits 0 on all-green, 2 on check-failure
+          status=${PIPESTATUS[0]}
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit $status
+
+      - name: Run B — warm-doc validation (stale-observer regression)
+        if: ${{ inputs.run_twice == 'true' }}
+        working-directory: packages/core-backend
+        run: |
+          # Give the server a moment to settle, but stay within the
+          # 60s idle-release threshold so the Y.Doc is still warm.
+          sleep 5
+          node scripts/ops/yjs-node-client.mjs 2>&1 | tee run-b.log
+          exit ${PIPESTATUS[0]}
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: yjs-validation-logs-${{ github.run_id }}
+          path: |
+            packages/core-backend/run-a.log
+            packages/core-backend/run-b.log
+          retention-days: 30
+          if-no-files-found: warn

--- a/docs/operations/poc-preflight-checklist.md
+++ b/docs/operations/poc-preflight-checklist.md
@@ -1,0 +1,134 @@
+# POC Preflight Checklist
+
+Status: adopted 2026-04-20 based on the Yjs internal rollout trial.
+
+## Why this document exists
+
+The Yjs POC went through **6 rounds of design review, 25+ unit tests, a
+full rollout packet, and a gate script** before anyone actually sat down
+and tried to use it. When we finally ran it against real staging:
+
+- The frontend editor was not wired to `/yjs` at all — 10 minutes of
+  human editing produced zero Yjs activity on the server.
+- The backend had a `stale observer` P1 bug that made every
+  second-and-later subscription silently drop edits.
+
+Both would have shipped. Neither was caught by the review process.
+
+The conclusion is simple and we should not re-learn it: **review is
+not validation**. A single end-to-end run against a real environment
+is worth more than another review round.
+
+This checklist is the minimum bar a POC must clear before it can be
+called "validated".
+
+## The preflight checklist
+
+Before declaring any POC "ready for rollout" or "verified":
+
+### 1. End-to-end real run — not just unit tests
+
+- [ ] The feature has been exercised on a real deployed environment
+  (staging or better), not just locally or in tests.
+- [ ] The exercise used the product's actual entry point (browser UI,
+  public API, CLI — whatever users will use), not just a direct call
+  to the service under test.
+- [ ] There is a recorded artifact of this run (log, screenshot, JSON
+  dump) committed to the repo.
+
+If the feature cannot be exercised end-to-end yet (frontend not wired,
+tenant data missing, etc.) this is **not** a reason to skip the check.
+It is a finding that belongs in the verification report.
+
+### 2. Frontend wiring audit — did anything in the UI call this
+
+- [ ] `grep` / `ripgrep` the frontend for the feature's entry symbols
+  (hooks, composables, API methods).
+- [ ] Confirm at least one real component calls them in a user-facing
+  flow. `export` is not the same as `import`.
+- [ ] If the frontend only exports and nothing consumes, **say so
+  explicitly** in the verification report. Do not claim "validated".
+
+### 3. Warm and cold state — both
+
+POCs that only test cold state routinely ship bugs in warm paths.
+For any feature that caches, persists, or reuses instances:
+
+- [ ] Test the cold path: first request, first subscribe, first edit.
+- [ ] Test the warm path: second+ request against the same cached /
+  reloaded / reconnected state.
+- [ ] Test the cold-again path: force release / restart, then warm
+  again. Confirms cleanup and re-init are idempotent.
+
+This is where the Yjs stale-observer bug was hiding. Cold-then-warm is
+a 5-minute test and it catches a whole class of lifecycle bugs.
+
+### 4. Scope parity — admin vs user
+
+- [ ] If you used an admin token to verify, verify again (or at least
+  spot check) under the user scope real users will have.
+- [ ] Confirm multi-tenant / RBAC isolation works the way you expect.
+  "I can see it with the admin token" does not mean your user can.
+- [ ] Check that records your admin token can patch are actually
+  visible in the target user's browser view.
+
+The Yjs trial burned 15 minutes on this: admin-API records were not
+visible to the browser session, so cross-tool comparisons failed.
+
+### 5. Observability hooked up
+
+- [ ] There is an admin or ops endpoint that returns the feature's
+  runtime state (counts, errors, queues).
+- [ ] A scripted check of that endpoint has been run and committed
+  (like `check-yjs-rollout-status.mjs` for Yjs).
+- [ ] Metrics that *should* move under load have been confirmed to
+  actually move. "Zero activity" is a valid signal — investigate it
+  before declaring green.
+
+The Yjs trial would have declared success if we hadn't looked at
+`activeDocCount` staying at 0.
+
+### 6. Review is not sign-off
+
+- [ ] Design docs reviewed ≠ feature verified.
+- [ ] Green unit tests ≠ feature verified.
+- [ ] Merged PR ≠ feature verified.
+- [ ] Only steps 1–5 above, executed against real infra, count as
+  verification.
+
+### 7. Named artifact location
+
+Every POC must commit, under a predictable path:
+
+- [ ] `docs/operations/<feature>-trial-verification-<date>.md`
+  — honest summary of what was run, what worked, what didn't.
+- [ ] `scripts/ops/<feature>-validation/` (or similar)
+  — the actual script(s) used, so the verification is reproducible.
+- [ ] `output/<feature>/<date>/` (optional, if artifacts are small)
+  — logs, poll dumps, snapshots.
+
+If a future person cannot rerun the verification from these artifacts
+alone, the verification is not complete.
+
+## When to apply this
+
+- Before merging any PR with "POC validated" or "rollout ready" in the
+  title or description.
+- Before setting a feature flag to on in any shared environment.
+- Before marking a rollout milestone as done (packet, gate, advance,
+  promote — none of these are meaningful without the preflight).
+
+## When to *not* apply this
+
+- Pure internal refactors that have no runtime-visible surface.
+- Documentation-only changes.
+- Small bug fixes already covered by an added regression test (the
+  test itself is the verification artifact).
+
+## Meta
+
+If a POC passes this checklist and still ships a bug, update this
+document with the new lesson. The checklist is explicitly allowed to
+grow; review-and-remove rounds should only prune items that have
+been superseded by a tool or a hook that makes the human check
+unnecessary.

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -17,6 +17,8 @@
     "seed:demo": "echo 'Seeding demo data...' && exit 0",
     "seed:rbac": "tsx scripts/seed-rbac.ts",
     "smoke:plugins": "tsx scripts/smoke-plugins.ts",
+    "yjs:status": "node ../../scripts/ops/check-yjs-rollout-status.mjs",
+    "yjs:validate": "node scripts/ops/yjs-node-client.mjs",
     "test": "vitest",
     "test:phase5": "vitest --config vitest.phase5.config.ts run",
     "test:unit": "vitest run tests/unit --reporter=dot",

--- a/packages/core-backend/scripts/ops/yjs-node-client.mjs
+++ b/packages/core-backend/scripts/ops/yjs-node-client.mjs
@@ -36,7 +36,13 @@ async function fetchStatus() {
   const res = await fetch(`${BASE_URL}/api/admin/yjs/status`, {
     headers: { Authorization: `Bearer ${TOKEN}` },
   })
+  if (!res.ok) {
+    throw new Error(`status endpoint ${res.status} ${res.statusText} (token may be invalid/expired)`)
+  }
   const json = await res.json()
+  if (!json.yjs) {
+    throw new Error(`status endpoint responded ok but had no yjs payload: ${JSON.stringify(json).slice(0, 200)}`)
+  }
   return json.yjs
 }
 

--- a/scripts/ops/yjs-client-validation/README.md
+++ b/scripts/ops/yjs-client-validation/README.md
@@ -1,0 +1,26 @@
+# Yjs Client Validation
+
+The validation script has moved to `packages/core-backend/scripts/ops/yjs-node-client.mjs`
+so it can resolve `yjs`, `y-protocols`, and `socket.io-client` from the
+core-backend package's `node_modules`.
+
+## Run via npm script (recommended)
+
+```bash
+YJS_BASE_URL=http://<host>:<port> \
+YJS_TOKEN=<jwt> \
+RECORD_ID=<recordId> \
+pnpm --filter @metasheet/core-backend run yjs:validate
+```
+
+## Run directly
+
+```bash
+cd packages/core-backend
+YJS_BASE_URL=... YJS_TOKEN=... RECORD_ID=... node scripts/ops/yjs-node-client.mjs
+```
+
+## Run via CI (dispatch workflow)
+
+See `.github/workflows/yjs-staging-validation.yml` — triggered via
+`gh workflow run yjs-staging-validation.yml`.


### PR DESCRIPTION
## Summary

Sediments the lessons from today's Yjs internal rollout trial (PRs #937, #940) into reusable form.

## 1. POC preflight checklist

`docs/operations/poc-preflight-checklist.md` — six concrete checks before any POC can be called "validated":

1. End-to-end real run — not just unit tests
2. Frontend wiring audit — `export` ≠ `import`
3. Warm + cold state — both paths
4. Scope parity — admin vs user
5. Observability actually hooked up
6. Review is not sign-off

Backed by today's findings: Yjs POC passed 6 rounds of design review and 25+ unit tests, but **the frontend wasn't wired AND the backend had a stale-observer P1** — both would have shipped silently. A single real run caught both.

## 2. Validation as npm script

- Moved `yjs-node-client.mjs` into `packages/core-backend/scripts/ops/` for proper module resolution
- Added scripts:
  - `pnpm --filter @metasheet/core-backend run yjs:status`
  - `pnpm --filter @metasheet/core-backend run yjs:validate`
- Hardened error surfacing for expired tokens (previously crashed with `TypeError: undefined.sync`)

## 3. CI workflow (manual-dispatch only)

`.github/workflows/yjs-staging-validation.yml`:
- Requires `YJS_ADMIN_TOKEN` secret
- Inputs: `base_url`, `record_id`, `field_id`, `run_twice`
- Runs Run A (cold) → 5s sleep → Run B (warm, still < 60s idle threshold) to catch stale-observer regressions
- Uploads run logs as artifact (30-day retention)
- Not on push/PR — opt-in via `gh workflow run yjs-staging-validation.yml`

## Why this is valuable beyond Yjs

The preflight checklist is intentionally **feature-agnostic**. It's the bar for the next POC too (CRDT DAG, Redis multi-instance, rich-text, whatever). The cost of one more review round is high; the cost of one real run is low.

## Test plan

- [x] `pnpm --filter @metasheet/core-backend test tests/unit/yjs-poc.test.ts` → 27/27
- [x] YAML lint on workflow
- [x] `npm run` discovers `yjs:status` and `yjs:validate`
- [ ] Workflow dispatch smoke (after merge, once YJS_ADMIN_TOKEN is set as repo secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)