### PR TITLE
feat(dingtalk): open advanced automation editor on create

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -554,10 +554,25 @@
           </div>
         </section>
 
-        <!-- Add button -->
-        <button v-if="!showForm" class="meta-automation__btn meta-automation__btn--primary meta-automation__btn-add" type="button" @click="openCreateForm">
-          + New Automation
-        </button>
+        <!-- Add buttons -->
+        <div v-if="!showForm && !showRuleEditor" class="meta-automation__add-row">
+          <button
+            class="meta-automation__btn meta-automation__btn--primary"
+            type="button"
+            data-automation-new-rule="advanced"
+            @click="openRuleEditor()"
+          >
+            + New Automation
+          </button>
+          <button
+            class="meta-automation__btn meta-automation__btn-add"
+            type="button"
+            data-automation-new-rule="quick"
+            @click="openCreateForm"
+          >
+            Quick legacy form
+          </button>
+        </div>
 
         <!-- Rule list -->
         <div v-if="loading" class="meta-automation__empty">Loading automations&#x2026;</div>
@@ -1738,6 +1753,7 @@ watch(
   margin-bottom: 4px;
 }
 
+.meta-automation__add-row,
 .meta-automation__preset-row {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -304,6 +304,22 @@ describe('MetaAutomationManager', () => {
     expect(el!.textContent).toContain('No automations yet')
   })
 
+  it('opens the advanced rule editor from the primary new automation entry', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const advancedButton = container.querySelector('[data-automation-new-rule="advanced"]') as HTMLButtonElement
+    expect(advancedButton?.textContent).toContain('+ New Automation')
+    advancedButton.click()
+    await flushPromises()
+
+    expect(container.querySelector('.meta-rule-editor__title')?.textContent).toContain('New Automation Rule')
+    expect(container.querySelector('[data-field="triggerType"]')).not.toBeNull()
+    expect(container.querySelector('[data-field="dingtalkDestinationPickerId"]')).toBeNull()
+    expect(container.querySelector('[data-automation-field="name"]')).toBeNull()
+  })
+
   it('creates rule via form', async () => {
     const { client, fetchFn } = mockClient([])
     const updatedSpy = vi.fn()

--- a/docs/development/dingtalk-automation-create-editor-entry-development-20260421.md
+++ b/docs/development/dingtalk-automation-create-editor-entry-development-20260421.md
@@ -1,0 +1,41 @@
+# DingTalk Automation Create Editor Entry Development Notes
+
+Date: 2026-04-21
+
+## Scope
+
+This change makes the primary automation creation entry open the advanced `MetaAutomationRuleEditor`.
+
+Affected paths:
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Problem
+
+Automation editing already uses the advanced rule editor, which supports:
+
+- Rich triggers.
+- Conditions.
+- Multi-step actions.
+- DingTalk group messages.
+- DingTalk person messages.
+- Public form links.
+- Internal processing links.
+
+The primary `+ New Automation` entry still opened the older inline quick form, so users could only discover the full DingTalk automation workflow after creating or editing an existing rule.
+
+## Implementation
+
+The automation manager now renders two creation entries:
+
+- Primary `+ New Automation`: opens `MetaAutomationRuleEditor`.
+- Secondary `Quick legacy form`: keeps the existing inline form available for compatibility.
+
+The old inline form remains in place to reduce risk and preserve existing quick-form tests. A follow-up can remove it once the advanced editor is the only supported creation path.
+
+## Behavior
+
+Users who click `+ New Automation` now start in the same advanced editor used for edits. This makes DingTalk group/person notification configuration, form links, and internal processing links available immediately during creation.
+
+Existing quick-form behavior remains accessible through the secondary button.

--- a/docs/development/dingtalk-automation-create-editor-entry-development-20260421.md
+++ b/docs/development/dingtalk-automation-create-editor-entry-development-20260421.md
@@ -39,3 +39,7 @@ The old inline form remains in place to reduce risk and preserve existing quick-
 Users who click `+ New Automation` now start in the same advanced editor used for edits. This makes DingTalk group/person notification configuration, form links, and internal processing links available immediately during creation.
 
 Existing quick-form behavior remains accessible through the secondary button.
+
+## Main-target delivery note
+
+The source branch for this change was stacked on a non-`main` base. For final delivery, the single create-entry commit was cherry-picked onto `main` after the preceding DingTalk service validation work landed, so the PR contains only the automation manager entry-point change and its focused tests/docs.

--- a/docs/development/dingtalk-automation-create-editor-entry-verification-20260421.md
+++ b/docs/development/dingtalk-automation-create-editor-entry-verification-20260421.md
@@ -1,0 +1,53 @@
+# DingTalk Automation Create Editor Entry Verification
+
+Date: 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-automation-create-editor-entry-20260421`
+- Branch: `codex/dingtalk-automation-create-editor-entry-20260421`
+- Base: `dd6cee4a5fe1fcbc98474ff3decf7b1c13508cdd`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run apps/web/tests/multitable-automation-manager.spec.ts apps/web/tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: failed.
+
+Reason:
+
+- The command was run through `--filter @metasheet/web`, so Vitest executed from `apps/web`.
+- The paths included the `apps/web/` prefix and did not match test files.
+
+Corrected command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-automation-manager.spec.ts`: 62 tests passed.
+- `tests/multitable-automation-rule-editor.spec.ts`: 54 tests passed.
+- Total: 116 tests passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+## Notes
+
+- Build emitted existing Vite chunk-size warnings.
+- `pnpm install` emitted the existing ignored-build-scripts warning.

--- a/docs/development/dingtalk-automation-create-editor-entry-verification-20260421.md
+++ b/docs/development/dingtalk-automation-create-editor-entry-verification-20260421.md
@@ -51,3 +51,52 @@ Result: passed.
 
 - Build emitted existing Vite chunk-size warnings.
 - `pnpm install` emitted the existing ignored-build-scripts warning.
+
+## Main-target cherry-pick verification
+
+Date: 2026-04-21
+
+The original PR branch was stacked on `codex/dingtalk-automation-create-editor-entry-base-20260421`, so this change was cherry-picked onto the latest `main` to avoid re-merging older DingTalk/Yjs stack commits.
+
+- Worktree: `/private/tmp/metasheet2-dingtalk-create-editor-main`
+- Branch: `codex/dingtalk-automation-create-editor-entry-main-20260421`
+- Base: `cd818a8a0c48fd03f50764fa4ff402d488a08ce6`
+- Cherry-picked source commit: `ac0cce5766eae037e26ad8d301a5ff4c65d0b226`
+- Main-target commit: `dacf717eb`
+
+Commands rerun after the cherry-pick:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-automation-manager.spec.ts`: 62 tests passed.
+- `tests/multitable-automation-rule-editor.spec.ts`: 54 tests passed.
+- Total: 116 tests passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+```bash
+git diff --check HEAD~1..HEAD
+```
+
+Result: passed.
+
+Notes:
+
+- Build emitted existing Vite dynamic-import and chunk-size warnings.
+- `pnpm install` emitted the existing ignored-build-scripts warning.


### PR DESCRIPTION
## Summary

This is the main-target version of #1008. The original PR branch is stacked on a non-main base, so this PR cherry-picks only the create-entry change onto current main.

- Makes the primary `+ New Automation` entry open `MetaAutomationRuleEditor`.
- Keeps the existing inline create form as a secondary `Quick legacy form` entry.
- Adds focused UI regression coverage and development/verification docs.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 116 passed
- `pnpm --filter @metasheet/web build`
- `git diff --check origin/main..HEAD`

Docs:

- `docs/development/dingtalk-automation-create-editor-entry-development-20260421.md`
- `docs/development/dingtalk-automation-create-editor-entry-verification-20260421.md`

Supersedes #1008 for merge-to-main purposes.