### PR TITLE
feat(dingtalk): support multiple group destinations

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -79,13 +79,35 @@
               <button class="meta-automation__btn" type="button" data-automation-preset="group-internal" @click="applyGroupPreset('internal_process')">Internal processing</button>
               <button class="meta-automation__btn" type="button" data-automation-preset="group-both" @click="applyGroupPreset('form_and_process')">Form + processing</button>
             </div>
-            <label class="meta-automation__label">DingTalk group</label>
-            <select v-model="draft.dingtalkDestinationId" class="meta-automation__select" data-automation-field="dingtalkDestinationId">
-              <option value="">-- select DingTalk group --</option>
-              <option v-for="destination in dingTalkDestinations" :key="destination.id" :value="destination.id">
+            <label class="meta-automation__label">Add DingTalk groups</label>
+            <select
+              v-model="draft.dingtalkDestinationPickerId"
+              class="meta-automation__select"
+              data-automation-field="dingtalkDestinationPickerId"
+              @change="appendDingTalkGroupDestination($event.target as HTMLSelectElement)"
+            >
+              <option value="">-- add DingTalk group --</option>
+              <option v-for="destination in availableDingTalkGroupDestinations" :key="destination.id" :value="destination.id">
                 {{ destination.name }}
               </option>
             </select>
+            <div
+              v-if="selectedDingTalkGroupDestinations.length"
+              class="meta-automation__recipient-list meta-automation__recipient-list--selected"
+            >
+              <button
+                v-for="destination in selectedDingTalkGroupDestinations"
+                :key="destination.id"
+                class="meta-automation__recipient-chip"
+                type="button"
+                :data-automation-group-destination="destination.id"
+                @click="removeDingTalkGroupDestination(destination.id)"
+              >
+                <strong>{{ destination.label }}</strong>
+                <span>{{ destination.subtitle || destination.id }}</span>
+                <em>Remove</em>
+              </button>
+            </div>
             <label class="meta-automation__label">Title template</label>
             <input
               v-model="draft.dingtalkTitleTemplate"
@@ -154,7 +176,7 @@
             </select>
             <div class="meta-automation__preview" data-automation-summary="group">
               <div class="meta-automation__preview-title">Message summary</div>
-              <div><strong>Group:</strong> {{ dingTalkGroupName(draft.dingtalkDestinationId) }}</div>
+              <div><strong>Groups:</strong> {{ dingTalkGroupSummary }}</div>
               <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
               <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
               <div class="meta-automation__preview-line">
@@ -539,7 +561,8 @@ interface DraftState {
   notifyMessage: string
   targetFieldId: string
   targetValue: string
-  dingtalkDestinationId: string
+  dingtalkDestinationIds: string[]
+  dingtalkDestinationPickerId: string
   dingtalkTitleTemplate: string
   dingtalkBodyTemplate: string
   publicFormViewId: string
@@ -561,7 +584,8 @@ function emptyDraft(): DraftState {
     notifyMessage: '',
     targetFieldId: '',
     targetValue: '',
-    dingtalkDestinationId: '',
+    dingtalkDestinationIds: [],
+    dingtalkDestinationPickerId: '',
     dingtalkTitleTemplate: '',
     dingtalkBodyTemplate: '',
     publicFormViewId: '',
@@ -664,10 +688,53 @@ function removeDingTalkPersonRecipient(userId: string) {
     .join(', ')
 }
 
-function dingTalkGroupName(destinationId: string) {
-  if (!destinationId) return 'No group selected'
-  return dingTalkDestinations.value.find((item) => item.id === destinationId)?.name ?? destinationId
+function parseGroupDestinationIds(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(new Set(
+      value
+        .filter((item): item is string => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ))
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return [value.trim()]
+  }
+  return []
 }
+
+const selectedDingTalkGroupDestinations = computed(() =>
+  draft.value.dingtalkDestinationIds.map((id) => {
+    const destination = dingTalkDestinations.value.find((item) => item.id === id)
+    return {
+      id,
+      label: destination?.name ?? id,
+      subtitle: destination?.sheetId ? `sheet: ${destination.sheetId}` : undefined,
+    }
+  }),
+)
+
+const availableDingTalkGroupDestinations = computed(() => {
+  const selected = new Set(draft.value.dingtalkDestinationIds)
+  return dingTalkDestinations.value.filter((destination) => !selected.has(destination.id))
+})
+
+function appendDingTalkGroupDestination(select: HTMLSelectElement) {
+  const destinationId = select.value.trim()
+  if (!destinationId) return
+  draft.value.dingtalkDestinationIds = Array.from(new Set([...draft.value.dingtalkDestinationIds, destinationId]))
+  draft.value.dingtalkDestinationPickerId = ''
+  select.value = ''
+}
+
+function removeDingTalkGroupDestination(destinationId: string) {
+  draft.value.dingtalkDestinationIds = draft.value.dingtalkDestinationIds.filter((id) => id !== destinationId)
+}
+
+const dingTalkGroupSummary = computed(() => {
+  if (!selectedDingTalkGroupDestinations.value.length) return 'No groups selected'
+  return selectedDingTalkGroupDestinations.value.map((item) => item.label).join(', ')
+})
 
 function viewSummaryName(viewId: string, fallback: string) {
   if (!viewId) return fallback
@@ -891,7 +958,7 @@ const canSave = computed(() => {
   if (draft.value.actionType === 'notify' && !draft.value.notifyMessage.trim()) return false
   if (draft.value.actionType === 'update_field' && (!draft.value.targetFieldId || !draft.value.targetValue.trim())) return false
   if (draft.value.actionType === 'send_dingtalk_group_message') {
-    if (!draft.value.dingtalkDestinationId) return false
+    if (!draft.value.dingtalkDestinationIds.length) return false
     if (!draft.value.dingtalkTitleTemplate.trim()) return false
     if (!draft.value.dingtalkBodyTemplate.trim()) return false
   }
@@ -922,7 +989,8 @@ function openEditForm(rule: AutomationRule) {
     notifyMessage: (rule.actionConfig?.message as string) ?? '',
     targetFieldId: (rule.actionConfig?.fieldId as string) ?? '',
     targetValue: (rule.actionConfig?.value as string) ?? '',
-    dingtalkDestinationId: (rule.actionConfig?.destinationId as string) ?? '',
+    dingtalkDestinationIds: parseGroupDestinationIds(rule.actionConfig?.destinationIds ?? rule.actionConfig?.destinationId),
+    dingtalkDestinationPickerId: '',
     dingtalkTitleTemplate: (rule.actionConfig?.titleTemplate as string) ?? '',
     dingtalkBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
     publicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
@@ -966,8 +1034,10 @@ function buildActionConfig(): Record<string, unknown> {
     return { fieldId: draft.value.targetFieldId, value: draft.value.targetValue }
   }
   if (draft.value.actionType === 'send_dingtalk_group_message') {
+    const destinationIds = Array.from(new Set(draft.value.dingtalkDestinationIds.map((id) => id.trim()).filter(Boolean)))
     return {
-      destinationId: draft.value.dingtalkDestinationId,
+      destinationId: destinationIds[0] || undefined,
+      destinationIds: destinationIds.length ? destinationIds : undefined,
       titleTemplate: draft.value.dingtalkTitleTemplate,
       bodyTemplate: draft.value.dingtalkBodyTemplate,
       publicFormViewId: draft.value.publicFormViewId || undefined,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -193,17 +193,35 @@
                 <button class="meta-rule-editor__btn" type="button" data-field="groupPresetInternal" @click="applyGroupPreset(action, 'internal_process')">Internal processing</button>
                 <button class="meta-rule-editor__btn" type="button" data-field="groupPresetBoth" @click="applyGroupPreset(action, 'form_and_process')">Form + processing</button>
               </div>
-              <label class="meta-rule-editor__label">DingTalk group</label>
+              <label class="meta-rule-editor__label">Add DingTalk groups</label>
               <select
-                v-model="action.config.destinationId"
+                v-model="action.config.destinationPickerId"
                 class="meta-rule-editor__select"
-                data-field="dingtalkDestinationId"
+                data-field="dingtalkDestinationPickerId"
+                @change="appendGroupDestination(action, $event.target as HTMLSelectElement)"
               >
-                <option value="">-- select DingTalk group --</option>
-                <option v-for="destination in dingTalkDestinations" :key="destination.id" :value="destination.id">
+                <option value="">-- add DingTalk group --</option>
+                <option v-for="destination in availableGroupDestinations(action)" :key="destination.id" :value="destination.id">
                   {{ destination.name }}
                 </option>
               </select>
+              <div
+                v-if="selectedGroupDestinations(action).length"
+                class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
+              >
+                <button
+                  v-for="destination in selectedGroupDestinations(action)"
+                  :key="destination.id"
+                  class="meta-rule-editor__recipient-chip"
+                  type="button"
+                  :data-group-destination="destination.id"
+                  @click="removeGroupDestination(action, destination.id)"
+                >
+                  <strong>{{ destination.label }}</strong>
+                  <span>{{ destination.subtitle || destination.id }}</span>
+                  <em>Remove</em>
+                </button>
+              </div>
               <div v-if="dingTalkDestinationsError" class="meta-rule-editor__hint">{{ dingTalkDestinationsError }}</div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
@@ -281,7 +299,7 @@
               </select>
               <div class="meta-rule-editor__preview" data-field="groupMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
-                <div><strong>Group:</strong> {{ dingTalkGroupName(action.config.destinationId) }}</div>
+                <div><strong>Groups:</strong> {{ dingTalkGroupSummary(action) }}</div>
                 <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
                 <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
                 <div class="meta-rule-editor__preview-line">
@@ -588,6 +606,8 @@ type DraftActionConfig = Record<string, unknown> & {
   recipientFieldPath?: string
   message?: string
   destinationId?: string
+  destinationIds?: string[]
+  destinationPickerId?: string
   titleTemplate?: string
   bodyTemplate?: string
   publicFormViewId?: string
@@ -668,6 +688,13 @@ function emptyDraft(): Draft {
 }
 
 function draftConfigFromAction(type: AutomationActionType, config: Record<string, unknown>): DraftActionConfig {
+  if (type === 'send_dingtalk_group_message') {
+    return {
+      ...config,
+      destinationIds: parseGroupDestinationIds(config.destinationIds ?? config.destinationId),
+      destinationPickerId: '',
+    }
+  }
   if (type === 'send_dingtalk_person_message') {
     return {
       ...config,
@@ -732,10 +759,10 @@ const canSave = computed(() => {
   if (draft.value.actions.length < 1) return false
   for (const action of draft.value.actions) {
     if (action.type === 'send_dingtalk_group_message') {
-      const destinationId = typeof action.config.destinationId === 'string' ? action.config.destinationId.trim() : ''
+      const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if (!destinationId || !titleTemplate || !bodyTemplate) return false
+      if (!destinationIds.length || !titleTemplate || !bodyTemplate) return false
     }
     if (action.type === 'send_dingtalk_person_message') {
       const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
@@ -767,6 +794,21 @@ function parseUserIdsText(value: unknown): string[] {
     .split(/[\n,]+/)
     .map((entry) => entry.trim())
     .filter(Boolean)
+}
+
+function parseGroupDestinationIds(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(new Set(
+      value
+        .filter((item): item is string => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ))
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return [value.trim()]
+  }
+  return []
 }
 
 function rememberPersonRecipientSuggestions(items: MetaCommentMentionSuggestion[]) {
@@ -841,10 +883,43 @@ function removePersonRecipient(action: DraftAction, userId: string) {
     .join(', ')
 }
 
-function dingTalkGroupName(destinationId: unknown) {
-  const id = typeof destinationId === 'string' ? destinationId : ''
-  if (!id) return 'No group selected'
-  return dingTalkDestinations.value.find((item) => item.id === id)?.name ?? id
+function selectedGroupDestinations(action: DraftAction) {
+  return parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId).map((id) => {
+    const destination = dingTalkDestinations.value.find((item) => item.id === id)
+    return {
+      id,
+      label: destination?.name ?? id,
+      subtitle: destination?.sheetId ? `sheet: ${destination.sheetId}` : undefined,
+    }
+  })
+}
+
+function availableGroupDestinations(action: DraftAction) {
+  const selected = new Set(parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId))
+  return dingTalkDestinations.value.filter((destination) => !selected.has(destination.id))
+}
+
+function appendGroupDestination(action: DraftAction, select: HTMLSelectElement) {
+  const destinationId = select.value.trim()
+  if (!destinationId) return
+  const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
+  destinationIds.push(destinationId)
+  action.config.destinationIds = Array.from(new Set(destinationIds))
+  action.config.destinationId = action.config.destinationIds[0] || ''
+  action.config.destinationPickerId = ''
+  select.value = ''
+}
+
+function removeGroupDestination(action: DraftAction, destinationId: string) {
+  action.config.destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
+    .filter((id) => id !== destinationId)
+  action.config.destinationId = action.config.destinationIds[0] || ''
+}
+
+function dingTalkGroupSummary(action: DraftAction) {
+  const selected = selectedGroupDestinations(action)
+  if (!selected.length) return 'No groups selected'
+  return selected.map((item) => item.label).join(', ')
 }
 
 function viewSummaryName(viewId: unknown, fallback: string) {
@@ -1013,6 +1088,8 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
     case 'send_dingtalk_group_message':
       return {
         destinationId: '',
+        destinationIds: [],
+        destinationPickerId: '',
         titleTemplate: '',
         bodyTemplate: '',
         publicFormViewId: '',
@@ -1075,6 +1152,24 @@ function buildPayload(): Partial<AutomationRule> {
     triggerConfig.cron = cronPreset.value
   }
   const actions = d.actions.map((action) => {
+    if (action.type === 'send_dingtalk_group_message') {
+      const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
+      return {
+        type: action.type,
+        config: {
+          destinationId: destinationIds[0] || undefined,
+          destinationIds: destinationIds.length ? destinationIds : undefined,
+          titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : '',
+          bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : '',
+          publicFormViewId: typeof action.config.publicFormViewId === 'string' && action.config.publicFormViewId.trim()
+            ? action.config.publicFormViewId.trim()
+            : undefined,
+          internalViewId: typeof action.config.internalViewId === 'string' && action.config.internalViewId.trim()
+            ? action.config.internalViewId.trim()
+            : undefined,
+        },
+      }
+    }
     if (action.type === 'send_dingtalk_person_message') {
       const userIds = typeof action.config.userIdsText === 'string'
         ? action.config.userIdsText

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -57,15 +57,26 @@ function mockClient(rules: AutomationRule[] = []) {
     const method = init?.method ?? 'GET'
     if (method === 'GET' && url.includes('/dingtalk-groups')) {
       return ok({
-        destinations: [{
-          id: 'dt_1',
-          name: 'Ops Group',
-          webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test',
-          enabled: true,
-          sheetId: 'sheet_1',
-          createdBy: 'user_1',
-          createdAt: '2026-04-01T00:00:00Z',
-        }],
+        destinations: [
+          {
+            id: 'dt_1',
+            name: 'Ops Group',
+            webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test',
+            enabled: true,
+            sheetId: 'sheet_1',
+            createdBy: 'user_1',
+            createdAt: '2026-04-01T00:00:00Z',
+          },
+          {
+            id: 'dt_2',
+            name: 'Escalation Group',
+            webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-2',
+            enabled: true,
+            sheetId: 'sheet_1',
+            createdBy: 'user_1',
+            createdAt: '2026-04-01T00:00:00Z',
+          },
+        ],
       })
     }
     if (method === 'GET' && url.includes('/automations')) {
@@ -296,8 +307,11 @@ describe('MetaAutomationManager', () => {
     actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationId"]') as HTMLSelectElement
+    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
     destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+    destinationSelect.value = 'dt_2'
     destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
 
     const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
@@ -317,6 +331,9 @@ describe('MetaAutomationManager', () => {
     internalViewSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
+    expect(container.querySelector('[data-automation-group-destination="dt_1"]')).not.toBeNull()
+    expect(container.querySelector('[data-automation-group-destination="dt_2"]')).not.toBeNull()
+
     const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
     saveBtn.click()
     await flushPromises()
@@ -327,6 +344,7 @@ describe('MetaAutomationManager', () => {
     expect(body.actionType).toBe('send_dingtalk_group_message')
     expect(body.actionConfig).toEqual({
       destinationId: 'dt_1',
+      destinationIds: ['dt_1', 'dt_2'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please fill {{record.status}}',
       publicFormViewId: 'view_form',

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -32,6 +32,15 @@ function mockClient() {
         createdBy: 'user_1',
         createdAt: '2026-04-01T00:00:00Z',
       },
+      {
+        id: 'dt_2',
+        name: 'Escalation Group',
+        webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-2',
+        enabled: true,
+        sheetId: 'sheet_1',
+        createdBy: 'user_1',
+        createdAt: '2026-04-01T00:00:00Z',
+      },
     ]),
     listCommentMentionSuggestions: vi.fn(async () => ({
       items: [
@@ -235,8 +244,11 @@ describe('MetaAutomationRuleEditor', () => {
     actionSelect.dispatchEvent(new Event('change'))
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationId"]') as HTMLSelectElement
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
     destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    destinationSelect.value = 'dt_2'
     destinationSelect.dispatchEvent(new Event('change'))
 
     const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
@@ -266,6 +278,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(payload.actionType).toBe('send_dingtalk_group_message')
     expect(payload.actionConfig).toEqual({
       destinationId: 'dt_1',
+      destinationIds: ['dt_1', 'dt_2'],
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please review {{record.status}}',
       publicFormViewId: 'view_form',
@@ -275,12 +288,15 @@ describe('MetaAutomationRuleEditor', () => {
       type: 'send_dingtalk_group_message',
       config: {
         destinationId: 'dt_1',
+        destinationIds: ['dt_1', 'dt_2'],
         titleTemplate: 'Ticket {{recordId}}',
         bodyTemplate: 'Please review {{record.status}}',
         publicFormViewId: 'view_form',
         internalViewId: 'view_grid',
       },
     })
+    expect(container.querySelector('[data-group-destination="dt_1"]')).not.toBeNull()
+    expect(container.querySelector('[data-group-destination="dt_2"]')).not.toBeNull()
     expect(client.listDingTalkGroups).toHaveBeenCalledTimes(1)
     expect(client.listDingTalkGroups).toHaveBeenCalledWith('sheet_1')
   })
@@ -724,7 +740,7 @@ describe('MetaAutomationRuleEditor', () => {
     actionSelect.dispatchEvent(new Event('change'))
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationId"]') as HTMLSelectElement
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
     destinationSelect.value = 'dt_1'
     destinationSelect.dispatchEvent(new Event('change'))
 

--- a/docs/development/dingtalk-group-multi-destinations-development-20260420.md
+++ b/docs/development/dingtalk-group-multi-destinations-development-20260420.md
@@ -1,0 +1,51 @@
+# DingTalk Group Multi Destinations Development - 2026-04-20
+
+## Goal
+
+Let a single `send_dingtalk_group_message` automation rule send to multiple configured DingTalk group destinations, while keeping backward compatibility with the existing single `destinationId` payload shape.
+
+## Scope
+
+- Backend action config accepts `destinationIds?: string[]` with legacy `destinationId?: string` fallback.
+- Automation executor resolves, validates, deduplicates, and fan-outs one message send across multiple group destinations.
+- Delivery history is recorded per destination.
+- Automation editors support selecting multiple DingTalk groups in one rule.
+- Existing single-destination rules remain valid without migration.
+
+## Backend Changes
+
+- Extended `SendDingTalkGroupMessageConfig` in `packages/core-backend/src/multitable/automation-actions.ts`.
+- Updated `executeSendDingTalkGroupMessage` in `packages/core-backend/src/multitable/automation-executor.ts` to:
+  - normalize `destinationIds`
+  - validate missing/disabled destinations across the whole set
+  - send once per resolved destination
+  - accumulate success/failure details
+  - return aggregate output including `destinationIds`, `destinationNames`, and `sentCount`
+- Added a focused unit test for multi-destination fan-out in `packages/core-backend/tests/unit/automation-v1.test.ts`.
+
+## Frontend Changes
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+  - group destination picker now appends destinations instead of replacing one value
+  - selected groups render as removable chips
+  - save payload emits both `destinationId` and `destinationIds`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+  - same multi-destination picker/chip behavior in full rule editor
+  - edit/save path normalizes legacy single-destination config into array form
+- Updated UI tests in:
+  - `apps/web/tests/multitable-automation-manager.spec.ts`
+  - `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Compatibility
+
+- Old rules with only `destinationId` continue to load and execute.
+- New rules write both:
+  - first destination as `destinationId`
+  - full selection as `destinationIds`
+- No migration is required.
+
+## Non-Goals
+
+- No destination-sharing model changes.
+- No per-destination template variance.
+- No batching API; current behavior is one signed DingTalk request per destination.

--- a/docs/development/dingtalk-group-multi-destinations-verification-20260420.md
+++ b/docs/development/dingtalk-group-multi-destinations-verification-20260420.md
@@ -1,0 +1,31 @@
+# DingTalk Group Multi Destinations Verification - 2026-04-20
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend unit tests: `101 passed`
+- Frontend tests: `50 passed`
+- `@metasheet/core-backend` build: passed
+- `@metasheet/web` build: passed
+- `git diff --check`: passed
+
+## Notes
+
+- Frontend Vitest emitted the existing local warning:
+  - `WebSocket server error: Port is already in use`
+  - test suite still passed
+- Web build emitted the existing chunk-size warnings
+  - build still passed
+- `pnpm install` touched several nested `plugins/**/node_modules` and `tools/cli/node_modules` paths in this worktree
+  - these are install noise only
+  - they were intentionally excluded from commit/PR scope

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -49,7 +49,8 @@ export interface SendNotificationConfig {
 
 /** Config shape for send_dingtalk_group_message */
 export interface SendDingTalkGroupMessageConfig {
-  destinationId: string
+  destinationId?: string
+  destinationIds?: string[]
   titleTemplate: string
   bodyTemplate: string
   publicFormViewId?: string

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -932,14 +932,24 @@ export class AutomationExecutor {
     config: SendDingTalkGroupMessageConfig,
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
-    const destinationId = typeof config.destinationId === 'string' ? config.destinationId.trim() : ''
+    const destinationIds = Array.from(new Set([
+      ...(Array.isArray(config.destinationIds)
+        ? config.destinationIds
+          .filter((value): value is string => typeof value === 'string')
+          .map((value) => value.trim())
+          .filter(Boolean)
+        : []),
+      ...(typeof config.destinationId === 'string' && config.destinationId.trim()
+        ? [config.destinationId.trim()]
+        : []),
+    ]))
     const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
     const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
     const publicFormViewId = typeof config.publicFormViewId === 'string' ? config.publicFormViewId.trim() : ''
     const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
 
-    if (!destinationId) {
-      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk destination is required' }
+    if (!destinationIds.length) {
+      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'At least one DingTalk destination is required' }
     }
     if (!titleTemplate) {
       return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk title template is required' }
@@ -951,22 +961,34 @@ export class AutomationExecutor {
     const destinationResult = await this.deps.queryFn(
       `SELECT id, name, webhook_url, secret, enabled
          FROM dingtalk_group_destinations
-        WHERE id = $1`,
-      [destinationId],
+        WHERE id = ANY($1)`,
+      [destinationIds],
     )
-    const destination = (destinationResult.rows[0] ?? null) as {
+    const destinations = destinationResult.rows as Array<{
       id: string
       name: string
       webhook_url: string
       secret: string | null
       enabled: boolean
-    } | null
-
-    if (!destination) {
-      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk destination not found' }
+    }>
+    const destinationsById = new Map(destinations.map((destination) => [destination.id, destination]))
+    const missingDestinationIds = destinationIds.filter((id) => !destinationsById.has(id))
+    if (missingDestinationIds.length) {
+      return {
+        actionType: 'send_dingtalk_group_message',
+        status: 'failed',
+        error: `DingTalk destinations not found: ${missingDestinationIds.join(', ')}`,
+      }
     }
-    if (destination.enabled !== true) {
-      return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk destination is disabled' }
+    const disabledDestinations = destinationIds
+      .map((id) => destinationsById.get(id))
+      .filter((destination): destination is NonNullable<typeof destination> => Boolean(destination) && destination.enabled !== true)
+    if (disabledDestinations.length) {
+      return {
+        actionType: 'send_dingtalk_group_message',
+        status: 'failed',
+        error: `DingTalk destinations are disabled: ${disabledDestinations.map((destination) => destination.name || destination.id).join(', ')}`,
+      }
     }
 
     let baseUrl: string | null = null
@@ -1045,16 +1067,20 @@ export class AutomationExecutor {
       renderedBody,
       linkLines.length > 0 ? ['**快捷入口**', ...linkLines].join('\n') : '',
     ].filter(Boolean).join('\n\n')
-    let deliveryRecorded = false
-    let responseStatus: number | null = null
-    let responseBody: string | null = null
+    const orderedDestinations = destinationIds
+      .map((id) => destinationsById.get(id))
+      .filter((destination): destination is NonNullable<typeof destination> => Boolean(destination))
+    const successfulDestinations: Array<{ id: string; name: string }> = []
+    const failedDestinations: Array<{ id: string; name: string; error: string }> = []
 
-    try {
+    for (const destination of orderedDestinations) {
+      let deliveryRecorded = false
+      let responseStatus: number | null = null
+      let responseBody: string | null = null
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS)
-      let response: Response
       try {
-        response = await (this.deps.fetchFn ?? globalThis.fetch)(
+        const response = await (this.deps.fetchFn ?? globalThis.fetch)(
           buildSignedDingTalkWebhookUrl(destination.webhook_url, destination.secret ?? undefined),
           {
             method: 'POST',
@@ -1066,99 +1092,115 @@ export class AutomationExecutor {
             signal: controller.signal,
           },
         )
+        const parsed = await readJsonSafely(response)
+        responseStatus = response.status
+        responseBody = parsed ? JSON.stringify(parsed) : response.statusText || null
+        if (!response.ok) {
+          const errorMessage = `DingTalk request failed with HTTP ${response.status}`
+          deliveryRecorded = true
+          await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+            destinationId: destination.id,
+            sourceType: 'automation',
+            subject: renderedTitle,
+            content: bodyWithLinks,
+            success: false,
+            httpStatus: response.status,
+            responseBody,
+            errorMessage,
+            automationRuleId: context.ruleId,
+            recordId: context.recordId,
+            initiatedBy: context.actorId ?? null,
+          })
+          failedDestinations.push({ id: destination.id, name: destination.name, error: errorMessage })
+          continue
+        }
+        try {
+          validateDingTalkRobotResponse(parsed)
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err)
+          deliveryRecorded = true
+          await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+            destinationId: destination.id,
+            sourceType: 'automation',
+            subject: renderedTitle,
+            content: bodyWithLinks,
+            success: false,
+            httpStatus: response.status,
+            responseBody,
+            errorMessage,
+            automationRuleId: context.ruleId,
+            recordId: context.recordId,
+            initiatedBy: context.actorId ?? null,
+          })
+          failedDestinations.push({ id: destination.id, name: destination.name, error: errorMessage })
+          continue
+        }
+        deliveryRecorded = true
+        await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+          destinationId: destination.id,
+          sourceType: 'automation',
+          subject: renderedTitle,
+          content: bodyWithLinks,
+          success: true,
+          httpStatus: response.status,
+          responseBody,
+          automationRuleId: context.ruleId,
+          recordId: context.recordId,
+          initiatedBy: context.actorId ?? null,
+        })
+        successfulDestinations.push({ id: destination.id, name: destination.name })
+      } catch (err) {
+        if (!deliveryRecorded) {
+          await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+            destinationId: destination.id,
+            sourceType: 'automation',
+            subject: renderedTitle,
+            content: bodyWithLinks,
+            success: false,
+            httpStatus: responseStatus,
+            responseBody,
+            errorMessage: err instanceof Error ? err.message : String(err),
+            automationRuleId: context.ruleId,
+            recordId: context.recordId,
+            initiatedBy: context.actorId ?? null,
+          })
+        }
+        failedDestinations.push({
+          id: destination.id,
+          name: destination.name,
+          error: err instanceof Error ? err.message : String(err),
+        })
       } finally {
         clearTimeout(timeout)
       }
-      const parsed = await readJsonSafely(response)
-      responseStatus = response.status
-      responseBody = parsed ? JSON.stringify(parsed) : response.statusText || null
-      if (!response.ok) {
-        deliveryRecorded = true
-        await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
-          destinationId: destination.id,
-          sourceType: 'automation',
-          subject: renderedTitle,
-          content: bodyWithLinks,
-          success: false,
-          httpStatus: response.status,
-          responseBody,
-          errorMessage: `DingTalk request failed with HTTP ${response.status}`,
-          automationRuleId: context.ruleId,
-          recordId: context.recordId,
-          initiatedBy: context.actorId ?? null,
-        })
-        return {
-          actionType: 'send_dingtalk_group_message',
-          status: 'failed',
-          error: `DingTalk request failed with HTTP ${response.status}`,
-        }
-      }
-      try {
-        validateDingTalkRobotResponse(parsed)
-      } catch (err) {
-        deliveryRecorded = true
-        await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
-          destinationId: destination.id,
-          sourceType: 'automation',
-          subject: renderedTitle,
-          content: bodyWithLinks,
-          success: false,
-          httpStatus: response.status,
-          responseBody,
-          errorMessage: err instanceof Error ? err.message : String(err),
-          automationRuleId: context.ruleId,
-          recordId: context.recordId,
-          initiatedBy: context.actorId ?? null,
-        })
-        return {
-          actionType: 'send_dingtalk_group_message',
-          status: 'failed',
-          error: err instanceof Error ? err.message : String(err),
-        }
-      }
-      deliveryRecorded = true
-      await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
-        destinationId: destination.id,
-        sourceType: 'automation',
-        subject: renderedTitle,
-        content: bodyWithLinks,
-        success: true,
-        httpStatus: response.status,
-        responseBody,
-        automationRuleId: context.ruleId,
-        recordId: context.recordId,
-        initiatedBy: context.actorId ?? null,
-      })
-      return {
-        actionType: 'send_dingtalk_group_message',
-        status: 'success',
-        output: {
-          destinationId: destination.id,
-          destinationName: destination.name,
-          linkCount: linkLines.length,
-        },
-      }
-    } catch (err) {
-      if (!deliveryRecorded) {
-        await recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
-          destinationId: destination.id,
-          sourceType: 'automation',
-          subject: renderedTitle,
-          content: bodyWithLinks,
-          success: false,
-          httpStatus: responseStatus,
-          responseBody,
-          errorMessage: err instanceof Error ? err.message : String(err),
-          automationRuleId: context.ruleId,
-          recordId: context.recordId,
-          initiatedBy: context.actorId ?? null,
-        })
-      }
+    }
+
+    if (failedDestinations.length) {
       return {
         actionType: 'send_dingtalk_group_message',
         status: 'failed',
-        error: err instanceof Error ? err.message : String(err),
+        error: `${failedDestinations.length} of ${orderedDestinations.length} DingTalk destinations failed: ${failedDestinations.map((destination) => `${destination.name} (${destination.error})`).join('; ')}`,
+        output: {
+          destinationIds: orderedDestinations.map((destination) => destination.id),
+          destinationNames: orderedDestinations.map((destination) => destination.name),
+          sentCount: successfulDestinations.length,
+          failedDestinationIds: failedDestinations.map((destination) => destination.id),
+          linkCount: linkLines.length,
+        },
       }
+    }
+
+    return {
+      actionType: 'send_dingtalk_group_message',
+      status: 'success',
+      output: {
+        destinationId: successfulDestinations[0]?.id,
+        destinationName: successfulDestinations[0]?.name,
+        destinationIds: successfulDestinations.map((destination) => destination.id),
+        destinationNames: successfulDestinations.map((destination) => destination.name),
+        sentCount: successfulDestinations.length,
+        linkCount: linkLines.length,
+      },
     }
   }
 }

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -452,6 +452,59 @@ describe('AutomationExecutor', () => {
     expect((queryFn.mock.calls[3]?.[0] as string) ?? '').toContain('INSERT INTO dingtalk_group_deliveries')
   })
 
+  it('executes send_dingtalk_group_message across multiple destinations', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true },
+          { id: 'dt_2', name: 'Escalation Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test-2', secret: null, enabled: true },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationIds: ['dt_1', 'dt_2'],
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(result.steps[0].output).toEqual(expect.objectContaining({
+      destinationIds: ['dt_1', 'dt_2'],
+      destinationNames: ['Ops Group', 'Escalation Group'],
+      sentCount: 2,
+    }))
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(String(fetchFn.mock.calls[0]?.[0] ?? '')).toContain('access_token=test')
+    expect(String(fetchFn.mock.calls[1]?.[0] ?? '')).toContain('access_token=test-2')
+    const insertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_group_deliveries'))
+    expect(insertCalls).toHaveLength(2)
+  })
+
   it('records DingTalk application error diagnostics for send_dingtalk_group_message', async () => {
     const queryFn = vi.fn()
       .mockResolvedValueOnce({
@@ -553,7 +606,8 @@ describe('AutomationExecutor', () => {
     const result = await executor.execute(rule, { recordId: 'r1', sheetId: 'sheet_1' })
     expect(result.status).toBe('failed')
     expect(result.steps[0].status).toBe('failed')
-    expect(result.steps[0].error).toContain('destination not found')
+    expect(result.steps[0].error).toContain('destinations not found')
+    expect(result.steps[0].error).toContain('dt_missing')
   })
 
   it('executes send_dingtalk_person_message action successfully', async () => {


### PR DESCRIPTION
## Summary\n- allow a single  rule to target multiple DingTalk groups\n- keep backward compatibility by still emitting the first  alongside full \n- add editor support for multi-select group chips and document the slice\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false\n- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false\n- pnpm --filter @metasheet/core-backend build\n- pnpm --filter @metasheet/web build\n- git diff --check