### PR TITLE
fix(dingtalk): validate automation links in service

### DIFF
--- a/docs/development/dingtalk-action-service-link-validation-development-20260421.md
+++ b/docs/development/dingtalk-action-service-link-validation-development-20260421.md
@@ -1,0 +1,44 @@
+# DingTalk Automation Service Link Validation Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change moves DingTalk automation public-form and internal-view link validation into `AutomationService`.
+
+Affected paths:
+
+- `packages/core-backend/src/multitable/automation-service.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+
+## Problem
+
+The HTTP automation routes already validate DingTalk public form and internal processing links before persistence. However, direct service callers could still bypass those route checks and persist rules that reference missing, disabled, expired, or cross-sheet views.
+
+This was the remaining service-layer gap after adding service-level DingTalk action config validation.
+
+## Implementation
+
+`AutomationService.createRule` now runs `validateDingTalkAutomationLinks` after config validation and before DB insert.
+
+`AutomationService.updateRule` now validates the effective merged action state when action fields change:
+
+- `actionType`
+- `actionConfig`
+- `actions`
+
+The update path still avoids link validation for unrelated PATCH operations such as name or enabled changes. This preserves the existing behavior that allows toggling or renaming historical rules without revalidating view state.
+
+Validation failures throw `AutomationRuleValidationError`, which is already mapped to HTTP 400 by the route layer.
+
+## Behavior
+
+Service-level callers now reject DingTalk rules that reference:
+
+- Missing public form views.
+- Public links that point to non-form views.
+- Disabled or unshared public form views.
+- Expired public form views.
+- Missing internal processing views.
+
+The validation uses the service `queryFn`, so it applies to both legacy single-action configs and V1 `actions[]`.

--- a/docs/development/dingtalk-action-service-link-validation-verification-20260421.md
+++ b/docs/development/dingtalk-action-service-link-validation-verification-20260421.md
@@ -1,0 +1,52 @@
+# DingTalk Automation Service Link Validation Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-action-service-link-validation-20260421`
+- Branch: `codex/dingtalk-action-service-link-validation-20260421`
+- Base: `82217450de80d2fecc110b653e751bd8fe5bbcd7`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/unit/automation-v1.test.ts`: 119 tests passed.
+- Added service-level create/update coverage for invalid DingTalk public form links.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/unit/dingtalk-automation-link-validation.test.ts`: 12 tests passed.
+- `tests/integration/dingtalk-automation-link-routes.api.test.ts`: 9 tests passed.
+- Total: 21 tests passed.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+## Notes
+
+- Vitest emitted the existing Vite CJS Node API deprecation warning.
+- `pnpm install` emitted the existing ignored-build-scripts warning.
+- No live DingTalk webhook delivery was required because this change protects persistence-time link validation.

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -12,6 +12,7 @@ import { AutomationLogService } from './automation-log-service'
 import {
   normalizeDingTalkAutomationActionInputs,
   validateDingTalkAutomationActionConfigs,
+  validateDingTalkAutomationLinks,
 } from './dingtalk-automation-link-validation'
 import type { Database } from '../db/types'
 
@@ -219,6 +220,14 @@ export class AutomationService {
       : input.actions ?? null
     const actionConfigValidationError = validateDingTalkAutomationActionConfigs(input.actionType, actionConfig, actions)
     if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
+    const linkValidationError = await validateDingTalkAutomationLinks(
+      this.queryFn,
+      sheetId,
+      input.actionType,
+      actionConfig,
+      actions,
+    )
+    if (linkValidationError) throw new AutomationRuleValidationError(linkValidationError)
 
     const row = {
       id: ruleId,
@@ -317,6 +326,14 @@ export class AutomationService {
         normalizedNextActions,
       )
       if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
+      const linkValidationError = await validateDingTalkAutomationLinks(
+        this.queryFn,
+        sheetId,
+        nextActionType,
+        normalizedNextActionConfig,
+        normalizedNextActions,
+      )
+      if (linkValidationError) throw new AutomationRuleValidationError(linkValidationError)
 
       if (input.actionConfig !== undefined) normalizedActionConfigForUpdate = normalizedNextActionConfig
       if (input.actions !== undefined) normalizedActionsForUpdate = Array.isArray(input.actions) ? normalizedNextActions : null

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -1682,6 +1682,20 @@ describe('AutomationService — Rule CRUD', () => {
     }
   }
 
+  function makePublicFormViewRow(id: string, publicForm: Record<string, unknown> = {}) {
+    return {
+      id,
+      type: 'form',
+      config: {
+        publicForm: {
+          enabled: true,
+          publicToken: `pub_${id}`,
+          ...publicForm,
+        },
+      },
+    }
+  }
+
   beforeEach(() => {
     eventBus = new EventBus()
     queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
@@ -1778,6 +1792,30 @@ describe('AutomationService — Rule CRUD', () => {
     expect(dbExecuteResults).toHaveLength(0)
   })
 
+  it('createRule rejects invalid DingTalk public form links before insert', async () => {
+    queryFn.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+
+    const promise = service.createRule('sheet_1', {
+      name: 'Bad DingTalk link',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: {
+        destinationId: 'group_1',
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+        publicFormViewId: 'view_missing',
+      },
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('Public form view not found: view_missing')
+
+    expect(queryFn).toHaveBeenCalledWith(expect.stringContaining('FROM meta_views'), ['sheet_1', ['view_missing']])
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
   it('getRule returns a rule when found', async () => {
     const mockRow = {
       id: 'atr_123',
@@ -1836,6 +1874,7 @@ describe('AutomationService — Rule CRUD', () => {
     const rule = await service.updateRule('atr_1', 'sheet_1', { name: 'Updated' })
     expect(rule).not.toBeNull()
     expect(rule!.name).toBe('Updated')
+    expect(queryFn).not.toHaveBeenCalled()
   })
 
   it('updateRule validates the merged state when only actionType changes to DingTalk', async () => {
@@ -1910,6 +1949,41 @@ describe('AutomationService — Rule CRUD', () => {
     await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
     await expect(promise).rejects.toThrow('At least one local userId, memberGroupId, record recipient field path, or member group record field path is required')
 
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('updateRule rejects invalid merged DingTalk public form links before update', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      name: 'DingTalk person',
+      action_type: 'send_dingtalk_person_message',
+      action_config: {
+        userIds: ['user_1'],
+        titleTemplate: 'Old title',
+        bodyTemplate: 'Old body',
+      },
+    }))
+    queryFn.mockResolvedValueOnce({
+      rows: [
+        makePublicFormViewRow('view_expired', {
+          expiresAt: Date.now() - 1_000,
+        }),
+      ],
+      rowCount: 1,
+    })
+
+    const promise = service.updateRule('atr_1', 'sheet_1', {
+      actionConfig: {
+        userIds: ['user_1'],
+        titleTemplate: 'New title',
+        bodyTemplate: 'New body',
+        publicFormViewId: 'view_expired',
+      },
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    await expect(promise).rejects.toThrow('Selected public form view has expired: view_expired')
+
+    expect(queryFn).toHaveBeenCalledWith(expect.stringContaining('FROM meta_views'), ['sheet_1', ['view_expired']])
     expect(dbExecuteResults).toHaveLength(0)
   })
 


### PR DESCRIPTION
## Summary
- validate DingTalk public-form/internal-view links inside `AutomationService.createRule`
- validate merged DingTalk link state inside `AutomationService.updateRule` when action fields change
- add service-level tests for invalid create/update public form links
- add development and verification notes under `docs/development`

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --cached --check`