### PR TITLE
feat(dingtalk): support multiple dynamic person recipient fields

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -238,19 +238,19 @@
               placeholder="使用逗号或换行分隔本地 userId"
               data-automation-field="dingtalkPersonUserIds"
             ></textarea>
-            <label class="meta-automation__label">Record recipient field path (optional)</label>
+            <label class="meta-automation__label">Record recipient field paths (optional)</label>
             <input
               v-model="draft.dingtalkPersonRecipientFieldPath"
               class="meta-automation__input"
               type="text"
-              placeholder="例如：record.fld_assignee 或 record.assigneeUserIds"
+              placeholder="例如：record.assigneeUserIds, record.reviewerUserId"
               data-automation-field="dingtalkPersonRecipientFieldPath"
             />
             <label class="meta-automation__label">Pick recipient field</label>
             <select
-              v-model="dingTalkPersonRecipientFieldId"
               class="meta-automation__select"
               data-automation-field="dingtalkPersonRecipientFieldSelect"
+              @change="appendDingTalkPersonRecipientField($event.target as HTMLSelectElement)"
             >
               <option value="">-- choose a record field --</option>
               <option v-for="field in props.fields" :key="field.id" :value="field.id">
@@ -258,7 +258,7 @@
               </option>
             </select>
             <div class="meta-automation__hint">
-              Record data is keyed by field ID. Use a <code>record.&lt;fieldId&gt;</code> path or choose a field above.
+              Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
             </div>
             <label class="meta-automation__label">Title template</label>
             <input
@@ -679,24 +679,40 @@ const dingTalkPersonRecipientSummary = computed(() => {
   return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
 })
 
-const dingTalkPersonRecipientFieldSummary = computed(() => {
-  const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
-  if (!trimmed) return 'No dynamic recipient field'
-  const normalized = trimmed.replace(/^record\./, '')
-  if (!normalized) return 'No dynamic recipient field'
+function parseRecipientFieldPathsText(value: string): string[] {
+  return Array.from(new Set(
+    value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim().replace(/^record\./, ''))
+      .filter(Boolean),
+  ))
+}
+
+function recipientFieldSummaryLabel(path: string) {
+  const normalized = path.trim().replace(/^record\./, '')
+  if (!normalized) return ''
   const field = props.fields.find((item) => item.id === normalized)
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
+}
+
+const dingTalkPersonRecipientFieldSummary = computed(() => {
+  const labels = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+    .map((path) => recipientFieldSummaryLabel(path))
+    .filter(Boolean)
+  if (!labels.length) return 'No dynamic recipient field'
+  return labels.join(', ')
 })
 
-const dingTalkPersonRecipientFieldId = computed({
-  get() {
-    const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
-    return trimmed ? trimmed.replace(/^record\./, '') : ''
-  },
-  set(value: string) {
-    draft.value.dingtalkPersonRecipientFieldPath = value ? `record.${value}` : ''
-  },
-})
+function appendDingTalkPersonRecipientField(select: HTMLSelectElement) {
+  const value = select.value.trim()
+  if (!value) return
+  const paths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+  paths.push(value)
+  draft.value.dingtalkPersonRecipientFieldPath = Array.from(new Set(paths))
+    .map((path) => `record.${path}`)
+    .join(', ')
+  select.value = ''
+}
 
 function templateSyntaxWarnings(value: string) {
   return listDingTalkTemplateSyntaxWarnings(value)
@@ -868,7 +884,9 @@ function openEditForm(rule: AutomationRule) {
     publicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
     internalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
     dingtalkPersonUserIds: Array.isArray(rule.actionConfig?.userIds) ? rule.actionConfig?.userIds.join(', ') : '',
-    dingtalkPersonRecipientFieldPath: (rule.actionConfig?.userIdFieldPath as string) ?? '',
+    dingtalkPersonRecipientFieldPath: Array.isArray(rule.actionConfig?.userIdFieldPaths)
+      ? (rule.actionConfig?.userIdFieldPaths as string[]).join(', ')
+      : (rule.actionConfig?.userIdFieldPath as string) ?? '',
     dingtalkPersonTitleTemplate: (rule.actionConfig?.titleTemplate as string) ?? '',
     dingtalkPersonBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
     dingtalkPersonPublicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
@@ -913,12 +931,15 @@ function buildActionConfig(): Record<string, unknown> {
     }
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
+    const userIdFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+      .map((path) => `record.${path}`)
     return {
       userIds: draft.value.dingtalkPersonUserIds
         .split(/[\n,]+/)
         .map((entry) => entry.trim())
         .filter(Boolean),
-      userIdFieldPath: draft.value.dingtalkPersonRecipientFieldPath.trim() || undefined,
+      userIdFieldPath: userIdFieldPaths[0] || undefined,
+      userIdFieldPaths: userIdFieldPaths.length ? userIdFieldPaths : undefined,
       titleTemplate: draft.value.dingtalkPersonTitleTemplate,
       bodyTemplate: draft.value.dingtalkPersonBodyTemplate,
       publicFormViewId: draft.value.dingtalkPersonPublicFormViewId || undefined,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -366,20 +366,19 @@
                 placeholder="使用逗号或换行分隔本地 userId"
                 data-field="dingtalkPersonUserIds"
               ></textarea>
-              <label class="meta-rule-editor__label">Record recipient field path (optional)</label>
+              <label class="meta-rule-editor__label">Record recipient field paths (optional)</label>
               <input
                 v-model="action.config.recipientFieldPath"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="例如：record.fld_assignee 或 record.assigneeUserIds"
+                placeholder="例如：record.assigneeUserIds, record.reviewerUserId"
                 data-field="dingtalkPersonRecipientFieldPath"
               />
               <label class="meta-rule-editor__label">Pick recipient field</label>
               <select
-                :value="selectedRecipientFieldId(action.config.recipientFieldPath)"
                 class="meta-rule-editor__select"
                 data-field="dingtalkPersonRecipientFieldSelect"
-                @change="selectRecipientFieldPath(action, ($event.target as HTMLSelectElement).value)"
+                @change="appendRecipientFieldPath(action, ($event.target as HTMLSelectElement))"
               >
                 <option value="">-- choose a record field --</option>
                 <option v-for="field in props.fields" :key="field.id" :value="field.id">
@@ -387,7 +386,7 @@
                 </option>
               </select>
               <div class="meta-rule-editor__hint">
-                Record data is keyed by field ID. Use a <code>record.&lt;fieldId&gt;</code> path or choose a field above.
+                Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
               </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
@@ -651,9 +650,11 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
       userIdsText: Array.isArray(config.userIds)
         ? config.userIds.join(', ')
         : '',
-      recipientFieldPath: typeof config.userIdFieldPath === 'string'
-        ? config.userIdFieldPath
-        : '',
+      recipientFieldPath: Array.isArray(config.userIdFieldPaths)
+        ? config.userIdFieldPaths.join(', ')
+        : typeof config.userIdFieldPath === 'string'
+          ? config.userIdFieldPath
+          : '',
       userIdsSearch: '',
     }
   }
@@ -856,21 +857,40 @@ function personRecipientSummary(action: DraftAction) {
   return selected.map((item) => item.label).join(', ')
 }
 
-function recipientFieldPathSummary(value: unknown) {
-  if (typeof value !== 'string' || !value.trim()) return 'No dynamic recipient field'
-  const normalized = value.trim().replace(/^record\./, '')
-  if (!normalized) return 'No dynamic recipient field'
+function parseRecipientFieldPathsText(value: unknown): string[] {
+  if (typeof value !== 'string') return []
+  return Array.from(new Set(
+    value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim().replace(/^record\./, ''))
+      .filter(Boolean),
+  ))
+}
+
+function recipientFieldSummaryLabel(path: string) {
+  const normalized = path.trim().replace(/^record\./, '')
+  if (!normalized) return ''
   const field = props.fields.find((item) => item.id === normalized)
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
-function selectedRecipientFieldId(value: unknown) {
-  if (typeof value !== 'string' || !value.trim()) return ''
-  return value.trim().replace(/^record\./, '')
+function recipientFieldPathSummary(value: unknown) {
+  const labels = parseRecipientFieldPathsText(value)
+    .map((path) => recipientFieldSummaryLabel(path))
+    .filter(Boolean)
+  if (!labels.length) return 'No dynamic recipient field'
+  return labels.join(', ')
 }
 
-function selectRecipientFieldPath(action: DraftAction, fieldId: string) {
-  action.config.recipientFieldPath = fieldId ? `record.${fieldId}` : ''
+function appendRecipientFieldPath(action: DraftAction, select: HTMLSelectElement) {
+  const fieldId = select.value.trim()
+  if (!fieldId) return
+  const paths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+  paths.push(fieldId)
+  action.config.recipientFieldPath = Array.from(new Set(paths))
+    .map((path) => `record.${path}`)
+    .join(', ')
+  select.value = ''
 }
 
 function templateSyntaxWarnings(value: unknown) {
@@ -1015,13 +1035,14 @@ function buildPayload(): Partial<AutomationRule> {
           .map((entry) => entry.trim())
           .filter(Boolean)
         : []
+      const userIdFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+        .map((path) => `record.${path}`)
       return {
         type: action.type,
         config: {
           userIds,
-          userIdFieldPath: typeof action.config.recipientFieldPath === 'string' && action.config.recipientFieldPath.trim()
-            ? action.config.recipientFieldPath.trim()
-            : undefined,
+          userIdFieldPath: userIdFieldPaths[0] || undefined,
+          userIdFieldPaths: userIdFieldPaths.length ? userIdFieldPaths : undefined,
           titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : '',
           bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : '',
           publicFormViewId: typeof action.config.publicFormViewId === 'string' && action.config.publicFormViewId.trim()

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -436,6 +436,7 @@ describe('MetaAutomationManager', () => {
     expect(body.actionConfig).toEqual({
       userIds: [],
       userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please fill {{record.status}}',
     })
@@ -464,6 +465,59 @@ describe('MetaAutomationManager', () => {
     const summary = container.querySelector('[data-automation-summary="person"]')
     expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
     expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('can append multiple record recipient fields for DingTalk person automation', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk multi dynamic notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.fld_1')
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds', 'record.fld_1'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please fill {{record.status}}',
+    })
   })
 
   it('can search and add DingTalk person recipients before save', async () => {
@@ -705,6 +759,7 @@ describe('MetaAutomationManager', () => {
         actionConfig: {
           userIds: [],
           userIdFieldPath: 'record.assigneeUserIds',
+          userIdFieldPaths: ['record.assigneeUserIds'],
           titleTemplate: 'Ticket {{recordId}}',
           bodyTemplate: 'Please fill {{record.status}}',
         },
@@ -713,6 +768,7 @@ describe('MetaAutomationManager', () => {
           config: {
             userIds: [],
             userIdFieldPath: 'record.assigneeUserIds',
+            userIdFieldPaths: ['record.assigneeUserIds'],
             titleTemplate: 'Ticket {{recordId}}',
             bodyTemplate: 'Please fill {{record.status}}',
           },

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -401,6 +401,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(payload.actionConfig).toEqual({
       userIds: [],
       userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please review {{record.status}}',
     })
@@ -409,6 +410,7 @@ describe('MetaAutomationRuleEditor', () => {
       config: {
         userIds: [],
         userIdFieldPath: 'record.assigneeUserIds',
+        userIdFieldPaths: ['record.assigneeUserIds'],
         titleTemplate: 'Ticket {{recordId}}',
         bodyTemplate: 'Please review {{record.status}}',
       },
@@ -441,6 +443,63 @@ describe('MetaAutomationRuleEditor', () => {
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
     expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
     expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('can append multiple record recipient fields in the rule editor', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify multiple recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.fld_1')
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds', 'record.fld_1'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+    })
   })
 
   it('can search and add DingTalk person recipients', async () => {

--- a/docs/development/dingtalk-person-multi-recipient-fields-development-20260420.md
+++ b/docs/development/dingtalk-person-multi-recipient-fields-development-20260420.md
@@ -1,0 +1,49 @@
+# DingTalk Person Multi Recipient Fields Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-multi-recipient-fields-20260420`
+
+## Goal
+
+Extend `send_dingtalk_person_message` from one dynamic record recipient field to multiple fields, so a rule can notify combinations like assignee + reviewer without duplicating rules.
+
+## Scope
+
+- Backend:
+  - add optional `userIdFieldPaths` to `SendDingTalkPersonMessageConfig`
+  - keep single `userIdFieldPath` backward compatible
+  - normalize, merge, and dedupe recipients resolved from multiple record fields
+  - expose `recipientFieldPaths` in success output
+- Frontend:
+  - allow comma/newline separated dynamic recipient paths in both automation editors
+  - change field pickers from overwrite to append
+  - show multi-field summaries using field labels where possible
+  - map `userIdFieldPaths` back into edit state while still supporting legacy single-path rules
+
+## Implementation Notes
+
+- Runtime accepts both:
+  - `userIdFieldPath`
+  - `userIdFieldPaths`
+- Authoring still stores readable `record.<fieldId>` paths, but picker interactions now append instead of replace.
+- Runtime normalization strips the `record.` prefix, merges all configured fields, and removes duplicate local user IDs before DingTalk lookup.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/automation-actions.ts`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Outcome
+
+Admins can now configure a single DingTalk personal notification rule that targets:
+
+- static local users
+- one dynamic record field
+- or multiple dynamic record fields together
+
+This reduces rule duplication for multi-step fill/approve flows while keeping the existing single-field configuration valid.

--- a/docs/development/dingtalk-person-multi-recipient-fields-verification-20260420.md
+++ b/docs/development/dingtalk-person-multi-recipient-fields-verification-20260420.md
@@ -1,0 +1,36 @@
+# DingTalk Person Multi Recipient Fields Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-multi-recipient-fields-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend unit tests: `100 passed`
+- Frontend tests: `44 passed`
+- Backend build: passed
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- `send_dingtalk_person_message` still works with a legacy single `userIdFieldPath`
+- runtime merges recipients from multiple dynamic record fields and dedupes local user IDs
+- inline automation manager can append multiple recipient fields and save `userIdFieldPaths`
+- rule editor can append the same fields and emit the same payload shape
+- edit flows summarize multi-field recipients using human-readable field labels
+
+## Notes
+
+- Frontend Vitest still prints the repository's existing `WebSocket server error: Port is already in use` warning; it did not block the run.
+- Web build still prints the existing Vite chunk-size warning; no new build regression was introduced by this slice.

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -60,6 +60,7 @@ export interface SendDingTalkGroupMessageConfig {
 export interface SendDingTalkPersonMessageConfig {
   userIds: string[]
   userIdFieldPath?: string
+  userIdFieldPaths?: string[]
   titleTemplate: string
   bodyTemplate: string
   publicFormViewId?: string

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -111,10 +111,32 @@ function normalizeRecipientFieldPath(value: unknown): string {
   return trimmed.replace(/^record\./, '')
 }
 
-function resolveRecipientUserIdsFromRecord(recordData: Record<string, unknown>, fieldPath: unknown): string[] {
-  const normalizedPath = normalizeRecipientFieldPath(fieldPath)
-  if (!normalizedPath) return []
-  return normalizeUserIdsFromUnknown(lookupTemplateValue(normalizedPath, recordData))
+function normalizeRecipientFieldPaths(primary: unknown, additional: unknown): string[] {
+  const values = [
+    primary,
+    ...(Array.isArray(additional) ? additional : [additional]),
+  ]
+
+  return Array.from(new Set(
+    values
+      .flatMap((value) => {
+        if (typeof value !== 'string') return []
+        return value
+          .split(/[\n,]+/)
+          .map((entry) => normalizeRecipientFieldPath(entry))
+          .filter(Boolean)
+      }),
+  ))
+}
+
+function resolveRecipientUserIdsFromRecord(recordData: Record<string, unknown>, fieldPaths: unknown[]): string[] {
+  return Array.from(new Set(
+    fieldPaths.flatMap((fieldPath) => {
+      const normalizedPath = normalizeRecipientFieldPath(fieldPath)
+      if (!normalizedPath) return []
+      return normalizeUserIdsFromUnknown(lookupTemplateValue(normalizedPath, recordData))
+    }),
+  ))
 }
 
 function chunkItems<T>(items: T[], size: number): T[][] {
@@ -643,8 +665,8 @@ export class AutomationExecutor {
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
     const staticUserIds = normalizeUserIds(config.userIds)
-    const recipientFieldPath = normalizeRecipientFieldPath(config.userIdFieldPath)
-    const recordUserIds = resolveRecipientUserIdsFromRecord(context.recordData, recipientFieldPath)
+    const recipientFieldPaths = normalizeRecipientFieldPaths(config.userIdFieldPath, config.userIdFieldPaths)
+    const recordUserIds = resolveRecipientUserIdsFromRecord(context.recordData, recipientFieldPaths)
     const userIds = Array.from(new Set([...staticUserIds, ...recordUserIds]))
     const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
     const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
@@ -652,11 +674,11 @@ export class AutomationExecutor {
     const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
 
     if (userIds.length === 0) {
-      if (recipientFieldPath) {
+      if (recipientFieldPaths.length > 0) {
         return {
           actionType: 'send_dingtalk_person_message',
           status: 'failed',
-          error: `No local userIds resolved from record field path "${recipientFieldPath}"`,
+          error: `No local userIds resolved from record field paths: ${recipientFieldPaths.join(', ')}`,
         }
       }
       return {
@@ -844,7 +866,8 @@ export class AutomationExecutor {
           notifiedUsers: resolvedRecipients.length,
           staticRecipientCount: staticUserIds.length,
           dynamicRecipientCount: recordUserIds.length,
-          recipientFieldPath: recipientFieldPath || null,
+          recipientFieldPath: recipientFieldPaths[0] ?? null,
+          recipientFieldPaths,
           batchCount: batches.length,
           linkCount: linkLines.length,
           responseCount,

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -727,7 +727,65 @@ describe('AutomationExecutor', () => {
     })
 
     expect(result.status).toBe('failed')
-    expect(result.steps[0].error).toContain('record field path "assigneeUserIds"')
+    expect(result.steps[0].error).toContain('record field paths: assigneeUserIds')
+  })
+
+  it('merges multiple dynamic DingTalk person recipient fields from the record', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' },
+          { local_user_id: 'user_2', local_user_active: true, dingtalk_user_id: 'dt-user-2' },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIdFieldPaths: ['record.assigneeUserIds', 'record.reviewerUserId'],
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {
+        title: 'Incident',
+        status: 'open',
+        assigneeUserIds: ['user_1'],
+        reviewerUserId: 'user_2',
+      },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(result.steps[0].output).toMatchObject({
+      notifiedUsers: 2,
+      staticRecipientCount: 0,
+      dynamicRecipientCount: 2,
+      recipientFieldPath: 'assigneeUserIds',
+      recipientFieldPaths: ['assigneeUserIds', 'reviewerUserId'],
+    })
   })
 
   it('fails send_notification with no userIds', async () => {


### PR DESCRIPTION
## Summary
- extend DingTalk person automation to resolve recipients from multiple record field paths
- update both automation editors so field pickers append recipient fields instead of overwriting them
- add runtime, editor, and verification coverage for multi-field dynamic recipients

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- git diff --check