### PR TITLE
fix(dingtalk): validate automation configs in service

### DIFF
--- a/docs/development/dingtalk-action-service-validation-development-20260421.md
+++ b/docs/development/dingtalk-action-service-validation-development-20260421.md
@@ -1,0 +1,50 @@
+# DingTalk Automation Service Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change moves DingTalk automation action config validation into `AutomationService`, in addition to the existing route-level validation.
+
+Affected paths:
+
+- `packages/core-backend/src/multitable/automation-service.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+
+## Problem
+
+The HTTP routes already reject invalid DingTalk automation configs before persistence, but callers that use `AutomationService.createRule` or `AutomationService.updateRule` directly could still write invalid DingTalk rules.
+
+That left a gap for internal callers, tests, scripts, or future routes that bypass the current REST handlers.
+
+## Implementation
+
+`AutomationService.createRule` now normalizes and validates DingTalk action inputs before inserting a rule:
+
+- Legacy `title/content` fields are normalized to `titleTemplate/bodyTemplate`.
+- Legacy single-action configs are validated through `actionType/actionConfig`.
+- V1 multi-action configs are validated through `actions[]`.
+- Invalid configs throw `AutomationRuleValidationError` before DB writes.
+
+`AutomationService.updateRule` now validates the effective merged action state for PATCH semantics:
+
+- It only reads the existing rule when `actionType`, `actionConfig`, or `actions` is being changed.
+- It merges existing values with incoming values before validation.
+- It catches cases where only `actionType` changes to DingTalk but the existing config is not executable.
+- It validates changed V1 `actions[]` before update.
+- It preserves non-action updates, so enable/name-only updates do not revalidate historical DingTalk configs.
+
+`univer-meta` now maps `AutomationRuleValidationError` to HTTP 400 as a safety net, so future service-level validation failures are not reported as 500.
+
+## Behavior
+
+Service-level validation now rejects:
+
+- DingTalk group messages without static destinations or record destination field paths.
+- DingTalk person messages without local users, member groups, record recipient field paths, or record member-group field paths.
+- DingTalk actions without `titleTemplate`.
+- DingTalk actions without `bodyTemplate`.
+- Separator-only values such as `,` or `record.`.
+
+Route-level public form and internal view link validation remains unchanged.

--- a/docs/development/dingtalk-action-service-validation-verification-20260421.md
+++ b/docs/development/dingtalk-action-service-validation-verification-20260421.md
@@ -1,0 +1,52 @@
+# DingTalk Automation Service Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-action-service-validation-20260421`
+- Branch: `codex/dingtalk-action-service-validation-20260421`
+- Base: `e32d63eaa734b25fe5c75487937d8833d6813f18`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/unit/automation-v1.test.ts`: 117 tests passed.
+- Added coverage for service-level DingTalk config validation on create/update.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/unit/dingtalk-automation-link-validation.test.ts`: 12 tests passed.
+- `tests/integration/dingtalk-automation-link-routes.api.test.ts`: 9 tests passed.
+- Total: 21 tests passed.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+## Notes
+
+- Vitest emitted the existing Vite CJS Node API deprecation warning.
+- `pnpm install` emitted the existing ignored-build-scripts warning.
+- No live DingTalk webhook delivery was required because this change protects persistence-time validation.

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -9,11 +9,24 @@ import type { AutomationAction } from './automation-actions'
 import type { AutomationTrigger } from './automation-triggers'
 import { AutomationScheduler } from './automation-scheduler'
 import { AutomationLogService } from './automation-log-service'
+import {
+  normalizeDingTalkAutomationActionInputs,
+  validateDingTalkAutomationActionConfigs,
+} from './dingtalk-automation-link-validation'
 import type { Database } from '../db/types'
 
 const logger = new Logger('AutomationService')
 
 const MAX_AUTOMATION_DEPTH = 3
+
+export class AutomationRuleValidationError extends Error {
+  readonly code = 'VALIDATION_ERROR'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'AutomationRuleValidationError'
+  }
+}
 
 const VALID_TRIGGER_TYPES = new Set([
   'record.created',
@@ -193,6 +206,19 @@ export class AutomationService {
   async createRule(sheetId: string, input: CreateRuleInput): Promise<AutomationRule> {
     const ruleId = `atr_${randomUUID()}`
     const now = new Date().toISOString()
+    const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(
+      input.actionType,
+      input.actionConfig ?? {},
+      input.actions ?? null,
+    )
+    const actionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
+      ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
+      : input.actionConfig ?? {}
+    const actions = Array.isArray(normalizedDingTalkInputs.actions)
+      ? normalizedDingTalkInputs.actions as AutomationAction[]
+      : input.actions ?? null
+    const actionConfigValidationError = validateDingTalkAutomationActionConfigs(input.actionType, actionConfig, actions)
+    if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
 
     const row = {
       id: ruleId,
@@ -201,11 +227,11 @@ export class AutomationService {
       trigger_type: input.triggerType,
       trigger_config: JSON.stringify(input.triggerConfig ?? {}),
       action_type: input.actionType,
-      action_config: JSON.stringify(input.actionConfig ?? {}),
+      action_config: JSON.stringify(actionConfig),
       enabled: input.enabled ?? true,
       created_by: input.createdBy ?? null,
       conditions: input.conditions ? JSON.stringify(input.conditions) : null,
-      actions: input.actions ? JSON.stringify(input.actions) : null,
+      actions: actions ? JSON.stringify(actions) : null,
     }
 
     await this.db
@@ -220,13 +246,13 @@ export class AutomationService {
       trigger_type: input.triggerType,
       trigger_config: input.triggerConfig ?? {},
       action_type: input.actionType,
-      action_config: input.actionConfig ?? {},
+      action_config: actionConfig,
       enabled: input.enabled ?? true,
       created_at: now,
       updated_at: now,
       created_by: input.createdBy ?? null,
       conditions: input.conditions ?? null,
-      actions: input.actions ?? null,
+      actions,
     }
 
     this.registerSchedule(rule)
@@ -267,15 +293,43 @@ export class AutomationService {
    */
   async updateRule(ruleId: string, sheetId: string, input: UpdateRuleInput): Promise<AutomationRule | null> {
     const updates: Record<string, unknown> = {}
+    const shouldValidateActions = input.actionType !== undefined || input.actionConfig !== undefined || input.actions !== undefined
+    let normalizedActionConfigForUpdate: Record<string, unknown> | undefined
+    let normalizedActionsForUpdate: AutomationAction[] | null | undefined
+
+    if (shouldValidateActions) {
+      const existing = await this.getRule(ruleId)
+      if (!existing || existing.sheet_id !== sheetId) return null
+
+      const nextActionType = input.actionType ?? existing.action_type
+      const nextActionConfig = input.actionConfig ?? existing.action_config
+      const nextActions = input.actions !== undefined ? input.actions : existing.actions ?? null
+      const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(nextActionType, nextActionConfig, nextActions)
+      const normalizedNextActionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
+        ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
+        : nextActionConfig
+      const normalizedNextActions = Array.isArray(normalizedDingTalkInputs.actions)
+        ? normalizedDingTalkInputs.actions as AutomationAction[]
+        : nextActions
+      const actionConfigValidationError = validateDingTalkAutomationActionConfigs(
+        nextActionType,
+        normalizedNextActionConfig,
+        normalizedNextActions,
+      )
+      if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
+
+      if (input.actionConfig !== undefined) normalizedActionConfigForUpdate = normalizedNextActionConfig
+      if (input.actions !== undefined) normalizedActionsForUpdate = Array.isArray(input.actions) ? normalizedNextActions : null
+    }
 
     if (input.name !== undefined) updates.name = input.name
     if (input.triggerType !== undefined) updates.trigger_type = input.triggerType
     if (input.triggerConfig !== undefined) updates.trigger_config = JSON.stringify(input.triggerConfig)
     if (input.actionType !== undefined) updates.action_type = input.actionType
-    if (input.actionConfig !== undefined) updates.action_config = JSON.stringify(input.actionConfig)
+    if (input.actionConfig !== undefined) updates.action_config = JSON.stringify(normalizedActionConfigForUpdate ?? input.actionConfig)
     if (input.enabled !== undefined) updates.enabled = input.enabled
     if (input.conditions !== undefined) updates.conditions = input.conditions ? JSON.stringify(input.conditions) : null
-    if (input.actions !== undefined) updates.actions = input.actions ? JSON.stringify(input.actions) : null
+    if (input.actions !== undefined) updates.actions = normalizedActionsForUpdate ? JSON.stringify(normalizedActionsForUpdate) : null
 
     if (Object.keys(updates).length === 0) return this.getRule(ruleId)
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -31,7 +31,7 @@ import { MultitableFormulaEngine } from '../multitable/formula-engine'
 import { validateRecord, getDefaultValidationRules } from '../multitable/field-validation-engine'
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
-import { getAutomationServiceInstance } from '../multitable/automation-service'
+import { AutomationRuleValidationError, getAutomationServiceInstance } from '../multitable/automation-service'
 import {
   normalizeDingTalkAutomationActionInputs,
   validateDingTalkAutomationActionConfigs,
@@ -8414,6 +8414,9 @@ export function univerMetaRouter(): Router {
         },
       })
     } catch (err) {
+      if (err instanceof AutomationRuleValidationError) {
+        return res.status(400).json({ ok: false, error: { code: err.code, message: err.message } })
+      }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] create automation rule failed:', err)
@@ -8540,6 +8543,9 @@ export function univerMetaRouter(): Router {
 
       return res.json({ ok: true, data: { rule: updated } })
     } catch (err) {
+      if (err instanceof AutomationRuleValidationError) {
+        return res.status(400).json({ ok: false, error: { code: err.code, message: err.message } })
+      }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] update automation rule failed:', err)

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -47,7 +47,7 @@ vi.mock('../../src/db/db', () => {
 })
 
 import { AutomationLogService } from '../../src/multitable/automation-log-service'
-import { AutomationService } from '../../src/multitable/automation-service'
+import { AutomationRuleValidationError, AutomationService } from '../../src/multitable/automation-service'
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -1663,6 +1663,25 @@ describe('AutomationService — Rule CRUD', () => {
     return chain
   }
 
+  function makeRuleRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'atr_1',
+      sheet_id: 'sheet_1',
+      name: 'Rule',
+      trigger_type: 'record.created',
+      trigger_config: {},
+      action_type: 'update_record',
+      action_config: {},
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+      created_by: 'u1',
+      conditions: null,
+      actions: null,
+      ...overrides,
+    }
+  }
+
   beforeEach(() => {
     eventBus = new EventBus()
     queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
@@ -1686,6 +1705,77 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule.name).toBe('My Rule')
     expect(rule.trigger_type).toBe('record.created')
     expect(rule.enabled).toBe(true)
+  })
+
+  it('createRule normalizes legacy DingTalk title and content fields', async () => {
+    dbExecuteResults.push([])
+    const rule = await service.createRule('sheet_1', {
+      name: 'DingTalk group',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: {
+        destinationId: 'group_1',
+        title: 'Please fill',
+        content: 'Open form',
+      },
+      createdBy: 'user_1',
+    })
+
+    expect(rule.action_config).toMatchObject({
+      destinationId: 'group_1',
+      titleTemplate: 'Please fill',
+      bodyTemplate: 'Open form',
+    })
+  })
+
+  it('createRule rejects invalid DingTalk person configs before insert', async () => {
+    const promise = service.createRule('sheet_1', {
+      name: 'Bad DingTalk person',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'send_dingtalk_person_message',
+      actionConfig: {
+        userIds: [','],
+        memberGroupIds: [],
+        userIdFieldPath: 'record.',
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+      },
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('createRule rejects invalid V1 DingTalk actions before insert', async () => {
+    const promise = service.createRule('sheet_1', {
+      name: 'Bad DingTalk action',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'notify',
+      actionConfig: {},
+      actions: [
+        {
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationIds: [],
+            destinationIdFieldPath: 'record.',
+            titleTemplate: 'Please fill',
+            bodyTemplate: 'Open form',
+          },
+        },
+      ],
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one DingTalk destination or record destination field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
   })
 
   it('getRule returns a rule when found', async () => {
@@ -1741,17 +1831,86 @@ describe('AutomationService — Rule CRUD', () => {
   })
 
   it('updateRule returns updated rule', async () => {
-    const updatedRow = {
-      id: 'atr_1', sheet_id: 'sheet_1', name: 'Updated',
-      trigger_type: 'record.created', trigger_config: {},
-      action_type: 'update_record', action_config: {},
-      enabled: true, created_at: new Date(), updated_at: new Date(),
-      created_by: 'u1', conditions: null, actions: null,
-    }
+    const updatedRow = makeRuleRow({ name: 'Updated' })
     dbExecuteResults.push([updatedRow])
     const rule = await service.updateRule('atr_1', 'sheet_1', { name: 'Updated' })
     expect(rule).not.toBeNull()
     expect(rule!.name).toBe('Updated')
+  })
+
+  it('updateRule validates the merged state when only actionType changes to DingTalk', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'notify',
+      action_config: {},
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', {
+      actionType: 'send_dingtalk_group_message',
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one DingTalk destination or record destination field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('updateRule rejects merged invalid DingTalk configs before update', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      name: 'DingTalk person',
+      action_type: 'send_dingtalk_person_message',
+      action_config: {
+        userIds: ['user_1'],
+        titleTemplate: 'Old title',
+        bodyTemplate: 'Old body',
+      },
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', {
+      actionConfig: {
+        userIds: [],
+        memberGroupIds: [','],
+        userIdFieldPath: 'record.',
+        titleTemplate: 'New title',
+        bodyTemplate: 'New body',
+      },
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('updateRule rejects invalid V1 DingTalk actions before update', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'notify',
+      action_config: {},
+      actions: [
+        {
+          type: 'update_record',
+          config: { fields: { status: 'done' } },
+        },
+      ],
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', {
+      actions: [
+        {
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            memberGroupIdFieldPaths: ['record.'],
+            titleTemplate: 'Please fill',
+            bodyTemplate: 'Open form',
+          },
+        },
+      ],
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
   })
 
   it('updateRule returns null when rule not found', async () => {


### PR DESCRIPTION
## Summary
- add service-layer DingTalk automation action config validation for `createRule` and merged-state `updateRule`
- normalize legacy `title/content` fields before service persistence
- map `AutomationRuleValidationError` to HTTP 400 as a route safety net
- add development and verification notes under `docs/development`

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --cached --check`