### PR TITLE
refactor(dingtalk): share person recipient warnings

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -690,6 +690,7 @@ import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
   listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
+  listDingTalkPersonRecipientFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
   describeDingTalkPublicFormLinkAccess,
@@ -1069,10 +1070,7 @@ const selectedDingTalkPersonMemberGroupRecipientFields = computed(() => parseRec
   .filter((item) => item.label))
 
 function recipientFieldPathWarnings(value: string) {
-  const candidateIds = new Set(dingTalkPersonRecipientCandidateFields.value.map((field) => field.id))
-  return parseRecipientFieldPathsText(value)
-    .filter((path) => !candidateIds.has(path))
-    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+  return listDingTalkPersonRecipientFieldPathWarnings(value, props.fields)
 }
 
 function memberGroupRecipientFieldPathWarnings(value: string) {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -759,6 +759,7 @@ import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
   listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
+  listDingTalkPersonRecipientFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
   describeDingTalkPublicFormLinkAccess,
@@ -1326,10 +1327,7 @@ function selectedMemberGroupRecipientFields(action: DraftAction) {
 }
 
 function recipientFieldPathWarnings(value: unknown) {
-  const candidateIds = new Set(recipientCandidateFields.value.map((field) => field.id))
-  return parseRecipientFieldPathsText(value)
-    .filter((path) => !candidateIds.has(path))
-    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+  return listDingTalkPersonRecipientFieldPathWarnings(value, props.fields)
 }
 
 function memberGroupRecipientFieldPathWarnings(value: unknown) {

--- a/apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts
@@ -43,6 +43,18 @@ export function listDingTalkGroupDestinationFieldPathWarnings(
   })
 }
 
+export function listDingTalkPersonRecipientFieldPathWarnings(
+  value: unknown,
+  fields: readonly DingTalkRecipientWarningField[],
+): string[] {
+  const userFieldIds = new Set(fields
+    .filter((field) => field.type === 'user')
+    .map((field) => field.id))
+  return parseRecordFieldPaths(value)
+    .filter((path) => !userFieldIds.has(path))
+    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+}
+
 export function listDingTalkPersonMemberGroupRecipientFieldPathWarnings(
   value: unknown,
   fields: readonly DingTalkRecipientWarningField[],

--- a/apps/web/tests/dingtalk-recipient-field-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-recipient-field-warnings.spec.ts
@@ -4,6 +4,7 @@ import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
   listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
+  listDingTalkPersonRecipientFieldPathWarnings,
 } from '../src/multitable/utils/dingtalkRecipientFieldWarnings'
 
 const fields = [
@@ -42,6 +43,28 @@ describe('dingtalk recipient field warnings', () => {
   it('returns no dynamic group destination warnings for empty or non-string input', () => {
     expect(listDingTalkGroupDestinationFieldPathWarnings('', fields)).toEqual([])
     expect(listDingTalkGroupDestinationFieldPathWarnings(['record.assigneeUserIds'], fields)).toEqual([])
+  })
+
+  it('lists dynamic person recipient field path warnings from normalized record paths', () => {
+    expect(listDingTalkPersonRecipientFieldPathWarnings(
+      [
+        'record.missingUserId',
+        'record.name',
+        'record.assigneeUserIds',
+        'record.watcherGroupIds',
+        'name',
+      ].join(',\n'),
+      fields,
+    )).toEqual([
+      'record.missingUserId is not a user field; DingTalk person messages expect local user IDs.',
+      'record.name is not a user field; DingTalk person messages expect local user IDs.',
+      'record.watcherGroupIds is not a user field; DingTalk person messages expect local user IDs.',
+    ])
+  })
+
+  it('returns no person recipient warnings for empty or non-string input', () => {
+    expect(listDingTalkPersonRecipientFieldPathWarnings('', fields)).toEqual([])
+    expect(listDingTalkPersonRecipientFieldPathWarnings(['record.name'], fields)).toEqual([])
   })
 
   it('lists dynamic person member-group recipient field path warnings from normalized record paths', () => {

--- a/docs/development/dingtalk-person-recipient-warning-utils-development-20260421.md
+++ b/docs/development/dingtalk-person-recipient-warning-utils-development-20260421.md
@@ -1,0 +1,28 @@
+# DingTalk Person Recipient Warning Utils Development - 2026-04-21
+
+## Background
+
+DingTalk person automation supports dynamic record recipient paths such as `record.assigneeUserIds`. The inline automation manager and standalone rule editor previously duplicated the same warning logic for these paths.
+
+After centralizing member-group recipient warnings, the remaining duplicated user-recipient warning logic should also live in the shared DingTalk recipient warning utility.
+
+## Changes
+
+- Added `listDingTalkPersonRecipientFieldPathWarnings()` to `apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts`.
+- Updated `MetaAutomationManager.vue` to use the shared helper.
+- Updated `MetaAutomationRuleEditor.vue` to use the shared helper.
+- Added utility-level tests for dynamic person recipient path warning behavior.
+- Preserved existing user-facing warning text and behavior.
+
+## Behavior
+
+No user-facing behavior changes are intended in this slice.
+
+- Valid user fields still produce no warning.
+- Unknown fields still warn as not user fields.
+- Known non-user fields still warn as not user fields.
+- Member group fields still warn as not user fields when used in the user-recipient field path.
+
+## Scope
+
+This is a frontend refactor and test-hardening slice. It does not call DingTalk, change automation payloads, or change backend APIs.

--- a/docs/development/dingtalk-person-recipient-warning-utils-verification-20260421.md
+++ b/docs/development/dingtalk-person-recipient-warning-utils-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Person Recipient Warning Utils Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-recipient-warning-utils-20260421`
+- Branch: `codex/dingtalk-person-recipient-warning-utils-20260421`
+- Base: stacked on DingTalk recipient warning utility sharing (`297002e5f82be68334d4b49ad558f366c4123783`)
+- Dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-recipient-field-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `3 passed`
+- Tests: `116 passed`
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Build emitted existing Vite warnings about large chunks and one dynamic/static import overlap for `WorkflowDesigner.vue`; there were no build errors.
+
+```bash
+git diff --check -- apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/dingtalk-recipient-field-warnings.spec.ts docs/development/dingtalk-person-recipient-warning-utils-development-20260421.md docs/development/dingtalk-person-recipient-warning-utils-verification-20260421.md
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk robot webhook was called.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally excluded from the commit.
+- Verification focuses on shared frontend warning logic and both UI entry points that consume it.


### PR DESCRIPTION
## Summary
- Move DingTalk person user-recipient field path warnings into the shared `dingtalkRecipientFieldWarnings` utility.
- Update the inline automation manager and standalone rule editor to consume the shared helper.
- Add utility-level tests for person recipient path warnings.
- Add development and verification MD reports.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/dingtalk-recipient-field-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check -- apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/dingtalk-recipient-field-warnings.spec.ts docs/development/dingtalk-person-recipient-warning-utils-development-20260421.md docs/development/dingtalk-person-recipient-warning-utils-verification-20260421.md`

## Stack
- Temporary base branch points at #993 head (`297002e5f82be68334d4b49ad558f366c4123783`) so this PR shows only the current slice.