### PR TITLE
feat(dingtalk): warn on unscoped protected forms

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -98,7 +98,7 @@ async function parseJson<T>(res: Response): Promise<T> {
   const raw = await res.text()
   const body = raw ? safeParseJson(raw) : null
   if (!res.ok) {
-    const payload = (body?.error ?? {}) as ApiErrorPayload
+    const payload = normalizeApiErrorPayload(body)
     const error = new Error(firstFieldError(payload.fieldErrors) ?? payload.message ?? `API ${res.status}`) as Error & {
       status?: number
       code?: string
@@ -115,15 +115,30 @@ async function parseJson<T>(res: Response): Promise<T> {
     throw error
   }
   if (res.status === 204 || !raw.trim()) return undefined as T
-  return (body?.data ?? body) as T
+  return (unwrapDataBody(body) ?? body) as T
 }
 
-function safeParseJson(raw: string): any {
+function safeParseJson(raw: string): unknown {
   try {
     return JSON.parse(raw)
   } catch {
     return null
   }
+}
+
+function normalizeApiErrorPayload(body: unknown): ApiErrorPayload {
+  if (!body || typeof body !== 'object') return {}
+  const record = body as Record<string, unknown>
+  const error = record.error
+  if (typeof error === 'string') return { message: error }
+  if (error && typeof error === 'object') return error as ApiErrorPayload
+  if (typeof record.message === 'string') return { message: record.message }
+  return {}
+}
+
+function unwrapDataBody(body: unknown): unknown {
+  if (!body || typeof body !== 'object') return undefined
+  return (body as { data?: unknown }).data
 }
 
 function firstFieldError(fieldErrors?: Record<string, string>): string | null {

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -224,6 +224,13 @@
               <option value="">-- no internal link --</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
+            <div
+              v-for="warning in internalViewLinkWarnings(draft.internalViewId)"
+              :key="`draft-group-internal-view-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preview" data-automation-summary="group">
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Groups:</strong> {{ dingTalkGroupSummary }}</div>
@@ -253,6 +260,7 @@
                 </button>
               </div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
+              <div><strong>Public form access:</strong> {{ publicFormAccessSummary(draft.publicFormViewId) }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
             </div>
           </template>
@@ -496,6 +504,13 @@
               <option value="">-- no internal link --</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
+            <div
+              v-for="warning in internalViewLinkWarnings(draft.dingtalkPersonInternalViewId)"
+              :key="`draft-person-internal-view-${warning}`"
+              class="meta-automation__hint meta-automation__hint--warning"
+            >
+              {{ warning }}
+            </div>
             <div class="meta-automation__preview" data-automation-summary="person">
               <div class="meta-automation__preview-title">Message summary</div>
               <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
@@ -526,6 +541,7 @@
                 </button>
               </div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
+              <div><strong>Public form access:</strong> {{ publicFormAccessSummary(draft.dingtalkPersonPublicFormViewId) }}</div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
             </div>
           </template>
@@ -573,11 +589,20 @@
             <span class="meta-automation__stat meta-automation__stat--success">{{ ruleStats[rule.id].success }} ok</span>
             <span class="meta-automation__stat meta-automation__stat--failed">{{ ruleStats[rule.id].failed }} fail</span>
           </div>
+          <div
+            v-if="ruleTestRunStates[rule.id]"
+            class="meta-automation__test-run-status"
+            :class="`meta-automation__test-run-status--${ruleTestRunStates[rule.id].status}`"
+            :data-automation-test-status="rule.id"
+            :data-status="ruleTestRunStates[rule.id].status"
+          >
+            {{ ruleTestRunStates[rule.id].message }}
+          </div>
           <div class="meta-automation__card-actions">
             <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openRuleEditor(rule)">Edit</button>
             <button class="meta-automation__btn" type="button" data-automation-logs="true" @click="openLogViewer(rule)">View Logs</button>
             <button
-              v-if="rule.actionType === 'send_dingtalk_group_message'"
+              v-if="ruleHasActionType(rule, 'send_dingtalk_group_message')"
               class="meta-automation__btn"
               type="button"
               :data-automation-group-deliveries="rule.id"
@@ -586,7 +611,7 @@
               View Deliveries
             </button>
             <button
-              v-if="rule.actionType === 'send_dingtalk_person_message'"
+              v-if="ruleHasActionType(rule, 'send_dingtalk_person_message')"
               class="meta-automation__btn"
               type="button"
               :data-automation-person-deliveries="rule.id"
@@ -606,6 +631,7 @@
       :fields="fields"
       :client="client"
       :views="views"
+      :test-run-state="activeRuleTestRunState"
       @close="showRuleEditor = false"
       @save="onRuleEditorSave"
       @test="onTestRule"
@@ -637,6 +663,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import type {
+  AutomationExecution,
   AutomationRule,
   AutomationTriggerType,
   AutomationActionType,
@@ -663,7 +690,15 @@ import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
-import { listDingTalkPublicFormLinkWarnings } from '../utils/dingtalkPublicFormLinkWarnings'
+import {
+  describeDingTalkPublicFormLinkAccess,
+  listDingTalkPublicFormLinkBlockingErrors,
+  listDingTalkPublicFormLinkWarnings,
+} from '../utils/dingtalkPublicFormLinkWarnings'
+import {
+  listDingTalkInternalViewLinkBlockingErrors,
+  listDingTalkInternalViewLinkWarnings,
+} from '../utils/dingtalkInternalViewLinkWarnings'
 
 const props = defineProps<{
   visible: boolean
@@ -677,6 +712,11 @@ const emit = defineEmits<{
   (e: 'close'): void
   (e: 'updated'): void
 }>()
+
+type AutomationTestRunState = {
+  status: 'running' | 'success' | 'failed' | 'skipped'
+  message: string
+}
 
 const { rules, loading, error, loadRules, createRule, updateRule, deleteRule, toggleRule } =
   useMultitableAutomations(props.client)
@@ -746,8 +786,10 @@ const dingtalkPersonUserDirectory = ref<Record<string, { label: string; subtitle
 const copiedPreviewKey = ref('')
 let dingtalkPersonSuggestionLoadId = 0
 let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
-const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
-const internalViews = computed(() => props.views ?? [])
+const formViews = computed(() => (props.views ?? []).filter((view) =>
+  view.type === 'form' && (!view.sheetId || view.sheetId === props.sheetId),
+))
+const internalViews = computed(() => (props.views ?? []).filter((view) => !view.sheetId || view.sheetId === props.sheetId))
 
 function parseUserIdsText(value: string): string[] {
   return value
@@ -936,10 +978,26 @@ function renderedTemplateExample(value: string, fallback: string) {
 }
 
 function publicFormLinkWarnings(value: unknown, warnWhenGroupAccessRisk = false) {
-  return listDingTalkPublicFormLinkWarnings(value, props.views ?? [], {
+  return listDingTalkPublicFormLinkWarnings(value, formViews.value, {
     warnWhenFullyPublic: warnWhenGroupAccessRisk,
     warnWhenProtectedWithoutAllowlist: warnWhenGroupAccessRisk,
   })
+}
+
+function publicFormLinkBlockingErrors(value: unknown) {
+  return listDingTalkPublicFormLinkBlockingErrors(value, formViews.value)
+}
+
+function internalViewLinkWarnings(value: unknown) {
+  return listDingTalkInternalViewLinkWarnings(value, internalViews.value)
+}
+
+function internalViewLinkBlockingErrors(value: unknown) {
+  return listDingTalkInternalViewLinkBlockingErrors(value, internalViews.value)
+}
+
+function publicFormAccessSummary(value: unknown) {
+  return describeDingTalkPublicFormLinkAccess(value, formViews.value)
 }
 
 function copyPreviewText(key: string, text: string) {
@@ -1172,6 +1230,11 @@ const groupDeliveryViewerRuleId = ref('')
 const showPersonDeliveryViewer = ref(false)
 const personDeliveryViewerRuleId = ref('')
 const ruleStats = ref<Record<string, AutomationStats>>({})
+const ruleTestRunStates = ref<Record<string, AutomationTestRunState>>({})
+const activeRuleTestRunState = computed(() => {
+  const ruleId = editingRule.value?.id
+  return ruleId ? ruleTestRunStates.value[ruleId] : undefined
+})
 
 function openRuleEditor(rule?: AutomationRule) {
   editingRule.value = rule ?? null
@@ -1212,22 +1275,85 @@ async function onRuleEditorSave(payload: Partial<AutomationRule>) {
 
 async function onTestRule(ruleId: string) {
   if (!props.client) return
+  setRuleTestRunState(ruleId, {
+    status: 'running',
+    message: testRunPendingMessage(ruleId),
+  })
   try {
-    await props.client.testAutomationRule(props.sheetId, ruleId)
+    const execution = await props.client.testAutomationRule(props.sheetId, ruleId)
+    setRuleTestRunState(ruleId, describeTestRunExecution(execution))
+    await loadRuleStatsForRule(ruleId)
+  } catch (err: unknown) {
+    setRuleTestRunState(ruleId, {
+      status: 'failed',
+      message: `Test run request failed: ${readErrorMessage(err)}`,
+    })
+  }
+}
+
+function setRuleTestRunState(ruleId: string, state: AutomationTestRunState) {
+  ruleTestRunStates.value = { ...ruleTestRunStates.value, [ruleId]: state }
+}
+
+function readErrorMessage(err: unknown): string {
+  return err instanceof Error && err.message.trim() ? err.message : 'Unknown error'
+}
+
+function testRunPendingMessage(ruleId: string): string {
+  return hasDingTalkRuleActions(rules.value.find((rule) => rule.id === ruleId))
+    ? 'Running test. DingTalk actions may send real messages.'
+    : 'Running test.'
+}
+
+function hasDingTalkRuleActions(rule: AutomationRule | undefined): boolean {
+  if (!rule) return false
+  return isDingTalkActionType(rule.actionType) || Boolean(rule.actions?.some((action) => isDingTalkActionType(action.type)))
+}
+
+function isDingTalkActionType(actionType: AutomationActionType): boolean {
+  return actionType === 'send_dingtalk_group_message' || actionType === 'send_dingtalk_person_message'
+}
+
+function describeTestRunExecution(execution: AutomationExecution): AutomationTestRunState {
+  const failedStep = execution.steps?.find((step) => step.status === 'failed')
+  const durationMs = typeof execution.durationMs === 'number'
+    ? execution.durationMs
+    : typeof execution.duration === 'number'
+      ? execution.duration
+      : undefined
+  const duration = typeof durationMs === 'number' ? ` (${Math.round(durationMs)} ms)` : ''
+  if (execution.status === 'failed' || failedStep) {
+    return {
+      status: 'failed',
+      message: `Test run failed: ${execution.error || failedStep?.error || 'At least one action failed.'}`,
+    }
+  }
+  if (execution.status === 'skipped') {
+    return {
+      status: 'skipped',
+      message: `Test run skipped${duration}.`,
+    }
+  }
+  return {
+    status: 'success',
+    message: `Test run succeeded${duration}.`,
+  }
+}
+
+async function loadRuleStatsForRule(ruleId: string) {
+  if (!props.client) return
+  try {
+    const st = await props.client.getAutomationStats(props.sheetId, ruleId)
+    ruleStats.value = { ...ruleStats.value, [ruleId]: st }
   } catch {
-    // silently fail
+    // skip
   }
 }
 
 async function loadRuleStats() {
   if (!props.client) return
   for (const rule of rules.value) {
-    try {
-      const st = await props.client.getAutomationStats(props.sheetId, rule.id)
-      ruleStats.value[rule.id] = st
-    } catch {
-      // skip
-    }
+    await loadRuleStatsForRule(rule.id)
   }
 }
 
@@ -1240,6 +1366,8 @@ const canSave = computed(() => {
     if (!draft.value.dingtalkDestinationIds.length && !draft.value.dingtalkDestinationFieldPath.trim()) return false
     if (!draft.value.dingtalkTitleTemplate.trim()) return false
     if (!draft.value.dingtalkBodyTemplate.trim()) return false
+    if (publicFormLinkBlockingErrors(draft.value.publicFormViewId).length) return false
+    if (internalViewLinkBlockingErrors(draft.value.internalViewId).length) return false
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
     if (
@@ -1250,6 +1378,8 @@ const canSave = computed(() => {
     ) return false
     if (!draft.value.dingtalkPersonTitleTemplate.trim()) return false
     if (!draft.value.dingtalkPersonBodyTemplate.trim()) return false
+    if (publicFormLinkBlockingErrors(draft.value.dingtalkPersonPublicFormViewId).length) return false
+    if (internalViewLinkBlockingErrors(draft.value.dingtalkPersonInternalViewId).length) return false
   }
   return true
 })
@@ -1428,20 +1558,40 @@ function describeTrigger(rule: AutomationRule): string {
 }
 
 function describeAction(rule: AutomationRule): string {
-  switch (rule.actionType) {
+  if (rule.actions?.length) {
+    return rule.actions.map((action) => describeActionType(action.type, action.config)).join(' + ')
+  }
+  return describeActionType(rule.actionType, rule.actionConfig)
+}
+
+function describeActionType(actionType: AutomationActionType, actionConfig: Record<string, unknown>): string {
+  switch (actionType) {
     case 'notify':
+    case 'send_notification':
       return 'Send notification'
     case 'update_field': {
-      const fid = rule.actionConfig?.fieldId as string | undefined
+      const fid = actionConfig?.fieldId as string | undefined
       return fid ? `Update "${fieldNameById(fid)}"` : 'Update field value'
     }
+    case 'update_record':
+      return 'Update record'
+    case 'create_record':
+      return 'Create record'
+    case 'send_webhook':
+      return 'Send webhook'
     case 'send_dingtalk_group_message':
       return 'Send DingTalk group message'
     case 'send_dingtalk_person_message':
       return 'Send DingTalk person message'
+    case 'lock_record':
+      return 'Lock record'
     default:
-      return String(rule.actionType)
+      return String(actionType)
   }
+}
+
+function ruleHasActionType(rule: AutomationRule, actionType: AutomationActionType): boolean {
+  return rule.actionType === actionType || (rule.actions ?? []).some((action) => action.type === actionType)
 }
 
 watch(
@@ -1756,4 +1906,14 @@ watch(
 .meta-automation__stat { font-weight: 600; }
 .meta-automation__stat--success { color: #16a34a; }
 .meta-automation__stat--failed { color: #dc2626; }
+
+.meta-automation__test-run-status {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.meta-automation__test-run-status--success { color: #15803d; }
+.meta-automation__test-run-status--failed { color: #b91c1c; }
+.meta-automation__test-run-status--skipped { color: #b45309; }
+.meta-automation__test-run-status--running { color: #1d4ed8; }
 </style>

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -935,8 +935,11 @@ function renderedTemplateExample(value: string, fallback: string) {
   return rendered || fallback
 }
 
-function publicFormLinkWarnings(value: unknown, warnWhenFullyPublic = false) {
-  return listDingTalkPublicFormLinkWarnings(value, props.views ?? [], { warnWhenFullyPublic })
+function publicFormLinkWarnings(value: unknown, warnWhenGroupAccessRisk = false) {
+  return listDingTalkPublicFormLinkWarnings(value, props.views ?? [], {
+    warnWhenFullyPublic: warnWhenGroupAccessRisk,
+    warnWhenProtectedWithoutAllowlist: warnWhenGroupAccessRisk,
+  })
 }
 
 function copyPreviewText(key: string, text: string) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -347,6 +347,13 @@
                 <option value="">-- no internal link --</option>
                 <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
+              <div
+                v-for="warning in internalViewLinkWarnings(action.config.internalViewId)"
+                :key="`group-internal-view-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__preview" data-field="groupMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Groups:</strong> {{ dingTalkGroupSummary(action) }}</div>
@@ -376,6 +383,7 @@
                   </button>
                 </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
+                <div><strong>Public form access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
             </div>
@@ -628,6 +636,13 @@
                 <option value="">-- no internal link --</option>
                 <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
+              <div
+                v-for="warning in internalViewLinkWarnings(action.config.internalViewId)"
+                :key="`person-internal-view-${warning}`"
+                class="meta-rule-editor__hint meta-rule-editor__hint--warning"
+              >
+                {{ warning }}
+              </div>
               <div class="meta-rule-editor__preview" data-field="personMessageSummary">
                 <div class="meta-rule-editor__preview-title">Message summary</div>
                 <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
@@ -658,6 +673,7 @@
                   </button>
                 </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
+                <div><strong>Public form access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
             </div>
@@ -682,10 +698,35 @@
 
       <!-- Footer -->
       <div class="meta-rule-editor__footer">
+        <div class="meta-rule-editor__test-run-feedback">
+          <div v-if="savedRuleHasDingTalkActions" class="meta-rule-editor__hint meta-rule-editor__hint--warning" data-field="dingtalkTestRunWarning">
+            Test Run executes the saved rule and can send real DingTalk messages to configured groups or users.
+          </div>
+          <div v-if="!props.rule?.id" class="meta-rule-editor__hint" data-field="testRunUnsavedHint">
+            Save this automation before running a test.
+          </div>
+          <div
+            v-if="props.testRunState"
+            class="meta-rule-editor__test-run-status"
+            :class="`meta-rule-editor__test-run-status--${props.testRunState.status}`"
+            data-field="testRunStatus"
+            :data-status="props.testRunState.status"
+          >
+            {{ props.testRunState.message }}
+          </div>
+        </div>
         <button class="meta-rule-editor__btn meta-rule-editor__btn--primary" type="button" :disabled="!canSave || saving" data-action="save" @click="onSave">
           {{ saving ? 'Saving...' : 'Save' }}
         </button>
-        <button class="meta-rule-editor__btn" type="button" :disabled="saving" @click="onTestRun" data-action="test">Test Run</button>
+        <button
+          class="meta-rule-editor__btn"
+          type="button"
+          :disabled="saving || !props.rule?.id || props.testRunState?.status === 'running'"
+          @click="onTestRun"
+          data-action="test"
+        >
+          {{ props.testRunState?.status === 'running' ? 'Running...' : 'Test Run' }}
+        </button>
         <button class="meta-rule-editor__btn" type="button" @click="$emit('close')">Cancel</button>
       </div>
     </div>
@@ -718,7 +759,15 @@ import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
-import { listDingTalkPublicFormLinkWarnings } from '../utils/dingtalkPublicFormLinkWarnings'
+import {
+  describeDingTalkPublicFormLinkAccess,
+  listDingTalkPublicFormLinkBlockingErrors,
+  listDingTalkPublicFormLinkWarnings,
+} from '../utils/dingtalkPublicFormLinkWarnings'
+import {
+  listDingTalkInternalViewLinkBlockingErrors,
+  listDingTalkInternalViewLinkWarnings,
+} from '../utils/dingtalkInternalViewLinkWarnings'
 
 interface FieldPair {
   fieldId: string
@@ -765,6 +814,10 @@ interface Draft {
 const props = defineProps<{
   sheetId: string
   rule?: AutomationRule
+  testRunState?: {
+    status: 'running' | 'success' | 'failed' | 'skipped'
+    message: string
+  }
   visible: boolean
   fields: Array<{ id: string; name: string; type: string; property?: Record<string, unknown> }>
   client?: MultitableApiClient
@@ -790,11 +843,16 @@ const copiedPreviewKey = ref('')
 let personRecipientSuggestionLoadId = 0
 let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 
-const formViews = computed(() => (props.views ?? []).filter((view) => view.type === 'form'))
-const internalViews = computed(() => props.views ?? [])
+const formViews = computed(() => (props.views ?? []).filter((view) =>
+  view.type === 'form' && (!view.sheetId || view.sheetId === props.sheetId),
+))
+const internalViews = computed(() => (props.views ?? []).filter((view) => !view.sheetId || view.sheetId === props.sheetId))
 const groupDestinationCandidateFields = computed(() => props.fields)
 const recipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
 const memberGroupRecipientCandidateFields = computed(() => props.fields.filter(isDingTalkMemberGroupRecipientField))
+const savedRuleHasDingTalkActions = computed(() => ruleHasDingTalkActions(props.rule))
+const DINGTALK_TEST_RUN_CONFIRM_MESSAGE =
+  'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users. Unsaved changes are not included. Continue?'
 
 const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
   { value: 'equals', label: 'Equals' },
@@ -913,6 +971,8 @@ const canSave = computed(() => {
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
       if ((!destinationIds.length && !destinationFieldPath) || !titleTemplate || !bodyTemplate) return false
+      if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
+      if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }
     if (action.type === 'send_dingtalk_person_message') {
       const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
@@ -924,6 +984,8 @@ const canSave = computed(() => {
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
       if ((!userIdsText && !memberGroupIdsText && !recipientFieldPath && !memberGroupRecipientFieldPath) || !titleTemplate || !bodyTemplate) return false
+      if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
+      if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }
   }
   return true
@@ -1172,10 +1234,36 @@ function renderedTemplateExample(value: unknown, fallback: string) {
 }
 
 function publicFormLinkWarnings(value: unknown, warnWhenGroupAccessRisk = false) {
-  return listDingTalkPublicFormLinkWarnings(value, props.views ?? [], {
+  return listDingTalkPublicFormLinkWarnings(value, formViews.value, {
     warnWhenFullyPublic: warnWhenGroupAccessRisk,
     warnWhenProtectedWithoutAllowlist: warnWhenGroupAccessRisk,
   })
+}
+
+function publicFormLinkBlockingErrors(value: unknown) {
+  return listDingTalkPublicFormLinkBlockingErrors(value, formViews.value)
+}
+
+function internalViewLinkWarnings(value: unknown) {
+  return listDingTalkInternalViewLinkWarnings(value, internalViews.value)
+}
+
+function internalViewLinkBlockingErrors(value: unknown) {
+  return listDingTalkInternalViewLinkBlockingErrors(value, internalViews.value)
+}
+
+function publicFormAccessSummary(value: unknown) {
+  return describeDingTalkPublicFormLinkAccess(value, formViews.value)
+}
+
+function isDingTalkActionType(value: unknown): boolean {
+  return value === 'send_dingtalk_group_message' || value === 'send_dingtalk_person_message'
+}
+
+function ruleHasDingTalkActions(rule: AutomationRule | undefined): boolean {
+  if (!rule) return false
+  return isDingTalkActionType(rule.actionType)
+    || (rule.actions ?? []).some((action) => isDingTalkActionType(action.type))
 }
 
 function copyPreviewText(key: string, text: string) {
@@ -1528,9 +1616,9 @@ async function onSave() {
 }
 
 function onTestRun() {
-  if (props.rule?.id) {
-    emit('test', props.rule.id)
-  }
+  if (saving.value || props.testRunState?.status === 'running' || !props.rule?.id) return
+  if (savedRuleHasDingTalkActions.value && !window.confirm(DINGTALK_TEST_RUN_CONFIRM_MESSAGE)) return
+  emit('test', props.rule.id)
 }
 </script>
 
@@ -1595,6 +1683,23 @@ function onTestRun() {
 .meta-rule-editor__hint--error { color: #b91c1c; }
 
 .meta-rule-editor__hint--warning { color: #b45309; }
+
+.meta-rule-editor__test-run-feedback {
+  flex: 1 1 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.meta-rule-editor__test-run-status {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.meta-rule-editor__test-run-status--success { color: #15803d; }
+.meta-rule-editor__test-run-status--failed { color: #b91c1c; }
+.meta-rule-editor__test-run-status--skipped { color: #b45309; }
+.meta-rule-editor__test-run-status--running { color: #1d4ed8; }
 
 .meta-rule-editor__input,
 .meta-rule-editor__select,
@@ -1770,6 +1875,8 @@ function onTestRun() {
 
 .meta-rule-editor__footer {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 12px 20px 16px;
   border-top: 1px solid #e2e8f0;

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1171,8 +1171,11 @@ function renderedTemplateExample(value: unknown, fallback: string) {
   return rendered || fallback
 }
 
-function publicFormLinkWarnings(value: unknown, warnWhenFullyPublic = false) {
-  return listDingTalkPublicFormLinkWarnings(value, props.views ?? [], { warnWhenFullyPublic })
+function publicFormLinkWarnings(value: unknown, warnWhenGroupAccessRisk = false) {
+  return listDingTalkPublicFormLinkWarnings(value, props.views ?? [], {
+    warnWhenFullyPublic: warnWhenGroupAccessRisk,
+    warnWhenProtectedWithoutAllowlist: warnWhenGroupAccessRisk,
+  })
 }
 
 function copyPreviewText(key: string, text: string) {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -634,6 +634,7 @@ export interface AutomationExecution {
   triggerType: AutomationTriggerType
   startedAt: string
   completedAt?: string
+  duration?: number
   durationMs?: number
   steps?: AutomationStepResult[]
   error?: string

--- a/apps/web/src/multitable/utils/dingtalkInternalViewLinkWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkInternalViewLinkWarnings.ts
@@ -1,0 +1,26 @@
+export interface DingTalkInternalViewLinkView {
+  id: string
+  name?: string
+}
+
+export function listDingTalkInternalViewLinkBlockingErrors(
+  viewId: unknown,
+  views: readonly DingTalkInternalViewLinkView[],
+): string[] {
+  const id = typeof viewId === 'string' ? viewId.trim() : ''
+  if (!id) return []
+
+  const view = views.find((item) => item.id === id)
+  if (!view) {
+    return [`Internal processing view "${id}" is not available in this sheet; DingTalk messages may not include a working processing link.`]
+  }
+
+  return []
+}
+
+export function listDingTalkInternalViewLinkWarnings(
+  viewId: unknown,
+  views: readonly DingTalkInternalViewLinkView[],
+): string[] {
+  return listDingTalkInternalViewLinkBlockingErrors(viewId, views)
+}

--- a/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
@@ -39,7 +39,45 @@ function hasAllowlistIds(value: unknown): boolean {
   return Array.isArray(value) && value.some((item) => typeof item === 'string' && item.trim())
 }
 
-export function listDingTalkPublicFormLinkWarnings(
+export function describeDingTalkPublicFormLinkAccess(
+  viewId: unknown,
+  views: readonly DingTalkPublicFormLinkView[],
+  optionsOrNowMs?: number | DingTalkPublicFormLinkWarningOptions,
+): string {
+  const options = normalizeWarningOptions(optionsOrNowMs)
+  const nowMs = options.nowMs ?? Date.now()
+  const id = typeof viewId === 'string' ? viewId.trim() : ''
+  if (!id) return 'No public form link'
+
+  const view = views.find((item) => item.id === id)
+  if (!view) return 'View unavailable in this sheet'
+  if (view.type !== 'form') return 'Selected view is not a form'
+
+  const publicForm = isRecord(view.config?.publicForm) ? view.config.publicForm : null
+  if (!publicForm) return 'Public form sharing is not configured'
+  if (publicForm.enabled !== true) return 'Public form sharing is disabled'
+
+  const publicToken = typeof publicForm.publicToken === 'string' ? publicForm.publicToken.trim() : ''
+  if (!publicToken) return 'Public form sharing is missing a public token'
+
+  const expiryMs = parseExpiryMs(publicForm.expiresAt ?? publicForm.expiresOn)
+  if (expiryMs !== null && nowMs >= expiryMs) return 'Public form sharing has expired'
+
+  const hasUserAllowlist = hasAllowlistIds(publicForm.allowedUserIds)
+  const hasGroupAllowlist = hasAllowlistIds(publicForm.allowedMemberGroupIds)
+  const hasAllowlist = hasUserAllowlist || hasGroupAllowlist
+  const accessMode = normalizeAccessMode(publicForm.accessMode)
+
+  if (accessMode === 'dingtalk') {
+    return hasAllowlist ? 'DingTalk-bound users in allowlist can submit' : 'All bound DingTalk users can submit'
+  }
+  if (accessMode === 'dingtalk_granted') {
+    return hasAllowlist ? 'Authorized DingTalk users in allowlist can submit' : 'All authorized DingTalk users can submit'
+  }
+  return 'Fully public; anyone with the link can submit'
+}
+
+export function listDingTalkPublicFormLinkBlockingErrors(
   viewId: unknown,
   views: readonly DingTalkPublicFormLinkView[],
   optionsOrNowMs?: number | DingTalkPublicFormLinkWarningOptions,
@@ -74,6 +112,25 @@ export function listDingTalkPublicFormLinkWarnings(
   if (expiryMs !== null && nowMs >= expiryMs) {
     return [`Public form sharing for "${publicFormLabel(view, id)}" has expired; renew sharing before sending this DingTalk fill link.`]
   }
+
+  return []
+}
+
+export function listDingTalkPublicFormLinkWarnings(
+  viewId: unknown,
+  views: readonly DingTalkPublicFormLinkView[],
+  optionsOrNowMs?: number | DingTalkPublicFormLinkWarningOptions,
+): string[] {
+  const options = normalizeWarningOptions(optionsOrNowMs)
+  const id = typeof viewId === 'string' ? viewId.trim() : ''
+  if (!id) return []
+
+  const blockingErrors = listDingTalkPublicFormLinkBlockingErrors(id, views, options)
+  if (blockingErrors.length) return blockingErrors
+
+  const view = views.find((item) => item.id === id)
+  const publicForm = isRecord(view?.config?.publicForm) ? view.config.publicForm : null
+  if (!publicForm) return []
 
   const accessMode = normalizeAccessMode(publicForm.accessMode)
   if (options.warnWhenFullyPublic && accessMode === 'public') {

--- a/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
@@ -8,6 +8,7 @@ export interface DingTalkPublicFormLinkView {
 export interface DingTalkPublicFormLinkWarningOptions {
   nowMs?: number
   warnWhenFullyPublic?: boolean
+  warnWhenProtectedWithoutAllowlist?: boolean
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -32,6 +33,10 @@ function normalizeWarningOptions(value: number | DingTalkPublicFormLinkWarningOp
 
 function normalizeAccessMode(value: unknown): 'public' | 'dingtalk' | 'dingtalk_granted' {
   return value === 'dingtalk' || value === 'dingtalk_granted' ? value : 'public'
+}
+
+function hasAllowlistIds(value: unknown): boolean {
+  return Array.isArray(value) && value.some((item) => typeof item === 'string' && item.trim())
 }
 
 export function listDingTalkPublicFormLinkWarnings(
@@ -70,8 +75,18 @@ export function listDingTalkPublicFormLinkWarnings(
     return [`Public form sharing for "${publicFormLabel(view, id)}" has expired; renew sharing before sending this DingTalk fill link.`]
   }
 
-  if (options.warnWhenFullyPublic && normalizeAccessMode(publicForm.accessMode) === 'public') {
+  const accessMode = normalizeAccessMode(publicForm.accessMode)
+  if (options.warnWhenFullyPublic && accessMode === 'public') {
     return [`Public form sharing for "${publicFormLabel(view, id)}" is fully public; everyone who can open the DingTalk message link can submit. Use DingTalk-protected access and an allowlist when only selected users should fill.`]
+  }
+  if (
+    options.warnWhenProtectedWithoutAllowlist
+    && (accessMode === 'dingtalk' || accessMode === 'dingtalk_granted')
+    && !hasAllowlistIds(publicForm.allowedUserIds)
+    && !hasAllowlistIds(publicForm.allowedMemberGroupIds)
+  ) {
+    const audience = accessMode === 'dingtalk_granted' ? 'authorized DingTalk users' : 'bound DingTalk users'
+    return [`Public form sharing for "${publicFormLabel(view, id)}" allows all ${audience} to submit; add allowed users or member groups when only selected users should fill.`]
   }
 
   return []

--- a/apps/web/tests/dingtalk-internal-view-link-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-internal-view-link-warnings.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  listDingTalkInternalViewLinkBlockingErrors,
+  listDingTalkInternalViewLinkWarnings,
+} from '../src/multitable/utils/dingtalkInternalViewLinkWarnings'
+
+const views = [
+  { id: 'view_grid', name: 'Grid' },
+  { id: 'view_form', name: 'Public Form' },
+]
+
+describe('dingtalk internal view link warnings', () => {
+  it('returns no warning for empty or available internal views', () => {
+    expect(listDingTalkInternalViewLinkBlockingErrors('', views)).toEqual([])
+    expect(listDingTalkInternalViewLinkBlockingErrors('view_grid', views)).toEqual([])
+    expect(listDingTalkInternalViewLinkWarnings('view_form', views)).toEqual([])
+  })
+
+  it('blocks missing internal processing views', () => {
+    expect(listDingTalkInternalViewLinkBlockingErrors('missing_view', views)).toEqual([
+      'Internal processing view "missing_view" is not available in this sheet; DingTalk messages may not include a working processing link.',
+    ])
+    expect(listDingTalkInternalViewLinkWarnings('missing_view', views)).toEqual([
+      'Internal processing view "missing_view" is not available in this sheet; DingTalk messages may not include a working processing link.',
+    ])
+  })
+})

--- a/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { listDingTalkPublicFormLinkWarnings } from '../src/multitable/utils/dingtalkPublicFormLinkWarnings'
+import {
+  describeDingTalkPublicFormLinkAccess,
+  listDingTalkPublicFormLinkBlockingErrors,
+  listDingTalkPublicFormLinkWarnings,
+} from '../src/multitable/utils/dingtalkPublicFormLinkWarnings'
 
 const nowMs = Date.parse('2026-04-21T00:00:00.000Z')
 
@@ -140,5 +144,28 @@ describe('dingtalk public form link warnings', () => {
     ])
     expect(listDingTalkPublicFormLinkWarnings('view_form_protected_allowed_user', views, { nowMs, warnWhenProtectedWithoutAllowlist: true })).toEqual([])
     expect(listDingTalkPublicFormLinkWarnings('view_form_granted_allowed_group', views, { nowMs, warnWhenProtectedWithoutAllowlist: true })).toEqual([])
+  })
+
+  it('describes selected public form access for DingTalk message summaries', () => {
+    expect(describeDingTalkPublicFormLinkAccess('', views, nowMs)).toBe('No public form link')
+    expect(describeDingTalkPublicFormLinkAccess('view_form_enabled', views, nowMs)).toBe('Fully public; anyone with the link can submit')
+    expect(describeDingTalkPublicFormLinkAccess('view_form_protected', views, nowMs)).toBe('All bound DingTalk users can submit')
+    expect(describeDingTalkPublicFormLinkAccess('view_form_protected_allowed_user', views, nowMs)).toBe('DingTalk-bound users in allowlist can submit')
+    expect(describeDingTalkPublicFormLinkAccess('view_form_granted_without_allowlist', views, nowMs)).toBe('All authorized DingTalk users can submit')
+    expect(describeDingTalkPublicFormLinkAccess('view_form_granted_allowed_group', views, nowMs)).toBe('Authorized DingTalk users in allowlist can submit')
+    expect(describeDingTalkPublicFormLinkAccess('view_form_expired', views, nowMs)).toBe('Public form sharing has expired')
+    expect(describeDingTalkPublicFormLinkAccess('view_grid', views, nowMs)).toBe('Selected view is not a form')
+    expect(describeDingTalkPublicFormLinkAccess('missing_view', views, nowMs)).toBe('View unavailable in this sheet')
+  })
+
+  it('separates blocking link errors from advisory access warnings', () => {
+    expect(listDingTalkPublicFormLinkBlockingErrors('view_form_disabled', views, nowMs)).toEqual([
+      'Public form sharing is disabled for "Disabled Form"; enable sharing before sending this DingTalk fill link.',
+    ])
+    expect(listDingTalkPublicFormLinkBlockingErrors('view_form_expired', views, nowMs)).toEqual([
+      'Public form sharing for "Expired Form" has expired; renew sharing before sending this DingTalk fill link.',
+    ])
+    expect(listDingTalkPublicFormLinkBlockingErrors('view_form_enabled', views, { nowMs, warnWhenFullyPublic: true })).toEqual([])
+    expect(listDingTalkPublicFormLinkBlockingErrors('view_form_protected', views, { nowMs, warnWhenProtectedWithoutAllowlist: true })).toEqual([])
   })
 })

--- a/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
@@ -25,6 +25,47 @@ const views = [
       },
     },
   },
+  {
+    id: 'view_form_protected_allowed_user',
+    name: 'Protected User Form',
+    type: 'form',
+    config: {
+      publicForm: {
+        enabled: true,
+        publicToken: 'pub_protected_user',
+        accessMode: 'dingtalk',
+        allowedUserIds: ['user_1'],
+        expiresAt: '2026-04-22T00:00:00.000Z',
+      },
+    },
+  },
+  {
+    id: 'view_form_granted_allowed_group',
+    name: 'Granted Group Form',
+    type: 'form',
+    config: {
+      publicForm: {
+        enabled: true,
+        publicToken: 'pub_granted_group',
+        accessMode: 'dingtalk_granted',
+        allowedMemberGroupIds: ['group_1'],
+        expiresAt: '2026-04-22T00:00:00.000Z',
+      },
+    },
+  },
+  {
+    id: 'view_form_granted_without_allowlist',
+    name: 'Granted Open Form',
+    type: 'form',
+    config: {
+      publicForm: {
+        enabled: true,
+        publicToken: 'pub_granted_open',
+        accessMode: 'dingtalk_granted',
+        expiresAt: '2026-04-22T00:00:00.000Z',
+      },
+    },
+  },
   { id: 'view_form_unconfigured', name: 'Unconfigured Form', type: 'form' },
   {
     id: 'view_form_disabled',
@@ -56,6 +97,7 @@ describe('dingtalk public form link warnings', () => {
   it('returns no warning for empty input or active public form sharing', () => {
     expect(listDingTalkPublicFormLinkWarnings('', views, nowMs)).toEqual([])
     expect(listDingTalkPublicFormLinkWarnings('view_form_enabled', views, nowMs)).toEqual([])
+    expect(listDingTalkPublicFormLinkWarnings('view_form_protected', views, nowMs)).toEqual([])
   })
 
   it('warns when the selected public form view cannot produce a working fill link', () => {
@@ -87,5 +129,16 @@ describe('dingtalk public form link warnings', () => {
       'Public form sharing for "Enabled Form" is fully public; everyone who can open the DingTalk message link can submit. Use DingTalk-protected access and an allowlist when only selected users should fill.',
     ])
     expect(listDingTalkPublicFormLinkWarnings('view_form_protected', views, { nowMs, warnWhenFullyPublic: true })).toEqual([])
+  })
+
+  it('warns for protected form links without allowlists when group-message access guardrails are enabled', () => {
+    expect(listDingTalkPublicFormLinkWarnings('view_form_protected', views, { nowMs, warnWhenProtectedWithoutAllowlist: true })).toEqual([
+      'Public form sharing for "Protected Form" allows all bound DingTalk users to submit; add allowed users or member groups when only selected users should fill.',
+    ])
+    expect(listDingTalkPublicFormLinkWarnings('view_form_granted_without_allowlist', views, { nowMs, warnWhenProtectedWithoutAllowlist: true })).toEqual([
+      'Public form sharing for "Granted Open Form" allows all authorized DingTalk users to submit; add allowed users or member groups when only selected users should fill.',
+    ])
+    expect(listDingTalkPublicFormLinkWarnings('view_form_protected_allowed_user', views, { nowMs, warnWhenProtectedWithoutAllowlist: true })).toEqual([])
+    expect(listDingTalkPublicFormLinkWarnings('view_form_granted_allowed_group', views, { nowMs, warnWhenProtectedWithoutAllowlist: true })).toEqual([])
   })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -150,6 +150,29 @@ const viewsWithMissingPublicToken = [
   },
 ]
 
+const viewsWithProtectedPublicFormWithoutAllowlist = [
+  views[0],
+  {
+    ...views[1],
+    config: { publicForm: { enabled: true, publicToken: 'pub_view_form', accessMode: 'dingtalk' } },
+  },
+]
+
+const viewsWithProtectedPublicFormAllowlist = [
+  views[0],
+  {
+    ...views[1],
+    config: {
+      publicForm: {
+        enabled: true,
+        publicToken: 'pub_view_form',
+        accessMode: 'dingtalk',
+        allowedMemberGroupIds: ['group_1'],
+      },
+    },
+  },
+]
+
 describe('MetaAutomationManager', () => {
   const originalClipboard = navigator.clipboard
 
@@ -487,6 +510,64 @@ describe('MetaAutomationManager', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
+  })
+
+  it('warns when a DingTalk group message uses a protected public form without an allowlist in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithProtectedPublicFormWithoutAllowlist,
+      client,
+    })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
+    expect(container.textContent).toContain('add allowed users or member groups')
+  })
+
+  it('does not warn when a DingTalk group message uses a protected public form with an allowlist in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithProtectedPublicFormAllowlist,
+      client,
+    })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
+    expect(container.textContent).not.toContain('is fully public')
   })
 
   it('warns when a DingTalk person message selects a public form without a token in the inline form', async () => {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -22,7 +22,14 @@ function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
   }
 }
 
-function mockClient(rules: AutomationRule[] = []) {
+function mockClient(
+  rules: AutomationRule[] = [],
+  options: {
+    testExecution?: Record<string, unknown> | Promise<Record<string, unknown>>
+    testErrorMessage?: string
+    stats?: Record<string, unknown>
+  } = {},
+) {
   const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
   const noContent = () => new Response(null, { status: 204 })
   const personDeliveries: DingTalkPersonDelivery[] = [
@@ -79,12 +86,32 @@ function mockClient(rules: AutomationRule[] = []) {
         ],
       })
     }
+    if (method === 'POST' && url.includes('/automations/') && url.endsWith('/test')) {
+      if (options.testErrorMessage) {
+        return new Response(
+          JSON.stringify({ error: options.testErrorMessage }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      return ok(await (options.testExecution ?? {
+        id: 'exec_1',
+        ruleId: 'rule_1',
+        status: 'success',
+        triggerType: 'record.created',
+        startedAt: '2026-04-21T00:00:00.000Z',
+        duration: 32,
+        steps: [],
+      }))
+    }
     if (method === 'GET' && url.includes('/automations')) {
       if (url.includes('/dingtalk-group-deliveries')) {
         return ok({ deliveries: groupDeliveries })
       }
       if (url.includes('/dingtalk-person-deliveries')) {
         return ok({ deliveries: personDeliveries })
+      }
+      if (url.endsWith('/stats')) {
+        return ok(options.stats ?? { total: 1, success: 1, failed: 0, skipped: 0, avgDurationMs: 32 })
       }
       return ok({ rules })
     }
@@ -202,6 +229,61 @@ describe('MetaAutomationManager', () => {
     const cards = container.querySelectorAll('[data-automation-rule]')
     expect(cards.length).toBe(1)
     expect(container.querySelector('.meta-automation__card-name')?.textContent).toBe('Notify on create')
+    expect(container.querySelector('.meta-automation__card-desc')?.textContent).toContain('Send notification')
+  })
+
+  it('describes V1 multi-action DingTalk group rules in the list', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        name: 'Multi-step group notify',
+        actionType: 'notify',
+        actionConfig: { message: 'Internal note' },
+        actions: [
+          { type: 'notify', config: { message: 'Internal note' } },
+          {
+            type: 'send_dingtalk_group_message',
+            config: {
+              destinationId: 'dt_1',
+              titleTemplate: 'Ticket {{recordId}}',
+              bodyTemplate: 'Please fill {{record.status}}',
+            },
+          },
+        ],
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const desc = container.querySelector('[data-automation-rule="rule_1"] .meta-automation__card-desc')
+    expect(desc?.textContent).toContain('Send notification')
+    expect(desc?.textContent).toContain('Send DingTalk group message')
+  })
+
+  it('describes V1 multi-action DingTalk person rules in the list', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        name: 'Multi-step person notify',
+        actionType: 'notify',
+        actionConfig: { message: 'Internal note' },
+        actions: [
+          { type: 'notify', config: { message: 'Internal note' } },
+          {
+            type: 'send_dingtalk_person_message',
+            config: {
+              userIds: ['user_1'],
+              titleTemplate: 'Ticket {{recordId}}',
+              bodyTemplate: 'Please fill {{record.status}}',
+            },
+          },
+        ],
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const desc = container.querySelector('[data-automation-rule="rule_1"] .meta-automation__card-desc')
+    expect(desc?.textContent).toContain('Send notification')
+    expect(desc?.textContent).toContain('Send DingTalk person message')
   })
 
   it('shows empty state when no rules', async () => {
@@ -394,6 +476,109 @@ describe('MetaAutomationManager', () => {
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups?sheetId=sheet_1'))).toBe(true)
   })
 
+  it('filters internal processing options to the current sheet in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: [
+        ...views,
+        { id: 'view_other_sheet', sheetId: 'sheet_2', name: 'Other Sheet Grid', type: 'grid' },
+      ],
+      client,
+    })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLSelectElement
+    const optionValues = Array.from(internalViewSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('view_grid')
+    expect(optionValues).not.toContain('view_other_sheet')
+  })
+
+  it('filters public form options to the current sheet in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: [
+        ...views,
+        { id: 'view_other_form', sheetId: 'sheet_2', name: 'Other Sheet Form', type: 'form' },
+      ],
+      client,
+    })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
+    const optionValues = Array.from(publicFormSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('view_form')
+    expect(optionValues).not.toContain('view_other_form')
+  })
+
+  it('disables creating a DingTalk group automation when the selected public form link cannot work', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views: viewsWithMissingPublicToken, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
+    destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(container.textContent).toContain('Public form sharing for "Public Form" is missing a public token')
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(0)
+  })
+
   it('creates DingTalk group automation with only dynamic record destination paths', async () => {
     const { client, fetchFn } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -510,6 +695,7 @@ describe('MetaAutomationManager', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
+    expect(container.querySelector('[data-automation-summary="group"]')?.textContent).toContain('Fully public; anyone with the link can submit')
   })
 
   it('warns when a DingTalk group message uses a protected public form without an allowlist in the inline form', async () => {
@@ -568,6 +754,7 @@ describe('MetaAutomationManager', () => {
 
     expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
     expect(container.textContent).not.toContain('is fully public')
+    expect(container.querySelector('[data-automation-summary="group"]')?.textContent).toContain('DingTalk-bound users in allowlist can submit')
   })
 
   it('warns when a DingTalk person message selects a public form without a token in the inline form', async () => {
@@ -590,6 +777,51 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is missing a public token')
+  })
+
+  it('disables creating a DingTalk person automation when the selected public form link cannot work', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views: viewsWithMissingPublicToken, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk person notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(container.textContent).toContain('Public form sharing for "Public Form" is missing a public token')
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(0)
   })
 
   it('creates DingTalk person automation via form', async () => {
@@ -1116,6 +1348,241 @@ describe('MetaAutomationManager', () => {
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/dingtalk-group-deliveries'))).toBe(true)
   })
 
+  it('opens DingTalk group delivery viewer for V1 multi-action rules', async () => {
+    const { client, fetchFn } = mockClient([
+      fakeRule({
+        name: 'Multi-step group notify',
+        actionType: 'notify',
+        actionConfig: { message: 'Internal note' },
+        actions: [
+          { type: 'notify', config: { message: 'Internal note' } },
+          {
+            type: 'send_dingtalk_group_message',
+            config: {
+              destinationId: 'dt_1',
+              titleTemplate: 'Ticket {{recordId}}',
+              bodyTemplate: 'Please fill {{record.status}}',
+            },
+          },
+        ],
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deliveriesBtn = container.querySelector('[data-automation-group-deliveries="rule_1"]') as HTMLButtonElement
+    expect(deliveriesBtn).toBeTruthy()
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const delivery = document.querySelector('[data-group-delivery-id="dgd_1"]')
+    expect(delivery?.textContent).toContain('Ops Group')
+    expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/dingtalk-group-deliveries'))).toBe(true)
+  })
+
+  it('opens DingTalk person delivery viewer for V1 multi-action rules', async () => {
+    const { client, fetchFn } = mockClient([
+      fakeRule({
+        name: 'Multi-step person notify',
+        actionType: 'notify',
+        actionConfig: { message: 'Internal note' },
+        actions: [
+          { type: 'notify', config: { message: 'Internal note' } },
+          {
+            type: 'send_dingtalk_person_message',
+            config: {
+              userIds: ['user_1'],
+              titleTemplate: 'Ticket {{recordId}}',
+              bodyTemplate: 'Please fill {{record.status}}',
+            },
+          },
+        ],
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deliveriesBtn = container.querySelector('[data-automation-person-deliveries="rule_1"]') as HTMLButtonElement
+    expect(deliveriesBtn).toBeTruthy()
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const delivery = document.querySelector('[data-person-delivery-id="dpd_1"]')
+    expect(delivery?.textContent).toContain('Lin Lan')
+    expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/dingtalk-person-deliveries'))).toBe(true)
+  })
+
+  it('shows a generic running status for non-DingTalk automation test runs', async () => {
+    let resolveExecution!: (value: Record<string, unknown>) => void
+    const testExecutionPromise = new Promise<Record<string, unknown>>((resolve) => {
+      resolveExecution = resolve
+    })
+    const { client } = mockClient([
+      fakeRule({
+        name: 'Internal notification',
+        actionType: 'notify',
+        actionConfig: { message: 'Internal only' },
+        actions: [{ type: 'notify', config: { message: 'Internal only' } }],
+      }),
+    ], { testExecution: testExecutionPromise })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement).click()
+    await flushPromises()
+    ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
+    await nextTick()
+
+    const status = container.querySelector('[data-field="testRunStatus"]')
+    expect(status?.textContent).toContain('Running test.')
+    expect(status?.textContent).not.toContain('DingTalk')
+
+    resolveExecution({
+      id: 'exec_1',
+      ruleId: 'rule_1',
+      status: 'success',
+      triggerType: 'record.created',
+      startedAt: '2026-04-21T00:00:00.000Z',
+      durationMs: 32,
+      steps: [],
+    })
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="testRunStatus"]')?.textContent).toContain('Test run succeeded')
+  })
+
+  it('shows a successful automation test run status and refreshes stats', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { client, fetchFn } = mockClient([
+      fakeRule({
+        name: 'DingTalk group notify',
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: { destinationId: 'dt_1', titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        }],
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const testBtn = container.querySelector('[data-action="test"]') as HTMLButtonElement
+    expect(testBtn.disabled).toBe(false)
+    expect(container.textContent).toContain('can send real DingTalk messages')
+
+    testBtn.click()
+    await flushPromises()
+
+    expect(fetchFn.mock.calls.some(([url, init]) =>
+      String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/test') && init?.method === 'POST',
+    )).toBe(true)
+    expect(container.querySelector('[data-field="testRunStatus"]')?.textContent).toContain('Test run succeeded (32 ms)')
+    expect(container.querySelector('[data-automation-test-status="rule_1"]')?.textContent).toContain('Test run succeeded (32 ms)')
+    expect(fetchFn.mock.calls.filter(([url]) => String(url).endsWith('/stats')).length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('uses a generic running message for non-DingTalk automation tests', async () => {
+    let resolveExecution!: (value: Record<string, unknown>) => void
+    const testExecution = new Promise<Record<string, unknown>>((resolve) => {
+      resolveExecution = resolve
+    })
+    const { client } = mockClient([
+      fakeRule({
+        actionType: 'update_record',
+        actionConfig: { fieldId: 'fld_1', value: 'Done' },
+        actions: [{ type: 'update_record', config: { fieldId: 'fld_1', value: 'Done' } }],
+      }),
+    ], { testExecution })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement).click()
+    await flushPromises()
+    ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
+    await nextTick()
+
+    const runningStatus = container.querySelector('[data-field="testRunStatus"]')
+    expect(runningStatus?.textContent).toContain('Running test.')
+    expect(runningStatus?.textContent).not.toContain('DingTalk actions may send real messages')
+
+    resolveExecution({
+      id: 'exec_1',
+      ruleId: 'rule_1',
+      status: 'success',
+      triggerType: 'record.created',
+      startedAt: '2026-04-21T00:00:00.000Z',
+      duration: 10,
+      steps: [],
+    })
+    await flushPromises()
+  })
+
+  it('shows failed automation test run step errors', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { client } = mockClient([
+      fakeRule({
+        name: 'DingTalk group notify',
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: { destinationId: 'dt_1', titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        actions: [{ type: 'send_dingtalk_group_message', config: { destinationId: 'dt_1' } }],
+      }),
+    ], {
+      testExecution: {
+        id: 'exec_failed',
+        ruleId: 'rule_1',
+        status: 'failed',
+        triggerType: 'record.created',
+        startedAt: '2026-04-21T00:00:00.000Z',
+        steps: [{
+          actionType: 'send_dingtalk_group_message',
+          status: 'failed',
+          error: 'DingTalk robot keyword blocked',
+        }],
+      },
+    })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement).click()
+    await flushPromises()
+    ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const status = container.querySelector('[data-field="testRunStatus"]')
+    expect(status?.textContent).toContain('DingTalk robot keyword blocked')
+    expect(status?.getAttribute('data-status')).toBe('failed')
+  })
+
+  it('shows automation test run API errors instead of failing silently', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { client } = mockClient([
+      fakeRule({
+        name: 'DingTalk person notify',
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: { userIds: ['user_1'], titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        actions: [{ type: 'send_dingtalk_person_message', config: { userIds: ['user_1'] } }],
+      }),
+    ], { testErrorMessage: 'Automation service unavailable' })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement).click()
+    await flushPromises()
+    ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="testRunStatus"]')?.textContent).toContain('Automation service unavailable')
+    expect(container.querySelector('[data-field="testRunStatus"]')?.getAttribute('data-status')).toBe('failed')
+  })
+
   it('applies DingTalk group presets in the inline create form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -1232,6 +1699,10 @@ describe('MetaAutomationManager', () => {
     const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
     bodyInput.value = 'Handle {{record.xxx}}'
     bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
     const summary = container.querySelector('[data-automation-summary="person"]')
@@ -1241,7 +1712,8 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Need action record_demo_001')
     expect(summary?.textContent).toContain('Handle 示例字段值')
     expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
-    expect(summary?.textContent).toContain('No public form link')
+    expect(summary?.textContent).toContain('Public Form')
+    expect(summary?.textContent).toContain('Fully public; anyone with the link can submit')
     expect(summary?.textContent).toContain('No internal link')
   })
 
@@ -1282,6 +1754,34 @@ describe('MetaAutomationManager', () => {
     expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
     expect(document.body.textContent).toContain('Record recipients:')
     expect(document.body.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('shows a blocking warning when editing a rule with a missing internal processing view', async () => {
+    const config = {
+      destinationIds: ['dt_1'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      internalViewId: 'missing_view',
+    }
+    const rules = [
+      fakeRule({
+        id: 'rule_missing_internal',
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: config,
+        actions: [{ type: 'send_dingtalk_group_message', config }],
+      }),
+    ]
+    const { client } = mockClient(rules)
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const editBtn = container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement
+    editBtn.click()
+    await flushPromises()
+
+    const saveBtn = document.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(document.body.textContent).toContain('Internal processing view "missing_view" is not available in this sheet')
+    expect(saveBtn.disabled).toBe(true)
   })
 
   it('shows DingTalk template syntax warnings in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -228,6 +228,204 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saveBtn.disabled).toBe(true)
   })
 
+  it('disables Test Run for unsaved rules and explains why', async () => {
+    const tested = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onTest: tested })
+    await flushPromises()
+
+    const testBtn = container.querySelector('[data-action="test"]') as HTMLButtonElement
+    expect(testBtn.disabled).toBe(true)
+    testBtn.click()
+    await flushPromises()
+
+    expect(tested).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Save this automation before running a test.')
+  })
+
+  it('warns that DingTalk Test Run can send real messages and emits the saved rule id', async () => {
+    const tested = vi.fn()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      rule: fakeRule({
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill',
+        },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: { destinationId: 'dt_1', titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        }],
+      }),
+      onTest: tested,
+    })
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="dingtalkTestRunWarning"]')?.textContent).toContain('can send real DingTalk messages')
+
+    const testBtn = container.querySelector('[data-action="test"]') as HTMLButtonElement
+    expect(testBtn.disabled).toBe(false)
+    testBtn.click()
+    await flushPromises()
+
+    expect(tested).toHaveBeenCalledWith('rule_1')
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('can send real DingTalk messages'))
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Unsaved changes are not included'))
+  })
+
+  it('requires confirmation when saved V1 actions contain DingTalk but legacy actionType does not', async () => {
+    const tested = vi.fn()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      rule: fakeRule({
+        actionType: 'notify',
+        actionConfig: { message: 'Internal notification' },
+        actions: [
+          { type: 'notify', config: { message: 'Internal notification' } },
+          {
+            type: 'send_dingtalk_group_message',
+            config: { destinationId: 'dt_1', titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+          },
+        ],
+      }),
+      onTest: tested,
+    })
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="dingtalkTestRunWarning"]')?.textContent).toContain('can send real DingTalk messages')
+
+    ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(tested).toHaveBeenCalledWith('rule_1')
+  })
+
+  it('does not emit DingTalk Test Run when confirmation is canceled', async () => {
+    const tested = vi.fn()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      rule: fakeRule({
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: ['user_1'],
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill',
+        },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: { userIds: ['user_1'], titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        }],
+      }),
+      onTest: tested,
+    })
+    await flushPromises()
+
+    const testBtn = container.querySelector('[data-action="test"]') as HTMLButtonElement
+    expect(testBtn.disabled).toBe(false)
+    testBtn.click()
+    await flushPromises()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(tested).not.toHaveBeenCalled()
+  })
+
+  it('requires confirmation based on the saved rule even when the draft action changes', async () => {
+    const tested = vi.fn()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      rule: fakeRule({
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill',
+        },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: { destinationId: 'dt_1', titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        }],
+      }),
+      onTest: tested,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'notify'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(tested).toHaveBeenCalledWith('rule_1')
+  })
+
+  it('does not require confirmation for non-DingTalk Test Run', async () => {
+    const tested = vi.fn()
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      rule: fakeRule({
+        actionType: 'notify',
+        actionConfig: { message: 'Hello' },
+        actions: [{ type: 'notify', config: { message: 'Hello' } }],
+      }),
+      onTest: tested,
+    })
+    await flushPromises()
+
+    const testBtn = container.querySelector('[data-action="test"]') as HTMLButtonElement
+    expect(testBtn.disabled).toBe(false)
+    testBtn.click()
+    await flushPromises()
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(tested).toHaveBeenCalledWith('rule_1')
+  })
+
+  it('shows Test Run feedback and disables duplicate clicks while running', async () => {
+    const tested = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      rule: fakeRule(),
+      testRunState: { status: 'running', message: 'Running test. DingTalk actions may send real messages.' },
+      onTest: tested,
+    })
+    await flushPromises()
+
+    const testBtn = container.querySelector('[data-action="test"]') as HTMLButtonElement
+    expect(testBtn.disabled).toBe(true)
+    expect(testBtn.textContent).toContain('Running...')
+    expect(container.querySelector('[data-field="testRunStatus"]')?.textContent).toContain('Running test')
+
+    testBtn.click()
+    await flushPromises()
+    expect(tested).not.toHaveBeenCalled()
+  })
+
   it('emits save with payload when name is filled', async () => {
     const saved = vi.fn()
     const { container } = mount({
@@ -475,6 +673,53 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Public form sharing is disabled for "Public Form"')
   })
 
+  it('disables saving a DingTalk group message when the selected public form link cannot work', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithDisabledPublicForm,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify DingTalk'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
+    destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(container.textContent).toContain('Public form sharing is disabled for "Public Form"')
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+    expect(saved).not.toHaveBeenCalled()
+  })
+
   it('warns when a DingTalk group message includes a fully public form link', async () => {
     const client = mockClient()
     const { container } = mount({
@@ -498,6 +743,7 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
+    expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('Fully public; anyone with the link can submit')
   })
 
   it('warns when a DingTalk group message uses a protected public form without an allowlist', async () => {
@@ -548,6 +794,7 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
     expect(container.textContent).not.toContain('is fully public')
+    expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('DingTalk-bound users in allowlist can submit')
   })
 
   it('emits DingTalk person action config with optional links', async () => {
@@ -594,6 +841,8 @@ describe('MetaAutomationRuleEditor', () => {
     internalViewSelect.dispatchEvent(new Event('change'))
     await flushPromises()
 
+    expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent).toContain('Fully public; anyone with the link can submit')
+
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
     expect(saveBtn.disabled).toBe(false)
     saveBtn.click()
@@ -619,6 +868,117 @@ describe('MetaAutomationRuleEditor', () => {
         internalViewId: 'view_grid',
       },
     })
+  })
+
+  it('disables saving a DingTalk group message when the internal processing view is missing', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const config = {
+      destinationIds: ['dt_1'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      internalViewId: 'missing_view',
+    }
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      rule: fakeRule({
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: config,
+        actions: [{ type: 'send_dingtalk_group_message', config }],
+      }),
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(container.textContent).toContain('Internal processing view "missing_view" is not available in this sheet')
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+    expect(saved).not.toHaveBeenCalled()
+  })
+
+  it('disables saving a DingTalk person message when the selected public form link cannot work', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithDisabledPublicForm,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify People'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1'
+    userIdsInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(container.textContent).toContain('Public form sharing is disabled for "Public Form"')
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+    expect(saved).not.toHaveBeenCalled()
+  })
+
+  it('disables saving a DingTalk person message when the internal processing view is missing', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const config = {
+      userIds: ['user_1'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      internalViewId: 'missing_view',
+    }
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      rule: fakeRule({
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: config,
+        actions: [{ type: 'send_dingtalk_person_message', config }],
+      }),
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(container.textContent).toContain('Internal processing view "missing_view" is not available in this sheet')
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+    expect(saved).not.toHaveBeenCalled()
   })
 
   it('emits DingTalk person action config with only a dynamic record recipient path', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -36,6 +36,29 @@ const viewsWithDisabledPublicForm = [
   },
 ]
 
+const viewsWithProtectedPublicFormWithoutAllowlist = [
+  views[0],
+  {
+    ...views[1],
+    config: { publicForm: { enabled: true, publicToken: 'pub_view_form', accessMode: 'dingtalk' } },
+  },
+]
+
+const viewsWithProtectedPublicFormAllowlist = [
+  views[0],
+  {
+    ...views[1],
+    config: {
+      publicForm: {
+        enabled: true,
+        publicToken: 'pub_view_form',
+        accessMode: 'dingtalk',
+        allowedUserIds: ['user_1'],
+      },
+    },
+  },
+]
+
 function mockClient() {
   return {
     listDingTalkGroups: vi.fn(async () => [
@@ -475,6 +498,56 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
+  })
+
+  it('warns when a DingTalk group message uses a protected public form without an allowlist', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithProtectedPublicFormWithoutAllowlist,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
+    expect(container.textContent).toContain('add allowed users or member groups')
+  })
+
+  it('does not warn when a DingTalk group message uses a protected public form with an allowlist', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithProtectedPublicFormAllowlist,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
+    expect(container.textContent).not.toContain('is fully public')
   })
 
   it('emits DingTalk person action config with optional links', async () => {

--- a/docs/development/dingtalk-automation-link-route-tests-development-20260421.md
+++ b/docs/development/dingtalk-automation-link-route-tests-development-20260421.md
@@ -1,0 +1,47 @@
+# DingTalk Automation Link Route Tests Development
+
+Date: 2026-04-21
+Branch: `codex/dingtalk-automation-link-route-tests-20260421`
+Base: `codex/dingtalk-public-form-save-validation-20260421`
+
+## Goal
+
+Lock the DingTalk automation link save-validation behavior at the real API route layer.
+
+The previous slice added a shared validator and unit coverage. This slice verifies that `POST /api/multitable/sheets/:sheetId/automations` and `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId` actually call that validator before persisting rules.
+
+## Changes
+
+- Added `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`.
+- The test mounts `univerMetaRouter()` with a mocked pool and mocked `AutomationService`.
+- Covered invalid public form links before `createRule`.
+- Covered valid public form plus internal processing links flowing to `createRule`.
+- Covered invalid internal processing links before `createRule`.
+- Covered V1 `actions[]` validation.
+- Covered PATCH merged-state validation before `updateRule`.
+- Covered enable-only PATCH bypassing link revalidation.
+
+## Review Fixes
+
+- Tightened the enable-only bypass assertion to inspect the actual SQL string in
+  `mockPool.query.mock.calls`. The previous `not.toHaveBeenCalledWith(...,
+  expect.anything())` form could miss a future `query(sql)` call because
+  `expect.anything()` does not match `undefined`.
+- Added a route-level negative case for invalid `internalViewId`, so the route
+  wiring now proves both public form and internal processing links are rejected
+  before persistence.
+
+## Behavioral Contract
+
+- Cross-sheet `publicFormViewId` is rejected as not found for the current sheet.
+- Disabled public form links are rejected before persistence.
+- Expired public form links are rejected before persistence.
+- Missing internal processing views are rejected before persistence.
+- Valid public form and internal view links are accepted.
+- Updating only `enabled` does not revalidate stale links, preserving low-risk operational toggles.
+
+## Risk Notes
+
+- This slice intentionally does not change production route logic.
+- Runtime public-form access control remains the final authority after a user opens a DingTalk message link.
+- Fully public or DingTalk-protected-without-allowlist form states remain advisory and are not changed here.

--- a/docs/development/dingtalk-automation-link-route-tests-verification-20260421.md
+++ b/docs/development/dingtalk-automation-link-route-tests-verification-20260421.md
@@ -1,0 +1,43 @@
+# DingTalk Automation Link Route Tests Verification
+
+Date: 2026-04-21
+Branch: `codex/dingtalk-automation-link-route-tests-20260421`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+- Initial route-test command failed because this new worktree did not have dependencies installed: `Command "vitest" not found`.
+- `pnpm install --frozen-lockfile` completed successfully. It printed the repository's normal ignored-build-scripts warning.
+- Route integration test passed: 1 file, 5 tests.
+- Combined helper unit plus route integration test passed: 2 files, 13 tests.
+- Backend TypeScript build passed.
+- Diff whitespace check passed.
+
+## Review-Fix Verification
+
+Additional targeted rerun after tightening the enable-only assertion and adding
+the invalid internal-view route case:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+git diff --check
+```
+
+Result:
+
+- Route integration test passed: 1 file, 6 tests.
+- Diff whitespace check passed.
+
+## Notes
+
+- No live DingTalk webhook call is made.
+- No database service is required; the route test uses mocked pool queries and mocked automation service persistence.

--- a/docs/development/dingtalk-form-access-summary-development-20260421.md
+++ b/docs/development/dingtalk-form-access-summary-development-20260421.md
@@ -1,0 +1,29 @@
+# DingTalk Form Access Summary Development 2026-04-21
+
+## Scope
+
+This change adds a read-only public form access summary to DingTalk automation message previews.
+
+## Changes
+
+- Added `describeDingTalkPublicFormLinkAccess()` in `apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts`.
+- The helper derives access state from `view.config.publicForm` without changing automation payloads.
+- `MetaAutomationRuleEditor.vue` now shows `Public form access` for DingTalk group and DingTalk person message summaries.
+- `MetaAutomationManager.vue` now shows the same summary in the inline create/edit form.
+- Updated the DingTalk admin and capability guides to mention the new preview summary.
+- Covered access states:
+  - No public form link.
+  - View unavailable or not a form.
+  - Sharing not configured, disabled, missing token, or expired.
+  - Fully public link.
+  - All bound DingTalk users.
+  - Bound DingTalk users constrained by allowlist.
+  - All authorized DingTalk users.
+  - Authorized DingTalk users constrained by allowlist.
+
+## Design Notes
+
+- The summary is intentionally read-only and does not persist into `actionConfig`.
+- Existing group-message warnings remain responsible for blocking risky configurations visually.
+- Person-message flows also display the access summary so owners can inspect the selected form link state even when group-specific warnings are not enabled.
+- The summary depends on `props.views` carrying `config.publicForm`. If a caller omits this config, the UI will show the conservative sharing-state fallback instead of making an unsafe assumption.

--- a/docs/development/dingtalk-form-access-summary-verification-20260421.md
+++ b/docs/development/dingtalk-form-access-summary-verification-20260421.md
@@ -1,0 +1,26 @@
+# DingTalk Form Access Summary Verification 2026-04-21
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- Initial targeted test run failed because this fresh worktree had no installed dependencies and `vitest` was not available.
+- Ran `pnpm install --frozen-lockfile`.
+- Targeted Vitest run passed:
+  - `tests/dingtalk-public-form-link-warnings.spec.ts`: 5 tests passed.
+  - `tests/multitable-automation-rule-editor.spec.ts`: 37 tests passed.
+  - `tests/multitable-automation-manager.spec.ts`: 39 tests passed.
+  - Total: 3 files, 81 tests passed.
+- `pnpm --filter @metasheet/web build` passed.
+- Build produced the existing Vite warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and large chunks; no new build failure was introduced.
+
+## Coverage Notes
+
+- Utility coverage verifies every access summary branch used by the UI.
+- Rule editor coverage verifies group summaries expose public and allowlisted DingTalk access, and person summaries expose selected form access.
+- Inline manager coverage verifies the same behavior in the create/edit automation form.

--- a/docs/development/dingtalk-form-link-save-validation-development-20260421.md
+++ b/docs/development/dingtalk-form-link-save-validation-development-20260421.md
@@ -1,0 +1,29 @@
+# DingTalk Form Link Save Validation Development 2026-04-21
+
+## Scope
+
+This change prevents saving DingTalk automation rules when the selected public form link cannot produce a working fill link.
+
+## Changes
+
+- Added `listDingTalkPublicFormLinkBlockingErrors()` in `apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts`.
+- Reused the existing public-form validation path for hard errors:
+  - selected view is missing from the current sheet
+  - selected view is not a form view
+  - public form sharing is not configured
+  - public form sharing is disabled
+  - public form sharing has no public token
+  - public form sharing has expired
+- `MetaAutomationRuleEditor.vue` now disables save for DingTalk group and person actions with blocking public-form link errors.
+- `MetaAutomationManager.vue` now applies the same save gate in the inline create/edit form.
+- Updated DingTalk admin and capability docs to document the save gate.
+- Advisory warnings remain advisory:
+  - fully public links in group messages
+  - DingTalk-protected links without allowed users or member groups
+
+## Design Notes
+
+- The save gate uses a dedicated helper instead of matching warning strings.
+- Existing visible warning text remains the user-facing explanation for why save is disabled.
+- The backend runtime validation remains in place, so this is a front-end guardrail rather than the only enforcement layer.
+- The automation payload schema is unchanged.

--- a/docs/development/dingtalk-form-link-save-validation-verification-20260421.md
+++ b/docs/development/dingtalk-form-link-save-validation-verification-20260421.md
@@ -1,0 +1,27 @@
+# DingTalk Form Link Save Validation Verification 2026-04-21
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- Initial targeted test run failed because this fresh worktree had no installed dependencies and `vitest` was not available.
+- Ran `pnpm install --frozen-lockfile`.
+- Targeted Vitest run passed:
+  - `tests/dingtalk-public-form-link-warnings.spec.ts`: 6 tests passed.
+  - `tests/multitable-automation-rule-editor.spec.ts`: 39 tests passed.
+  - `tests/multitable-automation-manager.spec.ts`: 41 tests passed.
+  - Total: 3 files, 86 tests passed.
+- `pnpm --filter @metasheet/web build` passed.
+- Build produced the existing Vite warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and large chunks; no new build failure was introduced.
+
+## Coverage Notes
+
+- Utility tests verify hard link errors are separated from advisory access warnings.
+- Rule editor tests verify group and person saves are disabled when the selected public form link cannot work.
+- Inline manager tests verify create calls are not sent when the selected public form link cannot work.
+- Existing create/save tests still verify fully public advisory warnings do not block saving.

--- a/docs/development/dingtalk-internal-link-validation-development-20260421.md
+++ b/docs/development/dingtalk-internal-link-validation-development-20260421.md
@@ -1,0 +1,24 @@
+# DingTalk Internal Link Validation Development 2026-04-21
+
+## Scope
+
+This change hardens DingTalk automation internal processing links. Public form links already had front-end and runtime guardrails; internal links now receive the same current-sheet existence checks before save and at runtime.
+
+## Changes
+
+- Added `apps/web/src/multitable/utils/dingtalkInternalViewLinkWarnings.ts`.
+- `MetaAutomationRuleEditor.vue` now:
+  - filters internal processing view choices to the current sheet
+  - shows a warning when a saved `internalViewId` no longer exists in the current sheet
+  - disables save for DingTalk group/person actions with missing internal processing views
+- `MetaAutomationManager.vue` now applies the same current-sheet filtering and warning behavior in inline automation forms.
+- `packages/core-backend/src/routes/univer-meta.ts` now rejects automation create/update payloads when DingTalk group/person `internalViewId` values do not exist in the target sheet.
+- `packages/core-backend/tests/unit/automation-v1.test.ts` now covers the existing runtime guardrail for group and person DingTalk delivery.
+- Existing runtime delivery still refuses missing internal views before sending DingTalk messages.
+
+## Design Notes
+
+- This does not restrict `internalViewId` to a specific view type; it only requires the view to exist in the same sheet.
+- Save-time validation covers both legacy single-action fields (`actionType` / `actionConfig`) and multi-action `actions[]`.
+- PATCH validation merges submitted fields with the existing rule when needed so partial updates cannot introduce or retain invalid DingTalk internal links.
+- The automation payload schema is unchanged.

--- a/docs/development/dingtalk-internal-link-validation-verification-20260421.md
+++ b/docs/development/dingtalk-internal-link-validation-verification-20260421.md
@@ -1,0 +1,33 @@
+# DingTalk Internal Link Validation Verification 2026-04-21
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-internal-view-link-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/web build
+pnpm --filter @metasheet/core-backend build
+```
+
+## Results
+
+- Initial targeted front-end test run failed because this fresh worktree had no installed dependencies and `vitest` was not available.
+- Ran `pnpm install --frozen-lockfile`.
+- Front-end targeted Vitest run passed:
+  - `tests/dingtalk-internal-view-link-warnings.spec.ts`: 2 tests passed.
+  - `tests/multitable-automation-rule-editor.spec.ts`: 41 tests passed.
+  - `tests/multitable-automation-manager.spec.ts`: 43 tests passed.
+  - Total: 3 files, 86 tests passed.
+- Back-end targeted Vitest run passed:
+  - `tests/unit/automation-v1.test.ts`: 111 tests passed.
+- `pnpm --filter @metasheet/web build` passed.
+- `pnpm --filter @metasheet/core-backend build` passed.
+- Front-end test output included a `WebSocket server error: Port is already in use` message, but all tests completed successfully.
+- Web build produced the existing Vite warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and large chunks; no new build failure was introduced.
+
+## Coverage Notes
+
+- Utility tests cover missing internal processing view warnings.
+- Rule editor tests cover stale group/person `internalViewId` save blocking.
+- Manager tests cover current-sheet internal view filtering and stale edit warnings.
+- Executor tests cover runtime group/person delivery failure before DingTalk send when `internalViewId` is missing.

--- a/docs/development/dingtalk-message-link-runtime-guardrails-development-20260421.md
+++ b/docs/development/dingtalk-message-link-runtime-guardrails-development-20260421.md
@@ -1,0 +1,113 @@
+# DingTalk Message Link Runtime Guardrails Development - 2026-04-21
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-message-link-runtime-guardrails-20260421`
+- Scope: backend runtime validation for DingTalk group/person message links
+- Status: implemented and verified locally
+
+## Background
+
+DingTalk automation messages can append two app links to the rendered message body:
+
+- a public form fill link from `publicFormViewId`
+- an internal processing link from `internalViewId`
+
+Frontend authoring warnings help users avoid bad selections, but they are not a security or consistency boundary. Automation rule configs can become stale after view changes, can be imported from older versions, or can be edited through backend paths. The backend `AutomationExecutor` therefore needs to validate every configured link at execution time before sending DingTalk group or person messages.
+
+The hardening goal is to prevent automations from emitting links that point to a stale view, a cross-sheet view, a non-form public entry, or a public form that is no longer actually public.
+
+## Design Goals
+
+Runtime validation should apply equally to:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Public form link requirements:
+
+- the selected `publicFormViewId` must resolve from `meta_views`
+- the view must belong to the executing rule sheet
+- the view type must be `form`
+- `config.publicForm.enabled` must be `true`
+- `config.publicForm.publicToken` must be a non-empty string after trimming
+- `config.publicForm.expiresAt` or `config.publicForm.expiresOn`, when present, must not be expired at execution time
+
+Internal link requirements:
+
+- the selected `internalViewId` must resolve from `meta_views`
+- the view must belong to the executing rule sheet
+
+Failure behavior:
+
+- fail the automation action with a specific error before sending any DingTalk message
+- do not append a partially validated link to the message body
+- do not call DingTalk group webhook delivery when link validation fails
+- do not resolve or send DingTalk person notifications when link validation fails
+- keep existing error text stable where practical for already-covered cases
+
+## Implemented Changes
+
+This branch applies the smallest runtime hardening needed for the current link execution path.
+
+Implemented in `packages/core-backend/src/multitable/automation-executor.ts`:
+
+- added `parsePublicFormExpiryMs()` with the same accepted input shapes as the public form route: finite number, `Date`, numeric string, or parseable datetime string
+- tightened group-message public-form lookup to `WHERE id = $1 AND sheet_id = $2 AND type = 'form'`
+- tightened person-message public-form lookup to `WHERE id = $1 AND sheet_id = $2 AND type = 'form'`
+- reject expired public form sharing before appending the fill link
+- keep existing disabled/missing-token failure behavior as `Selected public form view is not shared`
+- keep existing missing/non-form lookup failure behavior as `Public form view not found`
+
+Failure result stays action-specific:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+Expected link output remains unchanged after validation:
+
+- public form: `/multitable/public-form/{sheetId}/{publicFormViewId}?publicToken=...`
+- internal view: `/multitable/{sheetId}/{internalViewId}?recordId=...`
+
+## Non-Goals
+
+This change should not:
+
+- alter public form submission authorization semantics
+- change DingTalk access-mode or allowlist behavior
+- change frontend authoring warnings
+- add database migrations
+- modify OpenAPI contracts
+- change message template rendering
+- change group destination scoping beyond the existing destination lookup rules
+
+## Regression Coverage
+
+Focused backend unit coverage was added in `packages/core-backend/tests/unit/automation-v1.test.ts`.
+
+Group message path:
+
+- sends a message with a valid same-sheet shared public form view
+- sends a message with a valid same-sheet internal view
+- asserts public-form lookup includes `type = 'form'`
+- fails when `expiresAt` is expired
+- does not call the DingTalk webhook on validation failure
+
+Person message path:
+
+- sends a message with a valid same-sheet shared public form view
+- sends a message with a valid same-sheet internal view
+- asserts public-form lookup includes `type = 'form'`
+- fails when a selected public-form ID resolves as a non-form view because the query filters `type = 'form'`
+- does not emit person delivery requests on validation failure
+
+Shared assertions:
+
+- action status is `failed`
+- failure error identifies the invalid link category
+- no schema or migration diff is required
+
+## Rollout Notes
+
+This is a runtime guardrail. Existing automations that reference stale, cross-sheet, disabled, tokenless, expired, or non-form public links may start failing at execution time instead of sending a bad DingTalk message. That is the intended behavior.
+
+Operationally, failed runs should surface through the existing automation execution logs and step results. No separate migration is expected; owners can fix affected rules by selecting an in-sheet form view with public sharing enabled or by selecting an in-sheet internal view.

--- a/docs/development/dingtalk-message-link-runtime-guardrails-verification-20260421.md
+++ b/docs/development/dingtalk-message-link-runtime-guardrails-verification-20260421.md
@@ -1,0 +1,138 @@
+# DingTalk Message Link Runtime Guardrails Verification - 2026-04-21
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-message-link-runtime-guardrails-20260421`
+- Scope: backend verification for DingTalk group/person message link guardrails
+- Status: verified locally
+
+## Verification Goals
+
+Confirm that `AutomationExecutor` validates DingTalk message links at runtime before sending either group or person messages.
+
+Expected runtime behavior:
+
+- public form links are only emitted for same-sheet form views with public sharing enabled
+- public form links require a non-empty `publicToken`
+- public form links are rejected after `expiresAt` or `expiresOn`
+- internal processing links are only emitted for same-sheet views
+- group-message delivery does not call DingTalk webhooks when link validation fails
+- person-message delivery does not emit notifications when link validation fails
+- valid group/person message behavior remains unchanged
+
+## Static Review
+
+Implementation diff was reviewed for:
+
+- backend-only changes under `packages/core-backend/src/multitable/automation-executor.ts`
+- focused backend tests under `packages/core-backend/tests`
+- no frontend source changes
+- no schema, migration, or OpenAPI changes
+- no unrelated formatting churn
+
+Commands:
+
+```bash
+git diff -- packages/core-backend/src/multitable/automation-executor.ts packages/core-backend/tests docs/development/dingtalk-message-link-runtime-guardrails-*.md
+git diff --check
+```
+
+Result:
+
+- executor validates public and internal link configs before delivery
+- group and person paths use equivalent validation logic
+- `git diff --check` reports no whitespace errors
+
+## Automated Tests
+
+Focused backend tests:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+```
+
+Result: passed, 1 file / 109 tests.
+
+Backend build:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+Wider workspace gates were not run in this slice:
+
+```bash
+pnpm test
+pnpm lint
+pnpm type-check
+```
+
+## Required Regression Cases
+
+Valid group-message cases:
+
+- same-sheet form view with `publicForm.enabled = true`, non-empty `publicToken`, and no expiry
+- same-sheet form view with a future `expiresAt` or `expiresOn`
+- same-sheet internal view
+- public form link and internal link configured together
+
+Invalid group-message cases:
+
+- `publicFormViewId` not found
+- public form view from another sheet
+- public form view that is not type `form`
+- form view with `publicForm.enabled !== true`
+- form view with missing or blank `publicToken`
+- form view with past `expiresAt`
+- form view with past `expiresOn`
+- `internalViewId` from another sheet
+- validation failure leaves DingTalk webhook mock uncalled
+
+Valid person-message cases:
+
+- same-sheet form view with `publicForm.enabled = true`, non-empty `publicToken`, and no expiry
+- same-sheet form view with a future `expiresAt` or `expiresOn`
+- same-sheet internal view
+- public form link and internal link configured together
+
+Invalid person-message cases:
+
+- `publicFormViewId` not found
+- public form view from another sheet
+- public form view that is not type `form`
+- form view with `publicForm.enabled !== true`
+- form view with missing or blank `publicToken`
+- form view with past `expiresAt`
+- form view with past `expiresOn`
+- `internalViewId` from another sheet
+- validation failure leaves person-message delivery mock uncalled
+
+## Manual Verification Plan
+
+Use a local database and a safe DingTalk mock transport if manual verification is needed.
+
+1. Create sheet A with a normal grid view and a form view.
+2. Enable public sharing on the sheet A form view and confirm it has a public token.
+3. Create sheet B with a form view and a normal view.
+4. Configure a DingTalk group-message rule on sheet A with the sheet A public form view; expected delivery includes a fill link.
+5. Reconfigure the same group-message rule to use the sheet B form view; expected execution fails before webhook delivery.
+6. Disable public sharing on the sheet A form view; expected execution fails before webhook delivery.
+7. Restore sharing and set an expired public form expiry; expected execution fails before webhook delivery.
+8. Configure the group-message rule with a same-sheet internal view; expected delivery includes a processing link.
+9. Reconfigure the group-message rule with a sheet B internal view; expected execution fails before webhook delivery.
+10. Repeat the same public form and internal-link scenarios for a DingTalk person-message rule; expected failures occur before person delivery.
+
+## Result Template
+
+- Focused backend tests: passed, 1 file / 109 tests
+- Backend build: passed
+- `git diff --check`: passed
+- Workspace gates: not run
+- Manual group-message verification: not run; covered by unit tests
+- Manual person-message verification: not run; covered by unit tests
+- Notes: first focused test attempt failed before install because the fresh worktree had no local `vitest`; rerun passed after `pnpm install --frozen-lockfile`
+
+## Release Risk Notes
+
+This change may expose pre-existing invalid automation configs. That is expected, but release notes should mention that DingTalk automations with stale public form links, disabled public sharing, expired public forms, missing public tokens, non-form public views, or cross-sheet internal links will now fail during execution instead of sending an invalid link.

--- a/docs/development/dingtalk-protected-form-allowlist-guardrail-development-20260421.md
+++ b/docs/development/dingtalk-protected-form-allowlist-guardrail-development-20260421.md
@@ -1,0 +1,125 @@
+# DingTalk Protected Form Allowlist Guardrail Development - 2026-04-21
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-protected-form-allowlist-guardrail-20260421`
+- Scope: frontend authoring guardrails for DingTalk group-message public form selectors
+- Status: implemented and verified locally
+
+## Background
+
+DingTalk automation rules can include a public form link in group-message content. Existing frontend guardrails already warn when the selected form cannot produce a usable fill link, and a later access guardrail warns when a group-message form is fully public.
+
+Protected DingTalk access modes introduce another user-facing risk. A form with `publicForm.accessMode` set to `dingtalk` or `dingtalk_granted` is not fully public, but it is also not necessarily restricted to selected users. If both `allowedUserIds` and `allowedMemberGroupIds` are empty, the form still allows every local user who satisfies the selected DingTalk protection mode:
+
+- `dingtalk`: bound DingTalk local users
+- `dingtalk_granted`: authorized DingTalk local users
+
+That behavior is valid at runtime, but it can be surprising when the automation owner expects the group-message form to be filled only by specified users or member groups.
+
+## Goals
+
+- Keep the existing public-form risk warning for DingTalk group-message selectors when the selected form is fully public.
+- Add an advisory warning for DingTalk-protected public forms when `accessMode` is `dingtalk` or `dingtalk_granted` and both allowlist arrays are empty.
+- Limit the new allowlist guardrail to DingTalk group-message automation authoring.
+- Do not enable the new allowlist warning for DingTalk person-message automation authoring.
+- Do not block saving the automation rule.
+
+## Non-Goals
+
+- No backend behavior changes.
+- No database migration or schema change.
+- No change to public form token generation, form submission, or DingTalk delivery execution.
+- No automatic allowlist population from the DingTalk group destination.
+- No change to person-message recipient or public-form selector behavior beyond existing link-validity warnings.
+
+## Design
+
+### Warning Conditions
+
+The new warning should be considered only after the selected form view is known to be a valid, usable public form link. Existing link-validity warnings should remain higher priority for cases such as:
+
+- missing or stale selected view
+- selected view is not a form/public-form view
+- public sharing is disabled
+- missing public token
+- expired share configuration
+
+After link validity passes, the group-message selector should evaluate access risk in this order:
+
+1. Fully public form warning when `publicForm.accessMode` is missing or `public`.
+2. Protected-empty-allowlist warning when `publicForm.accessMode` is `dingtalk` or `dingtalk_granted` and both allowlist arrays are empty.
+3. No access warning when either `allowedUserIds` or `allowedMemberGroupIds` contains at least one ID.
+
+Missing `allowedUserIds` or `allowedMemberGroupIds` values should be treated as empty arrays for warning purposes. Duplicate IDs do not matter for this guardrail because it only needs to know whether at least one allowlist entry exists.
+
+### Implemented Warning Copy
+
+The protected-empty-allowlist warning distinguishes the selected access mode:
+
+- `dingtalk`: `Public form sharing for "{Form Name}" allows all bound DingTalk users to submit; add allowed users or member groups when only selected users should fill.`
+- `dingtalk_granted`: `Public form sharing for "{Form Name}" allows all authorized DingTalk users to submit; add allowed users or member groups when only selected users should fill.`
+
+The UI wording preserves these points:
+
+- the form is DingTalk-protected, not fully public
+- it is not restricted to selected users
+- empty allowlists allow all users admitted by the selected DingTalk protection mode
+- the owner should add allowed users or member groups for a selected-user workflow
+
+### UI Placement
+
+The warning should appear directly below the DingTalk group-message public form selector, matching the placement and visual treatment of existing public-form link warnings.
+
+Expected surfaces:
+
+- full automation rule editor group-message action
+- inline automation manager group-message action
+
+Not expected:
+
+- DingTalk person-message public form selector
+- non-DingTalk automation actions
+- backend validation responses
+
+### Shared Helper Behavior
+
+The implementation extends the existing shared frontend public-form warning helper instead of duplicating selector-specific logic in Vue components.
+
+Implementation details:
+
+- `DingTalkPublicFormLinkWarningOptions.warnWhenProtectedWithoutAllowlist`
+- `hasAllowlistIds()` checks whether either allowlist contains at least one non-empty string ID
+- full automation rule editor enables both fully-public and protected-without-allowlist warnings for DingTalk group-message public form links
+- inline automation manager enables the same group-message warnings
+- DingTalk person-message public form selectors do not enable the protected-without-allowlist option
+
+The helper should remain read-only:
+
+- inspect selected view metadata
+- inspect `publicForm` access fields
+- return warning strings
+- avoid mutating rule config or form-share config
+
+### Rollout Impact
+
+Expected impact is frontend-only and authoring-time only:
+
+- no API contract change
+- no backend runtime change
+- no migration
+- no schema update
+- no save-blocking behavior
+- no change to existing public form access enforcement
+
+## Verification Summary
+
+The detailed verification results live in `docs/development/dingtalk-protected-form-allowlist-guardrail-verification-20260421.md`.
+
+Verification covered:
+
+- fully public group-message forms still show the public-risk warning
+- `dingtalk` and `dingtalk_granted` group-message forms with empty allowlists show the new warning
+- either an allowed user or an allowed member group suppresses the new warning
+- DingTalk person-message selectors do not opt into the new allowlist warning
+- existing invalid-link warnings retain priority
+- frontend tests and web build pass

--- a/docs/development/dingtalk-protected-form-allowlist-guardrail-verification-20260421.md
+++ b/docs/development/dingtalk-protected-form-allowlist-guardrail-verification-20260421.md
@@ -1,0 +1,83 @@
+# DingTalk Protected Form Allowlist Guardrail Verification - 2026-04-21
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-protected-form-allowlist-guardrail-20260421`
+- Scope: frontend-only DingTalk group-message allowlist guardrail
+- Status: verified locally
+
+## Verification Goals
+
+Confirm that DingTalk group-message automation authoring warns for protected public forms that are not limited to selected users, without changing backend behavior or person-message behavior.
+
+The expected behavior is:
+
+- group-message selectors still warn when a selected public form is fully public
+- group-message selectors warn when `publicForm.accessMode` is `dingtalk` and both `allowedUserIds` and `allowedMemberGroupIds` are empty
+- group-message selectors warn when `publicForm.accessMode` is `dingtalk_granted` and both allowlist arrays are empty
+- group-message selectors do not show the protected-empty-allowlist warning when either allowlist has entries
+- person-message selectors do not show the protected-empty-allowlist warning
+- existing link-validity warnings remain higher priority than access-risk warnings
+
+## Automated Verification
+
+Commands run:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+Result:
+
+- focused frontend tests passed: 3 files, 80 tests
+- web build passed
+- `git diff --check` passed
+
+Covered test cases:
+
+- helper returns the existing fully public warning for a group-message selector when `accessMode` is missing or `public`
+- helper returns the new warning for `accessMode = dingtalk` with empty or missing allowlist arrays
+- helper returns the new warning for `accessMode = dingtalk_granted` with empty or missing allowlist arrays
+- helper returns no protected-empty-allowlist warning when `allowedUserIds` contains at least one ID
+- helper returns no protected-empty-allowlist warning when `allowedMemberGroupIds` contains at least one ID
+- helper keeps invalid-link warnings primary for disabled sharing, missing token, expired links, stale view IDs, and non-form views
+- full automation rule editor renders the new warning for DingTalk group-message actions
+- inline automation manager renders the new warning for DingTalk group-message actions
+- DingTalk person-message actions keep existing link warnings but do not render the new allowlist warning
+
+## Manual Verification Plan
+
+Use a sheet with a form view that has public sharing enabled and a valid public token.
+
+1. Configure the form as fully public and select it in a DingTalk group-message automation public form selector.
+2. Confirm the existing fully public risk warning appears.
+3. Change the form to `accessMode = dingtalk` with no allowed users and no allowed member groups.
+4. Confirm the new warning states the form is not limited to selected users and that all admitted DingTalk local users can submit.
+5. Add one allowed user.
+6. Confirm the new warning disappears.
+7. Remove the allowed user, add one allowed member group, and confirm the warning disappears.
+8. Repeat the empty-allowlist check for `accessMode = dingtalk_granted`.
+9. Configure an equivalent DingTalk person-message automation and confirm the new allowlist warning does not appear.
+10. Disable public sharing or remove the public token and confirm the existing link-validity warning is shown instead of the allowlist warning.
+11. Save the automation rule and confirm the warning is advisory only and does not block saving.
+
+## Regression Checks
+
+- No backend files should be required for this slice.
+- No schema or migration files should be changed.
+- Existing public form access enforcement should remain unchanged.
+- Existing DingTalk group/person delivery execution should remain unchanged.
+- Existing public-form link warnings should keep their previous wording unless implementation intentionally updates shared copy.
+
+## Results
+
+- Focused frontend tests: passed, 3 files / 80 tests
+- Web build: passed
+- `git diff --check`: passed
+- Manual group-message fully public warning: not run in browser in this slice; covered by component tests
+- Manual group-message protected empty allowlist warning: not run in browser in this slice; covered by component tests
+- Manual allowlist suppression: not run in browser in this slice; covered by component tests
+- Manual person-message non-applicability: not run in browser in this slice; person-message selectors do not enable the new option
+- Notes: first focused test attempt failed before install because fresh worktree had no local `vitest`; rerun passed after `pnpm install --frozen-lockfile`

--- a/docs/development/dingtalk-public-form-save-validation-development-20260421.md
+++ b/docs/development/dingtalk-public-form-save-validation-development-20260421.md
@@ -1,0 +1,26 @@
+# DingTalk Public Form Save Validation Development 2026-04-21
+
+## Scope
+
+This change moves DingTalk public form link validation into the back-end automation save path. Front-end and runtime guardrails already existed; create/update APIs now reject invalid `publicFormViewId` values before rules are persisted.
+
+## Changes
+
+- Added `packages/core-backend/src/multitable/dingtalk-automation-link-validation.ts`.
+- The helper scans both legacy single-action payloads and V1 `actions[]`.
+- Back-end save validation now rejects DingTalk group/person automation links when:
+  - the public form view is missing from the target sheet
+  - the selected view is not a `form` view
+  - public form sharing is disabled or not configured
+  - `publicToken` is missing or blank
+  - `expiresAt` or `expiresOn` is expired
+- Existing internal processing link validation now uses the same helper.
+- `univer-meta.ts` uses the shared helper for `POST /sheets/:sheetId/automations` and `PATCH /sheets/:sheetId/automations/:ruleId`.
+- Front-end public form selectors now filter to current-sheet form views, matching the back-end same-sheet save rule.
+
+## Design Notes
+
+- Fully public links remain allowed at save time; they are still surfaced as advisory warnings in the group-message UI.
+- DingTalk-protected public forms with or without allowlists remain allowed at save time; allowlist absence remains an advisory risk warning.
+- Runtime delivery validation remains in place as the final enforcement layer.
+- The automation payload schema is unchanged.

--- a/docs/development/dingtalk-public-form-save-validation-verification-20260421.md
+++ b/docs/development/dingtalk-public-form-save-validation-verification-20260421.md
@@ -1,0 +1,35 @@
+# DingTalk Public Form Save Validation Verification 2026-04-21
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+pnpm --filter @metasheet/core-backend build
+```
+
+## Results
+
+- Initial targeted test runs failed because this fresh worktree had no installed dependencies and `vitest` was not available.
+- Ran `pnpm install --frozen-lockfile`.
+- Back-end helper tests passed:
+  - `tests/unit/dingtalk-automation-link-validation.test.ts`: 8 tests passed.
+- Front-end targeted tests passed:
+  - `tests/dingtalk-public-form-link-warnings.spec.ts`: 6 tests passed.
+  - `tests/multitable-automation-rule-editor.spec.ts`: 41 tests passed.
+  - `tests/multitable-automation-manager.spec.ts`: 44 tests passed.
+  - Total: 3 files, 91 tests passed.
+- First `pnpm --filter @metasheet/core-backend build` failed on a TypeScript tuple inference issue in the new helper.
+- Fixed the helper by building explicit `[string, Record<string, unknown>]` entries.
+- Re-ran `pnpm --filter @metasheet/core-backend build`: passed.
+- Re-ran the back-end helper tests after the fix: 8 tests passed.
+- `pnpm --filter @metasheet/web build` passed.
+- Front-end test output included a `WebSocket server error: Port is already in use` message, but all tests completed successfully.
+- Web build produced the existing Vite warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and large chunks; no new build failure was introduced.
+
+## Coverage Notes
+
+- Helper tests cover legacy payloads, multi-action payloads, active public form links, fully public advisory allowance, DingTalk-protected advisory allowance, missing/non-form/disabled/missing-token/expired public form errors, and missing internal view errors.
+- Front-end tests cover current-sheet public form option filtering.
+- Builds cover `univer-meta.ts` route integration with the shared helper.

--- a/docs/development/dingtalk-test-run-confirm-development-20260421.md
+++ b/docs/development/dingtalk-test-run-confirm-development-20260421.md
@@ -1,0 +1,43 @@
+# DingTalk Test Run Confirmation Development
+
+Date: 2026-04-21
+Branch: `codex/dingtalk-test-run-confirm-20260421`
+Base: `codex/dingtalk-test-run-feedback-20260421`
+
+## Goal
+
+Prevent accidental real DingTalk sends from automation Test Run.
+
+The previous slice made Test Run feedback visible and warned that DingTalk rules can send real messages. This slice adds an explicit browser confirmation before the saved DingTalk rule is executed.
+
+## Changes
+
+- Added a DingTalk-only confirmation in `MetaAutomationRuleEditor`.
+- The confirmation is triggered when the saved rule contains:
+  - `send_dingtalk_group_message`, or
+  - `send_dingtalk_person_message`.
+- Canceling the confirmation stops the test event and no API call is triggered by the parent manager.
+- Non-DingTalk automation actions do not require confirmation.
+
+## Rebase Note
+
+After #980 and #982 were merged into the stacked base branch, this PR was
+rebased onto `origin/codex/dingtalk-public-form-save-validation-20260421`.
+Duplicate #980/#982 commits were skipped during rebase so the PR diff now
+contains only the Test Run confirmation slice.
+
+## Confirmation Message
+
+`Test Run executes the saved rule and can send real DingTalk messages to configured groups or users. Unsaved changes are not included. Continue?`
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Risk Notes
+
+- This is frontend-only governance; backend execution semantics are unchanged.
+- The confirmation is based on the saved rule because Test Run executes by `ruleId` and does not include unsaved draft edits.
+- The existing saved-rule gate remains in place, so new unsaved rules still cannot be tested.

--- a/docs/development/dingtalk-test-run-confirm-verification-20260421.md
+++ b/docs/development/dingtalk-test-run-confirm-verification-20260421.md
@@ -1,0 +1,54 @@
+# DingTalk Test Run Confirmation Verification
+
+Date: 2026-04-21
+Branch: `codex/dingtalk-test-run-confirm-20260421`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile` completed successfully with the repository's normal ignored-build-scripts warning.
+- Initial targeted test run failed because three manager integration tests clicked DingTalk Test Run without mocking `window.confirm`; jsdom reports `Window's confirm() method` as not implemented.
+- Manager tests were updated to explicitly mock confirmation for those DingTalk Test Run paths.
+- Targeted frontend tests passed after the fix: 2 files, 94 tests.
+- Frontend production build passed.
+- Build emitted existing Vite warnings for `WorkflowDesigner.vue` mixed dynamic/static imports and large chunks.
+
+## Rebase Verification
+
+After rebasing onto the updated stacked base branch:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+Result:
+
+- `multitable-automation-rule-editor.spec.ts`: 47/47 passed.
+- `multitable-automation-manager.spec.ts`: 48/48 passed.
+- Combined rerun: 2 files, 95/95 passed.
+- `vue-tsc -b --noEmit`: passed.
+- `git diff --check`: passed.
+
+## Coverage
+
+- DingTalk Test Run asks for confirmation before emitting the test event.
+- Canceling confirmation prevents Test Run.
+- Confirming allows Test Run.
+- Confirmation is based on the saved rule, even if the draft action is temporarily edited away from DingTalk.
+- Non-DingTalk Test Run does not show the DingTalk confirmation.
+- Existing Test Run feedback and status tests remain green.
+
+## Notes
+
+- No live DingTalk webhook is called in these tests.
+- The confirmation is tested with a mocked `window.confirm`.

--- a/docs/development/dingtalk-test-run-feedback-development-20260421.md
+++ b/docs/development/dingtalk-test-run-feedback-development-20260421.md
@@ -1,0 +1,52 @@
+# DingTalk Test Run Feedback Development
+
+Date: 2026-04-21
+Branch: `codex/dingtalk-test-run-feedback-20260421`
+Base: `codex/dingtalk-automation-link-route-tests-20260421`
+
+## Goal
+
+Make automation Test Run behavior explicit for DingTalk rules.
+
+Before this slice, `MetaAutomationRuleEditor` emitted a test event but did not explain that DingTalk actions can send real messages. `MetaAutomationManager` called the test API and ignored both success and failure results.
+
+## Changes
+
+- Added saved-rule gating in `MetaAutomationRuleEditor`.
+  - Unsaved automations now show a “save before test” hint.
+  - Test Run is disabled for unsaved rules and while a test is already running.
+- Added DingTalk real-send warning in `MetaAutomationRuleEditor`.
+  - The warning is based on draft `actions[]`, so it covers both group and person actions.
+- Added per-rule Test Run feedback state in `MetaAutomationManager`.
+  - Running, success, failed, and skipped outcomes are displayed.
+  - Failed execution step errors are surfaced instead of being swallowed.
+  - API errors are surfaced instead of silently failing.
+- Refreshed per-rule automation stats after a completed test run.
+
+## Review Fixes
+
+- Normalized the frontend API error parser so backend responses shaped as
+  `{ error: "message" }` surface the real message instead of falling back to
+  `API <status>`.
+- Kept compatibility with object-shaped errors such as
+  `{ error: { code, message, fieldErrors } }`.
+- Updated Test Run duration rendering to accept both backend-shaped
+  `duration` and frontend-shaped `durationMs`.
+- Scoped the running-state “DingTalk actions may send real messages” text to
+  rules that actually include DingTalk group/person actions.
+
+## Behavior Notes
+
+- Test Run executes the saved server-side automation rule.
+- Unsaved draft edits are not included until the rule is saved.
+- DingTalk group/person test runs may send real DingTalk messages to configured destinations or recipients.
+- This slice does not change backend execution semantics or DingTalk delivery logic.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`

--- a/docs/development/dingtalk-test-run-feedback-verification-20260421.md
+++ b/docs/development/dingtalk-test-run-feedback-verification-20260421.md
@@ -1,0 +1,57 @@
+# DingTalk Test Run Feedback Verification
+
+Date: 2026-04-21
+Branch: `codex/dingtalk-test-run-feedback-20260421`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- Initial frontend test command failed because the new worktree had no installed dependencies: `Command "vitest" not found`.
+- `pnpm install --frozen-lockfile` completed successfully with the repository's normal ignored-build-scripts warning.
+- Targeted frontend tests passed: 2 files, 91 tests.
+- Frontend production build passed.
+- Build emitted existing Vite warnings for `WorkflowDesigner.vue` mixed dynamic/static imports and large chunks.
+
+## Review-Fix Verification
+
+Additional targeted rerun after the API error-envelope and duration fixes:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+Result:
+
+- `multitable-automation-manager.spec.ts`: 48/48 passed.
+- `multitable-automation-rule-editor.spec.ts`: 44/44 passed.
+- Combined rerun: 2 files, 92/92 passed.
+- `vue-tsc -b --noEmit`: passed.
+- `git diff --check`: passed.
+
+Expected assertions added or strengthened:
+
+- Backend-shaped `{ error: "Automation service unavailable" }` is displayed as
+  `Automation service unavailable`, not `API 500`.
+- Backend-shaped `duration` renders in Test Run success feedback.
+- Non-DingTalk automations show a generic `Running test.` message while the
+  test request is pending.
+
+## Coverage
+
+- Unsaved rules cannot trigger Test Run.
+- DingTalk rules show a real-send warning.
+- Successful Test Run displays success feedback and refreshes stats.
+- Failed Test Run displays execution step errors.
+- Test Run API failures display errors instead of failing silently.
+- Non-DingTalk Test Run pending feedback does not warn about DingTalk sends.

--- a/docs/development/dingtalk-test-run-v1-risk-feedback-development-20260421.md
+++ b/docs/development/dingtalk-test-run-v1-risk-feedback-development-20260421.md
@@ -1,0 +1,51 @@
+# DingTalk Test Run V1 Risk Feedback Development - 2026-04-21
+
+## Goal
+
+Tighten automation Test Run risk feedback now that DingTalk automations can be represented as V1 `actions[]`.
+
+Two behaviors matter for users:
+
+- Saved V1 rules with DingTalk actions must still require confirmation before Test Run, even when the legacy top-level `actionType` is not DingTalk.
+- Non-DingTalk rules should not show a running-state warning that says DingTalk messages may be sent.
+
+## Implementation
+
+Production behavior is provided by the already-merged Test Run feedback logic in
+`apps/web/src/multitable/components/MetaAutomationManager.vue`.
+
+- `onTestRule(ruleId)` looks up the saved rule and checks both top-level and
+  V1 `actions[]` DingTalk action types through the shared pending-message
+  helper.
+- Running state uses:
+  - `Running test. DingTalk actions may send real messages.` for saved rules with DingTalk group/person actions.
+  - `Running test.` for non-DingTalk rules.
+
+After rebase onto the updated stacked base branch, this PR no longer needs to
+change production source. It keeps the behavior locked with regression tests and
+documents the V1 risk-feedback contract.
+
+Changed `apps/web/tests/multitable-automation-manager.spec.ts`.
+
+- Added a deferred Test Run response path in the local mock client so tests can assert the intermediate running state.
+- Added coverage that a non-DingTalk automation displays a generic running message and does not mention DingTalk.
+
+Changed `apps/web/tests/multitable-automation-rule-editor.spec.ts`.
+
+- Added coverage that a saved V1 rule with `actionType: 'notify'` and `actions[]` containing `send_dingtalk_group_message` still shows the DingTalk warning and requires confirmation.
+
+## Scope
+
+This slice is frontend test/documentation-only after rebase.
+
+- No backend API change.
+- No database migration.
+- No DingTalk delivery behavior change.
+- No permission behavior change.
+
+## User Impact
+
+Users get precise Test Run feedback:
+
+- Real DingTalk send risk is still confirmed for V1 multi-action rules.
+- Internal-only automations do not display a misleading DingTalk risk warning while running.

--- a/docs/development/dingtalk-test-run-v1-risk-feedback-verification-20260421.md
+++ b/docs/development/dingtalk-test-run-v1-risk-feedback-verification-20260421.md
@@ -1,0 +1,42 @@
+# DingTalk Test Run V1 Risk Feedback Verification - 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Result
+
+- Initial Vitest command before dependency install failed because `vitest` was not available in this new worktree.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false`: passed, 2 files / 100 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Rebase Verification
+
+After rebasing onto the updated stacked base branch:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+Result:
+
+- `multitable-automation-manager.spec.ts`: 53/53 passed.
+- `multitable-automation-rule-editor.spec.ts`: 48/48 passed.
+- Combined rerun: 2 files, 101/101 passed.
+- `vue-tsc -b --noEmit`: passed.
+- `git diff --check`: passed.
+
+## Notes
+
+The frontend build emitted existing Vite warnings about `WorkflowDesigner.vue` being both statically and dynamically imported, plus large chunk warnings. These warnings are unrelated to this Test Run feedback slice.
+
+`pnpm install` updated local `node_modules` links in several workspace packages. Those generated dependency-directory changes must remain unstaged.

--- a/docs/development/dingtalk-v1-action-summary-development-20260421.md
+++ b/docs/development/dingtalk-v1-action-summary-development-20260421.md
@@ -1,0 +1,57 @@
+# DingTalk V1 Action Summary Development - 2026-04-21
+
+## Goal
+
+Make automation list summaries accurately describe V1 multi-action rules that include DingTalk actions.
+
+Before this change, `MetaAutomationManager` rendered each automation card as:
+
+```text
+trigger description -> describeAction(rule)
+```
+
+`describeAction(rule)` only inspected the legacy top-level `rule.actionType` and `rule.actionConfig`. For V1 rules, DingTalk group/person actions can live in `rule.actions[]`, while `rule.actionType` may remain `notify` or another legacy primary action. Those rules could send DingTalk messages, but the card summary could still show only `Send notification`.
+
+## Implementation
+
+Changed `apps/web/src/multitable/components/MetaAutomationManager.vue`.
+
+- `describeAction(rule)` now prefers V1 `rule.actions[]` when present.
+- Added `describeActionType(actionType, actionConfig)` so both legacy and V1 paths use the same labels.
+- Added labels for V1 action types:
+  - `send_notification`
+  - `update_record`
+  - `create_record`
+  - `send_webhook`
+  - `lock_record`
+- Preserved existing legacy labels for:
+  - `notify`
+  - `update_field`
+  - `send_dingtalk_group_message`
+  - `send_dingtalk_person_message`
+
+Changed `apps/web/tests/multitable-automation-manager.spec.ts`.
+
+- Added list-summary coverage for a V1 rule containing `send_dingtalk_group_message`.
+- Added list-summary coverage for a V1 rule containing `send_dingtalk_person_message`.
+- Added a legacy list-summary assertion for the existing `notify` rule path.
+
+## Rebase Note
+
+After #980/#982/#983/#985 were merged into the stacked base branch, this PR was
+rebased onto `origin/codex/dingtalk-public-form-save-validation-20260421`.
+Duplicate ancestor commits were skipped during rebase so the PR diff now
+contains only the V1 action-summary slice.
+
+## Scope
+
+This slice is frontend-only.
+
+- No backend API change.
+- No database migration.
+- No delivery behavior change.
+- No permission behavior change.
+
+## User Impact
+
+Automation owners can see from the rule list that a V1 multi-step automation includes DingTalk group or person messaging, instead of seeing only the legacy primary action.

--- a/docs/development/dingtalk-v1-action-summary-verification-20260421.md
+++ b/docs/development/dingtalk-v1-action-summary-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk V1 Action Summary Verification - 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Result
+
+- Initial Vitest command before dependency install failed because `vitest` was not available in this new worktree.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false`: passed, 1 file / 51 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Rebase Verification
+
+After rebasing onto the updated stacked base branch:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+Result:
+
+- `multitable-automation-manager.spec.ts`: 52/52 passed.
+- `vue-tsc -b --noEmit`: passed.
+- `git diff --check`: passed.
+
+## Notes
+
+The frontend build emitted existing Vite warnings about `WorkflowDesigner.vue` being both statically and dynamically imported, plus large chunk warnings. These warnings are unrelated to this DingTalk summary slice.
+
+`pnpm install` updated local `node_modules` links in several workspace packages. Those generated dependency-directory changes must remain unstaged.

--- a/docs/development/dingtalk-v1-delivery-buttons-development-20260421.md
+++ b/docs/development/dingtalk-v1-delivery-buttons-development-20260421.md
@@ -1,0 +1,47 @@
+# DingTalk V1 Delivery Buttons Development - 2026-04-21
+
+## Goal
+
+Expose DingTalk delivery viewers for V1 multi-action automation rules.
+
+Previously the automation manager showed the delivery viewer buttons only when the legacy top-level `rule.actionType` was exactly:
+
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+
+V1 automation rules can store multiple actions in `rule.actions[]`. In that shape the top-level `actionType` may be a different primary action, while a DingTalk group or person action still exists inside the action list. Those rules could send DingTalk messages, but the UI did not show the delivery history button.
+
+## Implementation
+
+Changed `apps/web/src/multitable/components/MetaAutomationManager.vue`.
+
+- Added `ruleHasActionType(rule, actionType)` to check both the legacy top-level `rule.actionType` and V1 `rule.actions[]`.
+- Updated the group delivery viewer button to use `ruleHasActionType(rule, 'send_dingtalk_group_message')`.
+- Updated the person delivery viewer button to use `ruleHasActionType(rule, 'send_dingtalk_person_message')`.
+- Kept legacy behavior unchanged for rules that still use a single top-level action.
+
+Changed `apps/web/tests/multitable-automation-manager.spec.ts`.
+
+- Added coverage for a V1 multi-action rule containing `send_dingtalk_group_message`.
+- Added coverage for a V1 multi-action rule containing `send_dingtalk_person_message`.
+- Verified that clicking each button opens the correct delivery viewer and calls the expected delivery endpoint.
+
+## Rebase Note
+
+After #980/#982/#983 were merged into the stacked base branch, this PR was
+rebased onto `origin/codex/dingtalk-public-form-save-validation-20260421`.
+Duplicate ancestor commits were skipped during rebase so the PR diff now
+contains only the V1 delivery button slice.
+
+## Scope
+
+This slice is frontend-only.
+
+- No database migration.
+- No backend API contract change.
+- No delivery payload change.
+- No permission model change.
+
+## User Impact
+
+After this change, users can inspect DingTalk delivery records from the automation list even when a rule is configured as a V1 multi-step automation and DingTalk sending is not the top-level legacy action.

--- a/docs/development/dingtalk-v1-delivery-buttons-verification-20260421.md
+++ b/docs/development/dingtalk-v1-delivery-buttons-verification-20260421.md
@@ -1,0 +1,48 @@
+# DingTalk V1 Delivery Buttons Verification - 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Expected Coverage
+
+- Legacy DingTalk group delivery viewer behavior remains covered.
+- V1 multi-action DingTalk group delivery viewer button is visible and opens the group delivery viewer.
+- V1 multi-action DingTalk person delivery viewer button is visible and opens the person delivery viewer.
+- Frontend production build succeeds.
+- Diff whitespace check passes.
+
+## Result
+
+- `pnpm install --frozen-lockfile`: passed.
+- Initial Vitest command before dependency install failed because `vitest` was not available in this new worktree.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false`: passed, 1 file / 49 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Rebase Verification
+
+After rebasing onto the updated stacked base branch:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+Result:
+
+- `multitable-automation-manager.spec.ts`: 50/50 passed.
+- `vue-tsc -b --noEmit`: passed.
+- `git diff --check`: passed.
+
+## Notes
+
+The frontend build emitted existing Vite warnings about `WorkflowDesigner.vue` being both statically and dynamically imported, plus large chunk warnings. These warnings are unrelated to this DingTalk delivery button slice.
+
+`pnpm install` updated local `node_modules` links in several workspace packages. Those generated dependency-directory changes were intentionally left unstaged and are not part of the patch.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -98,6 +98,7 @@ Automation authoring guardrail:
 
 - if a selected public form view is not shared, has no public token, or has expired, the automation editor warns before save
 - if a DingTalk group rule links to a fully public form, the automation editor warns that anyone with the message link can submit
+- if a DingTalk group rule links to a DingTalk-protected form without allowed users or member groups, the editor warns that all bound or authorized DingTalk users can submit
 - the warning is advisory; runtime delivery still performs the backend validation before sending the link
 
 Supported access modes:
@@ -133,6 +134,7 @@ Behavior:
 - the visitor must pass the selected DingTalk protection mode first
 - the system then resolves the local user
 - the local user must be directly allowed or belong to an allowed member group
+- without an allowlist, `Bound DingTalk users only` admits all bound DingTalk local users and `Authorized DingTalk users only` admits all locally authorized DingTalk users
 
 Important rule:
 
@@ -204,6 +206,7 @@ Use:
 Authoring guardrail:
 
 - if the selected form is still fully public, the DingTalk group rule editor warns before save
+- if the selected protected form has no allowed users or member groups, the DingTalk group rule editor warns before save
 - switch the form to `Bound DingTalk users only` or `Authorized DingTalk users only` before relying on allowlists
 
 ### Scenario 3: Notify specific staff only

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -96,10 +96,15 @@ Management-side UI path:
 
 Automation authoring guardrail:
 
-- if a selected public form view is not shared, has no public token, or has expired, the automation editor warns before save
+- if a selected public form view is not shared, has no public token, or has expired, the automation editor warns and disables save
+- if a selected internal processing view is no longer in the current sheet, the automation editor warns and disables save
 - if a DingTalk group rule links to a fully public form, the automation editor warns that anyone with the message link can submit
 - if a DingTalk group rule links to a DingTalk-protected form without allowed users or member groups, the editor warns that all bound or authorized DingTalk users can submit
+- the message summary shows `Public form access`, including fully public, bound DingTalk users, authorized DingTalk users, and allowlist-constrained states
 - the warning is advisory; runtime delivery still performs the backend validation before sending the link
+- automation create/update APIs reject invalid public form or internal processing links before saving
+- runtime delivery refuses non-form public views and expired public-form shares before sending DingTalk messages
+- runtime delivery refuses missing internal processing views before sending DingTalk messages
 
 Supported access modes:
 
@@ -207,6 +212,7 @@ Authoring guardrail:
 
 - if the selected form is still fully public, the DingTalk group rule editor warns before save
 - if the selected protected form has no allowed users or member groups, the DingTalk group rule editor warns before save
+- check `Public form access` in the automation message summary before saving
 - switch the form to `Bound DingTalk users only` or `Authorized DingTalk users only` before relying on allowlists
 
 ### Scenario 3: Notify specific staff only

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -223,7 +223,8 @@ This is the preferred implementation for:
 Authoring guardrail:
 
 - group-message automations warn when the selected public form link is still fully public
-- the warning directs owners toward DingTalk-protected access plus allowlists
+- group-message automations warn when a DingTalk-protected form has no allowed users or member groups
+- the warnings direct owners toward DingTalk-protected access plus allowlists
 
 ## Current limitations
 

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -100,6 +100,11 @@ Protected forms still use the existing create-only public-form model:
 - public form != view the internal table
 - public form != edit existing records
 
+Runtime guardrail:
+
+- DingTalk automation delivery only emits public-form links for same-sheet form views with active sharing
+- expired public-form sharing is rejected before sending the DingTalk message
+
 ### 6. Protected public-form allowlists
 
 Implemented in the current protected-public-form branch:
@@ -222,8 +227,12 @@ This is the preferred implementation for:
 
 Authoring guardrail:
 
+- group-message and person-message automations disable save when the selected public form link cannot produce a working fill link
+- group-message and person-message automations disable save when the selected internal processing view is not in the current sheet
+- automation create/update APIs reject invalid public form or internal processing links before rules are saved
 - group-message automations warn when the selected public form link is still fully public
 - group-message automations warn when a DingTalk-protected form has no allowed users or member groups
+- group-message and person-message automation previews show the selected public form access range before save
 - the warnings direct owners toward DingTalk-protected access plus allowlists
 
 ## Current limitations

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -222,6 +222,20 @@ function parseViewConfig(raw: unknown): Record<string, unknown> | null {
   return typeof raw === 'object' && !Array.isArray(raw) ? raw as Record<string, unknown> : null
 }
 
+function parsePublicFormExpiryMs(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (value instanceof Date) return value.getTime()
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (/^\d+$/.test(trimmed)) {
+    const numeric = Number(trimmed)
+    return Number.isFinite(numeric) ? numeric : null
+  }
+  const parsed = Date.parse(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 function resolveAutomationAppBaseUrl(): string | null {
   const raw = process.env.PUBLIC_APP_URL?.trim() || process.env.APP_BASE_URL?.trim() || ''
   if (!raw) return null
@@ -751,7 +765,7 @@ export class AutomationExecutor {
       const publicViewResult = await this.deps.queryFn(
         `SELECT id, sheet_id, config
            FROM meta_views
-          WHERE id = $1 AND sheet_id = $2`,
+          WHERE id = $1 AND sheet_id = $2 AND type = 'form'`,
         [publicFormViewId, context.sheetId],
       )
       const publicView = (publicViewResult.rows[0] ?? null) as {
@@ -779,6 +793,18 @@ export class AutomationExecutor {
           actionType: 'send_dingtalk_person_message',
           status: 'failed',
           error: 'Selected public form view is not shared',
+        }
+      }
+      const expiryMs = parsePublicFormExpiryMs(
+        publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
+          ? (publicForm as Record<string, unknown>).expiresAt ?? (publicForm as Record<string, unknown>).expiresOn
+          : undefined,
+      )
+      if (expiryMs !== null && Date.now() >= expiryMs) {
+        return {
+          actionType: 'send_dingtalk_person_message',
+          status: 'failed',
+          error: 'Selected public form view has expired',
         }
       }
 
@@ -1139,7 +1165,7 @@ export class AutomationExecutor {
       const publicViewResult = await this.deps.queryFn(
         `SELECT id, sheet_id, config
            FROM meta_views
-          WHERE id = $1 AND sheet_id = $2`,
+          WHERE id = $1 AND sheet_id = $2 AND type = 'form'`,
         [publicFormViewId, context.sheetId],
       )
       const publicView = (publicViewResult.rows[0] ?? null) as {
@@ -1167,6 +1193,18 @@ export class AutomationExecutor {
           actionType: 'send_dingtalk_group_message',
           status: 'failed',
           error: 'Selected public form view is not shared',
+        }
+      }
+      const expiryMs = parsePublicFormExpiryMs(
+        publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
+          ? (publicForm as Record<string, unknown>).expiresAt ?? (publicForm as Record<string, unknown>).expiresOn
+          : undefined,
+      )
+      if (expiryMs !== null && Date.now() >= expiryMs) {
+        return {
+          actionType: 'send_dingtalk_group_message',
+          status: 'failed',
+          error: 'Selected public form view has expired',
         }
       }
 

--- a/packages/core-backend/src/multitable/dingtalk-automation-link-validation.ts
+++ b/packages/core-backend/src/multitable/dingtalk-automation-link-validation.ts
@@ -1,0 +1,143 @@
+export type AutomationLinkQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> {
+  if (isPlainObject(value)) return value
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      return isPlainObject(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
+function parsePublicFormExpiryMs(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (value instanceof Date) return value.getTime()
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (/^\d+$/.test(trimmed)) {
+    const numeric = Number(trimmed)
+    return Number.isFinite(numeric) ? numeric : null
+  }
+  const parsed = Date.parse(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function collectDingTalkActionConfigs(
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+): Record<string, unknown>[] {
+  const configs: Record<string, unknown>[] = []
+  const addIfDingTalkAction = (type: unknown, config: unknown) => {
+    if (type !== 'send_dingtalk_group_message' && type !== 'send_dingtalk_person_message') return
+    if (isPlainObject(config)) configs.push(config)
+  }
+
+  addIfDingTalkAction(actionType, actionConfig)
+  if (Array.isArray(actions)) {
+    for (const item of actions) {
+      if (!isPlainObject(item)) continue
+      addIfDingTalkAction(item.type, item.config)
+    }
+  }
+
+  return configs
+}
+
+export function collectDingTalkAutomationLinkIds(
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+): { publicFormViewIds: string[]; internalViewIds: string[] } {
+  const publicFormViewIds: string[] = []
+  const internalViewIds: string[] = []
+
+  for (const config of collectDingTalkActionConfigs(actionType, actionConfig, actions)) {
+    const publicFormViewId = typeof config.publicFormViewId === 'string' ? config.publicFormViewId.trim() : ''
+    const internalViewId = typeof config.internalViewId === 'string' ? config.internalViewId.trim() : ''
+    if (publicFormViewId) publicFormViewIds.push(publicFormViewId)
+    if (internalViewId) internalViewIds.push(internalViewId)
+  }
+
+  return {
+    publicFormViewIds: Array.from(new Set(publicFormViewIds)),
+    internalViewIds: Array.from(new Set(internalViewIds)),
+  }
+}
+
+export async function validateDingTalkAutomationLinks(
+  query: AutomationLinkQueryFn,
+  sheetId: string,
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+  nowMs = Date.now(),
+): Promise<string | null> {
+  const { publicFormViewIds, internalViewIds } = collectDingTalkAutomationLinkIds(actionType, actionConfig, actions)
+
+  if (publicFormViewIds.length > 0) {
+    const result = await query(
+      `SELECT id::text AS id, type, config
+         FROM meta_views
+        WHERE sheet_id = $1
+          AND id::text = ANY($2::text[])`,
+      [sheetId, publicFormViewIds],
+    )
+    const viewEntries: Array<[string, Record<string, unknown>]> = []
+    for (const row of result.rows) {
+      if (!isPlainObject(row)) continue
+      const id = typeof row.id === 'string' ? row.id.trim() : ''
+      if (id) viewEntries.push([id, row])
+    }
+    const viewsById = new Map<string, Record<string, unknown>>(viewEntries)
+
+    for (const id of publicFormViewIds) {
+      const view = viewsById.get(id)
+      if (!view) return `Public form view not found: ${id}`
+      if (view.type !== 'form') return `Public form view is not a form view: ${id}`
+
+      const viewConfig = parseJsonObject(view.config)
+      const publicForm = isPlainObject(viewConfig.publicForm) ? viewConfig.publicForm : null
+      const publicToken = typeof publicForm?.publicToken === 'string' ? publicForm.publicToken.trim() : ''
+      if (publicForm?.enabled !== true || !publicToken) {
+        return `Selected public form view is not shared: ${id}`
+      }
+
+      const expiryMs = parsePublicFormExpiryMs(publicForm.expiresAt ?? publicForm.expiresOn)
+      if (expiryMs !== null && nowMs >= expiryMs) {
+        return `Selected public form view has expired: ${id}`
+      }
+    }
+  }
+
+  if (internalViewIds.length > 0) {
+    const result = await query(
+      `SELECT id::text AS id
+         FROM meta_views
+        WHERE sheet_id = $1
+          AND id::text = ANY($2::text[])`,
+      [sheetId, internalViewIds],
+    )
+    const foundIds = new Set(
+      result.rows
+        .map((row) => (isPlainObject(row) && typeof row.id === 'string' ? row.id.trim() : ''))
+        .filter(Boolean),
+    )
+    const missingIds = internalViewIds.filter((id) => !foundIds.has(id))
+    if (missingIds.length > 0) return `Internal processing view not found: ${missingIds.join(', ')}`
+  }
+
+  return null
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -32,6 +32,7 @@ import { validateRecord, getDefaultValidationRules } from '../multitable/field-v
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import { getAutomationServiceInstance } from '../multitable/automation-service'
+import { validateDingTalkAutomationLinks } from '../multitable/dingtalk-automation-link-validation'
 import { listAutomationDingTalkGroupDeliveries } from '../multitable/dingtalk-group-delivery-service'
 import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
@@ -8356,6 +8357,16 @@ export function univerMetaRouter(): Router {
 
       const conditions = body?.conditions && typeof body.conditions === 'object' ? body.conditions as never : null
       const actions = Array.isArray(body?.actions) ? body.actions : null
+      const linkValidationError = await validateDingTalkAutomationLinks(
+        pool.query.bind(pool),
+        sheetId,
+        actionType,
+        actionConfig,
+        actions,
+      )
+      if (linkValidationError) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: linkValidationError } })
+      }
 
       const rule = await automationService.createRule(sheetId, {
         name,
@@ -8441,6 +8452,30 @@ export function univerMetaRouter(): Router {
 
       if (Object.keys(updates).length === 0) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'No fields to update' } })
+      }
+
+      if (typeof body?.actionType === 'string' || (body?.actionConfig && typeof body.actionConfig === 'object') || body?.actions !== undefined) {
+        const existing = await automationService.getRule(ruleId)
+        if (!existing || existing.sheet_id !== sheetId) {
+          return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
+        }
+        const nextActionType = typeof body?.actionType === 'string' ? body.actionType : existing.action_type
+        const nextActionConfig = body?.actionConfig && typeof body.actionConfig === 'object'
+          ? body.actionConfig
+          : existing.action_config
+        const nextActions = body?.actions !== undefined
+          ? Array.isArray(body.actions) ? body.actions : null
+          : existing.actions
+        const linkValidationError = await validateDingTalkAutomationLinks(
+          pool.query.bind(pool),
+          sheetId,
+          nextActionType,
+          nextActionConfig,
+          nextActions,
+        )
+        if (linkValidationError) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: linkValidationError } })
+        }
       }
 
       const updated = await automationService.updateRule(ruleId, sheetId, {

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -1,0 +1,370 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type QueryResult = {
+  rows: any[]
+  rowCount?: number
+}
+
+type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
+
+const SHEET_ID = 'sheet_dingtalk_links'
+const OTHER_SHEET_ID = 'sheet_other'
+const VALID_FORM_VIEW_ID = 'view_form_valid'
+const DISABLED_FORM_VIEW_ID = 'view_form_disabled'
+const EXPIRED_FORM_VIEW_ID = 'view_form_expired'
+const OTHER_SHEET_FORM_VIEW_ID = 'view_form_other_sheet'
+const INTERNAL_VIEW_ID = 'view_internal_grid'
+const MISSING_INTERNAL_VIEW_ID = 'view_internal_missing'
+const RULE_ID = 'rule_dingtalk_links'
+
+type ViewRow = {
+  id: string
+  sheet_id: string
+  type: string
+  config: Record<string, unknown> | string
+}
+
+function makePublicFormConfig(options: {
+  enabled?: boolean
+  token?: string
+  expiresAt?: number
+  accessMode?: string
+} = {}): Record<string, unknown> {
+  return {
+    publicForm: {
+      enabled: options.enabled ?? true,
+      publicToken: options.token ?? 'pub_valid_token',
+      accessMode: options.accessMode ?? 'public',
+      ...(options.expiresAt !== undefined ? { expiresAt: options.expiresAt } : {}),
+    },
+  }
+}
+
+function makeViewRows(nowMs = Date.now()): ViewRow[] {
+  return [
+    {
+      id: VALID_FORM_VIEW_ID,
+      sheet_id: SHEET_ID,
+      type: 'form',
+      config: makePublicFormConfig(),
+    },
+    {
+      id: DISABLED_FORM_VIEW_ID,
+      sheet_id: SHEET_ID,
+      type: 'form',
+      config: makePublicFormConfig({ enabled: false }),
+    },
+    {
+      id: EXPIRED_FORM_VIEW_ID,
+      sheet_id: SHEET_ID,
+      type: 'form',
+      config: makePublicFormConfig({ expiresAt: nowMs - 1_000 }),
+    },
+    {
+      id: OTHER_SHEET_FORM_VIEW_ID,
+      sheet_id: OTHER_SHEET_ID,
+      type: 'form',
+      config: makePublicFormConfig(),
+    },
+    {
+      id: INTERNAL_VIEW_ID,
+      sheet_id: SHEET_ID,
+      type: 'grid',
+      config: {},
+    },
+  ]
+}
+
+function createDingTalkLinkQueryHandler(views = makeViewRows()): QueryHandler {
+  return (sql, params) => {
+    if (sql.includes('FROM meta_views') && sql.includes('id::text = ANY')) {
+      const sheetId = typeof params?.[0] === 'string' ? params[0] : ''
+      const ids = Array.isArray(params?.[1]) ? params[1].map(String) : []
+      const rows = views
+        .filter((view) => view.sheet_id === sheetId && ids.includes(view.id))
+        .map((view) => ({
+          id: view.id,
+          type: view.type,
+          config: view.config,
+        }))
+      return { rows, rowCount: rows.length }
+    }
+
+    return { rows: [], rowCount: 0 }
+  }
+}
+
+function createMockPool(queryHandler: QueryHandler) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (
+      sql.includes('FROM spreadsheet_permissions')
+      || sql.includes('FROM field_permissions')
+      || sql.includes('FROM view_permissions')
+      || sql.includes('FROM meta_view_permissions')
+      || sql.includes('FROM record_permissions')
+      || sql.includes('FROM formula_dependencies')
+    ) {
+      return { rows: [], rowCount: 0 }
+    }
+    return queryHandler(sql, params)
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+function makeAutomationRule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RULE_ID,
+    sheet_id: SHEET_ID,
+    name: 'DingTalk rule',
+    trigger_type: 'record.created',
+    trigger_config: {},
+    action_type: 'send_dingtalk_group_message',
+    action_config: {},
+    enabled: true,
+    created_at: '2026-04-21T00:00:00.000Z',
+    updated_at: '2026-04-21T00:00:00.000Z',
+    created_by: 'admin_1',
+    conditions: null,
+    actions: null,
+    ...overrides,
+  }
+}
+
+function createMockAutomationService(existingRule = makeAutomationRule()) {
+  return {
+    createRule: vi.fn(async (sheetId: string, input: Record<string, unknown>) => makeAutomationRule({
+      sheet_id: sheetId,
+      name: input.name ?? null,
+      trigger_type: input.triggerType,
+      trigger_config: input.triggerConfig,
+      action_type: input.actionType,
+      action_config: input.actionConfig,
+      enabled: input.enabled,
+      created_by: input.createdBy,
+      conditions: input.conditions,
+      actions: input.actions,
+    })),
+    getRule: vi.fn(async (ruleId: string) => ruleId === RULE_ID ? existingRule : null),
+    updateRule: vi.fn(async (ruleId: string, sheetId: string, input: Record<string, unknown>) => makeAutomationRule({
+      id: ruleId,
+      sheet_id: sheetId,
+      action_type: input.actionType ?? existingRule.action_type,
+      action_config: input.actionConfig ?? existingRule.action_config,
+      actions: input.actions ?? existingRule.actions,
+      enabled: input.enabled ?? existingRule.enabled,
+    })),
+  }
+}
+
+async function createApp(options: {
+  queryHandler?: QueryHandler
+  automationService?: ReturnType<typeof createMockAutomationService>
+} = {}) {
+  vi.resetModules()
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(true),
+    userHasPermission: vi.fn().mockResolvedValue(true),
+    listUserPermissions: vi.fn().mockResolvedValue(['workflow:write', 'multitable:write']),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { setAutomationServiceInstance } = await import('../../src/multitable/automation-service')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+
+  const mockPool = createMockPool(options.queryHandler ?? createDingTalkLinkQueryHandler())
+  const automationService = options.automationService ?? createMockAutomationService()
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
+  setAutomationServiceInstance(automationService as any)
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = {
+      id: 'admin_1',
+      role: 'admin',
+      roles: ['admin'],
+      perms: ['workflow:write', 'multitable:write'],
+    }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+
+  return { app, mockPool, automationService, setAutomationServiceInstance }
+}
+
+describe('DingTalk automation link route validation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('rejects a cross-sheet public form link on automation create before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify group',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'group_1',
+          title: 'Please fill',
+          content: 'Open form',
+          publicFormViewId: OTHER_SHEET_FORM_VIEW_ID,
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: `Public form view not found: ${OTHER_SHEET_FORM_VIEW_ID}`,
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('persists a DingTalk group rule when public form and internal links are valid', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify group',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'group_1',
+          title: 'Please fill',
+          content: 'Open form',
+          publicFormViewId: VALID_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        },
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: expect.objectContaining({
+        publicFormViewId: VALID_FORM_VIEW_ID,
+        internalViewId: INTERNAL_VIEW_ID,
+      }),
+    }))
+  })
+
+  it('rejects an invalid internal processing link on automation create before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify group',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'group_1',
+          title: 'Please process',
+          content: 'Open internal link',
+          internalViewId: MISSING_INTERNAL_VIEW_ID,
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: `Internal processing view not found: ${MISSING_INTERNAL_VIEW_ID}`,
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('validates V1 actions on automation create', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Multi action rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        actions: [
+          {
+            type: 'send_dingtalk_group_message',
+            config: {
+              destinationId: 'group_1',
+              title: 'Please fill',
+              content: 'Open form',
+              publicFormViewId: DISABLED_FORM_VIEW_ID,
+            },
+          },
+        ],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: `Selected public form view is not shared: ${DISABLED_FORM_VIEW_ID}`,
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('validates the merged DingTalk link state on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'send_dingtalk_person_message',
+      action_config: {
+        title: 'Old title',
+        content: 'Old content',
+        publicFormViewId: VALID_FORM_VIEW_ID,
+      },
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actionConfig: {
+          title: 'New title',
+          content: 'New content',
+          publicFormViewId: EXPIRED_FORM_VIEW_ID,
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: `Selected public form view has expired: ${EXPIRED_FORM_VIEW_ID}`,
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
+  it('does not revalidate DingTalk links for enable-only updates', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_config: {
+        publicFormViewId: EXPIRED_FORM_VIEW_ID,
+      },
+    }))
+    const { app, mockPool } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({ enabled: false })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.getRule).not.toHaveBeenCalled()
+    expect(automationService.updateRule).toHaveBeenCalledWith(RULE_ID, SHEET_ID, expect.objectContaining({
+      enabled: false,
+    }))
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('FROM meta_views'))).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -443,6 +443,7 @@ describe('AutomationExecutor', () => {
     expect(String(queryFn.mock.calls[0]?.[0] ?? '')).toContain('sheet_id = $2')
     expect(String(queryFn.mock.calls[0]?.[0] ?? '')).toContain('created_by = $3')
     expect(queryFn.mock.calls[0]?.[1]).toEqual([['dt_1'], 'sheet_1', 'user_1'])
+    expect(String(queryFn.mock.calls[1]?.[0] ?? '')).toContain("type = 'form'")
 
     const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('https://oapi.dingtalk.com/robot/send?access_token=test')
@@ -453,6 +454,47 @@ describe('AutomationExecutor', () => {
     expect(payload.markdown.text).toContain('/multitable/public-form/sheet_1/view_form?publicToken=public-token')
     expect(payload.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
     expect((queryFn.mock.calls[3]?.[0] as string) ?? '').toContain('INSERT INTO dingtalk_group_deliveries')
+  })
+
+  it('fails send_dingtalk_group_message when the internal processing view is not in the sheet', async () => {
+    process.env.APP_BASE_URL = 'https://app.example.com'
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+          internalViewId: 'missing_view',
+        },
+      }],
+    })
+
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('Internal view not found')
+    expect(String(queryFn.mock.calls[1]?.[0] ?? '')).toContain('sheet_id = $2')
+    expect(queryFn.mock.calls[1]?.[1]).toEqual(['missing_view', 'sheet_1'])
+    expect(fetchFn).not.toHaveBeenCalled()
   })
 
   it('executes send_dingtalk_group_message across multiple destinations', async () => {
@@ -671,6 +713,51 @@ describe('AutomationExecutor', () => {
     expect(result.steps[0].error).toContain('dt_missing')
   })
 
+  it('fails send_dingtalk_group_message when the selected public form share is expired', async () => {
+    process.env.APP_BASE_URL = 'https://app.example.com'
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'view_form',
+          sheet_id: 'sheet_1',
+          config: { publicForm: { enabled: true, publicToken: 'public-token', expiresAt: '2000-01-01T00:00:00.000Z' } },
+        }],
+      })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Title',
+          bodyTemplate: 'Body',
+          publicFormViewId: 'view_form',
+        },
+      }],
+    })
+
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('Selected public form view has expired')
+    expect(String(queryFn.mock.calls[1]?.[0] ?? '')).toContain("type = 'form'")
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
   it('scopes send_dingtalk_group_message destinations to the current sheet and rule creator', async () => {
     const queryFn = vi.fn(async (sql: string, params?: unknown[]) => {
       expect(sql).toContain('sheet_id = $2')
@@ -785,6 +872,7 @@ describe('AutomationExecutor', () => {
     expect(result.status).toBe('success')
     expect(result.steps[0].actionType).toBe('send_dingtalk_person_message')
     expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(String(queryFn.mock.calls[0]?.[0] ?? '')).toContain("type = 'form'")
     const [, sendInit] = fetchFn.mock.calls[1] as [string, RequestInit]
     const payload = JSON.parse(sendInit.body as string)
     expect(payload.userid_list).toBe('dt-user-1,dt-user-2')
@@ -792,6 +880,85 @@ describe('AutomationExecutor', () => {
     expect(payload.msg.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
     const insertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
     expect(insertCalls).toHaveLength(2)
+  })
+
+  it('fails send_dingtalk_person_message when the internal processing view is not in the sheet', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+    process.env.APP_BASE_URL = 'https://app.example.com'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+          internalViewId: 'missing_view',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('Internal view not found')
+    expect(String(queryFn.mock.calls[0]?.[0] ?? '')).toContain('sheet_id = $2')
+    expect(queryFn.mock.calls[0]?.[1]).toEqual(['missing_view', 'sheet_1'])
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('fails send_dingtalk_person_message when the selected public form view is not a form view', async () => {
+    process.env.APP_BASE_URL = 'https://app.example.com'
+    const queryFn = vi.fn(async (sql: string, params?: unknown[]) => {
+      expect(sql).toContain("type = 'form'")
+      expect(params).toEqual(['view_grid', 'sheet_1'])
+      return { rows: [], rowCount: 0 }
+    })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          titleTemplate: 'Title',
+          bodyTemplate: 'Body',
+          publicFormViewId: 'view_grid',
+        },
+      }],
+    })
+
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('Public form view not found')
+    expect(fetchFn).not.toHaveBeenCalled()
   })
 
   it('executes send_dingtalk_person_message for member group recipients', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-automation-link-validation.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-automation-link-validation.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  collectDingTalkAutomationLinkIds,
+  validateDingTalkAutomationLinks,
+  type AutomationLinkQueryFn,
+} from '../../src/multitable/dingtalk-automation-link-validation'
+
+const nowMs = Date.parse('2026-04-21T00:00:00.000Z')
+
+function queryWithRows(rowsByCall: unknown[][]): AutomationLinkQueryFn {
+  const query = vi.fn(async () => ({ rows: rowsByCall.shift() ?? [] }))
+  return query as unknown as AutomationLinkQueryFn
+}
+
+describe('dingtalk automation link validation', () => {
+  it('collects public form and internal view ids from legacy and multi-action configs', () => {
+    expect(collectDingTalkAutomationLinkIds(
+      'send_dingtalk_group_message',
+      { publicFormViewId: ' view_form ', internalViewId: 'view_grid' },
+      [
+        { type: 'send_dingtalk_person_message', config: { publicFormViewId: 'view_person_form', internalViewId: 'view_person_grid' } },
+        { type: 'notify', config: { publicFormViewId: 'ignored' } },
+      ],
+    )).toEqual({
+      publicFormViewIds: ['view_form', 'view_person_form'],
+      internalViewIds: ['view_grid', 'view_person_grid'],
+    })
+  })
+
+  it('allows active public form links and internal processing links in the current sheet', async () => {
+    const query = queryWithRows([
+      [
+        {
+          id: 'view_form',
+          type: 'form',
+          config: { publicForm: { enabled: true, publicToken: 'pub_view_form', accessMode: 'public' } },
+        },
+      ],
+      [{ id: 'view_grid' }],
+    ])
+
+    await expect(validateDingTalkAutomationLinks(
+      query,
+      'sheet_1',
+      'send_dingtalk_group_message',
+      { publicFormViewId: 'view_form', internalViewId: 'view_grid' },
+      null,
+      nowMs,
+    )).resolves.toBeNull()
+  })
+
+  it('allows DingTalk-protected public forms with or without allowlists', async () => {
+    const query = queryWithRows([
+      [
+        {
+          id: 'view_bound',
+          type: 'form',
+          config: { publicForm: { enabled: true, publicToken: 'pub_bound', accessMode: 'dingtalk' } },
+        },
+        {
+          id: 'view_granted',
+          type: 'form',
+          config: { publicForm: { enabled: true, publicToken: 'pub_granted', accessMode: 'dingtalk_granted', allowedUserIds: ['user_1'] } },
+        },
+      ],
+    ])
+
+    await expect(validateDingTalkAutomationLinks(
+      query,
+      'sheet_1',
+      'send_dingtalk_group_message',
+      {},
+      [
+        { type: 'send_dingtalk_group_message', config: { publicFormViewId: 'view_bound' } },
+        { type: 'send_dingtalk_person_message', config: { publicFormViewId: 'view_granted' } },
+      ],
+      nowMs,
+    )).resolves.toBeNull()
+  })
+
+  it('rejects missing public form views', async () => {
+    const query = queryWithRows([[]])
+
+    await expect(validateDingTalkAutomationLinks(
+      query,
+      'sheet_1',
+      'send_dingtalk_group_message',
+      { publicFormViewId: 'missing_view' },
+      null,
+      nowMs,
+    )).resolves.toBe('Public form view not found: missing_view')
+  })
+
+  it('rejects public form links that point to non-form views', async () => {
+    const query = queryWithRows([[{ id: 'view_grid', type: 'grid', config: {} }]])
+
+    await expect(validateDingTalkAutomationLinks(
+      query,
+      'sheet_1',
+      'send_dingtalk_group_message',
+      { publicFormViewId: 'view_grid' },
+      null,
+      nowMs,
+    )).resolves.toBe('Public form view is not a form view: view_grid')
+  })
+
+  it('rejects public form links without active sharing or public tokens', async () => {
+    const disabledQuery = queryWithRows([[
+      { id: 'view_disabled', type: 'form', config: { publicForm: { enabled: false, publicToken: 'pub_disabled' } } },
+    ]])
+    await expect(validateDingTalkAutomationLinks(
+      disabledQuery,
+      'sheet_1',
+      'send_dingtalk_group_message',
+      { publicFormViewId: 'view_disabled' },
+      null,
+      nowMs,
+    )).resolves.toBe('Selected public form view is not shared: view_disabled')
+
+    const missingTokenQuery = queryWithRows([[
+      { id: 'view_missing_token', type: 'form', config: { publicForm: { enabled: true, publicToken: ' ' } } },
+    ]])
+    await expect(validateDingTalkAutomationLinks(
+      missingTokenQuery,
+      'sheet_1',
+      'send_dingtalk_person_message',
+      { publicFormViewId: 'view_missing_token' },
+      null,
+      nowMs,
+    )).resolves.toBe('Selected public form view is not shared: view_missing_token')
+  })
+
+  it('rejects expired public form links', async () => {
+    const query = queryWithRows([[
+      {
+        id: 'view_expired',
+        type: 'form',
+        config: { publicForm: { enabled: true, publicToken: 'pub_expired', expiresAt: '2026-04-20T00:00:00.000Z' } },
+      },
+    ]])
+
+    await expect(validateDingTalkAutomationLinks(
+      query,
+      'sheet_1',
+      'send_dingtalk_group_message',
+      { publicFormViewId: 'view_expired' },
+      null,
+      nowMs,
+    )).resolves.toBe('Selected public form view has expired: view_expired')
+  })
+
+  it('rejects missing internal processing views after public form validation passes', async () => {
+    const query = queryWithRows([
+      [
+        {
+          id: 'view_form',
+          type: 'form',
+          config: { publicForm: { enabled: true, publicToken: 'pub_view_form' } },
+        },
+      ],
+      [],
+    ])
+
+    await expect(validateDingTalkAutomationLinks(
+      query,
+      'sheet_1',
+      'send_dingtalk_group_message',
+      { publicFormViewId: 'view_form', internalViewId: 'missing_internal' },
+      null,
+      nowMs,
+    )).resolves.toBe('Internal processing view not found: missing_internal')
+  })
+})


### PR DESCRIPTION
## Summary
- Warn DingTalk group-message automation authors when a DingTalk-protected public form has no allowed users or member groups.
- Distinguish `dingtalk` and `dingtalk_granted` copy so owners understand whether all bound or all authorized DingTalk users can submit.
- Keep fully-public link warnings and invalid-link warnings intact, and keep DingTalk person-message selectors out of this new allowlist warning.
- Update DingTalk operator/capability docs and add development + verification notes.

## Verification
- `pnpm install --frozen-lockfile`
- Initial focused test attempt before install failed with `Command "vitest" not found` in the fresh worktree.
- `pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false` (3 files, 80 tests passed)
- `pnpm --filter @metasheet/web build`
- `git diff --check`
- `git diff --cached --check`

## Notes
- Stacked on #972 (`codex/dingtalk-public-form-access-guardrail-20260421`).
- No backend/API/schema changes, no migration.
- Worktree-local `node_modules` noise was not staged.