### PR TITLE
test(dingtalk): cover Manager V1 editor hydration

### DIFF
--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1756,6 +1756,81 @@ describe('MetaAutomationManager', () => {
     expect(document.body.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
+  it('opens the rule editor with DingTalk group config from V1 actions when legacy action fields are stale', async () => {
+    const rules = [
+      fakeRule({
+        id: 'rule_stale_group',
+        name: 'Stale group action',
+        actionType: 'notify',
+        actionConfig: { message: 'stale legacy notification' },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationId: 'dt_1',
+            destinationIds: ['dt_1', 'dt_2'],
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please review {{record.status}}',
+            publicFormViewId: 'view_form',
+            internalViewId: 'view_grid',
+          },
+        }],
+      }),
+    ]
+    const { client } = mockClient(rules)
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const editBtn = container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement
+    expect(editBtn).toBeTruthy()
+    editBtn.click()
+    await flushPromises()
+
+    const actionSelect = document.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(actionSelect.value).toBe('send_dingtalk_group_message')
+    expect(document.querySelector('[data-group-destination="dt_1"]')?.textContent).toContain('Ops Group')
+    expect(document.querySelector('[data-group-destination="dt_2"]')?.textContent).toContain('Escalation Group')
+    expect((document.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
+    expect((document.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please review {{record.status}}')
+  })
+
+  it('opens the rule editor with DingTalk person dynamic recipients from V1 actions when legacy action fields are stale', async () => {
+    const rules = [
+      fakeRule({
+        id: 'rule_stale_person',
+        name: 'Stale person action',
+        actionType: 'notify',
+        actionConfig: { message: 'stale legacy notification' },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            userIdFieldPath: 'record.assigneeUserIds',
+            userIdFieldPaths: ['record.assigneeUserIds'],
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please fill {{record.status}}',
+          },
+        }],
+      }),
+    ]
+    const { client } = mockClient(rules)
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const editBtn = container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement
+    expect(editBtn).toBeTruthy()
+    editBtn.click()
+    await flushPromises()
+
+    const actionSelect = document.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    const recipientFieldInput = document.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(actionSelect.value).toBe('send_dingtalk_person_message')
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
+    expect((document.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
+    expect((document.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please fill {{record.status}}')
+    expect(document.body.textContent).toContain('Record recipients:')
+    expect(document.body.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
   it('shows a blocking warning when editing a rule with a missing internal processing view', async () => {
     const config = {
       destinationIds: ['dt_1'],

--- a/docs/development/dingtalk-v1-manager-edit-stale-top-level-development-20260421.md
+++ b/docs/development/dingtalk-v1-manager-edit-stale-top-level-development-20260421.md
@@ -1,0 +1,37 @@
+# DingTalk V1 Manager Edit Stale Top-Level Coverage Development - 2026-04-21
+
+## Goal
+
+Lock the full automation-list edit path for V1 DingTalk rules whose legacy top-level action fields are stale.
+
+`MetaAutomationRuleEditor` already prefers `rule.actions[]`, and PR #988 added direct editor coverage. This slice adds integration coverage through `MetaAutomationManager`: a user clicks `Edit` from the automation list, the manager passes the saved rule into the editor, and the editor must hydrate from V1 `actions[]` rather than stale `actionType/actionConfig`.
+
+## Implementation
+
+Changed `apps/web/tests/multitable-automation-manager.spec.ts`.
+
+- Added a regression test for a saved rule where:
+  - top-level `actionType` is stale `notify`.
+  - top-level `actionConfig` is a stale notification payload.
+  - `actions[]` contains the real `send_dingtalk_group_message` config.
+  - clicking list `Edit` opens the rule editor with DingTalk group destinations/templates loaded from `actions[]`.
+- Added a regression test for a saved rule where:
+  - top-level `actionType` is stale `notify`.
+  - top-level `actionConfig` is a stale notification payload.
+  - `actions[]` contains the real `send_dingtalk_person_message` dynamic-recipient config.
+  - clicking list `Edit` opens the rule editor with the dynamic recipient path/templates loaded from `actions[]`.
+
+No production code changed.
+
+## Scope
+
+This slice is frontend test coverage only.
+
+- No runtime code change.
+- No backend API change.
+- No database migration.
+- No DingTalk delivery behavior change.
+
+## User Impact
+
+This prevents regressions where a V1 DingTalk rule looks correct in the list but opens in the editor with stale legacy notification fields, which could otherwise lead to accidental overwrite of real DingTalk settings.

--- a/docs/development/dingtalk-v1-manager-edit-stale-top-level-verification-20260421.md
+++ b/docs/development/dingtalk-v1-manager-edit-stale-top-level-verification-20260421.md
@@ -1,0 +1,24 @@
+# DingTalk V1 Manager Edit Stale Top-Level Coverage Verification - 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Result
+
+- Initial Vitest command before dependency install failed because `vitest` was not available in this new worktree.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false`: passed, 1 file / 55 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Notes
+
+The frontend build emitted existing Vite warnings about `WorkflowDesigner.vue` being both statically and dynamically imported, plus large chunk warnings. These warnings are unrelated to this Manager edit-path coverage slice.
+
+`pnpm install` updated local `node_modules` links in several workspace packages. Those generated dependency-directory changes must remain unstaged.


### PR DESCRIPTION
## Summary
- Add Manager integration coverage for editing a V1 DingTalk group rule when legacy top-level action fields are stale.
- Add Manager integration coverage for editing a V1 DingTalk person dynamic-recipient rule when legacy fields are stale.
- Keep this as test-only; production editor code already hydrates from `rule.actions[]`.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

## Notes
- Frontend build still emits existing Vite warnings for `WorkflowDesigner.vue` static/dynamic import and large chunks.
- Dependency install produced local `node_modules` changes in the worktree; they are intentionally unstaged and not included in this PR.
- The base branch is a temporary stack base at #988's head so this PR diff only contains the current Manager edit-path coverage slice.