### PR TITLE
fix(dingtalk): validate automation action configs

### DIFF
--- a/docs/development/dingtalk-action-config-validation-development-20260421.md
+++ b/docs/development/dingtalk-action-config-validation-development-20260421.md
@@ -1,0 +1,37 @@
+# DingTalk Automation Action Config Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change adds backend write-time validation for DingTalk automation action configs.
+
+Affected areas:
+
+- `POST /api/multitable/sheets/:sheetId/automations`
+- `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId`
+- Legacy `actionType/actionConfig`
+- V1 `actions[]`
+
+## Problem
+
+The automation routes already validate DingTalk public-form and internal-view links before persistence, but they did not validate the basic executable DingTalk action config. A caller could bypass the frontend and persist a rule missing effective destinations, recipients, title templates, or body templates.
+
+Runtime execution would fail later, but the invalid rule was already stored.
+
+## Implementation
+
+Added synchronous DingTalk config validation in `dingtalk-automation-link-validation.ts`:
+
+- Group message actions require at least one effective static destination or record destination field path.
+- Person message actions require at least one effective recipient source: static user IDs, member group IDs, record user field paths, or record member-group field paths.
+- Both DingTalk actions require executable `titleTemplate` and `bodyTemplate`.
+- Empty separator-only values like `,` or `record.` are parsed as empty.
+
+For compatibility with older callers, DingTalk configs with `title/content` are normalized to `titleTemplate/bodyTemplate` before validation and persistence.
+
+The create/update routes now validate normalized DingTalk configs before existing link validation and before calling the automation service.
+
+## Notes
+
+Enable-only PATCH requests still avoid revalidating DingTalk config and links, preserving the existing behavior for toggling a rule without loading related view state.

--- a/docs/development/dingtalk-action-config-validation-verification-20260421.md
+++ b/docs/development/dingtalk-action-config-validation-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Automation Action Config Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-action-config-validation-20260421`
+- Branch: `codex/dingtalk-action-config-validation-20260421`
+- Base: `e2fc4e7fef7d2e4daa243b310ef924b9b3ff206e`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/unit/dingtalk-automation-link-validation.test.ts`: 12 tests passed.
+- `tests/integration/dingtalk-automation-link-routes.api.test.ts`: 9 tests passed.
+- Total: 21 tests passed.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+Notes:
+
+- Vitest emitted the existing Vite CJS Node API deprecation warning.
+- No live DingTalk webhook delivery was required because this change validates stored automation config at the API boundary.

--- a/packages/core-backend/src/multitable/dingtalk-automation-link-validation.ts
+++ b/packages/core-backend/src/multitable/dingtalk-automation-link-validation.ts
@@ -34,15 +34,26 @@ function parsePublicFormExpiryMs(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-function collectDingTalkActionConfigs(
+type DingTalkAutomationActionType = 'send_dingtalk_group_message' | 'send_dingtalk_person_message'
+
+type DingTalkAutomationActionEntry = {
+  type: DingTalkAutomationActionType
+  config: Record<string, unknown> | null
+}
+
+function isDingTalkAutomationActionType(value: unknown): value is DingTalkAutomationActionType {
+  return value === 'send_dingtalk_group_message' || value === 'send_dingtalk_person_message'
+}
+
+function collectDingTalkActionEntries(
   actionType: unknown,
   actionConfig: unknown,
   actions: unknown,
-): Record<string, unknown>[] {
-  const configs: Record<string, unknown>[] = []
+): DingTalkAutomationActionEntry[] {
+  const entries: DingTalkAutomationActionEntry[] = []
   const addIfDingTalkAction = (type: unknown, config: unknown) => {
-    if (type !== 'send_dingtalk_group_message' && type !== 'send_dingtalk_person_message') return
-    if (isPlainObject(config)) configs.push(config)
+    if (!isDingTalkAutomationActionType(type)) return
+    entries.push({ type, config: isPlainObject(config) ? config : null })
   }
 
   addIfDingTalkAction(actionType, actionConfig)
@@ -53,7 +64,129 @@ function collectDingTalkActionConfigs(
     }
   }
 
-  return configs
+  return entries
+}
+
+function collectDingTalkActionConfigs(
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+): Record<string, unknown>[] {
+  return collectDingTalkActionEntries(actionType, actionConfig, actions)
+    .map((entry) => entry.config)
+    .filter((config): config is Record<string, unknown> => Boolean(config))
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .flatMap((entry) => entry.split(/[\n,]+/))
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+function normalizeFieldPaths(value: unknown): string[] {
+  return normalizeStringList(value)
+    .map((entry) => entry.replace(/^record\./, '').trim())
+    .filter(Boolean)
+}
+
+function hasText(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function normalizeDingTalkMessageConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...config }
+  if (!hasText(normalized.titleTemplate) && hasText(normalized.title)) {
+    normalized.titleTemplate = normalized.title
+  }
+  if (!hasText(normalized.bodyTemplate) && hasText(normalized.content)) {
+    normalized.bodyTemplate = normalized.content
+  }
+  return normalized
+}
+
+export function normalizeDingTalkAutomationActionInputs(
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+): { actionConfig: unknown; actions: unknown } {
+  const normalizedActionConfig = isDingTalkAutomationActionType(actionType) && isPlainObject(actionConfig)
+    ? normalizeDingTalkMessageConfig(actionConfig)
+    : actionConfig
+  const normalizedActions = Array.isArray(actions)
+    ? actions.map((item) => {
+      if (!isPlainObject(item) || !isDingTalkAutomationActionType(item.type) || !isPlainObject(item.config)) return item
+      return { ...item, config: normalizeDingTalkMessageConfig(item.config) }
+    })
+    : actions
+  return { actionConfig: normalizedActionConfig, actions: normalizedActions }
+}
+
+function validateGroupMessageConfig(config: Record<string, unknown>): string | null {
+  const destinationIds = [
+    ...normalizeStringList(config.destinationId),
+    ...normalizeStringList(config.destinationIds),
+  ]
+  const destinationFieldPaths = [
+    ...normalizeFieldPaths(config.destinationIdFieldPath),
+    ...normalizeFieldPaths(config.destinationIdFieldPaths),
+  ]
+  if (destinationIds.length === 0 && destinationFieldPaths.length === 0) {
+    return 'At least one DingTalk destination or record destination field path is required'
+  }
+  if (!hasText(config.titleTemplate)) return 'DingTalk titleTemplate is required'
+  if (!hasText(config.bodyTemplate)) return 'DingTalk bodyTemplate is required'
+  return null
+}
+
+function validatePersonMessageConfig(config: Record<string, unknown>): string | null {
+  const userIds = normalizeStringList(config.userIds)
+  const memberGroupIds = normalizeStringList(config.memberGroupIds)
+  const recipientFieldPaths = [
+    ...normalizeFieldPaths(config.userIdFieldPath),
+    ...normalizeFieldPaths(config.userIdFieldPaths),
+  ]
+  const memberGroupRecipientFieldPaths = [
+    ...normalizeFieldPaths(config.memberGroupIdFieldPath),
+    ...normalizeFieldPaths(config.memberGroupIdFieldPaths),
+  ]
+  if (
+    userIds.length === 0
+    && memberGroupIds.length === 0
+    && recipientFieldPaths.length === 0
+    && memberGroupRecipientFieldPaths.length === 0
+  ) {
+    return 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required'
+  }
+  if (!hasText(config.titleTemplate)) return 'DingTalk titleTemplate is required'
+  if (!hasText(config.bodyTemplate)) return 'DingTalk bodyTemplate is required'
+  return null
+}
+
+export function validateDingTalkAutomationActionConfigs(
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+): string | null {
+  const normalized = normalizeDingTalkAutomationActionInputs(actionType, actionConfig, actions)
+  for (const entry of collectDingTalkActionEntries(actionType, normalized.actionConfig, normalized.actions)) {
+    if (!entry.config) return 'DingTalk action config must be an object'
+    const error = entry.type === 'send_dingtalk_group_message'
+      ? validateGroupMessageConfig(entry.config)
+      : validatePersonMessageConfig(entry.config)
+    if (error) return error
+  }
+  return null
 }
 
 export function collectDingTalkAutomationLinkIds(

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -32,7 +32,11 @@ import { validateRecord, getDefaultValidationRules } from '../multitable/field-v
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import { getAutomationServiceInstance } from '../multitable/automation-service'
-import { validateDingTalkAutomationLinks } from '../multitable/dingtalk-automation-link-validation'
+import {
+  normalizeDingTalkAutomationActionInputs,
+  validateDingTalkAutomationActionConfigs,
+  validateDingTalkAutomationLinks,
+} from '../multitable/dingtalk-automation-link-validation'
 import { listAutomationDingTalkGroupDeliveries } from '../multitable/dingtalk-group-delivery-service'
 import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
@@ -8348,7 +8352,7 @@ export function univerMetaRouter(): Router {
       const triggerType = typeof body?.triggerType === 'string' ? body.triggerType : ''
       const triggerConfig = (body?.triggerConfig && typeof body.triggerConfig === 'object') ? body.triggerConfig as Record<string, unknown> : {}
       const actionType = typeof body?.actionType === 'string' ? body.actionType : ''
-      const actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig as Record<string, unknown> : {}
+      let actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig as Record<string, unknown> : {}
       const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
 
       const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
@@ -8361,7 +8365,16 @@ export function univerMetaRouter(): Router {
       }
 
       const conditions = body?.conditions && typeof body.conditions === 'object' ? body.conditions as never : null
-      const actions = Array.isArray(body?.actions) ? body.actions : null
+      let actions = Array.isArray(body?.actions) ? body.actions : null
+      const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(actionType, actionConfig, actions)
+      actionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
+        ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
+        : actionConfig
+      actions = Array.isArray(normalizedDingTalkInputs.actions) ? normalizedDingTalkInputs.actions : actions
+      const actionConfigValidationError = validateDingTalkAutomationActionConfigs(actionType, actionConfig, actions)
+      if (actionConfigValidationError) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: actionConfigValidationError } })
+      }
       const linkValidationError = await validateDingTalkAutomationLinks(
         pool.query.bind(pool),
         sheetId,
@@ -8425,6 +8438,8 @@ export function univerMetaRouter(): Router {
 
       const body = req.body as Record<string, unknown> | undefined
       const updates: Record<string, unknown> = {}
+      let normalizedActionConfigForUpdate: Record<string, unknown> | undefined
+      let normalizedActionsForUpdate: unknown[] | null | undefined
 
       if (typeof body?.name === 'string') updates.name = body.name
       if (typeof body?.triggerType === 'string') {
@@ -8471,15 +8486,36 @@ export function univerMetaRouter(): Router {
         const nextActions = body?.actions !== undefined
           ? Array.isArray(body.actions) ? body.actions : null
           : existing.actions
+        const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(nextActionType, nextActionConfig, nextActions)
+        const normalizedNextActionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
+          ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
+          : nextActionConfig
+        const normalizedNextActions = Array.isArray(normalizedDingTalkInputs.actions)
+          ? normalizedDingTalkInputs.actions
+          : nextActions
+        const actionConfigValidationError = validateDingTalkAutomationActionConfigs(
+          nextActionType,
+          normalizedNextActionConfig,
+          normalizedNextActions,
+        )
+        if (actionConfigValidationError) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: actionConfigValidationError } })
+        }
         const linkValidationError = await validateDingTalkAutomationLinks(
           pool.query.bind(pool),
           sheetId,
           nextActionType,
-          nextActionConfig,
-          nextActions,
+          normalizedNextActionConfig,
+          normalizedNextActions,
         )
         if (linkValidationError) {
           return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: linkValidationError } })
+        }
+        if (body?.actionConfig && typeof body.actionConfig === 'object') {
+          normalizedActionConfigForUpdate = normalizedNextActionConfig as Record<string, unknown>
+        }
+        if (body?.actions !== undefined) {
+          normalizedActionsForUpdate = Array.isArray(body.actions) ? normalizedNextActions as unknown[] : null
         }
       }
 
@@ -8491,11 +8527,11 @@ export function univerMetaRouter(): Router {
           : undefined,
         actionType: updates.action_type as string | undefined,
         actionConfig: body?.actionConfig && typeof body.actionConfig === 'object'
-          ? body.actionConfig as Record<string, unknown>
+          ? normalizedActionConfigForUpdate ?? body.actionConfig as Record<string, unknown>
           : undefined,
         enabled: typeof body?.enabled === 'boolean' ? body.enabled : undefined,
         conditions: body?.conditions !== undefined ? (body.conditions as never) : undefined,
-        actions: body?.actions !== undefined ? (Array.isArray(body.actions) ? body.actions : null) as never : undefined,
+        actions: body?.actions !== undefined ? (normalizedActionsForUpdate ?? (Array.isArray(body.actions) ? body.actions : null)) as never : undefined,
       })
 
       if (!updated) {

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -253,10 +253,38 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
       actionType: 'send_dingtalk_group_message',
       actionConfig: expect.objectContaining({
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
         publicFormViewId: VALID_FORM_VIEW_ID,
         internalViewId: INTERNAL_VIEW_ID,
       }),
     }))
+  })
+
+  it('rejects a DingTalk group rule without an effective destination before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify group',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationIds: [],
+          destinationIdFieldPath: 'record., ,',
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one DingTalk destination or record destination field path is required',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
   })
 
   it('rejects an invalid internal processing link on automation create before persisting the rule', async () => {
@@ -281,6 +309,39 @@ describe('DingTalk automation link route validation', () => {
     expect(res.body.error).toEqual({
       code: 'VALIDATION_ERROR',
       message: `Internal processing view not found: ${MISSING_INTERNAL_VIEW_ID}`,
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects a V1 DingTalk person action without an effective recipient before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Multi action person rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        actions: [
+          {
+            type: 'send_dingtalk_person_message',
+            config: {
+              userIds: [],
+              memberGroupIds: [','],
+              userIdFieldPath: 'record.',
+              titleTemplate: 'Please fill',
+              bodyTemplate: 'Open form',
+            },
+          },
+        ],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required',
     })
     expect(automationService.createRule).not.toHaveBeenCalled()
   })
@@ -321,6 +382,7 @@ describe('DingTalk automation link route validation', () => {
     const automationService = createMockAutomationService(makeAutomationRule({
       action_type: 'send_dingtalk_person_message',
       action_config: {
+        userIds: ['user_1'],
         title: 'Old title',
         content: 'Old content',
         publicFormViewId: VALID_FORM_VIEW_ID,
@@ -332,6 +394,7 @@ describe('DingTalk automation link route validation', () => {
       .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
       .send({
         actionConfig: {
+          userIds: ['user_1'],
           title: 'New title',
           content: 'New content',
           publicFormViewId: EXPIRED_FORM_VIEW_ID,
@@ -344,6 +407,37 @@ describe('DingTalk automation link route validation', () => {
       message: `Selected public form view has expired: ${EXPIRED_FORM_VIEW_ID}`,
     })
     expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
+  it('validates merged DingTalk action config on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'send_dingtalk_person_message',
+      action_config: {
+        userIds: ['user_1'],
+        titleTemplate: 'Old title',
+        bodyTemplate: 'Old body',
+      },
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actionConfig: {
+          userIds: [],
+          memberGroupIds: [],
+          userIdFieldPath: 'record.',
+          titleTemplate: 'New title',
+          bodyTemplate: 'New body',
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required',
+    })
     expect(automationService.updateRule).not.toHaveBeenCalled()
   })
 

--- a/packages/core-backend/tests/unit/dingtalk-automation-link-validation.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-automation-link-validation.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   collectDingTalkAutomationLinkIds,
+  normalizeDingTalkAutomationActionInputs,
+  validateDingTalkAutomationActionConfigs,
   validateDingTalkAutomationLinks,
   type AutomationLinkQueryFn,
 } from '../../src/multitable/dingtalk-automation-link-validation'
@@ -14,6 +16,77 @@ function queryWithRows(rowsByCall: unknown[][]): AutomationLinkQueryFn {
 }
 
 describe('dingtalk automation link validation', () => {
+  it('normalizes legacy DingTalk title and content fields before persistence', () => {
+    const normalized = normalizeDingTalkAutomationActionInputs(
+      'send_dingtalk_group_message',
+      { destinationId: 'group_1', title: 'Please fill', content: 'Open form' },
+      [
+        {
+          type: 'send_dingtalk_person_message',
+          config: { userIds: ['user_1'], title: 'Person title', content: 'Person body' },
+        },
+      ],
+    )
+
+    expect(normalized.actionConfig).toMatchObject({
+      titleTemplate: 'Please fill',
+      bodyTemplate: 'Open form',
+    })
+    expect(normalized.actions).toEqual([
+      {
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          title: 'Person title',
+          content: 'Person body',
+          titleTemplate: 'Person title',
+          bodyTemplate: 'Person body',
+        },
+      },
+    ])
+  })
+
+  it('rejects DingTalk group actions without an effective destination source', () => {
+    expect(validateDingTalkAutomationActionConfigs(
+      'send_dingtalk_group_message',
+      {
+        destinationIds: [],
+        destinationIdFieldPath: 'record., ,',
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+      },
+      null,
+    )).toBe('At least one DingTalk destination or record destination field path is required')
+  })
+
+  it('rejects DingTalk person actions without an effective recipient source', () => {
+    expect(validateDingTalkAutomationActionConfigs(
+      'send_dingtalk_person_message',
+      {
+        userIds: [','],
+        memberGroupIds: [],
+        userIdFieldPaths: ['record.'],
+        memberGroupIdFieldPath: ',',
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+      },
+      null,
+    )).toBe('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
+  })
+
+  it('rejects DingTalk actions without executable template fields', () => {
+    expect(validateDingTalkAutomationActionConfigs(
+      'notify',
+      {},
+      [
+        {
+          type: 'send_dingtalk_person_message',
+          config: { userIds: ['user_1'], titleTemplate: ' ', bodyTemplate: 'Open form' },
+        },
+      ],
+    )).toBe('DingTalk titleTemplate is required')
+  })
+
   it('collects public form and internal view ids from legacy and multi-action configs', () => {
     expect(collectDingTalkAutomationLinkIds(
       'send_dingtalk_group_message',


### PR DESCRIPTION
## Summary

- Validate DingTalk group/person automation action configs before create/update persistence
- Reject missing effective destinations, recipients, title templates, or body templates for legacy and V1 actions
- Normalize legacy `title`/`content` fields to `titleTemplate`/`bodyTemplate` before validation and persistence
- Add backend unit and route regression coverage plus development/verification notes

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

## Docs

- `docs/development/dingtalk-action-config-validation-development-20260421.md`
- `docs/development/dingtalk-action-config-validation-verification-20260421.md`