### PR TITLE
fix(collab): notify Yjs clients after REST invalidation

### DIFF
--- a/apps/web/src/multitable/composables/useYjsDocument.ts
+++ b/apps/web/src/multitable/composables/useYjsDocument.ts
@@ -175,6 +175,12 @@ export function useYjsDocument(recordId: Ref<string | null>, options: UseYjsDocu
       error.value = `${code}: ${msg}`
     })
 
+    socket.on('yjs:invalidated', ({ recordId: rid2 }: { recordId: string; reason?: string }) => {
+      if (rid2 !== currentRecordId) return
+      error.value = 'INVALIDATED: document invalidated by REST write'
+      disconnect()
+    })
+
     socket.on('disconnect', () => {
       connected.value = false
       synced.value = false

--- a/apps/web/src/multitable/composables/useYjsDocument.ts
+++ b/apps/web/src/multitable/composables/useYjsDocument.ts
@@ -175,7 +175,10 @@ export function useYjsDocument(recordId: Ref<string | null>, options: UseYjsDocu
       error.value = `${code}: ${msg}`
     })
 
-    socket.on('yjs:invalidated', ({ recordId: rid2 }: { recordId: string; reason?: string }) => {
+    socket.on('yjs:invalidated', (payload: unknown) => {
+      if (!payload || typeof payload !== 'object') return
+      const rid2 = (payload as { recordId?: unknown }).recordId
+      if (typeof rid2 !== 'string') return
       if (rid2 !== currentRecordId) return
       error.value = 'INVALIDATED: document invalidated by REST write'
       disconnect()

--- a/apps/web/tests/yjs-document-invalidation.spec.ts
+++ b/apps/web/tests/yjs-document-invalidation.spec.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, shallowRef, type App } from 'vue'
+
+type Handler = (...args: any[]) => void
+const handlers = new Map<string, Handler>()
+const emitMock = vi.fn()
+const disconnectMock = vi.fn()
+const ioMock = vi.fn(() => ({
+  connected: true,
+  on: (event: string, handler: Handler) => {
+    handlers.set(event, handler)
+  },
+  emit: emitMock,
+  disconnect: disconnectMock,
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: (...args: unknown[]) => ioMock(...args),
+}))
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getToken: vi.fn(() => 'jwt-token'),
+    getCurrentUserId: vi.fn().mockResolvedValue('user_self'),
+  }),
+}))
+
+import { useYjsDocument } from '../src/multitable/composables/useYjsDocument'
+
+async function flushUi(cycles = 8): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('useYjsDocument invalidation event', () => {
+  let app: App<Element> | null = null
+
+  beforeEach(() => {
+    handlers.clear()
+    emitMock.mockReset()
+    disconnectMock.mockReset()
+    ioMock.mockClear()
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    app = null
+  })
+
+  function mountDocument(recordId = 'rec_1') {
+    let apiRef: ReturnType<typeof useYjsDocument> | null = null
+    const recordRef = shallowRef<string | null>(recordId)
+
+    app = createApp(defineComponent({
+      setup() {
+        apiRef = useYjsDocument(recordRef as any)
+        return () => h('div')
+      },
+    }))
+    app.mount(document.createElement('div'))
+
+    return {
+      get api() {
+        if (!apiRef) throw new Error('api not mounted')
+        return apiRef
+      },
+      recordRef,
+    }
+  }
+
+  it('disconnects the current Yjs document when the server invalidates its record', async () => {
+    const { api } = mountDocument('rec_1')
+    await flushUi()
+
+    expect(ioMock).toHaveBeenCalledTimes(1)
+    expect(api.doc.value).not.toBeNull()
+
+    handlers.get('connect')?.()
+    await flushUi()
+    expect(api.connected.value).toBe(true)
+
+    handlers.get('yjs:invalidated')?.({ recordId: 'rec_1', reason: 'rest-write' })
+    await flushUi()
+
+    expect(emitMock).toHaveBeenCalledWith('yjs:unsubscribe', { recordId: 'rec_1' })
+    expect(disconnectMock).toHaveBeenCalledTimes(1)
+    expect(api.doc.value).toBeNull()
+    expect(api.connected.value).toBe(false)
+    expect(api.synced.value).toBe(false)
+    expect(api.error.value).toBe('INVALIDATED: document invalidated by REST write')
+  })
+
+  it('ignores invalidation events for another record', async () => {
+    const { api } = mountDocument('rec_1')
+    await flushUi()
+
+    handlers.get('connect')?.()
+    await flushUi()
+
+    handlers.get('yjs:invalidated')?.({ recordId: 'rec_other', reason: 'rest-write' })
+    await flushUi()
+
+    expect(disconnectMock).not.toHaveBeenCalled()
+    expect(api.doc.value).not.toBeNull()
+    expect(api.connected.value).toBe(true)
+    expect(api.error.value).toBeNull()
+  })
+})

--- a/apps/web/tests/yjs-document-invalidation.spec.ts
+++ b/apps/web/tests/yjs-document-invalidation.spec.ts
@@ -107,4 +107,23 @@ describe('useYjsDocument invalidation event', () => {
     expect(api.connected.value).toBe(true)
     expect(api.error.value).toBeNull()
   })
+
+  it('ignores malformed invalidation payloads without throwing', async () => {
+    const { api } = mountDocument('rec_1')
+    await flushUi()
+
+    handlers.get('connect')?.()
+    await flushUi()
+
+    const invalidatedHandler = handlers.get('yjs:invalidated')
+    expect(() => invalidatedHandler?.(undefined)).not.toThrow()
+    expect(() => invalidatedHandler?.('rec_1')).not.toThrow()
+    expect(() => invalidatedHandler?.({ recordId: 123 })).not.toThrow()
+    await flushUi()
+
+    expect(disconnectMock).not.toHaveBeenCalled()
+    expect(api.doc.value).not.toBeNull()
+    expect(api.connected.value).toBe(true)
+    expect(api.error.value).toBeNull()
+  })
 })

--- a/docs/development/yjs-rest-invalidation-live-client-event-development-20260421.md
+++ b/docs/development/yjs-rest-invalidation-live-client-event-development-20260421.md
@@ -69,8 +69,10 @@ needed.
   - Calls `yjsWsAdapter.notifyInvalidated(recordIds)` after
     `yjsSyncService.invalidateDocs(recordIds)`.
 - `apps/web/src/multitable/composables/useYjsDocument.ts`
-  - Handles `yjs:invalidated` for the current record by setting error and
-    disconnecting the document.
+  - Handles validated `yjs:invalidated` payloads for the current record by
+    setting error and disconnecting the document.
+  - Ignores malformed / non-object invalidation payloads defensively so a
+    protocol mismatch cannot throw inside the socket event handler.
 - `packages/core-backend/tests/unit/yjs-awareness.test.ts`
   - Covers room-scoped invalidation broadcast.
 - `apps/web/tests/yjs-document-invalidation.spec.ts`
@@ -84,6 +86,7 @@ needed.
   stop using the old in-memory doc.
 - Non-subscribed sockets do not receive the event.
 - Events for another record are ignored client-side.
+- Malformed invalidation payloads are ignored client-side.
 
 ## Remaining Limits
 

--- a/docs/development/yjs-rest-invalidation-live-client-event-development-20260421.md
+++ b/docs/development/yjs-rest-invalidation-live-client-event-development-20260421.md
@@ -1,0 +1,95 @@
+# Yjs REST Invalidation Live Client Event
+
+- Branch: `codex/yjs-invalidation-event-20260421`
+- Date: 2026-04-21
+- Base: `origin/main` after PR `#960`
+- Scope: close the live-editor gap left by REST -> Yjs invalidation.
+
+## Context
+
+PR `#960` made REST writes authoritative over Yjs state by cancelling pending
+bridge flushes, evicting in-memory Y.Docs, and purging persisted snapshots /
+updates. That closed the next-open stale snapshot bug.
+
+The remaining limitation was live clients: an editor already connected to the
+old Y.Doc could keep showing an active collaboration state until it manually
+reconnected or hit another error.
+
+## Change
+
+The backend websocket adapter now exposes:
+
+```ts
+notifyInvalidated(recordIds: string[]): void
+```
+
+It emits this room-scoped payload to each affected record:
+
+```ts
+{
+  recordId,
+  reason: 'rest-write',
+}
+```
+
+Startup wiring now calls the notification in a `finally` block after the
+destructive invalidation attempt:
+
+```text
+cancel pending bridge flushes
+attempt to invalidate in-memory + persisted Yjs doc
+emit yjs:invalidated to yjs:<recordId>
+```
+
+Ordering matters. In the successful path, emitting after purge avoids a client
+reconnecting while stale Yjs state still exists. If persistence purge fails, the
+event is still emitted because `invalidateDocs()` may already have destroyed the
+in-memory server doc; the existing best-effort invalidator error still bubbles to
+the caller's log-and-continue path.
+
+The frontend `useYjsDocument` listens for `yjs:invalidated` for the current
+record, sets an explicit error, and disconnects:
+
+```ts
+error.value = 'INVALIDATED: document invalidated by REST write'
+disconnect()
+```
+
+`useYjsCellBinding` already watches document connectivity and falls back to the
+REST path when the Yjs document disconnects, so no extra grid-level code was
+needed.
+
+## Files Changed
+
+- `packages/core-backend/src/collab/yjs-websocket-adapter.ts`
+  - Adds `YjsInvalidatedPayload`.
+  - Adds `notifyInvalidated(recordIds)` to broadcast `yjs:invalidated` to
+    subscribed sockets in each record room.
+- `packages/core-backend/src/index.ts`
+  - Calls `yjsWsAdapter.notifyInvalidated(recordIds)` after
+    `yjsSyncService.invalidateDocs(recordIds)`.
+- `apps/web/src/multitable/composables/useYjsDocument.ts`
+  - Handles `yjs:invalidated` for the current record by setting error and
+    disconnecting the document.
+- `packages/core-backend/tests/unit/yjs-awareness.test.ts`
+  - Covers room-scoped invalidation broadcast.
+- `apps/web/tests/yjs-document-invalidation.spec.ts`
+  - Covers frontend disconnect on current-record invalidation and ignore for
+    other records.
+
+## Behavior
+
+- REST write still succeeds even if invalidation is best-effort elsewhere.
+- Subscribed live Yjs clients are told their document was invalidated and should
+  stop using the old in-memory doc.
+- Non-subscribed sockets do not receive the event.
+- Events for another record are ignored client-side.
+
+## Remaining Limits
+
+- The event is process-local Socket.IO room broadcast. A future multi-instance
+  Redis adapter rollout must ensure cross-node room delivery before enabling
+  Yjs in a horizontally scaled topology.
+- Clients disconnect/fallback rather than auto-reconnect. That is intentional
+  for this hardening step: reconnect should be an explicit user/editor action so
+  the UI does not silently race with a REST overwrite.

--- a/docs/development/yjs-rest-invalidation-live-client-event-verification-20260421.md
+++ b/docs/development/yjs-rest-invalidation-live-client-event-verification-20260421.md
@@ -1,0 +1,159 @@
+# Verification - Yjs REST Invalidation Live Client Event
+
+- Branch: `codex/yjs-invalidation-event-20260421`
+- Date: 2026-04-21
+- Linked development MD:
+  `docs/development/yjs-rest-invalidation-live-client-event-development-20260421.md`
+
+## Focused Backend Verification
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/yjs-awareness.test.ts \
+  tests/unit/yjs-rest-invalidation.test.ts \
+  --reporter=verbose
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       12 passed (12)
+```
+
+Coverage:
+
+- Existing REST -> Yjs invalidation regression still passes.
+- `invalidateDocs()` still evicts in-memory docs without snapshotting stale
+  content.
+- `YjsRecordBridge.cancelPending()` still prevents debounce re-materialization.
+- New `notifyInvalidated()` event is delivered to sockets subscribed to
+  `yjs:<recordId>`.
+- Connected but unsubscribed sockets do not receive `yjs:invalidated`.
+
+## Focused Frontend Verification
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/yjs-document-invalidation.spec.ts \
+  tests/yjs-document-stale-guard.spec.ts \
+  tests/multitable-yjs-cell-binding.spec.ts \
+  --reporter=verbose
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       8 passed (8)
+```
+
+Coverage:
+
+- Current-record `yjs:invalidated` disconnects the socket, destroys the local
+  Y.Doc, clears connected/synced state, and leaves an explicit invalidation
+  error.
+- Other-record `yjs:invalidated` events are ignored.
+- Existing stale-connect guard and cell-binding fallback behavior still pass.
+
+## Wider Yjs Regression
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/yjs-text-field-diff.spec.ts \
+  tests/yjs-text-field-seed-guard.spec.ts \
+  tests/yjs-document-stale-guard.spec.ts \
+  tests/yjs-document-invalidation.spec.ts \
+  tests/yjs-awareness-presence.spec.ts \
+  tests/multitable-yjs-cell-binding.spec.ts \
+  tests/multitable-yjs-cell-editor.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  7 passed (7)
+Tests       34 passed (34)
+```
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/yjs-poc.test.ts \
+  tests/unit/yjs-hardening.test.ts \
+  tests/unit/yjs-awareness.test.ts \
+  tests/unit/yjs-rest-invalidation.test.ts \
+  tests/unit/record-write-service.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  5 passed (5)
+Tests       71 passed (71)
+```
+
+## Typecheck And Build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result:
+
+```text
+EXIT=0
+```
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+```text
+tsc
+EXIT=0
+```
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+vue-tsc -b && vite build
+✓ 2351 modules transformed.
+✓ built in 5.21s
+EXIT=0
+```
+
+The production build emitted only the existing non-Yjs assets in the default
+flag-off configuration; no `useYjsDocument-*`, `useYjsTextField-*`, or `yjs-*`
+runtime chunk was produced.
+
+## Decision
+
+Code-level verification is green. The next required validation after merge is a
+staging manual check:
+
+1. Open the same text cell through Yjs in one browser.
+2. Update the same record field through REST or another non-Yjs editor path.
+3. Confirm the Yjs editor receives invalidation, disconnects, and falls back to
+   REST instead of continuing to edit the stale Y.Doc.

--- a/docs/development/yjs-rest-invalidation-live-client-event-verification-20260421.md
+++ b/docs/development/yjs-rest-invalidation-live-client-event-verification-20260421.md
@@ -49,7 +49,7 @@ Result:
 
 ```text
 Test Files  3 passed (3)
-Tests       8 passed (8)
+Tests       9 passed (9)
 ```
 
 Coverage:
@@ -58,6 +58,8 @@ Coverage:
   Y.Doc, clears connected/synced state, and leaves an explicit invalidation
   error.
 - Other-record `yjs:invalidated` events are ignored.
+- Malformed invalidation payloads (`undefined`, primitive values, and non-string
+  `recordId`) are ignored without throwing or disconnecting.
 - Existing stale-connect guard and cell-binding fallback behavior still pass.
 
 ## Wider Yjs Regression

--- a/packages/core-backend/src/collab/yjs-websocket-adapter.ts
+++ b/packages/core-backend/src/collab/yjs-websocket-adapter.ts
@@ -36,6 +36,11 @@ export type YjsPresenceSnapshot = {
   users: YjsPresenceUser[]
 }
 
+export type YjsInvalidatedPayload = {
+  recordId: string
+  reason: 'rest-write'
+}
+
 type SocketPresenceState = {
   userId: string
   fieldId: string | null
@@ -106,6 +111,22 @@ export class YjsWebSocketAdapter {
     return {
       activeRecordCount: this.recordPresence.size,
       activeSocketCount: [...this.recordPresence.values()].reduce((total, perRecord) => total + perRecord.size, 0),
+    }
+  }
+
+  /**
+   * Notify live editors that their in-memory Y.Doc was invalidated by an
+   * authoritative REST write. Clients should disconnect and fall back to REST
+   * until they explicitly reopen/reconnect, at which point the server will
+   * seed from the committed meta_records.data row.
+   */
+  notifyInvalidated(recordIds: string[]): void {
+    if (!this.namespace) return
+    for (const recordId of [...new Set(recordIds.filter((id) => typeof id === 'string' && id.length > 0))]) {
+      this.namespace.to(`yjs:${recordId}`).emit('yjs:invalidated', {
+        recordId,
+        reason: 'rest-write',
+      } satisfies YjsInvalidatedPayload)
     }
   }
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1887,7 +1887,11 @@ export class MetaSheetServer {
         const yjsInvalidate = async (recordIds: string[]) => {
           if (recordIds.length === 0) return
           yjsBridge.cancelPending(recordIds)
-          await yjsSyncService.invalidateDocs(recordIds)
+          try {
+            await yjsSyncService.invalidateDocs(recordIds)
+          } finally {
+            yjsWsAdapter.notifyInvalidated(recordIds)
+          }
         }
         recordWriteService.setYjsInvalidator(yjsInvalidate)
         const univerMetaModule = await import('./routes/univer-meta')

--- a/packages/core-backend/tests/unit/yjs-awareness.test.ts
+++ b/packages/core-backend/tests/unit/yjs-awareness.test.ts
@@ -70,6 +70,23 @@ function waitForEvent<T>(
   })
 }
 
+function waitForNoEvent(client: ClientSocket, event: string, timeoutMs = 100): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      client.off(event, handler)
+      resolve()
+    }, timeoutMs)
+
+    const handler = (payload: unknown) => {
+      clearTimeout(timeout)
+      client.off(event, handler)
+      reject(new Error(`unexpected ${event}: ${JSON.stringify(payload)}`))
+    }
+
+    client.on(event, handler)
+  })
+}
+
 describe('Yjs awareness presence socket protocol', () => {
   let httpServer: ReturnType<typeof createServer>
   let io: Server
@@ -179,6 +196,37 @@ describe('Yjs awareness presence socket protocol', () => {
       })
     } finally {
       client.disconnect()
+    }
+  })
+
+  it('broadcasts invalidation only to sockets subscribed to the record room', async () => {
+    const alice = await connectClient(baseUrl, 'token-user_alice')
+    const bob = await connectClient(baseUrl, 'token-user_bob')
+
+    try {
+      const alicePresence = waitForEvent(alice, 'yjs:presence', (payload: any) => (
+        payload.recordId === 'rec_presence'
+        && payload.activeCount === 1
+      ))
+      alice.emit('yjs:subscribe', { recordId: 'rec_presence' })
+      await alicePresence
+
+      const invalidated = waitForEvent(alice, 'yjs:invalidated', (payload: any) => (
+        payload.recordId === 'rec_presence'
+        && payload.reason === 'rest-write'
+      ))
+      const noBobEvent = waitForNoEvent(bob, 'yjs:invalidated')
+
+      adapter.notifyInvalidated(['rec_presence'])
+
+      await expect(invalidated).resolves.toMatchObject({
+        recordId: 'rec_presence',
+        reason: 'rest-write',
+      })
+      await expect(noBobEvent).resolves.toBeUndefined()
+    } finally {
+      alice.disconnect()
+      bob.disconnect()
     }
   })
 })


### PR DESCRIPTION
## Summary

- Adds a room-scoped `yjs:invalidated` event so live Yjs editors are notified after an authoritative REST write invalidates their record's Y.Doc state.
- Wires startup invalidation as `cancelPending -> invalidateDocs -> notifyInvalidated`, with notification in `finally` so clients still fall back if persistence purge throws after in-memory eviction.
- Handles `yjs:invalidated` in `useYjsDocument` by setting an explicit invalidation error and disconnecting, allowing the existing cell binding to fall back to REST.
- Adds backend socket coverage and frontend composable coverage plus development/verification MDs.

## Verification

- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/yjs-awareness.test.ts tests/unit/yjs-rest-invalidation.test.ts --reporter=verbose` -> 12/12 passed
- [x] `pnpm --filter @metasheet/web exec vitest run tests/yjs-document-invalidation.spec.ts tests/yjs-document-stale-guard.spec.ts tests/multitable-yjs-cell-binding.spec.ts --reporter=verbose` -> 8/8 passed
- [x] `pnpm --filter @metasheet/web exec vitest run tests/yjs-text-field-diff.spec.ts tests/yjs-text-field-seed-guard.spec.ts tests/yjs-document-stale-guard.spec.ts tests/yjs-document-invalidation.spec.ts tests/yjs-awareness-presence.spec.ts tests/multitable-yjs-cell-binding.spec.ts tests/multitable-yjs-cell-editor.spec.ts --reporter=dot` -> 34/34 passed
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/yjs-poc.test.ts tests/unit/yjs-hardening.test.ts tests/unit/yjs-awareness.test.ts tests/unit/yjs-rest-invalidation.test.ts tests/unit/record-write-service.test.ts --reporter=dot` -> 71/71 passed
- [x] `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` -> pass
- [x] `pnpm --filter @metasheet/core-backend build` -> pass
- [x] `pnpm --filter @metasheet/web build` -> pass

## Docs

- `docs/development/yjs-rest-invalidation-live-client-event-development-20260421.md`
- `docs/development/yjs-rest-invalidation-live-client-event-verification-20260421.md`

## Follow-up

Staging manual check after merge: open a Yjs text cell, update the same record through REST/non-Yjs path, confirm the live Yjs editor receives invalidation and falls back instead of continuing to edit the stale Y.Doc.
