### PR TITLE
docs(dingtalk): add rollout notes for #954 and #955

### DIFF
--- a/docs/development/dingtalk-group-and-person-recipient-rollout-development-20260420.md
+++ b/docs/development/dingtalk-group-and-person-recipient-rollout-development-20260420.md
@@ -1,0 +1,62 @@
+# DingTalk Group And Person Recipient Rollout Development
+
+Date: 2026-04-20
+
+## Scope
+
+This rollout packet covers the production landing for:
+
+- `#954` `feat(dingtalk): support multiple group destinations`
+- `#955` `feat(dingtalk): support person message member groups`
+
+Both features were already merged to `main`. This slice only captures rollout evidence and production verification.
+
+## Included Runtime Changes
+
+### Group Messaging
+
+`send_dingtalk_group_message` now supports multiple DingTalk group destinations in one rule.
+
+- Existing single `destinationId` remains backward-compatible
+- New `destinationIds` lets one rule fan out to multiple groups
+- Delivery history is still recorded per destination
+
+### Person Messaging
+
+`send_dingtalk_person_message` now supports static local member groups.
+
+- Rule config accepts `memberGroupIds`
+- Runtime expands member groups through `platform_member_group_members`
+- Only active local users continue to the existing DingTalk-account resolution path
+- Frontend authoring supports searching and adding both users and member groups
+
+## Rollout Path
+
+Both changes were deployed through the existing mainline Docker pipeline, not by manual host patching.
+
+Primary production run:
+
+- Workflow: `Build and Push Docker Images`
+- Run: `24674833062`
+- Head SHA: `0b18d2bc82c4b833d07805b8d77ef096bd65c69f`
+
+The corresponding deploy workflow evidence shows:
+
+- backend/frontend images published with `image_tag=0b18d2bc82c4b833d07805b8d77ef096bd65c69f`
+- remote `.env` updated with `IMAGE_OWNER` and `IMAGE_TAG`
+- remote deploy stage completed
+- migrate stage completed
+- smoke stage completed
+
+## Evidence Files
+
+Downloaded artifact evidence lives at:
+
+- [deploy.log](/Users/chouhua/Downloads/Github/metasheet2/output/dingtalk-954-955-deploy-20260420/deploy-logs-24674833062-1/deploy.log:1)
+- [step-summary.md](/Users/chouhua/Downloads/Github/metasheet2/output/dingtalk-954-955-deploy-20260420/deploy-logs-24674833062-1/step-summary.md:1)
+
+## Notes
+
+- This slice does not add migrations
+- This slice does not introduce any manual hotfix on the deploy host
+- Production evidence is based on GitHub Actions deploy logs and uploaded deploy artifacts

--- a/docs/development/dingtalk-group-and-person-recipient-rollout-verification-20260420.md
+++ b/docs/development/dingtalk-group-and-person-recipient-rollout-verification-20260420.md
@@ -1,0 +1,66 @@
+# DingTalk Group And Person Recipient Rollout Verification
+
+Date: 2026-04-20
+
+## Source Runs
+
+Mainline merge/deploy evidence checked for:
+
+- `#954` merge commit `bab4f5c52b9f8a8f021e2ee6655adfa4334984c1`
+- `#955` merge commit `0b18d2bc82c4b833d07805b8d77ef096bd65c69f`
+
+Primary production rollout run:
+
+- `Build and Push Docker Images`
+- Run `24674833062`
+
+## Commands
+
+```bash
+gh run list --repo zensgit/metasheet2 --branch main --limit 8 --json databaseId,workflowName,displayTitle,headSha,status,conclusion,createdAt
+gh run view 24674833062 --repo zensgit/metasheet2 --json databaseId,displayTitle,headSha,status,conclusion,jobs,workflowName
+gh run view 24674833062 --repo zensgit/metasheet2 --log --job 72156120286
+gh run download 24674833062 --repo zensgit/metasheet2 -n deploy-logs-24674833062-1 -D output/dingtalk-954-955-deploy-20260420
+rg -n "image_tag=|persisted IMAGE_OWNER and IMAGE_TAG|=== DEPLOY START ===|=== DEPLOY END ===|=== MIGRATE START ===|=== MIGRATE END ===|Smoke:|=== SMOKE START ===|=== SMOKE END ===" output/dingtalk-954-955-deploy-20260420/deploy-logs-24674833062-1/deploy.log output/dingtalk-954-955-deploy-20260420/deploy-logs-24674833062-1/step-summary.md
+git diff --check
+```
+
+## Results
+
+From `gh run list`:
+
+- `Deploy to Production` completed for `#955`
+- `Build and Push Docker Images` completed for `#955`
+- all listed mainline workflows around the merge were `success`
+
+From `gh run view 24674833062`:
+
+- workflow conclusion: `success`
+- build job: `success`
+- deploy job: `success`
+
+From [deploy.log](/Users/chouhua/Downloads/Github/metasheet2/output/dingtalk-954-955-deploy-20260420/deploy-logs-24674833062-1/deploy.log:1):
+
+- `[deploy] image_tag=0b18d2bc82c4b833d07805b8d77ef096bd65c69f`
+- `[deploy] persisted IMAGE_OWNER and IMAGE_TAG in .env`
+- `=== DEPLOY START ===`
+- `=== DEPLOY END ===`
+- `=== MIGRATE START ===`
+- `=== MIGRATE END ===`
+- `=== SMOKE START ===`
+- `Smoke: api/plugins=ok health=ok web=ok`
+- `=== SMOKE END ===`
+
+From [step-summary.md](/Users/chouhua/Downloads/Github/metasheet2/output/dingtalk-954-955-deploy-20260420/deploy-logs-24674833062-1/step-summary.md:1):
+
+- `Smoke: PASS`
+
+## Verification Conclusion
+
+`#954` and `#955` are both in `main`, and the production Docker rollout for `0b18d2bc82c4b833d07805b8d77ef096bd65c69f` completed successfully with:
+
+- published images
+- remote `.env` reconciliation
+- deploy success
+- migrate success
+- smoke success


### PR DESCRIPTION
## Summary
- capture production rollout evidence for `#954` and `#955`
- link the successful mainline Docker run and deploy artifact evidence
- record deploy/migrate/smoke confirmation for the merged DingTalk notification changes

## Verification
- `gh run list --repo zensgit/metasheet2 --branch main --limit 8 --json databaseId,workflowName,displayTitle,headSha,status,conclusion,createdAt`
- `gh run view 24674833062 --repo zensgit/metasheet2 --json databaseId,displayTitle,headSha,status,conclusion,jobs,workflowName`
- `gh run view 24674833062 --repo zensgit/metasheet2 --log --job 72156120286`
- `gh run download 24674833062 --repo zensgit/metasheet2 -n deploy-logs-24674833062-1 -D output/dingtalk-954-955-deploy-20260420`
- `rg -n "image_tag=|persisted IMAGE_OWNER and IMAGE_TAG|=== DEPLOY START ===|=== DEPLOY END ===|=== MIGRATE START ===|=== MIGRATE END ===|Smoke:|=== SMOKE START ===|=== SMOKE END ===" output/dingtalk-954-955-deploy-20260420/deploy-logs-24674833062-1/deploy.log output/dingtalk-954-955-deploy-20260420/deploy-logs-24674833062-1/step-summary.md`
- `git diff --check`