### PR TITLE
feat(dingtalk): guard dynamic recipient fields

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -252,8 +252,8 @@
               data-automation-field="dingtalkPersonRecipientFieldSelect"
               @change="appendDingTalkPersonRecipientField($event.target as HTMLSelectElement)"
             >
-              <option value="">-- choose a record field --</option>
-              <option v-for="field in props.fields" :key="field.id" :value="field.id">
+              <option value="">-- choose a user field --</option>
+              <option v-for="field in dingTalkPersonRecipientCandidateFields" :key="field.id" :value="field.id">
                 {{ field.name }} (record.{{ field.id }})
               </option>
             </select>
@@ -273,8 +273,15 @@
                 <em>Remove</em>
               </button>
             </div>
+            <div
+              v-for="warning in recipientFieldPathWarnings(draft.dingtalkPersonRecipientFieldPath)"
+              :key="`draft-person-recipient-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__hint">
-              Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
+              Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths. The picker only lists user fields.
             </div>
             <label class="meta-automation__label">Title template</label>
             <input
@@ -711,12 +718,21 @@ function recipientFieldSummaryLabel(path: string) {
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
+const dingTalkPersonRecipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
+
 const selectedDingTalkPersonRecipientFields = computed(() => parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
   .map((path) => ({
     id: path,
     label: recipientFieldSummaryLabel(path),
   }))
   .filter((item) => item.label))
+
+function recipientFieldPathWarnings(value: string) {
+  const candidateIds = new Set(dingTalkPersonRecipientCandidateFields.value.map((field) => field.id))
+  return parseRecipientFieldPathsText(value)
+    .filter((path) => !candidateIds.has(path))
+    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+}
 
 const dingTalkPersonRecipientFieldSummary = computed(() => {
   const labels = selectedDingTalkPersonRecipientFields.value.map((item) => item.label)

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -380,8 +380,8 @@
                 data-field="dingtalkPersonRecipientFieldSelect"
                 @change="appendRecipientFieldPath(action, ($event.target as HTMLSelectElement))"
               >
-                <option value="">-- choose a record field --</option>
-                <option v-for="field in props.fields" :key="field.id" :value="field.id">
+                <option value="">-- choose a user field --</option>
+                <option v-for="field in recipientCandidateFields" :key="field.id" :value="field.id">
                   {{ field.name }} (record.{{ field.id }})
                 </option>
               </select>
@@ -401,8 +401,15 @@
                   <em>Remove</em>
                 </button>
               </div>
+              <div
+                v-for="warning in recipientFieldPathWarnings(action.config.recipientFieldPath)"
+                :key="`person-recipient-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__hint">
-                Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
+                Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths. The picker only lists user fields.
               </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
@@ -631,6 +638,7 @@ let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
+const recipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
 
 const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
   { value: 'equals', label: 'Equals' },
@@ -897,6 +905,13 @@ function selectedRecipientFields(action: DraftAction) {
       label: recipientFieldSummaryLabel(path),
     }))
     .filter((item) => item.label)
+}
+
+function recipientFieldPathWarnings(value: unknown) {
+  const candidateIds = new Set(recipientCandidateFields.value.map((field) => field.id))
+  return parseRecipientFieldPathsText(value)
+    .filter((path) => !candidateIds.has(path))
+    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
 }
 
 function recipientFieldPathSummary(value: unknown) {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -113,6 +113,7 @@ const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
   { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
+  { id: 'reviewerUserId', name: 'Reviewer', type: 'user' },
 ]
 
 const views = [
@@ -467,6 +468,27 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
+  it('only lists user fields in the DingTalk person recipient picker', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('assigneeUserIds')
+    expect(optionValues).toContain('reviewerUserId')
+    expect(optionValues).not.toContain('fld_1')
+  })
+
   it('can append multiple record recipient fields for DingTalk person automation', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -489,12 +511,12 @@ describe('MetaAutomationManager', () => {
     fieldSelect.value = 'assigneeUserIds'
     fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
-    fieldSelect.value = 'fld_1'
+    fieldSelect.value = 'reviewerUserId'
     fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.fld_1')
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.reviewerUserId')
 
     const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -514,7 +536,7 @@ describe('MetaAutomationManager', () => {
     expect(body.actionConfig).toEqual({
       userIds: [],
       userIdFieldPath: 'record.assigneeUserIds',
-      userIdFieldPaths: ['record.assigneeUserIds', 'record.fld_1'],
+      userIdFieldPaths: ['record.assigneeUserIds', 'record.reviewerUserId'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please fill {{record.status}}',
     })
@@ -538,7 +560,7 @@ describe('MetaAutomationManager', () => {
     fieldSelect.value = 'assigneeUserIds'
     fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
-    fieldSelect.value = 'fld_1'
+    fieldSelect.value = 'reviewerUserId'
     fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
@@ -548,7 +570,7 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(recipientFieldInput.value).toBe('record.fld_1')
+    expect(recipientFieldInput.value).toBe('record.reviewerUserId')
     expect(container.querySelector('[data-automation-recipient-field="assigneeUserIds"]')).toBeNull()
   })
 
@@ -864,6 +886,28 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Unknown placeholder {{record}}')
+  })
+
+  it('warns when a DingTalk person recipient path is not a user field in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.fld_1'
+    recipientFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.fld_1 is not a user field')
   })
 
   it('copies rendered DingTalk person body example in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -12,6 +12,7 @@ const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
   { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
+  { id: 'reviewerUserId', name: 'Reviewer', type: 'user' },
 ]
 
 const views = [
@@ -445,6 +446,29 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
+  it('only lists user fields in the DingTalk person recipient picker for the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('assigneeUserIds')
+    expect(optionValues).toContain('reviewerUserId')
+    expect(optionValues).not.toContain('fld_1')
+  })
+
   it('can append multiple record recipient fields in the rule editor', async () => {
     const saved = vi.fn()
     const client = mockClient()
@@ -472,12 +496,12 @@ describe('MetaAutomationRuleEditor', () => {
     fieldSelect.value = 'assigneeUserIds'
     fieldSelect.dispatchEvent(new Event('change'))
     await flushPromises()
-    fieldSelect.value = 'fld_1'
+    fieldSelect.value = 'reviewerUserId'
     fieldSelect.dispatchEvent(new Event('change'))
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.fld_1')
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.reviewerUserId')
 
     const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -496,7 +520,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(payload.actionConfig).toEqual({
       userIds: [],
       userIdFieldPath: 'record.assigneeUserIds',
-      userIdFieldPaths: ['record.assigneeUserIds', 'record.fld_1'],
+      userIdFieldPaths: ['record.assigneeUserIds', 'record.reviewerUserId'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please review {{record.status}}',
     })
@@ -522,7 +546,7 @@ describe('MetaAutomationRuleEditor', () => {
     fieldSelect.value = 'assigneeUserIds'
     fieldSelect.dispatchEvent(new Event('change'))
     await flushPromises()
-    fieldSelect.value = 'fld_1'
+    fieldSelect.value = 'reviewerUserId'
     fieldSelect.dispatchEvent(new Event('change'))
     await flushPromises()
 
@@ -532,7 +556,7 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(recipientFieldInput.value).toBe('record.fld_1')
+    expect(recipientFieldInput.value).toBe('record.reviewerUserId')
     expect(container.querySelector('[data-field-recipient="assigneeUserIds"]')).toBeNull()
   })
 
@@ -769,6 +793,30 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Unknown placeholder {{recoredId}}')
+  })
+
+  it('warns when a DingTalk person recipient path is not a user field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.fld_1'
+    recipientFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.fld_1 is not a user field')
   })
 
   it('copies rendered DingTalk group body example in the rule editor', async () => {

--- a/docs/development/dingtalk-person-recipient-field-guardrails-development-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-guardrails-development-20260420.md
@@ -1,0 +1,35 @@
+# DingTalk Person Recipient Field Guardrails Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-guardrails-20260420`
+
+## Goal
+
+Add authoring guardrails for dynamic DingTalk person recipient fields so admins are guided toward real user fields instead of arbitrary record paths.
+
+## Scope
+
+- Frontend only
+- no backend protocol changes
+- no migration changes
+- no runtime behavior changes
+
+## Implementation Notes
+
+- Limit the dynamic recipient field picker to fields with `type === 'user'`.
+- Keep manual text entry available for backward compatibility and advanced cases.
+- When a manually entered path points at a non-user field, show a warning instead of blocking save.
+- Update both automation editors:
+  - inline automation manager
+  - full rule editor
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Outcome
+
+Dynamic DingTalk personal notifications now guide admins toward valid user fields by default, while still preserving the existing text-based escape hatch for nonstandard record schemas.

--- a/docs/development/dingtalk-person-recipient-field-guardrails-verification-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-guardrails-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Person Recipient Field Guardrails Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-guardrails-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `50 passed`
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- recipient field pickers only list `user` fields
+- multi-field authoring still works with the user-field-only picker
+- inline automation manager warns on non-user recipient paths
+- full rule editor warns on non-user recipient paths
+
+## Notes
+
+- Frontend Vitest still emits the repository's existing `WebSocket server error: Port is already in use` warning; it did not block the run.
+- Web build still emits the repository's existing Vite chunk-size warning; no new build regression was introduced by this slice.


### PR DESCRIPTION
## Summary
- limit DingTalk person recipient pickers to user fields
- show warnings when manually entered recipient paths point at non-user fields
- add frontend regression coverage for picker filtering and warnings

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --check