### PR TITLE
test(dingtalk): cover V1 editor stale legacy fields

### DIFF
--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -545,6 +545,64 @@ describe('MetaAutomationRuleEditor', () => {
     expect(client.listDingTalkGroups).toHaveBeenCalledWith('sheet_1')
   })
 
+  it('loads and saves DingTalk group config from V1 actions when legacy action fields are stale', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      rule: fakeRule({
+        name: 'V1 group action',
+        actionType: 'notify',
+        actionConfig: { message: 'stale legacy value' },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationId: 'dt_1',
+            destinationIds: ['dt_1', 'dt_2'],
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please review {{record.status}}',
+            publicFormViewId: 'view_form',
+            internalViewId: 'view_grid',
+          },
+        }],
+      }),
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(actionSelect.value).toBe('send_dingtalk_group_message')
+    expect(container.querySelector('[data-group-destination="dt_1"]')?.textContent).toContain('Ops Group')
+    expect(container.querySelector('[data-group-destination="dt_2"]')?.textContent).toContain('Escalation Group')
+    expect((container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
+    expect((container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please review {{record.status}}')
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionType).toBe('send_dingtalk_group_message')
+    expect(payload.actionConfig).toEqual({
+      destinationId: 'dt_1',
+      destinationIds: ['dt_1', 'dt_2'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      publicFormViewId: 'view_form',
+      internalViewId: 'view_grid',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_dingtalk_group_message',
+      config: payload.actionConfig,
+    })
+  })
+
   it('emits DingTalk group action config with only dynamic record destination paths', async () => {
     const saved = vi.fn()
     const client = mockClient()
@@ -1043,6 +1101,66 @@ describe('MetaAutomationRuleEditor', () => {
     })
     expect(container.textContent).toContain('Record recipients:')
     expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('loads and saves DingTalk person dynamic recipients from V1 actions when legacy action fields are stale', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      rule: fakeRule({
+        name: 'V1 person action',
+        actionType: 'notify',
+        actionConfig: { message: 'stale legacy value' },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            userIdFieldPath: 'record.assigneeUserIds',
+            userIdFieldPaths: ['record.assigneeUserIds'],
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please review {{record.status}}',
+            publicFormViewId: 'view_form',
+            internalViewId: 'view_grid',
+          },
+        }],
+      }),
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(actionSelect.value).toBe('send_dingtalk_person_message')
+    expect((container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement).value).toBe('record.assigneeUserIds')
+    expect((container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
+    expect((container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please review {{record.status}}')
+    expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionType).toBe('send_dingtalk_person_message')
+    expect(payload.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      publicFormViewId: 'view_form',
+      internalViewId: 'view_grid',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_dingtalk_person_message',
+      config: payload.actionConfig,
+    })
   })
 
   it('emits DingTalk person action config with only a dynamic member group record path', async () => {

--- a/docs/development/dingtalk-v1-editor-stale-top-level-development-20260421.md
+++ b/docs/development/dingtalk-v1-editor-stale-top-level-development-20260421.md
@@ -1,0 +1,39 @@
+# DingTalk V1 Editor Stale Top-Level Coverage Development - 2026-04-21
+
+## Goal
+
+Lock the rule editor behavior for V1 DingTalk automation rules where the legacy top-level fields are stale.
+
+V1 automation rules should treat `rule.actions[]` as the source of truth. Older or migrated records may still carry legacy `actionType/actionConfig` values that do not match the real V1 action list. The editor already prefers `actions[]`, but the test suite did not prove this for DingTalk group/person configurations.
+
+## Implementation
+
+Changed `apps/web/tests/multitable-automation-rule-editor.spec.ts`.
+
+- Added a regression test for a DingTalk group message rule where:
+  - `actionType` is stale `notify`.
+  - `actionConfig` contains only a stale internal notification value.
+  - `actions[]` contains `send_dingtalk_group_message`.
+  - The editor loads group destinations/templates from `actions[]`.
+  - Save emits a DingTalk group action and matching top-level compatibility fields.
+- Added a regression test for a DingTalk person message rule where:
+  - `actionType` is stale `notify`.
+  - `actionConfig` contains only a stale internal notification value.
+  - `actions[]` contains `send_dingtalk_person_message` with dynamic record recipients.
+  - The editor loads dynamic recipient paths/templates from `actions[]`.
+  - Save emits a DingTalk person action and matching top-level compatibility fields.
+
+No production code changed. The existing `draftFromRule(...)` implementation already gives `rule.actions[]` precedence.
+
+## Scope
+
+This slice is frontend test coverage only.
+
+- No runtime code change.
+- No backend API change.
+- No database migration.
+- No DingTalk delivery behavior change.
+
+## User Impact
+
+This prevents future regressions where editing a V1 DingTalk automation could accidentally read stale legacy action fields and overwrite the real DingTalk configuration.

--- a/docs/development/dingtalk-v1-editor-stale-top-level-verification-20260421.md
+++ b/docs/development/dingtalk-v1-editor-stale-top-level-verification-20260421.md
@@ -1,0 +1,24 @@
+# DingTalk V1 Editor Stale Top-Level Coverage Verification - 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Result
+
+- Initial Vitest command before dependency install failed because `vitest` was not available in this new worktree.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false`: passed, 1 file / 50 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Notes
+
+The frontend build emitted existing Vite warnings about `WorkflowDesigner.vue` being both statically and dynamically imported, plus large chunk warnings. These warnings are unrelated to this DingTalk editor coverage slice.
+
+`pnpm install` updated local `node_modules` links in several workspace packages. Those generated dependency-directory changes must remain unstaged.


### PR DESCRIPTION
## Summary
- Add RuleEditor regression coverage for V1 DingTalk group actions when legacy `actionType/actionConfig` are stale.
- Add RuleEditor regression coverage for V1 DingTalk person dynamic-recipient actions when legacy fields are stale.
- Document that production code already prefers `rule.actions[]`; this PR locks that behavior with tests.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

## Notes
- Frontend build still emits existing Vite warnings for `WorkflowDesigner.vue` static/dynamic import and large chunks.
- Dependency install produced local `node_modules` changes in the worktree; they are intentionally unstaged and not included in this PR.
- The base branch is a temporary stack base at #987's head so this PR diff only contains the current editor coverage slice.