### PR TITLE
feat(dingtalk): add dynamic person recipients

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -238,6 +238,17 @@
               placeholder="使用逗号或换行分隔本地 userId"
               data-automation-field="dingtalkPersonUserIds"
             ></textarea>
+            <label class="meta-automation__label">Record recipient field path (optional)</label>
+            <input
+              v-model="draft.dingtalkPersonRecipientFieldPath"
+              class="meta-automation__input"
+              type="text"
+              placeholder="例如：record.assigneeUserIds"
+              data-automation-field="dingtalkPersonRecipientFieldPath"
+            />
+            <div class="meta-automation__hint">
+              Supports `record.xxx` paths that resolve to one userId, a comma-separated string, or a userId array.
+            </div>
             <label class="meta-automation__label">Title template</label>
             <input
               v-model="draft.dingtalkPersonTitleTemplate"
@@ -307,6 +318,7 @@
             <div class="meta-automation__preview" data-automation-summary="person">
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
+              <div><strong>Record recipients:</strong> {{ dingTalkPersonRecipientFieldSummary }}</div>
               <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
               <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
               <div class="meta-automation__preview-line">
@@ -499,6 +511,7 @@ interface DraftState {
   publicFormViewId: string
   internalViewId: string
   dingtalkPersonUserIds: string
+  dingtalkPersonRecipientFieldPath: string
   dingtalkPersonTitleTemplate: string
   dingtalkPersonBodyTemplate: string
   dingtalkPersonPublicFormViewId: string
@@ -520,6 +533,7 @@ function emptyDraft(): DraftState {
     publicFormViewId: '',
     internalViewId: '',
     dingtalkPersonUserIds: '',
+    dingtalkPersonRecipientFieldPath: '',
     dingtalkPersonTitleTemplate: '',
     dingtalkPersonBodyTemplate: '',
     dingtalkPersonPublicFormViewId: '',
@@ -652,6 +666,13 @@ function copyPreviewText(key: string, text: string) {
 const dingTalkPersonRecipientSummary = computed(() => {
   if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
   return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
+})
+
+const dingTalkPersonRecipientFieldSummary = computed(() => {
+  const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
+  if (!trimmed) return 'No dynamic recipient field'
+  const normalized = trimmed.replace(/^record\./, '')
+  return normalized ? `record.${normalized}` : 'No dynamic recipient field'
 })
 
 function templateSyntaxWarnings(value: string) {
@@ -792,7 +813,7 @@ const canSave = computed(() => {
     if (!draft.value.dingtalkBodyTemplate.trim()) return false
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
-    if (!draft.value.dingtalkPersonUserIds.trim()) return false
+    if (!draft.value.dingtalkPersonUserIds.trim() && !draft.value.dingtalkPersonRecipientFieldPath.trim()) return false
     if (!draft.value.dingtalkPersonTitleTemplate.trim()) return false
     if (!draft.value.dingtalkPersonBodyTemplate.trim()) return false
   }
@@ -824,6 +845,7 @@ function openEditForm(rule: AutomationRule) {
     publicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
     internalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
     dingtalkPersonUserIds: Array.isArray(rule.actionConfig?.userIds) ? rule.actionConfig?.userIds.join(', ') : '',
+    dingtalkPersonRecipientFieldPath: (rule.actionConfig?.userIdFieldPath as string) ?? '',
     dingtalkPersonTitleTemplate: (rule.actionConfig?.titleTemplate as string) ?? '',
     dingtalkPersonBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
     dingtalkPersonPublicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
@@ -873,6 +895,7 @@ function buildActionConfig(): Record<string, unknown> {
         .split(/[\n,]+/)
         .map((entry) => entry.trim())
         .filter(Boolean),
+      userIdFieldPath: draft.value.dingtalkPersonRecipientFieldPath.trim() || undefined,
       titleTemplate: draft.value.dingtalkPersonTitleTemplate,
       bodyTemplate: draft.value.dingtalkPersonBodyTemplate,
       publicFormViewId: draft.value.dingtalkPersonPublicFormViewId || undefined,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -366,6 +366,17 @@
                 placeholder="使用逗号或换行分隔本地 userId"
                 data-field="dingtalkPersonUserIds"
               ></textarea>
+              <label class="meta-rule-editor__label">Record recipient field path (optional)</label>
+              <input
+                v-model="action.config.recipientFieldPath"
+                class="meta-rule-editor__input"
+                type="text"
+                placeholder="例如：record.assigneeUserIds"
+                data-field="dingtalkPersonRecipientFieldPath"
+              />
+              <div class="meta-rule-editor__hint">
+                Supports `record.xxx` paths that resolve to one userId, a comma-separated string, or a userId array.
+              </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
                 v-model="action.config.titleTemplate"
@@ -443,6 +454,7 @@
               <div class="meta-rule-editor__preview" data-field="personMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
+                <div><strong>Record recipients:</strong> {{ recipientFieldPathSummary(action.config.recipientFieldPath) }}</div>
                 <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
                 <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
                 <div class="meta-rule-editor__preview-line">
@@ -539,6 +551,7 @@ type DraftActionConfig = Record<string, unknown> & {
   userId?: string
   userIdsText?: string
   userIdsSearch?: string
+  recipientFieldPath?: string
   message?: string
   destinationId?: string
   titleTemplate?: string
@@ -626,6 +639,9 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
       userIdsText: Array.isArray(config.userIds)
         ? config.userIds.join(', ')
         : '',
+      recipientFieldPath: typeof config.userIdFieldPath === 'string'
+        ? config.userIdFieldPath
+        : '',
       userIdsSearch: '',
     }
   }
@@ -686,9 +702,10 @@ const canSave = computed(() => {
     }
     if (action.type === 'send_dingtalk_person_message') {
       const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
+      const recipientFieldPath = typeof action.config.recipientFieldPath === 'string' ? action.config.recipientFieldPath.trim() : ''
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if (!userIdsText || !titleTemplate || !bodyTemplate) return false
+      if ((!userIdsText && !recipientFieldPath) || !titleTemplate || !bodyTemplate) return false
     }
   }
   return true
@@ -827,6 +844,12 @@ function personRecipientSummary(action: DraftAction) {
   return selected.map((item) => item.label).join(', ')
 }
 
+function recipientFieldPathSummary(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return 'No dynamic recipient field'
+  const normalized = value.trim().replace(/^record\./, '')
+  return normalized ? `record.${normalized}` : 'No dynamic recipient field'
+}
+
 function templateSyntaxWarnings(value: unknown) {
   return typeof value === 'string' ? listDingTalkTemplateSyntaxWarnings(value) : []
 }
@@ -909,6 +932,7 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
       return {
         userIdsText: '',
         userIdsSearch: '',
+        recipientFieldPath: '',
         titleTemplate: '',
         bodyTemplate: '',
         publicFormViewId: '',
@@ -972,6 +996,9 @@ function buildPayload(): Partial<AutomationRule> {
         type: action.type,
         config: {
           userIds,
+          userIdFieldPath: typeof action.config.recipientFieldPath === 'string' && action.config.recipientFieldPath.trim()
+            ? action.config.recipientFieldPath.trim()
+            : undefined,
           titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : '',
           bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : '',
           publicFormViewId: typeof action.config.publicFormViewId === 'string' && action.config.publicFormViewId.trim()

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -389,6 +389,57 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('creates DingTalk person automation with only a dynamic record recipient path', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk dynamic notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.assigneeUserIds'
+    recipientFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(summary?.textContent).toContain('Record recipients:')
+    expect(summary?.textContent).toContain('record.assigneeUserIds')
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please fill {{record.status}}',
+    })
+  })
+
   it('can search and add DingTalk person recipients before save', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -592,6 +643,10 @@ describe('MetaAutomationManager', () => {
     actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.assigneeUserIds'
+    recipientFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
     const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
     userIdsInput.value = 'user_1'
     userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
@@ -611,8 +666,46 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Handle {{record.xxx}}')
     expect(summary?.textContent).toContain('Need action record_demo_001')
     expect(summary?.textContent).toContain('Handle 示例字段值')
+    expect(summary?.textContent).toContain('record.assigneeUserIds')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
+  })
+
+  it('loads dynamic record recipient path into the edit form', async () => {
+    const rules = [
+      fakeRule({
+        id: 'rule_dynamic',
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: [],
+          userIdFieldPath: 'record.assigneeUserIds',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            userIdFieldPath: 'record.assigneeUserIds',
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please fill {{record.status}}',
+          },
+        }],
+      }),
+    ]
+    const { client } = mockClient(rules)
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const editBtn = container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement
+    expect(editBtn).toBeTruthy()
+    editBtn.click()
+    await flushPromises()
+
+    const recipientFieldInput = document.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
+    expect(document.body.textContent).toContain('Record recipients:')
+    expect(document.body.textContent).toContain('record.assigneeUserIds')
   })
 
   it('shows DingTalk template syntax warnings in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -354,6 +354,68 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('emits DingTalk person action config with only a dynamic record recipient path', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify dynamic recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.assigneeUserIds'
+    recipientFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_dingtalk_person_message',
+      config: {
+        userIds: [],
+        userIdFieldPath: 'record.assigneeUserIds',
+        titleTemplate: 'Ticket {{recordId}}',
+        bodyTemplate: 'Please review {{record.status}}',
+      },
+    })
+    expect(container.textContent).toContain('Record recipients:')
+    expect(container.textContent).toContain('record.assigneeUserIds')
+  })
+
   it('can search and add DingTalk person recipients', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/docs/development/dingtalk-person-dynamic-recipients-development-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-recipients-development-20260420.md
@@ -1,0 +1,53 @@
+# DingTalk Person Dynamic Recipients Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-dynamic-recipients-20260420`
+
+## Goal
+
+Extend `send_dingtalk_person_message` so a rule can resolve recipient local user IDs from record data, instead of requiring only static `userIds`.
+
+## Scope
+
+- Backend:
+  - add optional `userIdFieldPath` to `SendDingTalkPersonMessageConfig`
+  - resolve recipient user IDs from `context.recordData`
+  - merge static and dynamic recipients with dedupe
+  - return clearer failure when a configured record path resolves no users
+- Frontend:
+  - add `Record recipient field path (optional)` to both automation editors
+  - allow saving person-message rules with either static user IDs or a dynamic field path
+  - show dynamic recipient summary in authoring UI
+  - map `userIdFieldPath` back into edit state
+
+## Implementation Notes
+
+- Supported dynamic field path format:
+  - `record.assigneeUserIds`
+- Supported record values:
+  - one string
+  - comma/newline separated string
+  - string array
+  - numeric ID
+  - object entries such as `{ id }`, `{ userId }`, `{ localUserId }`, `{ value }`
+- Runtime normalization removes duplicate local user IDs before DingTalk lookup.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/automation-actions.ts`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Outcome
+
+Admins can now configure a DingTalk personal notification rule that targets:
+
+- explicit local users
+- record-derived local users
+- or both together
+
+This gives a lightweight “who should fill this record” mechanism without introducing a new row/column ACL model first.

--- a/docs/development/dingtalk-person-dynamic-recipients-verification-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-recipients-verification-20260420.md
@@ -1,0 +1,36 @@
+# DingTalk Person Dynamic Recipients Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-dynamic-recipients-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend unit tests: `99 passed`
+- Frontend tests: `40 passed`
+- Backend build: passed
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- `send_dingtalk_person_message` succeeds with dynamic recipients from `record.assigneeUserIds`
+- `send_dingtalk_person_message` fails clearly when a configured path resolves no recipients
+- inline automation manager can save a person-message rule with only `userIdFieldPath`
+- rule editor can save the same payload shape
+- edit flows map `userIdFieldPath` back into the authoring form
+
+## Notes
+
+- Frontend Vitest may still print the existing `WebSocket server error: Port is already in use` warning in this repository; it did not block the test run.
+- Web build still shows the existing Vite chunk-size warning; no new build regressions were introduced by this slice.

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -59,6 +59,7 @@ export interface SendDingTalkGroupMessageConfig {
 /** Config shape for send_dingtalk_person_message */
 export interface SendDingTalkPersonMessageConfig {
   userIds: string[]
+  userIdFieldPath?: string
   titleTemplate: string
   bodyTemplate: string
   publicFormViewId?: string

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -74,6 +74,49 @@ function normalizeUserIds(value: unknown): string[] {
   ))
 }
 
+function normalizeUserIdScalar(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return [String(value)]
+  }
+  if (typeof value === 'object' && value && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>
+    for (const key of ['localUserId', 'userId', 'id', 'value']) {
+      const candidate = record[key]
+      if (typeof candidate === 'string' && candidate.trim()) return [candidate.trim()]
+      if (typeof candidate === 'number' && Number.isFinite(candidate)) return [String(candidate)]
+    }
+  }
+  return []
+}
+
+function normalizeUserIdsFromUnknown(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(new Set(
+      value.flatMap((entry) => normalizeUserIdsFromUnknown(entry)),
+    ))
+  }
+  return normalizeUserIdScalar(value)
+}
+
+function normalizeRecipientFieldPath(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  return trimmed.replace(/^record\./, '')
+}
+
+function resolveRecipientUserIdsFromRecord(recordData: Record<string, unknown>, fieldPath: unknown): string[] {
+  const normalizedPath = normalizeRecipientFieldPath(fieldPath)
+  if (!normalizedPath) return []
+  return normalizeUserIdsFromUnknown(lookupTemplateValue(normalizedPath, recordData))
+}
+
 function chunkItems<T>(items: T[], size: number): T[][] {
   if (items.length === 0) return []
   const chunks: T[][] = []
@@ -599,14 +642,28 @@ export class AutomationExecutor {
     config: SendDingTalkPersonMessageConfig,
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
-    const userIds = normalizeUserIds(config.userIds)
+    const staticUserIds = normalizeUserIds(config.userIds)
+    const recipientFieldPath = normalizeRecipientFieldPath(config.userIdFieldPath)
+    const recordUserIds = resolveRecipientUserIdsFromRecord(context.recordData, recipientFieldPath)
+    const userIds = Array.from(new Set([...staticUserIds, ...recordUserIds]))
     const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
     const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
     const publicFormViewId = typeof config.publicFormViewId === 'string' ? config.publicFormViewId.trim() : ''
     const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
 
     if (userIds.length === 0) {
-      return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'At least one local userId is required' }
+      if (recipientFieldPath) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: `No local userIds resolved from record field path "${recipientFieldPath}"`,
+        }
+      }
+      return {
+        actionType: 'send_dingtalk_person_message',
+        status: 'failed',
+        error: 'At least one local userId or record recipient field path is required',
+      }
     }
     if (!titleTemplate) {
       return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'DingTalk title template is required' }
@@ -785,6 +842,9 @@ export class AutomationExecutor {
         status: 'success',
         output: {
           notifiedUsers: resolvedRecipients.length,
+          staticRecipientCount: staticUserIds.length,
+          dynamicRecipientCount: recordUserIds.length,
+          recipientFieldPath: recipientFieldPath || null,
           batchCount: batches.length,
           linkCount: linkLines.length,
           responseCount,

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -645,6 +645,91 @@ describe('AutomationExecutor', () => {
     expect(insertCall?.[1]?.[1]).toBe('user_2')
   })
 
+  it('executes send_dingtalk_person_message with dynamic record recipients', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' },
+          { local_user_id: 'user_2', local_user_active: true, dingtalk_user_id: 'dt-user-2' },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIdFieldPath: 'record.assigneeUserIds',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {
+        title: 'Incident',
+        status: 'open',
+        assigneeUserIds: ['user_1', { id: 'user_2' }, 'user_1'],
+      },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    const [, sendInit] = fetchFn.mock.calls[1] as [string, RequestInit]
+    const payload = JSON.parse(sendInit.body as string)
+    expect(payload.userid_list).toBe('dt-user-1,dt-user-2')
+    expect(result.steps[0].output).toMatchObject({
+      notifiedUsers: 2,
+      staticRecipientCount: 0,
+      dynamicRecipientCount: 2,
+      recipientFieldPath: 'assigneeUserIds',
+    })
+  })
+
+  it('fails send_dingtalk_person_message when dynamic record path resolves no recipients', async () => {
+    deps = createMockDeps()
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIdFieldPath: 'record.assigneeUserIds',
+          titleTemplate: 'Title',
+          bodyTemplate: 'Body',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { assigneeUserIds: [] },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('record field path "assigneeUserIds"')
+  })
+
   it('fails send_notification with no userIds', async () => {
     const rule = createMockRule({
       actions: [{ type: 'send_notification', config: { message: 'Hi' } }],


### PR DESCRIPTION
## Summary\n- add optional record-based recipient resolution for DingTalk person automation rules\n- support authoring these rules in both automation editors with summary and edit-state mapping\n- add backend and frontend regression coverage plus development/verification notes\n\n## Verification\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false\n- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false\n- pnpm --filter @metasheet/core-backend build\n- pnpm --filter @metasheet/web build\n- git diff --check