### PR TITLE
fix(dingtalk): require parsed person recipient paths

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1359,11 +1359,13 @@ const canSave = computed(() => {
     if (internalViewLinkBlockingErrors(draft.value.internalViewId).length) return false
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
+    const recipientFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+    const memberGroupRecipientFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
     if (
       !draft.value.dingtalkPersonUserIds.trim()
       && !draft.value.dingtalkPersonMemberGroupIds.trim()
-      && !draft.value.dingtalkPersonRecipientFieldPath.trim()
-      && !draft.value.dingtalkPersonMemberGroupRecipientFieldPath.trim()
+      && !recipientFieldPaths.length
+      && !memberGroupRecipientFieldPaths.length
     ) return false
     if (!draft.value.dingtalkPersonTitleTemplate.trim()) return false
     if (!draft.value.dingtalkPersonBodyTemplate.trim()) return false

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -979,13 +979,11 @@ const canSave = computed(() => {
     if (action.type === 'send_dingtalk_person_message') {
       const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
       const memberGroupIdsText = typeof action.config.memberGroupIdsText === 'string' ? action.config.memberGroupIdsText.trim() : ''
-      const recipientFieldPath = typeof action.config.recipientFieldPath === 'string' ? action.config.recipientFieldPath.trim() : ''
-      const memberGroupRecipientFieldPath = typeof action.config.memberGroupRecipientFieldPath === 'string'
-        ? action.config.memberGroupRecipientFieldPath.trim()
-        : ''
+      const recipientFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+      const memberGroupRecipientFieldPaths = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!userIdsText && !memberGroupIdsText && !recipientFieldPath && !memberGroupRecipientFieldPath) || !titleTemplate || !bodyTemplate) return false
+      if ((!userIdsText && !memberGroupIdsText && !recipientFieldPaths.length && !memberGroupRecipientFieldPaths.length) || !titleTemplate || !bodyTemplate) return false
       if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
       if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -992,6 +992,50 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('disables creating a DingTalk person automation when dynamic recipient paths parse empty', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk invalid dynamic recipients'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record., ,'
+    recipientFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = ','
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(0)
+  })
+
   it('can remove a selected dynamic member group recipient field chip in the inline form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1103,6 +1103,54 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
+  it('disables saving a DingTalk person message when dynamic recipient paths parse empty', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify invalid dynamic recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record., ,'
+    recipientFieldInput.dispatchEvent(new Event('input'))
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = ','
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).not.toHaveBeenCalled()
+  })
+
   it('loads and saves DingTalk person dynamic recipients from V1 actions when legacy action fields are stale', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/docs/development/dingtalk-person-recipient-can-save-development-20260421.md
+++ b/docs/development/dingtalk-person-recipient-can-save-development-20260421.md
@@ -1,0 +1,43 @@
+# DingTalk Person Recipient Save Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change tightens the frontend save guard for DingTalk person-message automations.
+
+Affected entry points:
+
+- `MetaAutomationRuleEditor.vue`
+- `MetaAutomationManager.vue`
+
+## Problem
+
+The UI previously treated a dynamic recipient field input as valid when the raw text was non-empty. Inputs such as `record.` or `,` passed the raw `.trim()` check, but the save payload parser normalized them into an empty field-path list.
+
+That allowed a DingTalk person-message automation to be saved without any effective recipient when no static users or member groups were selected.
+
+## Implementation
+
+The save guard now uses the same recipient path parser used by the save payload:
+
+- `recipientFieldPath` is parsed before validation.
+- `memberGroupRecipientFieldPath` is parsed before validation.
+- Save remains disabled unless at least one effective recipient source exists:
+  - static user IDs,
+  - static member group IDs,
+  - parsed user field paths,
+  - parsed member-group field paths.
+
+This keeps validation behavior aligned with the final action config persisted by the editor.
+
+## Tests
+
+Added regression coverage for both frontend paths:
+
+- Rule editor: invalid dynamic person-recipient paths keep the save button disabled and do not emit `onSave`.
+- Inline automation manager: invalid dynamic person-recipient paths keep the create button disabled and do not issue a `POST`.
+
+## Notes
+
+This slice only changes DingTalk person-message recipient validation. The existing group-message destination validation was intentionally left unchanged to keep this patch narrowly scoped.

--- a/docs/development/dingtalk-person-recipient-can-save-verification-20260421.md
+++ b/docs/development/dingtalk-person-recipient-can-save-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Person Recipient Save Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-person-recipient-can-save-20260421`
+- Branch: `codex/dingtalk-person-recipient-can-save-20260421`
+- Base: `6350c854f34156dd89aa5def43a1bd06fe398c39`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-automation-rule-editor.spec.ts`: 52 tests passed.
+- `tests/multitable-automation-manager.spec.ts`: 59 tests passed.
+- Total: 111 tests passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Notes:
+
+- Vite reported existing chunk-size and mixed dynamic/static import warnings.
+- No live DingTalk webhook delivery was required for this frontend validation change.


### PR DESCRIPTION
## Summary

- Align DingTalk person-message save validation with parsed dynamic recipient paths
- Keep save/create disabled when dynamic recipient inputs like `record.` or `,` parse to no effective recipients
- Add rule editor and inline automation manager regression coverage
- Add development and verification notes

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

## Docs

- `docs/development/dingtalk-person-recipient-can-save-development-20260421.md`
- `docs/development/dingtalk-person-recipient-can-save-verification-20260421.md`