### PR TITLE
feat(dingtalk): add member group field picker

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -335,6 +335,17 @@
               placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
               data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"
             />
+            <label class="meta-automation__label">Pick member group field</label>
+            <select
+              class="meta-automation__select"
+              data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"
+              @change="appendDingTalkPersonMemberGroupRecipientField($event.target as HTMLSelectElement)"
+            >
+              <option value="">-- choose a member group field --</option>
+              <option v-for="field in dingTalkPersonMemberGroupRecipientCandidateFields" :key="field.id" :value="field.id">
+                {{ field.name }} (record.{{ field.id }})
+              </option>
+            </select>
             <div
               v-if="selectedDingTalkPersonMemberGroupRecipientFields.length"
               class="meta-automation__recipient-list meta-automation__recipient-list--selected"
@@ -359,7 +370,7 @@
               {{ warning }}
             </div>
             <div class="meta-automation__hint">
-              Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
+              Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs. The picker only lists explicit member group fields.
             </div>
             <label class="meta-automation__label">Title template</label>
             <input
@@ -896,7 +907,17 @@ function recipientFieldSummaryLabel(path: string) {
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
+function isMemberGroupRecipientCandidateField(field: { type?: unknown, property?: Record<string, unknown> | undefined }) {
+  const type = typeof field.type === 'string' ? field.type.trim().toLowerCase() : ''
+  const refKind = typeof field.property?.refKind === 'string' ? field.property.refKind.trim().toLowerCase() : ''
+  return refKind === 'member-group'
+    || type === 'member-group'
+    || type === 'member_group'
+    || type === 'membergroup'
+}
+
 const dingTalkPersonRecipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
+const dingTalkPersonMemberGroupRecipientCandidateFields = computed(() => props.fields.filter(isMemberGroupRecipientCandidateField))
 
 const selectedDingTalkPersonRecipientFields = computed(() => parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
   .map((path) => ({
@@ -963,6 +984,17 @@ function removeDingTalkPersonRecipientField(path: string) {
     .filter((entry) => entry !== path)
     .map((entry) => `record.${entry}`)
     .join(', ')
+}
+
+function appendDingTalkPersonMemberGroupRecipientField(select: HTMLSelectElement) {
+  const value = select.value.trim()
+  if (!value) return
+  const paths = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
+  paths.push(value)
+  draft.value.dingtalkPersonMemberGroupRecipientFieldPath = Array.from(new Set(paths))
+    .map((path) => `record.${path}`)
+    .join(', ')
+  select.value = ''
 }
 
 function removeDingTalkPersonMemberGroupRecipientField(path: string) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -459,6 +459,17 @@
                 placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
                 data-field="dingtalkPersonMemberGroupRecipientFieldPath"
               />
+              <label class="meta-rule-editor__label">Pick member group field</label>
+              <select
+                class="meta-rule-editor__select"
+                data-field="dingtalkPersonMemberGroupRecipientFieldSelect"
+                @change="appendMemberGroupRecipientFieldPath(action, $event.target as HTMLSelectElement)"
+              >
+                <option value="">-- choose a member group field --</option>
+                <option v-for="field in memberGroupRecipientCandidateFields" :key="field.id" :value="field.id">
+                  {{ field.name }} (record.{{ field.id }})
+                </option>
+              </select>
               <div
                 v-if="selectedMemberGroupRecipientFields(action).length"
                 class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
@@ -483,7 +494,7 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__hint">
-                Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs.
+                Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs. The picker only lists explicit member group fields.
               </div>
               <label class="meta-rule-editor__label">Title template</label>
               <input
@@ -718,6 +729,7 @@ let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
 const internalViews = computed(() => props.views ?? [])
 const recipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
+const memberGroupRecipientCandidateFields = computed(() => props.fields.filter(isMemberGroupRecipientCandidateField))
 
 const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
   { value: 'equals', label: 'Equals' },
@@ -1089,6 +1101,15 @@ function recipientFieldSummaryLabel(path: string) {
   return field ? `${field.name} (record.${normalized})` : `record.${normalized}`
 }
 
+function isMemberGroupRecipientCandidateField(field: { type?: unknown, property?: Record<string, unknown> | undefined }) {
+  const type = typeof field.type === 'string' ? field.type.trim().toLowerCase() : ''
+  const refKind = typeof field.property?.refKind === 'string' ? field.property.refKind.trim().toLowerCase() : ''
+  return refKind === 'member-group'
+    || type === 'member-group'
+    || type === 'member_group'
+    || type === 'membergroup'
+}
+
 function selectedRecipientFields(action: DraftAction) {
   return parseRecipientFieldPathsText(action.config.recipientFieldPath)
     .map((path) => ({
@@ -1152,6 +1173,17 @@ function removeRecipientFieldPath(action: DraftAction, path: string) {
     .filter((entry) => entry !== path)
     .map((entry) => `record.${entry}`)
     .join(', ')
+}
+
+function appendMemberGroupRecipientFieldPath(action: DraftAction, select: HTMLSelectElement) {
+  const fieldId = select.value.trim()
+  if (!fieldId) return
+  const paths = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
+  paths.push(fieldId)
+  action.config.memberGroupRecipientFieldPath = Array.from(new Set(paths))
+    .map((path) => `record.${path}`)
+    .join(', ')
+  select.value = ''
 }
 
 function removeMemberGroupRecipientFieldPath(action: DraftAction, path: string) {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -127,6 +127,8 @@ const fields = [
   { id: 'fld_2', name: 'Name', type: 'string' },
   { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
   { id: 'reviewerUserId', name: 'Reviewer', type: 'user' },
+  { id: 'watcherGroupIds', name: 'Watcher groups', type: 'link', property: { refKind: 'member-group' } },
+  { id: 'escalationGroupId', name: 'Escalation group', type: 'member-group' },
 ]
 
 const views = [
@@ -585,6 +587,53 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('record.assigneeUserIds is a user field; use Record recipient field paths instead.')
+  })
+
+  it('can pick a member group recipient field for DingTalk person automation', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'watcherGroupIds'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(memberGroupFieldInput.value).toBe('record.watcherGroupIds')
+    expect(summary?.textContent).toContain('Watcher groups (record.watcherGroupIds)')
+  })
+
+  it('only lists explicit member group fields in the member group recipient picker', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLSelectElement
+    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('watcherGroupIds')
+    expect(optionValues).toContain('escalationGroupId')
+    expect(optionValues).not.toContain('assigneeUserIds')
+    expect(optionValues).not.toContain('fld_1')
   })
 
   it('can pick a record recipient field for DingTalk person automation', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -13,6 +13,8 @@ const fields = [
   { id: 'fld_2', name: 'Name', type: 'string' },
   { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
   { id: 'reviewerUserId', name: 'Reviewer', type: 'user' },
+  { id: 'watcherGroupIds', name: 'Watcher groups', type: 'link', property: { refKind: 'member-group' } },
+  { id: 'escalationGroupId', name: 'Escalation group', type: 'member-group' },
 ]
 
 const views = [
@@ -573,6 +575,56 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('record.assigneeUserIds is a user field; use Record recipient field paths instead.')
+  })
+
+  it('can pick a member group recipient field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLSelectElement
+    fieldSelect.value = 'watcherGroupIds'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    expect(memberGroupFieldInput.value).toBe('record.watcherGroupIds')
+    expect(container.textContent).toContain('Watcher groups (record.watcherGroupIds)')
+  })
+
+  it('only lists explicit member group fields in the member group recipient picker for the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLSelectElement
+    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('watcherGroupIds')
+    expect(optionValues).toContain('escalationGroupId')
+    expect(optionValues).not.toContain('assigneeUserIds')
+    expect(optionValues).not.toContain('fld_1')
   })
 
   it('can pick a record recipient field in the rule editor', async () => {

--- a/docs/development/dingtalk-person-member-group-field-picker-development-20260421.md
+++ b/docs/development/dingtalk-person-member-group-field-picker-development-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Person Member Group Field Picker Development
+
+Date: 2026-04-21
+
+## Goal
+
+Improve authoring for `send_dingtalk_person_message` after dynamic member-group recipient fields were packaged in `#964`.
+
+This slice does not change runtime behavior. It only makes member-group field path selection easier and less error-prone in both automation editors.
+
+## Scope
+
+- Add a picker for dynamic member-group recipient fields
+- Only list explicit member-group fields in the picker
+- Keep the existing freeform text input as the source of truth
+- Do not change backend config shape or runtime execution
+
+## Frontend Changes
+
+Updated [MetaAutomationRuleEditor.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-picker-20260421/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue:1):
+
+- Added `Pick member group field`
+- Added `memberGroupRecipientCandidateFields`
+- Added `appendMemberGroupRecipientFieldPath(...)`
+- Kept chips and warnings working on top of the same comma-separated `record.<fieldId>` string
+
+Updated [MetaAutomationManager.vue](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-picker-20260421/apps/web/src/multitable/components/MetaAutomationManager.vue:1):
+
+- Added inline member-group field picker for create/edit form
+- Added `dingTalkPersonMemberGroupRecipientCandidateFields`
+- Added `appendDingTalkPersonMemberGroupRecipientField(...)`
+- Restricted picker candidates to explicit member-group fields
+
+Updated tests:
+
+- [multitable-automation-rule-editor.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-picker-20260421/apps/web/tests/multitable-automation-rule-editor.spec.ts:1)
+- [multitable-automation-manager.spec.ts](/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-field-picker-20260421/apps/web/tests/multitable-automation-manager.spec.ts:1)
+
+## Behavior Notes
+
+- Dynamic member-group recipient paths remain freeform `record.<fieldId>` strings
+- Picker candidates are limited to explicit member-group fields:
+  - `link` fields with `property.refKind === 'member-group'`
+  - custom field types named `member-group`, `member_group`, or `membergroup`
+- No backend/runtime config or API change was made in this PR

--- a/docs/development/dingtalk-person-member-group-field-picker-verification-20260421.md
+++ b/docs/development/dingtalk-person-member-group-field-picker-verification-20260421.md
@@ -1,0 +1,32 @@
+# DingTalk Person Member Group Field Picker Verification
+
+Date: 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Frontend tests: `62 passed`
+- Web build: passed
+- `git diff --check`: passed
+
+## Focus Checks
+
+- Rule editor can pick a member-group recipient field and writes `record.<fieldId>`
+- Inline automation manager can pick a member-group recipient field and writes `record.<fieldId>`
+- Member-group picker only lists explicit member-group fields
+- Existing chips and warnings continue to work with picker-added paths
+- No runtime payload shape changed
+
+## Notes
+
+- Web build still emits the repository's existing Vite chunk-size warning; this PR does not change chunking strategy.
+- `pnpm install` updated several `plugins/**/node_modules` and `tools/cli/node_modules` paths in this worktree.
+- Those dependency noise changes are not part of the feature and should not be committed.


### PR DESCRIPTION
## Summary
- add a member-group field picker for DingTalk person message dynamic member-group recipients
- only list explicit member-group fields in both automation editors
- keep the existing freeform record path input as the source of truth

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --check