### PR TITLE
feat(dingtalk): export staging evidence packet

### DIFF
--- a/docs/development/dingtalk-staging-evidence-packet-development-20260421.md
+++ b/docs/development/dingtalk-staging-evidence-packet-development-20260421.md
@@ -1,0 +1,60 @@
+# DingTalk Staging Evidence Packet Development 2026-04-21
+
+## Context
+
+The Yjs rollout path already has a packet exporter that copies its checklist,
+runbook, scripts, and signoff helpers into one handoff directory. The DingTalk
+shared-dev/staging path did not have the same operator handoff shape: the
+deploy runbook, env repair scripts, and execution checklist existed, but they
+were scattered across `docs/`, `docker/`, and `scripts/`.
+
+This change adds a read-only packet exporter for the DingTalk staging stack. It
+does not deploy, call Docker, contact staging, or require secrets.
+
+## Changes
+
+- Added `scripts/ops/export-dingtalk-staging-evidence-packet.mjs`.
+- Added `scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`.
+- The exporter copies the current staging handoff files into
+  `artifacts/dingtalk-staging-evidence-packet` by default:
+  - `docs/development/dingtalk-staging-canary-deploy-20260408.md`
+  - `docs/development/dingtalk-staging-execution-checklist-20260408.md`
+  - `docs/development/dingtalk-live-tenant-validation-checklist-20260408.md`
+  - `docs/development/dingtalk-stack-merge-readiness-20260408.md`
+  - `docker/app.staging.env.example`
+  - `scripts/ops/validate-env-file.sh`
+  - `scripts/ops/repair-env-file.sh`
+  - `scripts/ops/build-dingtalk-staging-images.sh`
+  - `scripts/ops/deploy-dingtalk-staging.sh`
+- The exporter writes:
+  - `manifest.json`
+  - `README.md`
+- Optional runtime evidence can be attached with repeated
+  `--include-output <dir>` arguments. Each directory is copied under
+  `evidence/NN-<basename>`.
+
+## Design Notes
+
+- This intentionally mirrors the Yjs rollout packet pattern, but stays scoped to
+  DingTalk staging operations.
+- The exporter is fail-closed for required packet files. If a runbook or script
+  moves, export fails instead of silently producing an incomplete handoff.
+- Optional runtime evidence must point to existing directories. Missing evidence
+  paths fail because otherwise an operator could believe a staging smoke was
+  attached when it was not.
+- Secrets are never read or copied. The packet includes only the staging env
+  template, not `docker/app.staging.env`.
+
+## Usage
+
+```bash
+node scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+```
+
+With runtime smoke evidence:
+
+```bash
+node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \
+  --include-output output/playwright/dingtalk-directory-staging-smoke/<run>
+```
+

--- a/docs/development/dingtalk-staging-evidence-packet-verification-20260421.md
+++ b/docs/development/dingtalk-staging-evidence-packet-verification-20260421.md
@@ -1,0 +1,66 @@
+# DingTalk Staging Evidence Packet Verification 2026-04-21
+
+## Scope
+
+Verify the new packet exporter locally without requiring staging credentials or
+remote access.
+
+## Commands Run
+
+```bash
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result:
+
+```text
+tests 4
+pass 4
+fail 0
+duration_ms 143.40625
+```
+
+```bash
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result: both syntax checks passed.
+
+```bash
+rm -rf tmp/dingtalk-staging-evidence-packet-smoke
+node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \
+  --output-dir tmp/dingtalk-staging-evidence-packet-smoke
+find tmp/dingtalk-staging-evidence-packet-smoke -maxdepth 3 -type f | sort
+```
+
+Result: export completed and wrote:
+
+```text
+tmp/dingtalk-staging-evidence-packet-smoke/README.md
+tmp/dingtalk-staging-evidence-packet-smoke/docker/app.staging.env.example
+tmp/dingtalk-staging-evidence-packet-smoke/docs/development/dingtalk-live-tenant-validation-checklist-20260408.md
+tmp/dingtalk-staging-evidence-packet-smoke/docs/development/dingtalk-stack-merge-readiness-20260408.md
+tmp/dingtalk-staging-evidence-packet-smoke/docs/development/dingtalk-staging-canary-deploy-20260408.md
+tmp/dingtalk-staging-evidence-packet-smoke/docs/development/dingtalk-staging-execution-checklist-20260408.md
+tmp/dingtalk-staging-evidence-packet-smoke/manifest.json
+tmp/dingtalk-staging-evidence-packet-smoke/scripts/ops/build-dingtalk-staging-images.sh
+tmp/dingtalk-staging-evidence-packet-smoke/scripts/ops/deploy-dingtalk-staging.sh
+tmp/dingtalk-staging-evidence-packet-smoke/scripts/ops/repair-env-file.sh
+tmp/dingtalk-staging-evidence-packet-smoke/scripts/ops/validate-env-file.sh
+```
+
+## Test Coverage
+
+- Required docs/config/scripts are copied into the packet.
+- `manifest.json` records packet identity, file list, and optional evidence.
+- `README.md` includes operator order and no-evidence warning.
+- Optional evidence directories are copied into `evidence/`.
+- Missing optional evidence directories fail closed.
+- Unknown CLI arguments fail closed.
+
+## Not Run
+
+- Real 142/shared-dev staging smoke was not run in this change. The exporter is
+  a local handoff generator and deliberately avoids remote dependencies.
+

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_DIR = 'artifacts/dingtalk-staging-evidence-packet'
+
+const requiredPacketFiles = [
+  {
+    path: 'docs/development/dingtalk-staging-canary-deploy-20260408.md',
+    kind: 'runbook',
+    description: 'staging topology, deploy, rollback, and drift recovery notes',
+  },
+  {
+    path: 'docs/development/dingtalk-staging-execution-checklist-20260408.md',
+    kind: 'checklist',
+    description: 'tenant inputs, execution order, pass criteria, and stop conditions',
+  },
+  {
+    path: 'docs/development/dingtalk-live-tenant-validation-checklist-20260408.md',
+    kind: 'checklist',
+    description: 'live tenant validation scope for login, directory, attendance, and robot send',
+  },
+  {
+    path: 'docs/development/dingtalk-stack-merge-readiness-20260408.md',
+    kind: 'readiness',
+    description: 'DingTalk stack merge readiness context',
+  },
+  {
+    path: 'docker/app.staging.env.example',
+    kind: 'config-template',
+    description: 'canonical staging env template; copy to docker/app.staging.env and fill secrets',
+  },
+  {
+    path: 'scripts/ops/validate-env-file.sh',
+    kind: 'script',
+    description: 'fails fast on corrupted one-line env files before docker compose runs',
+  },
+  {
+    path: 'scripts/ops/repair-env-file.sh',
+    kind: 'script',
+    description: 'repairs env files that contain literal \\n sequences',
+  },
+  {
+    path: 'scripts/ops/build-dingtalk-staging-images.sh',
+    kind: 'script',
+    description: 'builds local PR-stack images for staging when GHCR tags are unavailable',
+  },
+  {
+    path: 'scripts/ops/deploy-dingtalk-staging.sh',
+    kind: 'script',
+    description: 'validates env, resolves image tag, runs docker compose, and checks backend health',
+  },
+]
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/export-dingtalk-staging-evidence-packet.mjs [options]
+
+Exports the DingTalk/shared-dev staging operations packet into one artifact directory.
+
+Options:
+  --output-dir <dir>        Output directory, default ${DEFAULT_OUTPUT_DIR}
+  --include-output <dir>    Optional existing evidence directory to copy into evidence/
+  --help                    Show this help
+
+Examples:
+  node scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+  node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \\
+    --include-output output/playwright/dingtalk-directory-staging-smoke/20260416-package-script
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function parseArgs(argv) {
+  const opts = {
+    outputDir: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR),
+    includeOutputDirs: [],
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+
+    switch (arg) {
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--include-output':
+        opts.includeOutputDirs.push(path.resolve(process.cwd(), readRequiredValue(argv, i, arg)))
+        i += 1
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return opts
+}
+
+function ensureSourceFile(file) {
+  const source = path.resolve(process.cwd(), file)
+  if (!existsSync(source) || !statSync(source).isFile()) {
+    throw new Error(`missing required packet file: ${file}`)
+  }
+  return source
+}
+
+function copyFileIntoPacket(file, outputDir) {
+  const source = ensureSourceFile(file)
+  const destination = path.join(outputDir, file)
+  mkdirSync(path.dirname(destination), { recursive: true })
+  cpSync(source, destination)
+  return destination
+}
+
+function sanitizeEvidenceName(sourceDir) {
+  return path
+    .basename(sourceDir)
+    .replace(/[^A-Za-z0-9._-]/g, '-')
+    .replace(/^-+|-+$/g, '') || 'evidence'
+}
+
+function copyEvidenceDir(sourceDir, outputDir, index) {
+  if (!existsSync(sourceDir) || !statSync(sourceDir).isDirectory()) {
+    throw new Error(`--include-output must point to an existing directory: ${sourceDir}`)
+  }
+
+  const destinationName = `${String(index + 1).padStart(2, '0')}-${sanitizeEvidenceName(sourceDir)}`
+  const destination = path.join(outputDir, 'evidence', destinationName)
+  mkdirSync(path.dirname(destination), { recursive: true })
+  cpSync(sourceDir, destination, { recursive: true })
+  return {
+    source: path.relative(process.cwd(), sourceDir).replaceAll('\\', '/'),
+    destination: path.relative(outputDir, destination).replaceAll('\\', '/'),
+  }
+}
+
+function renderReadme(manifest) {
+  const docs = manifest.files.filter((file) => file.kind !== 'script')
+  const scripts = manifest.files.filter((file) => file.kind === 'script')
+  const evidence = manifest.includedEvidence
+
+  const fileLine = (file) => `- \`${file.path}\` — ${file.description}`
+  const evidenceLines = evidence.length
+    ? evidence.map((entry) => `- \`${entry.destination}\` copied from \`${entry.source}\``).join('\n')
+    : '- No runtime evidence directory was included. Re-run with `--include-output <dir>` after staging smoke.'
+
+  return `# DingTalk Staging Evidence Packet
+
+Generated at: ${manifest.generatedAt}
+
+This packet is the operator handoff bundle for the shared-dev/142 DingTalk
+staging stack. It is intentionally read-only: exporting it does not deploy,
+call Docker, hit staging, or require credentials.
+
+## Included Docs And Config
+
+${docs.map(fileLine).join('\n')}
+
+## Included Scripts
+
+${scripts.map(fileLine).join('\n')}
+
+## Included Runtime Evidence
+
+${evidenceLines}
+
+## Recommended Order
+
+1. Read \`docs/development/dingtalk-staging-canary-deploy-20260408.md\`.
+2. Copy \`docker/app.staging.env.example\` to \`docker/app.staging.env\` and fill real secrets on the server only.
+3. Validate the env with \`bash scripts/ops/validate-env-file.sh docker/app.staging.env\`.
+4. Deploy a pinned tag with \`DEPLOY_IMAGE_TAG=<tag> bash scripts/ops/deploy-dingtalk-staging.sh\`.
+5. Execute \`docs/development/dingtalk-staging-execution-checklist-20260408.md\`.
+6. Re-export this packet with \`--include-output <evidence-dir>\` after smoke evidence exists.
+
+## Non-Goals
+
+- Does not store secrets.
+- Does not mutate \`docker/app.staging.env\`.
+- Does not run remote smoke tests.
+- Does not decide whether a staging result is production-ready.
+`
+}
+
+async function main() {
+  try {
+    const opts = parseArgs(process.argv.slice(2))
+    mkdirSync(opts.outputDir, { recursive: true })
+
+    const copiedFiles = requiredPacketFiles.map((entry) => {
+      const destination = copyFileIntoPacket(entry.path, opts.outputDir)
+      console.log(`Copied ${entry.path}`)
+      return {
+        ...entry,
+        destination: path.relative(opts.outputDir, destination).replaceAll('\\', '/'),
+      }
+    })
+
+    const includedEvidence = opts.includeOutputDirs.map((dir, index) => {
+      const copied = copyEvidenceDir(dir, opts.outputDir, index)
+      console.log(`Copied evidence ${copied.source}`)
+      return copied
+    })
+
+    const manifest = {
+      packet: 'dingtalk-staging-evidence-packet',
+      generatedAt: new Date().toISOString(),
+      repoRoot: process.cwd(),
+      files: copiedFiles,
+      includedEvidence,
+    }
+
+    const manifestPath = path.join(opts.outputDir, 'manifest.json')
+    const readmePath = path.join(opts.outputDir, 'README.md')
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+    writeFileSync(readmePath, `${renderReadme(manifest)}\n`, 'utf8')
+    console.log(`Wrote ${path.relative(process.cwd(), manifestPath)}`)
+    console.log(`Wrote ${path.relative(process.cwd(), readmePath)}`)
+  } catch (error) {
+    console.error(`[export-dingtalk-staging-evidence-packet] ERROR: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+await main()

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'export-dingtalk-staging-evidence-packet.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-staging-evidence-packet-'))
+}
+
+test('export-dingtalk-staging-evidence-packet copies required handoff files and writes manifest', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    const result = spawnSync(process.execPath, [scriptPath, '--output-dir', outputDir], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Copied docs\/development\/dingtalk-staging-canary-deploy-20260408\.md/)
+    assert.equal(
+      existsSync(
+        path.join(outputDir, 'docs/development/dingtalk-staging-execution-checklist-20260408.md'),
+      ),
+      true,
+    )
+    assert.equal(existsSync(path.join(outputDir, 'scripts/ops/deploy-dingtalk-staging.sh')), true)
+    assert.equal(existsSync(path.join(outputDir, 'docker/app.staging.env.example')), true)
+
+    const manifest = JSON.parse(readFileSync(path.join(outputDir, 'manifest.json'), 'utf8'))
+    assert.equal(manifest.packet, 'dingtalk-staging-evidence-packet')
+    assert.equal(manifest.includedEvidence.length, 0)
+    assert.equal(
+      manifest.files.some((file) => file.path === 'scripts/ops/validate-env-file.sh'),
+      true,
+    )
+
+    const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
+    assert.match(readme, /DingTalk Staging Evidence Packet/)
+    assert.match(readme, /No runtime evidence directory was included/)
+    assert.match(readme, /Does not store secrets/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet copies optional runtime evidence directories', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const evidenceDir = path.join(tmpDir, 'smoke-output')
+
+  try {
+    mkdirSync(evidenceDir, { recursive: true })
+    writeFileSync(path.join(evidenceDir, 'summary.json'), JSON.stringify({ ok: true }), 'utf8')
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', evidenceDir],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    const manifest = JSON.parse(readFileSync(path.join(outputDir, 'manifest.json'), 'utf8'))
+    assert.equal(manifest.includedEvidence.length, 1)
+    assert.equal(manifest.includedEvidence[0].destination, 'evidence/01-smoke-output')
+    assert.equal(existsSync(path.join(outputDir, 'evidence/01-smoke-output/summary.json')), true)
+
+    const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
+    assert.match(readme, /evidence\/01-smoke-output/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet rejects missing optional evidence directory', () => {
+  const tmpDir = makeTmpDir()
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        '--output-dir',
+        path.join(tmpDir, 'packet'),
+        '--include-output',
+        path.join(tmpDir, 'missing-output'),
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /--include-output must point to an existing directory/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet rejects unknown arguments', () => {
+  const result = spawnSync(process.execPath, [scriptPath, '--unknown'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Unknown argument: --unknown/)
+})


### PR DESCRIPTION
## Summary
- add a read-only DingTalk/shared-dev staging evidence packet exporter
- copy the staging runbook, execution checklist, env template, env repair/validation scripts, and deploy/build scripts into one handoff directory
- support optional runtime evidence attachment with `--include-output <dir>`
- add development and verification notes

## Verification
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs` (4/4 passed)
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs && node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `node scripts/ops/export-dingtalk-staging-evidence-packet.mjs --output-dir tmp/dingtalk-staging-evidence-packet-smoke`

## Notes
This is local evidence packaging only. It does not deploy, call Docker, contact staging, or read secrets.