### PR TITLE
fix(dingtalk): surface delivery viewer load errors

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
@@ -13,10 +13,13 @@
             <option value="success">Success</option>
             <option value="failed">Failed</option>
           </select>
-          <button class="meta-group-delivery__btn" type="button" data-action="refresh" @click="loadData">Refresh</button>
+          <button class="meta-group-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">Refresh</button>
         </div>
 
         <div v-if="loading" class="meta-group-delivery__empty">Loading deliveries...</div>
+        <div v-else-if="errorMessage" class="meta-group-delivery__error-state" data-group-delivery-error="true">
+          {{ errorMessage }}
+        </div>
         <div v-else-if="filteredDeliveries.length === 0" class="meta-group-delivery__empty" data-empty="true">
           No DingTalk group deliveries found.
         </div>
@@ -65,6 +68,7 @@ defineEmits<{
 const loading = ref(false)
 const deliveries = ref<DingTalkGroupDelivery[]>([])
 const statusFilter = ref('')
+const errorMessage = ref('')
 
 const filteredDeliveries = computed(() => {
   if (!statusFilter.value) return deliveries.value
@@ -80,13 +84,21 @@ function formatTime(ts: string): string {
   }
 }
 
+function readErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : 'Failed to load DingTalk group deliveries.'
+}
+
 async function loadData() {
   if (!props.client || !props.sheetId || !props.ruleId) return
   loading.value = true
+  errorMessage.value = ''
   try {
     deliveries.value = await props.client.getAutomationDingTalkGroupDeliveries(props.sheetId, props.ruleId, 50)
-  } catch {
+  } catch (error) {
     deliveries.value = []
+    errorMessage.value = readErrorMessage(error)
   } finally {
     loading.value = false
   }
@@ -244,5 +256,14 @@ watch(
 .meta-group-delivery__error {
   color: #dc2626;
   font-size: 12px;
+}
+
+.meta-group-delivery__error-state {
+  padding: 10px 12px;
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 13px;
 }
 </style>

--- a/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
@@ -13,10 +13,13 @@
             <option value="success">Success</option>
             <option value="failed">Failed</option>
           </select>
-          <button class="meta-person-delivery__btn" type="button" data-action="refresh" @click="loadData">Refresh</button>
+          <button class="meta-person-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">Refresh</button>
         </div>
 
         <div v-if="loading" class="meta-person-delivery__empty">Loading deliveries...</div>
+        <div v-else-if="errorMessage" class="meta-person-delivery__error-state" data-person-delivery-error="true">
+          {{ errorMessage }}
+        </div>
         <div v-else-if="filteredDeliveries.length === 0" class="meta-person-delivery__empty" data-empty="true">
           No DingTalk person deliveries found.
         </div>
@@ -72,6 +75,7 @@ defineEmits<{
 const loading = ref(false)
 const deliveries = ref<DingTalkPersonDelivery[]>([])
 const statusFilter = ref('')
+const errorMessage = ref('')
 
 const filteredDeliveries = computed(() => {
   if (!statusFilter.value) return deliveries.value
@@ -87,13 +91,21 @@ function formatTime(ts: string): string {
   }
 }
 
+function readErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : 'Failed to load DingTalk person deliveries.'
+}
+
 async function loadData() {
   if (!props.client || !props.sheetId || !props.ruleId) return
   loading.value = true
+  errorMessage.value = ''
   try {
     deliveries.value = await props.client.getAutomationDingTalkPersonDeliveries(props.sheetId, props.ruleId, 50)
-  } catch {
+  } catch (error) {
     deliveries.value = []
+    errorMessage.value = readErrorMessage(error)
   } finally {
     loading.value = false
   }
@@ -266,5 +278,14 @@ watch(
 .meta-person-delivery__error {
   font-size: 12px;
   color: #b91c1c;
+}
+
+.meta-person-delivery__error-state {
+  padding: 10px 12px;
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 13px;
 }
 </style>

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -27,10 +27,16 @@ function mockClient(
   options: {
     testExecution?: Record<string, unknown> | Promise<Record<string, unknown>>
     testErrorMessage?: string
+    groupDeliveryErrorMessage?: string
+    personDeliveryErrorMessage?: string
     stats?: Record<string, unknown>
   } = {},
 ) {
   const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  const apiError = (message: string) => new Response(
+    JSON.stringify({ error: { code: 'INTERNAL_ERROR', message } }),
+    { status: 500, headers: { 'Content-Type': 'application/json' } },
+  )
   const noContent = () => new Response(null, { status: 204 })
   const personDeliveries: DingTalkPersonDelivery[] = [
     {
@@ -105,9 +111,11 @@ function mockClient(
     }
     if (method === 'GET' && url.includes('/automations')) {
       if (url.includes('/dingtalk-group-deliveries')) {
+        if (options.groupDeliveryErrorMessage) return apiError(options.groupDeliveryErrorMessage)
         return ok({ deliveries: groupDeliveries })
       }
       if (url.includes('/dingtalk-person-deliveries')) {
+        if (options.personDeliveryErrorMessage) return apiError(options.personDeliveryErrorMessage)
         return ok({ deliveries: personDeliveries })
       }
       if (url.endsWith('/stats')) {
@@ -1348,6 +1356,31 @@ describe('MetaAutomationManager', () => {
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/dingtalk-group-deliveries'))).toBe(true)
   })
 
+  it('shows DingTalk group delivery load errors instead of an empty history', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        name: 'DingTalk group notify',
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+      }),
+    ], { groupDeliveryErrorMessage: 'Delivery history unavailable' })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deliveriesBtn = container.querySelector('[data-automation-group-deliveries="rule_1"]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const error = document.querySelector('[data-group-delivery-error="true"]')
+    expect(error?.textContent).toContain('Delivery history unavailable')
+    expect(document.querySelector('[data-group-delivery-id="dgd_1"]')).toBeNull()
+    expect(document.querySelector('.meta-group-delivery [data-empty="true"]')).toBeNull()
+  })
+
   it('opens DingTalk group delivery viewer for V1 multi-action rules', async () => {
     const { client, fetchFn } = mockClient([
       fakeRule({
@@ -1410,6 +1443,31 @@ describe('MetaAutomationManager', () => {
     const delivery = document.querySelector('[data-person-delivery-id="dpd_1"]')
     expect(delivery?.textContent).toContain('Lin Lan')
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/dingtalk-person-deliveries'))).toBe(true)
+  })
+
+  it('shows DingTalk person delivery load errors instead of an empty history', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        name: 'Multi-step person notify',
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: ['user_1'],
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+      }),
+    ], { personDeliveryErrorMessage: 'Person delivery query failed' })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deliveriesBtn = container.querySelector('[data-automation-person-deliveries="rule_1"]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const error = document.querySelector('[data-person-delivery-error="true"]')
+    expect(error?.textContent).toContain('Person delivery query failed')
+    expect(document.querySelector('[data-person-delivery-id="dpd_1"]')).toBeNull()
+    expect(document.querySelector('.meta-person-delivery [data-empty="true"]')).toBeNull()
   })
 
   it('shows a generic running status for non-DingTalk automation test runs', async () => {

--- a/docs/development/dingtalk-delivery-viewer-errors-development-20260421.md
+++ b/docs/development/dingtalk-delivery-viewer-errors-development-20260421.md
@@ -1,0 +1,29 @@
+# DingTalk Delivery Viewer Errors Development - 2026-04-21
+
+## Background
+
+Automation DingTalk delivery history is now part of the standard table-trigger workflow. The backend returns explicit `403`, `404`, and `500` responses for delivery history routes, but the frontend delivery viewers previously swallowed load failures and rendered the same empty state as a valid empty history.
+
+That behavior is misleading for administrators because a permission, route, or server problem looks like "no DingTalk deliveries yet".
+
+## Changes
+
+- Updated `MetaAutomationGroupDeliveryViewer.vue`.
+- Updated `MetaAutomationPersonDeliveryViewer.vue`.
+- Added an explicit error state for failed delivery history loads.
+- Cleared stale errors whenever a refresh starts.
+- Disabled the refresh button while a load is already in progress.
+- Kept the existing empty state only for successful empty responses.
+- Added frontend coverage in `apps/web/tests/multitable-automation-manager.spec.ts`.
+
+## User-Facing Behavior
+
+- Successful delivery history loads are unchanged.
+- Empty successful responses still show the existing empty-history message.
+- Failed group delivery history loads now show the backend error message in the group delivery dialog.
+- Failed person delivery history loads now show the backend error message in the person delivery dialog.
+- Error states no longer render stale delivery rows or the empty-history message.
+
+## Notes
+
+This slice does not call DingTalk directly. It improves the standard UI around the already-defined delivery history APIs so administrators can distinguish "no deliveries" from "delivery history failed to load".

--- a/docs/development/dingtalk-delivery-viewer-errors-verification-20260421.md
+++ b/docs/development/dingtalk-delivery-viewer-errors-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Delivery Viewer Errors Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-delivery-viewer-errors-20260421`
+- Branch: `codex/dingtalk-delivery-viewer-errors-20260421`
+- Base: stacked on DingTalk delivery route contracts (`7c970778e41ba483cb9c20d66219cbe682baf382`)
+- Dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `1 passed`
+- Tests: `57 passed`
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Build emitted existing Vite warnings about large chunks and one dynamic/static import overlap for `WorkflowDesigner.vue`; there were no build errors.
+
+```bash
+git diff --check -- apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue apps/web/tests/multitable-automation-manager.spec.ts docs/development/dingtalk-delivery-viewer-errors-development-20260421.md docs/development/dingtalk-delivery-viewer-errors-verification-20260421.md
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk robot webhook was called.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally excluded from the commit.
+- Verification focuses on frontend delivery viewer behavior for failed person/group automation delivery history loads.


### PR DESCRIPTION
## Summary
- Show explicit error states when DingTalk automation group/person delivery history fails to load.
- Clear stale errors on refresh and disable refresh while loading.
- Keep the existing empty-state only for successful empty responses.
- Add frontend coverage for failed group/person delivery history loads.
- Add development and verification MD reports.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check -- apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue apps/web/tests/multitable-automation-manager.spec.ts docs/development/dingtalk-delivery-viewer-errors-development-20260421.md docs/development/dingtalk-delivery-viewer-errors-verification-20260421.md`

## Stack
- Temporary base branch points at #990 head (`7c970778e41ba483cb9c20d66219cbe682baf382`) so this PR shows only the current slice.