### PR TITLE
fix(dingtalk): canonicalize automation rule api contract

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -141,6 +141,56 @@ function unwrapDataBody(body: unknown): unknown {
   return (body as { data?: unknown }).data
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function optionalStringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {}
+}
+
+function normalizeAutomationRulePayload(value: unknown): AutomationRule {
+  const payload = isPlainObject(value) && isPlainObject(value.rule) ? value.rule : value
+  const record = objectValue(payload)
+  const triggerType = stringValue(record.triggerType ?? record.trigger_type) as AutomationRule['triggerType']
+  const triggerConfig = objectValue(record.triggerConfig ?? record.trigger_config)
+  const actionType = stringValue(record.actionType ?? record.action_type) as AutomationRule['actionType']
+  const actionConfig = objectValue(record.actionConfig ?? record.action_config)
+  const conditions = isPlainObject(record.conditions)
+    ? record.conditions as unknown as AutomationRule['conditions']
+    : undefined
+  const actions = Array.isArray(record.actions)
+    ? record.actions as AutomationRule['actions']
+    : undefined
+
+  return {
+    id: stringValue(record.id),
+    sheetId: stringValue(record.sheetId ?? record.sheet_id),
+    name: stringValue(record.name),
+    triggerType,
+    triggerConfig,
+    trigger: isPlainObject(record.trigger)
+      ? record.trigger as unknown as AutomationRule['trigger']
+      : { type: triggerType, config: triggerConfig },
+    conditions,
+    actions,
+    actionType,
+    actionConfig,
+    enabled: record.enabled !== false,
+    createdAt: optionalStringValue(record.createdAt ?? record.created_at),
+    updatedAt: optionalStringValue(record.updatedAt ?? record.updated_at),
+    createdBy: optionalStringValue(record.createdBy ?? record.created_by),
+  }
+}
+
 function firstFieldError(fieldErrors?: Record<string, string>): string | null {
   if (!fieldErrors) return null
   const first = Object.values(fieldErrors).find((msg) => typeof msg === 'string' && msg.trim())
@@ -885,8 +935,13 @@ export class MultitableApiClient {
   // --- Automation rules ---
   async listAutomationRules(sheetId: string): Promise<AutomationRule[]> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations`)
-    const data = await parseJson<{ rules: AutomationRule[] }>(res)
-    return Array.isArray(data?.rules) ? data.rules : []
+    const data = await parseJson<{ rules?: unknown[] } | unknown[]>(res)
+    const rules = Array.isArray(data)
+      ? data
+      : isPlainObject(data) && Array.isArray(data.rules)
+        ? data.rules
+        : []
+    return rules.map(normalizeAutomationRulePayload)
   }
 
   async createAutomationRule(
@@ -898,7 +953,8 @@ export class MultitableApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(rule),
     })
-    return parseJson<AutomationRule>(res)
+    const data = await parseJson<unknown>(res)
+    return normalizeAutomationRulePayload(data)
   }
 
   async updateAutomationRule(sheetId: string, ruleId: string, updates: Partial<AutomationRule>): Promise<void> {

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -7,6 +7,7 @@ import {
   normalizeMultitableCommentMentions,
   parseRetryAfterMs,
 } from '../src/multitable/api/client'
+import type { AutomationRule } from '../src/multitable/types'
 
 describe('MultitableApiClient', () => {
   beforeEach(() => {
@@ -24,6 +25,129 @@ describe('MultitableApiClient', () => {
     })
 
     await expect(client.resolveComment('c1')).resolves.toBeUndefined()
+  })
+
+  it('normalizes automation rule list responses from snake_case API rows', async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      expect(input).toBe('/api/multitable/sheets/sheet_1/automations')
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          rules: [{
+            id: 'atr_1',
+            sheet_id: 'sheet_1',
+            name: 'DingTalk group',
+            trigger_type: 'record.created',
+            trigger_config: {},
+            action_type: 'send_dingtalk_group_message',
+            action_config: { destinationId: 'dt_1' },
+            enabled: true,
+            created_at: '2026-04-21T00:00:00.000Z',
+            updated_at: '2026-04-21T00:01:00.000Z',
+            created_by: 'user_1',
+            conditions: { conjunction: 'AND', conditions: [] },
+            actions: [{
+              type: 'send_dingtalk_group_message',
+              config: {
+                destinationIds: ['dt_1'],
+                titleTemplate: 'Please fill',
+                bodyTemplate: 'Open form',
+              },
+            }],
+          }],
+        },
+      }), { status: 200 })
+    })
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(client.listAutomationRules('sheet_1')).resolves.toEqual([{
+      id: 'atr_1',
+      sheetId: 'sheet_1',
+      name: 'DingTalk group',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      trigger: {
+        type: 'record.created',
+        config: {},
+      },
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: { destinationId: 'dt_1' },
+      enabled: true,
+      createdAt: '2026-04-21T00:00:00.000Z',
+      updatedAt: '2026-04-21T00:01:00.000Z',
+      createdBy: 'user_1',
+      conditions: { conjunction: 'AND', conditions: [] },
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationIds: ['dt_1'],
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+        },
+      }],
+    }])
+  })
+
+  it('unwraps automation create rule envelopes before returning the rule', async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      data: {
+        rule: {
+          id: 'atr_new',
+          sheetId: 'sheet_1',
+          name: 'Advanced group',
+          triggerType: 'record.created',
+          triggerConfig: {},
+          actionType: 'send_dingtalk_group_message',
+          actionConfig: { destinationId: 'dt_1' },
+          actions: [{
+            type: 'send_dingtalk_group_message',
+            config: {
+              destinationIds: ['dt_1'],
+              titleTemplate: 'Please fill',
+              bodyTemplate: 'Open form',
+            },
+          }],
+          enabled: true,
+        },
+      },
+    }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+    const input: Omit<AutomationRule, 'id' | 'sheetId' | 'enabled' | 'createdAt' | 'updatedAt' | 'createdBy'> = {
+      name: 'Advanced group',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: { destinationId: 'dt_1' },
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationIds: ['dt_1'],
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+        },
+      }],
+    }
+
+    const rule = await client.createAutomationRule('sheet_1', input)
+
+    expect(rule).toMatchObject({
+      id: 'atr_new',
+      sheetId: 'sheet_1',
+      actionType: 'send_dingtalk_group_message',
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationIds: ['dt_1'],
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+        },
+      }],
+    })
+    expect(fetchFn).toHaveBeenCalledWith('/api/multitable/sheets/sheet_1/automations', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify(input),
+    }))
   })
 
   it('updates and deletes comments through dedicated endpoints', async () => {

--- a/docs/development/dingtalk-automation-api-rule-contract-development-20260421.md
+++ b/docs/development/dingtalk-automation-api-rule-contract-development-20260421.md
@@ -1,0 +1,45 @@
+# DingTalk Automation API Rule Contract Development - 2026-04-21
+
+## Background
+
+The DingTalk automation editor now emits advanced V1 payloads with `actions`, `conditions`, and action-specific link configuration. The frontend manager needs the automation API to return a stable `AutomationRule` shape immediately after list/create, otherwise saved DingTalk group/person rules can be inserted into UI state as wrapped or snake_case objects.
+
+## Scope
+
+- Canonicalize backend automation rule responses from `/api/multitable/sheets/:sheetId/automations`.
+- Preserve V1 `trigger`, `conditions`, and `actions` in create/list/update responses.
+- Add frontend response normalization for old snake_case rows and wrapped `{ rule }` create envelopes.
+- Add regression coverage for DingTalk V1 group action contract shape.
+
+## Backend Changes
+
+- Added `serializeAutomationRule()` in `packages/core-backend/src/routes/univer-meta.ts`.
+- `GET /automations` now returns `rules` as frontend-ready camelCase objects.
+- `POST /automations` now returns the serialized rule instead of a minimal legacy subset.
+- `PATCH /automations/:ruleId` now returns the serialized updated rule.
+- `POST /automations` now derives `actionType/actionConfig` from the first V1 action when legacy fields are omitted, keeping advanced editor payloads compatible.
+
+## Frontend Changes
+
+- Added automation rule normalization in `apps/web/src/multitable/api/client.ts`.
+- `listAutomationRules()` now accepts either array-style payloads or `{ rules }` payloads and normalizes snake_case/camelCase fields.
+- `createAutomationRule()` now unwraps `{ data: { rule } }` and returns the actual `AutomationRule`.
+- Missing `enabled` defaults to `true` unless the API explicitly returns `false`.
+
+## Tests Added
+
+- Backend integration test for canonical camelCase automation rule response with V1 DingTalk group `actions`.
+- Frontend client test for snake_case automation list normalization.
+- Frontend client test for create-rule envelope unwrapping.
+
+## Files Changed
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/tests/multitable-client.spec.ts`
+
+## Notes
+
+- This PR is stacked on the DingTalk automation editor entry work. It is intentionally focused on API contract correctness, not adding new UI controls.
+- `pnpm install --frozen-lockfile` produced tracked `node_modules` symlink changes under plugin/tool workspaces in this worktree. Those files are dependency artifacts and are intentionally excluded from the commit.

--- a/docs/development/dingtalk-automation-api-rule-contract-development-20260421.md
+++ b/docs/development/dingtalk-automation-api-rule-contract-development-20260421.md
@@ -43,3 +43,7 @@ The DingTalk automation editor now emits advanced V1 payloads with `actions`, `c
 
 - This PR is stacked on the DingTalk automation editor entry work. It is intentionally focused on API contract correctness, not adding new UI controls.
 - `pnpm install --frozen-lockfile` produced tracked `node_modules` symlink changes under plugin/tool workspaces in this worktree. Those files are dependency artifacts and are intentionally excluded from the commit.
+
+## Main-target delivery note
+
+The source branch for this change was stacked on a non-`main` base. For final delivery, the single API-contract commit was cherry-picked onto `main` after the create-entry PR landed, so the PR contains only the route/client contract normalization and its focused tests/docs.

--- a/docs/development/dingtalk-automation-api-rule-contract-verification-20260421.md
+++ b/docs/development/dingtalk-automation-api-rule-contract-verification-20260421.md
@@ -55,3 +55,71 @@ Result: passed.
 
 - Full browser E2E for creating a DingTalk automation from the real manager page was not run in this worktree. The covered path validates the backend route contract, frontend client contract, and existing manager/editor unit suites.
 - Build output still reports existing Vite chunk-size warnings unrelated to this change.
+
+## Main-target cherry-pick verification
+
+Date: 2026-04-21
+
+The original PR branch was stacked on `codex/dingtalk-automation-api-rule-contract-base-20260421`, so this change was cherry-picked onto the latest `main` after the create-entry work landed. This avoids re-merging older DingTalk/Yjs stack commits.
+
+- Worktree: `/private/tmp/metasheet2-dingtalk-api-contract-main`
+- Branch: `codex/dingtalk-automation-api-rule-contract-main-20260421`
+- Base: `c1dae37f9e9d2c96651f6e40f68baebaa2e02c72`
+- Cherry-picked source commit: `818bab3bdc3240ece9e1b748815570c7ef200e09`
+- Main-target commit: `14c0b0619`
+
+Commands rerun after the cherry-pick:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/integration/dingtalk-automation-link-routes.api.test.ts`: 10 tests passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed.
+
+Summary:
+
+- `tests/multitable-client.spec.ts`: 14 tests passed.
+- `tests/multitable-automation-manager.spec.ts`: 62 tests passed.
+- `tests/multitable-automation-rule-editor.spec.ts`: 54 tests passed.
+- Total: 130 tests passed.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+```bash
+git diff --check HEAD~1..HEAD
+```
+
+Result: passed.
+
+Notes:
+
+- Frontend Vitest emitted the existing WebSocket port warning.
+- Backend Vitest emitted the existing Vite CJS Node API deprecation warning.
+- Web build emitted existing Vite dynamic-import and chunk-size warnings.
+- `pnpm install` emitted the existing ignored-build-scripts warning.

--- a/docs/development/dingtalk-automation-api-rule-contract-verification-20260421.md
+++ b/docs/development/dingtalk-automation-api-rule-contract-verification-20260421.md
@@ -1,0 +1,57 @@
+# DingTalk Automation API Rule Contract Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-automation-api-rule-contract-20260421`
+- Branch: `codex/dingtalk-automation-api-rule-contract-20260421`
+- Base: `codex/dingtalk-automation-api-rule-contract-base-20260421`
+- Package manager: `pnpm`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. Dependencies installed from the existing lockfile.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+```
+
+Result: passed. `1` file, `10` tests.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed. `3` files, `130` tests.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed after tightening TypeScript casts in the automation rule normalizer.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Coverage Notes
+
+- Backend now verifies a created DingTalk group automation rule returns `sheetId`, `triggerType`, `actionType`, `actionConfig`, `trigger`, `conditions`, `actions`, timestamps, and `createdBy` in camelCase.
+- Frontend now verifies list responses can consume DB-shaped snake_case rows without leaking those fields into UI state.
+- Frontend now verifies create responses unwrap `{ rule }` before returning to `useMultitableAutomation`.
+
+## Residual Risk
+
+- Full browser E2E for creating a DingTalk automation from the real manager page was not run in this worktree. The covered path validates the backend route contract, frontend client contract, and existing manager/editor unit suites.
+- Build output still reports existing Vite chunk-size warnings unrelated to this change.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -31,7 +31,11 @@ import { MultitableFormulaEngine } from '../multitable/formula-engine'
 import { validateRecord, getDefaultValidationRules } from '../multitable/field-validation-engine'
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
-import { AutomationRuleValidationError, getAutomationServiceInstance } from '../multitable/automation-service'
+import {
+  AutomationRuleValidationError,
+  getAutomationServiceInstance,
+  type AutomationRule as AutomationServiceRule,
+} from '../multitable/automation-service'
 import {
   normalizeDingTalkAutomationActionInputs,
   validateDingTalkAutomationActionConfigs,
@@ -8347,6 +8351,30 @@ export function univerMetaRouter(): Router {
 
   // ── Automation rule CRUD ──────────────────────────────────────────────
 
+  function serializeAutomationRule(rule: AutomationServiceRule) {
+    const triggerConfig = rule.trigger_config ?? {}
+    const actionConfig = rule.action_config ?? {}
+    return {
+      id: rule.id,
+      sheetId: rule.sheet_id,
+      name: rule.name ?? '',
+      triggerType: rule.trigger_type,
+      triggerConfig,
+      trigger: {
+        type: rule.trigger_type,
+        config: triggerConfig,
+      },
+      conditions: rule.conditions ?? undefined,
+      actions: rule.actions ?? undefined,
+      actionType: rule.action_type,
+      actionConfig,
+      enabled: rule.enabled,
+      createdAt: rule.created_at,
+      updatedAt: rule.updated_at,
+      createdBy: rule.created_by ?? undefined,
+    }
+  }
+
   router.get('/sheets/:sheetId/automations', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId : ''
     if (!sheetId) {
@@ -8363,7 +8391,7 @@ export function univerMetaRouter(): Router {
 
       const rules = await automationService.listRules(sheetId)
 
-      return res.json({ ok: true, data: { rules } })
+      return res.json({ ok: true, data: { rules: rules.map(serializeAutomationRule) } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -8392,8 +8420,14 @@ export function univerMetaRouter(): Router {
       const name = typeof body?.name === 'string' ? body.name : null
       const triggerType = typeof body?.triggerType === 'string' ? body.triggerType : ''
       const triggerConfig = (body?.triggerConfig && typeof body.triggerConfig === 'object') ? body.triggerConfig as Record<string, unknown> : {}
-      const actionType = typeof body?.actionType === 'string' ? body.actionType : ''
+      let actions = Array.isArray(body?.actions) ? body.actions : null
+      const firstAction = actions?.find((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+      let actionType = typeof body?.actionType === 'string' ? body.actionType : ''
       let actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig as Record<string, unknown> : {}
+      if (!actionType && typeof firstAction?.type === 'string') actionType = firstAction.type
+      if (Object.keys(actionConfig).length === 0 && firstAction?.config && typeof firstAction.config === 'object' && !Array.isArray(firstAction.config)) {
+        actionConfig = firstAction.config as Record<string, unknown>
+      }
       const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
 
       const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
@@ -8406,7 +8440,6 @@ export function univerMetaRouter(): Router {
       }
 
       const conditions = body?.conditions && typeof body.conditions === 'object' ? body.conditions as never : null
-      let actions = Array.isArray(body?.actions) ? body.actions : null
       const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(actionType, actionConfig, actions)
       actionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
         ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
@@ -8442,16 +8475,7 @@ export function univerMetaRouter(): Router {
       return res.json({
         ok: true,
         data: {
-          rule: {
-            id: rule.id,
-            sheetId,
-            name: rule.name,
-            triggerType: rule.trigger_type,
-            triggerConfig: rule.trigger_config,
-            actionType: rule.action_type,
-            actionConfig: rule.action_config,
-            enabled: rule.enabled,
-          },
+          rule: serializeAutomationRule(rule),
         },
       })
     } catch (err) {
@@ -8582,7 +8606,7 @@ export function univerMetaRouter(): Router {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 
-      return res.json({ ok: true, data: { rule: updated } })
+      return res.json({ ok: true, data: { rule: serializeAutomationRule(updated) } })
     } catch (err) {
       if (err instanceof AutomationRuleValidationError) {
         return res.status(400).json({ ok: false, error: { code: err.code, message: err.message } })

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -261,6 +261,76 @@ describe('DingTalk automation link route validation', () => {
     }))
   })
 
+  it('returns a canonical camelCase automation rule response with V1 DingTalk actions', async () => {
+    const { app } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Advanced group rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'group_1',
+          title: 'Please fill',
+          content: 'Open form',
+          publicFormViewId: VALID_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        },
+        conditions: { conjunction: 'AND', conditions: [] },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationIds: ['group_1'],
+            title: 'Please fill',
+            content: 'Open form',
+            publicFormViewId: VALID_FORM_VIEW_ID,
+            internalViewId: INTERNAL_VIEW_ID,
+          },
+        }],
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.rule).toMatchObject({
+      id: RULE_ID,
+      sheetId: SHEET_ID,
+      name: 'Advanced group rule',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      trigger: {
+        type: 'record.created',
+        config: {},
+      },
+      conditions: { conjunction: 'AND', conditions: [] },
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: expect.objectContaining({
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+        publicFormViewId: VALID_FORM_VIEW_ID,
+        internalViewId: INTERNAL_VIEW_ID,
+      }),
+      enabled: true,
+      createdAt: '2026-04-21T00:00:00.000Z',
+      updatedAt: '2026-04-21T00:00:00.000Z',
+      createdBy: 'admin_1',
+    })
+    expect(res.body.data.rule.actions).toEqual([
+      expect.objectContaining({
+        type: 'send_dingtalk_group_message',
+        config: expect.objectContaining({
+          destinationIds: ['group_1'],
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+          publicFormViewId: VALID_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        }),
+      }),
+    ])
+    expect(res.body.data.rule).not.toHaveProperty('sheet_id')
+    expect(res.body.data.rule).not.toHaveProperty('action_type')
+  })
+
   it('rejects a DingTalk group rule without an effective destination before persisting the rule', async () => {
     const { app, automationService } = await createApp()
 


### PR DESCRIPTION
## Summary

This is the main-target version of #1010. The original PR branch is stacked on a non-main base, so this PR cherry-picks only the automation API contract normalization onto current main.

- Serializes backend automation rule responses as frontend-ready camelCase objects.
- Preserves V1 `trigger`, `conditions`, and `actions` in list/create/update responses.
- Lets create derive legacy `actionType`/`actionConfig` from the first V1 action when omitted.
- Normalizes frontend client list/create responses, including snake_case rows and `{ rule }` envelopes.
- Adds backend/frontend regression tests and development/verification docs.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false` → 10 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 130 passed
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web build`
- `git diff --check origin/main..HEAD`

Docs:

- `docs/development/dingtalk-automation-api-rule-contract-development-20260421.md`
- `docs/development/dingtalk-automation-api-rule-contract-verification-20260421.md`

Supersedes #1010 for merge-to-main purposes.