### PR TITLE
feat(dingtalk): add recipient field chips

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -257,6 +257,22 @@
                 {{ field.name }} (record.{{ field.id }})
               </option>
             </select>
+            <div
+              v-if="selectedDingTalkPersonRecipientFields.length"
+              class="meta-automation__recipient-list meta-automation__recipient-list--selected"
+            >
+              <button
+                v-for="field in selectedDingTalkPersonRecipientFields"
+                :key="field.id"
+                class="meta-automation__recipient-chip"
+                type="button"
+                :data-automation-recipient-field="field.id"
+                @click="removeDingTalkPersonRecipientField(field.id)"
+              >
+                <strong>{{ field.label }}</strong>
+                <em>Remove</em>
+              </button>
+            </div>
             <div class="meta-automation__hint">
               Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
             </div>
@@ -695,10 +711,15 @@ function recipientFieldSummaryLabel(path: string) {
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
+const selectedDingTalkPersonRecipientFields = computed(() => parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+  .map((path) => ({
+    id: path,
+    label: recipientFieldSummaryLabel(path),
+  }))
+  .filter((item) => item.label))
+
 const dingTalkPersonRecipientFieldSummary = computed(() => {
-  const labels = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
-    .map((path) => recipientFieldSummaryLabel(path))
-    .filter(Boolean)
+  const labels = selectedDingTalkPersonRecipientFields.value.map((item) => item.label)
   if (!labels.length) return 'No dynamic recipient field'
   return labels.join(', ')
 })
@@ -712,6 +733,13 @@ function appendDingTalkPersonRecipientField(select: HTMLSelectElement) {
     .map((path) => `record.${path}`)
     .join(', ')
   select.value = ''
+}
+
+function removeDingTalkPersonRecipientField(path: string) {
+  draft.value.dingtalkPersonRecipientFieldPath = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+    .filter((entry) => entry !== path)
+    .map((entry) => `record.${entry}`)
+    .join(', ')
 }
 
 function templateSyntaxWarnings(value: string) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -385,6 +385,22 @@
                   {{ field.name }} (record.{{ field.id }})
                 </option>
               </select>
+              <div
+                v-if="selectedRecipientFields(action).length"
+                class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
+              >
+                <button
+                  v-for="field in selectedRecipientFields(action)"
+                  :key="field.id"
+                  class="meta-rule-editor__recipient-chip"
+                  type="button"
+                  :data-field-recipient="field.id"
+                  @click="removeRecipientFieldPath(action, field.id)"
+                >
+                  <strong>{{ field.label }}</strong>
+                  <em>Remove</em>
+                </button>
+              </div>
               <div class="meta-rule-editor__hint">
                 Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
               </div>
@@ -874,6 +890,15 @@ function recipientFieldSummaryLabel(path: string) {
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
+function selectedRecipientFields(action: DraftAction) {
+  return parseRecipientFieldPathsText(action.config.recipientFieldPath)
+    .map((path) => ({
+      id: path,
+      label: recipientFieldSummaryLabel(path),
+    }))
+    .filter((item) => item.label)
+}
+
 function recipientFieldPathSummary(value: unknown) {
   const labels = parseRecipientFieldPathsText(value)
     .map((path) => recipientFieldSummaryLabel(path))
@@ -891,6 +916,13 @@ function appendRecipientFieldPath(action: DraftAction, select: HTMLSelectElement
     .map((path) => `record.${path}`)
     .join(', ')
   select.value = ''
+}
+
+function removeRecipientFieldPath(action: DraftAction, path: string) {
+  action.config.recipientFieldPath = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+    .filter((entry) => entry !== path)
+    .map((entry) => `record.${entry}`)
+    .join(', ')
 }
 
 function templateSyntaxWarnings(value: unknown) {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -520,6 +520,38 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('can remove a selected dynamic recipient field chip in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const firstChip = container.querySelector('[data-automation-recipient-field="assigneeUserIds"]') as HTMLButtonElement
+    expect(firstChip?.textContent).toContain('Assignees')
+    firstChip.click()
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.fld_1')
+    expect(container.querySelector('[data-automation-recipient-field="assigneeUserIds"]')).toBeNull()
+  })
+
   it('can search and add DingTalk person recipients before save', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -502,6 +502,40 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('can remove a selected dynamic recipient field chip in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const firstChip = container.querySelector('[data-field-recipient="assigneeUserIds"]') as HTMLButtonElement
+    expect(firstChip?.textContent).toContain('Assignees')
+    firstChip.click()
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.fld_1')
+    expect(container.querySelector('[data-field-recipient="assigneeUserIds"]')).toBeNull()
+  })
+
   it('can search and add DingTalk person recipients', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/docs/development/dingtalk-person-recipient-field-chips-development-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-chips-development-20260420.md
@@ -1,0 +1,41 @@
+# DingTalk Person Recipient Field Chips Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-chips-20260420`
+
+## Goal
+
+Make multi-field dynamic recipient authoring easier by showing selected recipient fields as removable chips in both automation editors.
+
+## Scope
+
+- Frontend only
+- no runtime protocol changes
+- no backend changes
+- no migration changes
+
+## Implementation Notes
+
+- Reuse the existing comma/newline based `recipientFieldPath` text state.
+- Add selected field chips below the picker:
+  - inline automation manager
+  - full automation rule editor
+- Clicking a chip removes that `record.<fieldId>` entry from the underlying text field.
+- Keep the raw text input for direct editing and backward compatibility.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Outcome
+
+Admins can now:
+
+- append multiple dynamic recipient fields with the picker
+- see which fields are currently selected
+- remove a field without manually editing the raw path string
+
+This keeps the new multi-field capability from `#948` usable without forcing admins back into raw text management.

--- a/docs/development/dingtalk-person-recipient-field-chips-verification-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-chips-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Person Recipient Field Chips Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-chips-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `46 passed`
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- inline automation manager shows selected dynamic recipient fields as chips
+- inline automation manager can remove a selected dynamic recipient field chip
+- full rule editor shows the same chip state
+- full rule editor can remove a selected dynamic recipient field chip
+
+## Notes
+
+- Frontend Vitest still emits the repository's existing `WebSocket server error: Port is already in use` warning; it did not block the run.
+- Web build still emits the repository's existing Vite chunk-size warning; no new build regression was introduced by this slice.


### PR DESCRIPTION
## Summary
- show selected dynamic DingTalk recipient fields as removable chips in both automation editors
- keep the existing text-based recipient path config while making multi-field authoring easier
- add frontend regression coverage for chip rendering and removal

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --check