### PR TITLE
fix(dingtalk): warn on invalid member group paths

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1084,6 +1084,9 @@ function memberGroupRecipientFieldPathWarnings(value: string) {
     if (field.type === 'user') {
       return [`record.${path} is a user field; use Record recipient field paths instead.`]
     }
+    if (!isDingTalkMemberGroupRecipientField(field)) {
+      return [`record.${path} is not a member group field; DingTalk person member-group recipients expect member group fields.`]
+    }
     return []
   })
 }

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1341,6 +1341,9 @@ function memberGroupRecipientFieldPathWarnings(value: unknown) {
     if (field.type === 'user') {
       return [`record.${path} is a user field; use Record recipient field paths instead.`]
     }
+    if (!isDingTalkMemberGroupRecipientField(field)) {
+      return [`record.${path} is not a member group field; DingTalk person member-group recipients expect member group fields.`]
+    }
     return []
   })
 }

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1983,6 +1983,28 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).toContain('record.fld_1 is not a user field')
   })
 
+  it('warns when a DingTalk person member-group recipient path is not a member group field in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.fld_1'
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.fld_1 is not a member group field')
+  })
+
   it('copies rendered DingTalk person body example in the inline create form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1756,6 +1756,30 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('record.fld_1 is not a user field')
   })
 
+  it('warns when a DingTalk person member-group recipient path is not a member group field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.fld_1'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.fld_1 is not a member group field')
+  })
+
   it('copies rendered DingTalk group body example in the rule editor', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/docs/development/dingtalk-person-member-group-path-warnings-development-20260421.md
+++ b/docs/development/dingtalk-person-member-group-path-warnings-development-20260421.md
@@ -1,0 +1,28 @@
+# DingTalk Person Member Group Path Warnings Development - 2026-04-21
+
+## Background
+
+DingTalk person automations can target local users directly and can also resolve member groups from record field paths. The member-group picker only lists explicit member group fields, but manually typed paths were only warning for unknown fields and `user` fields.
+
+That left known ordinary fields such as `record.fld_1` silent, even though they are not valid member group fields.
+
+## Changes
+
+- Updated `MetaAutomationManager.vue`.
+- Updated `MetaAutomationRuleEditor.vue`.
+- Reused `isDingTalkMemberGroupRecipientField()` for manual member-group recipient path validation.
+- Added warnings when a known field is not a member group field.
+- Preserved existing specialized warning for `user` fields: users should use the regular record recipient field path instead.
+- Added coverage in both inline manager and standalone rule editor specs.
+
+## Behavior
+
+- Unknown fields still warn as unknown.
+- `user` fields still warn to use Record recipient field paths.
+- Known non-member-group fields now warn: `record.<fieldId> is not a member group field`.
+- Valid member group fields remain accepted without warnings.
+- This is a warning-only frontend guardrail; payload shape and save behavior are unchanged.
+
+## Scope
+
+No live DingTalk API or webhook is called by this change. The slice is limited to frontend validation feedback for configuring DingTalk person automations.

--- a/docs/development/dingtalk-person-member-group-path-warnings-verification-20260421.md
+++ b/docs/development/dingtalk-person-member-group-path-warnings-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Person Member Group Path Warnings Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-path-warnings-20260421`
+- Branch: `codex/dingtalk-person-member-group-path-warnings-20260421`
+- Base: stacked on DingTalk delivery viewer error handling (`a914af4a40344532b4216ebdbedcad1976f15679`)
+- Dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `2 passed`
+- Tests: `109 passed`
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Build emitted existing Vite warnings about large chunks and one dynamic/static import overlap for `WorkflowDesigner.vue`; there were no build errors.
+
+```bash
+git diff --check -- apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/multitable-automation-manager.spec.ts apps/web/tests/multitable-automation-rule-editor.spec.ts docs/development/dingtalk-person-member-group-path-warnings-development-20260421.md docs/development/dingtalk-person-member-group-path-warnings-verification-20260421.md
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk robot webhook was called.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally excluded from the commit.
+- Verification focuses on warning visibility for manually typed non-member-group field paths in DingTalk person automation configuration.


### PR DESCRIPTION
## Summary
- Warn when a manually typed DingTalk person member-group recipient path points to a known non-member-group field.
- Preserve the existing specialized warning for user fields and existing unknown-field warnings.
- Add coverage for both the inline automation manager and standalone rule editor.
- Add development and verification MD reports.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check -- apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/multitable-automation-manager.spec.ts apps/web/tests/multitable-automation-rule-editor.spec.ts docs/development/dingtalk-person-member-group-path-warnings-development-20260421.md docs/development/dingtalk-person-member-group-path-warnings-verification-20260421.md`

## Stack
- Temporary base branch points at #991 head (`a914af4a40344532b4216ebdbedcad1976f15679`) so this PR shows only the current slice.