### PR TITLE
docs(dingtalk): add action validation post-merge verification

### DIFF
--- a/docs/development/dingtalk-action-validation-postmerge-verification-20260421.md
+++ b/docs/development/dingtalk-action-validation-postmerge-verification-20260421.md
@@ -1,0 +1,118 @@
+# DingTalk Action Validation Post-Merge Verification - 2026-04-21
+
+## Scope
+
+Post-merge verification for PR #1004 after it landed on `main`.
+
+Verified target:
+
+```text
+origin/main 957d0e6a2 feat(dingtalk): promote automation validation stack
+PR #1004   MERGED at 2026-04-21T12:41:00Z
+```
+
+The goal was to confirm the squash-merged mainline, not only the pre-merge PR branch.
+
+## Queue State
+
+GitHub PR queue after #1004:
+
+```text
+Open PRs: none
+```
+
+Superseded stack PRs:
+
+```text
+#1002 CLOSED - superseded by #1004
+#1003 CLOSED - superseded by #1004
+```
+
+## GitHub Checks
+
+PR #1004 completed successfully:
+
+```text
+pr-validate                SUCCESS
+contracts (openapi)        SUCCESS
+contracts (strict)         SUCCESS
+contracts (dashboard)      SUCCESS
+core-backend-cache         SUCCESS
+telemetry-plugin           SUCCESS
+migration-replay           SUCCESS
+e2e                        SUCCESS
+after-sales integration    SUCCESS
+test (18.x)                SUCCESS
+test (20.x)                SUCCESS
+coverage                   SUCCESS
+Strict E2E                 SKIPPED by workflow configuration
+```
+
+## Local Post-Merge Verification
+
+Clean worktree:
+
+```bash
+git worktree add -b codex/dingtalk-action-validation-postmerge-20260421 \
+  /private/tmp/metasheet2-dingtalk-action-validation-postmerge origin/main
+pnpm install --frozen-lockfile
+```
+
+Backend focused regression:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/dingtalk-automation-link-validation.test.ts \
+  tests/integration/dingtalk-automation-link-routes.api.test.ts \
+  tests/integration/dingtalk-delivery-routes.api.test.ts \
+  tests/unit/automation-v1.test.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests       142 passed (142)
+```
+
+Frontend focused regression:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/dingtalk-recipient-field-warnings.spec.ts \
+  tests/multitable-automation-rule-editor.spec.ts \
+  tests/multitable-automation-manager.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       122 passed (122)
+```
+
+Build and type gates:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+Result:
+
+```text
+All passed.
+```
+
+## Notes
+
+- Frontend Vitest emitted the existing warning `WebSocket server error: Port is already in use`; the run still passed.
+- `pnpm install --frozen-lockfile` created local workspace `node_modules` link noise under plugin/tool folders; this was treated as local install noise and not committed.
+- The primary local worktree remained dirty and was not used for edits.
+
+## Conclusion
+
+The DingTalk automation validation stack is now fully landed on `main` and verified post-merge. No open GitHub PRs remain after this closure pass.


### PR DESCRIPTION
## Summary

Adds the post-merge verification note for PR #1004 after the DingTalk automation validation stack landed on `main`.

## Verification Recorded

- GitHub #1004 checks all successful, with Strict E2E skipped by workflow configuration
- Open PR queue empty
- #1002/#1003 closed as superseded by #1004
- Backend focused regression: 4 files / 142 tests passed
- Frontend focused regression: 3 files / 122 tests passed
- Backend build passed
- Web vue-tsc passed
- git diff --check passed

## File

`docs/development/dingtalk-action-validation-postmerge-verification-20260421.md`