### PR TITLE
docs(dingtalk): add dynamic recipient deploy notes

### DIFF
--- a/docs/development/dingtalk-person-dynamic-deploy-development-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-deploy-development-20260420.md
@@ -1,0 +1,38 @@
+# DingTalk Person Dynamic Recipients Deploy Development
+
+- Date: 2026-04-20
+- Scope: production rollout verification for `#952 feat(dingtalk): package dynamic person recipient automation`
+- Base commit on `main`: `67d23da123b92d9d8fb96940c718f716a9d0c023`
+
+## Goal
+
+Confirm that the packaged DingTalk personal dynamic-recipient automation feature was not only merged to `main`, but also built, deployed, and smoke-checked by the production workflow.
+
+## What Was Done
+
+1. Confirmed `#952` merged into `main` at `67d23da123b92d9d8fb96940c718f716a9d0c023`.
+2. Checked GitHub Actions runs triggered by that merge.
+3. Verified the real production path came from `Build and Push Docker Images` run `24670485107`.
+4. Downloaded the deploy artifact `deploy-logs-24670485107-1` and inspected:
+   - deployed image tag
+   - `.env` tag persistence
+   - deploy / migrate / smoke markers
+5. Recorded the rollout evidence into repository docs.
+
+## Deployment Evidence Used
+
+- Workflow run:
+  - `Build and Push Docker Images`
+  - run id `24670485107`
+- Deploy job:
+  - job id `72140017011`
+- Artifact:
+  - `deploy-logs-24670485107-1`
+- Local evidence path:
+  - `output/playwright/ga/24670485107/deploy.log`
+  - `output/playwright/ga/24670485107/step-summary.md`
+
+## Notes
+
+- A direct SSH verification from the local terminal was not available in this run because non-interactive auth to `142.171.239.56` was rejected.
+- Production verification therefore used the signed GitHub deploy job output plus the uploaded deploy artifact, which includes the remote deploy, migrate, and smoke logs.

--- a/docs/development/dingtalk-person-dynamic-deploy-verification-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-deploy-verification-20260420.md
@@ -1,0 +1,71 @@
+# DingTalk Person Dynamic Recipients Deploy Verification
+
+- Date: 2026-04-20
+- Target change: `#952 feat(dingtalk): package dynamic person recipient automation`
+- Target commit: `67d23da123b92d9d8fb96940c718f716a9d0c023`
+
+## Verification Commands
+
+```bash
+gh run list --branch main --limit 6 --json databaseId,workflowName,displayTitle,headSha,status,conclusion,createdAt
+gh run view 24670485107 --json databaseId,displayTitle,headSha,status,conclusion,jobs,workflowName
+gh run view 24670485107 --job 72140017011 --log
+gh run download 24670485107 -n deploy-logs-24670485107-1 -D output/playwright/ga/24670485107
+rg -n "image_tag=|=== DEPLOY START ===|=== DEPLOY END ===|=== MIGRATE START ===|=== MIGRATE END ===|Smoke:|=== SMOKE START ===|=== SMOKE END ===|persisted IMAGE_OWNER and IMAGE_TAG" output/playwright/ga/24670485107/deploy.log
+sed -n '1,220p' output/playwright/ga/24670485107/step-summary.md
+git diff --check
+```
+
+## Results
+
+### Mainline
+
+- `origin/main` head:
+  - `67d23da123b92d9d8fb96940c718f716a9d0c023`
+- PR `#952` merged successfully.
+
+### Workflows
+
+- `Build and Push Docker Images` run `24670485107`: `success`
+- Jobs:
+  - `build`: `success`
+  - `deploy`: `success`
+
+### Deploy Artifact Evidence
+
+From `output/playwright/ga/24670485107/deploy.log`:
+
+- `[deploy] image_tag=67d23da123b92d9d8fb96940c718f716a9d0c023`
+- `[deploy] persisted IMAGE_OWNER and IMAGE_TAG in .env`
+- `=== DEPLOY START ===`
+- `=== DEPLOY END ===`
+- `=== MIGRATE START ===`
+- `=== MIGRATE END ===`
+- `=== SMOKE START ===`
+- `Smoke: api/plugins=ok health=ok web=ok`
+- `=== SMOKE END ===`
+
+### Step Summary Evidence
+
+From `output/playwright/ga/24670485107/step-summary.md`:
+
+- Overall: `PASS`
+- Remote exit code: `0`
+- Remote preflight: `PASS`
+- Deploy: `PASS`
+- Migrate: `PASS`
+- Smoke: `PASS`
+
+## Conclusion
+
+`#952` was built and deployed through the production Docker workflow, and the remote deploy artifact shows:
+
+- the new SHA-tagged backend/web images were used,
+- the remote `.env` tag persistence ran,
+- migration completed,
+- smoke checks passed with `api/plugins=ok health=ok web=ok`.
+
+## Known Limits
+
+- Direct non-interactive SSH verification from the local terminal was not available during this run.
+- Public access to `http://142.171.239.56:8900/health` returned an empty reply, so the verification source of truth for this rollout is the successful production deploy artifact rather than direct host probing.


### PR DESCRIPTION
## Summary\n- record production rollout evidence for #952\n- capture the successful build/deploy workflow and deploy artifact checks\n- note the verification source and known limits for this rollout\n\n## Verification\n- git diff --check\n- gh run view 24670485107 --json databaseId,displayTitle,headSha,status,conclusion,jobs,workflowName\n- gh run view 24670485107 --job 72140017011 --log\n- gh run download 24670485107 -n deploy-logs-24670485107-1 -D output/playwright/ga/24670485107\n- rg -n "image_tag=|=== DEPLOY START ===|=== DEPLOY END ===|=== MIGRATE START ===|=== MIGRATE END ===|Smoke:|=== SMOKE START ===|=== SMOKE END ===|persisted IMAGE_OWNER and IMAGE_TAG" output/playwright/ga/24670485107/deploy.log\n- sed -n '1,220p' output/playwright/ga/24670485107/step-summary.md