### PR TITLE
refactor(dingtalk): share recipient warning logic

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -689,6 +689,7 @@ import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemp
 import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
+  listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
   describeDingTalkPublicFormLinkAccess,
@@ -1075,20 +1076,7 @@ function recipientFieldPathWarnings(value: string) {
 }
 
 function memberGroupRecipientFieldPathWarnings(value: string) {
-  const fieldMap = new Map(props.fields.map((field) => [field.id, field]))
-  return parseRecipientFieldPathsText(value).flatMap((path) => {
-    const field = fieldMap.get(path)
-    if (!field) {
-      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
-    }
-    if (field.type === 'user') {
-      return [`record.${path} is a user field; use Record recipient field paths instead.`]
-    }
-    if (!isDingTalkMemberGroupRecipientField(field)) {
-      return [`record.${path} is not a member group field; DingTalk person member-group recipients expect member group fields.`]
-    }
-    return []
-  })
+  return listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, props.fields)
 }
 
 const dingTalkPersonRecipientFieldSummary = computed(() => {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -758,6 +758,7 @@ import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemp
 import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
+  listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
   describeDingTalkPublicFormLinkAccess,
@@ -1332,20 +1333,7 @@ function recipientFieldPathWarnings(value: unknown) {
 }
 
 function memberGroupRecipientFieldPathWarnings(value: unknown) {
-  const fieldMap = new Map(props.fields.map((field) => [field.id, field]))
-  return parseRecipientFieldPathsText(value).flatMap((path) => {
-    const field = fieldMap.get(path)
-    if (!field) {
-      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
-    }
-    if (field.type === 'user') {
-      return [`record.${path} is a user field; use Record recipient field paths instead.`]
-    }
-    if (!isDingTalkMemberGroupRecipientField(field)) {
-      return [`record.${path} is not a member group field; DingTalk person member-group recipients expect member group fields.`]
-    }
-    return []
-  })
+  return listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, props.fields)
 }
 
 function recipientFieldPathSummary(value: unknown) {

--- a/apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts
@@ -42,3 +42,23 @@ export function listDingTalkGroupDestinationFieldPathWarnings(
     return []
   })
 }
+
+export function listDingTalkPersonMemberGroupRecipientFieldPathWarnings(
+  value: unknown,
+  fields: readonly DingTalkRecipientWarningField[],
+): string[] {
+  const fieldMap = new Map(fields.map((field) => [field.id, field]))
+  return parseRecordFieldPaths(value).flatMap((path) => {
+    const field = fieldMap.get(path)
+    if (!field) {
+      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
+    }
+    if (field.type === 'user') {
+      return [`record.${path} is a user field; use Record recipient field paths instead.`]
+    }
+    if (!isDingTalkMemberGroupRecipientField(field)) {
+      return [`record.${path} is not a member group field; DingTalk person member-group recipients expect member group fields.`]
+    }
+    return []
+  })
+}

--- a/apps/web/tests/dingtalk-recipient-field-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-recipient-field-warnings.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
+  listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
 } from '../src/multitable/utils/dingtalkRecipientFieldWarnings'
 
 const fields = [
@@ -41,6 +42,31 @@ describe('dingtalk recipient field warnings', () => {
   it('returns no dynamic group destination warnings for empty or non-string input', () => {
     expect(listDingTalkGroupDestinationFieldPathWarnings('', fields)).toEqual([])
     expect(listDingTalkGroupDestinationFieldPathWarnings(['record.assigneeUserIds'], fields)).toEqual([])
+  })
+
+  it('lists dynamic person member-group recipient field path warnings from normalized record paths', () => {
+    expect(listDingTalkPersonMemberGroupRecipientFieldPathWarnings(
+      [
+        'record.missingGroupId',
+        'record.assigneeUserIds',
+        'record.name',
+        'record.watcherGroupIds',
+        'record.escalationGroupId',
+        'record.reviewGroupId',
+        'record.approvalGroupId',
+        'name',
+      ].join(',\n'),
+      fields,
+    )).toEqual([
+      'record.missingGroupId is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.',
+      'record.assigneeUserIds is a user field; use Record recipient field paths instead.',
+      'record.name is not a member group field; DingTalk person member-group recipients expect member group fields.',
+    ])
+  })
+
+  it('returns no person member-group recipient warnings for empty or non-string input', () => {
+    expect(listDingTalkPersonMemberGroupRecipientFieldPathWarnings('', fields)).toEqual([])
+    expect(listDingTalkPersonMemberGroupRecipientFieldPathWarnings(['record.name'], fields)).toEqual([])
   })
 
   it('detects member group recipient fields from type aliases and ref metadata', () => {

--- a/docs/development/dingtalk-recipient-warning-utils-development-20260421.md
+++ b/docs/development/dingtalk-recipient-warning-utils-development-20260421.md
@@ -1,0 +1,28 @@
+# DingTalk Recipient Warning Utils Development - 2026-04-21
+
+## Background
+
+DingTalk automation field-path warnings are shown in both the inline automation manager and the standalone rule editor. The group destination field warnings already live in `dingtalkRecipientFieldWarnings.ts`, but person member-group recipient warnings were duplicated in both Vue components.
+
+After adding stricter warnings for manually typed member-group paths, keeping the same logic duplicated would make the two entry points easier to drift apart.
+
+## Changes
+
+- Added `listDingTalkPersonMemberGroupRecipientFieldPathWarnings()` to `apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts`.
+- Updated `MetaAutomationManager.vue` to call the shared utility.
+- Updated `MetaAutomationRuleEditor.vue` to call the shared utility.
+- Added utility-level tests for person member-group recipient path warning behavior.
+- Preserved the existing user-facing warning strings and behavior.
+
+## Behavior
+
+No user-facing behavior changes are intended in this slice.
+
+- Unknown member-group recipient paths still warn as unknown fields.
+- User fields still warn to use regular record recipient paths.
+- Known non-member-group fields still warn that they are not member group fields.
+- Valid member group fields still produce no warning.
+
+## Scope
+
+This is a frontend refactor and test-hardening slice. It does not call DingTalk, change automation payloads, or change backend APIs.

--- a/docs/development/dingtalk-recipient-warning-utils-verification-20260421.md
+++ b/docs/development/dingtalk-recipient-warning-utils-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Recipient Warning Utils Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-recipient-warning-utils-20260421`
+- Branch: `codex/dingtalk-recipient-warning-utils-20260421`
+- Base: stacked on DingTalk member-group path warnings (`f0aa0d23d4cce6dd78d87c8124735a75f35e937f`)
+- Dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-recipient-field-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `3 passed`
+- Tests: `114 passed`
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Build emitted existing Vite warnings about large chunks and one dynamic/static import overlap for `WorkflowDesigner.vue`; there were no build errors.
+
+```bash
+git diff --check -- apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/dingtalk-recipient-field-warnings.spec.ts docs/development/dingtalk-recipient-warning-utils-development-20260421.md docs/development/dingtalk-recipient-warning-utils-verification-20260421.md
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk robot webhook was called.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally excluded from the commit.
+- Verification focuses on shared frontend warning logic and both UI entry points that consume it.


### PR DESCRIPTION
## Summary
- Move DingTalk person member-group recipient field path warnings into the shared `dingtalkRecipientFieldWarnings` utility.
- Update the inline automation manager and standalone rule editor to consume the shared helper.
- Add utility-level tests for person member-group recipient path warnings.
- Add development and verification MD reports.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/dingtalk-recipient-field-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check -- apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/dingtalk-recipient-field-warnings.spec.ts docs/development/dingtalk-recipient-warning-utils-development-20260421.md docs/development/dingtalk-recipient-warning-utils-verification-20260421.md`

## Stack
- Temporary base branch points at #992 head (`f0aa0d23d4cce6dd78d87c8124735a75f35e937f`) so this PR shows only the current slice.