### PR TITLE
test(collab): add Yjs invalidation staging smoke

### DIFF
--- a/docs/development/yjs-staging-invalidation-smoke-tool-development-20260421.md
+++ b/docs/development/yjs-staging-invalidation-smoke-tool-development-20260421.md
@@ -1,0 +1,96 @@
+# Yjs Staging Invalidation Smoke Tool
+
+- Branch: `codex/yjs-staging-invalidation-smoke-20260421`
+- Date: 2026-04-21
+- Base: `origin/main` after PR `#979`
+- Scope: provide a repeatable remote/staging check for the Yjs invalidation
+  event added by PR `#979`.
+
+## Context
+
+PR `#979` made live Yjs clients disconnect and fall back to REST after a REST
+write invalidates the server-side Y.Doc. The remaining rollout gap was
+operational: staging validation still required a manual two-browser flow.
+
+This change adds a CLI smoke tool that exercises the same contract through real
+HTTP + Socket.IO:
+
+1. Connect to `${BASE_URL}/yjs` with a JWT.
+2. Subscribe to the target record.
+3. Wait for the initial `yjs:message` sync response.
+4. PATCH the target record through the canonical REST route.
+5. Assert the subscribed socket receives `yjs:invalidated` with
+   `reason: "rest-write"`.
+
+## Files Added
+
+- `scripts/ops/yjs-invalidation-smoke.mjs`
+  - Remote/staging smoke runner.
+  - Writes JSON and Markdown reports.
+  - Resolves `socket.io-client` from `apps/web/package.json`, avoiding a new
+    root dependency.
+- `scripts/ops/yjs-invalidation-smoke.test.mjs`
+  - Node built-in test coverage for config parsing, URL construction, safety
+    gates, and Markdown rendering.
+
+## Safety Gates
+
+The tool is intentionally write-safe by default:
+
+- Requires `CONFIRM_WRITE=1` before it sends any PATCH request.
+- Requires `AUTH_TOKEN` / `TOKEN` by default.
+- Only uses `/api/auth/dev-token` when `ALLOW_DEV_TOKEN=1` is explicitly set.
+- Fails during config validation if required inputs are missing, while still
+  writing a failure report.
+
+## Required Environment
+
+```bash
+BASE_URL="http://<staging-host>:<port>"
+AUTH_TOKEN="<jwt>"
+RECORD_ID="<record-id>"
+FIELD_ID="<string-field-id>"
+CONFIRM_WRITE=1
+```
+
+Optional:
+
+```bash
+SHEET_ID="<sheet-id>"
+PATCH_VALUE="manual-smoke-$(date -u +%Y%m%dT%H%M%SZ)"
+PATCH_URL="http://<host>/api/multitable/records/<record-id>"
+OUTPUT_DIR="output/yjs-invalidation-smoke/<run-id>"
+TIMEOUT_MS=10000
+ALLOW_DEV_TOKEN=1
+```
+
+## Usage
+
+```bash
+BASE_URL="http://142.171.239.56:<api-port>" \
+AUTH_TOKEN="<jwt>" \
+RECORD_ID="<record-id>" \
+FIELD_ID="<string-field-id>" \
+CONFIRM_WRITE=1 \
+OUTPUT_DIR="output/yjs-invalidation-smoke/$(date -u +%Y%m%d-%H%M%S)" \
+node scripts/ops/yjs-invalidation-smoke.mjs
+```
+
+Expected successful checks:
+
+- `config.required-env`
+- `auth.token-present` or `auth.dev-token`
+- `api.health`
+- `api.record.get`
+- `socket.connect`
+- `socket.subscribe-sync`
+- `api.record.patch`
+- `socket.invalidated`
+
+## Notes
+
+- The smoke mutates the target record field. Use a dedicated staging/test sheet
+  and a disposable text field.
+- The script validates the backend event contract, not the browser UI. The
+  browser click test remains useful after deployment, but this CLI gives ops a
+  fast deterministic gate before manual trial.

--- a/docs/development/yjs-staging-invalidation-smoke-tool-verification-20260421.md
+++ b/docs/development/yjs-staging-invalidation-smoke-tool-verification-20260421.md
@@ -1,0 +1,111 @@
+# Verification - Yjs Staging Invalidation Smoke Tool
+
+- Branch: `codex/yjs-staging-invalidation-smoke-20260421`
+- Date: 2026-04-21
+- Linked development MD:
+  `docs/development/yjs-staging-invalidation-smoke-tool-development-20260421.md`
+
+## Static Syntax Check
+
+Command:
+
+```bash
+node --check scripts/ops/yjs-invalidation-smoke.mjs
+node --check scripts/ops/yjs-invalidation-smoke.test.mjs
+```
+
+Result:
+
+```text
+EXIT=0
+```
+
+## Unit Tests
+
+Command:
+
+```bash
+node --test scripts/ops/yjs-invalidation-smoke.test.mjs
+```
+
+Result:
+
+```text
+tests 5
+pass  5
+fail  0
+```
+
+Coverage:
+
+- `normalizeBaseUrl()` trims trailing slashes and whitespace.
+- `buildDefaultPatchUrl()` targets
+  `/api/multitable/records/:recordId`.
+- `parseConfig()` accepts token aliases, explicit `PATCH_URL`, `SHEET_ID`,
+  `PATCH_VALUE`, `OUTPUT_DIR`, and timeout.
+- `validateConfig()` requires `CONFIRM_WRITE=1` and auth by default.
+- Markdown rendering includes failing checks, error text, and invalidation
+  payload.
+
+## Safety Failure Path
+
+Command:
+
+```bash
+OUTPUT_DIR=tmp/yjs-invalidation-smoke-missing-env \
+node scripts/ops/yjs-invalidation-smoke.mjs
+```
+
+Result:
+
+```text
+Overall: FAIL
+Failing checks: config.required-env
+Error: Missing required configuration: API_BASE or BASE_URL, RECORD_ID, FIELD_ID, PATCH_URL, AUTH_TOKEN or TOKEN, CONFIRM_WRITE=1
+```
+
+Artifacts written:
+
+```text
+tmp/yjs-invalidation-smoke-missing-env/report.json
+tmp/yjs-invalidation-smoke-missing-env/report.md
+```
+
+This verifies missing configuration fails before any socket connection or REST
+write attempt.
+
+## Real Staging Smoke
+
+Not executed in this local run because no real staging JWT / target
+`RECORD_ID` / target `FIELD_ID` was available in the environment.
+
+Run this after deploying `origin/main` containing PR `#979`:
+
+```bash
+BASE_URL="http://142.171.239.56:<api-port>" \
+AUTH_TOKEN="<jwt-with-multitable-write>" \
+RECORD_ID="<test-record-id>" \
+FIELD_ID="<test-string-field-id>" \
+CONFIRM_WRITE=1 \
+OUTPUT_DIR="output/yjs-invalidation-smoke/$(date -u +%Y%m%d-%H%M%S)" \
+node scripts/ops/yjs-invalidation-smoke.mjs
+```
+
+Expected result:
+
+```text
+Overall: PASS
+config.required-env: PASS
+auth.token-present: PASS
+api.health: PASS
+api.record.get: PASS
+socket.connect: PASS
+socket.subscribe-sync: PASS
+api.record.patch: PASS
+socket.invalidated: PASS
+```
+
+## Decision
+
+Tool-level verification is green. The remaining gate is an environment-backed
+staging run with a disposable text field on a Yjs-enabled deployment.

--- a/scripts/ops/yjs-invalidation-smoke.mjs
+++ b/scripts/ops/yjs-invalidation-smoke.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '../..')
+const webRequire = createRequire(path.join(repoRoot, 'apps/web/package.json'))
+const { io } = webRequire('socket.io-client')
+
+const DEFAULT_TIMEOUT_MS = 10_000
+
+export function normalizeBaseUrl(value) {
+  return String(value || '').trim().replace(/\/+$/, '')
+}
+
+export function buildDefaultPatchUrl(baseUrl, recordId) {
+  return `${normalizeBaseUrl(baseUrl)}/api/multitable/records/${encodeURIComponent(recordId)}`
+}
+
+export function renderInvalidationSmokeMarkdown(report) {
+  const checks = Array.isArray(report?.checks) ? report.checks : []
+  const failing = checks.filter((check) => check && check.ok === false)
+  const lines = [
+    '# Yjs Invalidation Smoke',
+    '',
+    `- Overall: **${report?.ok === false ? 'FAIL' : 'PASS'}**`,
+    `- API base: \`${report?.apiBase || 'missing'}\``,
+    `- Record ID: \`${report?.recordId || 'missing'}\``,
+    `- Field ID: \`${report?.fieldId || 'missing'}\``,
+    `- Patch URL: \`${report?.patchUrl || 'missing'}\``,
+    `- Started at: \`${report?.startedAt || 'missing'}\``,
+    `- Finished at: \`${report?.finishedAt || 'missing'}\``,
+    `- JSON report: \`${report?.reportPath || 'missing'}\``,
+    `- Markdown report: \`${report?.reportMdPath || 'missing'}\``,
+    '',
+    '## Checks',
+    '',
+    `- Total checks: \`${checks.length}\``,
+    failing.length
+      ? `- Failing checks: ${failing.map((check) => `\`${check.name}\``).join(', ')}`
+      : '- Failing checks: none',
+  ]
+
+  if (report?.error) {
+    lines.push(`- Error: \`${report.error}\``)
+  }
+
+  lines.push('', '## Check Results', '')
+  for (const check of checks) {
+    lines.push(`- \`${check.name}\`: **${check.ok ? 'PASS' : 'FAIL'}**`)
+  }
+
+  if (report?.invalidatedPayload) {
+    lines.push('', '## Invalidation Payload', '', '```json')
+    lines.push(JSON.stringify(report.invalidatedPayload, null, 2))
+    lines.push('```')
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+export function parseConfig(env = process.env) {
+  const apiBase = normalizeBaseUrl(env.API_BASE || env.BASE_URL || env.STAGING_BASE_URL)
+  const recordId = String(env.RECORD_ID || '').trim()
+  const fieldId = String(env.FIELD_ID || '').trim()
+  const sheetId = String(env.SHEET_ID || '').trim()
+  const token = String(env.AUTH_TOKEN || env.TOKEN || '').trim()
+  const patchValue = env.PATCH_VALUE ?? `yjs-invalidation-smoke-${new Date().toISOString()}`
+  const patchUrl = String(env.PATCH_URL || (apiBase && recordId ? buildDefaultPatchUrl(apiBase, recordId) : '')).trim()
+  const outputDir = String(env.OUTPUT_DIR || `output/yjs-invalidation-smoke/${new Date().toISOString().replace(/[:.]/g, '-')}`)
+  const reportPath = String(env.REPORT_JSON || path.join(outputDir, 'report.json'))
+  const reportMdPath = String(env.REPORT_MD || path.join(outputDir, 'report.md'))
+  const timeoutMs = Number(env.TIMEOUT_MS || DEFAULT_TIMEOUT_MS)
+  const confirmWrite = env.CONFIRM_WRITE === '1' || env.CONFIRM_WRITE === 'true'
+  const allowDevToken = env.ALLOW_DEV_TOKEN === '1' || env.ALLOW_DEV_TOKEN === 'true'
+
+  return {
+    apiBase,
+    recordId,
+    fieldId,
+    sheetId,
+    token,
+    patchValue,
+    patchUrl,
+    outputDir,
+    reportPath,
+    reportMdPath,
+    timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS,
+    confirmWrite,
+    allowDevToken,
+  }
+}
+
+export function validateConfig(config) {
+  const missing = []
+  if (!config.apiBase) missing.push('API_BASE or BASE_URL')
+  if (!config.recordId) missing.push('RECORD_ID')
+  if (!config.fieldId) missing.push('FIELD_ID')
+  if (!config.patchUrl) missing.push('PATCH_URL')
+  if (!config.token && !config.allowDevToken) missing.push('AUTH_TOKEN or TOKEN')
+  if (!config.confirmWrite) missing.push('CONFIRM_WRITE=1')
+  return missing
+}
+
+function authHeaders(token, extra = {}) {
+  return {
+    Authorization: `Bearer ${token}`,
+    ...extra,
+  }
+}
+
+async function fetchJson(url, options = {}) {
+  const res = await fetch(url, options)
+  const text = await res.text()
+  let json = null
+  if (text) {
+    try {
+      json = JSON.parse(text)
+    } catch {
+      json = { raw: text }
+    }
+  }
+  return { res, json }
+}
+
+async function resolveToken(config, record) {
+  if (config.token) {
+    record('auth.token-present', true)
+    return config.token
+  }
+
+  const perms = [
+    'multitable:read',
+    'multitable:write',
+    'multitable:admin',
+  ].join(',')
+  const url = `${config.apiBase}/api/auth/dev-token?userId=yjs-smoke-admin&roles=admin&perms=${encodeURIComponent(perms)}`
+  const result = await fetchJson(url)
+  const token = result.json?.token
+  const ok = Boolean(result.res.ok && token)
+  record('auth.dev-token', ok, { status: result.res.status })
+  if (!ok) throw new Error('Unable to obtain dev token; provide AUTH_TOKEN/TOKEN for staging')
+  return token
+}
+
+function waitForSocketConnect(socket, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('Socket connect timeout'))
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timeout)
+      socket.off('connect', onConnect)
+      socket.off('connect_error', onConnectError)
+    }
+    const onConnect = () => {
+      cleanup()
+      resolve()
+    }
+    const onConnectError = (error) => {
+      cleanup()
+      reject(error instanceof Error ? error : new Error(String(error)))
+    }
+    socket.once('connect', onConnect)
+    socket.once('connect_error', onConnectError)
+  })
+}
+
+function waitForEvent(socket, event, predicate, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let lastPayload = null
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Timed out waiting for ${event}: ${JSON.stringify(lastPayload)}`))
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timeout)
+      socket.off(event, onEvent)
+      socket.off('yjs:error', onError)
+    }
+    const onEvent = (payload) => {
+      lastPayload = payload
+      if (!predicate(payload)) return
+      cleanup()
+      resolve(payload)
+    }
+    const onError = (payload) => {
+      cleanup()
+      reject(new Error(`yjs:error: ${JSON.stringify(payload)}`))
+    }
+    socket.on(event, onEvent)
+    socket.on('yjs:error', onError)
+  })
+}
+
+async function patchRecord(config, token) {
+  const body = {
+    ...(config.sheetId ? { sheetId: config.sheetId } : {}),
+    data: {
+      [config.fieldId]: config.patchValue,
+    },
+  }
+  return fetchJson(config.patchUrl, {
+    method: 'PATCH',
+    headers: authHeaders(token, { 'Content-Type': 'application/json' }),
+    body: JSON.stringify(body),
+  })
+}
+
+async function fetchRecord(config, token) {
+  const url = buildDefaultPatchUrl(config.apiBase, config.recordId)
+  return fetchJson(url, {
+    headers: authHeaders(token),
+  })
+}
+
+function writeArtifacts(report) {
+  fs.mkdirSync(path.dirname(report.reportPath), { recursive: true })
+  fs.writeFileSync(report.reportPath, JSON.stringify(report, null, 2))
+  fs.mkdirSync(path.dirname(report.reportMdPath), { recursive: true })
+  fs.writeFileSync(report.reportMdPath, renderInvalidationSmokeMarkdown(report))
+}
+
+export async function runInvalidationSmoke(config = parseConfig()) {
+  const report = {
+    ok: true,
+    apiBase: config.apiBase,
+    recordId: config.recordId,
+    fieldId: config.fieldId,
+    patchUrl: config.patchUrl,
+    outputDir: path.resolve(config.outputDir),
+    reportPath: path.resolve(config.reportPath),
+    reportMdPath: path.resolve(config.reportMdPath),
+    startedAt: new Date().toISOString(),
+    checks: [],
+  }
+
+  const record = (name, ok, details = {}) => {
+    report.checks.push({ name, ok, ...details })
+    if (!ok) report.ok = false
+  }
+
+  const missing = validateConfig(config)
+  if (missing.length > 0) {
+    record('config.required-env', false, { missing })
+    report.error = `Missing required configuration: ${missing.join(', ')}`
+    report.finishedAt = new Date().toISOString()
+    writeArtifacts(report)
+    return report
+  }
+  record('config.required-env', true)
+
+  let socket = null
+  try {
+    const token = await resolveToken(config, record)
+
+    const health = await fetchJson(`${config.apiBase}/health`)
+    record('api.health', health.res.ok, { status: health.res.status })
+    if (!health.res.ok) throw new Error(`Health check failed: ${health.res.status}`)
+
+    const recordResult = await fetchRecord(config, token)
+    record('api.record.get', recordResult.res.ok && recordResult.json?.ok !== false, {
+      status: recordResult.res.status,
+    })
+    if (!recordResult.res.ok || recordResult.json?.ok === false) {
+      throw new Error(`Record preflight failed: ${recordResult.res.status}`)
+    }
+
+    const socketUrl = `${config.apiBase}/yjs`
+    socket = io(socketUrl, {
+      transports: ['websocket'],
+      auth: { token },
+      forceNew: true,
+      reconnection: false,
+      timeout: config.timeoutMs,
+    })
+    await waitForSocketConnect(socket, config.timeoutMs)
+    record('socket.connect', true, { socketUrl })
+
+    const syncMessage = waitForEvent(
+      socket,
+      'yjs:message',
+      (payload) => payload?.recordId === config.recordId && Array.isArray(payload?.data),
+      config.timeoutMs,
+    )
+    socket.emit('yjs:subscribe', { recordId: config.recordId })
+    await syncMessage
+    record('socket.subscribe-sync', true)
+
+    const invalidated = waitForEvent(
+      socket,
+      'yjs:invalidated',
+      (payload) => payload?.recordId === config.recordId && payload?.reason === 'rest-write',
+      config.timeoutMs,
+    )
+    const patchResult = await patchRecord(config, token)
+    record('api.record.patch', patchResult.res.ok && patchResult.json?.ok !== false, {
+      status: patchResult.res.status,
+    })
+    if (!patchResult.res.ok || patchResult.json?.ok === false) {
+      invalidated.catch(() => {
+        // Avoid an unhandled timeout rejection after the REST failure has
+        // already determined the smoke result.
+      })
+      throw new Error(`Record patch failed: ${patchResult.res.status} ${JSON.stringify(patchResult.json)}`)
+    }
+
+    report.invalidatedPayload = await invalidated
+    record('socket.invalidated', true)
+  } catch (error) {
+    report.ok = false
+    report.error = error instanceof Error ? error.message : String(error)
+  } finally {
+    try {
+      socket?.disconnect()
+    } catch {
+      // ignore teardown errors
+    }
+    report.finishedAt = new Date().toISOString()
+    writeArtifacts(report)
+  }
+
+  return report
+}
+
+async function main() {
+  const report = await runInvalidationSmoke(parseConfig())
+  console.log(renderInvalidationSmokeMarkdown(report))
+  process.exitCode = report.ok ? 0 : 1
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/ops/yjs-invalidation-smoke.test.mjs
+++ b/scripts/ops/yjs-invalidation-smoke.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildDefaultPatchUrl,
+  normalizeBaseUrl,
+  parseConfig,
+  renderInvalidationSmokeMarkdown,
+  validateConfig,
+} from './yjs-invalidation-smoke.mjs'
+
+test('normalizeBaseUrl trims trailing slashes', () => {
+  assert.equal(normalizeBaseUrl('http://127.0.0.1:8900///'), 'http://127.0.0.1:8900')
+  assert.equal(normalizeBaseUrl('  https://example.test/base/  '), 'https://example.test/base')
+})
+
+test('buildDefaultPatchUrl targets canonical multitable record patch route', () => {
+  assert.equal(
+    buildDefaultPatchUrl('http://127.0.0.1:8900/', 'rec 1'),
+    'http://127.0.0.1:8900/api/multitable/records/rec%201',
+  )
+})
+
+test('parseConfig accepts API_BASE, token aliases, and explicit patch URL', () => {
+  const config = parseConfig({
+    API_BASE: 'http://127.0.0.1:8900/',
+    TOKEN: 'jwt',
+    RECORD_ID: 'rec_1',
+    FIELD_ID: 'fld_title',
+    SHEET_ID: 'sheet_1',
+    PATCH_VALUE: 'next',
+    PATCH_URL: 'http://override.test/patch',
+    OUTPUT_DIR: 'tmp/out',
+    CONFIRM_WRITE: '1',
+    TIMEOUT_MS: '1234',
+  })
+
+  assert.equal(config.apiBase, 'http://127.0.0.1:8900')
+  assert.equal(config.token, 'jwt')
+  assert.equal(config.recordId, 'rec_1')
+  assert.equal(config.fieldId, 'fld_title')
+  assert.equal(config.sheetId, 'sheet_1')
+  assert.equal(config.patchValue, 'next')
+  assert.equal(config.patchUrl, 'http://override.test/patch')
+  assert.equal(config.outputDir, 'tmp/out')
+  assert.equal(config.confirmWrite, true)
+  assert.equal(config.timeoutMs, 1234)
+})
+
+test('validateConfig requires write confirmation and auth by default', () => {
+  assert.deepEqual(validateConfig(parseConfig({})), [
+    'API_BASE or BASE_URL',
+    'RECORD_ID',
+    'FIELD_ID',
+    'PATCH_URL',
+    'AUTH_TOKEN or TOKEN',
+    'CONFIRM_WRITE=1',
+  ])
+
+  assert.deepEqual(validateConfig(parseConfig({
+    BASE_URL: 'http://127.0.0.1:8900',
+    RECORD_ID: 'rec_1',
+    FIELD_ID: 'fld_title',
+    ALLOW_DEV_TOKEN: '1',
+    CONFIRM_WRITE: 'true',
+  })), [])
+})
+
+test('renderInvalidationSmokeMarkdown includes failed checks and payload', () => {
+  const markdown = renderInvalidationSmokeMarkdown({
+    ok: false,
+    apiBase: 'http://127.0.0.1:8900',
+    recordId: 'rec_1',
+    fieldId: 'fld_title',
+    patchUrl: 'http://127.0.0.1:8900/api/multitable/records/rec_1',
+    startedAt: '2026-04-21T00:00:00.000Z',
+    finishedAt: '2026-04-21T00:00:01.000Z',
+    reportPath: '/tmp/report.json',
+    reportMdPath: '/tmp/report.md',
+    error: 'boom',
+    invalidatedPayload: { recordId: 'rec_1', reason: 'rest-write' },
+    checks: [
+      { name: 'socket.connect', ok: true },
+      { name: 'socket.invalidated', ok: false },
+    ],
+  })
+
+  assert.match(markdown, /# Yjs Invalidation Smoke/)
+  assert.match(markdown, /Overall: \*\*FAIL\*\*/)
+  assert.match(markdown, /Failing checks: `socket\.invalidated`/)
+  assert.match(markdown, /"reason": "rest-write"/)
+  assert.match(markdown, /Error: `boom`/)
+})


### PR DESCRIPTION
## Summary

- Adds `scripts/ops/yjs-invalidation-smoke.mjs`, a remote/staging smoke that connects to `/yjs`, subscribes to a record, patches the same record through REST, and asserts the socket receives `yjs:invalidated` with `reason='rest-write'`.
- Adds safety gates: no REST write unless `CONFIRM_WRITE=1`; no staging auth fallback unless `ALLOW_DEV_TOKEN=1`; writes JSON/Markdown reports even on config failure.
- Adds Node built-in tests for config parsing, default PATCH URL construction, safety validation, and Markdown rendering.
- Adds development/verification MDs for the tool and the real staging command.

## Verification

- [x] `node --check scripts/ops/yjs-invalidation-smoke.mjs && node --check scripts/ops/yjs-invalidation-smoke.test.mjs`
- [x] `node --test scripts/ops/yjs-invalidation-smoke.test.mjs` -> 5/5 passed
- [x] `OUTPUT_DIR=tmp/yjs-invalidation-smoke-missing-env-2 node scripts/ops/yjs-invalidation-smoke.mjs` -> expected safe FAIL before socket/REST write; report artifacts written

## Not run

- Real staging smoke was not run locally because no staging JWT + disposable `RECORD_ID` + string `FIELD_ID` were available in this environment.

## Real staging command

```bash
BASE_URL="http://142.171.239.56:<api-port>" \
AUTH_TOKEN="<jwt-with-multitable-write>" \
RECORD_ID="<test-record-id>" \
FIELD_ID="<test-string-field-id>" \
CONFIRM_WRITE=1 \
OUTPUT_DIR="output/yjs-invalidation-smoke/$(date -u +%Y%m%d-%H%M%S)" \
node scripts/ops/yjs-invalidation-smoke.mjs
```

Docs:
- `docs/development/yjs-staging-invalidation-smoke-tool-development-20260421.md`
- `docs/development/yjs-staging-invalidation-smoke-tool-verification-20260421.md`
