### PR TITLE
feat(dingtalk): promote automation validation stack

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
@@ -13,10 +13,13 @@
             <option value="success">Success</option>
             <option value="failed">Failed</option>
           </select>
-          <button class="meta-group-delivery__btn" type="button" data-action="refresh" @click="loadData">Refresh</button>
+          <button class="meta-group-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">Refresh</button>
         </div>
 
         <div v-if="loading" class="meta-group-delivery__empty">Loading deliveries...</div>
+        <div v-else-if="errorMessage" class="meta-group-delivery__error-state" data-group-delivery-error="true">
+          {{ errorMessage }}
+        </div>
         <div v-else-if="filteredDeliveries.length === 0" class="meta-group-delivery__empty" data-empty="true">
           No DingTalk group deliveries found.
         </div>
@@ -65,6 +68,7 @@ defineEmits<{
 const loading = ref(false)
 const deliveries = ref<DingTalkGroupDelivery[]>([])
 const statusFilter = ref('')
+const errorMessage = ref('')
 
 const filteredDeliveries = computed(() => {
   if (!statusFilter.value) return deliveries.value
@@ -80,13 +84,21 @@ function formatTime(ts: string): string {
   }
 }
 
+function readErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : 'Failed to load DingTalk group deliveries.'
+}
+
 async function loadData() {
   if (!props.client || !props.sheetId || !props.ruleId) return
   loading.value = true
+  errorMessage.value = ''
   try {
     deliveries.value = await props.client.getAutomationDingTalkGroupDeliveries(props.sheetId, props.ruleId, 50)
-  } catch {
+  } catch (error) {
     deliveries.value = []
+    errorMessage.value = readErrorMessage(error)
   } finally {
     loading.value = false
   }
@@ -244,5 +256,14 @@ watch(
 .meta-group-delivery__error {
   color: #dc2626;
   font-size: 12px;
+}
+
+.meta-group-delivery__error-state {
+  padding: 10px 12px;
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 13px;
 }
 </style>

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -689,6 +689,8 @@ import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemp
 import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
+  listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
+  listDingTalkPersonRecipientFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
   describeDingTalkPublicFormLinkAccess,
@@ -1068,24 +1070,11 @@ const selectedDingTalkPersonMemberGroupRecipientFields = computed(() => parseRec
   .filter((item) => item.label))
 
 function recipientFieldPathWarnings(value: string) {
-  const candidateIds = new Set(dingTalkPersonRecipientCandidateFields.value.map((field) => field.id))
-  return parseRecipientFieldPathsText(value)
-    .filter((path) => !candidateIds.has(path))
-    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+  return listDingTalkPersonRecipientFieldPathWarnings(value, props.fields)
 }
 
 function memberGroupRecipientFieldPathWarnings(value: string) {
-  const fieldMap = new Map(props.fields.map((field) => [field.id, field]))
-  return parseRecipientFieldPathsText(value).flatMap((path) => {
-    const field = fieldMap.get(path)
-    if (!field) {
-      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
-    }
-    if (field.type === 'user') {
-      return [`record.${path} is a user field; use Record recipient field paths instead.`]
-    }
-    return []
-  })
+  return listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, props.fields)
 }
 
 const dingTalkPersonRecipientFieldSummary = computed(() => {
@@ -1363,18 +1352,23 @@ const canSave = computed(() => {
   if (draft.value.actionType === 'notify' && !draft.value.notifyMessage.trim()) return false
   if (draft.value.actionType === 'update_field' && (!draft.value.targetFieldId || !draft.value.targetValue.trim())) return false
   if (draft.value.actionType === 'send_dingtalk_group_message') {
-    if (!draft.value.dingtalkDestinationIds.length && !draft.value.dingtalkDestinationFieldPath.trim()) return false
+    const destinationFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkDestinationFieldPath)
+    if (!draft.value.dingtalkDestinationIds.length && !destinationFieldPaths.length) return false
     if (!draft.value.dingtalkTitleTemplate.trim()) return false
     if (!draft.value.dingtalkBodyTemplate.trim()) return false
     if (publicFormLinkBlockingErrors(draft.value.publicFormViewId).length) return false
     if (internalViewLinkBlockingErrors(draft.value.internalViewId).length) return false
   }
   if (draft.value.actionType === 'send_dingtalk_person_message') {
+    const userIds = parseUserIdsText(draft.value.dingtalkPersonUserIds)
+    const memberGroupIds = parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds)
+    const recipientFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
+    const memberGroupRecipientFieldPaths = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
     if (
-      !draft.value.dingtalkPersonUserIds.trim()
-      && !draft.value.dingtalkPersonMemberGroupIds.trim()
-      && !draft.value.dingtalkPersonRecipientFieldPath.trim()
-      && !draft.value.dingtalkPersonMemberGroupRecipientFieldPath.trim()
+      !userIds.length
+      && !memberGroupIds.length
+      && !recipientFieldPaths.length
+      && !memberGroupRecipientFieldPaths.length
     ) return false
     if (!draft.value.dingtalkPersonTitleTemplate.trim()) return false
     if (!draft.value.dingtalkPersonBodyTemplate.trim()) return false

--- a/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
@@ -13,10 +13,13 @@
             <option value="success">Success</option>
             <option value="failed">Failed</option>
           </select>
-          <button class="meta-person-delivery__btn" type="button" data-action="refresh" @click="loadData">Refresh</button>
+          <button class="meta-person-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">Refresh</button>
         </div>
 
         <div v-if="loading" class="meta-person-delivery__empty">Loading deliveries...</div>
+        <div v-else-if="errorMessage" class="meta-person-delivery__error-state" data-person-delivery-error="true">
+          {{ errorMessage }}
+        </div>
         <div v-else-if="filteredDeliveries.length === 0" class="meta-person-delivery__empty" data-empty="true">
           No DingTalk person deliveries found.
         </div>
@@ -72,6 +75,7 @@ defineEmits<{
 const loading = ref(false)
 const deliveries = ref<DingTalkPersonDelivery[]>([])
 const statusFilter = ref('')
+const errorMessage = ref('')
 
 const filteredDeliveries = computed(() => {
   if (!statusFilter.value) return deliveries.value
@@ -87,13 +91,21 @@ function formatTime(ts: string): string {
   }
 }
 
+function readErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : 'Failed to load DingTalk person deliveries.'
+}
+
 async function loadData() {
   if (!props.client || !props.sheetId || !props.ruleId) return
   loading.value = true
+  errorMessage.value = ''
   try {
     deliveries.value = await props.client.getAutomationDingTalkPersonDeliveries(props.sheetId, props.ruleId, 50)
-  } catch {
+  } catch (error) {
     deliveries.value = []
+    errorMessage.value = readErrorMessage(error)
   } finally {
     loading.value = false
   }
@@ -266,5 +278,14 @@ watch(
 .meta-person-delivery__error {
   font-size: 12px;
   color: #b91c1c;
+}
+
+.meta-person-delivery__error-state {
+  padding: 10px 12px;
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 13px;
 }
 </style>

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -758,6 +758,8 @@ import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemp
 import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
+  listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
+  listDingTalkPersonRecipientFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
   describeDingTalkPublicFormLinkAccess,
@@ -967,23 +969,21 @@ const canSave = computed(() => {
   for (const action of draft.value.actions) {
     if (action.type === 'send_dingtalk_group_message') {
       const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
-      const destinationFieldPath = typeof action.config.destinationFieldPath === 'string' ? action.config.destinationFieldPath.trim() : ''
+      const destinationFieldPaths = parseRecipientFieldPathsText(action.config.destinationFieldPath)
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!destinationIds.length && !destinationFieldPath) || !titleTemplate || !bodyTemplate) return false
+      if ((!destinationIds.length && !destinationFieldPaths.length) || !titleTemplate || !bodyTemplate) return false
       if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
       if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }
     if (action.type === 'send_dingtalk_person_message') {
-      const userIdsText = typeof action.config.userIdsText === 'string' ? action.config.userIdsText.trim() : ''
-      const memberGroupIdsText = typeof action.config.memberGroupIdsText === 'string' ? action.config.memberGroupIdsText.trim() : ''
-      const recipientFieldPath = typeof action.config.recipientFieldPath === 'string' ? action.config.recipientFieldPath.trim() : ''
-      const memberGroupRecipientFieldPath = typeof action.config.memberGroupRecipientFieldPath === 'string'
-        ? action.config.memberGroupRecipientFieldPath.trim()
-        : ''
+      const userIds = parseUserIdsText(action.config.userIdsText)
+      const memberGroupIds = parseMemberGroupIdsText(action.config.memberGroupIdsText)
+      const recipientFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+      const memberGroupRecipientFieldPaths = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
       const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!userIdsText && !memberGroupIdsText && !recipientFieldPath && !memberGroupRecipientFieldPath) || !titleTemplate || !bodyTemplate) return false
+      if ((!userIds.length && !memberGroupIds.length && !recipientFieldPaths.length && !memberGroupRecipientFieldPaths.length) || !titleTemplate || !bodyTemplate) return false
       if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
       if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }
@@ -1325,24 +1325,11 @@ function selectedMemberGroupRecipientFields(action: DraftAction) {
 }
 
 function recipientFieldPathWarnings(value: unknown) {
-  const candidateIds = new Set(recipientCandidateFields.value.map((field) => field.id))
-  return parseRecipientFieldPathsText(value)
-    .filter((path) => !candidateIds.has(path))
-    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+  return listDingTalkPersonRecipientFieldPathWarnings(value, props.fields)
 }
 
 function memberGroupRecipientFieldPathWarnings(value: unknown) {
-  const fieldMap = new Map(props.fields.map((field) => [field.id, field]))
-  return parseRecipientFieldPathsText(value).flatMap((path) => {
-    const field = fieldMap.get(path)
-    if (!field) {
-      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
-    }
-    if (field.type === 'user') {
-      return [`record.${path} is a user field; use Record recipient field paths instead.`]
-    }
-    return []
-  })
+  return listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, props.fields)
 }
 
 function recipientFieldPathSummary(value: unknown) {

--- a/apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts
@@ -42,3 +42,35 @@ export function listDingTalkGroupDestinationFieldPathWarnings(
     return []
   })
 }
+
+export function listDingTalkPersonRecipientFieldPathWarnings(
+  value: unknown,
+  fields: readonly DingTalkRecipientWarningField[],
+): string[] {
+  const userFieldIds = new Set(fields
+    .filter((field) => field.type === 'user')
+    .map((field) => field.id))
+  return parseRecordFieldPaths(value)
+    .filter((path) => !userFieldIds.has(path))
+    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+}
+
+export function listDingTalkPersonMemberGroupRecipientFieldPathWarnings(
+  value: unknown,
+  fields: readonly DingTalkRecipientWarningField[],
+): string[] {
+  const fieldMap = new Map(fields.map((field) => [field.id, field]))
+  return parseRecordFieldPaths(value).flatMap((path) => {
+    const field = fieldMap.get(path)
+    if (!field) {
+      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
+    }
+    if (field.type === 'user') {
+      return [`record.${path} is a user field; use Record recipient field paths instead.`]
+    }
+    if (!isDingTalkMemberGroupRecipientField(field)) {
+      return [`record.${path} is not a member group field; DingTalk person member-group recipients expect member group fields.`]
+    }
+    return []
+  })
+}

--- a/apps/web/tests/dingtalk-recipient-field-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-recipient-field-warnings.spec.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest'
 import {
   isDingTalkMemberGroupRecipientField,
   listDingTalkGroupDestinationFieldPathWarnings,
+  listDingTalkPersonMemberGroupRecipientFieldPathWarnings,
+  listDingTalkPersonRecipientFieldPathWarnings,
 } from '../src/multitable/utils/dingtalkRecipientFieldWarnings'
 
 const fields = [
@@ -41,6 +43,53 @@ describe('dingtalk recipient field warnings', () => {
   it('returns no dynamic group destination warnings for empty or non-string input', () => {
     expect(listDingTalkGroupDestinationFieldPathWarnings('', fields)).toEqual([])
     expect(listDingTalkGroupDestinationFieldPathWarnings(['record.assigneeUserIds'], fields)).toEqual([])
+  })
+
+  it('lists dynamic person recipient field path warnings from normalized record paths', () => {
+    expect(listDingTalkPersonRecipientFieldPathWarnings(
+      [
+        'record.missingUserId',
+        'record.name',
+        'record.assigneeUserIds',
+        'record.watcherGroupIds',
+        'name',
+      ].join(',\n'),
+      fields,
+    )).toEqual([
+      'record.missingUserId is not a user field; DingTalk person messages expect local user IDs.',
+      'record.name is not a user field; DingTalk person messages expect local user IDs.',
+      'record.watcherGroupIds is not a user field; DingTalk person messages expect local user IDs.',
+    ])
+  })
+
+  it('returns no person recipient warnings for empty or non-string input', () => {
+    expect(listDingTalkPersonRecipientFieldPathWarnings('', fields)).toEqual([])
+    expect(listDingTalkPersonRecipientFieldPathWarnings(['record.name'], fields)).toEqual([])
+  })
+
+  it('lists dynamic person member-group recipient field path warnings from normalized record paths', () => {
+    expect(listDingTalkPersonMemberGroupRecipientFieldPathWarnings(
+      [
+        'record.missingGroupId',
+        'record.assigneeUserIds',
+        'record.name',
+        'record.watcherGroupIds',
+        'record.escalationGroupId',
+        'record.reviewGroupId',
+        'record.approvalGroupId',
+        'name',
+      ].join(',\n'),
+      fields,
+    )).toEqual([
+      'record.missingGroupId is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.',
+      'record.assigneeUserIds is a user field; use Record recipient field paths instead.',
+      'record.name is not a member group field; DingTalk person member-group recipients expect member group fields.',
+    ])
+  })
+
+  it('returns no person member-group recipient warnings for empty or non-string input', () => {
+    expect(listDingTalkPersonMemberGroupRecipientFieldPathWarnings('', fields)).toEqual([])
+    expect(listDingTalkPersonMemberGroupRecipientFieldPathWarnings(['record.name'], fields)).toEqual([])
   })
 
   it('detects member group recipient fields from type aliases and ref metadata', () => {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -27,10 +27,16 @@ function mockClient(
   options: {
     testExecution?: Record<string, unknown> | Promise<Record<string, unknown>>
     testErrorMessage?: string
+    groupDeliveryErrorMessage?: string
+    personDeliveryErrorMessage?: string
     stats?: Record<string, unknown>
   } = {},
 ) {
   const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  const apiError = (message: string) => new Response(
+    JSON.stringify({ error: { code: 'INTERNAL_ERROR', message } }),
+    { status: 500, headers: { 'Content-Type': 'application/json' } },
+  )
   const noContent = () => new Response(null, { status: 204 })
   const personDeliveries: DingTalkPersonDelivery[] = [
     {
@@ -105,9 +111,11 @@ function mockClient(
     }
     if (method === 'GET' && url.includes('/automations')) {
       if (url.includes('/dingtalk-group-deliveries')) {
+        if (options.groupDeliveryErrorMessage) return apiError(options.groupDeliveryErrorMessage)
         return ok({ deliveries: groupDeliveries })
       }
       if (url.includes('/dingtalk-person-deliveries')) {
+        if (options.personDeliveryErrorMessage) return apiError(options.personDeliveryErrorMessage)
         return ok({ deliveries: personDeliveries })
       }
       if (url.endsWith('/stats')) {
@@ -625,6 +633,46 @@ describe('MetaAutomationManager', () => {
     })
   })
 
+  it('disables creating a DingTalk group automation when dynamic destination paths parse empty', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk invalid dynamic groups'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const destinationFieldInput = container.querySelector('[data-automation-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
+    destinationFieldInput.value = 'record., ,'
+    destinationFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(0)
+  })
+
   it('can pick a dynamic DingTalk group destination field in the inline form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -982,6 +1030,94 @@ describe('MetaAutomationManager', () => {
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please fill {{record.status}}',
     })
+  })
+
+  it('disables creating a DingTalk person automation when dynamic recipient paths parse empty', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk invalid dynamic recipients'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record., ,'
+    recipientFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = ','
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(0)
+  })
+
+  it('disables creating a DingTalk person automation when static recipient lists parse empty', async () => {
+    const { client, fetchFn } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk invalid static recipients'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = ',\n,'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const memberGroupIdsInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    memberGroupIdsInput.value = ','
+    memberGroupIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(0)
   })
 
   it('can remove a selected dynamic member group recipient field chip in the inline form', async () => {
@@ -1348,6 +1484,31 @@ describe('MetaAutomationManager', () => {
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/dingtalk-group-deliveries'))).toBe(true)
   })
 
+  it('shows DingTalk group delivery load errors instead of an empty history', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        name: 'DingTalk group notify',
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+      }),
+    ], { groupDeliveryErrorMessage: 'Delivery history unavailable' })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deliveriesBtn = container.querySelector('[data-automation-group-deliveries="rule_1"]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const error = document.querySelector('[data-group-delivery-error="true"]')
+    expect(error?.textContent).toContain('Delivery history unavailable')
+    expect(document.querySelector('[data-group-delivery-id="dgd_1"]')).toBeNull()
+    expect(document.querySelector('.meta-group-delivery [data-empty="true"]')).toBeNull()
+  })
+
   it('opens DingTalk group delivery viewer for V1 multi-action rules', async () => {
     const { client, fetchFn } = mockClient([
       fakeRule({
@@ -1410,6 +1571,31 @@ describe('MetaAutomationManager', () => {
     const delivery = document.querySelector('[data-person-delivery-id="dpd_1"]')
     expect(delivery?.textContent).toContain('Lin Lan')
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/sheets/sheet_1/automations/rule_1/dingtalk-person-deliveries'))).toBe(true)
+  })
+
+  it('shows DingTalk person delivery load errors instead of an empty history', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        name: 'Multi-step person notify',
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: ['user_1'],
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+      }),
+    ], { personDeliveryErrorMessage: 'Person delivery query failed' })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deliveriesBtn = container.querySelector('[data-automation-person-deliveries="rule_1"]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    const error = document.querySelector('[data-person-delivery-error="true"]')
+    expect(error?.textContent).toContain('Person delivery query failed')
+    expect(document.querySelector('[data-person-delivery-id="dpd_1"]')).toBeNull()
+    expect(document.querySelector('.meta-person-delivery [data-empty="true"]')).toBeNull()
   })
 
   it('shows a generic running status for non-DingTalk automation test runs', async () => {
@@ -1756,6 +1942,81 @@ describe('MetaAutomationManager', () => {
     expect(document.body.textContent).toContain('Assignees (record.assigneeUserIds)')
   })
 
+  it('opens the rule editor with DingTalk group config from V1 actions when legacy action fields are stale', async () => {
+    const rules = [
+      fakeRule({
+        id: 'rule_stale_group',
+        name: 'Stale group action',
+        actionType: 'notify',
+        actionConfig: { message: 'stale legacy notification' },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationId: 'dt_1',
+            destinationIds: ['dt_1', 'dt_2'],
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please review {{record.status}}',
+            publicFormViewId: 'view_form',
+            internalViewId: 'view_grid',
+          },
+        }],
+      }),
+    ]
+    const { client } = mockClient(rules)
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const editBtn = container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement
+    expect(editBtn).toBeTruthy()
+    editBtn.click()
+    await flushPromises()
+
+    const actionSelect = document.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(actionSelect.value).toBe('send_dingtalk_group_message')
+    expect(document.querySelector('[data-group-destination="dt_1"]')?.textContent).toContain('Ops Group')
+    expect(document.querySelector('[data-group-destination="dt_2"]')?.textContent).toContain('Escalation Group')
+    expect((document.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
+    expect((document.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please review {{record.status}}')
+  })
+
+  it('opens the rule editor with DingTalk person dynamic recipients from V1 actions when legacy action fields are stale', async () => {
+    const rules = [
+      fakeRule({
+        id: 'rule_stale_person',
+        name: 'Stale person action',
+        actionType: 'notify',
+        actionConfig: { message: 'stale legacy notification' },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            userIdFieldPath: 'record.assigneeUserIds',
+            userIdFieldPaths: ['record.assigneeUserIds'],
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please fill {{record.status}}',
+          },
+        }],
+      }),
+    ]
+    const { client } = mockClient(rules)
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const editBtn = container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement
+    expect(editBtn).toBeTruthy()
+    editBtn.click()
+    await flushPromises()
+
+    const actionSelect = document.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    const recipientFieldInput = document.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    expect(actionSelect.value).toBe('send_dingtalk_person_message')
+    expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
+    expect((document.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
+    expect((document.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please fill {{record.status}}')
+    expect(document.body.textContent).toContain('Record recipients:')
+    expect(document.body.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
   it('shows a blocking warning when editing a rule with a missing internal processing view', async () => {
     const config = {
       destinationIds: ['dt_1'],
@@ -1848,6 +2109,28 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('record.fld_1 is not a user field')
+  })
+
+  it('warns when a DingTalk person member-group recipient path is not a member group field in the inline create form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.fld_1'
+    memberGroupFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.fld_1 is not a member group field')
   })
 
   it('copies rendered DingTalk person body example in the inline create form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -545,6 +545,64 @@ describe('MetaAutomationRuleEditor', () => {
     expect(client.listDingTalkGroups).toHaveBeenCalledWith('sheet_1')
   })
 
+  it('loads and saves DingTalk group config from V1 actions when legacy action fields are stale', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      rule: fakeRule({
+        name: 'V1 group action',
+        actionType: 'notify',
+        actionConfig: { message: 'stale legacy value' },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationId: 'dt_1',
+            destinationIds: ['dt_1', 'dt_2'],
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please review {{record.status}}',
+            publicFormViewId: 'view_form',
+            internalViewId: 'view_grid',
+          },
+        }],
+      }),
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(actionSelect.value).toBe('send_dingtalk_group_message')
+    expect(container.querySelector('[data-group-destination="dt_1"]')?.textContent).toContain('Ops Group')
+    expect(container.querySelector('[data-group-destination="dt_2"]')?.textContent).toContain('Escalation Group')
+    expect((container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
+    expect((container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please review {{record.status}}')
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionType).toBe('send_dingtalk_group_message')
+    expect(payload.actionConfig).toEqual({
+      destinationId: 'dt_1',
+      destinationIds: ['dt_1', 'dt_2'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      publicFormViewId: 'view_form',
+      internalViewId: 'view_grid',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_dingtalk_group_message',
+      config: payload.actionConfig,
+    })
+  })
+
   it('emits DingTalk group action config with only dynamic record destination paths', async () => {
     const saved = vi.fn()
     const client = mockClient()
@@ -594,6 +652,50 @@ describe('MetaAutomationRuleEditor', () => {
       titleTemplate: 'Ticket {{recordId}}',
       bodyTemplate: 'Please review {{record.status}}',
     })
+  })
+
+  it('disables saving a DingTalk group message when dynamic destination paths parse empty', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify invalid dynamic groups'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const destinationFieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
+    destinationFieldInput.value = 'record., ,'
+    destinationFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).not.toHaveBeenCalled()
   })
 
   it('can pick a dynamic DingTalk group destination field', async () => {
@@ -1043,6 +1145,162 @@ describe('MetaAutomationRuleEditor', () => {
     })
     expect(container.textContent).toContain('Record recipients:')
     expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
+  })
+
+  it('disables saving a DingTalk person message when dynamic recipient paths parse empty', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify invalid dynamic recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record., ,'
+    recipientFieldInput.dispatchEvent(new Event('input'))
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = ','
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).not.toHaveBeenCalled()
+  })
+
+  it('disables saving a DingTalk person message when static recipient lists parse empty', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify invalid static recipients'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = ',\n,'
+    userIdsInput.dispatchEvent(new Event('input'))
+
+    const memberGroupIdsInput = container.querySelector('[data-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    memberGroupIdsInput.value = ','
+    memberGroupIdsInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).not.toHaveBeenCalled()
+  })
+
+  it('loads and saves DingTalk person dynamic recipients from V1 actions when legacy action fields are stale', async () => {
+    const saved = vi.fn()
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      rule: fakeRule({
+        name: 'V1 person action',
+        actionType: 'notify',
+        actionConfig: { message: 'stale legacy value' },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            userIdFieldPath: 'record.assigneeUserIds',
+            userIdFieldPaths: ['record.assigneeUserIds'],
+            titleTemplate: 'Ticket {{recordId}}',
+            bodyTemplate: 'Please review {{record.status}}',
+            publicFormViewId: 'view_form',
+            internalViewId: 'view_grid',
+          },
+        }],
+      }),
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(actionSelect.value).toBe('send_dingtalk_person_message')
+    expect((container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement).value).toBe('record.assigneeUserIds')
+    expect((container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
+    expect((container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please review {{record.status}}')
+    expect(container.textContent).toContain('Assignees (record.assigneeUserIds)')
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionType).toBe('send_dingtalk_person_message')
+    expect(payload.actionConfig).toEqual({
+      userIds: [],
+      userIdFieldPath: 'record.assigneeUserIds',
+      userIdFieldPaths: ['record.assigneeUserIds'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+      publicFormViewId: 'view_form',
+      internalViewId: 'view_grid',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_dingtalk_person_message',
+      config: payload.actionConfig,
+    })
   })
 
   it('emits DingTalk person action config with only a dynamic member group record path', async () => {
@@ -1636,6 +1894,30 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('record.fld_1 is not a user field')
+  })
+
+  it('warns when a DingTalk person member-group recipient path is not a member group field in the rule editor', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.fld_1'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('record.fld_1 is not a member group field')
   })
 
   it('copies rendered DingTalk group body example in the rule editor', async () => {

--- a/docs/development/dingtalk-action-config-validation-development-20260421.md
+++ b/docs/development/dingtalk-action-config-validation-development-20260421.md
@@ -1,0 +1,37 @@
+# DingTalk Automation Action Config Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change adds backend write-time validation for DingTalk automation action configs.
+
+Affected areas:
+
+- `POST /api/multitable/sheets/:sheetId/automations`
+- `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId`
+- Legacy `actionType/actionConfig`
+- V1 `actions[]`
+
+## Problem
+
+The automation routes already validate DingTalk public-form and internal-view links before persistence, but they did not validate the basic executable DingTalk action config. A caller could bypass the frontend and persist a rule missing effective destinations, recipients, title templates, or body templates.
+
+Runtime execution would fail later, but the invalid rule was already stored.
+
+## Implementation
+
+Added synchronous DingTalk config validation in `dingtalk-automation-link-validation.ts`:
+
+- Group message actions require at least one effective static destination or record destination field path.
+- Person message actions require at least one effective recipient source: static user IDs, member group IDs, record user field paths, or record member-group field paths.
+- Both DingTalk actions require executable `titleTemplate` and `bodyTemplate`.
+- Empty separator-only values like `,` or `record.` are parsed as empty.
+
+For compatibility with older callers, DingTalk configs with `title/content` are normalized to `titleTemplate/bodyTemplate` before validation and persistence.
+
+The create/update routes now validate normalized DingTalk configs before existing link validation and before calling the automation service.
+
+## Notes
+
+Enable-only PATCH requests still avoid revalidating DingTalk config and links, preserving the existing behavior for toggling a rule without loading related view state.

--- a/docs/development/dingtalk-action-config-validation-verification-20260421.md
+++ b/docs/development/dingtalk-action-config-validation-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Automation Action Config Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-action-config-validation-20260421`
+- Branch: `codex/dingtalk-action-config-validation-20260421`
+- Base: `e2fc4e7fef7d2e4daa243b310ef924b9b3ff206e`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/unit/dingtalk-automation-link-validation.test.ts`: 12 tests passed.
+- `tests/integration/dingtalk-automation-link-routes.api.test.ts`: 9 tests passed.
+- Total: 21 tests passed.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+Notes:
+
+- Vitest emitted the existing Vite CJS Node API deprecation warning.
+- No live DingTalk webhook delivery was required because this change validates stored automation config at the API boundary.

--- a/docs/development/dingtalk-action-service-validation-development-20260421.md
+++ b/docs/development/dingtalk-action-service-validation-development-20260421.md
@@ -1,0 +1,50 @@
+# DingTalk Automation Service Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change moves DingTalk automation action config validation into `AutomationService`, in addition to the existing route-level validation.
+
+Affected paths:
+
+- `packages/core-backend/src/multitable/automation-service.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+
+## Problem
+
+The HTTP routes already reject invalid DingTalk automation configs before persistence, but callers that use `AutomationService.createRule` or `AutomationService.updateRule` directly could still write invalid DingTalk rules.
+
+That left a gap for internal callers, tests, scripts, or future routes that bypass the current REST handlers.
+
+## Implementation
+
+`AutomationService.createRule` now normalizes and validates DingTalk action inputs before inserting a rule:
+
+- Legacy `title/content` fields are normalized to `titleTemplate/bodyTemplate`.
+- Legacy single-action configs are validated through `actionType/actionConfig`.
+- V1 multi-action configs are validated through `actions[]`.
+- Invalid configs throw `AutomationRuleValidationError` before DB writes.
+
+`AutomationService.updateRule` now validates the effective merged action state for PATCH semantics:
+
+- It only reads the existing rule when `actionType`, `actionConfig`, or `actions` is being changed.
+- It merges existing values with incoming values before validation.
+- It catches cases where only `actionType` changes to DingTalk but the existing config is not executable.
+- It validates changed V1 `actions[]` before update.
+- It preserves non-action updates, so enable/name-only updates do not revalidate historical DingTalk configs.
+
+`univer-meta` now maps `AutomationRuleValidationError` to HTTP 400 as a safety net, so future service-level validation failures are not reported as 500.
+
+## Behavior
+
+Service-level validation now rejects:
+
+- DingTalk group messages without static destinations or record destination field paths.
+- DingTalk person messages without local users, member groups, record recipient field paths, or record member-group field paths.
+- DingTalk actions without `titleTemplate`.
+- DingTalk actions without `bodyTemplate`.
+- Separator-only values such as `,` or `record.`.
+
+Route-level public form and internal view link validation remains unchanged.

--- a/docs/development/dingtalk-action-service-validation-verification-20260421.md
+++ b/docs/development/dingtalk-action-service-validation-verification-20260421.md
@@ -1,0 +1,52 @@
+# DingTalk Automation Service Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-action-service-validation-20260421`
+- Branch: `codex/dingtalk-action-service-validation-20260421`
+- Base: `e32d63eaa734b25fe5c75487937d8833d6813f18`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/unit/automation-v1.test.ts`: 117 tests passed.
+- Added coverage for service-level DingTalk config validation on create/update.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/unit/dingtalk-automation-link-validation.test.ts`: 12 tests passed.
+- `tests/integration/dingtalk-automation-link-routes.api.test.ts`: 9 tests passed.
+- Total: 21 tests passed.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+## Notes
+
+- Vitest emitted the existing Vite CJS Node API deprecation warning.
+- `pnpm install` emitted the existing ignored-build-scripts warning.
+- No live DingTalk webhook delivery was required because this change protects persistence-time validation.

--- a/docs/development/dingtalk-action-validation-stack-promotion-20260421.md
+++ b/docs/development/dingtalk-action-validation-stack-promotion-20260421.md
@@ -1,0 +1,107 @@
+# DingTalk Action Validation Stack Promotion - 2026-04-21
+
+## Scope
+
+Promote the DingTalk automation validation stack onto the current `origin/main`.
+
+The active stack heads were:
+
+- PR #1002: `fix(dingtalk): validate automation action configs`
+- PR #1003: `fix(dingtalk): validate automation configs in service`
+
+The PR bases were stack branches, not `main`, so closing those PRs alone would not land the functional code on the mainline.
+
+## Development Notes
+
+Created a clean promotion worktree from `origin/main`:
+
+```bash
+git worktree add -b codex/dingtalk-action-validation-stack-promotion-20260421 \
+  /private/tmp/metasheet2-dingtalk-action-validation-promotion origin/main
+git merge --squash origin/codex/dingtalk-action-service-validation-20260421
+```
+
+The squash merge conflicted in DingTalk automation files and related tests. Conflict resolution policy:
+
+- Preserve `main` runtime changes, especially the Yjs REST invalidator wiring in `packages/core-backend/src/routes/univer-meta.ts`.
+- Keep DingTalk validation stack behavior for route/service action-config validation.
+- Keep the standard persisted backend field contract:
+  - group dynamic destinations: `destinationIdFieldPath(s)`
+  - person dynamic recipients: `userIdFieldPath(s)`
+  - member-group dynamic recipients: `memberGroupIdFieldPath(s)`
+- Keep frontend draft-only names internal to Vue components and preserve save-time conversion to backend contract fields.
+
+Resolved conflict groups:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts`
+- `apps/web/tests/dingtalk-recipient-field-warnings.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `packages/core-backend/src/multitable/dingtalk-automation-link-validation.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+- `packages/core-backend/tests/unit/dingtalk-automation-link-validation.test.ts`
+
+## Verification
+
+Installed dependencies in the promotion worktree:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Backend focused regression:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/dingtalk-automation-link-validation.test.ts \
+  tests/integration/dingtalk-automation-link-routes.api.test.ts \
+  tests/integration/dingtalk-delivery-routes.api.test.ts \
+  tests/unit/automation-v1.test.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests       142 passed (142)
+```
+
+Frontend focused regression:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/dingtalk-recipient-field-warnings.spec.ts \
+  tests/multitable-automation-rule-editor.spec.ts \
+  tests/multitable-automation-manager.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       122 passed (122)
+```
+
+Build and type gates:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+Result:
+
+```text
+All passed.
+```
+
+Notes:
+
+- Frontend test run emitted the existing `WebSocket server error: Port is already in use` warning; tests passed.
+- `pnpm install` produced local workspace `node_modules` link noise, which was removed before commit.

--- a/docs/development/dingtalk-delivery-route-contracts-development-20260421.md
+++ b/docs/development/dingtalk-delivery-route-contracts-development-20260421.md
@@ -1,0 +1,34 @@
+# DingTalk Delivery Route Contracts Development - 2026-04-21
+
+## Background
+
+This slice hardens the standard DingTalk automation delivery history APIs:
+
+- `GET /api/multitable/sheets/:sheetId/automations/:ruleId/dingtalk-person-deliveries`
+- `GET /api/multitable/sheets/:sheetId/automations/:ruleId/dingtalk-group-deliveries`
+
+The previous route-level limit parser used `Number(req.query.limit) || 50`. That made `limit=0` fall back to `50` instead of clamping to the lower bound `1`, so route behavior differed from the intended `[1, 200]` contract.
+
+## Changes
+
+- Added `parseDingTalkAutomationDeliveryLimit()` in `packages/core-backend/src/routes/univer-meta.ts`.
+- Shared the same limit parsing for person and group delivery history routes.
+- Preserved default behavior: missing or invalid `limit` defaults to `50`.
+- Preserved bounds: finite numeric limits are floored and clamped to `1..200`.
+- Added route-level integration coverage in `packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts`.
+
+## Route Contract Covered
+
+- Person delivery history returns `{ ok: true, data: { deliveries } }`.
+- Group delivery history returns `{ ok: true, data: { deliveries } }`.
+- `limit=0` is passed to the delivery service as `1`.
+- Large limits such as `999` are passed to the delivery service as `200`.
+- Users without automation management capability receive `403 FORBIDDEN`.
+- A rule that is missing or belongs to another sheet returns `404 NOT_FOUND`.
+- Delivery services are not called on `403` or `404`.
+
+## Implementation Notes
+
+The tests mock the delivery services directly and assert the limit argument passed by the route. This keeps the regression pinned to the route layer and avoids the service-layer clamp masking route parsing bugs.
+
+The tests keep `poolManager.get()` lightweight while still exercising `resolveSheetCapabilities()` through the router, so permission behavior remains covered without a real database.

--- a/docs/development/dingtalk-delivery-route-contracts-verification-20260421.md
+++ b/docs/development/dingtalk-delivery-route-contracts-verification-20260421.md
@@ -1,0 +1,43 @@
+# DingTalk Delivery Route Contracts Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-delivery-route-contracts-20260421`
+- Branch: `codex/dingtalk-delivery-route-contracts-20260421`
+- Base: stacked on DingTalk V1 Manager editor hydration work
+- Node dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest` available
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. PNPM reused the local store and installed workspace dependencies.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-delivery-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `1 passed`
+- Tests: `4 passed`
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+```bash
+git diff --check -- packages/core-backend/src/routes/univer-meta.ts packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk webhook was called in this slice.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally not part of the development commit.
+- Verification focuses on backend route contracts, permission behavior, rule-sheet validation, and route-level limit parsing.

--- a/docs/development/dingtalk-delivery-viewer-errors-development-20260421.md
+++ b/docs/development/dingtalk-delivery-viewer-errors-development-20260421.md
@@ -1,0 +1,29 @@
+# DingTalk Delivery Viewer Errors Development - 2026-04-21
+
+## Background
+
+Automation DingTalk delivery history is now part of the standard table-trigger workflow. The backend returns explicit `403`, `404`, and `500` responses for delivery history routes, but the frontend delivery viewers previously swallowed load failures and rendered the same empty state as a valid empty history.
+
+That behavior is misleading for administrators because a permission, route, or server problem looks like "no DingTalk deliveries yet".
+
+## Changes
+
+- Updated `MetaAutomationGroupDeliveryViewer.vue`.
+- Updated `MetaAutomationPersonDeliveryViewer.vue`.
+- Added an explicit error state for failed delivery history loads.
+- Cleared stale errors whenever a refresh starts.
+- Disabled the refresh button while a load is already in progress.
+- Kept the existing empty state only for successful empty responses.
+- Added frontend coverage in `apps/web/tests/multitable-automation-manager.spec.ts`.
+
+## User-Facing Behavior
+
+- Successful delivery history loads are unchanged.
+- Empty successful responses still show the existing empty-history message.
+- Failed group delivery history loads now show the backend error message in the group delivery dialog.
+- Failed person delivery history loads now show the backend error message in the person delivery dialog.
+- Error states no longer render stale delivery rows or the empty-history message.
+
+## Notes
+
+This slice does not call DingTalk directly. It improves the standard UI around the already-defined delivery history APIs so administrators can distinguish "no deliveries" from "delivery history failed to load".

--- a/docs/development/dingtalk-delivery-viewer-errors-verification-20260421.md
+++ b/docs/development/dingtalk-delivery-viewer-errors-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Delivery Viewer Errors Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-delivery-viewer-errors-20260421`
+- Branch: `codex/dingtalk-delivery-viewer-errors-20260421`
+- Base: stacked on DingTalk delivery route contracts (`7c970778e41ba483cb9c20d66219cbe682baf382`)
+- Dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `1 passed`
+- Tests: `57 passed`
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Build emitted existing Vite warnings about large chunks and one dynamic/static import overlap for `WorkflowDesigner.vue`; there were no build errors.
+
+```bash
+git diff --check -- apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue apps/web/tests/multitable-automation-manager.spec.ts docs/development/dingtalk-delivery-viewer-errors-development-20260421.md docs/development/dingtalk-delivery-viewer-errors-verification-20260421.md
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk robot webhook was called.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally excluded from the commit.
+- Verification focuses on frontend delivery viewer behavior for failed person/group automation delivery history loads.

--- a/docs/development/dingtalk-group-destination-can-save-development-20260421.md
+++ b/docs/development/dingtalk-group-destination-can-save-development-20260421.md
@@ -1,0 +1,39 @@
+# DingTalk Group Destination Save Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change tightens frontend save validation for DingTalk group-message automations.
+
+Affected entry points:
+
+- `MetaAutomationRuleEditor.vue`
+- `MetaAutomationManager.vue`
+
+## Problem
+
+The group-message dynamic destination field previously passed validation when its raw text was non-empty. Inputs such as `record.` or `,` could enable saving, even though the save payload parser normalized them into an empty destination field-path list.
+
+That made the save guard inconsistent with the persisted action config and could create an automation without an effective DingTalk group target when no static group destination was selected.
+
+## Implementation
+
+The save guard now uses the existing destination path parser before deciding whether a dynamic group destination is present:
+
+- `destinationFieldPath` is parsed through `parseRecipientFieldPathsText`.
+- Save requires at least one static destination ID or one parsed dynamic destination field path.
+- Title, body, public-form link, and internal-view link validations remain unchanged.
+
+This mirrors the previous person-message recipient fix and keeps group-message validation aligned with payload serialization.
+
+## Tests
+
+Added regression coverage for both frontend paths:
+
+- Rule editor: invalid dynamic group destination paths keep the save button disabled and do not emit `onSave`.
+- Inline automation manager: invalid dynamic group destination paths keep the create button disabled and do not issue a `POST`.
+
+## Notes
+
+This patch does not change backend delivery behavior or DingTalk webhook delivery. It only prevents invalid frontend saves before an automation can be submitted.

--- a/docs/development/dingtalk-group-destination-can-save-verification-20260421.md
+++ b/docs/development/dingtalk-group-destination-can-save-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Group Destination Save Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-group-destination-can-save-20260421`
+- Branch: `codex/dingtalk-group-destination-can-save-20260421`
+- Base: `6b940337226616457ad441de33eb99b0bf2008b4`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-automation-rule-editor.spec.ts`: 53 tests passed.
+- `tests/multitable-automation-manager.spec.ts`: 60 tests passed.
+- Total: 113 tests passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Notes:
+
+- Vite reported existing chunk-size and mixed dynamic/static import warnings.
+- No live DingTalk webhook delivery was required because this change is limited to frontend save validation.

--- a/docs/development/dingtalk-person-member-group-path-warnings-development-20260421.md
+++ b/docs/development/dingtalk-person-member-group-path-warnings-development-20260421.md
@@ -1,0 +1,28 @@
+# DingTalk Person Member Group Path Warnings Development - 2026-04-21
+
+## Background
+
+DingTalk person automations can target local users directly and can also resolve member groups from record field paths. The member-group picker only lists explicit member group fields, but manually typed paths were only warning for unknown fields and `user` fields.
+
+That left known ordinary fields such as `record.fld_1` silent, even though they are not valid member group fields.
+
+## Changes
+
+- Updated `MetaAutomationManager.vue`.
+- Updated `MetaAutomationRuleEditor.vue`.
+- Reused `isDingTalkMemberGroupRecipientField()` for manual member-group recipient path validation.
+- Added warnings when a known field is not a member group field.
+- Preserved existing specialized warning for `user` fields: users should use the regular record recipient field path instead.
+- Added coverage in both inline manager and standalone rule editor specs.
+
+## Behavior
+
+- Unknown fields still warn as unknown.
+- `user` fields still warn to use Record recipient field paths.
+- Known non-member-group fields now warn: `record.<fieldId> is not a member group field`.
+- Valid member group fields remain accepted without warnings.
+- This is a warning-only frontend guardrail; payload shape and save behavior are unchanged.
+
+## Scope
+
+No live DingTalk API or webhook is called by this change. The slice is limited to frontend validation feedback for configuring DingTalk person automations.

--- a/docs/development/dingtalk-person-member-group-path-warnings-verification-20260421.md
+++ b/docs/development/dingtalk-person-member-group-path-warnings-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Person Member Group Path Warnings Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-member-group-path-warnings-20260421`
+- Branch: `codex/dingtalk-person-member-group-path-warnings-20260421`
+- Base: stacked on DingTalk delivery viewer error handling (`a914af4a40344532b4216ebdbedcad1976f15679`)
+- Dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `2 passed`
+- Tests: `109 passed`
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Build emitted existing Vite warnings about large chunks and one dynamic/static import overlap for `WorkflowDesigner.vue`; there were no build errors.
+
+```bash
+git diff --check -- apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/multitable-automation-manager.spec.ts apps/web/tests/multitable-automation-rule-editor.spec.ts docs/development/dingtalk-person-member-group-path-warnings-development-20260421.md docs/development/dingtalk-person-member-group-path-warnings-verification-20260421.md
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk robot webhook was called.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally excluded from the commit.
+- Verification focuses on warning visibility for manually typed non-member-group field paths in DingTalk person automation configuration.

--- a/docs/development/dingtalk-person-recipient-can-save-development-20260421.md
+++ b/docs/development/dingtalk-person-recipient-can-save-development-20260421.md
@@ -1,0 +1,43 @@
+# DingTalk Person Recipient Save Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change tightens the frontend save guard for DingTalk person-message automations.
+
+Affected entry points:
+
+- `MetaAutomationRuleEditor.vue`
+- `MetaAutomationManager.vue`
+
+## Problem
+
+The UI previously treated a dynamic recipient field input as valid when the raw text was non-empty. Inputs such as `record.` or `,` passed the raw `.trim()` check, but the save payload parser normalized them into an empty field-path list.
+
+That allowed a DingTalk person-message automation to be saved without any effective recipient when no static users or member groups were selected.
+
+## Implementation
+
+The save guard now uses the same recipient path parser used by the save payload:
+
+- `recipientFieldPath` is parsed before validation.
+- `memberGroupRecipientFieldPath` is parsed before validation.
+- Save remains disabled unless at least one effective recipient source exists:
+  - static user IDs,
+  - static member group IDs,
+  - parsed user field paths,
+  - parsed member-group field paths.
+
+This keeps validation behavior aligned with the final action config persisted by the editor.
+
+## Tests
+
+Added regression coverage for both frontend paths:
+
+- Rule editor: invalid dynamic person-recipient paths keep the save button disabled and do not emit `onSave`.
+- Inline automation manager: invalid dynamic person-recipient paths keep the create button disabled and do not issue a `POST`.
+
+## Notes
+
+This slice only changes DingTalk person-message recipient validation. The existing group-message destination validation was intentionally left unchanged to keep this patch narrowly scoped.

--- a/docs/development/dingtalk-person-recipient-can-save-verification-20260421.md
+++ b/docs/development/dingtalk-person-recipient-can-save-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Person Recipient Save Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-person-recipient-can-save-20260421`
+- Branch: `codex/dingtalk-person-recipient-can-save-20260421`
+- Base: `6350c854f34156dd89aa5def43a1bd06fe398c39`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-automation-rule-editor.spec.ts`: 52 tests passed.
+- `tests/multitable-automation-manager.spec.ts`: 59 tests passed.
+- Total: 111 tests passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Notes:
+
+- Vite reported existing chunk-size and mixed dynamic/static import warnings.
+- No live DingTalk webhook delivery was required for this frontend validation change.

--- a/docs/development/dingtalk-person-recipient-warning-utils-development-20260421.md
+++ b/docs/development/dingtalk-person-recipient-warning-utils-development-20260421.md
@@ -1,0 +1,28 @@
+# DingTalk Person Recipient Warning Utils Development - 2026-04-21
+
+## Background
+
+DingTalk person automation supports dynamic record recipient paths such as `record.assigneeUserIds`. The inline automation manager and standalone rule editor previously duplicated the same warning logic for these paths.
+
+After centralizing member-group recipient warnings, the remaining duplicated user-recipient warning logic should also live in the shared DingTalk recipient warning utility.
+
+## Changes
+
+- Added `listDingTalkPersonRecipientFieldPathWarnings()` to `apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts`.
+- Updated `MetaAutomationManager.vue` to use the shared helper.
+- Updated `MetaAutomationRuleEditor.vue` to use the shared helper.
+- Added utility-level tests for dynamic person recipient path warning behavior.
+- Preserved existing user-facing warning text and behavior.
+
+## Behavior
+
+No user-facing behavior changes are intended in this slice.
+
+- Valid user fields still produce no warning.
+- Unknown fields still warn as not user fields.
+- Known non-user fields still warn as not user fields.
+- Member group fields still warn as not user fields when used in the user-recipient field path.
+
+## Scope
+
+This is a frontend refactor and test-hardening slice. It does not call DingTalk, change automation payloads, or change backend APIs.

--- a/docs/development/dingtalk-person-recipient-warning-utils-verification-20260421.md
+++ b/docs/development/dingtalk-person-recipient-warning-utils-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Person Recipient Warning Utils Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-person-recipient-warning-utils-20260421`
+- Branch: `codex/dingtalk-person-recipient-warning-utils-20260421`
+- Base: stacked on DingTalk recipient warning utility sharing (`297002e5f82be68334d4b49ad558f366c4123783`)
+- Dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-recipient-field-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `3 passed`
+- Tests: `116 passed`
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Build emitted existing Vite warnings about large chunks and one dynamic/static import overlap for `WorkflowDesigner.vue`; there were no build errors.
+
+```bash
+git diff --check -- apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/dingtalk-recipient-field-warnings.spec.ts docs/development/dingtalk-person-recipient-warning-utils-development-20260421.md docs/development/dingtalk-person-recipient-warning-utils-verification-20260421.md
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk robot webhook was called.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally excluded from the commit.
+- Verification focuses on shared frontend warning logic and both UI entry points that consume it.

--- a/docs/development/dingtalk-person-static-recipient-can-save-development-20260421.md
+++ b/docs/development/dingtalk-person-static-recipient-can-save-development-20260421.md
@@ -1,0 +1,44 @@
+# DingTalk Person Static Recipient Save Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change tightens frontend save validation for DingTalk person-message automations.
+
+Affected entry points:
+
+- `MetaAutomationRuleEditor.vue`
+- `MetaAutomationManager.vue`
+
+## Problem
+
+The previous frontend guard treated static recipient text as valid whenever the raw text was non-empty. Inputs such as `,` or `,\n,` enabled save/create, but the final payload parser split and filtered those values into empty recipient arrays.
+
+That allowed the UI to submit a DingTalk person-message automation without any effective recipient when no dynamic record recipient fields were selected.
+
+## Implementation
+
+The save guard now uses the same static recipient parsers used by payload serialization:
+
+- `parseUserIdsText(...)` for local user IDs.
+- `parseMemberGroupIdsText(...)` for member group IDs.
+- Existing parsed dynamic user and member-group field path checks remain unchanged.
+
+Save/create now requires at least one effective recipient source:
+
+- parsed static user ID,
+- parsed static member group ID,
+- parsed dynamic user field path,
+- parsed dynamic member-group field path.
+
+## Tests
+
+Added regression coverage for both frontend paths:
+
+- Rule editor: static recipient lists containing only separators keep the save button disabled and do not emit `onSave`.
+- Inline automation manager: static recipient lists containing only separators keep the create button disabled and do not issue a `POST`.
+
+## Notes
+
+This patch is frontend-only. Backend runtime execution already rejects DingTalk person actions that resolve to no recipients; this change prevents invalid submissions earlier in the UI.

--- a/docs/development/dingtalk-person-static-recipient-can-save-verification-20260421.md
+++ b/docs/development/dingtalk-person-static-recipient-can-save-verification-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Person Static Recipient Save Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-person-static-recipient-can-save-20260421`
+- Branch: `codex/dingtalk-person-static-recipient-can-save-20260421`
+- Base: `ed01245e431d60a5b07349b1abb5d4fb5b3328e2`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-automation-rule-editor.spec.ts`: 54 tests passed.
+- `tests/multitable-automation-manager.spec.ts`: 61 tests passed.
+- Total: 115 tests passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Notes:
+
+- Vite reported existing chunk-size and mixed dynamic/static import warnings.
+- No live DingTalk webhook delivery was required because this change is limited to frontend save validation.

--- a/docs/development/dingtalk-recipient-warning-utils-development-20260421.md
+++ b/docs/development/dingtalk-recipient-warning-utils-development-20260421.md
@@ -1,0 +1,28 @@
+# DingTalk Recipient Warning Utils Development - 2026-04-21
+
+## Background
+
+DingTalk automation field-path warnings are shown in both the inline automation manager and the standalone rule editor. The group destination field warnings already live in `dingtalkRecipientFieldWarnings.ts`, but person member-group recipient warnings were duplicated in both Vue components.
+
+After adding stricter warnings for manually typed member-group paths, keeping the same logic duplicated would make the two entry points easier to drift apart.
+
+## Changes
+
+- Added `listDingTalkPersonMemberGroupRecipientFieldPathWarnings()` to `apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts`.
+- Updated `MetaAutomationManager.vue` to call the shared utility.
+- Updated `MetaAutomationRuleEditor.vue` to call the shared utility.
+- Added utility-level tests for person member-group recipient path warning behavior.
+- Preserved the existing user-facing warning strings and behavior.
+
+## Behavior
+
+No user-facing behavior changes are intended in this slice.
+
+- Unknown member-group recipient paths still warn as unknown fields.
+- User fields still warn to use regular record recipient paths.
+- Known non-member-group fields still warn that they are not member group fields.
+- Valid member group fields still produce no warning.
+
+## Scope
+
+This is a frontend refactor and test-hardening slice. It does not call DingTalk, change automation payloads, or change backend APIs.

--- a/docs/development/dingtalk-recipient-warning-utils-verification-20260421.md
+++ b/docs/development/dingtalk-recipient-warning-utils-verification-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Recipient Warning Utils Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/dingtalk-recipient-warning-utils-20260421`
+- Branch: `codex/dingtalk-recipient-warning-utils-20260421`
+- Base: stacked on DingTalk member-group path warnings (`f0aa0d23d4cce6dd78d87c8124735a75f35e937f`)
+- Dependencies: installed with `pnpm install --frozen-lockfile` because the fresh worktree did not have `vitest`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-recipient-field-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: `3 passed`
+- Tests: `114 passed`
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Build emitted existing Vite warnings about large chunks and one dynamic/static import overlap for `WorkflowDesigner.vue`; there were no build errors.
+
+```bash
+git diff --check -- apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/dingtalk-recipient-field-warnings.spec.ts docs/development/dingtalk-recipient-warning-utils-development-20260421.md docs/development/dingtalk-recipient-warning-utils-verification-20260421.md
+```
+
+Result: passed.
+
+## Notes
+
+- No live DingTalk robot webhook was called.
+- `pnpm install` touched workspace `node_modules` entries in the worktree; these generated files are intentionally excluded from the commit.
+- Verification focuses on shared frontend warning logic and both UI entry points that consume it.

--- a/docs/development/dingtalk-v1-editor-stale-top-level-development-20260421.md
+++ b/docs/development/dingtalk-v1-editor-stale-top-level-development-20260421.md
@@ -1,0 +1,39 @@
+# DingTalk V1 Editor Stale Top-Level Coverage Development - 2026-04-21
+
+## Goal
+
+Lock the rule editor behavior for V1 DingTalk automation rules where the legacy top-level fields are stale.
+
+V1 automation rules should treat `rule.actions[]` as the source of truth. Older or migrated records may still carry legacy `actionType/actionConfig` values that do not match the real V1 action list. The editor already prefers `actions[]`, but the test suite did not prove this for DingTalk group/person configurations.
+
+## Implementation
+
+Changed `apps/web/tests/multitable-automation-rule-editor.spec.ts`.
+
+- Added a regression test for a DingTalk group message rule where:
+  - `actionType` is stale `notify`.
+  - `actionConfig` contains only a stale internal notification value.
+  - `actions[]` contains `send_dingtalk_group_message`.
+  - The editor loads group destinations/templates from `actions[]`.
+  - Save emits a DingTalk group action and matching top-level compatibility fields.
+- Added a regression test for a DingTalk person message rule where:
+  - `actionType` is stale `notify`.
+  - `actionConfig` contains only a stale internal notification value.
+  - `actions[]` contains `send_dingtalk_person_message` with dynamic record recipients.
+  - The editor loads dynamic recipient paths/templates from `actions[]`.
+  - Save emits a DingTalk person action and matching top-level compatibility fields.
+
+No production code changed. The existing `draftFromRule(...)` implementation already gives `rule.actions[]` precedence.
+
+## Scope
+
+This slice is frontend test coverage only.
+
+- No runtime code change.
+- No backend API change.
+- No database migration.
+- No DingTalk delivery behavior change.
+
+## User Impact
+
+This prevents future regressions where editing a V1 DingTalk automation could accidentally read stale legacy action fields and overwrite the real DingTalk configuration.

--- a/docs/development/dingtalk-v1-editor-stale-top-level-verification-20260421.md
+++ b/docs/development/dingtalk-v1-editor-stale-top-level-verification-20260421.md
@@ -1,0 +1,24 @@
+# DingTalk V1 Editor Stale Top-Level Coverage Verification - 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Result
+
+- Initial Vitest command before dependency install failed because `vitest` was not available in this new worktree.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false`: passed, 1 file / 50 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Notes
+
+The frontend build emitted existing Vite warnings about `WorkflowDesigner.vue` being both statically and dynamically imported, plus large chunk warnings. These warnings are unrelated to this DingTalk editor coverage slice.
+
+`pnpm install` updated local `node_modules` links in several workspace packages. Those generated dependency-directory changes must remain unstaged.

--- a/docs/development/dingtalk-v1-manager-edit-stale-top-level-development-20260421.md
+++ b/docs/development/dingtalk-v1-manager-edit-stale-top-level-development-20260421.md
@@ -1,0 +1,37 @@
+# DingTalk V1 Manager Edit Stale Top-Level Coverage Development - 2026-04-21
+
+## Goal
+
+Lock the full automation-list edit path for V1 DingTalk rules whose legacy top-level action fields are stale.
+
+`MetaAutomationRuleEditor` already prefers `rule.actions[]`, and PR #988 added direct editor coverage. This slice adds integration coverage through `MetaAutomationManager`: a user clicks `Edit` from the automation list, the manager passes the saved rule into the editor, and the editor must hydrate from V1 `actions[]` rather than stale `actionType/actionConfig`.
+
+## Implementation
+
+Changed `apps/web/tests/multitable-automation-manager.spec.ts`.
+
+- Added a regression test for a saved rule where:
+  - top-level `actionType` is stale `notify`.
+  - top-level `actionConfig` is a stale notification payload.
+  - `actions[]` contains the real `send_dingtalk_group_message` config.
+  - clicking list `Edit` opens the rule editor with DingTalk group destinations/templates loaded from `actions[]`.
+- Added a regression test for a saved rule where:
+  - top-level `actionType` is stale `notify`.
+  - top-level `actionConfig` is a stale notification payload.
+  - `actions[]` contains the real `send_dingtalk_person_message` dynamic-recipient config.
+  - clicking list `Edit` opens the rule editor with the dynamic recipient path/templates loaded from `actions[]`.
+
+No production code changed.
+
+## Scope
+
+This slice is frontend test coverage only.
+
+- No runtime code change.
+- No backend API change.
+- No database migration.
+- No DingTalk delivery behavior change.
+
+## User Impact
+
+This prevents regressions where a V1 DingTalk rule looks correct in the list but opens in the editor with stale legacy notification fields, which could otherwise lead to accidental overwrite of real DingTalk settings.

--- a/docs/development/dingtalk-v1-manager-edit-stale-top-level-verification-20260421.md
+++ b/docs/development/dingtalk-v1-manager-edit-stale-top-level-verification-20260421.md
@@ -1,0 +1,24 @@
+# DingTalk V1 Manager Edit Stale Top-Level Coverage Verification - 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Result
+
+- Initial Vitest command before dependency install failed because `vitest` was not available in this new worktree.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false`: passed, 1 file / 55 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Notes
+
+The frontend build emitted existing Vite warnings about `WorkflowDesigner.vue` being both statically and dynamically imported, plus large chunk warnings. These warnings are unrelated to this Manager edit-path coverage slice.
+
+`pnpm install` updated local `node_modules` links in several workspace packages. Those generated dependency-directory changes must remain unstaged.

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -9,11 +9,24 @@ import type { AutomationAction } from './automation-actions'
 import type { AutomationTrigger } from './automation-triggers'
 import { AutomationScheduler } from './automation-scheduler'
 import { AutomationLogService } from './automation-log-service'
+import {
+  normalizeDingTalkAutomationActionInputs,
+  validateDingTalkAutomationActionConfigs,
+} from './dingtalk-automation-link-validation'
 import type { Database } from '../db/types'
 
 const logger = new Logger('AutomationService')
 
 const MAX_AUTOMATION_DEPTH = 3
+
+export class AutomationRuleValidationError extends Error {
+  readonly code = 'VALIDATION_ERROR'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'AutomationRuleValidationError'
+  }
+}
 
 const VALID_TRIGGER_TYPES = new Set([
   'record.created',
@@ -193,6 +206,19 @@ export class AutomationService {
   async createRule(sheetId: string, input: CreateRuleInput): Promise<AutomationRule> {
     const ruleId = `atr_${randomUUID()}`
     const now = new Date().toISOString()
+    const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(
+      input.actionType,
+      input.actionConfig ?? {},
+      input.actions ?? null,
+    )
+    const actionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
+      ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
+      : input.actionConfig ?? {}
+    const actions = Array.isArray(normalizedDingTalkInputs.actions)
+      ? normalizedDingTalkInputs.actions as AutomationAction[]
+      : input.actions ?? null
+    const actionConfigValidationError = validateDingTalkAutomationActionConfigs(input.actionType, actionConfig, actions)
+    if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
 
     const row = {
       id: ruleId,
@@ -201,11 +227,11 @@ export class AutomationService {
       trigger_type: input.triggerType,
       trigger_config: JSON.stringify(input.triggerConfig ?? {}),
       action_type: input.actionType,
-      action_config: JSON.stringify(input.actionConfig ?? {}),
+      action_config: JSON.stringify(actionConfig),
       enabled: input.enabled ?? true,
       created_by: input.createdBy ?? null,
       conditions: input.conditions ? JSON.stringify(input.conditions) : null,
-      actions: input.actions ? JSON.stringify(input.actions) : null,
+      actions: actions ? JSON.stringify(actions) : null,
     }
 
     await this.db
@@ -220,13 +246,13 @@ export class AutomationService {
       trigger_type: input.triggerType,
       trigger_config: input.triggerConfig ?? {},
       action_type: input.actionType,
-      action_config: input.actionConfig ?? {},
+      action_config: actionConfig,
       enabled: input.enabled ?? true,
       created_at: now,
       updated_at: now,
       created_by: input.createdBy ?? null,
       conditions: input.conditions ?? null,
-      actions: input.actions ?? null,
+      actions,
     }
 
     this.registerSchedule(rule)
@@ -267,15 +293,43 @@ export class AutomationService {
    */
   async updateRule(ruleId: string, sheetId: string, input: UpdateRuleInput): Promise<AutomationRule | null> {
     const updates: Record<string, unknown> = {}
+    const shouldValidateActions = input.actionType !== undefined || input.actionConfig !== undefined || input.actions !== undefined
+    let normalizedActionConfigForUpdate: Record<string, unknown> | undefined
+    let normalizedActionsForUpdate: AutomationAction[] | null | undefined
+
+    if (shouldValidateActions) {
+      const existing = await this.getRule(ruleId)
+      if (!existing || existing.sheet_id !== sheetId) return null
+
+      const nextActionType = input.actionType ?? existing.action_type
+      const nextActionConfig = input.actionConfig ?? existing.action_config
+      const nextActions = input.actions !== undefined ? input.actions : existing.actions ?? null
+      const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(nextActionType, nextActionConfig, nextActions)
+      const normalizedNextActionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
+        ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
+        : nextActionConfig
+      const normalizedNextActions = Array.isArray(normalizedDingTalkInputs.actions)
+        ? normalizedDingTalkInputs.actions as AutomationAction[]
+        : nextActions
+      const actionConfigValidationError = validateDingTalkAutomationActionConfigs(
+        nextActionType,
+        normalizedNextActionConfig,
+        normalizedNextActions,
+      )
+      if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
+
+      if (input.actionConfig !== undefined) normalizedActionConfigForUpdate = normalizedNextActionConfig
+      if (input.actions !== undefined) normalizedActionsForUpdate = Array.isArray(input.actions) ? normalizedNextActions : null
+    }
 
     if (input.name !== undefined) updates.name = input.name
     if (input.triggerType !== undefined) updates.trigger_type = input.triggerType
     if (input.triggerConfig !== undefined) updates.trigger_config = JSON.stringify(input.triggerConfig)
     if (input.actionType !== undefined) updates.action_type = input.actionType
-    if (input.actionConfig !== undefined) updates.action_config = JSON.stringify(input.actionConfig)
+    if (input.actionConfig !== undefined) updates.action_config = JSON.stringify(normalizedActionConfigForUpdate ?? input.actionConfig)
     if (input.enabled !== undefined) updates.enabled = input.enabled
     if (input.conditions !== undefined) updates.conditions = input.conditions ? JSON.stringify(input.conditions) : null
-    if (input.actions !== undefined) updates.actions = input.actions ? JSON.stringify(input.actions) : null
+    if (input.actions !== undefined) updates.actions = normalizedActionsForUpdate ? JSON.stringify(normalizedActionsForUpdate) : null
 
     if (Object.keys(updates).length === 0) return this.getRule(ruleId)
 

--- a/packages/core-backend/src/multitable/dingtalk-automation-link-validation.ts
+++ b/packages/core-backend/src/multitable/dingtalk-automation-link-validation.ts
@@ -34,15 +34,26 @@ function parsePublicFormExpiryMs(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-function collectDingTalkActionConfigs(
+type DingTalkAutomationActionType = 'send_dingtalk_group_message' | 'send_dingtalk_person_message'
+
+type DingTalkAutomationActionEntry = {
+  type: DingTalkAutomationActionType
+  config: Record<string, unknown> | null
+}
+
+function isDingTalkAutomationActionType(value: unknown): value is DingTalkAutomationActionType {
+  return value === 'send_dingtalk_group_message' || value === 'send_dingtalk_person_message'
+}
+
+function collectDingTalkActionEntries(
   actionType: unknown,
   actionConfig: unknown,
   actions: unknown,
-): Record<string, unknown>[] {
-  const configs: Record<string, unknown>[] = []
+): DingTalkAutomationActionEntry[] {
+  const entries: DingTalkAutomationActionEntry[] = []
   const addIfDingTalkAction = (type: unknown, config: unknown) => {
-    if (type !== 'send_dingtalk_group_message' && type !== 'send_dingtalk_person_message') return
-    if (isPlainObject(config)) configs.push(config)
+    if (!isDingTalkAutomationActionType(type)) return
+    entries.push({ type, config: isPlainObject(config) ? config : null })
   }
 
   addIfDingTalkAction(actionType, actionConfig)
@@ -53,7 +64,129 @@ function collectDingTalkActionConfigs(
     }
   }
 
-  return configs
+  return entries
+}
+
+function collectDingTalkActionConfigs(
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+): Record<string, unknown>[] {
+  return collectDingTalkActionEntries(actionType, actionConfig, actions)
+    .map((entry) => entry.config)
+    .filter((config): config is Record<string, unknown> => Boolean(config))
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .flatMap((entry) => entry.split(/[\n,]+/))
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+function normalizeFieldPaths(value: unknown): string[] {
+  return normalizeStringList(value)
+    .map((entry) => entry.replace(/^record\./, '').trim())
+    .filter(Boolean)
+}
+
+function hasText(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function normalizeDingTalkMessageConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...config }
+  if (!hasText(normalized.titleTemplate) && hasText(normalized.title)) {
+    normalized.titleTemplate = normalized.title
+  }
+  if (!hasText(normalized.bodyTemplate) && hasText(normalized.content)) {
+    normalized.bodyTemplate = normalized.content
+  }
+  return normalized
+}
+
+export function normalizeDingTalkAutomationActionInputs(
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+): { actionConfig: unknown; actions: unknown } {
+  const normalizedActionConfig = isDingTalkAutomationActionType(actionType) && isPlainObject(actionConfig)
+    ? normalizeDingTalkMessageConfig(actionConfig)
+    : actionConfig
+  const normalizedActions = Array.isArray(actions)
+    ? actions.map((item) => {
+      if (!isPlainObject(item) || !isDingTalkAutomationActionType(item.type) || !isPlainObject(item.config)) return item
+      return { ...item, config: normalizeDingTalkMessageConfig(item.config) }
+    })
+    : actions
+  return { actionConfig: normalizedActionConfig, actions: normalizedActions }
+}
+
+function validateGroupMessageConfig(config: Record<string, unknown>): string | null {
+  const destinationIds = [
+    ...normalizeStringList(config.destinationId),
+    ...normalizeStringList(config.destinationIds),
+  ]
+  const destinationFieldPaths = [
+    ...normalizeFieldPaths(config.destinationIdFieldPath),
+    ...normalizeFieldPaths(config.destinationIdFieldPaths),
+  ]
+  if (destinationIds.length === 0 && destinationFieldPaths.length === 0) {
+    return 'At least one DingTalk destination or record destination field path is required'
+  }
+  if (!hasText(config.titleTemplate)) return 'DingTalk titleTemplate is required'
+  if (!hasText(config.bodyTemplate)) return 'DingTalk bodyTemplate is required'
+  return null
+}
+
+function validatePersonMessageConfig(config: Record<string, unknown>): string | null {
+  const userIds = normalizeStringList(config.userIds)
+  const memberGroupIds = normalizeStringList(config.memberGroupIds)
+  const recipientFieldPaths = [
+    ...normalizeFieldPaths(config.userIdFieldPath),
+    ...normalizeFieldPaths(config.userIdFieldPaths),
+  ]
+  const memberGroupRecipientFieldPaths = [
+    ...normalizeFieldPaths(config.memberGroupIdFieldPath),
+    ...normalizeFieldPaths(config.memberGroupIdFieldPaths),
+  ]
+  if (
+    userIds.length === 0
+    && memberGroupIds.length === 0
+    && recipientFieldPaths.length === 0
+    && memberGroupRecipientFieldPaths.length === 0
+  ) {
+    return 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required'
+  }
+  if (!hasText(config.titleTemplate)) return 'DingTalk titleTemplate is required'
+  if (!hasText(config.bodyTemplate)) return 'DingTalk bodyTemplate is required'
+  return null
+}
+
+export function validateDingTalkAutomationActionConfigs(
+  actionType: unknown,
+  actionConfig: unknown,
+  actions: unknown,
+): string | null {
+  const normalized = normalizeDingTalkAutomationActionInputs(actionType, actionConfig, actions)
+  for (const entry of collectDingTalkActionEntries(actionType, normalized.actionConfig, normalized.actions)) {
+    if (!entry.config) return 'DingTalk action config must be an object'
+    const error = entry.type === 'send_dingtalk_group_message'
+      ? validateGroupMessageConfig(entry.config)
+      : validatePersonMessageConfig(entry.config)
+    if (error) return error
+  }
+  return null
 }
 
 export function collectDingTalkAutomationLinkIds(

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -31,8 +31,12 @@ import { MultitableFormulaEngine } from '../multitable/formula-engine'
 import { validateRecord, getDefaultValidationRules } from '../multitable/field-validation-engine'
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
-import { getAutomationServiceInstance } from '../multitable/automation-service'
-import { validateDingTalkAutomationLinks } from '../multitable/dingtalk-automation-link-validation'
+import { AutomationRuleValidationError, getAutomationServiceInstance } from '../multitable/automation-service'
+import {
+  normalizeDingTalkAutomationActionInputs,
+  validateDingTalkAutomationActionConfigs,
+  validateDingTalkAutomationLinks,
+} from '../multitable/dingtalk-automation-link-validation'
 import { listAutomationDingTalkGroupDeliveries } from '../multitable/dingtalk-group-delivery-service'
 import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
@@ -1823,6 +1827,11 @@ function normalizePermissionCodes(value: unknown): string[] {
   return value
     .map((item) => (typeof item === 'string' ? item.trim() : ''))
     .filter((item) => item.length > 0)
+}
+
+function parseDingTalkAutomationDeliveryLimit(value: unknown): number {
+  const raw = typeof value === 'string' ? Number(value) : undefined
+  return Number.isFinite(raw) ? Math.min(Math.max(Math.floor(raw as number), 1), 200) : 50
 }
 
 type ResolvedRequestAccess = {
@@ -8384,7 +8393,7 @@ export function univerMetaRouter(): Router {
       const triggerType = typeof body?.triggerType === 'string' ? body.triggerType : ''
       const triggerConfig = (body?.triggerConfig && typeof body.triggerConfig === 'object') ? body.triggerConfig as Record<string, unknown> : {}
       const actionType = typeof body?.actionType === 'string' ? body.actionType : ''
-      const actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig as Record<string, unknown> : {}
+      let actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig as Record<string, unknown> : {}
       const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
 
       const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
@@ -8397,7 +8406,16 @@ export function univerMetaRouter(): Router {
       }
 
       const conditions = body?.conditions && typeof body.conditions === 'object' ? body.conditions as never : null
-      const actions = Array.isArray(body?.actions) ? body.actions : null
+      let actions = Array.isArray(body?.actions) ? body.actions : null
+      const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(actionType, actionConfig, actions)
+      actionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
+        ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
+        : actionConfig
+      actions = Array.isArray(normalizedDingTalkInputs.actions) ? normalizedDingTalkInputs.actions : actions
+      const actionConfigValidationError = validateDingTalkAutomationActionConfigs(actionType, actionConfig, actions)
+      if (actionConfigValidationError) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: actionConfigValidationError } })
+      }
       const linkValidationError = await validateDingTalkAutomationLinks(
         pool.query.bind(pool),
         sheetId,
@@ -8437,6 +8455,9 @@ export function univerMetaRouter(): Router {
         },
       })
     } catch (err) {
+      if (err instanceof AutomationRuleValidationError) {
+        return res.status(400).json({ ok: false, error: { code: err.code, message: err.message } })
+      }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] create automation rule failed:', err)
@@ -8461,6 +8482,8 @@ export function univerMetaRouter(): Router {
 
       const body = req.body as Record<string, unknown> | undefined
       const updates: Record<string, unknown> = {}
+      let normalizedActionConfigForUpdate: Record<string, unknown> | undefined
+      let normalizedActionsForUpdate: unknown[] | null | undefined
 
       if (typeof body?.name === 'string') updates.name = body.name
       if (typeof body?.triggerType === 'string') {
@@ -8507,15 +8530,36 @@ export function univerMetaRouter(): Router {
         const nextActions = body?.actions !== undefined
           ? Array.isArray(body.actions) ? body.actions : null
           : existing.actions
+        const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(nextActionType, nextActionConfig, nextActions)
+        const normalizedNextActionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
+          ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
+          : nextActionConfig
+        const normalizedNextActions = Array.isArray(normalizedDingTalkInputs.actions)
+          ? normalizedDingTalkInputs.actions
+          : nextActions
+        const actionConfigValidationError = validateDingTalkAutomationActionConfigs(
+          nextActionType,
+          normalizedNextActionConfig,
+          normalizedNextActions,
+        )
+        if (actionConfigValidationError) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: actionConfigValidationError } })
+        }
         const linkValidationError = await validateDingTalkAutomationLinks(
           pool.query.bind(pool),
           sheetId,
           nextActionType,
-          nextActionConfig,
-          nextActions,
+          normalizedNextActionConfig,
+          normalizedNextActions,
         )
         if (linkValidationError) {
           return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: linkValidationError } })
+        }
+        if (body?.actionConfig && typeof body.actionConfig === 'object') {
+          normalizedActionConfigForUpdate = normalizedNextActionConfig as Record<string, unknown>
+        }
+        if (body?.actions !== undefined) {
+          normalizedActionsForUpdate = Array.isArray(body.actions) ? normalizedNextActions as unknown[] : null
         }
       }
 
@@ -8527,11 +8571,11 @@ export function univerMetaRouter(): Router {
           : undefined,
         actionType: updates.action_type as string | undefined,
         actionConfig: body?.actionConfig && typeof body.actionConfig === 'object'
-          ? body.actionConfig as Record<string, unknown>
+          ? normalizedActionConfigForUpdate ?? body.actionConfig as Record<string, unknown>
           : undefined,
         enabled: typeof body?.enabled === 'boolean' ? body.enabled : undefined,
         conditions: body?.conditions !== undefined ? (body.conditions as never) : undefined,
-        actions: body?.actions !== undefined ? (Array.isArray(body.actions) ? body.actions : null) as never : undefined,
+        actions: body?.actions !== undefined ? (normalizedActionsForUpdate ?? (Array.isArray(body.actions) ? body.actions : null)) as never : undefined,
       })
 
       if (!updated) {
@@ -8540,6 +8584,9 @@ export function univerMetaRouter(): Router {
 
       return res.json({ ok: true, data: { rule: updated } })
     } catch (err) {
+      if (err instanceof AutomationRuleValidationError) {
+        return res.status(400).json({ ok: false, error: { code: err.code, message: err.message } })
+      }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] update automation rule failed:', err)
@@ -8597,7 +8644,7 @@ export function univerMetaRouter(): Router {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 
-      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
+      const limit = parseDingTalkAutomationDeliveryLimit(req.query.limit)
       const deliveries = await listAutomationDingTalkPersonDeliveries(pool.query.bind(pool), ruleId, limit)
       return res.json({ ok: true, data: { deliveries } })
     } catch (err) {
@@ -8628,7 +8675,7 @@ export function univerMetaRouter(): Router {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 
-      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200)
+      const limit = parseDingTalkAutomationDeliveryLimit(req.query.limit)
       const deliveries = await listAutomationDingTalkGroupDeliveries(pool.query.bind(pool), ruleId, limit)
       return res.json({ ok: true, data: { deliveries } })
     } catch (err) {

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -253,10 +253,38 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
       actionType: 'send_dingtalk_group_message',
       actionConfig: expect.objectContaining({
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
         publicFormViewId: VALID_FORM_VIEW_ID,
         internalViewId: INTERNAL_VIEW_ID,
       }),
     }))
+  })
+
+  it('rejects a DingTalk group rule without an effective destination before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify group',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationIds: [],
+          destinationIdFieldPath: 'record., ,',
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one DingTalk destination or record destination field path is required',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
   })
 
   it('rejects an invalid internal processing link on automation create before persisting the rule', async () => {
@@ -281,6 +309,39 @@ describe('DingTalk automation link route validation', () => {
     expect(res.body.error).toEqual({
       code: 'VALIDATION_ERROR',
       message: `Internal processing view not found: ${MISSING_INTERNAL_VIEW_ID}`,
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects a V1 DingTalk person action without an effective recipient before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Multi action person rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        actions: [
+          {
+            type: 'send_dingtalk_person_message',
+            config: {
+              userIds: [],
+              memberGroupIds: [','],
+              userIdFieldPath: 'record.',
+              titleTemplate: 'Please fill',
+              bodyTemplate: 'Open form',
+            },
+          },
+        ],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required',
     })
     expect(automationService.createRule).not.toHaveBeenCalled()
   })
@@ -321,6 +382,7 @@ describe('DingTalk automation link route validation', () => {
     const automationService = createMockAutomationService(makeAutomationRule({
       action_type: 'send_dingtalk_person_message',
       action_config: {
+        userIds: ['user_1'],
         title: 'Old title',
         content: 'Old content',
         publicFormViewId: VALID_FORM_VIEW_ID,
@@ -332,6 +394,7 @@ describe('DingTalk automation link route validation', () => {
       .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
       .send({
         actionConfig: {
+          userIds: ['user_1'],
           title: 'New title',
           content: 'New content',
           publicFormViewId: EXPIRED_FORM_VIEW_ID,
@@ -344,6 +407,37 @@ describe('DingTalk automation link route validation', () => {
       message: `Selected public form view has expired: ${EXPIRED_FORM_VIEW_ID}`,
     })
     expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
+  it('validates merged DingTalk action config on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'send_dingtalk_person_message',
+      action_config: {
+        userIds: ['user_1'],
+        titleTemplate: 'Old title',
+        bodyTemplate: 'Old body',
+      },
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actionConfig: {
+          userIds: [],
+          memberGroupIds: [],
+          userIdFieldPath: 'record.',
+          titleTemplate: 'New title',
+          bodyTemplate: 'New body',
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required',
+    })
     expect(automationService.updateRule).not.toHaveBeenCalled()
   })
 

--- a/packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-delivery-routes.api.test.ts
@@ -1,0 +1,192 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type QueryResult = {
+  rows: Record<string, unknown>[]
+  rowCount?: number
+}
+
+type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
+
+const SHEET_ID = 'sheet_dingtalk_delivery_routes'
+const OTHER_SHEET_ID = 'sheet_other'
+const RULE_ID = 'rule_dingtalk_delivery_routes'
+
+function createMockPool(queryHandler: QueryHandler = () => ({ rows: [], rowCount: 0 })) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM spreadsheet_permissions')) {
+      return { rows: [], rowCount: 0 }
+    }
+    return queryHandler(sql, params)
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+function makeAutomationRule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RULE_ID,
+    sheet_id: SHEET_ID,
+    name: 'DingTalk delivery route',
+    trigger_type: 'record.created',
+    trigger_config: {},
+    action_type: 'send_dingtalk_group_message',
+    action_config: {},
+    enabled: true,
+    created_at: '2026-04-21T00:00:00.000Z',
+    updated_at: '2026-04-21T00:00:00.000Z',
+    created_by: 'admin_1',
+    conditions: null,
+    actions: null,
+    ...overrides,
+  }
+}
+
+function createMockAutomationService(existingRule: ReturnType<typeof makeAutomationRule> | null = makeAutomationRule()) {
+  return {
+    getRule: vi.fn(async (ruleId: string) => {
+      if (!existingRule || ruleId !== existingRule.id) return null
+      return existingRule
+    }),
+  }
+}
+
+async function createApp(options: {
+  automationRule?: ReturnType<typeof makeAutomationRule> | null
+  groupDeliveries?: Array<Record<string, unknown>>
+  personDeliveries?: Array<Record<string, unknown>>
+  perms?: string[]
+  role?: string
+} = {}) {
+  vi.resetModules()
+
+  const groupDeliveries = options.groupDeliveries ?? []
+  const personDeliveries = options.personDeliveries ?? []
+  const listGroupDeliveries = vi.fn(async () => groupDeliveries)
+  const listPersonDeliveries = vi.fn(async () => personDeliveries)
+
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false),
+    userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue([]),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+  vi.doMock('../../src/multitable/dingtalk-group-delivery-service', () => ({
+    listAutomationDingTalkGroupDeliveries: listGroupDeliveries,
+  }))
+  vi.doMock('../../src/multitable/dingtalk-person-delivery-service', () => ({
+    listAutomationDingTalkPersonDeliveries: listPersonDeliveries,
+  }))
+
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { setAutomationServiceInstance } = await import('../../src/multitable/automation-service')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+
+  const mockPool = createMockPool()
+  const automationService = createMockAutomationService(
+    options.automationRule === undefined ? makeAutomationRule() : options.automationRule,
+  )
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as ReturnType<typeof poolManager.get>)
+  setAutomationServiceInstance(automationService as Parameters<typeof setAutomationServiceInstance>[0])
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = {
+      id: 'admin_1',
+      role: options.role,
+      roles: options.role === 'admin' ? ['admin'] : [],
+      perms: options.perms ?? ['workflow:write', 'multitable:write'],
+    }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+
+  return {
+    app,
+    automationService,
+    listGroupDeliveries,
+    listPersonDeliveries,
+    mockPool,
+  }
+}
+
+describe('DingTalk automation delivery routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('lists person delivery history and clamps limit=0 to one', async () => {
+    const personDeliveries = [{ id: 'person_delivery_1', success: true }]
+    const { app, listPersonDeliveries } = await createApp({ personDeliveries })
+
+    const response = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}/dingtalk-person-deliveries`)
+      .query({ limit: '0' })
+      .expect(200)
+
+    expect(response.body).toEqual({
+      ok: true,
+      data: { deliveries: personDeliveries },
+    })
+    expect(listPersonDeliveries).toHaveBeenCalledWith(expect.any(Function), RULE_ID, 1)
+  })
+
+  it('lists group delivery history and clamps large limits to 200', async () => {
+    const groupDeliveries = [{ id: 'group_delivery_1', success: true }]
+    const { app, listGroupDeliveries } = await createApp({ groupDeliveries })
+
+    const response = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}/dingtalk-group-deliveries`)
+      .query({ limit: '999' })
+      .expect(200)
+
+    expect(response.body).toEqual({
+      ok: true,
+      data: { deliveries: groupDeliveries },
+    })
+    expect(listGroupDeliveries).toHaveBeenCalledWith(expect.any(Function), RULE_ID, 200)
+  })
+
+  it('rejects delivery history reads when the user cannot manage automations', async () => {
+    const { app, automationService, listPersonDeliveries } = await createApp({
+      perms: ['multitable:read'],
+    })
+
+    const response = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}/dingtalk-person-deliveries`)
+      .expect(403)
+
+    expect(response.body).toEqual({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Insufficient permissions',
+      },
+    })
+    expect(automationService.getRule).not.toHaveBeenCalled()
+    expect(listPersonDeliveries).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the automation rule does not belong to the sheet', async () => {
+    const { app, listGroupDeliveries } = await createApp({
+      automationRule: makeAutomationRule({ sheet_id: OTHER_SHEET_ID }),
+    })
+
+    const response = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}/dingtalk-group-deliveries`)
+      .expect(404)
+
+    expect(response.body).toEqual({
+      ok: false,
+      error: {
+        code: 'NOT_FOUND',
+        message: 'Automation rule not found',
+      },
+    })
+    expect(listGroupDeliveries).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -47,7 +47,7 @@ vi.mock('../../src/db/db', () => {
 })
 
 import { AutomationLogService } from '../../src/multitable/automation-log-service'
-import { AutomationService } from '../../src/multitable/automation-service'
+import { AutomationRuleValidationError, AutomationService } from '../../src/multitable/automation-service'
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -1663,6 +1663,25 @@ describe('AutomationService — Rule CRUD', () => {
     return chain
   }
 
+  function makeRuleRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'atr_1',
+      sheet_id: 'sheet_1',
+      name: 'Rule',
+      trigger_type: 'record.created',
+      trigger_config: {},
+      action_type: 'update_record',
+      action_config: {},
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+      created_by: 'u1',
+      conditions: null,
+      actions: null,
+      ...overrides,
+    }
+  }
+
   beforeEach(() => {
     eventBus = new EventBus()
     queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
@@ -1686,6 +1705,77 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule.name).toBe('My Rule')
     expect(rule.trigger_type).toBe('record.created')
     expect(rule.enabled).toBe(true)
+  })
+
+  it('createRule normalizes legacy DingTalk title and content fields', async () => {
+    dbExecuteResults.push([])
+    const rule = await service.createRule('sheet_1', {
+      name: 'DingTalk group',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: {
+        destinationId: 'group_1',
+        title: 'Please fill',
+        content: 'Open form',
+      },
+      createdBy: 'user_1',
+    })
+
+    expect(rule.action_config).toMatchObject({
+      destinationId: 'group_1',
+      titleTemplate: 'Please fill',
+      bodyTemplate: 'Open form',
+    })
+  })
+
+  it('createRule rejects invalid DingTalk person configs before insert', async () => {
+    const promise = service.createRule('sheet_1', {
+      name: 'Bad DingTalk person',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'send_dingtalk_person_message',
+      actionConfig: {
+        userIds: [','],
+        memberGroupIds: [],
+        userIdFieldPath: 'record.',
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+      },
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('createRule rejects invalid V1 DingTalk actions before insert', async () => {
+    const promise = service.createRule('sheet_1', {
+      name: 'Bad DingTalk action',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'notify',
+      actionConfig: {},
+      actions: [
+        {
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationIds: [],
+            destinationIdFieldPath: 'record.',
+            titleTemplate: 'Please fill',
+            bodyTemplate: 'Open form',
+          },
+        },
+      ],
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one DingTalk destination or record destination field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
   })
 
   it('getRule returns a rule when found', async () => {
@@ -1741,17 +1831,86 @@ describe('AutomationService — Rule CRUD', () => {
   })
 
   it('updateRule returns updated rule', async () => {
-    const updatedRow = {
-      id: 'atr_1', sheet_id: 'sheet_1', name: 'Updated',
-      trigger_type: 'record.created', trigger_config: {},
-      action_type: 'update_record', action_config: {},
-      enabled: true, created_at: new Date(), updated_at: new Date(),
-      created_by: 'u1', conditions: null, actions: null,
-    }
+    const updatedRow = makeRuleRow({ name: 'Updated' })
     dbExecuteResults.push([updatedRow])
     const rule = await service.updateRule('atr_1', 'sheet_1', { name: 'Updated' })
     expect(rule).not.toBeNull()
     expect(rule!.name).toBe('Updated')
+  })
+
+  it('updateRule validates the merged state when only actionType changes to DingTalk', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'notify',
+      action_config: {},
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', {
+      actionType: 'send_dingtalk_group_message',
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one DingTalk destination or record destination field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('updateRule rejects merged invalid DingTalk configs before update', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      name: 'DingTalk person',
+      action_type: 'send_dingtalk_person_message',
+      action_config: {
+        userIds: ['user_1'],
+        titleTemplate: 'Old title',
+        bodyTemplate: 'Old body',
+      },
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', {
+      actionConfig: {
+        userIds: [],
+        memberGroupIds: [','],
+        userIdFieldPath: 'record.',
+        titleTemplate: 'New title',
+        bodyTemplate: 'New body',
+      },
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('updateRule rejects invalid V1 DingTalk actions before update', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'notify',
+      action_config: {},
+      actions: [
+        {
+          type: 'update_record',
+          config: { fields: { status: 'done' } },
+        },
+      ],
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', {
+      actions: [
+        {
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            memberGroupIdFieldPaths: ['record.'],
+            titleTemplate: 'Please fill',
+            bodyTemplate: 'Open form',
+          },
+        },
+      ],
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
+
+    expect(dbExecuteResults).toHaveLength(0)
   })
 
   it('updateRule returns null when rule not found', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-automation-link-validation.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-automation-link-validation.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   collectDingTalkAutomationLinkIds,
+  normalizeDingTalkAutomationActionInputs,
+  validateDingTalkAutomationActionConfigs,
   validateDingTalkAutomationLinks,
   type AutomationLinkQueryFn,
 } from '../../src/multitable/dingtalk-automation-link-validation'
@@ -14,6 +16,77 @@ function queryWithRows(rowsByCall: unknown[][]): AutomationLinkQueryFn {
 }
 
 describe('dingtalk automation link validation', () => {
+  it('normalizes legacy DingTalk title and content fields before persistence', () => {
+    const normalized = normalizeDingTalkAutomationActionInputs(
+      'send_dingtalk_group_message',
+      { destinationId: 'group_1', title: 'Please fill', content: 'Open form' },
+      [
+        {
+          type: 'send_dingtalk_person_message',
+          config: { userIds: ['user_1'], title: 'Person title', content: 'Person body' },
+        },
+      ],
+    )
+
+    expect(normalized.actionConfig).toMatchObject({
+      titleTemplate: 'Please fill',
+      bodyTemplate: 'Open form',
+    })
+    expect(normalized.actions).toEqual([
+      {
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          title: 'Person title',
+          content: 'Person body',
+          titleTemplate: 'Person title',
+          bodyTemplate: 'Person body',
+        },
+      },
+    ])
+  })
+
+  it('rejects DingTalk group actions without an effective destination source', () => {
+    expect(validateDingTalkAutomationActionConfigs(
+      'send_dingtalk_group_message',
+      {
+        destinationIds: [],
+        destinationIdFieldPath: 'record., ,',
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+      },
+      null,
+    )).toBe('At least one DingTalk destination or record destination field path is required')
+  })
+
+  it('rejects DingTalk person actions without an effective recipient source', () => {
+    expect(validateDingTalkAutomationActionConfigs(
+      'send_dingtalk_person_message',
+      {
+        userIds: [','],
+        memberGroupIds: [],
+        userIdFieldPaths: ['record.'],
+        memberGroupIdFieldPath: ',',
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+      },
+      null,
+    )).toBe('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
+  })
+
+  it('rejects DingTalk actions without executable template fields', () => {
+    expect(validateDingTalkAutomationActionConfigs(
+      'notify',
+      {},
+      [
+        {
+          type: 'send_dingtalk_person_message',
+          config: { userIds: ['user_1'], titleTemplate: ' ', bodyTemplate: 'Open form' },
+        },
+      ],
+    )).toBe('DingTalk titleTemplate is required')
+  })
+
   it('collects public form and internal view ids from legacy and multi-action configs', () => {
     expect(collectDingTalkAutomationLinkIds(
       'send_dingtalk_group_message',


### PR DESCRIPTION
## Summary

Promotes the DingTalk automation validation stack onto the current mainline instead of closing stack PRs only into non-main base branches.

Includes:
- route-level and service-level DingTalk action-config validation
- legacy title/content normalization before persistence
- dynamic group/person/member-group recipient field contract hardening
- delivery route limit/error handling follow-ups
- focused frontend/backend regression coverage
- promotion development and verification MD

## Merge Notes

Resolved stack-vs-main conflicts manually. Preserved main Yjs REST invalidator wiring in `packages/core-backend/src/routes/univer-meta.ts` while adding DingTalk validation hooks.

Related stack PRs: #1002, #1003.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts tests/integration/dingtalk-delivery-routes.api.test.ts tests/unit/automation-v1.test.ts --watch=false
pnpm --filter @metasheet/web exec vitest run tests/dingtalk-recipient-field-warnings.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
git diff --check
```

Results:
- Backend focused regression: 4 files / 142 tests passed
- Frontend focused regression: 3 files / 122 tests passed
- Backend build: passed
- Web vue-tsc: passed
- git diff --check: passed

Docs: `docs/development/dingtalk-action-validation-stack-promotion-20260421.md`