### PR TITLE
feat(dingtalk): add recipient field picker

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -243,11 +243,22 @@
               v-model="draft.dingtalkPersonRecipientFieldPath"
               class="meta-automation__input"
               type="text"
-              placeholder="例如：record.assigneeUserIds"
+              placeholder="例如：record.fld_assignee 或 record.assigneeUserIds"
               data-automation-field="dingtalkPersonRecipientFieldPath"
             />
+            <label class="meta-automation__label">Pick recipient field</label>
+            <select
+              v-model="dingTalkPersonRecipientFieldId"
+              class="meta-automation__select"
+              data-automation-field="dingtalkPersonRecipientFieldSelect"
+            >
+              <option value="">-- choose a record field --</option>
+              <option v-for="field in props.fields" :key="field.id" :value="field.id">
+                {{ field.name }} (record.{{ field.id }})
+              </option>
+            </select>
             <div class="meta-automation__hint">
-              Supports `record.xxx` paths that resolve to one userId, a comma-separated string, or a userId array.
+              Record data is keyed by field ID. Use a <code>record.&lt;fieldId&gt;</code> path or choose a field above.
             </div>
             <label class="meta-automation__label">Title template</label>
             <input
@@ -672,7 +683,19 @@ const dingTalkPersonRecipientFieldSummary = computed(() => {
   const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
   if (!trimmed) return 'No dynamic recipient field'
   const normalized = trimmed.replace(/^record\./, '')
-  return normalized ? `record.${normalized}` : 'No dynamic recipient field'
+  if (!normalized) return 'No dynamic recipient field'
+  const field = props.fields.find((item) => item.id === normalized)
+  return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
+})
+
+const dingTalkPersonRecipientFieldId = computed({
+  get() {
+    const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
+    return trimmed ? trimmed.replace(/^record\./, '') : ''
+  },
+  set(value: string) {
+    draft.value.dingtalkPersonRecipientFieldPath = value ? `record.${value}` : ''
+  },
 })
 
 function templateSyntaxWarnings(value: string) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -371,11 +371,23 @@
                 v-model="action.config.recipientFieldPath"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="例如：record.assigneeUserIds"
+                placeholder="例如：record.fld_assignee 或 record.assigneeUserIds"
                 data-field="dingtalkPersonRecipientFieldPath"
               />
+              <label class="meta-rule-editor__label">Pick recipient field</label>
+              <select
+                :value="selectedRecipientFieldId(action.config.recipientFieldPath)"
+                class="meta-rule-editor__select"
+                data-field="dingtalkPersonRecipientFieldSelect"
+                @change="selectRecipientFieldPath(action, ($event.target as HTMLSelectElement).value)"
+              >
+                <option value="">-- choose a record field --</option>
+                <option v-for="field in props.fields" :key="field.id" :value="field.id">
+                  {{ field.name }} (record.{{ field.id }})
+                </option>
+              </select>
               <div class="meta-rule-editor__hint">
-                Supports `record.xxx` paths that resolve to one userId, a comma-separated string, or a userId array.
+                Record data is keyed by field ID. Use a <code>record.&lt;fieldId&gt;</code> path or choose a field above.
               </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
@@ -847,7 +859,18 @@ function personRecipientSummary(action: DraftAction) {
 function recipientFieldPathSummary(value: unknown) {
   if (typeof value !== 'string' || !value.trim()) return 'No dynamic recipient field'
   const normalized = value.trim().replace(/^record\./, '')
-  return normalized ? `record.${normalized}` : 'No dynamic recipient field'
+  if (!normalized) return 'No dynamic recipient field'
+  const field = props.fields.find((item) => item.id === normalized)
+  return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
+}
+
+function selectedRecipientFieldId(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return ''
+  return value.trim().replace(/^record\./, '')
+}
+
+function selectRecipientFieldPath(action: DraftAction, fieldId: string) {
+  action.config.recipientFieldPath = fieldId ? `record.${fieldId}` : ''
 }
 
 function templateSyntaxWarnings(value: unknown) {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -112,6 +112,7 @@ function mount(props: Record<string, unknown>) {
 const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
+  { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
 ]
 
 const views = [
@@ -440,6 +441,31 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('can pick a record recipient field for DingTalk person automation', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
+    expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
   it('can search and add DingTalk person recipients before save', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -666,7 +692,7 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Handle {{record.xxx}}')
     expect(summary?.textContent).toContain('Need action record_demo_001')
     expect(summary?.textContent).toContain('Handle 示例字段值')
-    expect(summary?.textContent).toContain('record.assigneeUserIds')
+    expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })
@@ -705,7 +731,7 @@ describe('MetaAutomationManager', () => {
     const recipientFieldInput = document.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
     expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
     expect(document.body.textContent).toContain('Record recipients:')
-    expect(document.body.textContent).toContain('record.assigneeUserIds')
+    expect(document.body.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
   it('shows DingTalk template syntax warnings in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -11,6 +11,7 @@ import type { AutomationRule } from '../src/multitable/types'
 const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
+  { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
 ]
 
 const views = [
@@ -413,7 +414,33 @@ describe('MetaAutomationRuleEditor', () => {
       },
     })
     expect(container.textContent).toContain('Record recipients:')
-    expect(container.textContent).toContain('record.assigneeUserIds')
+    expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('can pick a record recipient field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
+    expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
   it('can search and add DingTalk person recipients', async () => {

--- a/docs/development/dingtalk-person-recipient-field-picker-development-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-picker-development-20260420.md
@@ -1,0 +1,38 @@
+# DingTalk Person Recipient Field Picker Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-picker-20260420`
+
+## Goal
+
+Improve authoring for dynamic DingTalk personal recipients by letting admins pick a record field instead of manually typing a `record.<fieldId>` path.
+
+## Scope
+
+- Frontend only
+- No runtime protocol changes
+- No migration changes
+
+## Changes
+
+- Added `Pick recipient field` selects to:
+  - `MetaAutomationRuleEditor`
+  - `MetaAutomationManager`
+- The picker writes the actual runtime-safe path:
+  - `record.<fieldId>`
+- Updated helper copy to clarify that automation `record` data is keyed by field ID.
+- Upgraded summary text so it shows both:
+  - field label
+  - runtime path
+  - example: `Assignees (record.assigneeUserIds)`
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Outcome
+
+Admins no longer need to guess or hand-type a recipient path. They can pick a field from the current sheet and get the exact runtime path that the automation executor expects.

--- a/docs/development/dingtalk-person-recipient-field-picker-verification-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-picker-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Person Recipient Field Picker Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-picker-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `42 passed`
+- Web build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- rule editor can pick a recipient field and writes `record.<fieldId>`
+- inline automation manager can do the same
+- summary text shows `Field Name (record.<fieldId>)`
+- existing dynamic-recipient create/edit flows remain valid
+
+## Notes
+
+- This slice is frontend-only and stacks on top of `#942`.
+- Web build still prints the existing Vite chunk-size warning; no new build regression was introduced.


### PR DESCRIPTION
## Summary
- add a record-field picker for DingTalk dynamic person recipients in both automation editors
- write runtime-safe `record.<fieldId>` paths and show label + path summaries
- add focused frontend regression coverage and development/verification notes

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --check
