### PR TITLE
feat(dingtalk): package dynamic person recipient automation

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -257,6 +257,22 @@
                 {{ field.name }} (record.{{ field.id }})
               </option>
             </select>
+            <div
+              v-if="selectedDingTalkPersonRecipientFields.length"
+              class="meta-automation__recipient-list meta-automation__recipient-list--selected"
+            >
+              <button
+                v-for="field in selectedDingTalkPersonRecipientFields"
+                :key="field.id"
+                class="meta-automation__recipient-chip"
+                type="button"
+                :data-automation-recipient-field="field.id"
+                @click="removeDingTalkPersonRecipientField(field.id)"
+              >
+                <strong>{{ field.label }}</strong>
+                <em>Remove</em>
+              </button>
+            </div>
             <div class="meta-automation__hint">
               Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
             </div>
@@ -695,10 +711,15 @@ function recipientFieldSummaryLabel(path: string) {
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
+const selectedDingTalkPersonRecipientFields = computed(() => parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+  .map((path) => ({
+    id: path,
+    label: recipientFieldSummaryLabel(path),
+  }))
+  .filter((item) => item.label))
+
 const dingTalkPersonRecipientFieldSummary = computed(() => {
-  const labels = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
-    .map((path) => recipientFieldSummaryLabel(path))
-    .filter(Boolean)
+  const labels = selectedDingTalkPersonRecipientFields.value.map((item) => item.label)
   if (!labels.length) return 'No dynamic recipient field'
   return labels.join(', ')
 })
@@ -712,6 +733,13 @@ function appendDingTalkPersonRecipientField(select: HTMLSelectElement) {
     .map((path) => `record.${path}`)
     .join(', ')
   select.value = ''
+}
+
+function removeDingTalkPersonRecipientField(path: string) {
+  draft.value.dingtalkPersonRecipientFieldPath = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+    .filter((entry) => entry !== path)
+    .map((entry) => `record.${entry}`)
+    .join(', ')
 }
 
 function templateSyntaxWarnings(value: string) {

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -243,11 +243,22 @@
               v-model="draft.dingtalkPersonRecipientFieldPath"
               class="meta-automation__input"
               type="text"
-              placeholder="例如：record.assigneeUserIds"
+              placeholder="例如：record.fld_assignee 或 record.assigneeUserIds"
               data-automation-field="dingtalkPersonRecipientFieldPath"
             />
+            <label class="meta-automation__label">Pick recipient field</label>
+            <select
+              v-model="dingTalkPersonRecipientFieldId"
+              class="meta-automation__select"
+              data-automation-field="dingtalkPersonRecipientFieldSelect"
+            >
+              <option value="">-- choose a record field --</option>
+              <option v-for="field in props.fields" :key="field.id" :value="field.id">
+                {{ field.name }} (record.{{ field.id }})
+              </option>
+            </select>
             <div class="meta-automation__hint">
-              Supports `record.xxx` paths that resolve to one userId, a comma-separated string, or a userId array.
+              Record data is keyed by field ID. Use a <code>record.&lt;fieldId&gt;</code> path or choose a field above.
             </div>
             <label class="meta-automation__label">Title template</label>
             <input
@@ -672,7 +683,19 @@ const dingTalkPersonRecipientFieldSummary = computed(() => {
   const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
   if (!trimmed) return 'No dynamic recipient field'
   const normalized = trimmed.replace(/^record\./, '')
-  return normalized ? `record.${normalized}` : 'No dynamic recipient field'
+  if (!normalized) return 'No dynamic recipient field'
+  const field = props.fields.find((item) => item.id === normalized)
+  return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
+})
+
+const dingTalkPersonRecipientFieldId = computed({
+  get() {
+    const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
+    return trimmed ? trimmed.replace(/^record\./, '') : ''
+  },
+  set(value: string) {
+    draft.value.dingtalkPersonRecipientFieldPath = value ? `record.${value}` : ''
+  },
 })
 
 function templateSyntaxWarnings(value: string) {

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -238,6 +238,17 @@
               placeholder="使用逗号或换行分隔本地 userId"
               data-automation-field="dingtalkPersonUserIds"
             ></textarea>
+            <label class="meta-automation__label">Record recipient field path (optional)</label>
+            <input
+              v-model="draft.dingtalkPersonRecipientFieldPath"
+              class="meta-automation__input"
+              type="text"
+              placeholder="例如：record.assigneeUserIds"
+              data-automation-field="dingtalkPersonRecipientFieldPath"
+            />
+            <div class="meta-automation__hint">
+              Supports `record.xxx` paths that resolve to one userId, a comma-separated string, or a userId array.
+            </div>
             <label class="meta-automation__label">Title template</label>
             <input
               v-model="draft.dingtalkPersonTitleTemplate"
@@ -307,6 +318,7 @@
             <div class="meta-automation__preview" data-automation-summary="person">
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
+              <div><strong>Record recipients:</strong> {{ dingTalkPersonRecipientFieldSummary }}</div>
               <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
               <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
               <div class="meta-automation__preview-line">
@@ -499,6 +511,7 @@ interface DraftState {
   publicFormViewId: string
   internalViewId: string
   dingtalkPersonUserIds: string
+  dingtalkPersonRecipientFieldPath: string
   dingtalkPersonTitleTemplate: string
   dingtalkPersonBodyTemplate: string
   dingtalkPersonPublicFormViewId: string
@@ -520,6 +533,7 @@ function emptyDraft(): DraftState {
     publicFormViewId: '',
     internalViewId: '',
     dingtalkPersonUserIds: '',
+    dingtalkPersonRecipientFieldPath: '',
     dingtalkPersonTitleTemplate: '',
     dingtalkPersonBodyTemplate: '',
     dingtalkPersonPublicFormViewId: '',
@@ -652,6 +666,13 @@ function copyPreviewText(key: string, text: string) {
 const dingTalkPersonRecipientSummary = computed(() => {
   if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
   return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
+})
+
+const dingTalkPersonRecipientFieldSummary = computed(() => {
+  const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
+  if (!trimmed) return 'No dynamic recipient field'
+  const normalized = trimmed.replace(/^record\./, '')
+  return normalized ? `record.${normalized}` : 'No dynamic recipient field'
 })
 
 function templateSyntaxWarnings(value: string) {
@@ -792,7 +813,7 @@ const canSave = computed(() => {
     if (!draft.value.dingtalkBodyTemplate.trim()) return false
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
-    if (!draft.value.dingtalkPersonUserIds.trim()) return false
+    if (!draft.value.dingtalkPersonUserIds.trim() && !draft.value.dingtalkPersonRecipientFieldPath.trim()) return false
     if (!draft.value.dingtalkPersonTitleTemplate.trim()) return false
     if (!draft.value.dingtalkPersonBodyTemplate.trim()) return false
   }
@@ -824,6 +845,7 @@ function openEditForm(rule: AutomationRule) {
     publicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
     internalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
     dingtalkPersonUserIds: Array.isArray(rule.actionConfig?.userIds) ? rule.actionConfig?.userIds.join(', ') : '',
+    dingtalkPersonRecipientFieldPath: (rule.actionConfig?.userIdFieldPath as string) ?? '',
     dingtalkPersonTitleTemplate: (rule.actionConfig?.titleTemplate as string) ?? '',
     dingtalkPersonBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
     dingtalkPersonPublicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
@@ -873,6 +895,7 @@ function buildActionConfig(): Record<string, unknown> {
         .split(/[\n,]+/)
         .map((entry) => entry.trim())
         .filter(Boolean),
+      userIdFieldPath: draft.value.dingtalkPersonRecipientFieldPath.trim() || undefined,
       titleTemplate: draft.value.dingtalkPersonTitleTemplate,
       bodyTemplate: draft.value.dingtalkPersonBodyTemplate,
       publicFormViewId: draft.value.dingtalkPersonPublicFormViewId || undefined,

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -238,19 +238,19 @@
               placeholder="使用逗号或换行分隔本地 userId"
               data-automation-field="dingtalkPersonUserIds"
             ></textarea>
-            <label class="meta-automation__label">Record recipient field path (optional)</label>
+            <label class="meta-automation__label">Record recipient field paths (optional)</label>
             <input
               v-model="draft.dingtalkPersonRecipientFieldPath"
               class="meta-automation__input"
               type="text"
-              placeholder="例如：record.fld_assignee 或 record.assigneeUserIds"
+              placeholder="例如：record.assigneeUserIds, record.reviewerUserId"
               data-automation-field="dingtalkPersonRecipientFieldPath"
             />
             <label class="meta-automation__label">Pick recipient field</label>
             <select
-              v-model="dingTalkPersonRecipientFieldId"
               class="meta-automation__select"
               data-automation-field="dingtalkPersonRecipientFieldSelect"
+              @change="appendDingTalkPersonRecipientField($event.target as HTMLSelectElement)"
             >
               <option value="">-- choose a record field --</option>
               <option v-for="field in props.fields" :key="field.id" :value="field.id">
@@ -258,7 +258,7 @@
               </option>
             </select>
             <div class="meta-automation__hint">
-              Record data is keyed by field ID. Use a <code>record.&lt;fieldId&gt;</code> path or choose a field above.
+              Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
             </div>
             <label class="meta-automation__label">Title template</label>
             <input
@@ -679,24 +679,40 @@ const dingTalkPersonRecipientSummary = computed(() => {
   return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
 })
 
-const dingTalkPersonRecipientFieldSummary = computed(() => {
-  const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
-  if (!trimmed) return 'No dynamic recipient field'
-  const normalized = trimmed.replace(/^record\./, '')
-  if (!normalized) return 'No dynamic recipient field'
+function parseRecipientFieldPathsText(value: string): string[] {
+  return Array.from(new Set(
+    value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim().replace(/^record\./, ''))
+      .filter(Boolean),
+  ))
+}
+
+function recipientFieldSummaryLabel(path: string) {
+  const normalized = path.trim().replace(/^record\./, '')
+  if (!normalized) return ''
   const field = props.fields.find((item) => item.id === normalized)
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
+}
+
+const dingTalkPersonRecipientFieldSummary = computed(() => {
+  const labels = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+    .map((path) => recipientFieldSummaryLabel(path))
+    .filter(Boolean)
+  if (!labels.length) return 'No dynamic recipient field'
+  return labels.join(', ')
 })
 
-const dingTalkPersonRecipientFieldId = computed({
-  get() {
-    const trimmed = draft.value.dingtalkPersonRecipientFieldPath.trim()
-    return trimmed ? trimmed.replace(/^record\./, '') : ''
-  },
-  set(value: string) {
-    draft.value.dingtalkPersonRecipientFieldPath = value ? `record.${value}` : ''
-  },
-})
+function appendDingTalkPersonRecipientField(select: HTMLSelectElement) {
+  const value = select.value.trim()
+  if (!value) return
+  const paths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+  paths.push(value)
+  draft.value.dingtalkPersonRecipientFieldPath = Array.from(new Set(paths))
+    .map((path) => `record.${path}`)
+    .join(', ')
+  select.value = ''
+}
 
 function templateSyntaxWarnings(value: string) {
   return listDingTalkTemplateSyntaxWarnings(value)
@@ -868,7 +884,9 @@ function openEditForm(rule: AutomationRule) {
     publicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
     internalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
     dingtalkPersonUserIds: Array.isArray(rule.actionConfig?.userIds) ? rule.actionConfig?.userIds.join(', ') : '',
-    dingtalkPersonRecipientFieldPath: (rule.actionConfig?.userIdFieldPath as string) ?? '',
+    dingtalkPersonRecipientFieldPath: Array.isArray(rule.actionConfig?.userIdFieldPaths)
+      ? (rule.actionConfig?.userIdFieldPaths as string[]).join(', ')
+      : (rule.actionConfig?.userIdFieldPath as string) ?? '',
     dingtalkPersonTitleTemplate: (rule.actionConfig?.titleTemplate as string) ?? '',
     dingtalkPersonBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
     dingtalkPersonPublicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
@@ -913,12 +931,15 @@ function buildActionConfig(): Record<string, unknown> {
     }
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
+    const userIdFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+      .map((path) => `record.${path}`)
     return {
       userIds: draft.value.dingtalkPersonUserIds
         .split(/[\n,]+/)
         .map((entry) => entry.trim())
         .filter(Boolean),
-      userIdFieldPath: draft.value.dingtalkPersonRecipientFieldPath.trim() || undefined,
+      userIdFieldPath: userIdFieldPaths[0] || undefined,
+      userIdFieldPaths: userIdFieldPaths.length ? userIdFieldPaths : undefined,
       titleTemplate: draft.value.dingtalkPersonTitleTemplate,
       bodyTemplate: draft.value.dingtalkPersonBodyTemplate,
       publicFormViewId: draft.value.dingtalkPersonPublicFormViewId || undefined,

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -252,8 +252,8 @@
               data-automation-field="dingtalkPersonRecipientFieldSelect"
               @change="appendDingTalkPersonRecipientField($event.target as HTMLSelectElement)"
             >
-              <option value="">-- choose a record field --</option>
-              <option v-for="field in props.fields" :key="field.id" :value="field.id">
+              <option value="">-- choose a user field --</option>
+              <option v-for="field in dingTalkPersonRecipientCandidateFields" :key="field.id" :value="field.id">
                 {{ field.name }} (record.{{ field.id }})
               </option>
             </select>
@@ -273,8 +273,15 @@
                 <em>Remove</em>
               </button>
             </div>
+            <div
+              v-for="warning in recipientFieldPathWarnings(draft.dingtalkPersonRecipientFieldPath)"
+              :key="`draft-person-recipient-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__hint">
-              Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
+              Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths. The picker only lists user fields.
             </div>
             <label class="meta-automation__label">Title template</label>
             <input
@@ -711,12 +718,21 @@ function recipientFieldSummaryLabel(path: string) {
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
+const dingTalkPersonRecipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
+
 const selectedDingTalkPersonRecipientFields = computed(() => parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
   .map((path) => ({
     id: path,
     label: recipientFieldSummaryLabel(path),
   }))
   .filter((item) => item.label))
+
+function recipientFieldPathWarnings(value: string) {
+  const candidateIds = new Set(dingTalkPersonRecipientCandidateFields.value.map((field) => field.id))
+  return parseRecipientFieldPathsText(value)
+    .filter((path) => !candidateIds.has(path))
+    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+}
 
 const dingTalkPersonRecipientFieldSummary = computed(() => {
   const labels = selectedDingTalkPersonRecipientFields.value.map((item) => item.label)

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -385,6 +385,22 @@
                   {{ field.name }} (record.{{ field.id }})
                 </option>
               </select>
+              <div
+                v-if="selectedRecipientFields(action).length"
+                class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
+              >
+                <button
+                  v-for="field in selectedRecipientFields(action)"
+                  :key="field.id"
+                  class="meta-rule-editor__recipient-chip"
+                  type="button"
+                  :data-field-recipient="field.id"
+                  @click="removeRecipientFieldPath(action, field.id)"
+                >
+                  <strong>{{ field.label }}</strong>
+                  <em>Remove</em>
+                </button>
+              </div>
               <div class="meta-rule-editor__hint">
                 Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
               </div>
@@ -874,6 +890,15 @@ function recipientFieldSummaryLabel(path: string) {
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
+function selectedRecipientFields(action: DraftAction) {
+  return parseRecipientFieldPathsText(action.config.recipientFieldPath)
+    .map((path) => ({
+      id: path,
+      label: recipientFieldSummaryLabel(path),
+    }))
+    .filter((item) => item.label)
+}
+
 function recipientFieldPathSummary(value: unknown) {
   const labels = parseRecipientFieldPathsText(value)
     .map((path) => recipientFieldSummaryLabel(path))
@@ -891,6 +916,13 @@ function appendRecipientFieldPath(action: DraftAction, select: HTMLSelectElement
     .map((path) => `record.${path}`)
     .join(', ')
   select.value = ''
+}
+
+function removeRecipientFieldPath(action: DraftAction, path: string) {
+  action.config.recipientFieldPath = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+    .filter((entry) => entry !== path)
+    .map((entry) => `record.${entry}`)
+    .join(', ')
 }
 
 function templateSyntaxWarnings(value: unknown) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -380,8 +380,8 @@
                 data-field="dingtalkPersonRecipientFieldSelect"
                 @change="appendRecipientFieldPath(action, ($event.target as HTMLSelectElement))"
               >
-                <option value="">-- choose a record field --</option>
-                <option v-for="field in props.fields" :key="field.id" :value="field.id">
+                <option value="">-- choose a user field --</option>
+                <option v-for="field in recipientCandidateFields" :key="field.id" :value="field.id">
                   {{ field.name }} (record.{{ field.id }})
                 </option>
               </select>
@@ -401,8 +401,15 @@
                   <em>Remove</em>
                 </button>
               </div>
+              <div
+                v-for="warning in recipientFieldPathWarnings(action.config.recipientFieldPath)"
+                :key="`person-recipient-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__hint">
-                Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
+                Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths. The picker only lists user fields.
               </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
@@ -631,6 +638,7 @@ let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
+const recipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
 
 const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
   { value: 'equals', label: 'Equals' },
@@ -897,6 +905,13 @@ function selectedRecipientFields(action: DraftAction) {
       label: recipientFieldSummaryLabel(path),
     }))
     .filter((item) => item.label)
+}
+
+function recipientFieldPathWarnings(value: unknown) {
+  const candidateIds = new Set(recipientCandidateFields.value.map((field) => field.id))
+  return parseRecipientFieldPathsText(value)
+    .filter((path) => !candidateIds.has(path))
+    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
 }
 
 function recipientFieldPathSummary(value: unknown) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -371,11 +371,23 @@
                 v-model="action.config.recipientFieldPath"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="例如：record.assigneeUserIds"
+                placeholder="例如：record.fld_assignee 或 record.assigneeUserIds"
                 data-field="dingtalkPersonRecipientFieldPath"
               />
+              <label class="meta-rule-editor__label">Pick recipient field</label>
+              <select
+                :value="selectedRecipientFieldId(action.config.recipientFieldPath)"
+                class="meta-rule-editor__select"
+                data-field="dingtalkPersonRecipientFieldSelect"
+                @change="selectRecipientFieldPath(action, ($event.target as HTMLSelectElement).value)"
+              >
+                <option value="">-- choose a record field --</option>
+                <option v-for="field in props.fields" :key="field.id" :value="field.id">
+                  {{ field.name }} (record.{{ field.id }})
+                </option>
+              </select>
               <div class="meta-rule-editor__hint">
-                Supports `record.xxx` paths that resolve to one userId, a comma-separated string, or a userId array.
+                Record data is keyed by field ID. Use a <code>record.&lt;fieldId&gt;</code> path or choose a field above.
               </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
@@ -847,7 +859,18 @@ function personRecipientSummary(action: DraftAction) {
 function recipientFieldPathSummary(value: unknown) {
   if (typeof value !== 'string' || !value.trim()) return 'No dynamic recipient field'
   const normalized = value.trim().replace(/^record\./, '')
-  return normalized ? `record.${normalized}` : 'No dynamic recipient field'
+  if (!normalized) return 'No dynamic recipient field'
+  const field = props.fields.find((item) => item.id === normalized)
+  return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
+}
+
+function selectedRecipientFieldId(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return ''
+  return value.trim().replace(/^record\./, '')
+}
+
+function selectRecipientFieldPath(action: DraftAction, fieldId: string) {
+  action.config.recipientFieldPath = fieldId ? `record.${fieldId}` : ''
 }
 
 function templateSyntaxWarnings(value: unknown) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -366,20 +366,19 @@
                 placeholder="使用逗号或换行分隔本地 userId"
                 data-field="dingtalkPersonUserIds"
               ></textarea>
-              <label class="meta-rule-editor__label">Record recipient field path (optional)</label>
+              <label class="meta-rule-editor__label">Record recipient field paths (optional)</label>
               <input
                 v-model="action.config.recipientFieldPath"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="例如：record.fld_assignee 或 record.assigneeUserIds"
+                placeholder="例如：record.assigneeUserIds, record.reviewerUserId"
                 data-field="dingtalkPersonRecipientFieldPath"
               />
               <label class="meta-rule-editor__label">Pick recipient field</label>
               <select
-                :value="selectedRecipientFieldId(action.config.recipientFieldPath)"
                 class="meta-rule-editor__select"
                 data-field="dingtalkPersonRecipientFieldSelect"
-                @change="selectRecipientFieldPath(action, ($event.target as HTMLSelectElement).value)"
+                @change="appendRecipientFieldPath(action, ($event.target as HTMLSelectElement))"
               >
                 <option value="">-- choose a record field --</option>
                 <option v-for="field in props.fields" :key="field.id" :value="field.id">
@@ -387,7 +386,7 @@
                 </option>
               </select>
               <div class="meta-rule-editor__hint">
-                Record data is keyed by field ID. Use a <code>record.&lt;fieldId&gt;</code> path or choose a field above.
+                Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths, or append fields above.
               </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
@@ -651,9 +650,11 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
       userIdsText: Array.isArray(config.userIds)
         ? config.userIds.join(', ')
         : '',
-      recipientFieldPath: typeof config.userIdFieldPath === 'string'
-        ? config.userIdFieldPath
-        : '',
+      recipientFieldPath: Array.isArray(config.userIdFieldPaths)
+        ? config.userIdFieldPaths.join(', ')
+        : typeof config.userIdFieldPath === 'string'
+          ? config.userIdFieldPath
+          : '',
       userIdsSearch: '',
     }
   }
@@ -856,21 +857,40 @@ function personRecipientSummary(action: DraftAction) {
   return selected.map((item) => item.label).join(', ')
 }
 
-function recipientFieldPathSummary(value: unknown) {
-  if (typeof value !== 'string' || !value.trim()) return 'No dynamic recipient field'
-  const normalized = value.trim().replace(/^record\./, '')
-  if (!normalized) return 'No dynamic recipient field'
+function parseRecipientFieldPathsText(value: unknown): string[] {
+  if (typeof value !== 'string') return []
+  return Array.from(new Set(
+    value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim().replace(/^record\./, ''))
+      .filter(Boolean),
+  ))
+}
+
+function recipientFieldSummaryLabel(path: string) {
+  const normalized = path.trim().replace(/^record\./, '')
+  if (!normalized) return ''
   const field = props.fields.find((item) => item.id === normalized)
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
-function selectedRecipientFieldId(value: unknown) {
-  if (typeof value !== 'string' || !value.trim()) return ''
-  return value.trim().replace(/^record\./, '')
+function recipientFieldPathSummary(value: unknown) {
+  const labels = parseRecipientFieldPathsText(value)
+    .map((path) => recipientFieldSummaryLabel(path))
+    .filter(Boolean)
+  if (!labels.length) return 'No dynamic recipient field'
+  return labels.join(', ')
 }
 
-function selectRecipientFieldPath(action: DraftAction, fieldId: string) {
-  action.config.recipientFieldPath = fieldId ? `record.${fieldId}` : ''
+function appendRecipientFieldPath(action: DraftAction, select: HTMLSelectElement) {
+  const fieldId = select.value.trim()
+  if (!fieldId) return
+  const paths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+  paths.push(fieldId)
+  action.config.recipientFieldPath = Array.from(new Set(paths))
+    .map((path) => `record.${path}`)
+    .join(', ')
+  select.value = ''
 }
 
 function templateSyntaxWarnings(value: unknown) {
@@ -1015,13 +1035,14 @@ function buildPayload(): Partial<AutomationRule> {
           .map((entry) => entry.trim())
           .filter(Boolean)
         : []
+      const userIdFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+        .map((path) => `record.${path}`)
       return {
         type: action.type,
         config: {
           userIds,
-          userIdFieldPath: typeof action.config.recipientFieldPath === 'string' && action.config.recipientFieldPath.trim()
-            ? action.config.recipientFieldPath.trim()
-            : undefined,
+          userIdFieldPath: userIdFieldPaths[0] || undefined,
+          userIdFieldPaths: userIdFieldPaths.length ? userIdFieldPaths : undefined,
           titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : '',
           bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : '',
           publicFormViewId: typeof action.config.publicFormViewId === 'string' && action.config.publicFormViewId.trim()

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -366,6 +366,17 @@
                 placeholder="使用逗号或换行分隔本地 userId"
                 data-field="dingtalkPersonUserIds"
               ></textarea>
+              <label class="meta-rule-editor__label">Record recipient field path (optional)</label>
+              <input
+                v-model="action.config.recipientFieldPath"
+                class="meta-rule-editor__input"
+                type="text"
+                placeholder="例如：record.assigneeUserIds"
+                data-field="dingtalkPersonRecipientFieldPath"
+              />
+              <div class="meta-rule-editor__hint">
+                Supports `record.xxx` paths that resolve to one userId, a comma-separated string, or a userId array.
+              </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
                 v-model="action.config.titleTemplate"
@@ -443,6 +454,7 @@
               <div class="meta-rule-editor__preview" data-field="personMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
+                <div><strong>Record recipients:</strong> {{ recipientFieldPathSummary(action.config.recipientFieldPath) }}</div>
                 <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
                 <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
                 <div class="meta-rule-editor__preview-line">
@@ -539,6 +551,7 @@ type DraftActionConfig = Record<string, unknown> & {
   userId?: string
   userIdsText?: string
   userIdsSearch?: string
+  recipientFieldPath?: string
   message?: string
   destinationId?: string
   titleTemplate?: string
@@ -626,6 +639,9 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
       userIdsText: Array.isArray(config.userIds)
         ? config.userIds.join(', ')
         : '',
+      recipientFieldPath: typeof config.userIdFieldPath === 'string'
+        ? config.userIdFieldPath
+        : '',
       userIdsSearch: '',
     }
   }
@@ -686,9 +702,10 @@ const canSave = computed(() => {
     }
     if (action.type === 'send_dingtalk_person_message') {
       const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
+      const recipientFieldPath = typeof action.config.recipientFieldPath === 'string' ? action.config.recipientFieldPath.trim() : ''
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if (!userIdsText || !titleTemplate || !bodyTemplate) return false
+      if ((!userIdsText && !recipientFieldPath) || !titleTemplate || !bodyTemplate) return false
     }
   }
   return true
@@ -827,6 +844,12 @@ function personRecipientSummary(action: DraftAction) {
   return selected.map((item) => item.label).join(', ')
 }
 
+function recipientFieldPathSummary(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return 'No dynamic recipient field'
+  const normalized = value.trim().replace(/^record\./, '')
+  return normalized ? `record.${normalized}` : 'No dynamic recipient field'
+}
+
 function templateSyntaxWarnings(value: unknown) {
   return typeof value === 'string' ? listDingTalkTemplateSyntaxWarnings(value) : []
 }
@@ -909,6 +932,7 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
       return {
         userIdsText: '',
         userIdsSearch: '',
+        recipientFieldPath: '',
         titleTemplate: '',
         bodyTemplate: '',
         publicFormViewId: '',
@@ -972,6 +996,9 @@ function buildPayload(): Partial<AutomationRule> {
         type: action.type,
         config: {
           userIds,
+          userIdFieldPath: typeof action.config.recipientFieldPath === 'string' && action.config.recipientFieldPath.trim()
+            ? action.config.recipientFieldPath.trim()
+            : undefined,
           titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : '',
           bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : '',
           publicFormViewId: typeof action.config.publicFormViewId === 'string' && action.config.publicFormViewId.trim()

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -436,6 +436,7 @@ describe('MetaAutomationManager', () => {
     expect(body.actionConfig).toEqual({
       userIds: [],
       userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please fill {{record.status}}',
     })
@@ -464,6 +465,59 @@ describe('MetaAutomationManager', () => {
     const summary = container.querySelector('[data-automation-summary="person"]')
     expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
     expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('can append multiple record recipient fields for DingTalk person automation', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk multi dynamic notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.fld_1')
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds', 'record.fld_1'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please fill {{record.status}}',
+    })
   })
 
   it('can search and add DingTalk person recipients before save', async () => {
@@ -705,6 +759,7 @@ describe('MetaAutomationManager', () => {
         actionConfig: {
           userIds: [],
           userIdFieldPath: 'record.assigneeUserIds',
+          userIdFieldPaths: ['record.assigneeUserIds'],
           titleTemplate: 'Ticket {{recordId}}',
           bodyTemplate: 'Please fill {{record.status}}',
         },
@@ -713,6 +768,7 @@ describe('MetaAutomationManager', () => {
           config: {
             userIds: [],
             userIdFieldPath: 'record.assigneeUserIds',
+            userIdFieldPaths: ['record.assigneeUserIds'],
             titleTemplate: 'Ticket {{recordId}}',
             bodyTemplate: 'Please fill {{record.status}}',
           },

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -389,6 +389,57 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('creates DingTalk person automation with only a dynamic record recipient path', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk dynamic notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.assigneeUserIds'
+    recipientFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(summary?.textContent).toContain('Record recipients:')
+    expect(summary?.textContent).toContain('record.assigneeUserIds')
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please fill {{record.status}}',
+    })
+  })
+
   it('can search and add DingTalk person recipients before save', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -592,6 +643,10 @@ describe('MetaAutomationManager', () => {
     actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.assigneeUserIds'
+    recipientFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
     const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
     userIdsInput.value = 'user_1'
     userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
@@ -611,8 +666,46 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Handle {{record.xxx}}')
     expect(summary?.textContent).toContain('Need action record_demo_001')
     expect(summary?.textContent).toContain('Handle 示例字段值')
+    expect(summary?.textContent).toContain('record.assigneeUserIds')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
+  })
+
+  it('loads dynamic record recipient path into the edit form', async () => {
+    const rules = [
+      fakeRule({
+        id: 'rule_dynamic',
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: [],
+          userIdFieldPath: 'record.assigneeUserIds',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            userIdFieldPath: 'record.assigneeUserIds',
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please fill {{record.status}}',
+          },
+        }],
+      }),
+    ]
+    const { client } = mockClient(rules)
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const editBtn = container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement
+    expect(editBtn).toBeTruthy()
+    editBtn.click()
+    await flushPromises()
+
+    const recipientFieldInput = document.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
+    expect(document.body.textContent).toContain('Record recipients:')
+    expect(document.body.textContent).toContain('record.assigneeUserIds')
   })
 
   it('shows DingTalk template syntax warnings in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -113,6 +113,7 @@ const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
   { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
+  { id: 'reviewerUserId', name: 'Reviewer', type: 'user' },
 ]
 
 const views = [
@@ -467,6 +468,27 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
+  it('only lists user fields in the DingTalk person recipient picker', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('assigneeUserIds')
+    expect(optionValues).toContain('reviewerUserId')
+    expect(optionValues).not.toContain('fld_1')
+  })
+
   it('can append multiple record recipient fields for DingTalk person automation', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -489,12 +511,12 @@ describe('MetaAutomationManager', () => {
     fieldSelect.value = 'assigneeUserIds'
     fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
-    fieldSelect.value = 'fld_1'
+    fieldSelect.value = 'reviewerUserId'
     fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.fld_1')
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.reviewerUserId')
 
     const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -514,7 +536,7 @@ describe('MetaAutomationManager', () => {
     expect(body.actionConfig).toEqual({
       userIds: [],
       userIdFieldPath: 'record.assigneeUserIds',
-      userIdFieldPaths: ['record.assigneeUserIds', 'record.fld_1'],
+      userIdFieldPaths: ['record.assigneeUserIds', 'record.reviewerUserId'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please fill {{record.status}}',
     })
@@ -538,7 +560,7 @@ describe('MetaAutomationManager', () => {
     fieldSelect.value = 'assigneeUserIds'
     fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
-    fieldSelect.value = 'fld_1'
+    fieldSelect.value = 'reviewerUserId'
     fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
@@ -548,7 +570,7 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(recipientFieldInput.value).toBe('record.fld_1')
+    expect(recipientFieldInput.value).toBe('record.reviewerUserId')
     expect(container.querySelector('[data-automation-recipient-field="assigneeUserIds"]')).toBeNull()
   })
 
@@ -864,6 +886,28 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Unknown placeholder {{record}}')
+  })
+
+  it('warns when a DingTalk person recipient path is not a user field in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.fld_1'
+    recipientFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.fld_1 is not a user field')
   })
 
   it('copies rendered DingTalk person body example in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -520,6 +520,38 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('can remove a selected dynamic recipient field chip in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const firstChip = container.querySelector('[data-automation-recipient-field="assigneeUserIds"]') as HTMLButtonElement
+    expect(firstChip?.textContent).toContain('Assignees')
+    firstChip.click()
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.fld_1')
+    expect(container.querySelector('[data-automation-recipient-field="assigneeUserIds"]')).toBeNull()
+  })
+
   it('can search and add DingTalk person recipients before save', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -112,6 +112,7 @@ function mount(props: Record<string, unknown>) {
 const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
+  { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
 ]
 
 const views = [
@@ -440,6 +441,31 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('can pick a record recipient field for DingTalk person automation', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
+    expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
   it('can search and add DingTalk person recipients before save', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -666,7 +692,7 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Handle {{record.xxx}}')
     expect(summary?.textContent).toContain('Need action record_demo_001')
     expect(summary?.textContent).toContain('Handle 示例字段值')
-    expect(summary?.textContent).toContain('record.assigneeUserIds')
+    expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })
@@ -705,7 +731,7 @@ describe('MetaAutomationManager', () => {
     const recipientFieldInput = document.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
     expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
     expect(document.body.textContent).toContain('Record recipients:')
-    expect(document.body.textContent).toContain('record.assigneeUserIds')
+    expect(document.body.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
   it('shows DingTalk template syntax warnings in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -11,6 +11,7 @@ import type { AutomationRule } from '../src/multitable/types'
 const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
+  { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
 ]
 
 const views = [
@@ -413,7 +414,33 @@ describe('MetaAutomationRuleEditor', () => {
       },
     })
     expect(container.textContent).toContain('Record recipients:')
-    expect(container.textContent).toContain('record.assigneeUserIds')
+    expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('can pick a record recipient field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
+    expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
   it('can search and add DingTalk person recipients', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -401,6 +401,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(payload.actionConfig).toEqual({
       userIds: [],
       userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please review {{record.status}}',
     })
@@ -409,6 +410,7 @@ describe('MetaAutomationRuleEditor', () => {
       config: {
         userIds: [],
         userIdFieldPath: 'record.assigneeUserIds',
+        userIdFieldPaths: ['record.assigneeUserIds'],
         titleTemplate: 'Ticket {{recordId}}',
         bodyTemplate: 'Please review {{record.status}}',
       },
@@ -441,6 +443,63 @@ describe('MetaAutomationRuleEditor', () => {
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
     expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
     expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('can append multiple record recipient fields in the rule editor', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify multiple recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.fld_1')
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds', 'record.fld_1'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+    })
   })
 
   it('can search and add DingTalk person recipients', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -354,6 +354,68 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('emits DingTalk person action config with only a dynamic record recipient path', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify dynamic recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.assigneeUserIds'
+    recipientFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_dingtalk_person_message',
+      config: {
+        userIds: [],
+        userIdFieldPath: 'record.assigneeUserIds',
+        titleTemplate: 'Ticket {{recordId}}',
+        bodyTemplate: 'Please review {{record.status}}',
+      },
+    })
+    expect(container.textContent).toContain('Record recipients:')
+    expect(container.textContent).toContain('record.assigneeUserIds')
+  })
+
   it('can search and add DingTalk person recipients', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -12,6 +12,7 @@ const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
   { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
+  { id: 'reviewerUserId', name: 'Reviewer', type: 'user' },
 ]
 
 const views = [
@@ -445,6 +446,29 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
+  it('only lists user fields in the DingTalk person recipient picker for the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('assigneeUserIds')
+    expect(optionValues).toContain('reviewerUserId')
+    expect(optionValues).not.toContain('fld_1')
+  })
+
   it('can append multiple record recipient fields in the rule editor', async () => {
     const saved = vi.fn()
     const client = mockClient()
@@ -472,12 +496,12 @@ describe('MetaAutomationRuleEditor', () => {
     fieldSelect.value = 'assigneeUserIds'
     fieldSelect.dispatchEvent(new Event('change'))
     await flushPromises()
-    fieldSelect.value = 'fld_1'
+    fieldSelect.value = 'reviewerUserId'
     fieldSelect.dispatchEvent(new Event('change'))
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.fld_1')
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds, record.reviewerUserId')
 
     const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -496,7 +520,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(payload.actionConfig).toEqual({
       userIds: [],
       userIdFieldPath: 'record.assigneeUserIds',
-      userIdFieldPaths: ['record.assigneeUserIds', 'record.fld_1'],
+      userIdFieldPaths: ['record.assigneeUserIds', 'record.reviewerUserId'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please review {{record.status}}',
     })
@@ -522,7 +546,7 @@ describe('MetaAutomationRuleEditor', () => {
     fieldSelect.value = 'assigneeUserIds'
     fieldSelect.dispatchEvent(new Event('change'))
     await flushPromises()
-    fieldSelect.value = 'fld_1'
+    fieldSelect.value = 'reviewerUserId'
     fieldSelect.dispatchEvent(new Event('change'))
     await flushPromises()
 
@@ -532,7 +556,7 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(recipientFieldInput.value).toBe('record.fld_1')
+    expect(recipientFieldInput.value).toBe('record.reviewerUserId')
     expect(container.querySelector('[data-field-recipient="assigneeUserIds"]')).toBeNull()
   })
 
@@ -769,6 +793,30 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Unknown placeholder {{recoredId}}')
+  })
+
+  it('warns when a DingTalk person recipient path is not a user field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.fld_1'
+    recipientFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.fld_1 is not a user field')
   })
 
   it('copies rendered DingTalk group body example in the rule editor', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -502,6 +502,40 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('can remove a selected dynamic recipient field chip in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'assigneeUserIds'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const firstChip = container.querySelector('[data-field-recipient="assigneeUserIds"]') as HTMLButtonElement
+    expect(firstChip?.textContent).toContain('Assignees')
+    firstChip.click()
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(recipientFieldInput.value).toBe('record.fld_1')
+    expect(container.querySelector('[data-field-recipient="assigneeUserIds"]')).toBeNull()
+  })
+
   it('can search and add DingTalk person recipients', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/docs/development/dingtalk-person-dynamic-package-development-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-package-development-20260420.md
@@ -1,0 +1,36 @@
+# DingTalk Person Dynamic Recipient Package Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-dynamic-package-20260420`
+
+## Goal
+
+Package the stacked DingTalk personal recipient enhancements into one clean `main`-based branch so the feature can be reviewed and deployed without depending on a five-PR stack.
+
+## Included Slices
+
+- dynamic record-derived recipients
+- recipient field picker
+- multiple dynamic recipient fields
+- recipient field chips
+- user-field guardrails and warnings
+
+## Scope
+
+- no new runtime feature beyond the stacked slices
+- no migration changes
+- package and roll forward the existing work onto `main`
+
+## Implementation Notes
+
+- Cherry-picked stacked heads onto a fresh branch from `main`:
+  - `cdc1d5b81`
+  - `ace235ad2`
+  - `abbafbaac`
+  - `fbf7eb0ae`
+  - `6b7d6feea`
+- Added package-level development and verification docs for the consolidated branch.
+
+## Outcome
+
+The full DingTalk personal dynamic recipient line now exists as a single `main`-based branch suitable for a single PR, instead of requiring review and merge in stack order.

--- a/docs/development/dingtalk-person-dynamic-package-verification-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-package-verification-20260420.md
@@ -1,0 +1,36 @@
+# DingTalk Person Dynamic Recipient Package Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-dynamic-package-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend unit tests: `100 passed`
+- Frontend tests: `50 passed`
+- Backend build: passed
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- static + dynamic DingTalk personal recipients
+- multi-field recipient resolution from record data
+- picker-based recipient field authoring
+- removable recipient field chips
+- picker guardrails and non-user-field warnings
+
+## Notes
+
+- Frontend Vitest still emits the repository's existing `WebSocket server error: Port is already in use` warning; it did not block the run.
+- Web build still emits the repository's existing Vite chunk-size warning; no new regression was introduced by packaging this branch on top of `main`.

--- a/docs/development/dingtalk-person-dynamic-recipients-development-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-recipients-development-20260420.md
@@ -1,0 +1,53 @@
+# DingTalk Person Dynamic Recipients Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-dynamic-recipients-20260420`
+
+## Goal
+
+Extend `send_dingtalk_person_message` so a rule can resolve recipient local user IDs from record data, instead of requiring only static `userIds`.
+
+## Scope
+
+- Backend:
+  - add optional `userIdFieldPath` to `SendDingTalkPersonMessageConfig`
+  - resolve recipient user IDs from `context.recordData`
+  - merge static and dynamic recipients with dedupe
+  - return clearer failure when a configured record path resolves no users
+- Frontend:
+  - add `Record recipient field path (optional)` to both automation editors
+  - allow saving person-message rules with either static user IDs or a dynamic field path
+  - show dynamic recipient summary in authoring UI
+  - map `userIdFieldPath` back into edit state
+
+## Implementation Notes
+
+- Supported dynamic field path format:
+  - `record.assigneeUserIds`
+- Supported record values:
+  - one string
+  - comma/newline separated string
+  - string array
+  - numeric ID
+  - object entries such as `{ id }`, `{ userId }`, `{ localUserId }`, `{ value }`
+- Runtime normalization removes duplicate local user IDs before DingTalk lookup.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/automation-actions.ts`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Outcome
+
+Admins can now configure a DingTalk personal notification rule that targets:
+
+- explicit local users
+- record-derived local users
+- or both together
+
+This gives a lightweight “who should fill this record” mechanism without introducing a new row/column ACL model first.

--- a/docs/development/dingtalk-person-dynamic-recipients-verification-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-recipients-verification-20260420.md
@@ -1,0 +1,36 @@
+# DingTalk Person Dynamic Recipients Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-dynamic-recipients-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend unit tests: `99 passed`
+- Frontend tests: `40 passed`
+- Backend build: passed
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- `send_dingtalk_person_message` succeeds with dynamic recipients from `record.assigneeUserIds`
+- `send_dingtalk_person_message` fails clearly when a configured path resolves no recipients
+- inline automation manager can save a person-message rule with only `userIdFieldPath`
+- rule editor can save the same payload shape
+- edit flows map `userIdFieldPath` back into the authoring form
+
+## Notes
+
+- Frontend Vitest may still print the existing `WebSocket server error: Port is already in use` warning in this repository; it did not block the test run.
+- Web build still shows the existing Vite chunk-size warning; no new build regressions were introduced by this slice.

--- a/docs/development/dingtalk-person-multi-recipient-fields-development-20260420.md
+++ b/docs/development/dingtalk-person-multi-recipient-fields-development-20260420.md
@@ -1,0 +1,49 @@
+# DingTalk Person Multi Recipient Fields Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-multi-recipient-fields-20260420`
+
+## Goal
+
+Extend `send_dingtalk_person_message` from one dynamic record recipient field to multiple fields, so a rule can notify combinations like assignee + reviewer without duplicating rules.
+
+## Scope
+
+- Backend:
+  - add optional `userIdFieldPaths` to `SendDingTalkPersonMessageConfig`
+  - keep single `userIdFieldPath` backward compatible
+  - normalize, merge, and dedupe recipients resolved from multiple record fields
+  - expose `recipientFieldPaths` in success output
+- Frontend:
+  - allow comma/newline separated dynamic recipient paths in both automation editors
+  - change field pickers from overwrite to append
+  - show multi-field summaries using field labels where possible
+  - map `userIdFieldPaths` back into edit state while still supporting legacy single-path rules
+
+## Implementation Notes
+
+- Runtime accepts both:
+  - `userIdFieldPath`
+  - `userIdFieldPaths`
+- Authoring still stores readable `record.<fieldId>` paths, but picker interactions now append instead of replace.
+- Runtime normalization strips the `record.` prefix, merges all configured fields, and removes duplicate local user IDs before DingTalk lookup.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/automation-actions.ts`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Outcome
+
+Admins can now configure a single DingTalk personal notification rule that targets:
+
+- static local users
+- one dynamic record field
+- or multiple dynamic record fields together
+
+This reduces rule duplication for multi-step fill/approve flows while keeping the existing single-field configuration valid.

--- a/docs/development/dingtalk-person-multi-recipient-fields-verification-20260420.md
+++ b/docs/development/dingtalk-person-multi-recipient-fields-verification-20260420.md
@@ -1,0 +1,36 @@
+# DingTalk Person Multi Recipient Fields Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-multi-recipient-fields-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend unit tests: `100 passed`
+- Frontend tests: `44 passed`
+- Backend build: passed
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- `send_dingtalk_person_message` still works with a legacy single `userIdFieldPath`
+- runtime merges recipients from multiple dynamic record fields and dedupes local user IDs
+- inline automation manager can append multiple recipient fields and save `userIdFieldPaths`
+- rule editor can append the same fields and emit the same payload shape
+- edit flows summarize multi-field recipients using human-readable field labels
+
+## Notes
+
+- Frontend Vitest still prints the repository's existing `WebSocket server error: Port is already in use` warning; it did not block the run.
+- Web build still prints the existing Vite chunk-size warning; no new build regression was introduced by this slice.

--- a/docs/development/dingtalk-person-recipient-field-chips-development-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-chips-development-20260420.md
@@ -1,0 +1,41 @@
+# DingTalk Person Recipient Field Chips Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-chips-20260420`
+
+## Goal
+
+Make multi-field dynamic recipient authoring easier by showing selected recipient fields as removable chips in both automation editors.
+
+## Scope
+
+- Frontend only
+- no runtime protocol changes
+- no backend changes
+- no migration changes
+
+## Implementation Notes
+
+- Reuse the existing comma/newline based `recipientFieldPath` text state.
+- Add selected field chips below the picker:
+  - inline automation manager
+  - full automation rule editor
+- Clicking a chip removes that `record.<fieldId>` entry from the underlying text field.
+- Keep the raw text input for direct editing and backward compatibility.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Outcome
+
+Admins can now:
+
+- append multiple dynamic recipient fields with the picker
+- see which fields are currently selected
+- remove a field without manually editing the raw path string
+
+This keeps the new multi-field capability from `#948` usable without forcing admins back into raw text management.

--- a/docs/development/dingtalk-person-recipient-field-chips-verification-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-chips-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Person Recipient Field Chips Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-chips-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `46 passed`
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- inline automation manager shows selected dynamic recipient fields as chips
+- inline automation manager can remove a selected dynamic recipient field chip
+- full rule editor shows the same chip state
+- full rule editor can remove a selected dynamic recipient field chip
+
+## Notes
+
+- Frontend Vitest still emits the repository's existing `WebSocket server error: Port is already in use` warning; it did not block the run.
+- Web build still emits the repository's existing Vite chunk-size warning; no new build regression was introduced by this slice.

--- a/docs/development/dingtalk-person-recipient-field-guardrails-development-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-guardrails-development-20260420.md
@@ -1,0 +1,35 @@
+# DingTalk Person Recipient Field Guardrails Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-guardrails-20260420`
+
+## Goal
+
+Add authoring guardrails for dynamic DingTalk person recipient fields so admins are guided toward real user fields instead of arbitrary record paths.
+
+## Scope
+
+- Frontend only
+- no backend protocol changes
+- no migration changes
+- no runtime behavior changes
+
+## Implementation Notes
+
+- Limit the dynamic recipient field picker to fields with `type === 'user'`.
+- Keep manual text entry available for backward compatibility and advanced cases.
+- When a manually entered path points at a non-user field, show a warning instead of blocking save.
+- Update both automation editors:
+  - inline automation manager
+  - full rule editor
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Outcome
+
+Dynamic DingTalk personal notifications now guide admins toward valid user fields by default, while still preserving the existing text-based escape hatch for nonstandard record schemas.

--- a/docs/development/dingtalk-person-recipient-field-guardrails-verification-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-guardrails-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Person Recipient Field Guardrails Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-guardrails-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `50 passed`
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- recipient field pickers only list `user` fields
+- multi-field authoring still works with the user-field-only picker
+- inline automation manager warns on non-user recipient paths
+- full rule editor warns on non-user recipient paths
+
+## Notes
+
+- Frontend Vitest still emits the repository's existing `WebSocket server error: Port is already in use` warning; it did not block the run.
+- Web build still emits the repository's existing Vite chunk-size warning; no new build regression was introduced by this slice.

--- a/docs/development/dingtalk-person-recipient-field-picker-development-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-picker-development-20260420.md
@@ -1,0 +1,38 @@
+# DingTalk Person Recipient Field Picker Development
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-picker-20260420`
+
+## Goal
+
+Improve authoring for dynamic DingTalk personal recipients by letting admins pick a record field instead of manually typing a `record.<fieldId>` path.
+
+## Scope
+
+- Frontend only
+- No runtime protocol changes
+- No migration changes
+
+## Changes
+
+- Added `Pick recipient field` selects to:
+  - `MetaAutomationRuleEditor`
+  - `MetaAutomationManager`
+- The picker writes the actual runtime-safe path:
+  - `record.<fieldId>`
+- Updated helper copy to clarify that automation `record` data is keyed by field ID.
+- Upgraded summary text so it shows both:
+  - field label
+  - runtime path
+  - example: `Assignees (record.assigneeUserIds)`
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Outcome
+
+Admins no longer need to guess or hand-type a recipient path. They can pick a field from the current sheet and get the exact runtime path that the automation executor expects.

--- a/docs/development/dingtalk-person-recipient-field-picker-verification-20260420.md
+++ b/docs/development/dingtalk-person-recipient-field-picker-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Person Recipient Field Picker Verification
+
+Date: 2026-04-20
+Branch: `codex/dingtalk-person-recipient-field-picker-20260420`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `42 passed`
+- Web build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- rule editor can pick a recipient field and writes `record.<fieldId>`
+- inline automation manager can do the same
+- summary text shows `Field Name (record.<fieldId>)`
+- existing dynamic-recipient create/edit flows remain valid
+
+## Notes
+
+- This slice is frontend-only and stacks on top of `#942`.
+- Web build still prints the existing Vite chunk-size warning; no new build regression was introduced.

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -59,6 +59,7 @@ export interface SendDingTalkGroupMessageConfig {
 /** Config shape for send_dingtalk_person_message */
 export interface SendDingTalkPersonMessageConfig {
   userIds: string[]
+  userIdFieldPath?: string
   titleTemplate: string
   bodyTemplate: string
   publicFormViewId?: string

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -60,6 +60,7 @@ export interface SendDingTalkGroupMessageConfig {
 export interface SendDingTalkPersonMessageConfig {
   userIds: string[]
   userIdFieldPath?: string
+  userIdFieldPaths?: string[]
   titleTemplate: string
   bodyTemplate: string
   publicFormViewId?: string

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -74,6 +74,49 @@ function normalizeUserIds(value: unknown): string[] {
   ))
 }
 
+function normalizeUserIdScalar(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return [String(value)]
+  }
+  if (typeof value === 'object' && value && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>
+    for (const key of ['localUserId', 'userId', 'id', 'value']) {
+      const candidate = record[key]
+      if (typeof candidate === 'string' && candidate.trim()) return [candidate.trim()]
+      if (typeof candidate === 'number' && Number.isFinite(candidate)) return [String(candidate)]
+    }
+  }
+  return []
+}
+
+function normalizeUserIdsFromUnknown(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(new Set(
+      value.flatMap((entry) => normalizeUserIdsFromUnknown(entry)),
+    ))
+  }
+  return normalizeUserIdScalar(value)
+}
+
+function normalizeRecipientFieldPath(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  return trimmed.replace(/^record\./, '')
+}
+
+function resolveRecipientUserIdsFromRecord(recordData: Record<string, unknown>, fieldPath: unknown): string[] {
+  const normalizedPath = normalizeRecipientFieldPath(fieldPath)
+  if (!normalizedPath) return []
+  return normalizeUserIdsFromUnknown(lookupTemplateValue(normalizedPath, recordData))
+}
+
 function chunkItems<T>(items: T[], size: number): T[][] {
   if (items.length === 0) return []
   const chunks: T[][] = []
@@ -599,14 +642,28 @@ export class AutomationExecutor {
     config: SendDingTalkPersonMessageConfig,
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
-    const userIds = normalizeUserIds(config.userIds)
+    const staticUserIds = normalizeUserIds(config.userIds)
+    const recipientFieldPath = normalizeRecipientFieldPath(config.userIdFieldPath)
+    const recordUserIds = resolveRecipientUserIdsFromRecord(context.recordData, recipientFieldPath)
+    const userIds = Array.from(new Set([...staticUserIds, ...recordUserIds]))
     const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
     const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
     const publicFormViewId = typeof config.publicFormViewId === 'string' ? config.publicFormViewId.trim() : ''
     const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
 
     if (userIds.length === 0) {
-      return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'At least one local userId is required' }
+      if (recipientFieldPath) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: `No local userIds resolved from record field path "${recipientFieldPath}"`,
+        }
+      }
+      return {
+        actionType: 'send_dingtalk_person_message',
+        status: 'failed',
+        error: 'At least one local userId or record recipient field path is required',
+      }
     }
     if (!titleTemplate) {
       return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'DingTalk title template is required' }
@@ -785,6 +842,9 @@ export class AutomationExecutor {
         status: 'success',
         output: {
           notifiedUsers: resolvedRecipients.length,
+          staticRecipientCount: staticUserIds.length,
+          dynamicRecipientCount: recordUserIds.length,
+          recipientFieldPath: recipientFieldPath || null,
           batchCount: batches.length,
           linkCount: linkLines.length,
           responseCount,

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -111,10 +111,32 @@ function normalizeRecipientFieldPath(value: unknown): string {
   return trimmed.replace(/^record\./, '')
 }
 
-function resolveRecipientUserIdsFromRecord(recordData: Record<string, unknown>, fieldPath: unknown): string[] {
-  const normalizedPath = normalizeRecipientFieldPath(fieldPath)
-  if (!normalizedPath) return []
-  return normalizeUserIdsFromUnknown(lookupTemplateValue(normalizedPath, recordData))
+function normalizeRecipientFieldPaths(primary: unknown, additional: unknown): string[] {
+  const values = [
+    primary,
+    ...(Array.isArray(additional) ? additional : [additional]),
+  ]
+
+  return Array.from(new Set(
+    values
+      .flatMap((value) => {
+        if (typeof value !== 'string') return []
+        return value
+          .split(/[\n,]+/)
+          .map((entry) => normalizeRecipientFieldPath(entry))
+          .filter(Boolean)
+      }),
+  ))
+}
+
+function resolveRecipientUserIdsFromRecord(recordData: Record<string, unknown>, fieldPaths: unknown[]): string[] {
+  return Array.from(new Set(
+    fieldPaths.flatMap((fieldPath) => {
+      const normalizedPath = normalizeRecipientFieldPath(fieldPath)
+      if (!normalizedPath) return []
+      return normalizeUserIdsFromUnknown(lookupTemplateValue(normalizedPath, recordData))
+    }),
+  ))
 }
 
 function chunkItems<T>(items: T[], size: number): T[][] {
@@ -643,8 +665,8 @@ export class AutomationExecutor {
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
     const staticUserIds = normalizeUserIds(config.userIds)
-    const recipientFieldPath = normalizeRecipientFieldPath(config.userIdFieldPath)
-    const recordUserIds = resolveRecipientUserIdsFromRecord(context.recordData, recipientFieldPath)
+    const recipientFieldPaths = normalizeRecipientFieldPaths(config.userIdFieldPath, config.userIdFieldPaths)
+    const recordUserIds = resolveRecipientUserIdsFromRecord(context.recordData, recipientFieldPaths)
     const userIds = Array.from(new Set([...staticUserIds, ...recordUserIds]))
     const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
     const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
@@ -652,11 +674,11 @@ export class AutomationExecutor {
     const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
 
     if (userIds.length === 0) {
-      if (recipientFieldPath) {
+      if (recipientFieldPaths.length > 0) {
         return {
           actionType: 'send_dingtalk_person_message',
           status: 'failed',
-          error: `No local userIds resolved from record field path "${recipientFieldPath}"`,
+          error: `No local userIds resolved from record field paths: ${recipientFieldPaths.join(', ')}`,
         }
       }
       return {
@@ -844,7 +866,8 @@ export class AutomationExecutor {
           notifiedUsers: resolvedRecipients.length,
           staticRecipientCount: staticUserIds.length,
           dynamicRecipientCount: recordUserIds.length,
-          recipientFieldPath: recipientFieldPath || null,
+          recipientFieldPath: recipientFieldPaths[0] ?? null,
+          recipientFieldPaths,
           batchCount: batches.length,
           linkCount: linkLines.length,
           responseCount,

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -645,6 +645,91 @@ describe('AutomationExecutor', () => {
     expect(insertCall?.[1]?.[1]).toBe('user_2')
   })
 
+  it('executes send_dingtalk_person_message with dynamic record recipients', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' },
+          { local_user_id: 'user_2', local_user_active: true, dingtalk_user_id: 'dt-user-2' },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIdFieldPath: 'record.assigneeUserIds',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {
+        title: 'Incident',
+        status: 'open',
+        assigneeUserIds: ['user_1', { id: 'user_2' }, 'user_1'],
+      },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    const [, sendInit] = fetchFn.mock.calls[1] as [string, RequestInit]
+    const payload = JSON.parse(sendInit.body as string)
+    expect(payload.userid_list).toBe('dt-user-1,dt-user-2')
+    expect(result.steps[0].output).toMatchObject({
+      notifiedUsers: 2,
+      staticRecipientCount: 0,
+      dynamicRecipientCount: 2,
+      recipientFieldPath: 'assigneeUserIds',
+    })
+  })
+
+  it('fails send_dingtalk_person_message when dynamic record path resolves no recipients', async () => {
+    deps = createMockDeps()
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIdFieldPath: 'record.assigneeUserIds',
+          titleTemplate: 'Title',
+          bodyTemplate: 'Body',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { assigneeUserIds: [] },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('record field path "assigneeUserIds"')
+  })
+
   it('fails send_notification with no userIds', async () => {
     const rule = createMockRule({
       actions: [{ type: 'send_notification', config: { message: 'Hi' } }],

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -727,7 +727,65 @@ describe('AutomationExecutor', () => {
     })
 
     expect(result.status).toBe('failed')
-    expect(result.steps[0].error).toContain('record field path "assigneeUserIds"')
+    expect(result.steps[0].error).toContain('record field paths: assigneeUserIds')
+  })
+
+  it('merges multiple dynamic DingTalk person recipient fields from the record', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' },
+          { local_user_id: 'user_2', local_user_active: true, dingtalk_user_id: 'dt-user-2' },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIdFieldPaths: ['record.assigneeUserIds', 'record.reviewerUserId'],
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {
+        title: 'Incident',
+        status: 'open',
+        assigneeUserIds: ['user_1'],
+        reviewerUserId: 'user_2',
+      },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(result.steps[0].output).toMatchObject({
+      notifiedUsers: 2,
+      staticRecipientCount: 0,
+      dynamicRecipientCount: 2,
+      recipientFieldPath: 'assigneeUserIds',
+      recipientFieldPaths: ['assigneeUserIds', 'reviewerUserId'],
+    })
   })
 
   it('fails send_notification with no userIds', async () => {


### PR DESCRIPTION
## Summary
- package the DingTalk person dynamic recipient stack into one main-based branch
- include dynamic recipient fields, multi-field resolution, field chips, and authoring guardrails
- add package-level development and verification notes

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- git diff --check