### PR TITLE
fix(dingtalk): require parsed static person recipients

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1360,11 +1360,13 @@ const canSave = computed(() => {
     if (internalViewLinkBlockingErrors(draft.value.internalViewId).length) return false
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
+    const userIds = parseUserIdsText(draft.value.dingtalkPersonUserIds)
+    const memberGroupIds = parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds)
     const recipientFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
     const memberGroupRecipientFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
     if (
-      !draft.value.dingtalkPersonUserIds.trim()
-      && !draft.value.dingtalkPersonMemberGroupIds.trim()
+      !userIds.length
+      && !memberGroupIds.length
       && !recipientFieldPaths.length
       && !memberGroupRecipientFieldPaths.length
     ) return false

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -977,13 +977,13 @@ const canSave = computed(() => {
       if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }
     if (action.type === 'send_dingtalk_person_message') {
-      const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
-      const memberGroupIdsText = typeof action.config.memberGroupIdsText === 'string' ? action.config.memberGroupIdsText.trim() : ''
+      const userIds = parseUserIdsText(action.config.userIdsText)
+      const memberGroupIds = parseMemberGroupIdsText(action.config.memberGroupIdsText)
       const recipientFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
       const memberGroupRecipientFieldPaths = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!userIdsText && !memberGroupIdsText && !recipientFieldPaths.length && !memberGroupRecipientFieldPaths.length) || !titleTemplate || !bodyTemplate) return false
+      if ((!userIds.length && !memberGroupIds.length && !recipientFieldPaths.length && !memberGroupRecipientFieldPaths.length) || !titleTemplate || !bodyTemplate) return false
       if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
       if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1076,6 +1076,50 @@ describe('MetaAutomationManager', () => {
     expect(postCalls.length).toBe(0)
   })
 
+  it('disables creating a DingTalk person automation when static recipient lists parse empty', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk invalid static recipients'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = ',\n,'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const memberGroupIdsInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    memberGroupIdsInput.value = ','
+    memberGroupIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(0)
+  })
+
   it('can remove a selected dynamic member group recipient field chip in the inline form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1195,6 +1195,54 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved).not.toHaveBeenCalled()
   })
 
+  it('disables saving a DingTalk person message when static recipient lists parse empty', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify invalid static recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = ',\n,'
+    userIdsInput.dispatchEvent(new Event('input'))
+
+    const memberGroupIdsInput = container.querySelector('[data-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    memberGroupIdsInput.value = ','
+    memberGroupIdsInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).not.toHaveBeenCalled()
+  })
+
   it('loads and saves DingTalk person dynamic recipients from V1 actions when legacy action fields are stale', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/docs/development/dingtalk-person-static-recipient-can-save-development-20260421.md
+++ b/docs/development/dingtalk-person-static-recipient-can-save-development-20260421.md
@@ -1,0 +1,44 @@
+# DingTalk Person Static Recipient Save Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change tightens frontend save validation for DingTalk person-message automations.
+
+Affected entry points:
+
+- `MetaAutomationRuleEditor.vue`
+- `MetaAutomationManager.vue`
+
+## Problem
+
+The previous frontend guard treated static recipient text as valid whenever the raw text was non-empty. Inputs such as `,` or `,\n,` enabled save/create, but the final payload parser split and filtered those values into empty recipient arrays.
+
+That allowed the UI to submit a DingTalk person-message automation without any effective recipient when no dynamic record recipient fields were selected.
+
+## Implementation
+
+The save guard now uses the same static recipient parsers used by payload serialization:
+
+- `parseUserIdsText(...)` for local user IDs.
+- `parseMemberGroupIdsText(...)` for member group IDs.
+- Existing parsed dynamic user and member-group field path checks remain unchanged.
+
+Save/create now requires at least one effective recipient source:
+
+- parsed static user ID,
+- parsed static member group ID,
+- parsed dynamic user field path,
+- parsed dynamic member-group field path.
+
+## Tests
+
+Added regression coverage for both frontend paths:
+
+- Rule editor: static recipient lists containing only separators keep the save button disabled and do not emit `onSave`.
+- Inline automation manager: static recipient lists containing only separators keep the create button disabled and do not issue a `POST`.
+
+## Notes
+
+This patch is frontend-only. Backend runtime execution already rejects DingTalk person actions that resolve to no recipients; this change prevents invalid submissions earlier in the UI.

--- a/docs/development/dingtalk-person-static-recipient-can-save-verification-20260421.md
+++ b/docs/development/dingtalk-person-static-recipient-can-save-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Person Static Recipient Save Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-person-static-recipient-can-save-20260421`
+- Branch: `codex/dingtalk-person-static-recipient-can-save-20260421`
+- Base: `ed01245e431d60a5b07349b1abb5d4fb5b3328e2`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-automation-rule-editor.spec.ts`: 54 tests passed.
+- `tests/multitable-automation-manager.spec.ts`: 61 tests passed.
+- Total: 115 tests passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Notes:
+
+- Vite reported existing chunk-size and mixed dynamic/static import warnings.
+- No live DingTalk webhook delivery was required because this change is limited to frontend save validation.


### PR DESCRIPTION
## Summary

- Align DingTalk person-message save validation with parsed static user/member-group recipient lists
- Keep save/create disabled when static recipient inputs like `,` or `,\n,` parse to no effective recipients
- Add rule editor and inline automation manager regression coverage
- Add development and verification notes

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

## Docs

- `docs/development/dingtalk-person-static-recipient-can-save-development-20260421.md`
- `docs/development/dingtalk-person-static-recipient-can-save-verification-20260421.md`