### PR TITLE
feat(collab): wire Yjs opt-in into grid text cells behind build flag

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -156,12 +156,14 @@
                   v-if="isEditing(row.id, field.id)"
                   :field="field"
                   :model-value="editCell!.value"
+                  :record-id="row.id"
                   :upload-fn="props.uploadFn"
                   :delete-attachment-fn="props.deleteAttachmentFn"
                   :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
                   :upload-context="{ recordId: row.id, fieldId: field.id }"
                   @update:model-value="editCell!.value = $event"
                   @confirm="confirmEdit(row)"
+                  @yjs-commit="markYjsHandled(row.id, field.id)"
                   @cancel="cancelEdit"
                   @open-link-picker="openLinkPickerFromCell(row.id, field)"
                 />
@@ -309,6 +311,19 @@ const focusCol = ref(-1)
 const selectedIds = ref<Set<string>>(new Set())
 const expandedRowIds = ref<Set<string>>(new Set())
 
+/**
+ * Set when MetaCellEditor emits `yjs-commit`, meaning the active edit was
+ * carried over Yjs and the server-side bridge will persist it. We then
+ * suppress the REST `patch-cell` emit in `confirmEdit` to avoid a
+ * redundant write — the backend Yjs bridge writes to `meta_records` via
+ * `RecordWriteService.patchRecords`. Cleared on every new edit start.
+ */
+const yjsHandledCellKey = ref<string | null>(null)
+const cellKey = (recordId: string, fieldId: string) => `${recordId}::${fieldId}`
+function markYjsHandled(recordId: string, fieldId: string): void {
+  yjsHandledCellKey.value = cellKey(recordId, fieldId)
+}
+
 function toggleRowExpand(rowId: string) {
   const s = new Set(expandedRowIds.value)
   if (s.has(rowId)) s.delete(rowId)
@@ -450,17 +465,25 @@ function onCellClick(ri: number, ci: number, rid: string) {
 
 function startEdit(row: MetaRecord, field: MetaField) {
   if (!isEditable(row.id, field)) return
+  yjsHandledCellKey.value = null
   editCell.value = { recordId: row.id, fieldId: field.id, value: row.data[field.id] ?? null }
 }
 
 function confirmEdit(row: MetaRecord) {
   if (!editCell.value) return
   const { recordId, fieldId, value } = editCell.value
-  if (value !== row.data[fieldId]) emit('patch-cell', recordId, fieldId, value, row.version)
+  // Skip the REST patch only when the editor signalled that Yjs carried
+  // the edit for this exact cell. If the Yjs path was not active (flag
+  // off, timeout, error) we stay on REST unchanged.
+  const handledViaYjs = yjsHandledCellKey.value === cellKey(recordId, fieldId)
+  if (!handledViaYjs && value !== row.data[fieldId]) {
+    emit('patch-cell', recordId, fieldId, value, row.version)
+  }
   editCell.value = null
+  yjsHandledCellKey.value = null
 }
 
-function cancelEdit() { editCell.value = null }
+function cancelEdit() { editCell.value = null; yjsHandledCellKey.value = null }
 
 function openLinkPickerFromCell(recordId: string, field: MetaField) {
   cancelEdit()

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -23,16 +23,23 @@
       @keydown.escape="emit('cancel')"
     />
     <!-- string: normal -->
-    <input
-      v-else-if="field.type === 'string'"
-      ref="inputRef"
-      class="meta-cell-editor__input"
-      type="text"
-      :value="modelValue ?? ''"
-      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
-      @keydown.enter="emit('confirm')"
-      @keydown.escape="emit('cancel')"
-    />
+    <div v-else-if="field.type === 'string'" class="meta-cell-editor__text-wrap">
+      <input
+        ref="inputRef"
+        class="meta-cell-editor__input"
+        type="text"
+        :value="yjsActive ? yjsText : (modelValue ?? '')"
+        @input="onTextInput"
+        @keydown.enter="onTextConfirm"
+        @keydown.escape="emit('cancel')"
+      />
+      <MetaYjsPresenceChip
+        v-if="yjsActive && yjsCollaborators.length > 0"
+        class="meta-cell-editor__presence"
+        label="Editing"
+        :users="yjsCollaborators"
+      />
+    </div>
 
     <!-- number -->
     <input
@@ -125,11 +132,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, toRef } from 'vue'
 import type { MetaAttachment, MetaAttachmentDeleteFn, MetaAttachmentUploadContext, MetaAttachmentUploadFn, MetaField } from '../../types'
 import MetaAttachmentList from '../MetaAttachmentList.vue'
+import MetaYjsPresenceChip from '../MetaYjsPresenceChip.vue'
 import { attachmentAcceptAttr, resolveAttachmentFieldProperty, shouldReplaceAttachmentSelection, validateAttachmentSelection } from '../../utils/field-config'
 import { linkActionLabel as formatLinkActionLabel } from '../../utils/link-fields'
+import { useYjsCellBinding } from '../../composables/useYjsCellBinding'
 
 const props = defineProps<{
   field: MetaField
@@ -138,6 +147,12 @@ const props = defineProps<{
   deleteAttachmentFn?: MetaAttachmentDeleteFn
   uploadContext?: MetaAttachmentUploadContext
   attachmentSummaries?: MetaAttachment[]
+  /**
+   * Record id of the cell being edited — required for Yjs binding. When
+   * absent, the Yjs opt-in cannot engage; the editor falls back to the
+   * existing REST path regardless of the build-time flag.
+   */
+  recordId?: string | null
 }>()
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}/
@@ -154,7 +169,57 @@ const emit = defineEmits<{
   (e: 'confirm'): void
   (e: 'cancel'): void
   (e: 'open-link-picker'): void
+  /**
+   * Emitted *before* `confirm` when the user's edit was carried by the
+   * Yjs opt-in path. Parents listening for this should suppress the
+   * normal REST patch — the server-side Yjs bridge will persist the
+   * change via `meta_records`. Pass-through REST is safe but redundant.
+   */
+  (e: 'yjs-commit'): void
 }>()
+
+// --- Yjs opt-in binding (text cells only; inert when flag off) ---
+// See useYjsCellBinding for flag gating + timeout + fallback. The editor
+// always renders; `yjsActive` flips true only when a live Y.Doc is
+// attached, at which point the `<input>` is driven by Y.Text instead of
+// `modelValue`. On any failure (flag off, timeout, server error, mid-edit
+// disconnect) `yjsActive` stays/returns to false and the input falls
+// back to the REST path untouched.
+const recordIdRef = toRef(props, 'recordId') as unknown as import('vue').Ref<string | null | undefined>
+const fieldIdRef = computed<string | null>(() => {
+  if (props.field?.type !== 'string') return null
+  if (isDateLike.value) return null
+  if (!props.recordId) return null
+  return props.field.id
+})
+const yjsBinding = useYjsCellBinding({
+  recordId: computed<string | null>(() => recordIdRef.value ?? null),
+  fieldId: fieldIdRef,
+  onFallback: (reason) => {
+    if (reason === 'disabled') return // expected, no noise
+    // Soft warning only — the REST path remains fully usable.
+    // eslint-disable-next-line no-console
+    console.warn(`[multitable] Yjs cell binding fell back to REST (${reason})`)
+  },
+})
+const yjsActive = computed(() => yjsBinding.active.value)
+const yjsText = computed(() => yjsBinding.text.value)
+const yjsCollaborators = computed(() => yjsBinding.collaborators.value)
+
+function onTextInput(event: Event) {
+  const next = (event.target as HTMLInputElement).value
+  if (yjsActive.value) {
+    // Drive Y.Text; mirror via update:modelValue so parent state
+    // (undo buffers, derived cell previews) stays in sync.
+    yjsBinding.setText(next)
+  }
+  emit('update:modelValue', next)
+}
+
+function onTextConfirm() {
+  if (yjsActive.value) emit('yjs-commit')
+  emit('confirm')
+}
 
 const inputRef = ref<HTMLElement | null>(null)
 const linkButtonLabel = computed(() => {
@@ -305,9 +370,15 @@ onMounted(() => {
 
 <style scoped>
 .meta-cell-editor { display: flex; align-items: center; }
+.meta-cell-editor__text-wrap {
+  display: flex; align-items: center; gap: 6px; width: 100%;
+}
 .meta-cell-editor__input {
   width: 100%; padding: 2px 6px; border: 1px solid #409eff; border-radius: 3px;
   font-size: 13px; outline: none;
+}
+.meta-cell-editor__presence {
+  flex-shrink: 0;
 }
 .meta-cell-editor__select {
   width: 100%; padding: 2px 4px; border: 1px solid #409eff; border-radius: 3px;

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -138,7 +138,7 @@ import MetaAttachmentList from '../MetaAttachmentList.vue'
 import MetaYjsPresenceChip from '../MetaYjsPresenceChip.vue'
 import { attachmentAcceptAttr, resolveAttachmentFieldProperty, shouldReplaceAttachmentSelection, validateAttachmentSelection } from '../../utils/field-config'
 import { linkActionLabel as formatLinkActionLabel } from '../../utils/link-fields'
-import { useYjsCellBinding } from '../../composables/useYjsCellBinding'
+import { useYjsCellBinding, type YjsCellBinding } from '../../composables/useYjsCellBinding'
 
 const props = defineProps<{
   field: MetaField
@@ -192,16 +192,26 @@ const fieldIdRef = computed<string | null>(() => {
   if (!props.recordId) return null
   return props.field.id
 })
-const yjsBinding = useYjsCellBinding({
-  recordId: computed<string | null>(() => recordIdRef.value ?? null),
-  fieldId: fieldIdRef,
-  onFallback: (reason) => {
-    if (reason === 'disabled') return // expected, no noise
-    // Soft warning only — the REST path remains fully usable.
-    // eslint-disable-next-line no-console
-    console.warn(`[multitable] Yjs cell binding fell back to REST (${reason})`)
-  },
-})
+const inertYjsBinding: YjsCellBinding = {
+  active: ref(false),
+  text: ref(''),
+  setText: () => { /* inactive: non-text editors keep using REST */ },
+  collaborators: ref([]),
+  release: () => { /* nothing to release */ },
+}
+const yjsEligibleAtSetup = props.field?.type === 'string' && !isDateLike.value && !!props.recordId
+const yjsBinding = yjsEligibleAtSetup
+  ? useYjsCellBinding({
+      recordId: computed<string | null>(() => recordIdRef.value ?? null),
+      fieldId: fieldIdRef,
+      onFallback: (reason) => {
+        if (reason === 'disabled') return // expected, no noise
+        // Soft warning only — the REST path remains fully usable.
+        // eslint-disable-next-line no-console
+        console.warn(`[multitable] Yjs cell binding fell back to REST (${reason})`)
+      },
+    })
+  : inertYjsBinding
 const yjsActive = computed(() => yjsBinding.active.value)
 const yjsText = computed(() => yjsBinding.text.value)
 const yjsCollaborators = computed(() => yjsBinding.collaborators.value)

--- a/apps/web/src/multitable/composables/useYjsCellBinding.ts
+++ b/apps/web/src/multitable/composables/useYjsCellBinding.ts
@@ -122,6 +122,13 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
   let released = false
   let yjsTextApi: { setText: (next: string) => void } | null = null
   let textWatchStop: (() => void) | null = null
+  let yjsActiveStop: (() => void) | null = null
+  // Mirrors the Y.Text-exists signal from useYjsTextField for the active
+  // field binding. Only when this is true AND the sync handshake has
+  // completed do we flip `active` on. See seed contract in
+  // useYjsTextField.ts — if the Y.Text doesn't exist we MUST fall back
+  // to REST rather than creating an empty Y.Text and risking overwrite.
+  const boundYjsActive = ref(false)
 
   const yjs = useYjsDocument(liveRecordId)
 
@@ -147,16 +154,18 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
   function fallback(reason: 'timeout' | 'error') {
     if (released) return
     clearTimer()
-    if (active.value === false && !yjs.connected.value && !yjs.synced.value) {
-      // already inert
-    }
     active.value = false
+    boundYjsActive.value = false
     collaborators.value = []
     text.value = ''
     yjsTextApi = null
     if (textWatchStop) {
       try { textWatchStop() } catch { /* ignore */ }
       textWatchStop = null
+    }
+    if (yjsActiveStop) {
+      try { yjsActiveStop() } catch { /* ignore */ }
+      yjsActiveStop = null
     }
     fieldKey.value = null
     // Setting liveRecordId to null triggers useYjsDocument's disconnect.
@@ -166,17 +175,26 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
 
   function bindField(fid: string) {
     fieldKey.value = fid
-    // useYjsTextField returns reactive text + setText/insertAt/deleteRange.
+    // useYjsTextField returns reactive text + setText/insertAt/deleteRange
+    // + yjsActive (true only when a Y.Text already exists under this
+    // fieldId). We refuse to activate our binding until yjsActive flips
+    // true so we never drive the input off an empty Y.Text.
     const bound = useYjsTextField(yjs.doc, fid, {
       setActiveField: yjs.setActiveField,
     })
     yjsTextApi = { setText: bound.setText }
-    // Mirror the Y.Text-backed ref into our own reactive `text` so the
-    // caller only needs to touch this module's API.
+    boundYjsActive.value = bound.yjsActive.value
     textWatchStop = watch(
       () => bound.text.value,
       (next) => {
         text.value = next
+      },
+      { immediate: true },
+    )
+    yjsActiveStop = watch(
+      () => bound.yjsActive.value,
+      (next) => {
+        boundYjsActive.value = next
       },
       { immediate: true },
     )
@@ -192,15 +210,24 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
     },
   )
 
-  // Consider the binding active once the sync handshake completes. This
-  // keeps us from marking active on a bare socket connect (we want a real
-  // Y.Doc with state, not just a TCP handshake).
+  // Consider the binding active once BOTH (a) the sync handshake
+  // completes AND (b) a Y.Text actually exists for this field. Without
+  // (b) we'd bind the input to a useYjsTextField that returns
+  // `text: ""` and a no-op `setText`, silently sending empty edits.
+  // The seed on the backend ensures (b) for existing fields, but if
+  // seed is delayed or failed we stay inactive and the caller keeps
+  // REST.
   const stopSyncedWatch = watch(
-    () => yjs.synced.value,
-    (isSynced) => {
-      if (isSynced && !released) {
+    [() => yjs.synced.value, () => boundYjsActive.value],
+    ([isSynced, hasYText]) => {
+      if (released) return
+      if (isSynced && hasYText) {
         clearTimer()
         active.value = true
+      } else if (!hasYText && active.value) {
+        // Y.Text disappeared mid-session (shouldn't happen in normal
+        // flow; defensive). Fall back to REST.
+        active.value = false
       }
     },
   )
@@ -220,12 +247,17 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
       if (released) return
       clearTimer()
       active.value = false
+      boundYjsActive.value = false
       collaborators.value = []
       text.value = ''
       yjsTextApi = null
       if (textWatchStop) {
         try { textWatchStop() } catch { /* ignore */ }
         textWatchStop = null
+      }
+      if (yjsActiveStop) {
+        try { yjsActiveStop() } catch { /* ignore */ }
+        yjsActiveStop = null
       }
       if (!newRecordId || !newFieldId) {
         fieldKey.value = null
@@ -258,6 +290,11 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
       try { textWatchStop() } catch { /* ignore */ }
       textWatchStop = null
     }
+    if (yjsActiveStop) {
+      try { yjsActiveStop() } catch { /* ignore */ }
+      yjsActiveStop = null
+    }
+    boundYjsActive.value = false
     fieldKey.value = null
     liveRecordId.value = null
     try { stopPresenceWatch() } catch { /* ignore */ }

--- a/apps/web/src/multitable/composables/useYjsCellBinding.ts
+++ b/apps/web/src/multitable/composables/useYjsCellBinding.ts
@@ -1,0 +1,280 @@
+import { ref, shallowRef, watch, onUnmounted } from 'vue'
+import type { Ref } from 'vue'
+import { useYjsDocument } from './useYjsDocument'
+import { useYjsTextField } from './useYjsTextField'
+import type { YjsPresenceUser } from '../types'
+
+/**
+ * Opt-in Yjs binding for a single text cell.
+ *
+ * Behavior summary:
+ * - Reads the build-time flag `VITE_ENABLE_YJS_COLLAB`. When not exactly the
+ *   string `"true"`, this composable is inert: `active` stays false, no
+ *   Socket.IO connection is attempted, no Y.Doc is created, and the caller's
+ *   existing REST submit path continues to run unchanged.
+ * - When the flag is on and a `recordId`/`fieldId` is supplied, this
+ *   composable connects to `/yjs`, binds a `Y.Text` under the field key,
+ *   and exposes reactive `text`, `setText`, and per-field `collaborators`.
+ * - Includes a conservative connect timeout (`CONNECT_TIMEOUT_MS`) so the
+ *   caller can fall back to REST without hanging. On timeout or error the
+ *   binding marks itself inactive and disconnects; the caller MUST continue
+ *   with REST — this composable never throws and never swallows user edits.
+ *
+ * Scope: POC wiring. Only text (`string` non-date-like) cells should call
+ * this. Other field types stay on REST.
+ *
+ * To enable at build time:
+ *   VITE_ENABLE_YJS_COLLAB=true npm --workspace @metasheet/web run build
+ */
+
+export const YJS_COLLAB_ENV_FLAG = 'VITE_ENABLE_YJS_COLLAB'
+
+/**
+ * Reads the build-time flag from `import.meta.env`, which Vite replaces at
+ * bundle time. Falls back to `process.env` so `vi.stubEnv` picks it up in
+ * Vitest (the stub is visible on `process.env` in Node, not in the
+ * per-file-transformed `import.meta.env`). Downstream: a browser build
+ * with the flag off has the Vite value `undefined` and the process
+ * fallback is a no-op, so the whole Yjs path stays inert.
+ */
+export function isYjsCollabEnabled(): boolean {
+  try {
+    const metaEnv = (import.meta as unknown as { env?: Record<string, unknown> }).env
+    const metaValue = metaEnv?.[YJS_COLLAB_ENV_FLAG]
+    if (metaValue === 'true') return true
+    // Fallback to process.env so `vi.stubEnv` (which writes to process.env
+    // in Node) picks the flag up in Vitest. In a browser build there is
+    // no `process` global, so this check is a no-op.
+    const globalProcess = (globalThis as unknown as {
+      process?: { env?: Record<string, string | undefined> }
+    }).process
+    return globalProcess?.env?.[YJS_COLLAB_ENV_FLAG] === 'true'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Hard cap on how long we wait for the Socket.IO handshake + initial sync.
+ * If neither `connected` nor `synced` flips true in this window, we give
+ * up, disconnect, and let the caller stick with REST.
+ */
+const CONNECT_TIMEOUT_MS = 2500
+
+export interface UseYjsCellBindingOptions {
+  /** Record being edited. When null, binding is inert. */
+  recordId: Ref<string | null>
+  /** Field being edited. When null, binding is inert. */
+  fieldId: Ref<string | null>
+  /** Connect-timeout override (tests). */
+  connectTimeoutMs?: number
+  /**
+   * Called when Yjs is unavailable so the caller can log or show a soft
+   * message (default: none). Failure is deliberately non-fatal; callers
+   * MUST continue with REST. `disabled` is emitted once if the flag is off.
+   */
+  onFallback?: (reason: 'timeout' | 'error' | 'disabled') => void
+}
+
+export interface YjsCellBinding {
+  /** True once a live Yjs Y.Doc is attached for this record/field. */
+  active: Ref<boolean>
+  /** Reactive Y.Text text value. Empty string when inactive. */
+  text: Ref<string>
+  /** Update the bound Y.Text atomically. No-op when inactive. */
+  setText: (next: string) => void
+  /** Users editing the same field (excluding the current user). */
+  collaborators: Ref<YjsPresenceUser[]>
+  /** Manually tear down the Yjs connection (e.g. on blur). */
+  release: () => void
+}
+
+/**
+ * Creates a binding to Y.Text for a single text cell. Always returns a
+ * consistent API regardless of flag state; callers read `active.value` to
+ * decide whether to drive the input from `text.value` or stick to REST.
+ */
+export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBinding {
+  const active = ref(false)
+  const text = ref('')
+  const collaborators = ref<YjsPresenceUser[]>([])
+
+  if (!isYjsCollabEnabled()) {
+    // Flag off: composable is inert. No watchers, no socket call.
+    options.onFallback?.('disabled')
+    return {
+      active,
+      text,
+      setText: () => { /* inactive: no-op, caller uses REST path */ },
+      collaborators,
+      release: () => { /* nothing to release */ },
+    }
+  }
+
+  const timeoutMs = options.connectTimeoutMs ?? CONNECT_TIMEOUT_MS
+
+  // Live record ref that drives useYjsDocument's internal watch. We keep
+  // a second ref so we can tear the binding down cleanly (setting to null
+  // triggers the composable's disconnect path).
+  const liveRecordId = shallowRef<string | null>(null)
+  const fieldKey = ref<string | null>(null)
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+  let released = false
+  let yjsTextApi: { setText: (next: string) => void } | null = null
+  let textWatchStop: (() => void) | null = null
+
+  const yjs = useYjsDocument(liveRecordId)
+
+  // Presence → per-field collaborators. `getFieldCollaborators` already
+  // excludes the current user; we only need to refresh on presence updates.
+  const stopPresenceWatch = watch(
+    () => yjs.activeUsers.value,
+    () => {
+      collaborators.value = fieldKey.value
+        ? yjs.getFieldCollaborators(fieldKey.value)
+        : []
+    },
+    { deep: true },
+  )
+
+  function clearTimer() {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle)
+      timeoutHandle = null
+    }
+  }
+
+  function fallback(reason: 'timeout' | 'error') {
+    if (released) return
+    clearTimer()
+    if (active.value === false && !yjs.connected.value && !yjs.synced.value) {
+      // already inert
+    }
+    active.value = false
+    collaborators.value = []
+    text.value = ''
+    yjsTextApi = null
+    if (textWatchStop) {
+      try { textWatchStop() } catch { /* ignore */ }
+      textWatchStop = null
+    }
+    fieldKey.value = null
+    // Setting liveRecordId to null triggers useYjsDocument's disconnect.
+    liveRecordId.value = null
+    options.onFallback?.(reason)
+  }
+
+  function bindField(fid: string) {
+    fieldKey.value = fid
+    // useYjsTextField returns reactive text + setText/insertAt/deleteRange.
+    const bound = useYjsTextField(yjs.doc, fid, {
+      setActiveField: yjs.setActiveField,
+    })
+    yjsTextApi = { setText: bound.setText }
+    // Mirror the Y.Text-backed ref into our own reactive `text` so the
+    // caller only needs to touch this module's API.
+    textWatchStop = watch(
+      () => bound.text.value,
+      (next) => {
+        text.value = next
+      },
+      { immediate: true },
+    )
+  }
+
+  // Listen for error events surfaced by useYjsDocument (missing JWT,
+  // explicit 'yjs:error' from server, etc.) and treat them as soft
+  // fallbacks.
+  const stopErrorWatch = watch(
+    () => yjs.error.value,
+    (err) => {
+      if (err) fallback('error')
+    },
+  )
+
+  // Consider the binding active once the sync handshake completes. This
+  // keeps us from marking active on a bare socket connect (we want a real
+  // Y.Doc with state, not just a TCP handshake).
+  const stopSyncedWatch = watch(
+    () => yjs.synced.value,
+    (isSynced) => {
+      if (isSynced && !released) {
+        clearTimer()
+        active.value = true
+      }
+    },
+  )
+
+  // Mid-session disconnect → fall back so the caller goes back to REST.
+  const stopConnectedWatch = watch(
+    () => yjs.connected.value,
+    (isConnected) => {
+      if (!isConnected && active.value) fallback('error')
+    },
+  )
+
+  // Main driver: (re)bind when record/field inputs change.
+  const stopInputsWatch = watch(
+    [options.recordId, options.fieldId],
+    ([newRecordId, newFieldId]) => {
+      if (released) return
+      clearTimer()
+      active.value = false
+      collaborators.value = []
+      text.value = ''
+      yjsTextApi = null
+      if (textWatchStop) {
+        try { textWatchStop() } catch { /* ignore */ }
+        textWatchStop = null
+      }
+      if (!newRecordId || !newFieldId) {
+        fieldKey.value = null
+        liveRecordId.value = null
+        return
+      }
+      liveRecordId.value = newRecordId
+      bindField(newFieldId)
+      timeoutHandle = setTimeout(() => {
+        if (!active.value) fallback('timeout')
+      }, timeoutMs)
+    },
+    { immediate: true },
+  )
+
+  function setText(next: string) {
+    if (!active.value) return
+    yjsTextApi?.setText(next)
+  }
+
+  function release() {
+    if (released) return
+    released = true
+    clearTimer()
+    active.value = false
+    collaborators.value = []
+    text.value = ''
+    yjsTextApi = null
+    if (textWatchStop) {
+      try { textWatchStop() } catch { /* ignore */ }
+      textWatchStop = null
+    }
+    fieldKey.value = null
+    liveRecordId.value = null
+    try { stopPresenceWatch() } catch { /* ignore */ }
+    try { stopErrorWatch() } catch { /* ignore */ }
+    try { stopSyncedWatch() } catch { /* ignore */ }
+    try { stopConnectedWatch() } catch { /* ignore */ }
+    try { stopInputsWatch() } catch { /* ignore */ }
+    try { yjs.disconnect() } catch { /* ignore */ }
+  }
+
+  onUnmounted(release)
+
+  return {
+    active,
+    text,
+    setText,
+    collaborators,
+    release,
+  }
+}

--- a/apps/web/src/multitable/composables/useYjsCellBinding.ts
+++ b/apps/web/src/multitable/composables/useYjsCellBinding.ts
@@ -39,9 +39,7 @@ export const YJS_COLLAB_ENV_FLAG = 'VITE_ENABLE_YJS_COLLAB'
  */
 export function isYjsCollabEnabled(): boolean {
   try {
-    const metaEnv = (import.meta as unknown as { env?: Record<string, unknown> }).env
-    const metaValue = metaEnv?.[YJS_COLLAB_ENV_FLAG]
-    if (metaValue === 'true') return true
+    if (import.meta.env.VITE_ENABLE_YJS_COLLAB === 'true') return true
     // Fallback to process.env so `vi.stubEnv` (which writes to process.env
     // in Node) picks the flag up in Vitest. In a browser build there is
     // no `process` global, so this check is a no-op.

--- a/apps/web/src/multitable/composables/useYjsCellBinding.ts
+++ b/apps/web/src/multitable/composables/useYjsCellBinding.ts
@@ -1,8 +1,10 @@
 import { ref, shallowRef, watch, onUnmounted } from 'vue'
 import type { Ref } from 'vue'
-import { useYjsDocument } from './useYjsDocument'
-import { useYjsTextField } from './useYjsTextField'
 import type { YjsPresenceUser } from '../types'
+
+type UseYjsDocumentFn = typeof import('./useYjsDocument')['useYjsDocument']
+type UseYjsTextFieldFn = typeof import('./useYjsTextField')['useYjsTextField']
+type YjsDocumentApi = ReturnType<UseYjsDocumentFn>
 
 /**
  * Opt-in Yjs binding for a single text cell.
@@ -21,13 +23,17 @@ import type { YjsPresenceUser } from '../types'
  *   with REST — this composable never throws and never swallows user edits.
  *
  * Scope: POC wiring. Only text (`string` non-date-like) cells should call
- * this. Other field types stay on REST.
+ * this. Other field types stay on REST. The Yjs runtime modules are loaded
+ * lazily only after the flag is on, keeping the default flag-off path from
+ * eagerly importing the Socket.IO/Yjs composables.
  *
  * To enable at build time:
  *   VITE_ENABLE_YJS_COLLAB=true npm --workspace @metasheet/web run build
  */
 
 export const YJS_COLLAB_ENV_FLAG = 'VITE_ENABLE_YJS_COLLAB'
+const viteYjsCollabEnabled = import.meta.env.VITE_ENABLE_YJS_COLLAB === 'true'
+const allowProcessEnvFlagFallback = import.meta.env.MODE === 'test'
 
 /**
  * Reads the build-time flag from `import.meta.env`, which Vite replaces at
@@ -39,10 +45,12 @@ export const YJS_COLLAB_ENV_FLAG = 'VITE_ENABLE_YJS_COLLAB'
  */
 export function isYjsCollabEnabled(): boolean {
   try {
-    if (import.meta.env.VITE_ENABLE_YJS_COLLAB === 'true') return true
+    if (viteYjsCollabEnabled) return true
+    if (!allowProcessEnvFlagFallback) return false
     // Fallback to process.env so `vi.stubEnv` (which writes to process.env
-    // in Node) picks the flag up in Vitest. In a browser build there is
-    // no `process` global, so this check is a no-op.
+    // in Node) picks the flag up in Vitest. This path is intentionally
+    // test-only; production flag-off builds can return before the lazy
+    // Yjs imports so the runtime chunk is dropped.
     const globalProcess = (globalThis as unknown as {
       process?: { env?: Record<string, string | undefined> }
     }).process
@@ -97,6 +105,17 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
   const text = ref('')
   const collaborators = ref<YjsPresenceUser[]>([])
 
+  if (!viteYjsCollabEnabled && !allowProcessEnvFlagFallback) {
+    options.onFallback?.('disabled')
+    return {
+      active,
+      text,
+      setText: () => { /* inactive: no-op, caller uses REST path */ },
+      collaborators,
+      release: () => { /* nothing to release */ },
+    }
+  }
+
   if (!isYjsCollabEnabled()) {
     // Flag off: composable is inert. No watchers, no socket call.
     options.onFallback?.('disabled')
@@ -119,6 +138,7 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null
   let released = false
   let yjsTextApi: { setText: (next: string) => void } | null = null
+  let yjsTextDispose: (() => void) | null = null
   let textWatchStop: (() => void) | null = null
   let yjsActiveStop: (() => void) | null = null
   // Mirrors the Y.Text-exists signal from useYjsTextField for the active
@@ -127,20 +147,16 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
   // useYjsTextField.ts — if the Y.Text doesn't exist we MUST fall back
   // to REST rather than creating an empty Y.Text and risking overwrite.
   const boundYjsActive = ref(false)
+  let yjs: YjsDocumentApi | null = null
+  let useYjsTextFieldRuntime: UseYjsTextFieldFn | null = null
+  let runtimeReady = false
 
-  const yjs = useYjsDocument(liveRecordId)
+  let stopPresenceWatch: (() => void) | null = null
+  let stopErrorWatch: (() => void) | null = null
+  let stopSyncedWatch: (() => void) | null = null
+  let stopConnectedWatch: (() => void) | null = null
 
-  // Presence → per-field collaborators. `getFieldCollaborators` already
-  // excludes the current user; we only need to refresh on presence updates.
-  const stopPresenceWatch = watch(
-    () => yjs.activeUsers.value,
-    () => {
-      collaborators.value = fieldKey.value
-        ? yjs.getFieldCollaborators(fieldKey.value)
-        : []
-    },
-    { deep: true },
-  )
+  void loadYjsRuntime()
 
   function clearTimer() {
     if (timeoutHandle) {
@@ -157,6 +173,10 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
     collaborators.value = []
     text.value = ''
     yjsTextApi = null
+    if (yjsTextDispose) {
+      try { yjsTextDispose() } catch { /* ignore */ }
+      yjsTextDispose = null
+    }
     if (textWatchStop) {
       try { textWatchStop() } catch { /* ignore */ }
       textWatchStop = null
@@ -172,15 +192,18 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
   }
 
   function bindField(fid: string) {
+    if (!yjs || !useYjsTextFieldRuntime) return
     fieldKey.value = fid
     // useYjsTextField returns reactive text + setText/insertAt/deleteRange
     // + yjsActive (true only when a Y.Text already exists under this
     // fieldId). We refuse to activate our binding until yjsActive flips
     // true so we never drive the input off an empty Y.Text.
-    const bound = useYjsTextField(yjs.doc, fid, {
+    const bound = useYjsTextFieldRuntime(yjs.doc, fid, {
       setActiveField: yjs.setActiveField,
+      registerUnmount: false,
     })
     yjsTextApi = { setText: bound.setText }
+    yjsTextDispose = bound.dispose
     boundYjsActive.value = bound.yjsActive.value
     textWatchStop = watch(
       () => bound.text.value,
@@ -198,75 +221,118 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
     )
   }
 
-  // Listen for error events surfaced by useYjsDocument (missing JWT,
-  // explicit 'yjs:error' from server, etc.) and treat them as soft
-  // fallbacks.
-  const stopErrorWatch = watch(
-    () => yjs.error.value,
-    (err) => {
-      if (err) fallback('error')
-    },
-  )
-
-  // Consider the binding active once BOTH (a) the sync handshake
-  // completes AND (b) a Y.Text actually exists for this field. Without
-  // (b) we'd bind the input to a useYjsTextField that returns
-  // `text: ""` and a no-op `setText`, silently sending empty edits.
-  // The seed on the backend ensures (b) for existing fields, but if
-  // seed is delayed or failed we stay inactive and the caller keeps
-  // REST.
-  const stopSyncedWatch = watch(
-    [() => yjs.synced.value, () => boundYjsActive.value],
-    ([isSynced, hasYText]) => {
+  async function loadYjsRuntime(): Promise<void> {
+    try {
+      const [{ useYjsDocument }, { useYjsTextField }] = await Promise.all([
+        import('./useYjsDocument'),
+        import('./useYjsTextField'),
+      ])
       if (released) return
-      if (isSynced && hasYText) {
-        clearTimer()
-        active.value = true
-      } else if (!hasYText && active.value) {
-        // Y.Text disappeared mid-session (shouldn't happen in normal
-        // flow; defensive). Fall back to REST.
-        active.value = false
-      }
-    },
-  )
+      yjs = useYjsDocument(liveRecordId, { registerUnmount: false })
+      useYjsTextFieldRuntime = useYjsTextField
 
-  // Mid-session disconnect → fall back so the caller goes back to REST.
-  const stopConnectedWatch = watch(
-    () => yjs.connected.value,
-    (isConnected) => {
-      if (!isConnected && active.value) fallback('error')
-    },
-  )
+      // Presence → per-field collaborators. `getFieldCollaborators` already
+      // excludes the current user; we only need to refresh on presence updates.
+      stopPresenceWatch = watch(
+        () => yjs!.activeUsers.value,
+        () => {
+          collaborators.value = fieldKey.value && yjs
+            ? yjs.getFieldCollaborators(fieldKey.value)
+            : []
+        },
+        { deep: true },
+      )
+
+      // Listen for error events surfaced by useYjsDocument (missing JWT,
+      // explicit 'yjs:error' from server, etc.) and treat them as soft
+      // fallbacks.
+      stopErrorWatch = watch(
+        () => yjs!.error.value,
+        (err) => {
+          if (err) fallback('error')
+        },
+      )
+
+      // Consider the binding active once BOTH (a) the sync handshake
+      // completes AND (b) a Y.Text actually exists for this field. Without
+      // (b) we'd bind the input to a useYjsTextField that returns
+      // `text: ""` and a no-op `setText`, silently sending empty edits.
+      // The seed on the backend ensures (b) for existing fields, but if
+      // seed is delayed or failed we stay inactive and the caller keeps
+      // REST.
+      stopSyncedWatch = watch(
+        [() => yjs!.synced.value, () => boundYjsActive.value],
+        ([isSynced, hasYText]) => {
+          if (released) return
+          if (isSynced && hasYText) {
+            clearTimer()
+            active.value = true
+          } else if (!hasYText && active.value) {
+            // Y.Text disappeared mid-session (shouldn't happen in normal
+            // flow; defensive). Fall back to REST.
+            active.value = false
+          }
+        },
+      )
+
+      // Mid-session disconnect → fall back so the caller goes back to REST.
+      stopConnectedWatch = watch(
+        () => yjs!.connected.value,
+        (isConnected) => {
+          if (!isConnected && active.value) fallback('error')
+        },
+      )
+
+      runtimeReady = true
+      startBinding(options.recordId.value, options.fieldId.value)
+    } catch (err) {
+      console.warn('[multitable] failed to load Yjs cell binding runtime', err)
+      fallback('error')
+    }
+  }
+
+  function resetActiveFieldBinding(): void {
+    clearTimer()
+    active.value = false
+    boundYjsActive.value = false
+    collaborators.value = []
+    text.value = ''
+    yjsTextApi = null
+    if (yjsTextDispose) {
+      try { yjsTextDispose() } catch { /* ignore */ }
+      yjsTextDispose = null
+    }
+    if (textWatchStop) {
+      try { textWatchStop() } catch { /* ignore */ }
+      textWatchStop = null
+    }
+    if (yjsActiveStop) {
+      try { yjsActiveStop() } catch { /* ignore */ }
+      yjsActiveStop = null
+    }
+  }
+
+  function startBinding(newRecordId: string | null, newFieldId: string | null): void {
+    resetActiveFieldBinding()
+    if (!runtimeReady) return
+    if (!newRecordId || !newFieldId) {
+      fieldKey.value = null
+      liveRecordId.value = null
+      return
+    }
+    liveRecordId.value = newRecordId
+    bindField(newFieldId)
+    timeoutHandle = setTimeout(() => {
+      if (!active.value) fallback('timeout')
+    }, timeoutMs)
+  }
 
   // Main driver: (re)bind when record/field inputs change.
   const stopInputsWatch = watch(
     [options.recordId, options.fieldId],
     ([newRecordId, newFieldId]) => {
       if (released) return
-      clearTimer()
-      active.value = false
-      boundYjsActive.value = false
-      collaborators.value = []
-      text.value = ''
-      yjsTextApi = null
-      if (textWatchStop) {
-        try { textWatchStop() } catch { /* ignore */ }
-        textWatchStop = null
-      }
-      if (yjsActiveStop) {
-        try { yjsActiveStop() } catch { /* ignore */ }
-        yjsActiveStop = null
-      }
-      if (!newRecordId || !newFieldId) {
-        fieldKey.value = null
-        liveRecordId.value = null
-        return
-      }
-      liveRecordId.value = newRecordId
-      bindField(newFieldId)
-      timeoutHandle = setTimeout(() => {
-        if (!active.value) fallback('timeout')
-      }, timeoutMs)
+      startBinding(newRecordId, newFieldId)
     },
     { immediate: true },
   )
@@ -284,6 +350,10 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
     collaborators.value = []
     text.value = ''
     yjsTextApi = null
+    if (yjsTextDispose) {
+      try { yjsTextDispose() } catch { /* ignore */ }
+      yjsTextDispose = null
+    }
     if (textWatchStop) {
       try { textWatchStop() } catch { /* ignore */ }
       textWatchStop = null
@@ -295,12 +365,12 @@ export function useYjsCellBinding(options: UseYjsCellBindingOptions): YjsCellBin
     boundYjsActive.value = false
     fieldKey.value = null
     liveRecordId.value = null
-    try { stopPresenceWatch() } catch { /* ignore */ }
-    try { stopErrorWatch() } catch { /* ignore */ }
-    try { stopSyncedWatch() } catch { /* ignore */ }
-    try { stopConnectedWatch() } catch { /* ignore */ }
+    if (stopPresenceWatch) try { stopPresenceWatch() } catch { /* ignore */ }
+    if (stopErrorWatch) try { stopErrorWatch() } catch { /* ignore */ }
+    if (stopSyncedWatch) try { stopSyncedWatch() } catch { /* ignore */ }
+    if (stopConnectedWatch) try { stopConnectedWatch() } catch { /* ignore */ }
     try { stopInputsWatch() } catch { /* ignore */ }
-    try { yjs.disconnect() } catch { /* ignore */ }
+    try { yjs?.dispose() } catch { /* ignore */ }
   }
 
   onUnmounted(release)

--- a/apps/web/src/multitable/composables/useYjsDocument.ts
+++ b/apps/web/src/multitable/composables/useYjsDocument.ts
@@ -41,7 +41,16 @@ function handleSyncMessage(
  * merge per-range via Yjs CRDT; overlapping edits interleave at the
  * nearest common anchor.
  */
-export function useYjsDocument(recordId: Ref<string | null>) {
+export interface UseYjsDocumentOptions {
+  /**
+   * Register Vue's onUnmounted cleanup automatically. Dynamic/lazy callers
+   * may instantiate this composable after setup(), where onUnmounted is not
+   * available; those callers must pass false and call dispose() themselves.
+   */
+  registerUnmount?: boolean
+}
+
+export function useYjsDocument(recordId: Ref<string | null>, options: UseYjsDocumentOptions = {}) {
   const doc = shallowRef<Y.Doc | null>(null)
   const connected = ref(false)
   const synced = ref(false)
@@ -222,7 +231,7 @@ export function useYjsDocument(recordId: Ref<string | null>) {
   }
 
   // Auto-connect when recordId changes
-  watch(
+  const stopRecordWatch = watch(
     recordId,
     (newId) => {
       if (newId) connect(newId)
@@ -231,7 +240,14 @@ export function useYjsDocument(recordId: Ref<string | null>) {
     { immediate: true },
   )
 
-  onUnmounted(disconnect)
+  function dispose(): void {
+    try { stopRecordWatch() } catch { /* ignore */ }
+    disconnect()
+  }
+
+  if (options.registerUnmount !== false) {
+    onUnmounted(dispose)
+  }
 
   return {
     doc,
@@ -244,6 +260,7 @@ export function useYjsDocument(recordId: Ref<string | null>) {
     activeCollaboratorCount,
     connect,
     disconnect,
+    dispose,
     setActiveField,
     getFieldCollaborators,
   }

--- a/apps/web/src/multitable/composables/useYjsDocument.ts
+++ b/apps/web/src/multitable/composables/useYjsDocument.ts
@@ -52,6 +52,15 @@ export function useYjsDocument(recordId: Ref<string | null>) {
   const auth = useAuth()
   let socket: Socket | null = null
   let currentRecordId: string | null = null
+  /**
+   * Monotonically-increasing generation counter for connect()/disconnect()
+   * cycles. Every connect() bumps it; every await path checks `connectGen`
+   * against a captured copy and aborts if they differ. This closes the
+   * race where `disconnect()` fires while `getCurrentUserId()` is in
+   * flight — without the guard, the resolved promise would proceed to
+   * create a socket that the caller has already marked stale.
+   */
+  let connectGen = 0
 
   function normalizePresenceSnapshot(payload: unknown, expectedRecordId: string): YjsRecordPresence | null {
     if (!payload || typeof payload !== 'object') return null
@@ -84,6 +93,11 @@ export function useYjsDocument(recordId: Ref<string | null>) {
 
   async function connect(rid: string) {
     disconnect()
+    // Bump generation AFTER disconnect() so any await in a prior
+    // connect() sees a different value and bails. Capture locally so
+    // we can compare after every await.
+    connectGen += 1
+    const myGen = connectGen
     currentRecordId = rid
     error.value = null
 
@@ -93,7 +107,12 @@ export function useYjsDocument(recordId: Ref<string | null>) {
       error.value = 'Not authenticated'
       return
     }
-    currentUserId.value = await auth.getCurrentUserId().catch(() => null)
+    const resolvedUserId = await auth.getCurrentUserId().catch(() => null)
+    // Stale-guard: if disconnect() or another connect() ran during the
+    // getCurrentUserId() await, do NOT proceed to open a socket. The
+    // newer call is already in charge of wiring up the next doc.
+    if (myGen !== connectGen) return
+    currentUserId.value = resolvedUserId
 
     const yDoc = new Y.Doc()
     doc.value = yDoc
@@ -182,6 +201,9 @@ export function useYjsDocument(recordId: Ref<string | null>) {
   }
 
   function disconnect() {
+    // Bump generation so any in-flight connect() await aborts before it
+    // creates a socket/doc that nobody is going to watch.
+    connectGen += 1
     if (socket) {
       if (currentRecordId) {
         socket.emit('yjs:unsubscribe', { recordId: currentRecordId })

--- a/apps/web/src/multitable/composables/useYjsDocument.ts
+++ b/apps/web/src/multitable/composables/useYjsDocument.ts
@@ -35,8 +35,11 @@ function handleSyncMessage(
  * Composable that manages a Yjs document bound to a specific record,
  * connected via Socket.IO /yjs namespace.
  *
- * POC scope: single record, single text field, character-level merge,
- * disconnect/reconnect recovery.
+ * Scope: single record, text fields with minimal-diff edits (see
+ * `useYjsTextField` for the diff semantics), disconnect/reconnect
+ * recovery. Concurrent edits to different ranges of the same field
+ * merge per-range via Yjs CRDT; overlapping edits interleave at the
+ * nearest common anchor.
  */
 export function useYjsDocument(recordId: Ref<string | null>) {
   const doc = shallowRef<Y.Doc | null>(null)

--- a/apps/web/src/multitable/composables/useYjsTextField.ts
+++ b/apps/web/src/multitable/composables/useYjsTextField.ts
@@ -5,30 +5,37 @@ import * as Y from 'yjs'
 /**
  * Composable that binds a Y.Text inside a Y.Doc to a Vue ref.
  *
- * The doc is expected to have a top-level Y.Map named "fields",
- * and the Y.Text is stored under the given fieldId key.
+ * The doc is expected to have a top-level Y.Map named "fields", and the
+ * Y.Text is stored under the given fieldId key.
  *
- * Scope: two-way sync between a local plain string and a Y.Text value.
+ * ## Seed contract (P0)
  *
- * `setText(newText)` computes a common-prefix/common-suffix diff against
- * the current Y.Text content and emits minimal `delete` + `insert` ops
- * instead of replacing the entire string. That means:
+ * This composable **does NOT create an empty Y.Text** when the fieldId
+ * is missing or points to a non-Y.Text value. Doing so previously caused
+ * a data-overwrite vector: the backend hadn't seeded Y.Doc from
+ * `meta_records.data`, so the first opener of an existing text cell saw
+ * an empty textbox and could silently overwrite the real value on
+ * confirm.
  *
- *  - Typing one character emits `insert(pos, char)` — not a full replace
- *  - Deleting one character emits `delete(pos, 1)` — not a full replace
- *  - Editing in the middle only touches the changed range
+ * Current behavior:
+ *   - Y.Text already at `fields.get(fieldId)` → bind, `yjsActive=true`
+ *   - Missing / non-Y.Text → `yjsActive=false`, `text=""`, the caller
+ *     MUST fall back to REST for this cell
  *
- * Because each local edit becomes a range-scoped op, two concurrent
- * editors changing *different* ranges of the same text merge per-char
- * (Yjs CRDT semantics on Y.Text). If they change *overlapping* ranges
- * the two inserts interleave at the nearest common anchor — still no
- * whole-string replacement.
+ * The backend `YjsSyncService` seeds fresh Y.Docs from `meta_records.data`
+ * on first creation, so in normal operation Y.Text entries exist for
+ * every string field. This guard defends against:
+ *   - Race between first subscribe and backend seed completing
+ *   - Records whose backend seed failed
+ *   - Non-string fields incorrectly routed here by the caller
  *
- * Known limitation: the diff uses a trivial prefix/suffix heuristic
- * (not a full LCS). If the user replaces the middle of a string in one
- * go (e.g. paste-replace a selection), we emit ONE `delete` for the
- * removed slice and ONE `insert` for the new slice — correct, but
- * coarser than a true character-level diff would produce.
+ * ## Diff semantics
+ *
+ * `setText(newText)` computes a common-prefix/common-suffix diff
+ * against the current Y.Text content and emits scoped `delete` + `insert`
+ * ops (not a full replace). See `_diffTextEdit` for the exact algorithm.
+ * Concurrent edits to different ranges survive merge; overlapping edits
+ * interleave at the closest common anchor.
  */
 export function useYjsTextField(
   doc: ShallowRef<Y.Doc | null> | Ref<Y.Doc | null>,
@@ -38,16 +45,41 @@ export function useYjsTextField(
   },
 ) {
   const text = ref('')
+  const yjsActive = ref(false)
   let yText: Y.Text | null = null
   let observer: ((event: Y.YTextEvent) => void) | null = null
+  let fieldsMap: Y.Map<unknown> | null = null
+  let fieldsObserver: ((event: Y.YMapEvent<unknown>) => void) | null = null
 
-  function cleanup() {
+  function attachToYText(next: Y.Text): void {
+    yText = next
+    text.value = next.toString()
+    yjsActive.value = true
+    options?.setActiveField?.(fieldId)
+    observer = () => {
+      text.value = yText!.toString()
+    }
+    yText.observe(observer)
+  }
+
+  function detachYText(): void {
     options?.setActiveField?.(null)
     if (yText && observer) {
       yText.unobserve(observer)
     }
     yText = null
     observer = null
+    yjsActive.value = false
+    text.value = ''
+  }
+
+  function cleanup() {
+    detachYText()
+    if (fieldsMap && fieldsObserver) {
+      fieldsMap.unobserve(fieldsObserver)
+    }
+    fieldsMap = null
+    fieldsObserver = null
   }
 
   watch(
@@ -55,33 +87,39 @@ export function useYjsTextField(
     (newDoc) => {
       cleanup()
 
-      if (!newDoc) {
-        text.value = ''
-        return
-      }
+      if (!newDoc) return
 
-      const fields = newDoc.getMap('fields')
-      let existing = fields.get(fieldId)
-      if (!(existing instanceof Y.Text)) {
-        existing = new Y.Text()
-        fields.set(fieldId, existing)
-      }
-      yText = existing as Y.Text
+      fieldsMap = newDoc.getMap('fields')
+      const existing = fieldsMap.get(fieldId)
 
-      text.value = yText.toString()
-      options?.setActiveField?.(fieldId)
-
-      observer = () => {
-        text.value = yText!.toString()
+      if (existing instanceof Y.Text) {
+        attachToYText(existing)
       }
-      yText.observe(observer)
+      // If the field is missing or non-Y.Text, we stay inactive. We also
+      // watch the fields map so that when a Y.Text arrives later (server
+      // seed delivered after initial sync, or another client creates the
+      // field), we attach without forcing a caller reconnect. Never creates
+      // a new Y.Text — see seed contract in the file-level JSDoc.
+      fieldsObserver = (event) => {
+        if (!event.keysChanged.has(fieldId)) return
+        const next = fieldsMap!.get(fieldId)
+        if (next instanceof Y.Text) {
+          if (next !== yText) {
+            detachYText()
+            attachToYText(next)
+          }
+        } else {
+          detachYText()
+        }
+      }
+      fieldsMap.observe(fieldsObserver)
     },
     { immediate: true },
   )
 
   /**
-   * Apply newText to the bound Y.Text using a minimal diff so
-   * concurrent edits on unchanged regions survive.
+   * Apply newText to the bound Y.Text using a minimal diff so concurrent
+   * edits on unchanged regions survive.
    *
    * Exported for tests. Pure function that returns the operations it
    * would emit so tests can assert the shape of each edit.
@@ -100,10 +138,9 @@ export function useYjsTextField(
       prefix += 1
     }
 
-    // Cap suffix so that the suffix region does not overlap the prefix
-    // region in EITHER string. Without this cap, a case like
-    // oldText="abc" newText="abbc" would find prefix=2 (ab), suffix=2
-    // (bc), which together imply removing a negative slice.
+    // Cap suffix so the suffix region does not overlap the prefix in
+    // either string. Without this, "abc" → "abbc" finds prefix=2 (ab)
+    // and suffix=2 (bc), implying a negative slice delete.
     let suffix = 0
     while (
       suffix < oldText.length - prefix &&
@@ -130,10 +167,6 @@ export function useYjsTextField(
     if (!edit) return
 
     d.transact(() => {
-      // Order matters: delete first, then insert at the same position.
-      // After delete, the suffix shifts left by deleteCount, but the
-      // insert position stays at `deletePos` because we haven't moved
-      // through the suffix region.
       if (edit.deleteCount > 0) {
         yText!.delete(edit.deletePos, edit.deleteCount)
       }
@@ -155,6 +188,8 @@ export function useYjsTextField(
 
   return {
     text: readonly(text),
+    /** True only when a Y.Text already exists for this fieldId. */
+    yjsActive: readonly(yjsActive),
     setText,
     insertAt,
     deleteRange,

--- a/apps/web/src/multitable/composables/useYjsTextField.ts
+++ b/apps/web/src/multitable/composables/useYjsTextField.ts
@@ -42,6 +42,11 @@ export function useYjsTextField(
   fieldId: string,
   options?: {
     setActiveField?: (fieldId: string | null) => void
+    /**
+     * Register Vue's onUnmounted cleanup automatically. Lazy callers that
+     * instantiate after setup() must pass false and call dispose() manually.
+     */
+    registerUnmount?: boolean
   },
 ) {
   const text = ref('')
@@ -82,7 +87,7 @@ export function useYjsTextField(
     fieldsObserver = null
   }
 
-  watch(
+  const stopDocWatch = watch(
     doc,
     (newDoc) => {
       cleanup()
@@ -116,6 +121,11 @@ export function useYjsTextField(
     },
     { immediate: true },
   )
+
+  function dispose() {
+    try { stopDocWatch() } catch { /* ignore */ }
+    cleanup()
+  }
 
   /**
    * Apply newText to the bound Y.Text using a minimal diff so concurrent
@@ -184,7 +194,9 @@ export function useYjsTextField(
     yText?.delete(index, length)
   }
 
-  onUnmounted(cleanup)
+  if (options?.registerUnmount !== false) {
+    onUnmounted(dispose)
+  }
 
   return {
     text: readonly(text),
@@ -193,6 +205,7 @@ export function useYjsTextField(
     setText,
     insertAt,
     deleteRange,
+    dispose,
     /** Internal — exposed for tests. Pure, does not touch Y.Text. */
     _diffTextEdit: diffTextEdit,
   }

--- a/apps/web/src/multitable/composables/useYjsTextField.ts
+++ b/apps/web/src/multitable/composables/useYjsTextField.ts
@@ -8,7 +8,27 @@ import * as Y from 'yjs'
  * The doc is expected to have a top-level Y.Map named "fields",
  * and the Y.Text is stored under the given fieldId key.
  *
- * POC scope: single text field, two-way sync, character-level merge.
+ * Scope: two-way sync between a local plain string and a Y.Text value.
+ *
+ * `setText(newText)` computes a common-prefix/common-suffix diff against
+ * the current Y.Text content and emits minimal `delete` + `insert` ops
+ * instead of replacing the entire string. That means:
+ *
+ *  - Typing one character emits `insert(pos, char)` — not a full replace
+ *  - Deleting one character emits `delete(pos, 1)` — not a full replace
+ *  - Editing in the middle only touches the changed range
+ *
+ * Because each local edit becomes a range-scoped op, two concurrent
+ * editors changing *different* ranges of the same text merge per-char
+ * (Yjs CRDT semantics on Y.Text). If they change *overlapping* ranges
+ * the two inserts interleave at the nearest common anchor — still no
+ * whole-string replacement.
+ *
+ * Known limitation: the diff uses a trivial prefix/suffix heuristic
+ * (not a full LCS). If the user replaces the middle of a string in one
+ * go (e.g. paste-replace a selection), we emit ONE `delete` for the
+ * removed slice and ONE `insert` for the new slice — correct, but
+ * coarser than a true character-level diff would produce.
  */
 export function useYjsTextField(
   doc: ShallowRef<Y.Doc | null> | Ref<Y.Doc | null>,
@@ -59,13 +79,67 @@ export function useYjsTextField(
     { immediate: true },
   )
 
+  /**
+   * Apply newText to the bound Y.Text using a minimal diff so
+   * concurrent edits on unchanged regions survive.
+   *
+   * Exported for tests. Pure function that returns the operations it
+   * would emit so tests can assert the shape of each edit.
+   */
+  function diffTextEdit(oldText: string, newText: string): {
+    deletePos: number
+    deleteCount: number
+    insertText: string
+  } | null {
+    if (oldText === newText) return null
+
+    const maxCommon = Math.min(oldText.length, newText.length)
+
+    let prefix = 0
+    while (prefix < maxCommon && oldText.charCodeAt(prefix) === newText.charCodeAt(prefix)) {
+      prefix += 1
+    }
+
+    // Cap suffix so that the suffix region does not overlap the prefix
+    // region in EITHER string. Without this cap, a case like
+    // oldText="abc" newText="abbc" would find prefix=2 (ab), suffix=2
+    // (bc), which together imply removing a negative slice.
+    let suffix = 0
+    while (
+      suffix < oldText.length - prefix &&
+      suffix < newText.length - prefix &&
+      oldText.charCodeAt(oldText.length - 1 - suffix)
+        === newText.charCodeAt(newText.length - 1 - suffix)
+    ) {
+      suffix += 1
+    }
+
+    const deletePos = prefix
+    const deleteCount = oldText.length - prefix - suffix
+    const insertText = newText.slice(prefix, newText.length - suffix)
+
+    return { deletePos, deleteCount, insertText }
+  }
+
   function setText(newText: string) {
     if (!yText) return
     const d = yText.doc
     if (!d) return
+    const current = yText.toString()
+    const edit = diffTextEdit(current, newText)
+    if (!edit) return
+
     d.transact(() => {
-      yText!.delete(0, yText!.length)
-      yText!.insert(0, newText)
+      // Order matters: delete first, then insert at the same position.
+      // After delete, the suffix shifts left by deleteCount, but the
+      // insert position stays at `deletePos` because we haven't moved
+      // through the suffix region.
+      if (edit.deleteCount > 0) {
+        yText!.delete(edit.deletePos, edit.deleteCount)
+      }
+      if (edit.insertText.length > 0) {
+        yText!.insert(edit.deletePos, edit.insertText)
+      }
     })
   }
 
@@ -79,5 +153,12 @@ export function useYjsTextField(
 
   onUnmounted(cleanup)
 
-  return { text: readonly(text), setText, insertAt, deleteRange }
+  return {
+    text: readonly(text),
+    setText,
+    insertAt,
+    deleteRange,
+    /** Internal — exposed for tests. Pure, does not touch Y.Text. */
+    _diffTextEdit: diffTextEdit,
+  }
 }

--- a/apps/web/tests/multitable-yjs-cell-binding.spec.ts
+++ b/apps/web/tests/multitable-yjs-cell-binding.spec.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import type { Ref } from 'vue'
+
+// Socket.IO mock: records every `io()` call and hands out a fake socket
+// whose lifecycle we drive from the tests.
+type Handler = (...args: any[]) => void
+const handlers = new Map<string, Handler>()
+const emitMock = vi.fn()
+const disconnectMock = vi.fn()
+const ioMock = vi.fn(() => ({
+  connected: true,
+  on: (event: string, handler: Handler) => {
+    handlers.set(event, handler)
+  },
+  emit: emitMock,
+  disconnect: disconnectMock,
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: (...args: unknown[]) => ioMock(...args),
+}))
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getToken: vi.fn(() => 'jwt-token'),
+    getCurrentUserId: vi.fn().mockResolvedValue('user_self'),
+  }),
+}))
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function loadBinding() {
+  // Dynamic import so each test picks up the current stubbed env.
+  return import('../src/multitable/composables/useYjsCellBinding')
+}
+
+describe('useYjsCellBinding', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    handlers.clear()
+    emitMock.mockReset()
+    disconnectMock.mockReset()
+    ioMock.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.unstubAllEnvs()
+    vi.useRealTimers()
+    vi.resetModules()
+  })
+
+  it('is inert when VITE_ENABLE_YJS_COLLAB is not "true" (flag off)', async () => {
+    vi.stubEnv('VITE_ENABLE_YJS_COLLAB', '')
+    vi.resetModules()
+    const { useYjsCellBinding } = await loadBinding()
+
+    const onFallback = vi.fn()
+    let activeRef: Ref<boolean> | null = null
+    let setText: (n: string) => void = () => {}
+
+    app = createApp(defineComponent({
+      setup() {
+        const binding = useYjsCellBinding({
+          recordId: ref('rec_1'),
+          fieldId: ref('fld_title'),
+          onFallback,
+        })
+        activeRef = binding.active
+        setText = binding.setText
+        return () => h('div')
+      },
+    }))
+    app.mount(container!)
+    await flushUi()
+
+    // Discriminating assertion: no Socket.IO client was constructed.
+    expect(ioMock).not.toHaveBeenCalled()
+    expect(activeRef?.value).toBe(false)
+    // fallback 'disabled' is the single contract signal.
+    expect(onFallback).toHaveBeenCalledWith('disabled')
+    expect(onFallback).toHaveBeenCalledTimes(1)
+
+    // setText is a safe no-op when flag off.
+    expect(() => setText('hello')).not.toThrow()
+    expect(emitMock).not.toHaveBeenCalled()
+  })
+
+  it('is inert when VITE_ENABLE_YJS_COLLAB is "1" (not exactly "true")', async () => {
+    vi.stubEnv('VITE_ENABLE_YJS_COLLAB', '1')
+    vi.resetModules()
+    const { useYjsCellBinding } = await loadBinding()
+
+    app = createApp(defineComponent({
+      setup() {
+        useYjsCellBinding({
+          recordId: ref('rec_1'),
+          fieldId: ref('fld_title'),
+        })
+        return () => h('div')
+      },
+    }))
+    app.mount(container!)
+    await flushUi()
+
+    expect(ioMock).not.toHaveBeenCalled()
+  })
+
+  it('drives Y.Text when flag is on and the sync handshake completes', async () => {
+    vi.stubEnv('VITE_ENABLE_YJS_COLLAB', 'true')
+    vi.resetModules()
+    const { useYjsCellBinding } = await loadBinding()
+
+    let activeRef: Ref<boolean> | null = null
+    let textRef: Ref<string> | null = null
+    let setText: (n: string) => void = () => {}
+
+    app = createApp(defineComponent({
+      setup() {
+        const binding = useYjsCellBinding({
+          recordId: ref('rec_1'),
+          fieldId: ref('fld_title'),
+          // Long enough that the test never trips the timeout.
+          connectTimeoutMs: 10_000,
+        })
+        activeRef = binding.active
+        textRef = binding.text
+        setText = binding.setText
+        return () => h('div')
+      },
+    }))
+    app.mount(container!)
+    await flushUi()
+
+    // io() was called, socket subscribe sent.
+    expect(ioMock).toHaveBeenCalledTimes(1)
+    handlers.get('connect')?.()
+    await flushUi()
+    expect(emitMock).toHaveBeenCalledWith('yjs:subscribe', { recordId: 'rec_1' })
+
+    // Simulate a sync-protocol message: useYjsDocument uses real
+    // y-protocols readSyncMessage, so we need a well-formed envelope. We
+    // send a SyncStep2 carrying an empty Y.Doc update; the handler
+    // applies it and flips `synced` true.
+    const encodingModule = await import('lib0/encoding')
+    const Y = await import('yjs')
+    const emptyDoc = new Y.Doc()
+    const emptyUpdate = Y.encodeStateAsUpdate(emptyDoc)
+    const encoder = encodingModule.createEncoder()
+    encodingModule.writeVarUint(encoder, 0) // MSG_SYNC (outer envelope in useYjsDocument)
+    encodingModule.writeVarUint(encoder, 1) // messageYjsSyncStep2 (y-protocols)
+    encodingModule.writeVarUint8Array(encoder, emptyUpdate)
+    const payload = encodingModule.toUint8Array(encoder)
+    handlers.get('yjs:message')?.({ recordId: 'rec_1', data: Array.from(payload) })
+    await flushUi()
+
+    expect(activeRef?.value).toBe(true)
+
+    // Writing via setText should fire a yjs:update emit (Y.Doc 'update' path).
+    setText('hello')
+    await flushUi()
+    const emittedEvents = emitMock.mock.calls.map((call) => call[0])
+    expect(emittedEvents).toContain('yjs:update')
+    const updateCall = emitMock.mock.calls.find((call) => call[0] === 'yjs:update')
+    expect(updateCall?.[1]).toMatchObject({ recordId: 'rec_1' })
+    expect(Array.isArray(updateCall?.[1].data)).toBe(true)
+
+    // text mirrors the Y.Text content.
+    expect(textRef?.value).toBe('hello')
+  })
+
+  it('falls back to REST when the connection times out', async () => {
+    vi.stubEnv('VITE_ENABLE_YJS_COLLAB', 'true')
+    vi.resetModules()
+    vi.useFakeTimers()
+    const { useYjsCellBinding } = await loadBinding()
+
+    const onFallback = vi.fn()
+    let activeRef: Ref<boolean> | null = null
+    let setText: (n: string) => void = () => {}
+
+    app = createApp(defineComponent({
+      setup() {
+        const binding = useYjsCellBinding({
+          recordId: ref('rec_1'),
+          fieldId: ref('fld_title'),
+          connectTimeoutMs: 100,
+          onFallback,
+        })
+        activeRef = binding.active
+        setText = binding.setText
+        return () => h('div')
+      },
+    }))
+    app.mount(container!)
+    // Flush the initial watcher without advancing the fake timer.
+    await Promise.resolve()
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(ioMock).toHaveBeenCalledTimes(1)
+    // Intentionally do NOT fire `connect` / `yjs:message`.
+
+    // Advance timers past the timeout → fallback fires.
+    vi.advanceTimersByTime(200)
+    await Promise.resolve()
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(onFallback).toHaveBeenCalledWith('timeout')
+    expect(activeRef?.value).toBe(false)
+    // disconnect was invoked as part of tearing down the stale socket.
+    expect(disconnectMock).toHaveBeenCalled()
+
+    // After fallback, setText is a no-op (nothing emitted via socket).
+    const emitCountBefore = emitMock.mock.calls.length
+    setText('post-fallback')
+    await Promise.resolve()
+    await nextTick()
+    expect(emitMock.mock.calls.length).toBe(emitCountBefore)
+  })
+})

--- a/apps/web/tests/multitable-yjs-cell-binding.spec.ts
+++ b/apps/web/tests/multitable-yjs-cell-binding.spec.ts
@@ -28,11 +28,16 @@ vi.mock('../src/composables/useAuth', () => ({
   }),
 }))
 
-async function flushUi(cycles = 6): Promise<void> {
+async function flushUi(cycles = 12): Promise<void> {
   for (let index = 0; index < cycles; index += 1) {
     await Promise.resolve()
     await nextTick()
   }
+}
+
+async function flushLazyRuntime(): Promise<void> {
+  await vi.dynamicImportSettled()
+  await flushUi()
 }
 
 async function loadBinding() {
@@ -86,7 +91,7 @@ describe('useYjsCellBinding', () => {
       },
     }))
     app.mount(container!)
-    await flushUi()
+    await flushLazyRuntime()
 
     // Discriminating assertion: no Socket.IO client was constructed.
     expect(ioMock).not.toHaveBeenCalled()
@@ -115,7 +120,7 @@ describe('useYjsCellBinding', () => {
       },
     }))
     app.mount(container!)
-    await flushUi()
+    await flushLazyRuntime()
 
     expect(ioMock).not.toHaveBeenCalled()
   })
@@ -123,7 +128,8 @@ describe('useYjsCellBinding', () => {
   it('drives Y.Text when flag is on and the sync handshake completes', async () => {
     vi.stubEnv('VITE_ENABLE_YJS_COLLAB', 'true')
     vi.resetModules()
-    const { useYjsCellBinding } = await loadBinding()
+    const { useYjsCellBinding, isYjsCollabEnabled } = await loadBinding()
+    expect(isYjsCollabEnabled()).toBe(true)
 
     let activeRef: Ref<boolean> | null = null
     let textRef: Ref<string> | null = null
@@ -144,7 +150,7 @@ describe('useYjsCellBinding', () => {
       },
     }))
     app.mount(container!)
-    await flushUi()
+    await flushLazyRuntime()
 
     // io() was called, socket subscribe sent.
     expect(ioMock).toHaveBeenCalledTimes(1)
@@ -194,7 +200,8 @@ describe('useYjsCellBinding', () => {
     vi.stubEnv('VITE_ENABLE_YJS_COLLAB', 'true')
     vi.resetModules()
     vi.useFakeTimers()
-    const { useYjsCellBinding } = await loadBinding()
+    const { useYjsCellBinding, isYjsCollabEnabled } = await loadBinding()
+    expect(isYjsCollabEnabled()).toBe(true)
 
     const onFallback = vi.fn()
     let activeRef: Ref<boolean> | null = null
@@ -214,11 +221,9 @@ describe('useYjsCellBinding', () => {
       },
     }))
     app.mount(container!)
-    // Flush the initial watcher without advancing the fake timer.
-    await Promise.resolve()
-    await nextTick()
-    await Promise.resolve()
-    await nextTick()
+    // Flush initial watcher + lazy Yjs runtime import without advancing
+    // the fake timer.
+    await flushLazyRuntime()
 
     expect(ioMock).toHaveBeenCalledTimes(1)
     // Intentionally do NOT fire `connect` / `yjs:message`.

--- a/apps/web/tests/multitable-yjs-cell-binding.spec.ts
+++ b/apps/web/tests/multitable-yjs-cell-binding.spec.ts
@@ -154,16 +154,23 @@ describe('useYjsCellBinding', () => {
 
     // Simulate a sync-protocol message: useYjsDocument uses real
     // y-protocols readSyncMessage, so we need a well-formed envelope. We
-    // send a SyncStep2 carrying an empty Y.Doc update; the handler
-    // applies it and flips `synced` true.
+    // send a SyncStep2 carrying a primer Y.Doc update that already
+    // contains a Y.Text for 'fld_title' — matching what the backend
+    // YjsSyncService does by seeding from meta_records.data. Without
+    // this, useYjsTextField's seed guard would keep yjsActive=false
+    // (no auto-create of empty Y.Text).
     const encodingModule = await import('lib0/encoding')
     const Y = await import('yjs')
-    const emptyDoc = new Y.Doc()
-    const emptyUpdate = Y.encodeStateAsUpdate(emptyDoc)
+    const primerDoc = new Y.Doc()
+    const seededText = new Y.Text()
+    seededText.insert(0, '')
+    primerDoc.getMap('fields').set('fld_title', seededText)
+    const primerUpdate = Y.encodeStateAsUpdate(primerDoc)
+    primerDoc.destroy()
     const encoder = encodingModule.createEncoder()
     encodingModule.writeVarUint(encoder, 0) // MSG_SYNC (outer envelope in useYjsDocument)
     encodingModule.writeVarUint(encoder, 1) // messageYjsSyncStep2 (y-protocols)
-    encodingModule.writeVarUint8Array(encoder, emptyUpdate)
+    encodingModule.writeVarUint8Array(encoder, primerUpdate)
     const payload = encodingModule.toUint8Array(encoder)
     handlers.get('yjs:message')?.({ recordId: 'rec_1', data: Array.from(payload) })
     await flushUi()

--- a/apps/web/tests/multitable-yjs-cell-editor.spec.ts
+++ b/apps/web/tests/multitable-yjs-cell-editor.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, ref, type App } from 'vue'
+
+const useYjsCellBindingMock = vi.fn(() => ({
+  active: ref(false),
+  text: ref(''),
+  setText: vi.fn(),
+  collaborators: ref([]),
+  release: vi.fn(),
+}))
+
+vi.mock('../src/multitable/composables/useYjsCellBinding', () => ({
+  useYjsCellBinding: (...args: unknown[]) => useYjsCellBindingMock(...args),
+}))
+
+async function loadEditor() {
+  return (await import('../src/multitable/components/cells/MetaCellEditor.vue')).default
+}
+
+describe('MetaCellEditor Yjs binding eligibility', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    useYjsCellBindingMock.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('does not construct a Yjs binding for non-string editors', async () => {
+    const MetaCellEditor = await loadEditor()
+
+    app = createApp(defineComponent({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_qty', name: 'Quantity', type: 'number' },
+          modelValue: 12,
+          recordId: 'rec_1',
+          'onUpdate:modelValue': vi.fn(),
+          onConfirm: vi.fn(),
+          onCancel: vi.fn(),
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    }))
+
+    app.mount(container!)
+
+    expect(useYjsCellBindingMock).not.toHaveBeenCalled()
+  })
+
+  it('constructs a Yjs binding for normal string editors with a record id', async () => {
+    const MetaCellEditor = await loadEditor()
+
+    app = createApp(defineComponent({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_title', name: 'Title', type: 'string' },
+          modelValue: 'hello',
+          recordId: 'rec_1',
+          'onUpdate:modelValue': vi.fn(),
+          onConfirm: vi.fn(),
+          onCancel: vi.fn(),
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    }))
+
+    app.mount(container!)
+
+    expect(useYjsCellBindingMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/tests/yjs-awareness-presence.spec.ts
+++ b/apps/web/tests/yjs-awareness-presence.spec.ts
@@ -78,6 +78,29 @@ describe('Yjs awareness presence', () => {
     await flushUi(2)
 
     expect(emitMock).toHaveBeenCalledWith('yjs:subscribe', { recordId: 'rec_yjs_1' })
+
+    // Backend seeds Y.Text entries for string fields on fresh-doc
+    // create. Simulate that by pushing a SyncStep2 carrying a primer
+    // Y.Doc with `fld_body` already present. Without this, the seed
+    // guard in useYjsTextField keeps it inactive and never emits
+    // `yjs:presence`.
+    const encodingModule = await import('lib0/encoding')
+    const Y = await import('yjs')
+    const primer = new Y.Doc()
+    const seededBody = new Y.Text()
+    primer.getMap('fields').set('fld_body', seededBody)
+    const primerUpdate = Y.encodeStateAsUpdate(primer)
+    primer.destroy()
+    const encoder = encodingModule.createEncoder()
+    encodingModule.writeVarUint(encoder, 0)
+    encodingModule.writeVarUint(encoder, 1)
+    encodingModule.writeVarUint8Array(encoder, primerUpdate)
+    handlers.get('yjs:message')?.({
+      recordId: 'rec_yjs_1',
+      data: Array.from(encodingModule.toUint8Array(encoder)),
+    })
+    await flushUi(3)
+
     expect(emitMock).toHaveBeenCalledWith('yjs:presence', {
       recordId: 'rec_yjs_1',
       fieldId: 'fld_body',

--- a/apps/web/tests/yjs-document-stale-guard.spec.ts
+++ b/apps/web/tests/yjs-document-stale-guard.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * P1 test: useYjsDocument's connect/disconnect generation guard.
+ *
+ * Reviewer finding on PR #960 (2026-04-20):
+ *
+ *   "在创建 doc/socket 前 await getCurrentUserId()，但 timeout fallback
+ *    会在 useYjsCellBinding 触发并断开。await 返回后没有 stale guard，
+ *    仍可能创建隐藏 socket/doc。"
+ *
+ * This test proves that if disconnect() runs while the pre-socket
+ * `getCurrentUserId()` promise is still pending, the resolve path
+ * aborts BEFORE the socket.io-client factory is called.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, shallowRef, nextTick, type App } from 'vue'
+
+const handlers = new Map<string, (...args: any[]) => void>()
+const emitMock = vi.fn()
+const disconnectMock = vi.fn()
+const ioMock = vi.fn(() => ({
+  connected: true,
+  on: (event: string, handler: (...args: any[]) => void) => {
+    handlers.set(event, handler)
+  },
+  emit: emitMock,
+  disconnect: disconnectMock,
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: (...args: unknown[]) => ioMock(...args),
+}))
+
+// Control the getCurrentUserId resolution manually per-test.
+let pendingUserIdResolve: ((v: string | null) => void) | null = null
+function primeUserIdPromise() {
+  return new Promise<string | null>((resolve) => {
+    pendingUserIdResolve = resolve
+  })
+}
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getToken: vi.fn(() => 'jwt'),
+    getCurrentUserId: vi.fn(() => primeUserIdPromise()),
+  }),
+}))
+
+import { useYjsDocument } from '../src/multitable/composables/useYjsDocument'
+
+describe('useYjsDocument stale-guard (P1)', () => {
+  beforeEach(() => {
+    handlers.clear()
+    emitMock.mockClear()
+    disconnectMock.mockClear()
+    ioMock.mockClear()
+    pendingUserIdResolve = null
+  })
+
+  it('disconnect before getCurrentUserId resolves must NOT create a socket', async () => {
+    let apiRef: ReturnType<typeof useYjsDocument> | null = null
+    const recordRef = shallowRef<string | null>('rec_1')
+    const Comp = defineComponent({
+      setup() {
+        apiRef = useYjsDocument(recordRef as any)
+        return () => h('div')
+      },
+    })
+    const app = createApp(Comp)
+    app.mount(document.createElement('div'))
+
+    // useYjsDocument auto-connects on mount because recordId is set.
+    // Give it a tick to start connect().
+    await nextTick()
+
+    // connect() is blocked at `await getCurrentUserId()`. Before the
+    // promise resolves, the caller "disconnects" (simulates the
+    // timeout fallback path).
+    apiRef!.disconnect()
+
+    // NOW resolve the user id. Without the guard, connect() would
+    // proceed and call `io('/yjs', ...)`.
+    pendingUserIdResolve!('user_self')
+    await nextTick()
+    await nextTick()
+
+    // io() must NOT have been called — the stale-guard aborts.
+    expect(ioMock).not.toHaveBeenCalled()
+    expect(apiRef!.doc.value).toBeNull()
+    expect(apiRef!.connected.value).toBe(false)
+
+    app.unmount()
+  })
+
+  it('a fresh connect that starts AFTER disconnect still works normally', async () => {
+    let apiRef: ReturnType<typeof useYjsDocument> | null = null
+    const recordRef = shallowRef<string | null>('rec_1')
+    const Comp = defineComponent({
+      setup() {
+        apiRef = useYjsDocument(recordRef as any)
+        return () => h('div')
+      },
+    })
+    const app = createApp(Comp)
+    app.mount(document.createElement('div'))
+
+    await nextTick()
+    // First connect is mid-flight. Cancel it.
+    apiRef!.disconnect()
+    // Drain the original pending resolve so it bails.
+    const firstResolve = pendingUserIdResolve!
+    pendingUserIdResolve = null
+
+    // Second connect (a normal user re-focus). Do NOT await — connect()
+    // is blocked at its own `await getCurrentUserId()`, so the returned
+    // promise only resolves after we resolve secondResolve below. The
+    // call synchronously runs up to the inner await, which assigns
+    // `pendingUserIdResolve` to the new resolve fn.
+    void apiRef!.connect('rec_2')
+    const secondResolve = pendingUserIdResolve!
+
+    // Old first promise now resolves — must be ignored.
+    firstResolve('stale_user')
+    await nextTick()
+    expect(ioMock).not.toHaveBeenCalled() // still nothing wired
+
+    // New promise resolves — THIS one should cause the socket to open.
+    secondResolve('user_self')
+    // connect() awaits a promise wrapped in .catch — several microtask
+    // hops are needed before the `socketIO(...)` call executes under
+    // Vue's scheduler.
+    for (let i = 0; i < 6; i += 1) await nextTick()
+    expect(ioMock).toHaveBeenCalledTimes(1)
+
+    app.unmount()
+  })
+})

--- a/apps/web/tests/yjs-text-field-diff.spec.ts
+++ b/apps/web/tests/yjs-text-field-diff.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for useYjsTextField's diff-based setText.
+ *
+ * Covers:
+ *   - Pure diff function: prefix/suffix detection, middle edits,
+ *     append, prepend, delete, insert, no-op, full replace
+ *   - Operation shape against a real Y.Text: transact observer
+ *     records only the minimal ops
+ *   - Concurrent non-overlapping edits at different offsets against
+ *     two Y.Docs synced via Yjs updates — merged text contains both
+ *     changes and is NOT the last-write-wins result
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, shallowRef, nextTick, type App } from 'vue'
+import * as Y from 'yjs'
+import { useYjsTextField } from '../src/multitable/composables/useYjsTextField'
+
+type Composable = ReturnType<typeof useYjsTextField>
+
+function harness(doc: Y.Doc, fieldId = 'fld_title') {
+  const docRef = shallowRef<Y.Doc | null>(doc)
+  let captured: Composable | null = null
+
+  const Comp = defineComponent({
+    setup() {
+      captured = useYjsTextField(docRef, fieldId)
+      return () => h('div')
+    },
+  })
+
+  const app = createApp(Comp)
+  const host = document.createElement('div')
+  app.mount(host)
+  return {
+    composable: captured!,
+    unmount: () => app.unmount(),
+    docRef,
+  }
+}
+
+describe('useYjsTextField diff', () => {
+  let app: App | null = null
+
+  beforeEach(() => {
+    if (app) { app.unmount(); app = null }
+  })
+
+  describe('_diffTextEdit pure function', () => {
+    const doc = new Y.Doc()
+    const { composable } = harness(doc)
+    const diff = composable._diffTextEdit
+
+    it('same string → null (no op)', () => {
+      expect(diff('abc', 'abc')).toBeNull()
+      expect(diff('', '')).toBeNull()
+    })
+
+    it('pure append at end → insert only at tail', () => {
+      expect(diff('abc', 'abcd')).toEqual({ deletePos: 3, deleteCount: 0, insertText: 'd' })
+    })
+
+    it('pure prepend at start → insert only at head', () => {
+      expect(diff('abc', 'xabc')).toEqual({ deletePos: 0, deleteCount: 0, insertText: 'x' })
+    })
+
+    it('delete at end → delete only at tail', () => {
+      expect(diff('abcd', 'abc')).toEqual({ deletePos: 3, deleteCount: 1, insertText: '' })
+    })
+
+    it('delete at start → delete only at head', () => {
+      expect(diff('abcd', 'bcd')).toEqual({ deletePos: 0, deleteCount: 1, insertText: '' })
+    })
+
+    it('insert in middle → insert only at that position', () => {
+      // "hello world" → "hello NEW world": 'hello ' prefix, 'world' suffix
+      expect(diff('hello world', 'hello NEW world'))
+        .toEqual({ deletePos: 6, deleteCount: 0, insertText: 'NEW ' })
+    })
+
+    it('delete from middle → delete only at that position', () => {
+      expect(diff('hello NEW world', 'hello world'))
+        .toEqual({ deletePos: 6, deleteCount: 4, insertText: '' })
+    })
+
+    it('replace in middle → single delete + single insert scoped to range', () => {
+      // "abcXYZdef" → "abcQRSdef": prefix "abc" suffix "def"
+      expect(diff('abcXYZdef', 'abcQRSdef'))
+        .toEqual({ deletePos: 3, deleteCount: 3, insertText: 'QRS' })
+    })
+
+    it('full replace (no common prefix/suffix) → delete all + insert all', () => {
+      expect(diff('abc', 'xyz'))
+        .toEqual({ deletePos: 0, deleteCount: 3, insertText: 'xyz' })
+    })
+
+    it('empty → non-empty → plain insert at 0', () => {
+      expect(diff('', 'hello'))
+        .toEqual({ deletePos: 0, deleteCount: 0, insertText: 'hello' })
+    })
+
+    it('non-empty → empty → plain delete all', () => {
+      expect(diff('hello', ''))
+        .toEqual({ deletePos: 0, deleteCount: 5, insertText: '' })
+    })
+
+    it('prefix and suffix must not overlap — "abc" → "abbc" picks prefix', () => {
+      // A naive algorithm could find prefix=2 and suffix=2 (both "ab"
+      // and "bc") which would imply deleting a negative slice.
+      const result = diff('abc', 'abbc')!
+      // The cap ensures prefix+suffix <= min(len) - so we end up
+      // inserting exactly one 'b' somewhere consistent, never with a
+      // negative deleteCount.
+      expect(result.deleteCount).toBeGreaterThanOrEqual(0)
+      expect(result.deletePos + result.deleteCount).toBeLessThanOrEqual(3)
+      expect(result.insertText.length).toBe(1 + result.deleteCount)
+    })
+  })
+
+  describe('setText emits minimal Y.Text ops', () => {
+    it('single-char insert only emits a 1-char insert', () => {
+      const doc = new Y.Doc()
+      const h = harness(doc)
+
+      h.composable.setText('hello')
+      // Seed the field with initial value
+
+      // Record only the follow-up op
+      const deltas: any[] = []
+      const yText = doc.getMap('fields').get('fld_title') as Y.Text
+      yText.observe((event) => {
+        deltas.push(event.changes.delta)
+      })
+
+      h.composable.setText('helloX')
+
+      expect(deltas.length).toBe(1)
+      // Delta shape: [{ retain: 5 }, { insert: 'X' }]
+      const delta = deltas[0]
+      const inserts = delta.filter((op: any) => typeof op.insert === 'string')
+      const deletes = delta.filter((op: any) => typeof op.delete === 'number')
+      expect(inserts).toHaveLength(1)
+      expect(inserts[0].insert).toBe('X')
+      expect(deletes).toHaveLength(0)
+
+      h.unmount()
+    })
+
+    it('single-char delete only emits a 1-char delete', () => {
+      const doc = new Y.Doc()
+      const h = harness(doc)
+
+      h.composable.setText('helloX')
+
+      const deltas: any[] = []
+      const yText = doc.getMap('fields').get('fld_title') as Y.Text
+      yText.observe((event) => {
+        deltas.push(event.changes.delta)
+      })
+
+      h.composable.setText('hello')
+
+      expect(deltas.length).toBe(1)
+      const delta = deltas[0]
+      const inserts = delta.filter((op: any) => typeof op.insert === 'string')
+      const deletes = delta.filter((op: any) => typeof op.delete === 'number')
+      expect(inserts).toHaveLength(0)
+      expect(deletes).toHaveLength(1)
+      expect(deletes[0].delete).toBe(1)
+
+      h.unmount()
+    })
+
+    it('middle-insert does not replace the whole string', () => {
+      const doc = new Y.Doc()
+      const h = harness(doc)
+
+      h.composable.setText('hello world')
+
+      const deltas: any[] = []
+      const yText = doc.getMap('fields').get('fld_title') as Y.Text
+      yText.observe((event) => {
+        deltas.push(event.changes.delta)
+      })
+
+      h.composable.setText('hello NEW world')
+
+      expect(deltas.length).toBe(1)
+      const delta = deltas[0]
+      // MUST NOT contain a delete that removes the entire string
+      const deletes = delta.filter((op: any) => typeof op.delete === 'number')
+      expect(deletes).toHaveLength(0)
+      // The insert MUST be only the new substring, not the full "hello NEW world"
+      const inserts = delta.filter((op: any) => typeof op.insert === 'string')
+      expect(inserts).toHaveLength(1)
+      expect(inserts[0].insert).toBe('NEW ')
+      expect(inserts[0].insert).not.toBe('hello NEW world')
+
+      h.unmount()
+    })
+  })
+
+  describe('concurrent non-overlapping edits merge (smoke)', () => {
+    it('two editors editing different ranges merge — both changes survive', () => {
+      // Editor A's doc
+      const docA = new Y.Doc()
+      const hA = harness(docA, 'fld_title')
+      hA.composable.setText('the quick brown fox')
+
+      // Mirror state to docB
+      const docB = new Y.Doc()
+      Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA))
+      const hB = harness(docB, 'fld_title')
+      // Ensure the Y.Text ref was attached in B
+      expect(hB.composable.text.value).toBe('the quick brown fox')
+
+      // Both editors edit different ranges independently
+      hA.composable.setText('the QUICK brown fox') // modifies "quick" → "QUICK"
+      hB.composable.setText('the quick brown FOXES') // modifies "fox" → "FOXES"
+
+      // Exchange updates
+      Y.applyUpdate(docA, Y.encodeStateAsUpdate(docB, Y.encodeStateVector(docA)))
+      Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA, Y.encodeStateVector(docB)))
+
+      const aFinal = (docA.getMap('fields').get('fld_title') as Y.Text).toString()
+      const bFinal = (docB.getMap('fields').get('fld_title') as Y.Text).toString()
+
+      // Both ends converge to the same result
+      expect(aFinal).toBe(bFinal)
+
+      // BOTH concurrent edits survive — the merged text contains
+      // BOTH "QUICK" and "FOXES". Under LWW per keystroke, one would
+      // overwrite the other.
+      expect(aFinal).toContain('QUICK')
+      expect(aFinal).toContain('FOXES')
+
+      hA.unmount()
+      hB.unmount()
+    })
+  })
+})

--- a/apps/web/tests/yjs-text-field-diff.spec.ts
+++ b/apps/web/tests/yjs-text-field-diff.spec.ts
@@ -116,13 +116,21 @@ describe('useYjsTextField diff', () => {
     })
   })
 
+  // Helper: seed doc with an initial Y.Text value before mounting
+  // (matches what the backend YjsSyncService does via its recordSeed
+  // callback — the composable declines to create a Y.Text from the
+  // client side to avoid the data-overwrite vector).
+  function seedDoc(doc: Y.Doc, value: string, fieldId = 'fld_title') {
+    const t = new Y.Text()
+    t.insert(0, value)
+    doc.getMap('fields').set(fieldId, t)
+  }
+
   describe('setText emits minimal Y.Text ops', () => {
     it('single-char insert only emits a 1-char insert', () => {
       const doc = new Y.Doc()
+      seedDoc(doc, 'hello')
       const h = harness(doc)
-
-      h.composable.setText('hello')
-      // Seed the field with initial value
 
       // Record only the follow-up op
       const deltas: any[] = []
@@ -147,9 +155,8 @@ describe('useYjsTextField diff', () => {
 
     it('single-char delete only emits a 1-char delete', () => {
       const doc = new Y.Doc()
+      seedDoc(doc, 'helloX')
       const h = harness(doc)
-
-      h.composable.setText('helloX')
 
       const deltas: any[] = []
       const yText = doc.getMap('fields').get('fld_title') as Y.Text
@@ -172,9 +179,8 @@ describe('useYjsTextField diff', () => {
 
     it('middle-insert does not replace the whole string', () => {
       const doc = new Y.Doc()
+      seedDoc(doc, 'hello world')
       const h = harness(doc)
-
-      h.composable.setText('hello world')
 
       const deltas: any[] = []
       const yText = doc.getMap('fields').get('fld_title') as Y.Text
@@ -201,12 +207,13 @@ describe('useYjsTextField diff', () => {
 
   describe('concurrent non-overlapping edits merge (smoke)', () => {
     it('two editors editing different ranges merge — both changes survive', () => {
-      // Editor A's doc
+      // Editor A's doc — seed so useYjsTextField activates.
       const docA = new Y.Doc()
+      seedDoc(docA, 'the quick brown fox')
       const hA = harness(docA, 'fld_title')
-      hA.composable.setText('the quick brown fox')
 
-      // Mirror state to docB
+      // Mirror state to docB BEFORE mounting so its useYjsTextField picks
+      // up the Y.Text as soon as the watch runs.
       const docB = new Y.Doc()
       Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA))
       const hB = harness(docB, 'fld_title')

--- a/apps/web/tests/yjs-text-field-seed-guard.spec.ts
+++ b/apps/web/tests/yjs-text-field-seed-guard.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * P0 guard tests for `useYjsTextField` seed contract.
+ *
+ * Reviewer finding on PR #960 (2026-04-20):
+ *
+ *   "对缺失字段直接创建空 Y.Text；active 后输入框切到 yjsText。但后端
+ *    只加载 Yjs snapshot/update，没有从 meta_records.data seed。结果：
+ *    首次打开未被 Yjs 初始化过的已有文本格，会显示为空；用户继续输入/
+ *    确认可能把原值覆盖成部分输入。"
+ *
+ * These tests lock in the fix:
+ *   1. When the Y.Doc has no Y.Text for the fieldId, `yjsActive` stays
+ *      false and `text` stays `""` — no empty Y.Text is created in the
+ *      doc.
+ *   2. When the Y.Doc HAS a seeded Y.Text (from backend seed), the
+ *      composable picks up the existing value immediately and
+ *      `yjsActive` flips true.
+ *   3. Calling setText when inactive is a no-op — no ghost Y.Text is
+ *      created, no "empty → typed text" overwrite vector.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, shallowRef, type App } from 'vue'
+import * as Y from 'yjs'
+import { useYjsTextField } from '../src/multitable/composables/useYjsTextField'
+
+type Composable = ReturnType<typeof useYjsTextField>
+
+function mount(doc: Y.Doc | null, fieldId = 'fld_title'): {
+  composable: Composable
+  docRef: ReturnType<typeof shallowRef<Y.Doc | null>>
+  app: App
+} {
+  const docRef = shallowRef<Y.Doc | null>(doc)
+  let captured: Composable | null = null
+  const Comp = defineComponent({
+    setup() {
+      captured = useYjsTextField(docRef, fieldId)
+      return () => h('div')
+    },
+  })
+  const app = createApp(Comp)
+  app.mount(document.createElement('div'))
+  return { composable: captured!, docRef, app }
+}
+
+describe('useYjsTextField seed guard (P0)', () => {
+  let mounted: { app: App } | null = null
+  beforeEach(() => {
+    if (mounted) { mounted.app.unmount(); mounted = null }
+  })
+
+  it('empty Y.Doc: yjsActive stays false, text stays "", no Y.Text created in doc', () => {
+    const doc = new Y.Doc()
+    const { composable, app } = mount(doc)
+    mounted = { app }
+
+    expect(composable.yjsActive.value).toBe(false)
+    expect(composable.text.value).toBe('')
+    // The doc must remain untouched — no stray Y.Text inserted.
+    expect(doc.getMap('fields').size).toBe(0)
+  })
+
+  it('non-string entry at fieldId (e.g. number): yjsActive stays false and entry is preserved', () => {
+    const doc = new Y.Doc()
+    const fields = doc.getMap('fields')
+    // Simulate backend having seeded something that is NOT a Y.Text
+    // (shouldn't happen for text fields, but defend against it).
+    fields.set('fld_count', 42)
+
+    const { composable, app } = mount(doc, 'fld_count')
+    mounted = { app }
+
+    expect(composable.yjsActive.value).toBe(false)
+    // The stored non-Y.Text value is preserved, not overwritten by an
+    // empty Y.Text (old buggy behavior).
+    expect(fields.get('fld_count')).toBe(42)
+  })
+
+  it('doc with seeded Y.Text: yjsActive true, text reflects seeded value (NOT empty)', () => {
+    const doc = new Y.Doc()
+    const seeded = new Y.Text()
+    seeded.insert(0, 'existing value')
+    doc.getMap('fields').set('fld_title', seeded)
+
+    const { composable, app } = mount(doc)
+    mounted = { app }
+
+    expect(composable.yjsActive.value).toBe(true)
+    // Must expose the seeded value immediately — if this ever returns
+    // "" the cell editor shows an empty input and the user can
+    // overwrite the original on confirm.
+    expect(composable.text.value).toBe('existing value')
+  })
+
+  it('setText while inactive is a no-op — no overwrite vector', () => {
+    const doc = new Y.Doc()
+    const { composable, app } = mount(doc)
+    mounted = { app }
+
+    expect(composable.yjsActive.value).toBe(false)
+    composable.setText('attempted overwrite')
+
+    // No Y.Text was ever created; the doc remains empty.
+    expect(doc.getMap('fields').size).toBe(0)
+    // The composable's own text ref stays empty.
+    expect(composable.text.value).toBe('')
+  })
+
+  it('doc swapped from null to seeded: yjsActive transitions false → true with correct text', async () => {
+    const { composable, docRef, app } = mount(null)
+    mounted = { app }
+
+    expect(composable.yjsActive.value).toBe(false)
+    expect(composable.text.value).toBe('')
+
+    const seeded = new Y.Doc()
+    const y = new Y.Text()
+    y.insert(0, 'seeded value')
+    seeded.getMap('fields').set('fld_title', y)
+
+    docRef.value = seeded
+    await nextTick()
+
+    expect(composable.yjsActive.value).toBe(true)
+    expect(composable.text.value).toBe('seeded value')
+  })
+
+  it('doc swapped from seeded to empty: yjsActive transitions true → false with text cleared', async () => {
+    const seeded = new Y.Doc()
+    const y = new Y.Text()
+    y.insert(0, 'v1')
+    seeded.getMap('fields').set('fld_title', y)
+    const { composable, docRef, app } = mount(seeded)
+    mounted = { app }
+
+    expect(composable.yjsActive.value).toBe(true)
+
+    docRef.value = null
+    await nextTick()
+
+    expect(composable.yjsActive.value).toBe(false)
+    expect(composable.text.value).toBe('')
+  })
+})

--- a/docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md
+++ b/docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md
@@ -1,0 +1,106 @@
+# Yjs REST Invalidation Final Wiring Fix
+
+- Branch: `codex/wire-yjs-text-cell-20260420`
+- PR: `#960`
+- Date: 2026-04-21
+- Commits: `96d2f76ca`, `e014c8182`
+- Scope: final REST -> Yjs consistency close-out before merge.
+
+## Context
+
+PR #960 already added the main REST -> Yjs invalidation seam:
+
+- `YjsPersistenceAdapter.purgeRecords(recordIds)` wipes persisted Yjs state.
+- `YjsSyncService.invalidateDocs(recordIds)` evicts live docs without snapshotting.
+- `YjsRecordBridge.cancelPending(recordIds)` cancels delayed bridge flushes before purge.
+- `RecordPatchInput.source = 'yjs-bridge'` prevents bridge-originated writes from invalidating their own live doc.
+
+The final review found two remaining consistency risks.
+
+## Finding 1: REST `/patch` route missed the invalidator
+
+`PATCH /records/:recordId` had a direct-SQL invalidator call, and the bridge-local
+`RecordWriteService` created in `index.ts` had `setYjsInvalidator(...)`.
+
+However, the REST `/patch` route creates a request-local `RecordWriteService`:
+
+```ts
+const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+```
+
+That service instance did not receive the module-level `yjsInvalidator`. Result:
+multi-record REST patch writes could still commit `meta_records.data` while
+leaving stale Yjs snapshots in `meta_record_yjs_states` /
+`meta_record_yjs_updates`.
+
+### Fix
+
+The route now injects the module-level invalidator into the request-local service:
+
+```ts
+const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers, yjsInvalidator)
+```
+
+The module-level comment was widened from "direct-SQL PATCH only" to all REST
+write handlers that must purge stale Yjs state after committing
+`meta_records.data`.
+
+## Finding 2: invalidation ran after notifications
+
+`RecordWriteService.patchRecords()` previously emitted realtime and eventBus
+notifications before purging Yjs state. That created a narrow but real race:
+
+1. REST write commits the DB row.
+2. Realtime/eventBus notifies clients/listeners.
+3. A client reacts immediately and opens/reconnects Yjs.
+4. The server can still load the old persisted Yjs snapshot before purge.
+
+### Fix
+
+The service now runs Yjs invalidation after DB commit and computed/summary work,
+but before realtime broadcast and eventBus emission:
+
+```text
+DB commit
+computed/related/summary rebuild
+Yjs invalidation
+realtime broadcast
+eventBus emit
+```
+
+The invalidator remains best effort. If it throws, the REST write still succeeds
+and the error is logged. This preserves write availability while reducing the
+normal successful path race.
+
+## Files Changed
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+  - Injects `yjsInvalidator` into the REST `/patch` route's
+    request-local `RecordWriteService`.
+- `packages/core-backend/src/multitable/record-write-service.ts`
+  - Moves invalidation before realtime/eventBus notification.
+- `packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts`
+  - Adds a route-source guard that locks the `/patch` constructor injection.
+- `packages/core-backend/tests/unit/record-write-service.test.ts`
+  - Adds an invocation-order test proving invalidation happens before
+    realtime and eventBus notification.
+
+## Remaining Limitations
+
+- Active WebSocket editors still need reconnect after REST invalidation. This is
+  already documented as a follow-up `yjs:invalidated` server event.
+- Record DELETE is still handled by orphan cleanup rather than immediate Yjs
+  purge. That remains acceptable for the current text-cell opt-in scope.
+- Invalidation failures are log-and-swallow. This is intentional for REST write
+  availability, but rollout monitoring should watch for these logs.
+
+## Merge Position
+
+After these fixes, the REST write paths that mutate `meta_records.data` are
+covered:
+
+- REST `/patch` route via injected `RecordWriteService` invalidator.
+- Direct-SQL `PATCH /records/:recordId` via `setYjsInvalidatorForRoutes(...)`.
+- Yjs bridge writes skip invalidation via `source = 'yjs-bridge'`.
+
+No additional blocking code gaps were found in this review.

--- a/docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md
+++ b/docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md
@@ -72,6 +72,49 @@ The invalidator remains best effort. If it throws, the REST write still succeeds
 and the error is logged. This preserves write availability while reducing the
 normal successful path race.
 
+## Review Thread Close-Out: Frontend Opt-In Boundaries
+
+After the backend consistency fixes, the PR still had non-blocking Copilot
+review threads around frontend opt-in boundaries. Two low-risk tightenings were
+landed:
+
+### Direct Vite env access
+
+`isYjsCollabEnabled()` now reads the Vite flag through direct property access:
+
+```ts
+import.meta.env.VITE_ENABLE_YJS_COLLAB === 'true'
+```
+
+The prior implementation used dynamic indexing:
+
+```ts
+metaEnv?.[YJS_COLLAB_ENV_FLAG]
+```
+
+Direct access preserves Vite's normal compile-time replacement behavior. The
+`process.env` fallback remains only for Vitest's `vi.stubEnv` path.
+
+### Non-text editors avoid Yjs binding construction
+
+`MetaCellEditor` now constructs `useYjsCellBinding()` only when the editor is
+eligible at setup time:
+
+- field type is `string`
+- value is not date-like
+- `recordId` is present
+
+Other editors receive a tiny inert binding object. This keeps number/date/select
+/link/attachment editors on the REST path without creating Yjs document watchers
+or socket-related state when the flag is enabled.
+
+The larger suggestion to move Yjs imports behind dynamic imports was not included
+in this PR because it would turn a small POC close-out into a chunking/lazy-load
+refactor. The current change closes the runtime-footprint issue and preserves
+direct Vite flag replacement. Bundle splitting can remain a separate follow-up if
+we decide the opt-in path must also be physically excluded from the default
+bundle.
+
 ## Files Changed
 
 - `packages/core-backend/src/routes/univer-meta.ts`
@@ -84,6 +127,13 @@ normal successful path race.
 - `packages/core-backend/tests/unit/record-write-service.test.ts`
   - Adds an invocation-order test proving invalidation happens before
     realtime and eventBus notification.
+- `apps/web/src/multitable/composables/useYjsCellBinding.ts`
+  - Switches to direct `import.meta.env.VITE_ENABLE_YJS_COLLAB` access.
+- `apps/web/src/multitable/components/cells/MetaCellEditor.vue`
+  - Avoids constructing a Yjs binding for non-text editors.
+- `apps/web/tests/multitable-yjs-cell-editor.spec.ts`
+  - Adds eligibility tests proving non-string editors do not instantiate the
+    Yjs binding while normal string editors still do.
 
 ## Remaining Limitations
 

--- a/docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md
+++ b/docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md
@@ -3,7 +3,7 @@
 - Branch: `codex/wire-yjs-text-cell-20260420`
 - PR: `#960`
 - Date: 2026-04-21
-- Commits: `96d2f76ca`, `e014c8182`
+- Fix commits after rebase: `ed32fce30`, `41a6826d6`
 - Scope: final REST -> Yjs consistency close-out before merge.
 
 ## Context

--- a/docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md
+++ b/docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md
@@ -75,8 +75,8 @@ normal successful path race.
 ## Review Thread Close-Out: Frontend Opt-In Boundaries
 
 After the backend consistency fixes, the PR still had non-blocking Copilot
-review threads around frontend opt-in boundaries. Two low-risk tightenings were
-landed:
+review threads around frontend opt-in boundaries. Three low-risk tightenings
+were landed:
 
 ### Direct Vite env access
 
@@ -108,12 +108,37 @@ Other editors receive a tiny inert binding object. This keeps number/date/select
 /link/attachment editors on the REST path without creating Yjs document watchers
 or socket-related state when the flag is enabled.
 
-The larger suggestion to move Yjs imports behind dynamic imports was not included
-in this PR because it would turn a small POC close-out into a chunking/lazy-load
-refactor. The current change closes the runtime-footprint issue and preserves
-direct Vite flag replacement. Bundle splitting can remain a separate follow-up if
-we decide the opt-in path must also be physically excluded from the default
-bundle.
+### Lazy Yjs runtime import
+
+The opt-in path now also physically lazy-loads the Yjs runtime modules:
+
+```ts
+const [{ useYjsDocument }, { useYjsTextField }] = await Promise.all([
+  import('./useYjsDocument'),
+  import('./useYjsTextField'),
+])
+```
+
+This keeps `useYjsCellBinding()` inert in default flag-off production builds
+before creating a `Y.Doc`, Socket.IO connection, document watcher, or Yjs runtime
+chunk. Production flag-off builds return through a compile-time early branch:
+
+```ts
+const viteYjsCollabEnabled = import.meta.env.VITE_ENABLE_YJS_COLLAB === 'true'
+const allowProcessEnvFlagFallback = import.meta.env.MODE === 'test'
+
+if (!viteYjsCollabEnabled && !allowProcessEnvFlagFallback) {
+  return inertBinding
+}
+```
+
+Vitest still uses the `process.env` fallback so `vi.stubEnv()` can exercise both
+enabled and disabled paths without changing the production bundle contract.
+
+Because dynamic imports can resolve after Vue setup has completed,
+`useYjsDocument()` and `useYjsTextField()` now support
+`registerUnmount: false` plus an explicit `dispose()` method. `useYjsCellBinding`
+owns those disposers and calls them from `release()` / component unmount.
 
 ## Files Changed
 
@@ -129,11 +154,22 @@ bundle.
     realtime and eventBus notification.
 - `apps/web/src/multitable/composables/useYjsCellBinding.ts`
   - Switches to direct `import.meta.env.VITE_ENABLE_YJS_COLLAB` access.
+  - Lazy-loads `useYjsDocument` / `useYjsTextField` only when the flag is
+    enabled.
+  - Adds a compile-time flag-off early return so default production builds do
+    not emit the Yjs runtime chunks.
+- `apps/web/src/multitable/composables/useYjsDocument.ts`
+  - Adds `registerUnmount: false` and explicit `dispose()` for lazy callers.
+- `apps/web/src/multitable/composables/useYjsTextField.ts`
+  - Adds `registerUnmount: false` and explicit `dispose()` for lazy callers.
 - `apps/web/src/multitable/components/cells/MetaCellEditor.vue`
   - Avoids constructing a Yjs binding for non-text editors.
 - `apps/web/tests/multitable-yjs-cell-editor.spec.ts`
   - Adds eligibility tests proving non-string editors do not instantiate the
     Yjs binding while normal string editors still do.
+- `apps/web/tests/multitable-yjs-cell-binding.spec.ts`
+  - Waits for lazy runtime imports in enabled-path tests and keeps disabled-path
+    tests locked to zero Socket.IO construction.
 
 ## Remaining Limitations
 

--- a/docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md
+++ b/docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md
@@ -1,0 +1,106 @@
+# Verification - Yjs REST Invalidation Final Wiring Fix
+
+- Branch: `codex/wire-yjs-text-cell-20260420`
+- PR: `#960`
+- Date: 2026-04-21
+- Verified commits: `96d2f76ca`, `e014c8182`
+- Linked development MD:
+  `docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md`
+
+## Local Verification
+
+### Focused backend tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/yjs-rest-invalidation.test.ts \
+  tests/unit/record-write-service.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       34 passed (34)
+```
+
+Coverage from this run:
+
+- Existing Yjs snapshot -> REST update -> invalidate -> next Yjs open reads the
+  REST value, not the stale snapshot.
+- `invalidateDocs` destroys in-memory docs without snapshotting stale content.
+- `YjsRecordBridge.cancelPending` cancels pending debounce timers so stale bridge
+  flushes cannot run after REST invalidation.
+- REST `/patch` route passes the module-level `yjsInvalidator` into its
+  request-local `RecordWriteService`.
+- `RecordWriteService.patchRecords()` calls invalidation before realtime
+  broadcast and before eventBus emission.
+- `source = 'yjs-bridge'` skips invalidation.
+- Invalidator throw does not fail the REST patch.
+
+### Backend build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+```text
+@metasheet/core-backend@2.5.0 build
+tsc
+EXIT=0
+```
+
+### GitHub checks
+
+Observed on PR #960 before adding this documentation-only commit:
+
+```text
+after-sales integration      pass
+contracts (dashboard)        pass
+contracts (openapi)          pass
+contracts (strict)           pass
+core-backend-cache           pass
+coverage                     pass
+e2e                          pass
+migration-replay             pass
+pr-validate                  pass
+telemetry-plugin             pass
+test (18.x)                  pass
+test (20.x)                  pass
+Strict E2E with Enhanced Gates skipping
+```
+
+PR metadata at that point:
+
+```text
+head: e014c81821dd5da82f58b82a27d6589bf6cd6638
+mergeable: MERGEABLE
+reviewDecision: REVIEW_REQUIRED
+```
+
+## Manual Staging Verification Still Required
+
+After PR #960 is merged and deployed with `VITE_ENABLE_YJS_COLLAB=true`, run the
+two-browser staging check:
+
+1. Open the same text cell in two browsers/users.
+2. Confirm a pre-existing text value opens as the DB value, not an empty string.
+3. Edit non-overlapping ranges concurrently and confirm both edits survive.
+4. Close the editor, update the same field through REST, then reopen through Yjs.
+5. Confirm the reopened Yjs value is the REST value.
+6. Check server logs for `[record-write] Yjs invalidation failed`.
+
+Expected result: no stale Yjs value appears after the REST write, and no
+invalidation failure log is emitted.
+
+## Decision
+
+Code-level verification is green. The remaining gate is repository review /
+branch protection plus staging manual verification after merge.

--- a/docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md
+++ b/docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md
@@ -113,12 +113,43 @@ Coverage from this run:
 - Non-string `MetaCellEditor` instances do not construct `useYjsCellBinding`.
 - Normal string `MetaCellEditor` instances with a record ID still construct the
   binding.
+- Flag-off `useYjsCellBinding()` remains inert and constructs no Socket.IO
+  client.
+- Flag-on `useYjsCellBinding()` waits for the lazy Yjs runtime import, then
+  connects, subscribes, and drives `Y.Text`.
+- Timeout fallback still tears down the lazy runtime and returns to REST.
 - Existing Yjs diff, seed-guard, stale-connect guard, awareness, and cell-binding
   behavior still pass.
 
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+vue-tsc -b && vite build
+✓ 2351 modules transformed.
+✓ built in 5.01s
+EXIT=0
+```
+
+Bundle check from this default flag-off production build:
+
+```text
+No dist asset named useYjsDocument-*.js
+No dist asset named useYjsTextField-*.js
+No dist asset named yjs-*.js
+```
+
+This verifies the opt-in boundary at bundle level: default builds do not emit the
+Yjs runtime chunks unless `VITE_ENABLE_YJS_COLLAB=true` is set for the build.
+
 ### GitHub checks
 
-Observed on PR #960 before adding this documentation-only commit:
+Observed on PR #960 before the latest lazy-runtime close-out commit:
 
 ```text
 after-sales integration      pass

--- a/docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md
+++ b/docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md
@@ -57,6 +57,65 @@ tsc
 EXIT=0
 ```
 
+### Frontend review-thread close-out
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-yjs-cell-binding.spec.ts \
+  tests/multitable-yjs-cell-editor.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       6 passed (6)
+```
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/yjs-text-field-diff.spec.ts \
+  tests/yjs-text-field-seed-guard.spec.ts \
+  tests/yjs-document-stale-guard.spec.ts \
+  tests/yjs-awareness-presence.spec.ts \
+  tests/multitable-yjs-cell-binding.spec.ts \
+  tests/multitable-yjs-cell-editor.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  6 passed (6)
+Tests       32 passed (32)
+```
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result:
+
+```text
+EXIT=0
+```
+
+Coverage from this run:
+
+- `isYjsCollabEnabled()` still treats only exact `"true"` as enabled.
+- Non-string `MetaCellEditor` instances do not construct `useYjsCellBinding`.
+- Normal string `MetaCellEditor` instances with a record ID still construct the
+  binding.
+- Existing Yjs diff, seed-guard, stale-connect guard, awareness, and cell-binding
+  behavior still pass.
+
 ### GitHub checks
 
 Observed on PR #960 before adding this documentation-only commit:

--- a/docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md
+++ b/docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md
@@ -3,7 +3,7 @@
 - Branch: `codex/wire-yjs-text-cell-20260420`
 - PR: `#960`
 - Date: 2026-04-21
-- Verified commits: `96d2f76ca`, `e014c8182`
+- Verified fix commits after rebase: `ed32fce30`, `41a6826d6`
 - Linked development MD:
   `docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md`
 
@@ -80,7 +80,7 @@ Strict E2E with Enhanced Gates skipping
 PR metadata at that point:
 
 ```text
-head: e014c81821dd5da82f58b82a27d6589bf6cd6638
+head: e014c81821dd5da82f58b82a27d6589bf6cd6638 (pre-rebase)
 mergeable: MERGEABLE
 reviewDecision: REVIEW_REQUIRED
 ```

--- a/docs/development/yjs-text-cell-seed-and-stale-guard-development-20260420.md
+++ b/docs/development/yjs-text-cell-seed-and-stale-guard-development-20260420.md
@@ -1,0 +1,174 @@
+# Yjs Text Cell — Seed & Stale-Guard Fix (PR #960 follow-up)
+
+- **Branch**: `codex/wire-yjs-text-cell-20260420`
+- **Date**: 2026-04-20
+- **Scope**: PR #960 post-review hardening; closes P0 data-overwrite vector
+  and P1 connect-timeout race flagged in the 2026-04-20 reviewer note.
+  Frontend + backend. Staging flag rollout unblocked by this fix.
+
+## Summary
+
+The initial PR #960 shipped a minimal-diff frontend binding (see the
+prior dev MD `yjs-text-cell-diff-binding-development-20260420.md`),
+but the reviewer found two blocking issues on top of the LWW fix:
+
+- **P0** — `useYjsTextField` auto-created an empty `Y.Text` whenever the
+  field was missing; the backend `YjsSyncService` only loaded Yjs
+  snapshots/updates and never seeded from `meta_records.data`. First
+  opener of an existing text cell saw an empty textbox; confirm/typing
+  overwrote the original DB value with whatever the user typed on top
+  of the empty state.
+- **P1** — `useYjsDocument.connect` awaited `getCurrentUserId()` before
+  creating the doc/socket. The cell-binding timeout fallback could fire
+  during that await. After the await returned, no stale-guard protected
+  the resume path — it could still construct a socket/doc that the
+  caller had already given up on.
+
+Both fixes land in this change.
+
+## Changes
+
+### Backend — fresh-doc seed from `meta_records`
+
+- `packages/core-backend/src/collab/yjs-sync-service.ts`
+  - New optional second constructor parameter `YjsRecordSeedFn`
+    (`(recordId) => Promise<Record<string, unknown> | null>`).
+  - On `getOrCreateDoc(recordId)`, if the persistence adapter returns
+    `null` (no existing Yjs state), we call `seedFreshDoc` which reads
+    the current row via the seeder and wraps every **string** field in
+    a new `Y.Text` inside the shared `fields` Y.Map.
+  - The seed transact uses `origin='seed'`; the persistence listener
+    skips that origin so the bootstrap stays in memory and does not
+    spawn a DB `yjs_doc_updates` row. The first real user edit (origin
+    undefined / `'rest'`) triggers persistence as usual.
+  - Non-string fields are intentionally skipped — only text cells are
+    routed through Yjs in the current rollout; numeric/date/select
+    stay on REST.
+  - Seed throws → logged, doc returned empty (never crashes the
+    handshake); seeder returns `null`/missing → doc stays empty.
+- `packages/core-backend/src/index.ts`
+  - Supplies a `yjsRecordSeeder` closure that queries
+    `SELECT data FROM meta_records WHERE id = $1`, defensively handling
+    non-object payloads.
+  - Passed as the second arg to `new YjsSyncService(...)`.
+
+### Frontend — `useYjsTextField` seed contract
+
+`apps/web/src/multitable/composables/useYjsTextField.ts`:
+
+- **Removed** the silent creation of an empty `Y.Text` when the field
+  was missing. That was the root of the P0 overwrite vector — the
+  composable used to create an empty Y.Text on mount, the editor bound
+  to it, the user typed, and the diff emitted `insert` against `''`
+  even though the DB row held `'existing value'`.
+- Added a `yjsActive` readonly ref (true only when an actual `Y.Text`
+  is attached).
+- The `doc` watcher now installs a **Y.Map observer on `fields`** so
+  that when the backend seed arrives via sync (or another client
+  creates the Y.Text), we attach without forcing a reconnect. This
+  was necessary even for normal flow: the client's freshly-constructed
+  Y.Doc is always empty for the brief window between `socketIO(...)`
+  and the initial sync handshake.
+- `setText` is now a no-op when inactive — no ghost Y.Text creation.
+- JSDoc updated with the seed contract so future editors don't
+  reintroduce the overwrite vector.
+
+### Frontend — `useYjsCellBinding` active gating
+
+`apps/web/src/multitable/composables/useYjsCellBinding.ts`:
+
+- Tracks `boundYjsActive` mirroring `useYjsTextField.yjsActive`.
+- `active` now requires **both** (a) the sync handshake completed AND
+  (b) `Y.Text` exists for this field. Without (b) we'd bind the input
+  to a composable returning `text: ""` and a no-op `setText`, silently
+  eating keystrokes and possibly showing a blank cell.
+- On mid-session loss of the Y.Text (defensive, shouldn't happen in
+  normal flow), we flip `active` back to false and let the caller go
+  to REST.
+
+### Frontend — `useYjsDocument` stale-guard
+
+`apps/web/src/multitable/composables/useYjsDocument.ts`:
+
+- Added a monotonic `connectGen` counter.
+- `connect()` bumps it, captures `myGen`, and re-checks
+  `myGen === connectGen` **after** the `await auth.getCurrentUserId()`
+  resolves. Different → bail before `socketIO(...)` runs.
+- `disconnect()` also bumps `connectGen` so any in-flight connect from
+  a prior cycle aborts cleanly.
+
+### View layer confirmation
+
+`apps/web/src/multitable/components/cells/MetaCellEditor.vue` was
+**not** changed — it already reads the Y.Text value only when
+`yjsActive` is true (`:value="yjsActive ? yjsText : (modelValue ?? '')"`)
+and `onTextInput` only calls `yjsBinding.setText(next)` when `yjsActive`.
+The P0 fix therefore cascades correctly to the render path.
+
+## Tests
+
+### New
+
+- `packages/core-backend/tests/unit/yjs-sync-seed.test.ts` (7 cases)
+  - Seeds string Y.Text from `meta_records.data`
+  - Skips non-string fields
+  - Does **not** seed when persistence returns existing state (persisted
+    state wins — avoids stale DB reverting concurrent edits)
+  - Seed does NOT create a `yjs_doc_updates` row (origin='seed'
+    filtered)
+  - Null seeder return → empty doc (no crash)
+  - Seeder throwing → empty doc, warning logged
+  - Idempotent on repeat `getOrCreateDoc` (cached Y.Doc returned,
+    seeder not called twice)
+  - No seeder provided → legacy behavior preserved
+- `apps/web/tests/yjs-text-field-seed-guard.spec.ts` (6 cases)
+  - Empty Y.Doc → `yjsActive=false`, `text=''`, no stray Y.Text
+    inserted into the doc
+  - Non-Y.Text entry (e.g. number) preserved, not overwritten
+  - Seeded Y.Text → `yjsActive=true`, text reflects seed (not `''`)
+  - `setText` while inactive is a no-op
+  - `docRef` swap null → seeded: transition false→true
+  - `docRef` swap seeded → null: transition true→false
+- `apps/web/tests/yjs-document-stale-guard.spec.ts` (2 cases)
+  - `disconnect()` during pending `getCurrentUserId()` — resolved
+    promise must NOT create a socket
+  - Fresh connect after disconnect still works; old resolve ignored
+
+### Updated (covering the contract change)
+
+- `apps/web/tests/yjs-text-field-diff.spec.ts` — the three setText-shape
+  tests and the concurrent-merge smoke test now seed the Y.Doc via a
+  new `seedDoc(doc, value)` helper (mirroring backend `recordSeed`
+  behavior) before mounting the harness.
+- `apps/web/tests/multitable-yjs-cell-binding.spec.ts` — the
+  "drives Y.Text when flag is on" case now sends a primer SyncStep2
+  carrying a Y.Text for the field, matching backend seed behavior.
+- `apps/web/tests/yjs-awareness-presence.spec.ts` — same primer pattern
+  so `setActiveField` fires as expected.
+
+## Risk
+
+- **Backend recordSeed DB cost**: one extra `SELECT` per fresh-doc
+  create. Not per handshake — the service caches docs. Negligible
+  under the current internal rollout cap (single tenant, low QPS).
+- **Non-string fields on Yjs cells**: this release stays text-only by
+  design. If the caller ever routes a non-string field through
+  `useYjsTextField`, the seed guard prevents a new overwrite vector
+  (yjsActive stays false, caller falls back to REST).
+- **Seed vs external edit races**: if two clients trigger
+  `getOrCreateDoc` at exactly the same ms, only one seeds (idempotent
+  cache). The other receives the same Y.Doc ref.
+- **Mid-session Y.Text deletion**: defensive — if the fields-map
+  observer ever sees a removal, `detachYText()` fires
+  `setActiveField(null)` (equivalent to "user unfocused the field").
+  The caller falls back to REST for subsequent edits. Shouldn't happen
+  in normal flow.
+
+## Merge/Rollout plan
+
+1. Commit and push to `codex/wire-yjs-text-cell-20260420`.
+2. Update PR #960 description: remove stale "delete(0,length)+insert"
+   claim, reflect prefix/suffix diff + backend seed + stale-guard.
+3. Merge PR #960.
+4. Staging: flag on with `VITE_ENABLE_YJS_COLLAB=true`, two-browser
+   concurrent-edit click test per `docs/operations/yjs-internal-rollout-test-assignment-20260417.md`.

--- a/docs/development/yjs-text-cell-seed-and-stale-guard-development-20260420.md
+++ b/docs/development/yjs-text-cell-seed-and-stale-guard-development-20260420.md
@@ -167,6 +167,24 @@ from a DB row that hasn't yet caught up to the just-committed patch.
 Default polarity is invalidate-on-unset, so any future REST entry
 point that forgets to set `source` errs on the safe side.
 
+#### Why the bridge-vs-REST race is safe
+
+Row-level `SELECT ... FOR UPDATE` inside `patchRecords`' transaction
+serializes bridge and REST writes for the same record. Whichever
+commits last is the final DB value, and because only `source='rest'`
+(or unset) triggers invalidation, the Yjs snapshot never outlives a
+commit that post-dates it:
+
+- REST commits first → invalidates → bridge commits second → bridge's
+  Yjs-cached value wins the final DB state, Yjs snapshot stays dropped
+  until next open re-seeds from that fresh value.
+- Bridge commits first → does NOT invalidate (source='yjs-bridge') →
+  REST commits second → invalidates → Yjs state purged; next open
+  re-seeds from REST's value.
+
+Either way, the next `getOrCreateDoc` reads the last committed DB
+value. No path leaves a stale snapshot shadowing a newer DB row.
+
 ### View layer confirmation
 
 `apps/web/src/multitable/components/cells/MetaCellEditor.vue` was
@@ -228,16 +246,22 @@ The P0 fix therefore cascades correctly to the render path.
 - `apps/web/tests/yjs-awareness-presence.spec.ts` — same primer pattern
   so `setActiveField` fires as expected.
 
-### Known limitation — documented, not fixed in this PR
+### Known limitations — documented, not fixed in this PR
 
-Active WebSocket editors on a record lose their in-memory Y.Doc when
-a REST write on that same record invalidates. They see subsequent
-local edits stop persisting until the socket is reconnected
-(refreshing the page reseeds from the new DB state). For POC /
-internal rollout this is acceptable — REST writes to records with
-live Yjs editors should be rare, and when they happen the user can
-refresh. The proper fix (`yjs:invalidated` server event → client-side
-reseed) is out of scope for this PR.
+- **Live editor mid-session invalidation.** Active WebSocket editors
+  on a record lose their in-memory Y.Doc when a REST write on that
+  same record invalidates. They see subsequent local edits stop
+  persisting until the socket is reconnected (refreshing the page
+  reseeds from the new DB state). For POC / internal rollout this is
+  acceptable — REST writes to records with live Yjs editors should
+  be rare, and when they happen the user can refresh. Proper fix:
+  `yjs:invalidated` server event → client-side reseed; out of scope.
+- **Record DELETE path.** Record deletion does not fire the
+  invalidator. The periodic 10-minute orphan cleanup
+  (`YjsPersistenceAdapter.cleanupOrphanStates`) eventually drops the
+  persisted rows, but a client cached on `recordId` could briefly
+  hit a stale Y.Doc on the server between delete and cleanup.
+  Out of scope; fold into follow-up alongside live-editor reseed.
 
 ## Risk
 

--- a/docs/development/yjs-text-cell-seed-and-stale-guard-development-20260420.md
+++ b/docs/development/yjs-text-cell-seed-and-stale-guard-development-20260420.md
@@ -10,21 +10,41 @@
 
 The initial PR #960 shipped a minimal-diff frontend binding (see the
 prior dev MD `yjs-text-cell-diff-binding-development-20260420.md`),
-but the reviewer found two blocking issues on top of the LWW fix:
+but two subsequent reviewer findings required additional work before
+merge:
 
-- **P0** — `useYjsTextField` auto-created an empty `Y.Text` whenever the
-  field was missing; the backend `YjsSyncService` only loaded Yjs
-  snapshots/updates and never seeded from `meta_records.data`. First
-  opener of an existing text cell saw an empty textbox; confirm/typing
-  overwrote the original DB value with whatever the user typed on top
-  of the empty state.
-- **P1** — `useYjsDocument.connect` awaited `getCurrentUserId()` before
-  creating the doc/socket. The cell-binding timeout fallback could fire
-  during that await. After the await returned, no stale-guard protected
-  the resume path — it could still construct a socket/doc that the
-  caller had already given up on.
+- **2026-04-20 review (P0/P1)** — empty Y.Text overwrite + connect race.
+- **2026-04-21 review (P0)** — REST → Yjs consistency gap.
 
-Both fixes land in this change.
+### P0 2026-04-20 — empty-Y.Text overwrite
+
+`useYjsTextField` auto-created an empty `Y.Text` whenever the field
+was missing; the backend `YjsSyncService` only loaded Yjs
+snapshots/updates and never seeded from `meta_records.data`. First
+opener of an existing text cell saw an empty textbox; confirm/typing
+overwrote the original DB value with whatever the user typed on top
+of the empty state.
+
+### P1 2026-04-20 — connect stale-guard
+
+`useYjsDocument.connect` awaited `getCurrentUserId()` before creating
+the doc/socket. The cell-binding timeout fallback could fire during
+that await. After the await returned, no stale-guard protected the
+resume path — it could still construct a socket/doc that the caller
+had already given up on.
+
+### P0 2026-04-21 — REST → Yjs stale snapshot
+
+With the seed fix landed (P0 above), a later class of bug became
+visible: `YjsSyncService.getOrCreateDoc` seeds from
+`meta_records.data` **only on fresh create** (when persistence
+returned `null`). Once a Y.Doc snapshot exists, any REST write to
+`meta_records.data` is invisible to the next Yjs opener — the
+snapshot wins. Example: user A edits via Yjs → snapshot stored; user
+B PATCHes the same record via REST; user A re-opens → sees the
+pre-REST value.
+
+All three fixes land in this change.
 
 ## Changes
 
@@ -97,6 +117,56 @@ Both fixes land in this change.
 - `disconnect()` also bumps `connectGen` so any in-flight connect from
   a prior cycle aborts cleanly.
 
+### REST → Yjs invalidation hook
+
+Three new surfaces close the stale-snapshot bug from the 2026-04-21 review:
+
+- `YjsPersistenceAdapter.purgeRecords(ids)` — single transaction deletes
+  from `meta_record_yjs_states` and `meta_record_yjs_updates` for the
+  given record IDs. No-op on empty input or unknown IDs.
+- `YjsSyncService.invalidateDocs(ids)` — destroys cached Y.Docs WITHOUT
+  snapshotting (a snapshot now would encode pre-REST state and defeat
+  the fix) then calls `purgeRecords`. Documented: callers MUST cancel
+  bridge pending flushes FIRST.
+- `YjsRecordBridge.cancelPending(ids)` — clears `pendingWrites` entries
+  and their `setTimeout` timers for the given records. Without this,
+  the 200–500ms debounce could fire after invalidation and re-write
+  the stale Y.Doc-cached value on top of the REST change.
+
+#### Wiring
+
+`packages/core-backend/src/index.ts` composes the invalidator:
+
+```ts
+const yjsInvalidate = async (recordIds: string[]) => {
+  if (recordIds.length === 0) return
+  yjsBridge.cancelPending(recordIds)              // 1. stop scheduled flushes
+  await yjsSyncService.invalidateDocs(recordIds)   // 2. evict + purge
+}
+recordWriteService.setYjsInvalidator(yjsInvalidate)
+univerMetaModule.setYjsInvalidatorForRoutes(yjsInvalidate)
+```
+
+Both write sites fire the hook **post-commit, best-effort**:
+
+- `RecordWriteService.patchRecords` — called for every record in the
+  patch unless `input.source === 'yjs-bridge'`. Errors are logged; the
+  REST write still returns success.
+- `PATCH /records/:recordId` direct-SQL handler in `univer-meta.ts` —
+  called after the transaction commits. Same log-and-swallow contract.
+
+#### Loop prevention
+
+`RecordPatchInput.source?: 'rest' | 'yjs-bridge'`. The bridge's
+`getWriteInput` closure sets `source: 'yjs-bridge'` on the input it
+builds. `RecordWriteService.patchRecords` skips invalidation when
+`source === 'yjs-bridge'` — those writes originate from the live
+in-memory Y.Doc; destroying it would tear out the editor and re-seed
+from a DB row that hasn't yet caught up to the just-committed patch.
+
+Default polarity is invalidate-on-unset, so any future REST entry
+point that forgets to set `source` errs on the safe side.
+
 ### View layer confirmation
 
 `apps/web/src/multitable/components/cells/MetaCellEditor.vue` was
@@ -109,6 +179,18 @@ The P0 fix therefore cascades correctly to the render path.
 
 ### New
 
+- `packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts` (7 cases)
+  - **Regression test from the 2026-04-21 review**: snapshot exists →
+    REST update + invalidate → next Yjs open reads the REST value, not
+    the stale snapshot
+  - `invalidateDocs` evicts in-memory without snapshotting (prevents a
+    "flush then invalidate" from persisting the stale value)
+  - Record never opened → no-op
+  - Empty array → no-op
+  - Service without seeder: invalidation still works, next open empty
+  - Bridge debounce race: scheduled flush is cancelled before timer
+    fires, so no `patchRecords` call after invalidation
+  - `cancelPending` on untouched records does not throw
 - `packages/core-backend/tests/unit/yjs-sync-seed.test.ts` (7 cases)
   - Seeds string Y.Text from `meta_records.data`
   - Skips non-string fields
@@ -145,6 +227,17 @@ The P0 fix therefore cascades correctly to the render path.
   carrying a Y.Text for the field, matching backend seed behavior.
 - `apps/web/tests/yjs-awareness-presence.spec.ts` — same primer pattern
   so `setActiveField` fires as expected.
+
+### Known limitation — documented, not fixed in this PR
+
+Active WebSocket editors on a record lose their in-memory Y.Doc when
+a REST write on that same record invalidates. They see subsequent
+local edits stop persisting until the socket is reconnected
+(refreshing the page reseeds from the new DB state). For POC /
+internal rollout this is acceptable — REST writes to records with
+live Yjs editors should be rare, and when they happen the user can
+refresh. The proper fix (`yjs:invalidated` server event → client-side
+reseed) is out of scope for this PR.
 
 ## Risk
 

--- a/docs/development/yjs-text-cell-seed-and-stale-guard-verification-20260420.md
+++ b/docs/development/yjs-text-cell-seed-and-stale-guard-verification-20260420.md
@@ -8,11 +8,14 @@
 
 | Risk surfaced in review      | How the fix closes it                                   | Test(s)                                                                    |
 | ---------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------- |
-| P0 empty-Y.Text overwrite    | Frontend refuses to create Y.Text; backend seeds from `meta_records.data` | `yjs-sync-seed.test.ts` (7), `yjs-text-field-seed-guard.spec.ts` (6)       |
+| P0 empty-Y.Text overwrite (2026-04-20) | Frontend refuses to create Y.Text; backend seeds from `meta_records.data` | `yjs-sync-seed.test.ts` (7), `yjs-text-field-seed-guard.spec.ts` (6)       |
 | P0 seed writes stale DB      | `origin='seed'` skipped in persistence listener         | `yjs-sync-seed.test.ts › seeding does NOT create a DB update row`          |
 | P0 cached-doc overwrite      | Second `getOrCreateDoc` returns cached, no re-seed      | `yjs-sync-seed.test.ts › does NOT overwrite an existing entry via seed`    |
 | Client Y.Text arrives async  | `fields` Y.Map observer attaches when Y.Text is set later | `multitable-yjs-cell-binding.spec.ts › drives Y.Text`                      |
 | P1 stale-guard on timeout    | `connectGen` monotonic counter; both connect/disconnect bump | `yjs-document-stale-guard.spec.ts` (2)                                     |
+| P0 REST stale snapshot (2026-04-21) | `invalidateDocs` + `purgeRecords` called post-commit; bridge `cancelPending` first | `yjs-rest-invalidation.test.ts` (7)                                        |
+| P0 bridge debounce race      | `cancelPending` clears scheduled `setTimeout` before the REST invalidation returns | `yjs-rest-invalidation.test.ts › cancelPending clears a scheduled flush` |
+| Bridge writes self-invalidate | `RecordPatchInput.source='yjs-bridge'` skipped in invalidation hook | Source check in `record-write-service.patchRecords`; negative path covered by bridge test |
 | View-layer fallback intact   | `MetaCellEditor.vue:31` reads modelValue when inactive  | Read-verified; `multitable-yjs-cell-binding.spec.ts › timeout` covers fallback |
 
 ## Test runs
@@ -23,14 +26,17 @@ files listed in the dev MD.
 ### Backend — `YjsSyncService` + existing Yjs suite
 
 ```
-pnpm --filter @metasheet/core-backend exec vitest run yjs
-# Test Files  7 passed (7)
-#      Tests  54 passed (54)
+pnpm --filter @metasheet/core-backend exec vitest run yjs record-write
+# Test Files  9 passed (9)
+#      Tests  79 passed (79)
 ```
 
 Covers:
 - New `yjs-sync-seed.test.ts` (7 cases)
-- Pre-existing `yjs-poc.test.ts`, `yjs-*.test.ts` (54 total)
+- New `yjs-rest-invalidation.test.ts` (7 cases — includes the
+  reviewer-requested regression: snapshot exists → REST update →
+  next Yjs open reads the REST value, not the stale snapshot)
+- Pre-existing `yjs-poc.test.ts`, `yjs-*.test.ts`, `record-write-service.test.ts` (79 total)
 
 ### Frontend — Yjs composables and cell binding
 
@@ -70,6 +76,14 @@ Run: `pnpm --filter @metasheet/web exec vitest run`.
   None touch Yjs / cell-editor / useYjs* paths.
 - No new failure introduced by this change.
 
+### Wider backend regression
+
+Run: `pnpm --filter @metasheet/core-backend exec vitest run`.
+
+- 2281 tests pass. One test file (`api-token-webhook-migration.test.ts`)
+  fails to load — missing migration file, pre-existing, unrelated to
+  this PR (untracked orphan test referencing a non-existent migration).
+
 ## Manual verification plan (staging)
 
 Blocked on merge of this PR. Per the rollout test assignment MD
@@ -94,6 +108,14 @@ Blocked on merge of this PR. Per the rollout test assignment MD
    - **Expected**: empty input; typing works via REST fallback if
      seed skipped that field (non-string) or via Yjs insert if seeded
      empty string.
+7. **REST → Yjs consistency (2026-04-21 review)**. With browser A's
+   cell editor closed (so the record is idle-released server-side),
+   PATCH the same field via REST (curl or the browser's dev console),
+   then open the cell again in browser A.
+   - **Expected**: the REST value appears. Y.Doc was wiped; seed
+     re-read from `meta_records.data`.
+   - **Fail signal**: old Yjs value appears — means the invalidation
+     didn't fire or `purgeRecords` didn't run.
 
 ## Rollback
 

--- a/docs/development/yjs-text-cell-seed-and-stale-guard-verification-20260420.md
+++ b/docs/development/yjs-text-cell-seed-and-stale-guard-verification-20260420.md
@@ -1,0 +1,107 @@
+# Verification — Yjs Text Cell Seed & Stale-Guard Fix
+
+- **Branch**: `codex/wire-yjs-text-cell-20260420`
+- **Date**: 2026-04-20
+- **Linked dev MD**: `yjs-text-cell-seed-and-stale-guard-development-20260420.md`
+
+## Evidence matrix
+
+| Risk surfaced in review      | How the fix closes it                                   | Test(s)                                                                    |
+| ---------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------- |
+| P0 empty-Y.Text overwrite    | Frontend refuses to create Y.Text; backend seeds from `meta_records.data` | `yjs-sync-seed.test.ts` (7), `yjs-text-field-seed-guard.spec.ts` (6)       |
+| P0 seed writes stale DB      | `origin='seed'` skipped in persistence listener         | `yjs-sync-seed.test.ts › seeding does NOT create a DB update row`          |
+| P0 cached-doc overwrite      | Second `getOrCreateDoc` returns cached, no re-seed      | `yjs-sync-seed.test.ts › does NOT overwrite an existing entry via seed`    |
+| Client Y.Text arrives async  | `fields` Y.Map observer attaches when Y.Text is set later | `multitable-yjs-cell-binding.spec.ts › drives Y.Text`                      |
+| P1 stale-guard on timeout    | `connectGen` monotonic counter; both connect/disconnect bump | `yjs-document-stale-guard.spec.ts` (2)                                     |
+| View-layer fallback intact   | `MetaCellEditor.vue:31` reads modelValue when inactive  | Read-verified; `multitable-yjs-cell-binding.spec.ts › timeout` covers fallback |
+
+## Test runs
+
+All runs are on the commit under verification, tree dirty only with
+files listed in the dev MD.
+
+### Backend — `YjsSyncService` + existing Yjs suite
+
+```
+pnpm --filter @metasheet/core-backend exec vitest run yjs
+# Test Files  7 passed (7)
+#      Tests  54 passed (54)
+```
+
+Covers:
+- New `yjs-sync-seed.test.ts` (7 cases)
+- Pre-existing `yjs-poc.test.ts`, `yjs-*.test.ts` (54 total)
+
+### Frontend — Yjs composables and cell binding
+
+```
+pnpm --filter @metasheet/web exec vitest run tests/yjs
+# Test Files  4 passed (4)
+#      Tests  26 passed (26)
+
+pnpm --filter @metasheet/web exec vitest run tests/multitable-yjs-cell-binding.spec.ts
+# Test Files  1 passed (1)
+#      Tests  4 passed (4)
+```
+
+Covers:
+- `yjs-text-field-diff.spec.ts` (16) — pure diff + minimal-op shape +
+  concurrent merge smoke
+- `yjs-text-field-seed-guard.spec.ts` (6, new)
+- `yjs-document-stale-guard.spec.ts` (2, new)
+- `yjs-awareness-presence.spec.ts` (2) — presence emit still fires
+  once Y.Text is seeded via sync
+- `multitable-yjs-cell-binding.spec.ts` (4) — flag off, flag "1",
+  flag on drives Y.Text, fallback on timeout
+
+### Type checks
+
+```
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit   # EXIT=0
+pnpm --filter @metasheet/core-backend exec tsc --noEmit # EXIT=0
+```
+
+### Wider web regression
+
+Run: `pnpm --filter @metasheet/web exec vitest run`.
+
+- 100 tests fail across 31 files — **all pre-existing** (confirmed by
+  running the same suite on `git stash`'d HEAD; failure list identical).
+  None touch Yjs / cell-editor / useYjs* paths.
+- No new failure introduced by this change.
+
+## Manual verification plan (staging)
+
+Blocked on merge of this PR. Per the rollout test assignment MD
+(`docs/operations/yjs-internal-rollout-test-assignment-20260417.md`):
+
+1. Deploy with `VITE_ENABLE_YJS_COLLAB=true` to staging.
+2. Open the same record in two browsers (same tenant, different users).
+3. Click a seeded text cell (one with pre-existing non-empty value).
+   - **Expected**: cell shows the existing value (NOT empty).
+   - **Fail signal**: empty textbox — means seed didn't reach this
+     client or `yjsActive` stayed false. Abort rollout.
+4. Edit different ranges concurrently.
+   - **Expected**: both edits survive in both browsers after a short
+     sync.
+   - **Fail signal**: one overwrites the other — means diff regressed
+     or transact is wrong.
+5. Time-slice disconnect: revoke the server socket on one browser
+   during an active edit.
+   - **Expected**: editor falls back to REST soft-console-warn; the
+     REST input still works; no console error.
+6. Open a cell for a field with no DB value yet.
+   - **Expected**: empty input; typing works via REST fallback if
+     seed skipped that field (non-string) or via Yjs insert if seeded
+     empty string.
+
+## Rollback
+
+If staging verification fails on step 3 (empty cell on existing value):
+
+1. Revert the merge commit on main (`git revert -m 1 <merge-sha>`).
+2. Force deploy of previous image.
+3. The REST path is the default branch — flag off returns the app to
+   pre-Yjs behavior with zero data risk.
+
+No DB schema change — rollback has no migration impact.

--- a/docs/operations/yjs-frontend-opt-in-wired-20260420.md
+++ b/docs/operations/yjs-frontend-opt-in-wired-20260420.md
@@ -1,0 +1,135 @@
+# Yjs Frontend Opt-In — Wired (Companion Note)
+
+Date: 2026-04-20
+Branch: `codex/wire-yjs-text-cell-20260420`
+Companion to: `docs/operations/yjs-internal-rollout-trial-verification-20260420.md`
+
+## TL;DR
+
+The frontend text-cell editor now has an opt-in code path that wires
+`useYjsDocument` + `useYjsTextField` through to the actual `<input>` used
+in `MetaGridTable`. The path is gated behind the build-time flag
+`VITE_ENABLE_YJS_COLLAB=true` and is **off by default**. When off, the
+cell editor behavior is byte-identical to what shipped before.
+
+This closes the third finding from the monthly delivery audit
+(`docs/operations/monthly-delivery-audit-20260420.md`, row "Yjs
+collaborative editing" / audit PR #944 gap #4): the composables are no
+longer orphan exports.
+
+**This does NOT claim end-to-end user validation.** Backend pipeline is
+validated (see `yjs-node-client-validation-20260420.md`), but a real
+two-browser concurrent edit has still not been exercised. The opt-in
+flag is intentionally off until someone runs an explicit POC session.
+
+## What got wired
+
+| Location | Change |
+|---|---|
+| `apps/web/src/multitable/composables/useYjsCellBinding.ts` | New composable. Reads `VITE_ENABLE_YJS_COLLAB`, owns connect timeout (`2500ms` default), owns fallback-to-REST on timeout/error. |
+| `apps/web/src/multitable/components/cells/MetaCellEditor.vue` | Text (`string`, non-date-like) branch now binds `<input>` value to `yjsText` when `yjsActive`, otherwise to `modelValue` as before. Renders `MetaYjsPresenceChip` next to the input when there are other collaborators on the same field. Emits new `yjs-commit` event when the edit was carried over Yjs. |
+| `apps/web/src/multitable/components/MetaGridTable.vue` | Passes `record-id` to cell editor, listens for `yjs-commit`, and suppresses the REST `patch-cell` emit when that exact cell was handled via Yjs. |
+| `apps/web/tests/multitable-yjs-cell-binding.spec.ts` | New test file (4 tests): flag off → no io() call; flag set to `"1"` → no io() call; flag on + synced → Y.Text drives input + `yjs:update` emitted; flag on + timeout → fallback + disconnect, no further Yjs emits. |
+
+No other cell types (number, date, select, boolean, link, attachment)
+were touched. No record create/delete paths were touched. No backend
+code was touched.
+
+## How to enable it for testing
+
+Build-time only (intentional — keeps the Yjs code tree-shakable from
+production bundles):
+
+```bash
+VITE_ENABLE_YJS_COLLAB=true pnpm --filter @metasheet/web build
+# or for dev server
+VITE_ENABLE_YJS_COLLAB=true pnpm --filter @metasheet/web dev
+```
+
+Then, to verify it is actually live in a browser session:
+
+1. Open a text cell in any grid view, start editing.
+2. Open devtools Network panel, look for Socket.IO handshake under
+   `/yjs` namespace.
+3. Hit `GET /api/admin/yjs/status` — `activeDocCount` should increment
+   while the cell editor is open and decrement on blur.
+4. On a different browser (or second user), open the same record/field
+   — both should see `MetaYjsPresenceChip` showing the other user.
+
+If any of the above fails silently, the composable's `onFallback`
+callback logs a `console.warn`. The REST submit continues to work
+regardless.
+
+## Fallback behavior (read before rolling out)
+
+The composable is explicitly designed so that any Yjs failure
+degrades to REST without user-visible breakage:
+
+| Trigger | Result |
+|---|---|
+| `VITE_ENABLE_YJS_COLLAB` not `"true"` at build time | No `socket.io-client.io()` call. Editor behaves exactly as before. |
+| Flag on, no JWT present | `useYjsDocument` surfaces `error = 'Not authenticated'`, composable enters fallback, editor keeps REST path. |
+| Flag on, `/yjs` handshake never completes within `2500ms` | Composable times out, disconnects, enters fallback, editor keeps REST path. |
+| Flag on, mid-edit socket disconnect | Composable enters fallback, editor keeps REST path (user's current text is preserved in `modelValue`). |
+| Flag on, backend returns `yjs:error` | Composable enters fallback, editor keeps REST path. |
+
+On each fallback reason other than `'disabled'`, a `console.warn` is
+emitted (single line). User never sees a blocking error, user never
+loses an edit — the REST patch path is still wired to the input's
+`update:modelValue` events and still fires on `confirm` when Yjs was
+not active for the cell.
+
+## Reviewer-attention items
+
+These are the places a reviewer should look closely, because they are
+the places a regression would be silent rather than loud:
+
+1. **Dual-write suppression** — when Yjs is active for a cell,
+   `MetaGridTable.confirmEdit` MUST NOT emit `patch-cell`. If the
+   `yjsHandledCellKey` comparison is broken (e.g. wrong key format),
+   every Yjs-handled edit will also trigger a REST patch. Not
+   corruption (idempotent), but defeats the purpose.
+2. **Flag gating at the call site** — the flag check is in
+   `useYjsCellBinding` **before** the `useYjsDocument` call. If anyone
+   moves the flag check *inside* `useYjsDocument`, the composable's
+   `watch(recordId, ..., { immediate: true })` will still fire on
+   mount and attempt an `io('/yjs')` call even when the flag is off.
+   The test `"flag off → no io() call"` catches this.
+3. **Focus / blur lifecycle** — the composable ties to the parent
+   component's lifecycle via `onUnmounted(release)`. Because the cell
+   editor is `v-if`'d in/out by `isEditing(...)`, the composable's
+   teardown runs whenever the user clicks out of a cell or presses
+   Esc/Enter. If someone refactors the cell editor to stay mounted
+   across edits (e.g. single persistent editor with dynamic target),
+   `release` must also be called explicitly on blur to avoid leaking
+   sockets.
+4. **Character-level merge NOT shipped** — `useYjsTextField.setText`
+   does `delete(0, length); insert(0, newText)` on every keystroke
+   (last-write-wins, not CRDT-per-character). For this opt-in POC
+   that's acceptable. A follow-up should diff `old` vs `new` and emit
+   `insertAt` / `deleteRange` ops for real character-level merge.
+   Until then, two simultaneous editors on the same cell will see
+   replacement, not merge.
+5. **Date-like string cells stay on REST** — `fieldIdRef` returns
+   `null` for `isDateLike` strings, so the Yjs path never engages for
+   them. Intentional: they render a `<input type="date">` which the
+   Y.Text bridge has no meaning for.
+
+## What still needs to happen (not in this PR)
+
+- A real two-browser session with the flag on, captured as video +
+  `/api/admin/yjs/status` samples, filed in
+  `output/yjs-rollout/frontend-opt-in-<date>/`. This is the preflight
+  step #1 per `docs/operations/poc-preflight-checklist.md`.
+- If that session reveals edge cases in merge semantics, file as
+  regression tests against the Node.js client validator first.
+- Decision on whether to expose the flag as a user-level feature flag
+  (runtime per-tenant) instead of build-time. Build-time is deliberate
+  today because it tree-shakes the Yjs code path from production
+  bundles that don't want it.
+
+## Link back
+
+Audit PR: #944 (gap #4 — frontend wiring).
+Monthly audit: `docs/operations/monthly-delivery-audit-20260420.md`.
+Preflight checklist: `docs/operations/poc-preflight-checklist.md`.

--- a/docs/operations/yjs-frontend-opt-in-wired-20260420.md
+++ b/docs/operations/yjs-frontend-opt-in-wired-20260420.md
@@ -103,13 +103,24 @@ the places a regression would be silent rather than loud:
    across edits (e.g. single persistent editor with dynamic target),
    `release` must also be called explicitly on blur to avoid leaking
    sockets.
-4. **Character-level merge NOT shipped** — `useYjsTextField.setText`
-   does `delete(0, length); insert(0, newText)` on every keystroke
-   (last-write-wins, not CRDT-per-character). For this opt-in POC
-   that's acceptable. A follow-up should diff `old` vs `new` and emit
-   `insertAt` / `deleteRange` ops for real character-level merge.
-   Until then, two simultaneous editors on the same cell will see
-   replacement, not merge.
+4. **Diff-based edits (common-prefix/common-suffix)** —
+   `useYjsTextField.setText` now computes a minimal diff between the
+   current Y.Text content and the new value, and emits scoped
+   `delete(pos, count)` + `insert(pos, slice)` ops. This means:
+
+   - Typing one char emits an `insert(pos, char)`, not a full replace
+   - Deleting one char emits a `delete(pos, 1)`
+   - Edits in the middle only touch the changed range
+
+   Two concurrent editors modifying *different* ranges of the same
+   text merge per-range via Yjs. Overlapping ranges interleave at the
+   nearest common anchor — still no whole-string replacement.
+
+   **Remaining limitation**: the diff is prefix/suffix heuristic, not
+   a true LCS. Paste-replacing a middle selection produces one
+   coarse `delete` + one coarse `insert`. That's correct, just
+   coarser than char-level. Good enough for the opt-in POC; revisit
+   if/when we need merges that survive paste-replaces.
 5. **Date-like string cells stay on REST** — `fieldIdRef` returns
    `null` for `isDateLike` strings, so the Yjs path never engages for
    them. Intentional: they render a `<input type="date">` which the

--- a/docs/operations/yjs-internal-rollout-trial-verification-20260420.md
+++ b/docs/operations/yjs-internal-rollout-trial-verification-20260420.md
@@ -104,7 +104,10 @@ The claim "Yjs collaborative editing is working end-to-end" is **not supported b
 
 What is NOT supported:
 
-- Two users editing the same text field → character-level merge (untested in browser)
+- Two users editing the same text field → range-scoped merge via the
+  diff-based `useYjsTextField.setText`
+  (common-prefix/common-suffix — see `yjs-frontend-opt-in-wired-20260420.md`)
+  (untested in browser)
 - Disconnect/reconnect recovery (untested in browser)
 - Real Presence UI showing who is editing (untested in browser)
 

--- a/docs/operations/yjs-internal-rollout-trial-verification-20260420.md
+++ b/docs/operations/yjs-internal-rollout-trial-verification-20260420.md
@@ -149,3 +149,23 @@ Record the current state, leave Yjs at "backend ready, frontend opt-in pending",
 - Baseline snapshot: `output/yjs-rollout/trial-20260420/monitoring/t0-before.json`
 - Full poll log (200 samples): `output/yjs-rollout/trial-20260420/monitoring/poll-log.ndjson`
 - Trial start marker: `output/yjs-rollout/trial-20260420/trial-start.txt`
+
+---
+
+## 7. Follow-up: Frontend opt-in wired (2026-04-20, same-day)
+
+A follow-up branch (`codex/wire-yjs-text-cell-20260420`) has now
+wired `useYjsDocument` / `useYjsTextField` into the actual
+`MetaCellEditor` for grid text cells, behind the build-time flag
+`VITE_ENABLE_YJS_COLLAB=true`. The flag is off by default and the
+REST path remains the default behavior.
+
+This closes audit PR #944 gap #4 (frontend wiring) at the code level.
+It does NOT retroactively validate end-to-end browser collaboration —
+that still requires a fresh session with the flag on, captured in
+`output/yjs-rollout/frontend-opt-in-<date>/` per the preflight
+checklist item #1.
+
+See `docs/operations/yjs-frontend-opt-in-wired-20260420.md` for the
+wiring contract, enabling instructions, fallback semantics, and
+reviewer-attention items.

--- a/packages/core-backend/src/collab/yjs-persistence-adapter.ts
+++ b/packages/core-backend/src/collab/yjs-persistence-adapter.ts
@@ -108,6 +108,31 @@ export class YjsPersistenceAdapter {
     return Number(orphanStates?.numDeletedRows ?? 0) + Number(orphanUpdates?.numDeletedRows ?? 0)
   }
 
+  /**
+   * Wipe all persisted Yjs state for the given records in one round trip.
+   *
+   * Used by the REST → Yjs invalidation hook: when a REST write changes
+   * `meta_records.data`, any snapshot/updates we have for those records
+   * are stale. Next `YjsSyncService.getOrCreateDoc` will then re-seed
+   * from `meta_records.data`.
+   *
+   * No-op for record IDs that have no rows. Best-effort — callers do
+   * not fail their REST write on purge failure (see `index.ts`).
+   */
+  async purgeRecords(recordIds: string[]): Promise<void> {
+    if (recordIds.length === 0) return
+    await this.db.transaction().execute(async (trx) => {
+      await trx
+        .deleteFrom('meta_record_yjs_states')
+        .where('record_id', 'in', recordIds)
+        .execute()
+      await trx
+        .deleteFrom('meta_record_yjs_updates')
+        .where('record_id', 'in', recordIds)
+        .execute()
+    })
+  }
+
   async compactDoc(recordId: string, doc: Y.Doc): Promise<void> {
     const state = Y.encodeStateAsUpdate(doc)
     const stateVector = Y.encodeStateVector(doc)

--- a/packages/core-backend/src/collab/yjs-record-bridge.ts
+++ b/packages/core-backend/src/collab/yjs-record-bridge.ts
@@ -209,6 +209,23 @@ export class YjsRecordBridge {
   }
 
   /**
+   * Cancel any pending debounced flushes for the given records.
+   *
+   * Called by the REST → Yjs invalidation path BEFORE wiping the Yjs
+   * state. Without this, the 200–500ms debounce window can fire AFTER
+   * invalidation and re-materialize the stale Yjs-cached values on top
+   * of the just-committed REST write.
+   */
+  cancelPending(recordIds: string[]): void {
+    for (const recordId of recordIds) {
+      const pending = this.pendingWrites.get(recordId)
+      if (!pending) continue
+      clearTimeout(pending.timer)
+      this.pendingWrites.delete(recordId)
+    }
+  }
+
+  /**
    * Flush all pending writes (e.g., on shutdown).
    */
   async flushAll(): Promise<void> {

--- a/packages/core-backend/src/collab/yjs-sync-service.ts
+++ b/packages/core-backend/src/collab/yjs-sync-service.ts
@@ -118,6 +118,41 @@ export class YjsSyncService {
     return entry?.doc
   }
 
+  /**
+   * Drop cached Y.Docs and persisted state for the given records so the
+   * next `getOrCreateDoc` re-seeds from `meta_records.data`.
+   *
+   * Contract:
+   *   - In-memory Y.Docs are destroyed WITHOUT snapshotting. The snapshot
+   *     would encode pre-REST state and thus "win" on the next open —
+   *     the exact bug this method exists to close.
+   *   - Persisted snapshot + update rows are deleted via
+   *     `persistence.purgeRecords` when available.
+   *   - Best effort on persistence failures: in-memory eviction still
+   *     happens, errors surface to the caller who should log and continue
+   *     (the REST write has already committed).
+   *
+   * Callers MUST cancel any in-flight bridge flushes for these records
+   * FIRST, otherwise a debounced bridge write will re-materialize the
+   * stale Yjs-cached value over the REST write.
+   */
+  async invalidateDocs(recordIds: string[]): Promise<void> {
+    if (recordIds.length === 0) return
+    for (const recordId of recordIds) {
+      const entry = this.docs.get(recordId)
+      if (entry) {
+        entry.doc.destroy()
+        this.docs.delete(recordId)
+      }
+    }
+    const adapter = this.persistence as YjsPersistenceAdapter & {
+      purgeRecords?: (ids: string[]) => Promise<void>
+    }
+    if (typeof adapter.purgeRecords === 'function') {
+      await adapter.purgeRecords(recordIds)
+    }
+  }
+
   async releaseDoc(recordId: string): Promise<void> {
     const entry = this.docs.get(recordId)
     if (entry) {

--- a/packages/core-backend/src/collab/yjs-sync-service.ts
+++ b/packages/core-backend/src/collab/yjs-sync-service.ts
@@ -1,13 +1,36 @@
 import * as Y from 'yjs'
 import type { YjsPersistenceAdapter } from './yjs-persistence-adapter'
 
+/**
+ * Seeds a fresh Y.Doc's `fields` Y.Map from the record's current value in
+ * `meta_records.data`. Only invoked when there's no persisted Yjs state
+ * yet (no snapshot, no incremental updates).
+ *
+ * Seeding rule:
+ *   - For each field whose current value is a string, create a Y.Text
+ *     pre-populated with that string and put it in the fields map under
+ *     the fieldId key.
+ *   - Non-string values are left out of the fields map. The frontend
+ *     `useYjsTextField` only binds to Y.Text entries, so non-string
+ *     fields continue to go through the existing REST edit path.
+ *
+ * Returning null (e.g. record was deleted) leaves the Y.Doc empty;
+ * `useYjsTextField` will then decline to activate for that cell and the
+ * caller falls back to REST.
+ */
+export type YjsRecordSeedFn = (
+  recordId: string,
+) => Promise<Record<string, unknown> | null>
+
 export class YjsSyncService {
   private docs = new Map<string, { doc: Y.Doc; lastAccess: number }>()
   private persistence: YjsPersistenceAdapter
   private cleanupTimer: NodeJS.Timeout
+  private recordSeed: YjsRecordSeedFn | null
 
-  constructor(persistence: YjsPersistenceAdapter) {
+  constructor(persistence: YjsPersistenceAdapter, recordSeed?: YjsRecordSeedFn) {
     this.persistence = persistence
+    this.recordSeed = recordSeed ?? null
     // Cleanup idle docs every 30 seconds
     this.cleanupTimer = setInterval(() => this.cleanupIdleDocs(), 30_000)
     this.cleanupTimer.unref()
@@ -19,6 +42,36 @@ export class YjsSyncService {
       return
     }
     await this.persistence.storeSnapshot(recordId, doc)
+  }
+
+  private async seedFreshDoc(recordId: string, doc: Y.Doc): Promise<void> {
+    if (!this.recordSeed) return
+    let data: Record<string, unknown> | null = null
+    try {
+      data = await this.recordSeed(recordId)
+    } catch (err) {
+      console.error(`[yjs] recordSeed threw for ${recordId}:`, err)
+      return
+    }
+    if (!data) return
+
+    const fields = doc.getMap('fields')
+    // Use 'seed' as the transaction origin so the persistence listener
+    // skips this initial seed — otherwise we'd write a bootstrap update
+    // to the DB on every fresh doc, bloating meta_record_yjs_updates.
+    doc.transact(() => {
+      for (const [fieldId, value] of Object.entries(data!)) {
+        if (typeof value !== 'string') continue
+        // Don't overwrite anything that already exists in fields (defense
+        // in depth — persistence.loadDoc returning null SHOULD mean an
+        // empty Y.Doc, but if future refactors change that, we'd rather
+        // no-op than clobber).
+        if (fields.has(fieldId)) continue
+        const yText = new Y.Text()
+        yText.insert(0, value)
+        fields.set(fieldId, yText)
+      }
+    }, 'seed')
   }
 
   async getOrCreateDoc(recordId: string): Promise<Y.Doc> {
@@ -36,14 +89,24 @@ export class YjsSyncService {
       Y.applyUpdate(doc, state, 'persistence')
     }
 
-    // Listen for updates to persist incrementally
+    // Wire the persistence listener BEFORE seeding, so if we later decide
+    // the seed should also be persisted we can opt in by changing the
+    // origin check. Today: origin === 'seed' is excluded, so the seed
+    // stays in memory and is materialized into DB only after a real
+    // user edit lands on top of it.
     doc.on('update', (update: Uint8Array, origin: unknown) => {
-      if (origin !== 'persistence') {
-        this.persistence.storeUpdate(recordId, update).catch((err) =>
-          console.error(`Failed to persist yjs update for ${recordId}:`, err),
-        )
-      }
+      if (origin === 'persistence' || origin === 'seed') return
+      this.persistence.storeUpdate(recordId, update).catch((err) =>
+        console.error(`Failed to persist yjs update for ${recordId}:`, err),
+      )
     })
+
+    // Only seed from meta_records if nothing had been persisted yet.
+    // A loaded snapshot/updates pair represents the authoritative Y.Doc
+    // state and must not be shadowed by stale `meta_records.data`.
+    if (!state) {
+      await this.seedFreshDoc(recordId, doc)
+    }
 
     this.docs.set(recordId, { doc, lastAccess: Date.now() })
     return doc

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1859,6 +1859,12 @@ export class MetaSheetServer {
                 capabilities,
                 sheetScope,
                 access: { userId: actorId, permissions: actorPerms, isAdminRole },
+                // Mark bridge-originated writes so RecordWriteService does NOT
+                // fire the Yjs invalidation hook on them — those writes ARE the
+                // Y.Doc's authoritative content; wiping it would tear out any
+                // live editor and re-seed from stale data (the bridge write
+                // hasn't finished appearing in meta_records.data at that point).
+                source: 'yjs-bridge' as const,
               }
             } catch (err) {
               console.error(`[yjs-bridge] Failed to build write input for ${recordId}:`, err)
@@ -1871,6 +1877,22 @@ export class MetaSheetServer {
 
         yjsWsAdapter.setBridge(yjsBridge)
         yjsWsAdapter.register(collabIO)
+
+        // REST → Yjs invalidator: every REST write to meta_records.data
+        // wipes the corresponding Y.Doc state so the next getOrCreateDoc
+        // re-seeds from the authoritative DB row. Must cancel bridge
+        // pending flushes FIRST — without that a 200–500ms debounced
+        // bridge write would re-materialize the stale Yjs-cached value
+        // on top of the just-committed REST change.
+        const yjsInvalidate = async (recordIds: string[]) => {
+          if (recordIds.length === 0) return
+          yjsBridge.cancelPending(recordIds)
+          await yjsSyncService.invalidateDocs(recordIds)
+        }
+        recordWriteService.setYjsInvalidator(yjsInvalidate)
+        const univerMetaModule = await import('./routes/univer-meta')
+        univerMetaModule.setYjsInvalidatorForRoutes(yjsInvalidate)
+
         this.yjsSyncMetricsSource = yjsSyncService
         this.yjsBridgeMetricsSource = yjsBridge
         this.yjsSocketMetricsSource = yjsWsAdapter

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1707,7 +1707,28 @@ export class MetaSheetServer {
       const collabIO = this.injector.get(ICollabService).getIO()
       if (collabIO) {
         const yjsPersistence = new YjsPersistenceAdapter(kyselyDbYjs)
-        const yjsSyncService = new YjsSyncService(yjsPersistence)
+        // Seed fresh Y.Docs from meta_records so the first opener of an
+        // existing cell sees its current value, not an empty textbox.
+        // See yjs-sync-service.ts for the seeding rule (strings only).
+        const yjsPoolRef = poolManager.get()
+        const yjsRecordSeeder = async (recordId: string) => {
+          try {
+            const result = await yjsPoolRef.query(
+              'SELECT data FROM meta_records WHERE id = $1',
+              [recordId],
+            )
+            const row = (result.rows as Array<{ data: unknown } | undefined>)[0]
+            if (!row) return null
+            if (row.data && typeof row.data === 'object' && !Array.isArray(row.data)) {
+              return row.data as Record<string, unknown>
+            }
+            return null
+          } catch (err) {
+            console.error(`[yjs] recordSeeder query failed for ${recordId}:`, err)
+            return null
+          }
+        }
+        const yjsSyncService = new YjsSyncService(yjsPersistence, yjsRecordSeeder)
         const yjsWsAdapter = new YjsWebSocketAdapter(yjsSyncService)
 
         // JWT token verifier: verify token, extract trusted userId

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -699,7 +699,29 @@ export class RecordWriteService {
         : undefined
 
     // -----------------------------------------------------------------------
-    // Step 5: Realtime broadcast
+    // Step 5: Yjs invalidation (post-commit, pre-notification, best effort)
+    //
+    // REST writes to meta_records.data make any persisted Y.Doc snapshot
+    // for those records stale. Drop in-memory + persisted Yjs state before
+    // notifying clients/listeners, so a fast reconnect cannot reopen the old
+    // snapshot. Skipped when the write itself originated from the Yjs bridge
+    // (those writes ARE the Y.Doc's content; invalidating would nuke a live
+    // editor).
+    // -----------------------------------------------------------------------
+    if (this.yjsInvalidator && input.source !== 'yjs-bridge' && updates.length > 0) {
+      const recordIds = updates.map((u) => u.recordId)
+      try {
+        await this.yjsInvalidator(recordIds)
+      } catch (err) {
+        console.error(
+          `[record-write] Yjs invalidation failed for records ${recordIds.join(',')} — Yjs state may be stale until next idle-release:`,
+          err,
+        )
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 6: Realtime broadcast
     // -----------------------------------------------------------------------
     if (updates.length > 0) {
       publishMultitableSheetRealtime({
@@ -723,7 +745,7 @@ export class RecordWriteService {
       })
 
       // -------------------------------------------------------------------
-      // Step 6: EventBus emit
+      // Step 7: EventBus emit
       // -------------------------------------------------------------------
       for (const update of updates) {
         const changes = Object.fromEntries(
@@ -735,27 +757,6 @@ export class RecordWriteService {
           changes,
           actorId,
         })
-      }
-    }
-
-    // -----------------------------------------------------------------------
-    // Step 7: Yjs invalidation (post-commit, best effort)
-    //
-    // REST writes to meta_records.data make any persisted Y.Doc snapshot
-    // for those records stale. Drop in-memory + persisted Yjs state so the
-    // next `getOrCreateDoc` re-seeds from the just-updated DB row. Skipped
-    // when the write itself originated from the Yjs bridge (those writes
-    // ARE the Y.Doc's content; invalidating would nuke a live editor).
-    // -----------------------------------------------------------------------
-    if (this.yjsInvalidator && input.source !== 'yjs-bridge' && updates.length > 0) {
-      const recordIds = updates.map((u) => u.recordId)
-      try {
-        await this.yjsInvalidator(recordIds)
-      } catch (err) {
-        console.error(
-          `[record-write] Yjs invalidation failed for records ${recordIds.join(',')} — Yjs state may be stale until next idle-release:`,
-          err,
-        )
       }
     }
 

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -169,7 +169,28 @@ export interface RecordPatchInput {
   capabilities: MultitableCapabilities
   sheetScope?: SheetPermissionScope
   access: AccessInfo
+  /**
+   * Write origin. Default (unset or `'rest'`) triggers post-commit Yjs
+   * invalidation so any persisted Y.Doc state for the affected records
+   * is wiped — next `getOrCreateDoc` re-seeds from `meta_records.data`.
+   *
+   * The `YjsRecordBridge` sets this to `'yjs-bridge'` on its own flushes
+   * because those writes originate from the in-memory Y.Doc; destroying
+   * that doc immediately after would tear out a live editor's state.
+   */
+  source?: 'rest' | 'yjs-bridge'
 }
+
+/**
+ * Injected by `index.ts` when the Yjs path is wired. Takes record IDs
+ * whose REST write just committed and wipes any Yjs state for them
+ * (in-memory + persisted). Must first cancel any bridge-pending flushes
+ * for those records — the wiring in `index.ts` composes both.
+ *
+ * Best-effort: errors are logged and swallowed; a failed invalidation
+ * does NOT fail the REST write that already succeeded.
+ */
+export type YjsInvalidator = (recordIds: string[]) => Promise<void>
 
 export interface RecordPatchResult {
   updated: Array<{ recordId: string; version: number }>
@@ -260,7 +281,23 @@ export class RecordWriteService {
     private pool: ConnectionPool,
     private eventBus: EventBus,
     private helpers: RecordWriteHelpers,
+    /**
+     * Optional Yjs invalidator. Leave `null` when the Yjs collab path is
+     * disabled (flag off, non-Yjs deployments). When present, called
+     * after every successful `patchRecords` that did NOT originate from
+     * the Yjs bridge itself.
+     */
+    private yjsInvalidator: YjsInvalidator | null = null,
   ) {}
+
+  /**
+   * Replace the Yjs invalidator after construction. Used when
+   * `YjsSyncService`/bridge are wired up later in the boot sequence than
+   * `RecordWriteService`.
+   */
+  setYjsInvalidator(invalidator: YjsInvalidator | null): void {
+    this.yjsInvalidator = invalidator
+  }
 
   /**
    * Validate all changes before executing the write pipeline.
@@ -698,6 +735,27 @@ export class RecordWriteService {
           changes,
           actorId,
         })
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 7: Yjs invalidation (post-commit, best effort)
+    //
+    // REST writes to meta_records.data make any persisted Y.Doc snapshot
+    // for those records stale. Drop in-memory + persisted Yjs state so the
+    // next `getOrCreateDoc` re-seeds from the just-updated DB row. Skipped
+    // when the write itself originated from the Yjs bridge (those writes
+    // ARE the Y.Doc's content; invalidating would nuke a live editor).
+    // -----------------------------------------------------------------------
+    if (this.yjsInvalidator && input.source !== 'yjs-bridge' && updates.length > 0) {
+      const recordIds = updates.map((u) => u.recordId)
+      try {
+        await this.yjsInvalidator(recordIds)
+      } catch (err) {
+        console.error(
+          `[record-write] Yjs invalidation failed for records ${recordIds.join(',')} — Yjs state may be stale until next idle-release:`,
+          err,
+        )
       }
     }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -53,8 +53,8 @@ const multitableFormulaEngine = new MultitableFormulaEngine()
 
 /**
  * Module-level Yjs invalidator set by `index.ts` when the Yjs collab
- * path is wired. Used by the direct-SQL PATCH handler at
- * `PATCH /records/:recordId` which bypasses `RecordWriteService`.
+ * path is wired. Used by REST write handlers that must purge stale Yjs
+ * state after committing `meta_records.data` outside the Yjs bridge.
  *
  * When `null`, no invalidation happens — safe for Yjs-off deployments.
  */
@@ -8278,7 +8278,7 @@ export function univerMetaRouter(): Router {
         buildAttachmentSummaries: (q, sid, rows, af) => buildAttachmentSummaries(q, req, sid, rows, af),
         ensureAttachmentIdsExist,
       }
-      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers, yjsInvalidator)
 
       const result = await recordWriteService.patchRecords({
         sheetId,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7061,10 +7061,22 @@ export function univerMetaRouter(): Router {
         }
       })
 
-      // Post-commit: wipe any Yjs state for this record so the next Y.Doc
-      // open re-seeds from the just-updated meta_records.data. Best-effort —
-      // a failure here does NOT fail the REST write. See record-write-service
-      // for the matching hook on the batch PATCH path.
+      // -----------------------------------------------------------------
+      // LOAD-BEARING — DO NOT REMOVE
+      //
+      // Wipes any persisted / in-memory Y.Doc state for this record so the
+      // next getOrCreateDoc re-seeds from the just-updated meta_records.data.
+      // Without this, the P0 stale-snapshot bug returns (docs/development/
+      // yjs-text-cell-seed-and-stale-guard-development-20260420.md).
+      //
+      // The batch PATCH path goes through RecordWriteService.patchRecords,
+      // which runs an equivalent hook on every commit that isn't
+      // source='yjs-bridge'. This direct-SQL route bypasses that service,
+      // so it must fire the invalidator itself.
+      //
+      // Best-effort: a purge failure is logged and swallowed; the REST
+      // write still succeeds.
+      // -----------------------------------------------------------------
       if (yjsInvalidator) {
         try {
           await yjsInvalidator([recordId])

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -46,9 +46,23 @@ import {
   RecordValidationError as ServiceValidationError,
   RecordFieldForbiddenError as ServiceFieldForbiddenError,
   type RecordWriteHelpers,
+  type YjsInvalidator,
 } from '../multitable/record-write-service'
 
 const multitableFormulaEngine = new MultitableFormulaEngine()
+
+/**
+ * Module-level Yjs invalidator set by `index.ts` when the Yjs collab
+ * path is wired. Used by the direct-SQL PATCH handler at
+ * `PATCH /records/:recordId` which bypasses `RecordWriteService`.
+ *
+ * When `null`, no invalidation happens — safe for Yjs-off deployments.
+ */
+let yjsInvalidator: YjsInvalidator | null = null
+
+export function setYjsInvalidatorForRoutes(invalidator: YjsInvalidator | null): void {
+  yjsInvalidator = invalidator
+}
 
 type UniverMetaField = {
   id: string
@@ -7046,6 +7060,21 @@ export function univerMetaRouter(): Router {
           }
         }
       })
+
+      // Post-commit: wipe any Yjs state for this record so the next Y.Doc
+      // open re-seeds from the just-updated meta_records.data. Best-effort —
+      // a failure here does NOT fail the REST write. See record-write-service
+      // for the matching hook on the batch PATCH path.
+      if (yjsInvalidator) {
+        try {
+          await yjsInvalidator([recordId])
+        } catch (err) {
+          console.error(
+            `[univer-meta] Yjs invalidation failed for record ${recordId} — Yjs state may be stale until next idle-release:`,
+            err,
+          )
+        }
+      }
 
       const recordRes = await pool.query(
         'SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2',

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -506,6 +506,19 @@ describe('RecordWriteService', () => {
       expect(invalidator).toHaveBeenCalledWith(['rec1'])
     })
 
+    it('invalidates before realtime broadcast and eventBus notification', async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+
+      await service.patchRecords(buildTestInput())
+
+      expect(invalidator).toHaveBeenCalledOnce()
+      expect(mockPublish).toHaveBeenCalledOnce()
+      expect(eventBus.emit).toHaveBeenCalledOnce()
+      expect(invalidator.mock.invocationCallOrder[0]).toBeLessThan(mockPublish.mock.invocationCallOrder[0])
+      expect(invalidator.mock.invocationCallOrder[0]).toBeLessThan(eventBus.emit.mock.invocationCallOrder[0])
+    })
+
     it("calls the invalidator when source === 'rest' (explicit)", async () => {
       const invalidator = vi.fn().mockResolvedValue(undefined)
       const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -483,4 +483,90 @@ describe('RecordWriteService', () => {
         .resolves.not.toThrow()
     })
   })
+
+  // -------------------------------------------------------------------------
+  // Yjs invalidation wiring (REST → Yjs consistency hook)
+  // -------------------------------------------------------------------------
+  //
+  // These tests prove that `patchRecords` correctly drives the injected
+  // invalidator so Yjs snapshots are dropped after REST commits. The
+  // isolated `yjs-rest-invalidation.test.ts` covers what `invalidateDocs`
+  // actually does; this block proves the HOOK fires at all and respects
+  // the `source` field that prevents bridge-originated writes from
+  // destroying the live Y.Doc they just read from.
+  //
+  describe('Yjs invalidation hook', () => {
+    it('calls the invalidator with committed record IDs on a default (source unset) patch', async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+
+      await service.patchRecords(buildTestInput())
+
+      expect(invalidator).toHaveBeenCalledTimes(1)
+      expect(invalidator).toHaveBeenCalledWith(['rec1'])
+    })
+
+    it("calls the invalidator when source === 'rest' (explicit)", async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+
+      await service.patchRecords(buildTestInput({ source: 'rest' }))
+
+      expect(invalidator).toHaveBeenCalledWith(['rec1'])
+    })
+
+    it("does NOT call the invalidator when source === 'yjs-bridge'", async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+
+      // The bridge's own writes must not invalidate the Y.Doc they were
+      // derived from — that would tear out a live editor mid-session and
+      // re-seed from DB that hasn't yet caught up to the bridge's commit.
+      await service.patchRecords(buildTestInput({ source: 'yjs-bridge' }))
+
+      expect(invalidator).not.toHaveBeenCalled()
+    })
+
+    it('does not fail the REST patch when the invalidator throws', async () => {
+      const invalidator = vi.fn().mockRejectedValue(new Error('purge failed'))
+      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+
+      const result = await service.patchRecords(buildTestInput())
+
+      expect(result.updated).toHaveLength(1)
+      expect(invalidator).toHaveBeenCalledOnce()
+    })
+
+    it('setYjsInvalidator replaces the callable post-construction', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const first = vi.fn().mockResolvedValue(undefined)
+      service.setYjsInvalidator(first)
+
+      await service.patchRecords(buildTestInput())
+      expect(first).toHaveBeenCalledTimes(1)
+
+      // Replace with null → no-op, no throw.
+      service.setYjsInvalidator(null)
+      await service.patchRecords(buildTestInput())
+      expect(first).toHaveBeenCalledTimes(1) // still 1, no new call
+    })
+
+    it('passes every committed record ID (multi-record patch)', async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+
+      // Two records in the same patch. The mock pool returns version=2
+      // for any UPDATE regardless of recordId, so both commit.
+      const changesByRecord = new Map<string, Array<{ fieldId: string; value: unknown }>>([
+        ['rec1', [{ fieldId: 'fld_name', value: 'Alice' }]],
+        ['rec2', [{ fieldId: 'fld_name', value: 'Bob' }]],
+      ])
+
+      await service.patchRecords(buildTestInput({ changesByRecord }))
+
+      expect(invalidator).toHaveBeenCalledTimes(1)
+      const args = invalidator.mock.calls[0][0] as string[]
+      expect(args.sort()).toEqual(['rec1', 'rec2'])
+    })
+  })
 })

--- a/packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts
+++ b/packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts
@@ -243,6 +243,27 @@ describe('YjsRecordBridge.cancelPending', () => {
     vi.useRealTimers()
   })
 
+  it('route-level setter accepts and replaces the invalidator', async () => {
+    // The direct-SQL PATCH /records/:recordId handler in univer-meta.ts
+    // reads a module-level `yjsInvalidator` variable that is wired up by
+    // index.ts on boot via `setYjsInvalidatorForRoutes(...)`. The full
+    // HTTP-level path is out of scope for a unit test (heavy auth +
+    // permission + sheet fixtures), but locking in the setter's
+    // existence + shape guards against a future refactor that drops the
+    // wiring point.
+    const routesModule = await import('../../src/routes/univer-meta')
+    expect(typeof routesModule.setYjsInvalidatorForRoutes).toBe('function')
+
+    const first = vi.fn()
+    routesModule.setYjsInvalidatorForRoutes(first)
+    // Replace with null — safe no-op for Yjs-off deployments.
+    routesModule.setYjsInvalidatorForRoutes(null)
+    // (Nothing to assert on the stored var directly — it's file-private.
+    // The manual staging verification plan step #7 in the verification MD
+    // exercises the end-to-end path with a real HTTP PATCH.)
+    expect(() => routesModule.setYjsInvalidatorForRoutes(null)).not.toThrow()
+  })
+
   it('cancelPending on records with no pending flush is a no-op', () => {
     const persistence = makePersistence()
     const svc = new YjsSyncService(persistence as any)

--- a/packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts
+++ b/packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts
@@ -1,0 +1,260 @@
+/**
+ * REST → Yjs consistency tests.
+ *
+ * Reviewer finding (2026-04-21): the P0 seed fix in `YjsSyncService`
+ * seeds from `meta_records.data` only on fresh-doc create (when the
+ * persistence adapter returns no state). That left a hole: once a
+ * Y.Doc snapshot exists for a record, a later REST write to
+ * `meta_records.data` is invisible to the next Yjs opener — the
+ * snapshot wins.
+ *
+ * The fix: after every REST write that touches `meta_records.data`,
+ * call `YjsSyncService.invalidateDocs` (composed with
+ * `YjsRecordBridge.cancelPending` in `index.ts`) so any persisted
+ * Y.Doc state for those records is wiped. Next `getOrCreateDoc`
+ * re-seeds from the just-updated DB row.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import * as Y from 'yjs'
+import { YjsSyncService } from '../../src/collab/yjs-sync-service'
+import { YjsRecordBridge } from '../../src/collab/yjs-record-bridge'
+
+/**
+ * In-memory persistence stub that mirrors the real adapter's contract
+ * but backs everything with JS maps. Supports the full lifecycle:
+ * storeSnapshot / storeUpdate / loadDoc / purgeRecords.
+ */
+function makePersistence() {
+  const snapshots = new Map<string, Uint8Array>()
+  const updates = new Map<string, Uint8Array[]>()
+  return {
+    store: { snapshots, updates },
+    loadDoc: vi.fn(async (recordId: string): Promise<Uint8Array | null> => {
+      const snap = snapshots.get(recordId)
+      const ups = updates.get(recordId) ?? []
+      if (!snap && ups.length === 0) return null
+      const doc = new Y.Doc()
+      if (snap) Y.applyUpdate(doc, snap)
+      for (const u of ups) Y.applyUpdate(doc, u)
+      const out = Y.encodeStateAsUpdate(doc)
+      doc.destroy()
+      return out
+    }),
+    storeUpdate: vi.fn(async (recordId: string, update: Uint8Array) => {
+      const list = updates.get(recordId) ?? []
+      list.push(update)
+      updates.set(recordId, list)
+    }),
+    storeSnapshot: vi.fn(async (recordId: string, doc: Y.Doc) => {
+      snapshots.set(recordId, Y.encodeStateAsUpdate(doc))
+      // Real adapter's compactDoc also clears updates; emulate that
+      // so snapshot+updates don't double-apply on next load.
+      updates.set(recordId, [])
+    }),
+    compactDoc: vi.fn(async (recordId: string, doc: Y.Doc) => {
+      snapshots.set(recordId, Y.encodeStateAsUpdate(doc))
+      updates.set(recordId, [])
+    }),
+    purgeRecords: vi.fn(async (recordIds: string[]) => {
+      for (const id of recordIds) {
+        snapshots.delete(id)
+        updates.delete(id)
+      }
+    }),
+  }
+}
+
+describe('REST → Yjs invalidation', () => {
+  it('after Yjs snapshot exists, REST update + invalidate → next open reads the REST value (not the stale snapshot)', async () => {
+    const persistence = makePersistence()
+
+    // Mutable row used by the seeder so we can simulate a REST write
+    // flipping meta_records.data between opens.
+    let row: { fld_title: string } = { fld_title: 'v1' }
+    const recordSeed = vi.fn(async () => row)
+
+    const svc = new YjsSyncService(persistence as any, recordSeed)
+
+    // --- Phase 1: first open seeds from meta_records.data = 'v1' -----------
+    const doc1 = await svc.getOrCreateDoc('rec_1')
+    const text1 = doc1.getMap('fields').get('fld_title') as Y.Text
+    expect(text1.toString()).toBe('v1')
+
+    // --- Phase 2: a user edits via Yjs → 'v2' ------------------------------
+    text1.delete(0, text1.length)
+    text1.insert(0, 'v2')
+
+    // Release the doc (idle cleanup path): writes the snapshot.
+    await svc.releaseDoc('rec_1')
+    // Snapshot now contains 'v2'; seeder will NOT be consulted on the
+    // next open because the persistence adapter returns non-null state.
+
+    // --- Phase 3: REST write updates the DB to 'v3' and invalidates --------
+    row = { fld_title: 'v3' }
+    await svc.invalidateDocs(['rec_1'])
+    expect(persistence.purgeRecords).toHaveBeenCalledWith(['rec_1'])
+
+    // --- Phase 4: next Yjs open must read 'v3', not 'v2' -------------------
+    const doc2 = await svc.getOrCreateDoc('rec_1')
+    const text2 = doc2.getMap('fields').get('fld_title') as Y.Text
+    expect(text2).toBeInstanceOf(Y.Text)
+    expect(text2.toString()).toBe('v3')
+    expect(text2.toString()).not.toBe('v2')
+
+    await svc.destroy()
+  })
+
+  it('invalidateDocs destroys the in-memory Y.Doc without snapshotting it (prevents stale re-materialize)', async () => {
+    const persistence = makePersistence()
+    let row: { fld_title: string } = { fld_title: 'v1' }
+    const svc = new YjsSyncService(persistence as any, async () => row)
+
+    const doc = await svc.getOrCreateDoc('rec_1')
+    const text = doc.getMap('fields').get('fld_title') as Y.Text
+    text.delete(0, text.length)
+    text.insert(0, 'v2-in-memory-only')
+
+    // Before any releaseDoc — snapshot NOT written yet. invalidateDocs
+    // must NOT snapshot now (that would persist stale 'v2' after the
+    // REST write).
+    const snapshotCallsBefore = persistence.storeSnapshot.mock.calls.length
+    const compactCallsBefore = persistence.compactDoc.mock.calls.length
+    row = { fld_title: 'v3' }
+    await svc.invalidateDocs(['rec_1'])
+    expect(persistence.storeSnapshot.mock.calls.length).toBe(snapshotCallsBefore)
+    expect(persistence.compactDoc.mock.calls.length).toBe(compactCallsBefore)
+
+    // Next open reads 'v3' via fresh seed.
+    const doc2 = await svc.getOrCreateDoc('rec_1')
+    expect((doc2.getMap('fields').get('fld_title') as Y.Text).toString()).toBe('v3')
+
+    await svc.destroy()
+  })
+
+  it('invalidateDocs tolerates records with no persisted state and no in-memory doc (no-op)', async () => {
+    const persistence = makePersistence()
+    const svc = new YjsSyncService(persistence as any, async () => null)
+
+    await svc.invalidateDocs(['rec_never_opened'])
+    // Delete on a non-existent row is a safe no-op.
+    expect(persistence.purgeRecords).toHaveBeenCalledWith(['rec_never_opened'])
+
+    await svc.destroy()
+  })
+
+  it('invalidateDocs with empty recordIds array does nothing', async () => {
+    const persistence = makePersistence()
+    const svc = new YjsSyncService(persistence as any, async () => null)
+
+    await svc.invalidateDocs([])
+    expect(persistence.purgeRecords).not.toHaveBeenCalled()
+
+    await svc.destroy()
+  })
+
+  it('works on a service without a recordSeed — in-memory eviction still happens, next open is empty', async () => {
+    const persistence = makePersistence()
+    const svc = new YjsSyncService(persistence as any) // no seeder
+
+    // Seed manually so loadDoc returns state on next open without seeder.
+    const primer = new Y.Doc()
+    const t = new Y.Text()
+    t.insert(0, 'v1')
+    primer.getMap('fields').set('fld_title', t)
+    persistence.store.snapshots.set('rec_1', Y.encodeStateAsUpdate(primer))
+    primer.destroy()
+
+    // First open — loads 'v1' from snapshot.
+    const doc1 = await svc.getOrCreateDoc('rec_1')
+    expect((doc1.getMap('fields').get('fld_title') as Y.Text).toString()).toBe('v1')
+
+    // Invalidate — wipes snapshot.
+    await svc.invalidateDocs(['rec_1'])
+
+    // Next open — no snapshot, no seeder → empty Y.Doc.
+    const doc2 = await svc.getOrCreateDoc('rec_1')
+    expect(doc2.getMap('fields').size).toBe(0)
+
+    await svc.destroy()
+  })
+})
+
+describe('YjsRecordBridge.cancelPending', () => {
+  /**
+   * Simulates the full race described in the reviewer finding:
+   *   t=0:  Y.Text edit → bridge schedules flush at t=200
+   *   t=50: REST write commits, invalidate runs → cancels bridge, purges state
+   *   t=200: bridge timer would have fired → MUST be cancelled
+   */
+  it('cancelPending clears a scheduled flush so a debounce timer does not fire post-invalidate', async () => {
+    vi.useFakeTimers()
+
+    const persistence = makePersistence()
+    const svc = new YjsSyncService(persistence as any, async () => ({ fld_title: 'seed' }))
+    const recordWriteService = {
+      patchRecords: vi.fn().mockResolvedValue({ updated: [{ recordId: 'rec_1', version: 2 }] }),
+    }
+
+    const bridge = new YjsRecordBridge(
+      svc as any,
+      recordWriteService as any,
+      async () => ({
+        sheetId: 'sh_1',
+        changesByRecord: new Map(),
+        actorId: 'user_1',
+        fields: [],
+        visiblePropertyFields: [],
+        visiblePropertyFieldIds: new Set(),
+        attachmentFields: [],
+        fieldById: new Map(),
+        capabilities: {} as any,
+        access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      }),
+      { mergeWindowMs: 200, maxDelayMs: 500 },
+    )
+
+    const doc = await svc.getOrCreateDoc('rec_1')
+    bridge.observe('rec_1', doc)
+
+    // t=0: Y.Text edit — schedules a flush at t=200.
+    const text = doc.getMap('fields').get('fld_title') as Y.Text
+    text.insert(text.length, ' edited')
+
+    // Pump microtasks so the observer runs and scheduleFlush takes effect.
+    await Promise.resolve()
+    expect(bridge.getMetrics().pendingWriteCount).toBe(1)
+
+    // t=50: REST write commits → invalidator cancels pending + purges state.
+    bridge.cancelPending(['rec_1'])
+    await svc.invalidateDocs(['rec_1'])
+    expect(bridge.getMetrics().pendingWriteCount).toBe(0)
+
+    // Advance well past the original merge window.
+    vi.advanceTimersByTime(500)
+    await Promise.resolve()
+
+    // The bridge MUST NOT have flushed after cancellation — if it did,
+    // it would have written the stale Yjs-cached value on top of the
+    // REST write.
+    expect(recordWriteService.patchRecords).not.toHaveBeenCalled()
+
+    bridge.destroy()
+    await svc.destroy()
+    vi.useRealTimers()
+  })
+
+  it('cancelPending on records with no pending flush is a no-op', () => {
+    const persistence = makePersistence()
+    const svc = new YjsSyncService(persistence as any)
+    const bridge = new YjsRecordBridge(
+      svc as any,
+      { patchRecords: vi.fn() } as any,
+      async () => null,
+    )
+
+    expect(() => bridge.cancelPending(['rec_never_touched'])).not.toThrow()
+    expect(bridge.getMetrics().pendingWriteCount).toBe(0)
+
+    bridge.destroy()
+  })
+})

--- a/packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts
+++ b/packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts
@@ -14,6 +14,7 @@
  * Y.Doc state for those records is wiped. Next `getOrCreateDoc`
  * re-seeds from the just-updated DB row.
  */
+import { readFile } from 'node:fs/promises'
 import { describe, it, expect, vi } from 'vitest'
 import * as Y from 'yjs'
 import { YjsSyncService } from '../../src/collab/yjs-sync-service'
@@ -262,6 +263,12 @@ describe('YjsRecordBridge.cancelPending', () => {
     // The manual staging verification plan step #7 in the verification MD
     // exercises the end-to-end path with a real HTTP PATCH.)
     expect(() => routesModule.setYjsInvalidatorForRoutes(null)).not.toThrow()
+  })
+
+  it('REST /patch route passes the module-level invalidator into RecordWriteService', async () => {
+    const source = await readFile(new URL('../../src/routes/univer-meta.ts', import.meta.url), 'utf8')
+
+    expect(source).toContain('new RecordWriteService(pool, eventBus, writeHelpers, yjsInvalidator)')
   })
 
   it('cancelPending on records with no pending flush is a no-op', () => {

--- a/packages/core-backend/tests/unit/yjs-sync-seed.test.ts
+++ b/packages/core-backend/tests/unit/yjs-sync-seed.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for YjsSyncService's fresh-doc seed from meta_records.
+ *
+ * This closes the P0 data-overwrite vector from the 2026-04-20 review
+ * of PR #960: before the fix, opening an existing text cell for the
+ * first time in Yjs mode would show an empty textbox (no Y.Text yet)
+ * and the first user edit would overwrite the real value in meta_records
+ * with whatever they typed on top of the empty state.
+ *
+ * The fix: when getOrCreateDoc runs and the persistence adapter returns
+ * no state, call the injected recordSeed to load the record's current
+ * data and seed the Y.Doc fields map with one Y.Text per string field.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import * as Y from 'yjs'
+import { YjsSyncService } from '../../src/collab/yjs-sync-service'
+
+function makePersistence(load: Uint8Array | null = null) {
+  return {
+    loadDoc: vi.fn().mockResolvedValue(load),
+    storeUpdate: vi.fn().mockResolvedValue(undefined),
+    storeSnapshot: vi.fn().mockResolvedValue(undefined),
+    compactDoc: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('YjsSyncService fresh-doc seed', () => {
+  it('seeds Y.Text entries from meta_records.data when no Yjs state exists', async () => {
+    const persistence = makePersistence(null)
+    const recordSeed = vi.fn().mockResolvedValue({
+      fld_title: 'existing value',
+      fld_name: 'alice',
+      fld_count: 42, // non-string, must NOT be seeded
+    })
+    const svc = new YjsSyncService(persistence as any, recordSeed)
+
+    const doc = await svc.getOrCreateDoc('rec_1')
+
+    expect(recordSeed).toHaveBeenCalledWith('rec_1')
+
+    const fields = doc.getMap('fields')
+    const title = fields.get('fld_title')
+    const name = fields.get('fld_name')
+    const count = fields.get('fld_count')
+
+    expect(title).toBeInstanceOf(Y.Text)
+    expect((title as Y.Text).toString()).toBe('existing value')
+    expect(name).toBeInstanceOf(Y.Text)
+    expect((name as Y.Text).toString()).toBe('alice')
+    // Non-string left out of fields map on purpose — frontend only
+    // binds Y.Text entries; other field types continue using REST.
+    expect(count).toBeUndefined()
+
+    await svc.destroy()
+  })
+
+  it('does NOT seed if the persistence adapter returns existing state', async () => {
+    // Simulate existing Y.Doc with a different value in the snapshot.
+    const primer = new Y.Doc()
+    const primerFields = primer.getMap('fields')
+    const primerText = new Y.Text()
+    primerText.insert(0, 'persisted value')
+    primerFields.set('fld_title', primerText)
+    const persistedState = Y.encodeStateAsUpdate(primer)
+    primer.destroy()
+
+    const persistence = makePersistence(persistedState)
+    const recordSeed = vi.fn().mockResolvedValue({
+      fld_title: 'stale DB value',
+    })
+    const svc = new YjsSyncService(persistence as any, recordSeed)
+
+    const doc = await svc.getOrCreateDoc('rec_1')
+
+    expect(recordSeed).not.toHaveBeenCalled()
+
+    const title = doc.getMap('fields').get('fld_title') as Y.Text
+    expect(title).toBeInstanceOf(Y.Text)
+    // Persisted Y.Doc wins — the record_seed's stale DB value would
+    // have silently reverted concurrent edits.
+    expect(title.toString()).toBe('persisted value')
+
+    await svc.destroy()
+  })
+
+  it('seeding does NOT create a DB update row (origin=seed is filtered)', async () => {
+    const persistence = makePersistence(null)
+    const recordSeed = vi.fn().mockResolvedValue({ fld_title: 'v' })
+    const svc = new YjsSyncService(persistence as any, recordSeed)
+
+    await svc.getOrCreateDoc('rec_seed')
+
+    // The persistence listener should skip origin='seed' so the seed
+    // stays in memory; it's only written to DB on the first compact()
+    // (e.g. after an actual user edit triggered a flush).
+    expect(persistence.storeUpdate).not.toHaveBeenCalled()
+
+    await svc.destroy()
+  })
+
+  it('returning null from recordSeed leaves the Y.Doc empty (no crash)', async () => {
+    const persistence = makePersistence(null)
+    const recordSeed = vi.fn().mockResolvedValue(null)
+    const svc = new YjsSyncService(persistence as any, recordSeed)
+
+    const doc = await svc.getOrCreateDoc('rec_missing')
+
+    expect(doc.getMap('fields').size).toBe(0)
+
+    await svc.destroy()
+  })
+
+  it('recordSeed throwing is caught and yields an empty Y.Doc', async () => {
+    const persistence = makePersistence(null)
+    const recordSeed = vi.fn().mockRejectedValue(new Error('db down'))
+    const svc = new YjsSyncService(persistence as any, recordSeed)
+
+    const doc = await svc.getOrCreateDoc('rec_err')
+
+    expect(doc.getMap('fields').size).toBe(0)
+
+    await svc.destroy()
+  })
+
+  it('does NOT overwrite an existing entry via seed (idempotent)', async () => {
+    // Two calls to getOrCreateDoc for the same record should not
+    // re-seed. First creates the doc; second returns cached.
+    const persistence = makePersistence(null)
+    const recordSeed = vi.fn().mockResolvedValue({ fld_title: 'first' })
+    const svc = new YjsSyncService(persistence as any, recordSeed)
+
+    const doc1 = await svc.getOrCreateDoc('rec_1')
+    // User edits
+    const text = doc1.getMap('fields').get('fld_title') as Y.Text
+    text.delete(0, text.length)
+    text.insert(0, 'edited')
+
+    // Second getOrCreateDoc should return the same cached doc; recordSeed
+    // should NOT be called again.
+    const doc2 = await svc.getOrCreateDoc('rec_1')
+    expect(doc2).toBe(doc1)
+    expect(recordSeed).toHaveBeenCalledTimes(1)
+    const stillEdited = doc2.getMap('fields').get('fld_title') as Y.Text
+    expect(stillEdited.toString()).toBe('edited')
+
+    await svc.destroy()
+  })
+
+  it('no recordSeed provided → behavior unchanged (empty Y.Doc, no error)', async () => {
+    const persistence = makePersistence(null)
+    // Legacy call site with no seeder — must still work.
+    const svc = new YjsSyncService(persistence as any)
+
+    const doc = await svc.getOrCreateDoc('rec_1')
+    expect(doc.getMap('fields').size).toBe(0)
+
+    await svc.destroy()
+  })
+})


### PR DESCRIPTION
## Summary

- Wires `useYjsDocument` + `useYjsTextField` into `MetaCellEditor` for grid text cells, behind the build-time flag `VITE_ENABLE_YJS_COLLAB=true` (off by default). Closes audit PR #944 gap #4.
- Adds `useYjsCellBinding` to gate the Yjs call path, lazy-load the Yjs runtime only after the flag is enabled, enforce a 2.5s connect timeout, and fall back to REST on flag-off, timeout, error, or mid-session disconnect.
- Ships **character-level minimal-diff merge** (prefix/suffix diff) and a **fresh-doc seed from `meta_records`** so opening an existing text cell shows the current value instead of an empty textbox.
- Ships **REST → Yjs invalidation**: every REST write to `meta_records.data` purges the corresponding Y.Doc state (in-memory + persisted) so the next `getOrCreateDoc` re-seeds from the updated DB row. Bridge pending flushes are cancelled first so a 200–500ms debounce cannot re-materialize stale values.

## Reviewer attention list

1. **Fresh-doc seed** in `YjsSyncService.getOrCreateDoc` + `yjsRecordSeeder` in `index.ts`. Origin='seed' skipped in persistence listener.
2. **Seed contract in `useYjsTextField`** — refuses to create empty Y.Text; exposes `yjsActive`; observes the `fields` Y.Map so async-delivered Y.Text attaches without reconnect.
3. **`useYjsCellBinding` active gating** — requires both `synced` AND `yjsActive`.
4. **Lazy frontend runtime boundary** — `useYjsCellBinding` uses a compile-time flag-off early return and dynamic imports `useYjsDocument` / `useYjsTextField` only after the flag is on. `useYjsDocument` / `useYjsTextField` expose explicit `dispose()` for lazy callers.
5. **Stale-guard on connect** — `connectGen` monotonic counter in `useYjsDocument`.
6. **Minimal-diff `setText`** — common-prefix/common-suffix diff.
7. **REST → Yjs invalidation**: `YjsSyncService.invalidateDocs` + `YjsRecordBridge.cancelPending` + `YjsPersistenceAdapter.purgeRecords`, composed in `index.ts`, injected into the bridge `RecordWriteService`, the REST `/patch` route-local `RecordWriteService`, AND the direct-SQL `PATCH /records/:recordId`. Loop-preventing: `RecordPatchInput.source='yjs-bridge'` is skipped.
8. **View-layer fallback** — `MetaCellEditor.vue:31` reads modelValue when inactive.
9. **Frontend opt-in boundary** — `MetaCellEditor` only constructs Yjs binding for eligible string cells; non-text editors use an inert local binding.
10. **Dual-write suppression** — `yjsHandledCellKey` in `MetaGridTable.vue`.

## Test plan

- [x] `yjs-rest-invalidation.test.ts` (+10) — regression the reviewer asked for: snapshot exists → REST update → next Yjs open reads the REST value, not the stale snapshot. Plus bridge debounce-race cancellation, in-memory evict without snapshotting, route-level setter shape, /patch constructor injection, and invalidation-before-notification order.
- [x] `record-write-service.test.ts` (+6) — the wiring itself: invalidator fires on `source='rest'` / unset, skipped on `source='yjs-bridge'`, tolerates throws, multi-record patch.
- [x] `yjs-sync-seed.test.ts` (7), `yjs-text-field-seed-guard.spec.ts` (6), `yjs-document-stale-guard.spec.ts` (2), `yjs-text-field-diff.spec.ts` (16), `multitable-yjs-cell-binding.spec.ts` (4), `multitable-yjs-cell-editor.spec.ts` (2), `yjs-awareness-presence.spec.ts` — all green.
- [x] `vue-tsc` + backend `tsc` clean.
- [x] `pnpm --filter @metasheet/web build` with default flag-off build: no `useYjsDocument-*`, `useYjsTextField-*`, or `yjs-*` runtime asset emitted.
- [x] Backend suite: 2281 pass (one pre-existing unrelated orphan test fails to load).
- [x] Full web suite: no new failures; 100 pre-existing unrelated failures match baseline.

## Known limitations (documented)

- Active WebSocket editors lose their in-memory doc on REST invalidation — must reconnect. Follow-up: `yjs:invalidated` server event.
- Record DELETE does not fire the invalidator; 10-min orphan cleanup closes the gap eventually.

Dev MDs:
- `docs/development/yjs-text-cell-diff-binding-development-20260420.md`
- `docs/development/yjs-text-cell-seed-and-stale-guard-development-20260420.md`
- `docs/development/yjs-text-cell-seed-and-stale-guard-verification-20260420.md`
- `docs/development/yjs-rest-invalidation-final-wiring-development-20260421.md`
- `docs/development/yjs-rest-invalidation-final-wiring-verification-20260421.md`

Audit PR: #944.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
