### PR TITLE
feat(dingtalk): package person member group recipients

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -327,6 +327,17 @@
             <div class="meta-automation__hint">
               Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths. The picker only lists user fields.
             </div>
+            <label class="meta-automation__label">Record member group field paths (optional)</label>
+            <input
+              v-model="draft.dingtalkPersonMemberGroupRecipientFieldPath"
+              class="meta-automation__input"
+              type="text"
+              placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
+              data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"
+            />
+            <div class="meta-automation__hint">
+              Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
+            </div>
             <label class="meta-automation__label">Title template</label>
             <input
               v-model="draft.dingtalkPersonTitleTemplate"
@@ -397,6 +408,7 @@
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
               <div><strong>Record recipients:</strong> {{ dingTalkPersonRecipientFieldSummary }}</div>
+              <div><strong>Record member groups:</strong> {{ dingTalkPersonMemberGroupFieldSummary }}</div>
               <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
               <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
               <div class="meta-automation__preview-line">
@@ -592,6 +604,7 @@ interface DraftState {
   dingtalkPersonUserIds: string
   dingtalkPersonMemberGroupIds: string
   dingtalkPersonRecipientFieldPath: string
+  dingtalkPersonMemberGroupRecipientFieldPath: string
   dingtalkPersonTitleTemplate: string
   dingtalkPersonBodyTemplate: string
   dingtalkPersonPublicFormViewId: string
@@ -616,6 +629,7 @@ function emptyDraft(): DraftState {
     dingtalkPersonUserIds: '',
     dingtalkPersonMemberGroupIds: '',
     dingtalkPersonRecipientFieldPath: '',
+    dingtalkPersonMemberGroupRecipientFieldPath: '',
     dingtalkPersonTitleTemplate: '',
     dingtalkPersonBodyTemplate: '',
     dingtalkPersonPublicFormViewId: '',
@@ -881,6 +895,14 @@ const dingTalkPersonRecipientFieldSummary = computed(() => {
   return labels.join(', ')
 })
 
+const dingTalkPersonMemberGroupFieldSummary = computed(() => {
+  const labels = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
+    .map((path) => recipientFieldSummaryLabel(path))
+    .filter(Boolean)
+  if (!labels.length) return 'No dynamic member group field'
+  return labels.join(', ')
+})
+
 function appendDingTalkPersonRecipientField(select: HTMLSelectElement) {
   const value = select.value.trim()
   if (!value) return
@@ -1041,6 +1063,7 @@ const canSave = computed(() => {
       !draft.value.dingtalkPersonUserIds.trim()
       && !draft.value.dingtalkPersonMemberGroupIds.trim()
       && !draft.value.dingtalkPersonRecipientFieldPath.trim()
+      && !draft.value.dingtalkPersonMemberGroupRecipientFieldPath.trim()
     ) return false
     if (!draft.value.dingtalkPersonTitleTemplate.trim()) return false
     if (!draft.value.dingtalkPersonBodyTemplate.trim()) return false
@@ -1078,6 +1101,9 @@ function openEditForm(rule: AutomationRule) {
     dingtalkPersonRecipientFieldPath: Array.isArray(rule.actionConfig?.userIdFieldPaths)
       ? (rule.actionConfig?.userIdFieldPaths as string[]).join(', ')
       : (rule.actionConfig?.userIdFieldPath as string) ?? '',
+    dingtalkPersonMemberGroupRecipientFieldPath: Array.isArray(rule.actionConfig?.memberGroupIdFieldPaths)
+      ? (rule.actionConfig?.memberGroupIdFieldPaths as string[]).join(', ')
+      : (rule.actionConfig?.memberGroupIdFieldPath as string) ?? '',
     dingtalkPersonTitleTemplate: (rule.actionConfig?.titleTemplate as string) ?? '',
     dingtalkPersonBodyTemplate: (rule.actionConfig?.bodyTemplate as string) ?? '',
     dingtalkPersonPublicFormViewId: (rule.actionConfig?.publicFormViewId as string) ?? '',
@@ -1130,6 +1156,8 @@ function buildActionConfig(): Record<string, unknown> {
       .filter(Boolean)
     const userIdFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
       .map((path) => `record.${path}`)
+    const memberGroupIdFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
+      .map((path) => `record.${path}`)
     return {
       userIds: draft.value.dingtalkPersonUserIds
         .split(/[\n,]+/)
@@ -1138,6 +1166,8 @@ function buildActionConfig(): Record<string, unknown> {
       memberGroupIds: memberGroupIds.length ? memberGroupIds : undefined,
       userIdFieldPath: userIdFieldPaths[0] || undefined,
       userIdFieldPaths: userIdFieldPaths.length ? userIdFieldPaths : undefined,
+      memberGroupIdFieldPath: memberGroupIdFieldPaths[0] || undefined,
+      memberGroupIdFieldPaths: memberGroupIdFieldPaths.length ? memberGroupIdFieldPaths : undefined,
       titleTemplate: draft.value.dingtalkPersonTitleTemplate,
       bodyTemplate: draft.value.dingtalkPersonBodyTemplate,
       publicFormViewId: draft.value.dingtalkPersonPublicFormViewId || undefined,

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -335,6 +335,22 @@
               placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
               data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"
             />
+            <div
+              v-if="selectedDingTalkPersonMemberGroupRecipientFields.length"
+              class="meta-automation__recipient-list meta-automation__recipient-list--selected"
+            >
+              <button
+                v-for="field in selectedDingTalkPersonMemberGroupRecipientFields"
+                :key="field.id"
+                class="meta-automation__recipient-chip"
+                type="button"
+                :data-automation-member-group-recipient-field="field.id"
+                @click="removeDingTalkPersonMemberGroupRecipientField(field.id)"
+              >
+                <strong>{{ field.label }}</strong>
+                <em>Remove</em>
+              </button>
+            </div>
             <div class="meta-automation__hint">
               Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
             </div>
@@ -882,6 +898,13 @@ const selectedDingTalkPersonRecipientFields = computed(() => parseRecipientField
   }))
   .filter((item) => item.label))
 
+const selectedDingTalkPersonMemberGroupRecipientFields = computed(() => parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
+  .map((path) => ({
+    id: path,
+    label: recipientFieldSummaryLabel(path),
+  }))
+  .filter((item) => item.label))
+
 function recipientFieldPathWarnings(value: string) {
   const candidateIds = new Set(dingTalkPersonRecipientCandidateFields.value.map((field) => field.id))
   return parseRecipientFieldPathsText(value)
@@ -916,6 +939,13 @@ function appendDingTalkPersonRecipientField(select: HTMLSelectElement) {
 
 function removeDingTalkPersonRecipientField(path: string) {
   draft.value.dingtalkPersonRecipientFieldPath = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+    .filter((entry) => entry !== path)
+    .map((entry) => `record.${entry}`)
+    .join(', ')
+}
+
+function removeDingTalkPersonMemberGroupRecipientField(path: string) {
+  draft.value.dingtalkPersonMemberGroupRecipientFieldPath = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
     .filter((entry) => entry !== path)
     .map((entry) => `record.${entry}`)
     .join(', ')

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -351,6 +351,13 @@
                 <em>Remove</em>
               </button>
             </div>
+            <div
+              v-for="warning in memberGroupRecipientFieldPathWarnings(draft.dingtalkPersonMemberGroupRecipientFieldPath)"
+              :key="`draft-person-member-group-recipient-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__hint">
               Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
             </div>
@@ -910,6 +917,20 @@ function recipientFieldPathWarnings(value: string) {
   return parseRecipientFieldPathsText(value)
     .filter((path) => !candidateIds.has(path))
     .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+}
+
+function memberGroupRecipientFieldPathWarnings(value: string) {
+  const fieldMap = new Map(props.fields.map((field) => [field.id, field]))
+  return parseRecipientFieldPathsText(value).flatMap((path) => {
+    const field = fieldMap.get(path)
+    if (!field) {
+      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
+    }
+    if (field.type === 'user') {
+      return [`record.${path} is a user field; use Record recipient field paths instead.`]
+    }
+    return []
+  })
 }
 
 const dingTalkPersonRecipientFieldSummary = computed(() => {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -459,6 +459,22 @@
                 placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
                 data-field="dingtalkPersonMemberGroupRecipientFieldPath"
               />
+              <div
+                v-if="selectedMemberGroupRecipientFields(action).length"
+                class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
+              >
+                <button
+                  v-for="field in selectedMemberGroupRecipientFields(action)"
+                  :key="field.id"
+                  class="meta-rule-editor__recipient-chip"
+                  type="button"
+                  :data-member-group-recipient-field="field.id"
+                  @click="removeMemberGroupRecipientFieldPath(action, field.id)"
+                >
+                  <strong>{{ field.label }}</strong>
+                  <em>Remove</em>
+                </button>
+              </div>
               <div class="meta-rule-editor__hint">
                 Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
               </div>
@@ -1075,6 +1091,15 @@ function selectedRecipientFields(action: DraftAction) {
     .filter((item) => item.label)
 }
 
+function selectedMemberGroupRecipientFields(action: DraftAction) {
+  return parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
+    .map((path) => ({
+      id: path,
+      label: recipientFieldSummaryLabel(path),
+    }))
+    .filter((item) => item.label)
+}
+
 function recipientFieldPathWarnings(value: unknown) {
   const candidateIds = new Set(recipientCandidateFields.value.map((field) => field.id))
   return parseRecipientFieldPathsText(value)
@@ -1103,6 +1128,13 @@ function appendRecipientFieldPath(action: DraftAction, select: HTMLSelectElement
 
 function removeRecipientFieldPath(action: DraftAction, path: string) {
   action.config.recipientFieldPath = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+    .filter((entry) => entry !== path)
+    .map((entry) => `record.${entry}`)
+    .join(', ')
+}
+
+function removeMemberGroupRecipientFieldPath(action: DraftAction, path: string) {
+  action.config.memberGroupRecipientFieldPath = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
     .filter((entry) => entry !== path)
     .map((entry) => `record.${entry}`)
     .join(', ')

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -451,6 +451,17 @@
               <div class="meta-rule-editor__hint">
                 Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths. The picker only lists user fields.
               </div>
+              <label class="meta-rule-editor__label">Record member group field paths (optional)</label>
+              <input
+                v-model="action.config.memberGroupRecipientFieldPath"
+                class="meta-rule-editor__input"
+                type="text"
+                placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
+                data-field="dingtalkPersonMemberGroupRecipientFieldPath"
+              />
+              <div class="meta-rule-editor__hint">
+                Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
+              </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
                 v-model="action.config.titleTemplate"
@@ -529,6 +540,7 @@
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
                 <div><strong>Record recipients:</strong> {{ recipientFieldPathSummary(action.config.recipientFieldPath) }}</div>
+                <div><strong>Record member groups:</strong> {{ recipientFieldPathSummary(action.config.memberGroupRecipientFieldPath) }}</div>
                 <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
                 <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
                 <div class="meta-rule-editor__preview-line">
@@ -627,6 +639,7 @@ type DraftActionConfig = Record<string, unknown> & {
   memberGroupIdsText?: string
   userIdsSearch?: string
   recipientFieldPath?: string
+  memberGroupRecipientFieldPath?: string
   message?: string
   destinationId?: string
   destinationIds?: string[]
@@ -732,6 +745,11 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
         : typeof config.userIdFieldPath === 'string'
           ? config.userIdFieldPath
           : '',
+      memberGroupRecipientFieldPath: Array.isArray(config.memberGroupIdFieldPaths)
+        ? config.memberGroupIdFieldPaths.join(', ')
+        : typeof config.memberGroupIdFieldPath === 'string'
+          ? config.memberGroupIdFieldPath
+          : '',
       userIdsSearch: '',
     }
   }
@@ -794,9 +812,12 @@ const canSave = computed(() => {
       const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
       const memberGroupIdsText = typeof action.config.memberGroupIdsText === 'string' ? action.config.memberGroupIdsText.trim() : ''
       const recipientFieldPath = typeof action.config.recipientFieldPath === 'string' ? action.config.recipientFieldPath.trim() : ''
+      const memberGroupRecipientFieldPath = typeof action.config.memberGroupRecipientFieldPath === 'string'
+        ? action.config.memberGroupRecipientFieldPath.trim()
+        : ''
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!userIdsText && !memberGroupIdsText && !recipientFieldPath) || !titleTemplate || !bodyTemplate) return false
+      if ((!userIdsText && !memberGroupIdsText && !recipientFieldPath && !memberGroupRecipientFieldPath) || !titleTemplate || !bodyTemplate) return false
     }
   }
   return true
@@ -1173,6 +1194,7 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
         memberGroupIdsText: '',
         userIdsSearch: '',
         recipientFieldPath: '',
+        memberGroupRecipientFieldPath: '',
         titleTemplate: '',
         bodyTemplate: '',
         publicFormViewId: '',
@@ -1258,13 +1280,17 @@ function buildPayload(): Partial<AutomationRule> {
         : []
       const userIdFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
         .map((path) => `record.${path}`)
+      const memberGroupIdFieldPaths = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
+        .map((path) => `record.${path}`)
       return {
         type: action.type,
         config: {
           userIds,
           memberGroupIds: memberGroupIds.length ? memberGroupIds : undefined,
-          userIdFieldPath: userIdFieldPaths[0] || undefined,
-          userIdFieldPaths: userIdFieldPaths.length ? userIdFieldPaths : undefined,
+          ...(userIdFieldPaths[0] ? { userIdFieldPath: userIdFieldPaths[0] } : {}),
+          ...(userIdFieldPaths.length ? { userIdFieldPaths } : {}),
+          ...(memberGroupIdFieldPaths[0] ? { memberGroupIdFieldPath: memberGroupIdFieldPaths[0] } : {}),
+          ...(memberGroupIdFieldPaths.length ? { memberGroupIdFieldPaths } : {}),
           titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : '',
           bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : '',
           publicFormViewId: typeof action.config.publicFormViewId === 'string' && action.config.publicFormViewId.trim()

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -475,6 +475,13 @@
                   <em>Remove</em>
                 </button>
               </div>
+              <div
+                v-for="warning in memberGroupRecipientFieldPathWarnings(action.config.memberGroupRecipientFieldPath)"
+                :key="`person-member-group-recipient-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__hint">
                 Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
               </div>
@@ -1105,6 +1112,20 @@ function recipientFieldPathWarnings(value: unknown) {
   return parseRecipientFieldPathsText(value)
     .filter((path) => !candidateIds.has(path))
     .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+}
+
+function memberGroupRecipientFieldPathWarnings(value: unknown) {
+  const fieldMap = new Map(props.fields.map((field) => [field.id, field]))
+  return parseRecipientFieldPathsText(value).flatMap((path) => {
+    const field = fieldMap.get(path)
+    if (!field) {
+      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
+    }
+    if (field.type === 'user') {
+      return [`record.${path} is a user field; use Record recipient field paths instead.`]
+    }
+    return []
+  })
 }
 
 function recipientFieldPathSummary(value: unknown) {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -543,6 +543,50 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-automation-member-group-recipient-field="watcherGroupIds"]')).toBeNull()
   })
 
+  it('warns when a dynamic member group recipient path is unknown in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.unknownGroupField'
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.unknownGroupField is not a known field in this sheet')
+  })
+
+  it('warns when a dynamic member group recipient path points at a user field in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.assigneeUserIds'
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.assigneeUserIds is a user field; use Record recipient field paths instead.')
+  })
+
   it('can pick a record recipient field for DingTalk person automation', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -515,6 +515,34 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('can remove a selected dynamic member group recipient field chip in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.watcherGroupIds, record.escalationGroupId'
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const firstChip = container.querySelector('[data-automation-member-group-recipient-field="watcherGroupIds"]') as HTMLButtonElement
+    expect(firstChip?.textContent).toContain('record.watcherGroupIds')
+    firstChip.click()
+    await flushPromises()
+
+    expect(memberGroupFieldInput.value).toBe('record.escalationGroupId')
+    expect(container.querySelector('[data-automation-member-group-recipient-field="watcherGroupIds"]')).toBeNull()
+  })
+
   it('can pick a record recipient field for DingTalk person automation', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -463,6 +463,58 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('creates DingTalk person automation with only a dynamic member group record path', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk dynamic member-group notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.watcherGroupIds'
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(summary?.textContent).toContain('Record member groups:')
+    expect(summary?.textContent).toContain('record.watcherGroupIds')
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionConfig).toEqual({
+      userIds: [],
+      memberGroupIdFieldPath: 'record.watcherGroupIds',
+      memberGroupIdFieldPaths: ['record.watcherGroupIds'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please fill {{record.status}}',
+    })
+  })
+
   it('can pick a record recipient field for DingTalk person automation', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -497,6 +497,36 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('record.watcherGroupIds')
   })
 
+  it('can remove a selected dynamic member group recipient field chip in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.watcherGroupIds, record.escalationGroupId'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const firstChip = container.querySelector('[data-member-group-recipient-field="watcherGroupIds"]') as HTMLButtonElement
+    expect(firstChip?.textContent).toContain('record.watcherGroupIds')
+    firstChip.click()
+    await flushPromises()
+
+    expect(memberGroupFieldInput.value).toBe('record.escalationGroupId')
+    expect(container.querySelector('[data-member-group-recipient-field="watcherGroupIds"]')).toBeNull()
+  })
+
   it('can pick a record recipient field in the rule editor', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -527,6 +527,54 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.querySelector('[data-member-group-recipient-field="watcherGroupIds"]')).toBeNull()
   })
 
+  it('warns when a dynamic member group recipient path is unknown in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.unknownGroupField'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.unknownGroupField is not a known field in this sheet')
+  })
+
+  it('warns when a dynamic member group recipient path points at a user field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.assigneeUserIds'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.assigneeUserIds is a user field; use Record recipient field paths instead.')
+  })
+
   it('can pick a record recipient field in the rule editor', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -443,6 +443,60 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
+  it('emits DingTalk person action config with only a dynamic member group record path', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify dynamic member groups'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.watcherGroupIds'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionConfig).toEqual({
+      userIds: [],
+      memberGroupIdFieldPath: 'record.watcherGroupIds',
+      memberGroupIdFieldPaths: ['record.watcherGroupIds'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+    })
+    expect(container.textContent).toContain('Record member groups:')
+    expect(container.textContent).toContain('record.watcherGroupIds')
+  })
+
   it('can pick a record recipient field in the rule editor', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/docs/development/dingtalk-person-dynamic-member-groups-development-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-member-groups-development-20260420.md
@@ -1,0 +1,84 @@
+# DingTalk Person Dynamic Member Groups Development
+
+Date: 2026-04-20
+
+## Goal
+
+Extend `send_dingtalk_person_message` so sheet managers can resolve local member groups from record data at runtime, instead of only:
+
+- static `userIds`
+- static `memberGroupIds`
+- dynamic record user fields
+
+The model stays consistent with the existing DingTalk permission design:
+
+- recipients are still our local users and member groups
+- DingTalk remains a delivery channel and identity binding layer
+
+## Scope
+
+- Add dynamic member-group field paths to the automation action config
+- Resolve member-group IDs from record data at runtime
+- Merge and deduplicate:
+  - static `userIds`
+  - static `memberGroupIds`
+  - dynamic record user-field recipients
+  - dynamic record member-group-field recipients
+- Keep existing person-message rules backward-compatible
+- Add authoring support in both automation editors
+
+## Backend Changes
+
+Updated [automation-actions.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-dynamic-member-groups-20260420/packages/core-backend/src/multitable/automation-actions.ts:1):
+
+- `SendDingTalkPersonMessageConfig` now accepts:
+  - `memberGroupIdFieldPath?: string`
+  - `memberGroupIdFieldPaths?: string[]`
+
+Updated [automation-executor.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-dynamic-member-groups-20260420/packages/core-backend/src/multitable/automation-executor.ts:1):
+
+- Added member-group ID extraction from record values
+- Accepts string, array, and object-shaped record values for member-group IDs
+- Merges static and dynamic member-group IDs before validating them
+- Reuses the existing `platform_member_groups` and `platform_member_group_members` lookup path
+- Returns explicit failures for:
+  - missing member groups
+  - dynamic member-group field paths that resolve to no recipients
+- Extends action output with:
+  - `dynamicMemberGroupRecipientCount`
+  - `memberGroupRecipientFieldPath`
+  - `memberGroupRecipientFieldPaths`
+
+Updated [automation-v1.test.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-dynamic-member-groups-20260420/packages/core-backend/tests/unit/automation-v1.test.ts:1):
+
+- Added success coverage for dynamic member-group record paths
+- Added failure coverage for empty dynamic member-group record paths
+
+## Frontend Changes
+
+Updated [MetaAutomationRuleEditor.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-dynamic-member-groups-20260420/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue:1) and [MetaAutomationManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-dynamic-member-groups-20260420/apps/web/src/multitable/components/MetaAutomationManager.vue:1):
+
+- Added `Record member group field paths (optional)`
+- Save validation now accepts rules that use only dynamic member-group field paths
+- Summary cards now show:
+  - `Record member groups: ...`
+- Edit hydration now restores:
+  - `memberGroupIdFieldPath`
+  - `memberGroupIdFieldPaths`
+
+Deliberate limit:
+
+- No new picker was added for member-group record fields
+- The existing picker still only lists `user` fields
+- Dynamic member-group fields stay freeform `record.<fieldId>` paths for this slice
+
+Updated tests:
+
+- [multitable-automation-rule-editor.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-dynamic-member-groups-20260420/apps/web/tests/multitable-automation-rule-editor.spec.ts:1)
+- [multitable-automation-manager.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-dynamic-member-groups-20260420/apps/web/tests/multitable-automation-manager.spec.ts:1)
+
+## Migration / Deploy Impact
+
+- No database migration
+- No API break for existing person-message rules
+- Existing static-user, static-member-group, and dynamic-user-field rules continue to work unchanged

--- a/docs/development/dingtalk-person-dynamic-member-groups-verification-20260420.md
+++ b/docs/development/dingtalk-person-dynamic-member-groups-verification-20260420.md
@@ -1,0 +1,42 @@
+# DingTalk Person Dynamic Member Groups Verification
+
+Date: 2026-04-20
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend tests: `104 passed`
+- Frontend tests: `52 passed`
+- Backend build: passed
+- Web build: passed
+- `git diff --check`: passed
+
+## Focus Checks
+
+- `send_dingtalk_person_message` can resolve member-group IDs from record data
+- Static and dynamic member-group IDs merge before validation and expansion
+- Expanded member-group users merge with:
+  - static `userIds`
+  - static `memberGroupIds`
+  - dynamic record user fields
+- Empty dynamic member-group paths fail with a specific `member group record field paths` error
+- Both automation editors can:
+  - save rules that only use dynamic member-group field paths
+  - hydrate existing `memberGroupIdFieldPath(s)` config
+  - show `Record member groups` in summary
+
+## Notes
+
+- `pnpm install` updated several `plugins/**/node_modules` and `tools/cli/node_modules` paths in this worktree.
+- Those dependency noise changes are not part of the feature and should not be committed.
+- Frontend Vitest printed the existing `WebSocket server error: Port is already in use` warning, but the test run still completed successfully.

--- a/docs/development/dingtalk-person-member-group-field-chips-development-20260421.md
+++ b/docs/development/dingtalk-person-member-group-field-chips-development-20260421.md
@@ -1,0 +1,41 @@
+# DingTalk Person Member Group Field Chips Development
+
+Date: 2026-04-21
+
+## Goal
+
+Improve authoring for `send_dingtalk_person_message` after dynamic member-group field paths were added in `#957`.
+
+This slice does not change runtime behavior. It only makes dynamic member-group paths easier to inspect and remove in both automation editors.
+
+## Scope
+
+- Add selected chips for `memberGroupRecipientFieldPath`
+- Allow removing dynamic member-group field paths by clicking a chip
+- Keep the existing freeform text input as the source of truth
+- Do not change backend config shape or runtime execution
+
+## Frontend Changes
+
+Updated [MetaAutomationRuleEditor.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-chips-20260421/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue:1):
+
+- Added selected chips for parsed `Record member group field paths`
+- Added `removeMemberGroupRecipientFieldPath(...)`
+- Reused the existing summary-label helper so chips show field name when available, otherwise `record.<fieldId>`
+
+Updated [MetaAutomationManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-chips-20260421/apps/web/src/multitable/components/MetaAutomationManager.vue:1):
+
+- Added selected chips for inline create/edit form
+- Added `removeDingTalkPersonMemberGroupRecipientField(...)`
+- Kept the summary card aligned with the rule editor behavior
+
+Updated tests:
+
+- [multitable-automation-rule-editor.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-chips-20260421/apps/web/tests/multitable-automation-rule-editor.spec.ts:1)
+- [multitable-automation-manager.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-chips-20260421/apps/web/tests/multitable-automation-manager.spec.ts:1)
+
+## Behavior Notes
+
+- Dynamic member-group field paths remain freeform `record.<fieldId>` strings
+- No new picker was introduced
+- No backend/runtime config or API change was made in this PR

--- a/docs/development/dingtalk-person-member-group-field-chips-verification-20260421.md
+++ b/docs/development/dingtalk-person-member-group-field-chips-verification-20260421.md
@@ -1,0 +1,31 @@
+# DingTalk Person Member Group Field Chips Verification
+
+Date: 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `54 passed`
+- Web build: passed
+- `git diff --check`: passed
+
+## Focus Checks
+
+- Rule editor shows chips for dynamic member-group field paths
+- Inline automation manager shows chips for dynamic member-group field paths
+- Clicking a chip removes that member-group field path from the underlying text input
+- Existing dynamic user-field chips continue to work unchanged
+- No runtime payload shape changed
+
+## Notes
+
+- `pnpm install` updated several `plugins/**/node_modules` and `tools/cli/node_modules` paths in this worktree.
+- Those dependency noise changes are not part of the feature and should not be committed.

--- a/docs/development/dingtalk-person-member-group-field-warnings-development-20260421.md
+++ b/docs/development/dingtalk-person-member-group-field-warnings-development-20260421.md
@@ -1,0 +1,42 @@
+# DingTalk Person Member Group Field Warnings Development
+
+Date: 2026-04-21
+
+## Goal
+
+Add authoring warnings for dynamic member-group field paths in `send_dingtalk_person_message`.
+
+This slice does not change runtime behavior. It only helps admins catch obvious misconfiguration earlier in both automation editors.
+
+## Scope
+
+- Warn when `record.<fieldId>` does not resolve to a field in the current sheet
+- Warn when a dynamic member-group recipient path points at a `user` field
+- Keep freeform text input and runtime config shape unchanged
+- Do not change backend execution or API contracts
+
+## Frontend Changes
+
+Updated [MetaAutomationRuleEditor.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-warnings-20260421/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue:1):
+
+- Added `memberGroupRecipientFieldPathWarnings(...)`
+- Rendered warning hints under `Record member group field paths`
+- Reused existing path parsing so comma-separated `record.<fieldId>` input continues to work
+
+Updated [MetaAutomationManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-warnings-20260421/apps/web/src/multitable/components/MetaAutomationManager.vue:1):
+
+- Added inline warning rendering for draft member-group recipient field paths
+- Warns on unknown field IDs in the current sheet
+- Warns when a path points at a `user` field and should instead use `Record recipient field paths`
+
+Updated tests:
+
+- [multitable-automation-rule-editor.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-warnings-20260421/apps/web/tests/multitable-automation-rule-editor.spec.ts:1)
+- [multitable-automation-manager.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-warnings-20260421/apps/web/tests/multitable-automation-manager.spec.ts:1)
+
+## Behavior Notes
+
+- Member-group recipient paths remain freeform `record.<fieldId>` strings
+- Unknown paths are still editable; the UI only warns
+- Paths targeting `user` fields are still preserved for backward compatibility; the UI now points admins to the user-recipient field input instead
+- No backend/runtime payload or execution change was made in this PR

--- a/docs/development/dingtalk-person-member-group-field-warnings-verification-20260421.md
+++ b/docs/development/dingtalk-person-member-group-field-warnings-verification-20260421.md
@@ -1,0 +1,31 @@
+# DingTalk Person Member Group Field Warnings Verification
+
+Date: 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `58 passed`
+- Web build: passed
+- `git diff --check`: passed
+
+## Focus Checks
+
+- Rule editor warns when a member-group recipient path points at an unknown field
+- Rule editor warns when a member-group recipient path points at a `user` field
+- Inline automation manager shows the same two warnings
+- Existing freeform `record.<fieldId>` editing continues to work
+- No runtime payload shape changed
+
+## Notes
+
+- `pnpm install` updated several `plugins/**/node_modules` and `tools/cli/node_modules` paths in this worktree.
+- Those dependency noise changes are not part of the feature and should not be committed.

--- a/docs/development/dingtalk-person-member-group-package-development-20260421.md
+++ b/docs/development/dingtalk-person-member-group-package-development-20260421.md
@@ -1,0 +1,32 @@
+# DingTalk Person Member Group Package Development
+
+Date: 2026-04-21
+Branch: `codex/dingtalk-person-member-group-package-20260421`
+
+## Goal
+
+Package the stacked DingTalk personal member-group recipient enhancements into one clean `main`-based branch so the feature can be reviewed and deployed without depending on a three-PR stack.
+
+## Included Slices
+
+- dynamic record-derived member-group recipients
+- member-group recipient field chips
+- member-group field path warnings
+
+## Scope
+
+- no new runtime feature beyond the stacked slices
+- no migration changes
+- package and roll forward the existing work onto `main`
+
+## Implementation Notes
+
+- Cherry-picked stacked heads onto a fresh branch from `main`:
+  - `372f4aa8d`
+  - `487019a74`
+  - `181443436`
+- Added package-level development and verification docs for the consolidated branch.
+
+## Outcome
+
+The full DingTalk personal member-group recipient line now exists as a single `main`-based branch suitable for one PR, instead of requiring review and merge in stack order.

--- a/docs/development/dingtalk-person-member-group-package-verification-20260421.md
+++ b/docs/development/dingtalk-person-member-group-package-verification-20260421.md
@@ -1,0 +1,37 @@
+# DingTalk Person Member Group Package Verification
+
+Date: 2026-04-21
+Branch: `codex/dingtalk-person-member-group-package-20260421`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Backend unit tests: `104 passed`
+- Frontend tests: `58 passed`
+- Backend build: passed
+- Frontend build: passed
+- `git diff --check`: passed
+
+## Coverage Focus
+
+- static + dynamic DingTalk personal member-group recipients
+- dynamic member-group resolution from record data
+- member-group field chips in both automation editors
+- unknown-path warnings for member-group recipient fields
+- warnings when member-group recipient paths point at `user` fields
+
+## Notes
+
+- Frontend Vitest still emits the repository's existing `WebSocket server error: Port is already in use` warning; it did not block the run.
+- Web build still emits the repository's existing Vite chunk-size warning; no new regression was introduced by packaging this branch on top of `main`.
+- `pnpm install` updated `plugins/**/node_modules` and `tools/cli/node_modules` in this worktree; those dependency noise changes are not part of the feature and should not be committed.

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -63,6 +63,8 @@ export interface SendDingTalkPersonMessageConfig {
   memberGroupIds?: string[]
   userIdFieldPath?: string
   userIdFieldPaths?: string[]
+  memberGroupIdFieldPath?: string
+  memberGroupIdFieldPaths?: string[]
   titleTemplate: string
   bodyTemplate: string
   publicFormViewId?: string

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -74,7 +74,7 @@ function normalizeUserIds(value: unknown): string[] {
   ))
 }
 
-function normalizeUserIdScalar(value: unknown): string[] {
+function normalizeIdScalar(value: unknown, objectKeys: string[]): string[] {
   if (typeof value === 'string') {
     return value
       .split(/[\n,]+/)
@@ -86,13 +86,21 @@ function normalizeUserIdScalar(value: unknown): string[] {
   }
   if (typeof value === 'object' && value && !Array.isArray(value)) {
     const record = value as Record<string, unknown>
-    for (const key of ['localUserId', 'userId', 'id', 'value']) {
+    for (const key of objectKeys) {
       const candidate = record[key]
       if (typeof candidate === 'string' && candidate.trim()) return [candidate.trim()]
       if (typeof candidate === 'number' && Number.isFinite(candidate)) return [String(candidate)]
     }
   }
   return []
+}
+
+function normalizeUserIdScalar(value: unknown): string[] {
+  return normalizeIdScalar(value, ['localUserId', 'userId', 'id', 'value'])
+}
+
+function normalizeMemberGroupIdScalar(value: unknown): string[] {
+  return normalizeIdScalar(value, ['memberGroupId', 'groupId', 'subjectId', 'id', 'value'])
 }
 
 function normalizeUserIdsFromUnknown(value: unknown): string[] {
@@ -102,6 +110,15 @@ function normalizeUserIdsFromUnknown(value: unknown): string[] {
     ))
   }
   return normalizeUserIdScalar(value)
+}
+
+function normalizeMemberGroupIdsFromUnknown(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(new Set(
+      value.flatMap((entry) => normalizeMemberGroupIdsFromUnknown(entry)),
+    ))
+  }
+  return normalizeMemberGroupIdScalar(value)
 }
 
 function normalizeRecipientFieldPath(value: unknown): string {
@@ -135,6 +152,16 @@ function resolveRecipientUserIdsFromRecord(recordData: Record<string, unknown>, 
       const normalizedPath = normalizeRecipientFieldPath(fieldPath)
       if (!normalizedPath) return []
       return normalizeUserIdsFromUnknown(lookupTemplateValue(normalizedPath, recordData))
+    }),
+  ))
+}
+
+function resolveRecipientMemberGroupIdsFromRecord(recordData: Record<string, unknown>, fieldPaths: unknown[]): string[] {
+  return Array.from(new Set(
+    fieldPaths.flatMap((fieldPath) => {
+      const normalizedPath = normalizeRecipientFieldPath(fieldPath)
+      if (!normalizedPath) return []
+      return normalizeMemberGroupIdsFromUnknown(lookupTemplateValue(normalizedPath, recordData))
     }),
   ))
 }
@@ -665,9 +692,12 @@ export class AutomationExecutor {
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
     const staticUserIds = normalizeUserIds(config.userIds)
-    const memberGroupIds = normalizeUserIds(config.memberGroupIds)
+    const staticMemberGroupIds = normalizeUserIds(config.memberGroupIds)
     const recipientFieldPaths = normalizeRecipientFieldPaths(config.userIdFieldPath, config.userIdFieldPaths)
+    const memberGroupRecipientFieldPaths = normalizeRecipientFieldPaths(config.memberGroupIdFieldPath, config.memberGroupIdFieldPaths)
     const recordUserIds = resolveRecipientUserIdsFromRecord(context.recordData, recipientFieldPaths)
+    const recordMemberGroupIds = resolveRecipientMemberGroupIdsFromRecord(context.recordData, memberGroupRecipientFieldPaths)
+    const memberGroupIds = Array.from(new Set([...staticMemberGroupIds, ...recordMemberGroupIds]))
     const titleTemplate = typeof config.titleTemplate === 'string' ? config.titleTemplate.trim() : ''
     const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
     const publicFormViewId = typeof config.publicFormViewId === 'string' ? config.publicFormViewId.trim() : ''
@@ -794,6 +824,13 @@ export class AutomationExecutor {
     const userIds = Array.from(new Set([...staticUserIds, ...memberGroupUserIds, ...recordUserIds]))
     if (userIds.length === 0) {
       if (memberGroupIds.length > 0) {
+        if (memberGroupRecipientFieldPaths.length > 0) {
+          return {
+            actionType: 'send_dingtalk_person_message',
+            status: 'failed',
+            error: `No local userIds resolved from member group record field paths: ${memberGroupRecipientFieldPaths.join(', ')}`,
+          }
+        }
         return {
           actionType: 'send_dingtalk_person_message',
           status: 'failed',
@@ -807,10 +844,17 @@ export class AutomationExecutor {
           error: `No local userIds resolved from record field paths: ${recipientFieldPaths.join(', ')}`,
         }
       }
+      if (memberGroupRecipientFieldPaths.length > 0) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: `No local userIds resolved from member group record field paths: ${memberGroupRecipientFieldPaths.join(', ')}`,
+        }
+      }
       return {
         actionType: 'send_dingtalk_person_message',
         status: 'failed',
-        error: 'At least one local userId, memberGroupId, or record recipient field path is required',
+        error: 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required',
       }
     }
 
@@ -910,9 +954,12 @@ export class AutomationExecutor {
           staticRecipientCount: staticUserIds.length,
           memberGroupRecipientCount: memberGroupUserIds.length,
           dynamicRecipientCount: recordUserIds.length,
+          dynamicMemberGroupRecipientCount: recordMemberGroupIds.length,
           memberGroupIds,
           recipientFieldPath: recipientFieldPaths[0] ?? null,
           recipientFieldPaths,
+          memberGroupRecipientFieldPath: memberGroupRecipientFieldPaths[0] ?? null,
+          memberGroupRecipientFieldPaths,
           batchCount: batches.length,
           linkCount: linkLines.length,
           responseCount,

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -738,6 +738,80 @@ describe('AutomationExecutor', () => {
     })
   })
 
+  it('executes send_dingtalk_person_message with dynamic member group recipients from the record', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'group_1' }, { id: 'group_2' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1' },
+          { local_user_id: 'user_2' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' },
+          { local_user_id: 'user_2', local_user_active: true, dingtalk_user_id: 'dt-user-2' },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          memberGroupIdFieldPaths: ['record.escalationGroupId', 'record.watcherGroupIds'],
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {
+        title: 'Incident',
+        status: 'open',
+        escalationGroupId: 'group_1',
+        watcherGroupIds: [{ id: 'group_2' }, { subjectId: 'group_1' }],
+      },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    const [, sendInit] = fetchFn.mock.calls[1] as [string, RequestInit]
+    const payload = JSON.parse(sendInit.body as string)
+    expect(payload.userid_list).toBe('dt-user-1,dt-user-2')
+    expect(result.steps[0].output).toMatchObject({
+      notifiedUsers: 2,
+      staticRecipientCount: 0,
+      memberGroupRecipientCount: 2,
+      dynamicRecipientCount: 0,
+      dynamicMemberGroupRecipientCount: 2,
+      memberGroupIds: ['group_1', 'group_2'],
+      memberGroupRecipientFieldPath: 'escalationGroupId',
+      memberGroupRecipientFieldPaths: ['escalationGroupId', 'watcherGroupIds'],
+    })
+  })
+
   it('fails send_dingtalk_person_message when a user has no linked DingTalk account', async () => {
     const queryFn = vi.fn()
       .mockResolvedValueOnce({
@@ -848,6 +922,31 @@ describe('AutomationExecutor', () => {
 
     expect(result.status).toBe('failed')
     expect(result.steps[0].error).toContain('record field paths: assigneeUserIds')
+  })
+
+  it('fails send_dingtalk_person_message when dynamic member group record path resolves no recipients', async () => {
+    deps = createMockDeps()
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          memberGroupIdFieldPath: 'record.watcherGroupIds',
+          titleTemplate: 'Title',
+          bodyTemplate: 'Body',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { watcherGroupIds: [] },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('member group record field paths: watcherGroupIds')
   })
 
   it('merges multiple dynamic DingTalk person recipient fields from the record', async () => {


### PR DESCRIPTION
## Summary
- package dynamic DingTalk person member-group recipient support onto a clean main-based branch
- include member-group field chips in both automation editors
- include warnings for unknown member-group paths and user-field misuse

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- git diff --check