### PR TITLE
fix(dingtalk): harden delivery route limits

### DIFF
--- a/docs/development/dingtalk-delivery-route-contracts-development-20260421.md
+++ b/docs/development/dingtalk-delivery-route-contracts-development-20260421.md
@@ -1,0 +1,34 @@
+# DingTalk Delivery Route Contracts Development - 2026-04-21
+
+## Background
+
+This slice hardens the standard DingTalk automation delivery history APIs:
+
+- `GET /api/multitable/sheets/:sheetId/automations/:ruleId/dingtalk-person-deliveries`
+- `GET /api/multitable/sheets/:sheetId/automations/:ruleId/dingtalk-group-deliveries`
+
+The previous route-level limit parser used `Number(req.query.limit) || 50`. That made `limit=0` fall back to `50` instead of clamping to the lower bound `1`, so route behavior differed from the intended `[1, 200]` contract.
+
+## Changes
+
+- Added `parseDingTalkAutomationDeliveryLimit()` in `packages/core-backend/src/routes/univer-meta.ts`.
+- Shared the same limit parsing for person and group delivery history routes.
+- Preserved default behavior: missing or invalid `limit` defaults to `50`.
+- Preserved bounds: finite numeric limits are floored and clamped to `1..200`.
+- Added route-level integration coverage in `packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts`.
+
+## Route Contract Covered
+
+- Person delivery history returns `{ ok: true, data: { deliveries } }`.
+- Group delivery history returns `{ ok: true, data: { deliveries } }`.
+- `limit=0` is passed to the delivery service as `1`.
+- Large limits such as `999` are passed to the delivery service as `200`.
+- Users without automation management capability receive `403 FORBIDDEN`.
+- A rule that is missing or belongs to another sheet returns `404 NOT_FOUND`.
+- Delivery services are not called on `403` or `404`.
+
+## Implementation Notes
+
+The tests mock the delivery services directly and assert the limit argument passed by the route. This keeps the regression pinned to the route layer and avoids the service-layer clamp masking route parsing bugs.
+
+The tests keep `poolManager.get()` lightweight while still exercising `resolveSheetCapabilities()` through the router, so permission behavior remains covered without a real database.

--- a/docs/development/dingtalk-delivery-route-contracts-verification-20260421.md
+++ b/docs/development/dingtalk-delivery-route-contracts-verification-20260421.md
@@ -1,0 +1,43 @@
+# DingTalk Delivery Route Contracts Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-delivery-route-contracts-20260421`
+- Branch: `codex/dingtalk-delivery-route-contracts-20260421`
+- Base: stacked on DingTalk V1 Manager editor hydration work
+- Node dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest` available
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. PNPM reused the local store and installed workspace dependencies.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-delivery-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `1 passed`
+- Tests: `4 passed`
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+```bash
+git diff --check -- packages/core-backend/src/routes/univer-meta.ts packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk webhook was called in this slice.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally not part of the development commit.
+- Verification focuses on backend route contracts, permission behavior, rule-sheet validation, and route-level limit parsing.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1811,6 +1811,11 @@ function normalizePermissionCodes(value: unknown): string[] {
     .filter((item) => item.length > 0)
 }
 
+function parseDingTalkAutomationDeliveryLimit(value: unknown): number {
+  const raw = typeof value === 'string' ? Number(value) : undefined
+  return Number.isFinite(raw) ? Math.min(Math.max(Math.floor(raw as number), 1), 200) : 50
+}
+
 type ResolvedRequestAccess = {
   userId: string
   permissions: string[]
@@ -8556,7 +8561,7 @@ export function univerMetaRouter(): Router {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 
-      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
+      const limit = parseDingTalkAutomationDeliveryLimit(req.query.limit)
       const deliveries = await listAutomationDingTalkPersonDeliveries(pool.query.bind(pool), ruleId, limit)
       return res.json({ ok: true, data: { deliveries } })
     } catch (err) {
@@ -8587,7 +8592,7 @@ export function univerMetaRouter(): Router {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 
-      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
+      const limit = parseDingTalkAutomationDeliveryLimit(req.query.limit)
       const deliveries = await listAutomationDingTalkGroupDeliveries(pool.query.bind(pool), ruleId, limit)
       return res.json({ ok: true, data: { deliveries } })
     } catch (err) {

--- a/packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts
@@ -1,0 +1,192 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type QueryResult = {
+  rows: Record<string, unknown>[]
+  rowCount?: number
+}
+
+type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
+
+const SHEET_ID = 'sheet_dingtalk_delivery_routes'
+const OTHER_SHEET_ID = 'sheet_other'
+const RULE_ID = 'rule_dingtalk_delivery_routes'
+
+function createMockPool(queryHandler: QueryHandler = () => ({ rows: [], rowCount: 0 })) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM spreadsheet_permissions')) {
+      return { rows: [], rowCount: 0 }
+    }
+    return queryHandler(sql, params)
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+function makeAutomationRule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RULE_ID,
+    sheet_id: SHEET_ID,
+    name: 'DingTalk delivery route',
+    trigger_type: 'record.created',
+    trigger_config: {},
+    action_type: 'send_dingtalk_group_message',
+    action_config: {},
+    enabled: true,
+    created_at: '2026-04-21T00:00:00.000Z',
+    updated_at: '2026-04-21T00:00:00.000Z',
+    created_by: 'admin_1',
+    conditions: null,
+    actions: null,
+    ...overrides,
+  }
+}
+
+function createMockAutomationService(existingRule: ReturnType<typeof makeAutomationRule> | null = makeAutomationRule()) {
+  return {
+    getRule: vi.fn(async (ruleId: string) => {
+      if (!existingRule || ruleId !== existingRule.id) return null
+      return existingRule
+    }),
+  }
+}
+
+async function createApp(options: {
+  automationRule?: ReturnType<typeof makeAutomationRule> | null
+  groupDeliveries?: Array<Record<string, unknown>>
+  personDeliveries?: Array<Record<string, unknown>>
+  perms?: string[]
+  role?: string
+} = {}) {
+  vi.resetModules()
+
+  const groupDeliveries = options.groupDeliveries ?? []
+  const personDeliveries = options.personDeliveries ?? []
+  const listGroupDeliveries = vi.fn(async () => groupDeliveries)
+  const listPersonDeliveries = vi.fn(async () => personDeliveries)
+
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false),
+    userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue([]),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+  vi.doMock('../../src/multitable/dingtalk-group-delivery-service', () => ({
+    listAutomationDingTalkGroupDeliveries: listGroupDeliveries,
+  }))
+  vi.doMock('../../src/multitable/dingtalk-person-delivery-service', () => ({
+    listAutomationDingTalkPersonDeliveries: listPersonDeliveries,
+  }))
+
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { setAutomationServiceInstance } = await import('../../src/multitable/automation-service')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+
+  const mockPool = createMockPool()
+  const automationService = createMockAutomationService(
+    options.automationRule === undefined ? makeAutomationRule() : options.automationRule,
+  )
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as ReturnType<typeof poolManager.get>)
+  setAutomationServiceInstance(automationService as Parameters<typeof setAutomationServiceInstance>[0])
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = {
+      id: 'admin_1',
+      role: options.role,
+      roles: options.role === 'admin' ? ['admin'] : [],
+      perms: options.perms ?? ['workflow:write', 'multitable:write'],
+    }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+
+  return {
+    app,
+    automationService,
+    listGroupDeliveries,
+    listPersonDeliveries,
+    mockPool,
+  }
+}
+
+describe('DingTalk automation delivery routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('lists person delivery history and clamps limit=0 to one', async () => {
+    const personDeliveries = [{ id: 'person_delivery_1', success: true }]
+    const { app, listPersonDeliveries } = await createApp({ personDeliveries })
+
+    const response = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}/dingtalk-person-deliveries`)
+      .query({ limit: '0' })
+      .expect(200)
+
+    expect(response.body).toEqual({
+      ok: true,
+      data: { deliveries: personDeliveries },
+    })
+    expect(listPersonDeliveries).toHaveBeenCalledWith(expect.any(Function), RULE_ID, 1)
+  })
+
+  it('lists group delivery history and clamps large limits to 200', async () => {
+    const groupDeliveries = [{ id: 'group_delivery_1', success: true }]
+    const { app, listGroupDeliveries } = await createApp({ groupDeliveries })
+
+    const response = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}/dingtalk-group-deliveries`)
+      .query({ limit: '999' })
+      .expect(200)
+
+    expect(response.body).toEqual({
+      ok: true,
+      data: { deliveries: groupDeliveries },
+    })
+    expect(listGroupDeliveries).toHaveBeenCalledWith(expect.any(Function), RULE_ID, 200)
+  })
+
+  it('rejects delivery history reads when the user cannot manage automations', async () => {
+    const { app, automationService, listPersonDeliveries } = await createApp({
+      perms: ['multitable:read'],
+    })
+
+    const response = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}/dingtalk-person-deliveries`)
+      .expect(403)
+
+    expect(response.body).toEqual({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Insufficient permissions',
+      },
+    })
+    expect(automationService.getRule).not.toHaveBeenCalled()
+    expect(listPersonDeliveries).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the automation rule does not belong to the sheet', async () => {
+    const { app, listGroupDeliveries } = await createApp({
+      automationRule: makeAutomationRule({ sheet_id: OTHER_SHEET_ID }),
+    })
+
+    const response = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}/dingtalk-group-deliveries`)
+      .expect(404)
+
+    expect(response.body).toEqual({
+      ok: false,
+      error: {
+        code: 'NOT_FOUND',
+        message: 'Automation rule not found',
+      },
+    })
+    expect(listGroupDeliveries).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Add shared DingTalk automation delivery history limit parsing for person and group routes.
- Clamp finite limits to 1..200 while preserving default 50 for missing/invalid input.
- Add route-level integration coverage for person/group history, 403, 404, and limit boundaries.
- Add development and verification MD reports.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-delivery-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check -- packages/core-backend/src/routes/univer-meta.ts packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts docs/development/dingtalk-delivery-route-contracts-development-20260421.md docs/development/dingtalk-delivery-route-contracts-verification-20260421.md`

## Stack
- Temporary base branch points at #989 head (`fdfa558cffa3b4c6eb9f7ef159b8722a0ee24d08`) so this PR shows only the current slice.