### PR TITLE
feat(dingtalk): warn on member group field paths

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -351,6 +351,13 @@
                 <em>Remove</em>
               </button>
             </div>
+            <div
+              v-for="warning in memberGroupRecipientFieldPathWarnings(draft.dingtalkPersonMemberGroupRecipientFieldPath)"
+              :key="`draft-person-member-group-recipient-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__hint">
               Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
             </div>
@@ -910,6 +917,20 @@ function recipientFieldPathWarnings(value: string) {
   return parseRecipientFieldPathsText(value)
     .filter((path) => !candidateIds.has(path))
     .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+}
+
+function memberGroupRecipientFieldPathWarnings(value: string) {
+  const fieldMap = new Map(props.fields.map((field) => [field.id, field]))
+  return parseRecipientFieldPathsText(value).flatMap((path) => {
+    const field = fieldMap.get(path)
+    if (!field) {
+      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
+    }
+    if (field.type === 'user') {
+      return [`record.${path} is a user field; use Record recipient field paths instead.`]
+    }
+    return []
+  })
 }
 
 const dingTalkPersonRecipientFieldSummary = computed(() => {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -475,6 +475,13 @@
                   <em>Remove</em>
                 </button>
               </div>
+              <div
+                v-for="warning in memberGroupRecipientFieldPathWarnings(action.config.memberGroupRecipientFieldPath)"
+                :key="`person-member-group-recipient-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__hint">
                 Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
               </div>
@@ -1105,6 +1112,20 @@ function recipientFieldPathWarnings(value: unknown) {
   return parseRecipientFieldPathsText(value)
     .filter((path) => !candidateIds.has(path))
     .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+}
+
+function memberGroupRecipientFieldPathWarnings(value: unknown) {
+  const fieldMap = new Map(props.fields.map((field) => [field.id, field]))
+  return parseRecipientFieldPathsText(value).flatMap((path) => {
+    const field = fieldMap.get(path)
+    if (!field) {
+      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
+    }
+    if (field.type === 'user') {
+      return [`record.${path} is a user field; use Record recipient field paths instead.`]
+    }
+    return []
+  })
 }
 
 function recipientFieldPathSummary(value: unknown) {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -543,6 +543,50 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-automation-member-group-recipient-field="watcherGroupIds"]')).toBeNull()
   })
 
+  it('warns when a dynamic member group recipient path is unknown in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.unknownGroupField'
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.unknownGroupField is not a known field in this sheet')
+  })
+
+  it('warns when a dynamic member group recipient path points at a user field in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.assigneeUserIds'
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.assigneeUserIds is a user field; use Record recipient field paths instead.')
+  })
+
   it('can pick a record recipient field for DingTalk person automation', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -527,6 +527,54 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.querySelector('[data-member-group-recipient-field="watcherGroupIds"]')).toBeNull()
   })
 
+  it('warns when a dynamic member group recipient path is unknown in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.unknownGroupField'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.unknownGroupField is not a known field in this sheet')
+  })
+
+  it('warns when a dynamic member group recipient path points at a user field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.assigneeUserIds'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.assigneeUserIds is a user field; use Record recipient field paths instead.')
+  })
+
   it('can pick a record recipient field in the rule editor', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/docs/development/dingtalk-person-member-group-field-warnings-development-20260421.md
+++ b/docs/development/dingtalk-person-member-group-field-warnings-development-20260421.md
@@ -1,0 +1,42 @@
+# DingTalk Person Member Group Field Warnings Development
+
+Date: 2026-04-21
+
+## Goal
+
+Add authoring warnings for dynamic member-group field paths in `send_dingtalk_person_message`.
+
+This slice does not change runtime behavior. It only helps admins catch obvious misconfiguration earlier in both automation editors.
+
+## Scope
+
+- Warn when `record.<fieldId>` does not resolve to a field in the current sheet
+- Warn when a dynamic member-group recipient path points at a `user` field
+- Keep freeform text input and runtime config shape unchanged
+- Do not change backend execution or API contracts
+
+## Frontend Changes
+
+Updated [MetaAutomationRuleEditor.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-warnings-20260421/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue:1):
+
+- Added `memberGroupRecipientFieldPathWarnings(...)`
+- Rendered warning hints under `Record member group field paths`
+- Reused existing path parsing so comma-separated `record.<fieldId>` input continues to work
+
+Updated [MetaAutomationManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-warnings-20260421/apps/web/src/multitable/components/MetaAutomationManager.vue:1):
+
+- Added inline warning rendering for draft member-group recipient field paths
+- Warns on unknown field IDs in the current sheet
+- Warns when a path points at a `user` field and should instead use `Record recipient field paths`
+
+Updated tests:
+
+- [multitable-automation-rule-editor.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-warnings-20260421/apps/web/tests/multitable-automation-rule-editor.spec.ts:1)
+- [multitable-automation-manager.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-warnings-20260421/apps/web/tests/multitable-automation-manager.spec.ts:1)
+
+## Behavior Notes
+
+- Member-group recipient paths remain freeform `record.<fieldId>` strings
+- Unknown paths are still editable; the UI only warns
+- Paths targeting `user` fields are still preserved for backward compatibility; the UI now points admins to the user-recipient field input instead
+- No backend/runtime payload or execution change was made in this PR

--- a/docs/development/dingtalk-person-member-group-field-warnings-verification-20260421.md
+++ b/docs/development/dingtalk-person-member-group-field-warnings-verification-20260421.md
@@ -1,0 +1,31 @@
+# DingTalk Person Member Group Field Warnings Verification
+
+Date: 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `58 passed`
+- Web build: passed
+- `git diff --check`: passed
+
+## Focus Checks
+
+- Rule editor warns when a member-group recipient path points at an unknown field
+- Rule editor warns when a member-group recipient path points at a `user` field
+- Inline automation manager shows the same two warnings
+- Existing freeform `record.<fieldId>` editing continues to work
+- No runtime payload shape changed
+
+## Notes
+
+- `pnpm install` updated several `plugins/**/node_modules` and `tools/cli/node_modules` paths in this worktree.
+- Those dependency noise changes are not part of the feature and should not be committed.


### PR DESCRIPTION
## Summary
- add warning hints for dynamic person-message member-group field paths
- warn when a record path is unknown in the current sheet
- warn when a member-group path points at a user field and should use recipient field paths instead

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --check