### PR TITLE
fix(dingtalk): require parsed group destination paths

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1352,7 +1352,8 @@ const canSave = computed(() => {
   if (draft.value.actionType === 'notify' && !draft.value.notifyMessage.trim()) return false
   if (draft.value.actionType === 'update_field' && (!draft.value.targetFieldId || !draft.value.targetValue.trim())) return false
   if (draft.value.actionType === 'send_dingtalk_group_message') {
-    if (!draft.value.dingtalkDestinationIds.length && !draft.value.dingtalkDestinationFieldPath.trim()) return false
+    const destinationFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkDestinationFieldPath)
+    if (!draft.value.dingtalkDestinationIds.length && !destinationFieldPaths.length) return false
     if (!draft.value.dingtalkTitleTemplate.trim()) return false
     if (!draft.value.dingtalkBodyTemplate.trim()) return false
     if (publicFormLinkBlockingErrors(draft.value.publicFormViewId).length) return false

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -969,10 +969,10 @@ const canSave = computed(() => {
   for (const action of draft.value.actions) {
     if (action.type === 'send_dingtalk_group_message') {
       const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
-      const destinationFieldPath = typeof action.config.destinationFieldPath === 'string' ? action.config.destinationFieldPath.trim() : ''
+      const destinationFieldPaths = parseRecipientFieldPathsText(action.config.destinationFieldPath)
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!destinationIds.length && !destinationFieldPath) || !titleTemplate || !bodyTemplate) return false
+      if ((!destinationIds.length && !destinationFieldPaths.length) || !titleTemplate || !bodyTemplate) return false
       if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
       if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -633,6 +633,46 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('disables creating a DingTalk group automation when dynamic destination paths parse empty', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk invalid dynamic groups'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const destinationFieldInput = container.querySelector('[data-automation-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
+    destinationFieldInput.value = 'record., ,'
+    destinationFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(0)
+  })
+
   it('can pick a dynamic DingTalk group destination field in the inline form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -654,6 +654,50 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('disables saving a DingTalk group message when dynamic destination paths parse empty', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify invalid dynamic groups'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const destinationFieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
+    destinationFieldInput.value = 'record., ,'
+    destinationFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).not.toHaveBeenCalled()
+  })
+
   it('can pick a dynamic DingTalk group destination field', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/docs/development/dingtalk-group-destination-can-save-development-20260421.md
+++ b/docs/development/dingtalk-group-destination-can-save-development-20260421.md
@@ -1,0 +1,39 @@
+# DingTalk Group Destination Save Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change tightens frontend save validation for DingTalk group-message automations.
+
+Affected entry points:
+
+- `MetaAutomationRuleEditor.vue`
+- `MetaAutomationManager.vue`
+
+## Problem
+
+The group-message dynamic destination field previously passed validation when its raw text was non-empty. Inputs such as `record.` or `,` could enable saving, even though the save payload parser normalized them into an empty destination field-path list.
+
+That made the save guard inconsistent with the persisted action config and could create an automation without an effective DingTalk group target when no static group destination was selected.
+
+## Implementation
+
+The save guard now uses the existing destination path parser before deciding whether a dynamic group destination is present:
+
+- `destinationFieldPath` is parsed through `parseRecipientFieldPathsText`.
+- Save requires at least one static destination ID or one parsed dynamic destination field path.
+- Title, body, public-form link, and internal-view link validations remain unchanged.
+
+This mirrors the previous person-message recipient fix and keeps group-message validation aligned with payload serialization.
+
+## Tests
+
+Added regression coverage for both frontend paths:
+
+- Rule editor: invalid dynamic group destination paths keep the save button disabled and do not emit `onSave`.
+- Inline automation manager: invalid dynamic group destination paths keep the create button disabled and do not issue a `POST`.
+
+## Notes
+
+This patch does not change backend delivery behavior or DingTalk webhook delivery. It only prevents invalid frontend saves before an automation can be submitted.

--- a/docs/development/dingtalk-group-destination-can-save-verification-20260421.md
+++ b/docs/development/dingtalk-group-destination-can-save-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Group Destination Save Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-group-destination-can-save-20260421`
+- Branch: `codex/dingtalk-group-destination-can-save-20260421`
+- Base: `6b940337226616457ad441de33eb99b0bf2008b4`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-automation-rule-editor.spec.ts`: 53 tests passed.
+- `tests/multitable-automation-manager.spec.ts`: 60 tests passed.
+- Total: 113 tests passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Notes:
+
+- Vite reported existing chunk-size and mixed dynamic/static import warnings.
+- No live DingTalk webhook delivery was required because this change is limited to frontend save validation.


### PR DESCRIPTION
## Summary

- Align DingTalk group-message save validation with parsed dynamic destination paths
- Keep save/create disabled when dynamic destination inputs like `record.` or `,` parse to no effective destinations
- Add rule editor and inline automation manager regression coverage
- Add development and verification notes

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

## Docs

- `docs/development/dingtalk-group-destination-can-save-development-20260421.md`
- `docs/development/dingtalk-group-destination-can-save-verification-20260421.md`