### PR TITLE
docs(ops): add static person recipient guard verification

### DIFF
--- a/docs/development/pr-queue-closure-and-validation-20260421.md
+++ b/docs/development/pr-queue-closure-and-validation-20260421.md
@@ -38,6 +38,7 @@ These PRs were not merged directly to `main`; they were merged into their stack 
 | #995 | `refactor(dingtalk): share person recipient warnings` | Merged to `codex/dingtalk-person-recipient-warning-utils-base-20260421` | `7bb22b2697396c0bf1f6edb6a4b96fd8cc04f310` |
 | #996 | `fix(dingtalk): require parsed person recipient paths` | Merged to `codex/dingtalk-person-recipient-can-save-base-20260421` | `a9198b44a1c460c52c46e0cab689701d83cb64ea` |
 | #998 | `fix(dingtalk): require parsed group destination paths` | Merged to `codex/dingtalk-group-destination-can-save-base-20260421` | `ef12119d8948841bc7a42a9d552d9ea9e0375fef` |
+| #1000 | `fix(dingtalk): require parsed static person recipients` | Merged to `codex/dingtalk-person-static-recipient-can-save-base-20260421` | `aeab1f9f32af4ccb18083bf4e0b6d883aa8a3ba3` |
 
 ## Verification
 
@@ -132,6 +133,28 @@ Result:
 ```text
 Test Files  2 passed (2)
 Tests       113 passed (113)
+```
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Vite emitted existing chunk-size and mixed dynamic/static import warnings.
+
+For #1000:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-automation-rule-editor.spec.ts \
+  tests/multitable-automation-manager.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       115 passed (115)
 ```
 
 ```bash


### PR DESCRIPTION
## Summary
- updates the PR queue closure validation record with #1000
- records local focused tests and web build for static person recipient save validation

## Verification
- git diff --check
- documentation-only change