### PR TITLE
feat(dingtalk): support person message member groups

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -213,31 +213,31 @@
               <button class="meta-automation__btn" type="button" data-automation-preset="person-internal" @click="applyPersonPreset('internal_process')">Internal processing</button>
               <button class="meta-automation__btn" type="button" data-automation-preset="person-both" @click="applyPersonPreset('form_and_process')">Form + processing</button>
             </div>
-            <label class="meta-automation__label">Search and add users</label>
+            <label class="meta-automation__label">Search and add users or member groups</label>
             <input
               v-model="dingtalkPersonUserSearch"
               class="meta-automation__input"
               type="text"
-              placeholder="Search by name, email, or userId"
+              placeholder="Search by user, member group, email, or subject ID"
               data-automation-field="dingtalkPersonUserSearch"
               @input="void loadDingTalkPersonSuggestions()"
             />
-            <div v-if="dingtalkPersonUserSearchLoading" class="meta-automation__hint">Searching users…</div>
+            <div v-if="dingtalkPersonUserSearchLoading" class="meta-automation__hint">Searching users and member groups…</div>
             <div v-else-if="dingtalkPersonUserSearchError" class="meta-automation__hint meta-automation__hint--error">{{ dingtalkPersonUserSearchError }}</div>
             <div v-else-if="availableDingTalkPersonSuggestions.length" class="meta-automation__recipient-list">
               <button
                 v-for="candidate in availableDingTalkPersonSuggestions"
-                :key="candidate.id"
+                :key="personRecipientCandidateKey(candidate)"
                 class="meta-automation__recipient-option"
                 type="button"
-                :data-automation-person-suggestion="candidate.id"
+                :data-automation-person-suggestion="personRecipientCandidateKey(candidate)"
                 @click="addDingTalkPersonRecipient(candidate)"
               >
                 <strong>{{ candidate.label }}</strong>
-                <span>{{ candidate.subtitle || candidate.id }}</span>
+                <span>{{ candidate.subtitle || candidate.subjectId }}</span>
               </button>
             </div>
-            <div v-else-if="dingtalkPersonUserSearch.trim()" class="meta-automation__hint">No matching users</div>
+            <div v-else-if="dingtalkPersonUserSearch.trim()" class="meta-automation__hint">No matching users or member groups</div>
             <div v-if="selectedDingTalkPersonRecipients.length" class="meta-automation__recipient-list meta-automation__recipient-list--selected">
               <button
                 v-for="recipient in selectedDingTalkPersonRecipients"
@@ -252,6 +252,20 @@
                 <em>Remove</em>
               </button>
             </div>
+            <div v-if="selectedDingTalkPersonMemberGroups.length" class="meta-automation__recipient-list meta-automation__recipient-list--selected">
+              <button
+                v-for="group in selectedDingTalkPersonMemberGroups"
+                :key="group.id"
+                class="meta-automation__recipient-chip"
+                type="button"
+                :data-automation-person-member-group="group.id"
+                @click="removeDingTalkPersonMemberGroup(group.id)"
+              >
+                <strong>{{ group.label }}</strong>
+                <span>{{ group.subtitle || group.id }}</span>
+                <em>Remove</em>
+              </button>
+            </div>
             <label class="meta-automation__label">Local user IDs</label>
             <textarea
               v-model="draft.dingtalkPersonUserIds"
@@ -259,6 +273,14 @@
               rows="3"
               placeholder="使用逗号或换行分隔本地 userId"
               data-automation-field="dingtalkPersonUserIds"
+            ></textarea>
+            <label class="meta-automation__label">Member group IDs (optional)</label>
+            <textarea
+              v-model="draft.dingtalkPersonMemberGroupIds"
+              class="meta-automation__input"
+              rows="2"
+              placeholder="使用逗号或换行分隔成员组 ID"
+              data-automation-field="dingtalkPersonMemberGroupIds"
             ></textarea>
             <label class="meta-automation__label">Record recipient field paths (optional)</label>
             <input
@@ -516,7 +538,7 @@ import type {
   AutomationActionType,
   AutomationStats,
   DingTalkGroupDestination,
-  MetaCommentMentionSuggestion,
+  MetaSheetPermissionCandidate,
   MetaView,
 } from '../types'
 import { useMultitableAutomations } from '../composables/useMultitableAutomations'
@@ -568,6 +590,7 @@ interface DraftState {
   publicFormViewId: string
   internalViewId: string
   dingtalkPersonUserIds: string
+  dingtalkPersonMemberGroupIds: string
   dingtalkPersonRecipientFieldPath: string
   dingtalkPersonTitleTemplate: string
   dingtalkPersonBodyTemplate: string
@@ -591,6 +614,7 @@ function emptyDraft(): DraftState {
     publicFormViewId: '',
     internalViewId: '',
     dingtalkPersonUserIds: '',
+    dingtalkPersonMemberGroupIds: '',
     dingtalkPersonRecipientFieldPath: '',
     dingtalkPersonTitleTemplate: '',
     dingtalkPersonBodyTemplate: '',
@@ -604,7 +628,7 @@ const dingTalkDestinations = ref<DingTalkGroupDestination[]>([])
 const dingtalkPersonUserSearch = ref('')
 const dingtalkPersonUserSearchLoading = ref(false)
 const dingtalkPersonUserSearchError = ref('')
-const dingtalkPersonUserSuggestions = ref<MetaCommentMentionSuggestion[]>([])
+const dingtalkPersonUserSuggestions = ref<MetaSheetPermissionCandidate[]>([])
 const dingtalkPersonUserDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
 const copiedPreviewKey = ref('')
 let dingtalkPersonSuggestionLoadId = 0
@@ -619,10 +643,26 @@ function parseUserIdsText(value: string): string[] {
     .filter(Boolean)
 }
 
-function rememberDingTalkPersonSuggestions(items: MetaCommentMentionSuggestion[]) {
+function parseMemberGroupIdsText(value: string): string[] {
+  return value
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function personRecipientDirectoryKey(subjectType: 'user' | 'member-group', subjectId: string) {
+  return `${subjectType}:${subjectId}`
+}
+
+function personRecipientCandidateKey(candidate: MetaSheetPermissionCandidate) {
+  return personRecipientDirectoryKey(candidate.subjectType === 'member-group' ? 'member-group' : 'user', candidate.subjectId)
+}
+
+function rememberDingTalkPersonSuggestions(items: MetaSheetPermissionCandidate[]) {
   const next = { ...dingtalkPersonUserDirectory.value }
   for (const item of items) {
-    next[item.id] = { label: item.label, subtitle: item.subtitle }
+    if (item.subjectType !== 'user' && item.subjectType !== 'member-group') continue
+    next[personRecipientDirectoryKey(item.subjectType, item.subjectId)] = { label: item.label, subtitle: item.subtitle ?? undefined }
   }
   dingtalkPersonUserDirectory.value = next
 }
@@ -630,14 +670,26 @@ function rememberDingTalkPersonSuggestions(items: MetaCommentMentionSuggestion[]
 const selectedDingTalkPersonRecipients = computed(() =>
   parseUserIdsText(draft.value.dingtalkPersonUserIds).map((id) => ({
     id,
-    label: dingtalkPersonUserDirectory.value[id]?.label ?? id,
-    subtitle: dingtalkPersonUserDirectory.value[id]?.subtitle,
+    label: dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('user', id)]?.label ?? id,
+    subtitle: dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('user', id)]?.subtitle,
+  })),
+)
+
+const selectedDingTalkPersonMemberGroups = computed(() =>
+  parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds).map((id) => ({
+    id,
+    label: dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('member-group', id)]?.label ?? id,
+    subtitle: dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('member-group', id)]?.subtitle,
   })),
 )
 
 const availableDingTalkPersonSuggestions = computed(() => {
   const selected = new Set(parseUserIdsText(draft.value.dingtalkPersonUserIds))
-  return dingtalkPersonUserSuggestions.value.filter((candidate) => !selected.has(candidate.id))
+  const selectedGroups = new Set(parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds))
+  return dingtalkPersonUserSuggestions.value.filter((candidate) => {
+    if (candidate.subjectType === 'member-group') return !selectedGroups.has(candidate.subjectId)
+    return !selected.has(candidate.subjectId)
+  })
 })
 
 async function loadDingTalkPersonSuggestions() {
@@ -653,8 +705,7 @@ async function loadDingTalkPersonSuggestions() {
   dingtalkPersonUserSearchLoading.value = true
   dingtalkPersonUserSearchError.value = ''
   try {
-    const response = await props.client.listCommentMentionSuggestions({
-      spreadsheetId: props.sheetId,
+    const response = await props.client.listFormShareCandidates(props.sheetId, {
       q: query,
       limit: 8,
     })
@@ -664,7 +715,7 @@ async function loadDingTalkPersonSuggestions() {
   } catch (error) {
     if (requestId !== dingtalkPersonSuggestionLoadId) return
     dingtalkPersonUserSuggestions.value = []
-    dingtalkPersonUserSearchError.value = error instanceof Error ? error.message : 'Failed to search users'
+    dingtalkPersonUserSearchError.value = error instanceof Error ? error.message : 'Failed to search users and member groups'
   } finally {
     if (requestId === dingtalkPersonSuggestionLoadId) {
       dingtalkPersonUserSearchLoading.value = false
@@ -672,10 +723,16 @@ async function loadDingTalkPersonSuggestions() {
   }
 }
 
-function addDingTalkPersonRecipient(candidate: MetaCommentMentionSuggestion) {
-  const ids = new Set(parseUserIdsText(draft.value.dingtalkPersonUserIds))
-  ids.add(candidate.id)
-  draft.value.dingtalkPersonUserIds = Array.from(ids).join(', ')
+function addDingTalkPersonRecipient(candidate: MetaSheetPermissionCandidate) {
+  if (candidate.subjectType === 'member-group') {
+    const ids = new Set(parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds))
+    ids.add(candidate.subjectId)
+    draft.value.dingtalkPersonMemberGroupIds = Array.from(ids).join(', ')
+  } else {
+    const ids = new Set(parseUserIdsText(draft.value.dingtalkPersonUserIds))
+    ids.add(candidate.subjectId)
+    draft.value.dingtalkPersonUserIds = Array.from(ids).join(', ')
+  }
   rememberDingTalkPersonSuggestions([candidate])
   dingtalkPersonUserSearch.value = ''
   dingtalkPersonUserSuggestions.value = []
@@ -685,6 +742,12 @@ function addDingTalkPersonRecipient(candidate: MetaCommentMentionSuggestion) {
 function removeDingTalkPersonRecipient(userId: string) {
   draft.value.dingtalkPersonUserIds = parseUserIdsText(draft.value.dingtalkPersonUserIds)
     .filter((id) => id !== userId)
+    .join(', ')
+}
+
+function removeDingTalkPersonMemberGroup(groupId: string) {
+  draft.value.dingtalkPersonMemberGroupIds = parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds)
+    .filter((id) => id !== groupId)
     .join(', ')
 }
 
@@ -701,6 +764,11 @@ function parseGroupDestinationIds(value: unknown): string[] {
     return [value.trim()]
   }
   return []
+}
+
+function dingTalkGroupName(destinationId: string) {
+  if (!destinationId) return 'No group selected'
+  return dingTalkDestinations.value.find((item) => item.id === destinationId)?.name ?? destinationId
 }
 
 const selectedDingTalkGroupDestinations = computed(() =>
@@ -765,8 +833,14 @@ function copyPreviewText(key: string, text: string) {
 }
 
 const dingTalkPersonRecipientSummary = computed(() => {
-  if (!selectedDingTalkPersonRecipients.value.length) return 'No recipients selected'
-  return selectedDingTalkPersonRecipients.value.map((item) => item.label).join(', ')
+  const userLabels = selectedDingTalkPersonRecipients.value.map((item) => item.label)
+  const groupLabels = selectedDingTalkPersonMemberGroups.value.map((item) => item.label)
+  const parts = [
+    userLabels.length ? `Users: ${userLabels.join(', ')}` : '',
+    groupLabels.length ? `Groups: ${groupLabels.join(', ')}` : '',
+  ].filter(Boolean)
+  if (!parts.length) return 'No recipients selected'
+  return parts.join(' | ')
 })
 
 function parseRecipientFieldPathsText(value: string): string[] {
@@ -963,7 +1037,11 @@ const canSave = computed(() => {
     if (!draft.value.dingtalkBodyTemplate.trim()) return false
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
-    if (!draft.value.dingtalkPersonUserIds.trim() && !draft.value.dingtalkPersonRecipientFieldPath.trim()) return false
+    if (
+      !draft.value.dingtalkPersonUserIds.trim()
+      && !draft.value.dingtalkPersonMemberGroupIds.trim()
+      && !draft.value.dingtalkPersonRecipientFieldPath.trim()
+    ) return false
     if (!draft.value.dingtalkPersonTitleTemplate.trim()) return false
     if (!draft.value.dingtalkPersonBodyTemplate.trim()) return false
   }
@@ -996,6 +1074,7 @@ function openEditForm(rule: AutomationRule) {
     publicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
     internalViewId: (rule.actionConfig?.internalViewId as string) ?? '',
     dingtalkPersonUserIds: Array.isArray(rule.actionConfig?.userIds) ? rule.actionConfig?.userIds.join(', ') : '',
+    dingtalkPersonMemberGroupIds: Array.isArray(rule.actionConfig?.memberGroupIds) ? rule.actionConfig?.memberGroupIds.join(', ') : '',
     dingtalkPersonRecipientFieldPath: Array.isArray(rule.actionConfig?.userIdFieldPaths)
       ? (rule.actionConfig?.userIdFieldPaths as string[]).join(', ')
       : (rule.actionConfig?.userIdFieldPath as string) ?? '',
@@ -1045,6 +1124,10 @@ function buildActionConfig(): Record<string, unknown> {
     }
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
+    const memberGroupIds = draft.value.dingtalkPersonMemberGroupIds
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
     const userIdFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
       .map((path) => `record.${path}`)
     return {
@@ -1052,6 +1135,7 @@ function buildActionConfig(): Record<string, unknown> {
         .split(/[\n,]+/)
         .map((entry) => entry.trim())
         .filter(Boolean),
+      memberGroupIds: memberGroupIds.length ? memberGroupIds : undefined,
       userIdFieldPath: userIdFieldPaths[0] || undefined,
       userIdFieldPaths: userIdFieldPaths.length ? userIdFieldPaths : undefined,
       titleTemplate: draft.value.dingtalkPersonTitleTemplate,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -337,31 +337,31 @@
                 <button class="meta-rule-editor__btn" type="button" data-field="personPresetInternal" @click="applyPersonPreset(action, 'internal_process')">Internal processing</button>
                 <button class="meta-rule-editor__btn" type="button" data-field="personPresetBoth" @click="applyPersonPreset(action, 'form_and_process')">Form + processing</button>
               </div>
-              <label class="meta-rule-editor__label">Search and add users</label>
+              <label class="meta-rule-editor__label">Search and add users or member groups</label>
               <input
                 v-model="action.config.userIdsSearch"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="Search by name, email, or userId"
+                placeholder="Search by user, member group, email, or subject ID"
                 data-field="dingtalkPersonUserSearch"
                 @input="void loadPersonRecipientSuggestions(idx, action)"
               />
-              <div v-if="personRecipientLoading[idx]" class="meta-rule-editor__hint">Searching users…</div>
+              <div v-if="personRecipientLoading[idx]" class="meta-rule-editor__hint">Searching users and member groups…</div>
               <div v-else-if="personRecipientErrors[idx]" class="meta-rule-editor__hint meta-rule-editor__hint--error">{{ personRecipientErrors[idx] }}</div>
               <div v-else-if="availablePersonRecipientSuggestions(idx, action).length" class="meta-rule-editor__recipient-list">
                 <button
                   v-for="candidate in availablePersonRecipientSuggestions(idx, action)"
-                  :key="candidate.id"
+                  :key="personRecipientCandidateKey(candidate)"
                   class="meta-rule-editor__recipient-option"
                   type="button"
-                  :data-person-recipient-suggestion="candidate.id"
+                  :data-person-recipient-suggestion="personRecipientCandidateKey(candidate)"
                   @click="addPersonRecipient(action, candidate, idx)"
                 >
                   <strong>{{ candidate.label }}</strong>
-                  <span>{{ candidate.subtitle || candidate.id }}</span>
+                  <span>{{ candidate.subtitle || candidate.subjectId }}</span>
                 </button>
               </div>
-              <div v-else-if="typeof action.config.userIdsSearch === 'string' && action.config.userIdsSearch.trim()" class="meta-rule-editor__hint">No matching users</div>
+              <div v-else-if="typeof action.config.userIdsSearch === 'string' && action.config.userIdsSearch.trim()" class="meta-rule-editor__hint">No matching users or member groups</div>
               <div v-if="selectedPersonRecipients(action).length" class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected">
                 <button
                   v-for="recipient in selectedPersonRecipients(action)"
@@ -376,6 +376,20 @@
                   <em>Remove</em>
                 </button>
               </div>
+              <div v-if="selectedPersonRecipientGroups(action).length" class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected">
+                <button
+                  v-for="group in selectedPersonRecipientGroups(action)"
+                  :key="group.id"
+                  class="meta-rule-editor__recipient-chip"
+                  type="button"
+                  :data-person-member-group="group.id"
+                  @click="removePersonRecipientGroup(action, group.id)"
+                >
+                  <strong>{{ group.label }}</strong>
+                  <span>{{ group.subtitle || group.id }}</span>
+                  <em>Remove</em>
+                </button>
+              </div>
               <label class="meta-rule-editor__label">Local user IDs</label>
               <textarea
                 v-model="action.config.userIdsText"
@@ -383,6 +397,14 @@
                 rows="3"
                 placeholder="使用逗号或换行分隔本地 userId"
                 data-field="dingtalkPersonUserIds"
+              ></textarea>
+              <label class="meta-rule-editor__label">Member group IDs (optional)</label>
+              <textarea
+                v-model="action.config.memberGroupIdsText"
+                class="meta-rule-editor__textarea"
+                rows="2"
+                placeholder="使用逗号或换行分隔成员组 ID"
+                data-field="dingtalkPersonMemberGroupIds"
               ></textarea>
               <label class="meta-rule-editor__label">Record recipient field paths (optional)</label>
               <input
@@ -577,7 +599,7 @@ import type {
   AutomationAction,
   AutomationCondition,
   DingTalkGroupDestination,
-  MetaCommentMentionSuggestion,
+  MetaSheetPermissionCandidate,
   MetaView,
 } from '../types'
 import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
@@ -602,6 +624,7 @@ type DraftActionConfig = Record<string, unknown> & {
   method?: string
   userId?: string
   userIdsText?: string
+  memberGroupIdsText?: string
   userIdsSearch?: string
   recipientFieldPath?: string
   message?: string
@@ -648,7 +671,7 @@ const saving = ref(false)
 const cronPreset = ref('0 * * * *')
 const dingTalkDestinations = ref<DingTalkGroupDestination[]>([])
 const dingTalkDestinationsError = ref('')
-const personRecipientSuggestions = ref<Record<number, MetaCommentMentionSuggestion[]>>({})
+const personRecipientSuggestions = ref<Record<number, MetaSheetPermissionCandidate[]>>({})
 const personRecipientLoading = ref<Record<number, boolean>>({})
 const personRecipientErrors = ref<Record<number, string>>({})
 const personRecipientDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
@@ -700,6 +723,9 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
       ...config,
       userIdsText: Array.isArray(config.userIds)
         ? config.userIds.join(', ')
+        : '',
+      memberGroupIdsText: Array.isArray(config.memberGroupIds)
+        ? config.memberGroupIds.join(', ')
         : '',
       recipientFieldPath: Array.isArray(config.userIdFieldPaths)
         ? config.userIdFieldPaths.join(', ')
@@ -766,10 +792,11 @@ const canSave = computed(() => {
     }
     if (action.type === 'send_dingtalk_person_message') {
       const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
+      const memberGroupIdsText = typeof action.config.memberGroupIdsText === 'string' ? action.config.memberGroupIdsText.trim() : ''
       const recipientFieldPath = typeof action.config.recipientFieldPath === 'string' ? action.config.recipientFieldPath.trim() : ''
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!userIdsText && !recipientFieldPath) || !titleTemplate || !bodyTemplate) return false
+      if ((!userIdsText && !memberGroupIdsText && !recipientFieldPath) || !titleTemplate || !bodyTemplate) return false
     }
   }
   return true
@@ -811,10 +838,27 @@ function parseGroupDestinationIds(value: unknown): string[] {
   return []
 }
 
-function rememberPersonRecipientSuggestions(items: MetaCommentMentionSuggestion[]) {
+function parseMemberGroupIdsText(value: unknown): string[] {
+  if (typeof value !== 'string') return []
+  return value
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function personRecipientDirectoryKey(subjectType: 'user' | 'member-group', subjectId: string) {
+  return `${subjectType}:${subjectId}`
+}
+
+function personRecipientCandidateKey(candidate: MetaSheetPermissionCandidate) {
+  return personRecipientDirectoryKey(candidate.subjectType === 'member-group' ? 'member-group' : 'user', candidate.subjectId)
+}
+
+function rememberPersonRecipientSuggestions(items: MetaSheetPermissionCandidate[]) {
   const next = { ...personRecipientDirectory.value }
   for (const item of items) {
-    next[item.id] = { label: item.label, subtitle: item.subtitle }
+    if (item.subjectType !== 'user' && item.subjectType !== 'member-group') continue
+    next[personRecipientDirectoryKey(item.subjectType, item.subjectId)] = { label: item.label, subtitle: item.subtitle ?? undefined }
   }
   personRecipientDirectory.value = next
 }
@@ -822,14 +866,26 @@ function rememberPersonRecipientSuggestions(items: MetaCommentMentionSuggestion[
 function selectedPersonRecipients(action: DraftAction) {
   return parseUserIdsText(action.config.userIdsText).map((id) => ({
     id,
-    label: personRecipientDirectory.value[id]?.label ?? id,
-    subtitle: personRecipientDirectory.value[id]?.subtitle,
+    label: personRecipientDirectory.value[personRecipientDirectoryKey('user', id)]?.label ?? id,
+    subtitle: personRecipientDirectory.value[personRecipientDirectoryKey('user', id)]?.subtitle,
+  }))
+}
+
+function selectedPersonRecipientGroups(action: DraftAction) {
+  return parseMemberGroupIdsText(action.config.memberGroupIdsText).map((id) => ({
+    id,
+    label: personRecipientDirectory.value[personRecipientDirectoryKey('member-group', id)]?.label ?? id,
+    subtitle: personRecipientDirectory.value[personRecipientDirectoryKey('member-group', id)]?.subtitle,
   }))
 }
 
 function availablePersonRecipientSuggestions(idx: number, action: DraftAction) {
   const selected = new Set(parseUserIdsText(action.config.userIdsText))
-  return (personRecipientSuggestions.value[idx] ?? []).filter((candidate) => !selected.has(candidate.id))
+  const selectedGroups = new Set(parseMemberGroupIdsText(action.config.memberGroupIdsText))
+  return (personRecipientSuggestions.value[idx] ?? []).filter((candidate) => {
+    if (candidate.subjectType === 'member-group') return !selectedGroups.has(candidate.subjectId)
+    return !selected.has(candidate.subjectId)
+  })
 }
 
 async function loadPersonRecipientSuggestions(idx: number, action: DraftAction) {
@@ -845,8 +901,7 @@ async function loadPersonRecipientSuggestions(idx: number, action: DraftAction) 
   personRecipientLoading.value = { ...personRecipientLoading.value, [idx]: true }
   personRecipientErrors.value = { ...personRecipientErrors.value, [idx]: '' }
   try {
-    const response = await props.client.listCommentMentionSuggestions({
-      spreadsheetId: props.sheetId,
+    const response = await props.client.listFormShareCandidates(props.sheetId, {
       q: query,
       limit: 8,
     })
@@ -858,7 +913,7 @@ async function loadPersonRecipientSuggestions(idx: number, action: DraftAction) 
     personRecipientSuggestions.value = { ...personRecipientSuggestions.value, [idx]: [] }
     personRecipientErrors.value = {
       ...personRecipientErrors.value,
-      [idx]: error instanceof Error ? error.message : 'Failed to search users',
+      [idx]: error instanceof Error ? error.message : 'Failed to search users and member groups',
     }
   } finally {
     if (requestId === personRecipientSuggestionLoadId) {
@@ -867,10 +922,16 @@ async function loadPersonRecipientSuggestions(idx: number, action: DraftAction) 
   }
 }
 
-function addPersonRecipient(action: DraftAction, candidate: MetaCommentMentionSuggestion, idx: number) {
-  const ids = new Set(parseUserIdsText(action.config.userIdsText))
-  ids.add(candidate.id)
-  action.config.userIdsText = Array.from(ids).join(', ')
+function addPersonRecipient(action: DraftAction, candidate: MetaSheetPermissionCandidate, idx: number) {
+  if (candidate.subjectType === 'member-group') {
+    const ids = new Set(parseMemberGroupIdsText(action.config.memberGroupIdsText))
+    ids.add(candidate.subjectId)
+    action.config.memberGroupIdsText = Array.from(ids).join(', ')
+  } else {
+    const ids = new Set(parseUserIdsText(action.config.userIdsText))
+    ids.add(candidate.subjectId)
+    action.config.userIdsText = Array.from(ids).join(', ')
+  }
   action.config.userIdsSearch = ''
   rememberPersonRecipientSuggestions([candidate])
   personRecipientSuggestions.value = { ...personRecipientSuggestions.value, [idx]: [] }
@@ -922,6 +983,12 @@ function dingTalkGroupSummary(action: DraftAction) {
   return selected.map((item) => item.label).join(', ')
 }
 
+function removePersonRecipientGroup(action: DraftAction, groupId: string) {
+  action.config.memberGroupIdsText = parseMemberGroupIdsText(action.config.memberGroupIdsText)
+    .filter((id) => id !== groupId)
+    .join(', ')
+}
+
 function viewSummaryName(viewId: unknown, fallback: string) {
   const id = typeof viewId === 'string' ? viewId : ''
   if (!id) return fallback
@@ -951,9 +1018,14 @@ function copyPreviewText(key: string, text: string) {
 }
 
 function personRecipientSummary(action: DraftAction) {
-  const selected = selectedPersonRecipients(action)
-  if (!selected.length) return 'No recipients selected'
-  return selected.map((item) => item.label).join(', ')
+  const selectedUsers = selectedPersonRecipients(action).map((item) => item.label)
+  const selectedGroups = selectedPersonRecipientGroups(action).map((item) => item.label)
+  const parts = [
+    selectedUsers.length ? `Users: ${selectedUsers.join(', ')}` : '',
+    selectedGroups.length ? `Groups: ${selectedGroups.join(', ')}` : '',
+  ].filter(Boolean)
+  if (!parts.length) return 'No recipients selected'
+  return parts.join(' | ')
 }
 
 function parseRecipientFieldPathsText(value: unknown): string[] {
@@ -1098,6 +1170,7 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
     case 'send_dingtalk_person_message':
       return {
         userIdsText: '',
+        memberGroupIdsText: '',
         userIdsSearch: '',
         recipientFieldPath: '',
         titleTemplate: '',
@@ -1177,12 +1250,19 @@ function buildPayload(): Partial<AutomationRule> {
           .map((entry) => entry.trim())
           .filter(Boolean)
         : []
+      const memberGroupIds = typeof action.config.memberGroupIdsText === 'string'
+        ? action.config.memberGroupIdsText
+          .split(/[\n,]+/)
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+        : []
       const userIdFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
         .map((path) => `record.${path}`)
       return {
         type: action.type,
         config: {
           userIds,
+          memberGroupIds: memberGroupIds.length ? memberGroupIds : undefined,
           userIdFieldPath: userIdFieldPaths[0] || undefined,
           userIdFieldPaths: userIdFieldPaths.length ? userIdFieldPaths : undefined,
           titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : '',

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -101,13 +101,15 @@ function mockClient(rules: AutomationRule[] = []) {
     return ok({})
   })
   const client = new MultitableApiClient({ fetchFn })
-  client.listCommentMentionSuggestions = vi.fn(async () => ({
+  client.listFormShareCandidates = vi.fn(async () => ({
     items: [
-      { id: 'user_1', label: 'Lin Lan', subtitle: 'lin@example.com' },
-      { id: 'user_2', label: 'Zhao Ming', subtitle: 'zhao@example.com' },
+      { subjectType: 'user', subjectId: 'user_1', label: 'Lin Lan', subtitle: 'lin@example.com', isActive: true },
+      { subjectType: 'user', subjectId: 'user_2', label: 'Zhao Ming', subtitle: 'zhao@example.com', isActive: true },
+      { subjectType: 'member-group', subjectId: 'group_1', label: 'Sales Team', subtitle: '3 members', isActive: true },
     ],
-    total: 2,
+    total: 3,
     limit: 8,
+    query: '',
   }))
   return { client, fetchFn }
 }
@@ -615,13 +617,24 @@ describe('MetaAutomationManager', () => {
     searchInput.dispatchEvent(new Event('input', { bubbles: true }))
     await flushPromises()
 
-    const suggestion = container.querySelector('[data-automation-person-suggestion="user_1"]') as HTMLButtonElement
+    const suggestion = container.querySelector('[data-automation-person-suggestion="user:user_1"]') as HTMLButtonElement
     expect(suggestion).toBeTruthy()
     suggestion.click()
     await flushPromises()
 
+    searchInput.value = 'sales'
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const groupSuggestion = container.querySelector('[data-automation-person-suggestion="member-group:group_1"]') as HTMLButtonElement
+    expect(groupSuggestion).toBeTruthy()
+    groupSuggestion.click()
+    await flushPromises()
+
     const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
     expect(userIdsInput.value).toBe('user_1')
+    const memberGroupIdsInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    expect(memberGroupIdsInput.value).toBe('group_1')
 
     const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -640,7 +653,8 @@ describe('MetaAutomationManager', () => {
     expect(postCalls.length).toBe(1)
     const body = JSON.parse(postCalls[0][1]?.body as string)
     expect(body.actionConfig.userIds).toEqual(['user_1'])
-    expect(client.listCommentMentionSuggestions).toHaveBeenCalledTimes(1)
+    expect(body.actionConfig.memberGroupIds).toEqual(['group_1'])
+    expect(client.listFormShareCandidates).toHaveBeenCalledTimes(2)
   })
 
   it('opens DingTalk person delivery viewer for person message rules', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -43,12 +43,19 @@ function mockClient() {
       },
     ]),
     listCommentMentionSuggestions: vi.fn(async () => ({
-      items: [
-        { id: 'user_1', label: 'Lin Lan', subtitle: 'lin@example.com' },
-        { id: 'user_2', label: 'Zhao Ming', subtitle: 'zhao@example.com' },
-      ],
-      total: 2,
+      items: [],
+      total: 0,
       limit: 8,
+    })),
+    listFormShareCandidates: vi.fn(async () => ({
+      items: [
+        { subjectType: 'user', subjectId: 'user_1', label: 'Lin Lan', subtitle: 'lin@example.com', isActive: true },
+        { subjectType: 'user', subjectId: 'user_2', label: 'Zhao Ming', subtitle: 'zhao@example.com', isActive: true },
+        { subjectType: 'member-group', subjectId: 'group_1', label: 'Sales Team', subtitle: '3 members', isActive: true },
+      ],
+      total: 3,
+      limit: 8,
+      query: '',
     })),
   }
 }
@@ -604,13 +611,24 @@ describe('MetaAutomationRuleEditor', () => {
     searchInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const suggestion = container.querySelector('[data-person-recipient-suggestion="user_1"]') as HTMLButtonElement
+    const suggestion = container.querySelector('[data-person-recipient-suggestion="user:user_1"]') as HTMLButtonElement
     expect(suggestion).toBeTruthy()
     suggestion.click()
     await flushPromises()
 
+    searchInput.value = 'sales'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const groupSuggestion = container.querySelector('[data-person-recipient-suggestion="member-group:group_1"]') as HTMLButtonElement
+    expect(groupSuggestion).toBeTruthy()
+    groupSuggestion.click()
+    await flushPromises()
+
     const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
     expect(userIdsInput.value).toBe('user_1')
+    const memberGroupIdsInput = container.querySelector('[data-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    expect(memberGroupIdsInput.value).toBe('group_1')
 
     const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -628,7 +646,8 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved).toHaveBeenCalledTimes(1)
     const payload = saved.mock.calls[0][0]
     expect(payload.actionConfig.userIds).toEqual(['user_1'])
-    expect(client.listCommentMentionSuggestions).toHaveBeenCalledTimes(1)
+    expect(payload.actionConfig.memberGroupIds).toEqual(['group_1'])
+    expect(client.listFormShareCandidates).toHaveBeenCalledTimes(2)
   })
 
   it('applies DingTalk group message presets', async () => {

--- a/docs/development/dingtalk-person-member-group-recipients-development-20260420.md
+++ b/docs/development/dingtalk-person-member-group-recipients-development-20260420.md
@@ -1,0 +1,73 @@
+# DingTalk Person Member Group Recipients Development
+
+Date: 2026-04-20
+
+## Goal
+
+Extend `send_dingtalk_person_message` so sheet managers can target local member groups directly, instead of only:
+
+- static `userIds`
+- dynamic record user fields
+
+The system should resolve selected member groups to active local users, then continue through the existing DingTalk binding and personal notification pipeline.
+
+## Scope
+
+- Add `memberGroupIds` to the automation action config
+- Expand member groups to active local users at runtime
+- Merge and deduplicate:
+  - static `userIds`
+  - member-group recipients
+  - dynamic record user-field recipients
+- Add manager-side authoring support in both automation editors
+- Reuse existing sheet permission candidate search for user/member-group lookup
+- Keep the change backward-compatible with existing person-message rules
+
+## Backend Changes
+
+Updated [automation-actions.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-recipients-20260420/packages/core-backend/src/multitable/automation-actions.ts:1):
+
+- `SendDingTalkPersonMessageConfig` now accepts `memberGroupIds?: string[]`
+
+Updated [automation-executor.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-recipients-20260420/packages/core-backend/src/multitable/automation-executor.ts:1):
+
+- Validates requested member groups exist
+- Resolves selected groups through `platform_member_group_members`
+- Filters to active local users
+- Merges resolved group users with static and dynamic recipients
+- Returns explicit failures for:
+  - missing groups
+  - groups that resolve to no active users
+  - rules with no effective recipients
+- Reports member-group recipient counts in the action output
+
+Updated [automation-v1.test.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-recipients-20260420/packages/core-backend/tests/unit/automation-v1.test.ts:1):
+
+- Added focused coverage for member-group recipient expansion
+
+## Frontend Changes
+
+Updated [MetaAutomationManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-recipients-20260420/apps/web/src/multitable/components/MetaAutomationManager.vue:1) and [MetaAutomationRuleEditor.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-recipients-20260420/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue:1):
+
+- Search now uses `listFormShareCandidates(...)` so users and member groups can be suggested together
+- Static person recipients and member-group recipients can both be added from search
+- Added `Member group IDs (optional)` input
+- Added selected member-group chips with remove actions
+- Summary text now distinguishes:
+  - `Users: ...`
+  - `Groups: ...`
+- Save validation now allows any of:
+  - static users
+  - static member groups
+  - dynamic record recipient fields
+
+Updated tests:
+
+- [multitable-automation-manager.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-recipients-20260420/apps/web/tests/multitable-automation-manager.spec.ts:1)
+- [multitable-automation-rule-editor.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-recipients-20260420/apps/web/tests/multitable-automation-rule-editor.spec.ts:1)
+
+## Migration / Deploy Impact
+
+- No database migration
+- No API shape break for existing rules
+- Existing `userIds` and dynamic recipient-field rules continue to work unchanged

--- a/docs/development/dingtalk-person-member-group-recipients-verification-20260420.md
+++ b/docs/development/dingtalk-person-member-group-recipients-verification-20260420.md
@@ -1,0 +1,41 @@
+# DingTalk Person Member Group Recipients Verification
+
+Date: 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend tests: `101 passed`
+- Frontend tests: `50 passed`
+- Backend build: passed
+- Web build: passed
+- `git diff --check`: passed
+
+## Focus Checks
+
+- `send_dingtalk_person_message` can target static member groups
+- Member groups resolve to active local users before DingTalk delivery
+- Member-group users merge with:
+  - static `userIds`
+  - dynamic record recipient fields
+- Manager-side editors can:
+  - search users and member groups together
+  - add member groups from suggestions
+  - persist `memberGroupIds`
+  - render/removes member-group chips
+  - save rules that use only member groups
+
+## Notes
+
+- `pnpm install` updated several `plugins/**/node_modules` and `tools/cli/node_modules` paths in the worktree.
+- Those dependency noise changes are not part of the feature and should not be committed.

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -60,6 +60,7 @@ export interface SendDingTalkGroupMessageConfig {
 /** Config shape for send_dingtalk_person_message */
 export interface SendDingTalkPersonMessageConfig {
   userIds: string[]
+  memberGroupIds?: string[]
   userIdFieldPath?: string
   userIdFieldPaths?: string[]
   titleTemplate: string

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -665,28 +665,13 @@ export class AutomationExecutor {
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
     const staticUserIds = normalizeUserIds(config.userIds)
+    const memberGroupIds = normalizeUserIds(config.memberGroupIds)
     const recipientFieldPaths = normalizeRecipientFieldPaths(config.userIdFieldPath, config.userIdFieldPaths)
     const recordUserIds = resolveRecipientUserIdsFromRecord(context.recordData, recipientFieldPaths)
-    const userIds = Array.from(new Set([...staticUserIds, ...recordUserIds]))
     const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
     const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
     const publicFormViewId = typeof config.publicFormViewId === 'string' ? config.publicFormViewId.trim() : ''
     const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
-
-    if (userIds.length === 0) {
-      if (recipientFieldPaths.length > 0) {
-        return {
-          actionType: 'send_dingtalk_person_message',
-          status: 'failed',
-          error: `No local userIds resolved from record field paths: ${recipientFieldPaths.join(', ')}`,
-        }
-      }
-      return {
-        actionType: 'send_dingtalk_person_message',
-        status: 'failed',
-        error: 'At least one local userId or record recipient field path is required',
-      }
-    }
     if (!titleTemplate) {
       return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'DingTalk title template is required' }
     }
@@ -770,6 +755,64 @@ export class AutomationExecutor {
       renderedBody,
       linkLines.length > 0 ? ['**快捷入口**', ...linkLines].join('\n') : '',
     ].filter(Boolean).join('\n\n')
+
+    let memberGroupUserIds: string[] = []
+    if (memberGroupIds.length > 0) {
+      const existingGroupsResult = await this.deps.queryFn(
+        'SELECT id::text AS id FROM platform_member_groups WHERE id::text = ANY($1::text[])',
+        [memberGroupIds],
+      )
+      const existingGroupIds = new Set(
+        (existingGroupsResult.rows as Array<Record<string, unknown>>)
+          .map((row) => (typeof row.id === 'string' ? row.id.trim() : ''))
+          .filter(Boolean),
+      )
+      const missingGroupIds = memberGroupIds.filter((groupId) => !existingGroupIds.has(groupId))
+      if (missingGroupIds.length > 0) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: `Member groups not found: ${missingGroupIds.join(', ')}`,
+        }
+      }
+
+      const memberGroupRecipientsResult = await this.deps.queryFn(
+        `SELECT DISTINCT gm.user_id::text AS local_user_id
+           FROM platform_member_group_members gm
+           JOIN users u ON u.id = gm.user_id
+          WHERE gm.group_id::text = ANY($1::text[])
+            AND u.is_active = TRUE`,
+        [memberGroupIds],
+      )
+      memberGroupUserIds = Array.from(new Set(
+        (memberGroupRecipientsResult.rows as Array<Record<string, unknown>>)
+          .map((row) => (typeof row.local_user_id === 'string' ? row.local_user_id.trim() : ''))
+          .filter(Boolean),
+      ))
+    }
+
+    const userIds = Array.from(new Set([...staticUserIds, ...memberGroupUserIds, ...recordUserIds]))
+    if (userIds.length === 0) {
+      if (memberGroupIds.length > 0) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: `No local userIds resolved from member groups: ${memberGroupIds.join(', ')}`,
+        }
+      }
+      if (recipientFieldPaths.length > 0) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: `No local userIds resolved from record field paths: ${recipientFieldPaths.join(', ')}`,
+        }
+      }
+      return {
+        actionType: 'send_dingtalk_person_message',
+        status: 'failed',
+        error: 'At least one local userId, memberGroupId, or record recipient field path is required',
+      }
+    }
 
     const recipientsResult = await this.deps.queryFn(
       `SELECT u.id AS local_user_id,
@@ -865,7 +908,9 @@ export class AutomationExecutor {
         output: {
           notifiedUsers: resolvedRecipients.length,
           staticRecipientCount: staticUserIds.length,
+          memberGroupRecipientCount: memberGroupUserIds.length,
           dynamicRecipientCount: recordUserIds.length,
+          memberGroupIds,
           recipientFieldPath: recipientFieldPaths[0] ?? null,
           recipientFieldPaths,
           batchCount: batches.length,

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -672,6 +672,72 @@ describe('AutomationExecutor', () => {
     expect(insertCalls).toHaveLength(2)
   })
 
+  it('executes send_dingtalk_person_message for member group recipients', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'group_1' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1' },
+          { local_user_id: 'user_2' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' },
+          { local_user_id: 'user_2', local_user_active: true, dingtalk_user_id: 'dt-user-2' },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          memberGroupIds: ['group_1'],
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    const [, sendInit] = fetchFn.mock.calls[1] as [string, RequestInit]
+    const payload = JSON.parse(sendInit.body as string)
+    expect(payload.userid_list).toBe('dt-user-1,dt-user-2')
+    expect(result.steps[0].output).toMatchObject({
+      notifiedUsers: 2,
+      staticRecipientCount: 0,
+      memberGroupRecipientCount: 2,
+      dynamicRecipientCount: 0,
+      memberGroupIds: ['group_1'],
+    })
+  })
+
   it('fails send_dingtalk_person_message when a user has no linked DingTalk account', async () => {
     const queryFn = vi.fn()
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- extend `send_dingtalk_person_message` to accept static `memberGroupIds`
- resolve selected member groups to active local users before DingTalk delivery
- let both automation editors search/add local users and member groups together

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web build`
- `git diff --check`