### PR TITLE
test(dingtalk): cover advanced automation create manager flow

### DIFF
--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -125,7 +125,16 @@ function mockClient(
     }
     if (method === 'POST' && url.includes('/automations')) {
       const body = JSON.parse(init?.body as string)
-      return ok({ id: 'rule_new', sheetId: 'sheet_1', enabled: true, ...body })
+      return ok({
+        rule: {
+          id: 'rule_new',
+          sheetId: 'sheet_1',
+          enabled: true,
+          createdAt: '2026-04-21T00:00:00.000Z',
+          updatedAt: '2026-04-21T00:00:00.000Z',
+          ...body,
+        },
+      })
     }
     if (method === 'PATCH' && url.includes('/automations/')) {
       return noContent()
@@ -318,6 +327,191 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-field="triggerType"]')).not.toBeNull()
     expect(container.querySelector('[data-field="dingtalkDestinationPickerId"]')).toBeNull()
     expect(container.querySelector('[data-automation-field="name"]')).toBeNull()
+  })
+
+  it('creates DingTalk group automation via the advanced rule editor', async () => {
+    const { client, fetchFn } = mockClient([])
+    const updatedSpy = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client, onUpdated: updatedSpy })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-new-rule="advanced"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Advanced DingTalk group'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
+    destinationSelect.value = 'dt_1'
+    destinationSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    destinationSelect.value = 'dt_2'
+    destinationSelect.dispatchEvent(new Event('change'))
+
+    const destinationFieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
+    destinationFieldInput.value = 'record.fld_2'
+    destinationFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+
+    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLSelectElement
+    internalViewSelect.value = 'view_grid'
+    internalViewSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body).toMatchObject({
+      name: 'Advanced DingTalk group',
+      triggerType: 'record.created',
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: {
+        destinationId: 'dt_1',
+        destinationIds: ['dt_1', 'dt_2'],
+        destinationIdFieldPath: 'record.fld_2',
+        destinationIdFieldPaths: ['record.fld_2'],
+        titleTemplate: 'Ticket {{recordId}}',
+        bodyTemplate: 'Please fill {{record.status}}',
+        publicFormViewId: 'view_form',
+        internalViewId: 'view_grid',
+      },
+    })
+    expect(body.actions).toEqual([{
+      type: 'send_dingtalk_group_message',
+      config: {
+        destinationId: 'dt_1',
+        destinationIds: ['dt_1', 'dt_2'],
+        destinationIdFieldPath: 'record.fld_2',
+        destinationIdFieldPaths: ['record.fld_2'],
+        titleTemplate: 'Ticket {{recordId}}',
+        bodyTemplate: 'Please fill {{record.status}}',
+        publicFormViewId: 'view_form',
+        internalViewId: 'view_grid',
+      },
+    }])
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-automation-rule="rule_new"]')?.textContent).toContain('Advanced DingTalk group')
+    expect(container.querySelector('[data-automation-rule="rule_new"] .meta-automation__card-desc')?.textContent).toContain('Send DingTalk group message')
+    expect(container.querySelector('.meta-rule-editor__overlay')).toBeNull()
+  })
+
+  it('creates DingTalk person automation via the advanced rule editor', async () => {
+    const { client, fetchFn } = mockClient([])
+    const updatedSpy = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client, onUpdated: updatedSpy })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-new-rule="advanced"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Advanced DingTalk person'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    userIdsInput.value = 'user_1, user_2'
+    userIdsInput.dispatchEvent(new Event('input'))
+
+    const memberGroupIdsInput = container.querySelector('[data-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    memberGroupIdsInput.value = 'group_1'
+    memberGroupIdsInput.dispatchEvent(new Event('input'))
+
+    const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
+    recipientFieldInput.value = 'record.assigneeUserIds'
+    recipientFieldInput.dispatchEvent(new Event('input'))
+
+    const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
+    memberGroupFieldInput.value = 'record.watcherGroupIds'
+    memberGroupFieldInput.dispatchEvent(new Event('input'))
+
+    const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please process {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+
+    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+    internalViewSelect.value = 'view_grid'
+    internalViewSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body).toMatchObject({
+      name: 'Advanced DingTalk person',
+      triggerType: 'record.created',
+      actionType: 'send_dingtalk_person_message',
+      actionConfig: {
+        userIds: ['user_1', 'user_2'],
+        memberGroupIds: ['group_1'],
+        userIdFieldPath: 'record.assigneeUserIds',
+        userIdFieldPaths: ['record.assigneeUserIds'],
+        memberGroupIdFieldPath: 'record.watcherGroupIds',
+        memberGroupIdFieldPaths: ['record.watcherGroupIds'],
+        titleTemplate: 'Ticket {{recordId}}',
+        bodyTemplate: 'Please process {{record.status}}',
+        publicFormViewId: 'view_form',
+        internalViewId: 'view_grid',
+      },
+    })
+    expect(body.actions).toEqual([{
+      type: 'send_dingtalk_person_message',
+      config: {
+        userIds: ['user_1', 'user_2'],
+        memberGroupIds: ['group_1'],
+        userIdFieldPath: 'record.assigneeUserIds',
+        userIdFieldPaths: ['record.assigneeUserIds'],
+        memberGroupIdFieldPath: 'record.watcherGroupIds',
+        memberGroupIdFieldPaths: ['record.watcherGroupIds'],
+        titleTemplate: 'Ticket {{recordId}}',
+        bodyTemplate: 'Please process {{record.status}}',
+        publicFormViewId: 'view_form',
+        internalViewId: 'view_grid',
+      },
+    }])
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-automation-rule="rule_new"]')?.textContent).toContain('Advanced DingTalk person')
+    expect(container.querySelector('[data-automation-rule="rule_new"] .meta-automation__card-desc')?.textContent).toContain('Send DingTalk person message')
+    expect(container.querySelector('.meta-rule-editor__overlay')).toBeNull()
   })
 
   it('creates rule via form', async () => {

--- a/docs/development/dingtalk-automation-advanced-create-manager-development-20260421.md
+++ b/docs/development/dingtalk-automation-advanced-create-manager-development-20260421.md
@@ -1,0 +1,43 @@
+# DingTalk Automation Advanced Create Manager Development - 2026-04-21
+
+## Background
+
+The DingTalk automation stack already has:
+
+- Advanced rule editor entry from the automation manager.
+- Editor-level payload coverage for DingTalk group/person actions.
+- API contract normalization for `{ data: { rule } }` create responses.
+
+The missing coverage was the manager-level save-through path: a user clicks the primary `+ New Automation` entry, configures DingTalk in `MetaAutomationRuleEditor`, saves, and the manager calls `MultitableApiClient.createAutomationRule()` with the full V1 payload.
+
+## Scope
+
+- Add manager-level regression coverage for advanced DingTalk group automation creation.
+- Add manager-level regression coverage for advanced DingTalk person automation creation.
+- Make the test `POST /automations` mock return the backend-like `{ rule }` envelope so the manager path also exercises the client normalizer from the API contract PR.
+
+## Implementation
+
+- Updated `apps/web/tests/multitable-automation-manager.spec.ts`.
+- Group test verifies:
+  - Primary advanced entry opens the editor.
+  - Static DingTalk groups and dynamic record destination fields are preserved.
+  - Public form and internal processing view IDs are preserved.
+  - Legacy `actionType/actionConfig` and V1 `actions[]` are both posted.
+  - Created rule appears in the manager list using the normalized returned rule.
+- Person test verifies:
+  - Static user IDs and member group IDs are preserved.
+  - Dynamic user and member-group record field paths are preserved.
+  - Public form and internal processing view IDs are preserved.
+  - Legacy `actionType/actionConfig` and V1 `actions[]` are both posted.
+  - Created rule appears in the manager list using the normalized returned rule.
+
+## Files Changed
+
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Notes
+
+- No production component code was required because the advanced create entry already exists in the stacked base branch.
+- This PR is intentionally a focused frontend regression hardening slice after the API contract canonicalization work.
+- Dependency install created tracked `node_modules` symlink changes in plugin/tool workspaces; those artifacts are intentionally excluded from the commit.

--- a/docs/development/dingtalk-automation-advanced-create-manager-verification-20260421.md
+++ b/docs/development/dingtalk-automation-advanced-create-manager-verification-20260421.md
@@ -1,0 +1,48 @@
+# DingTalk Automation Advanced Create Manager Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-automation-advanced-create-manager-20260421`
+- Branch: `codex/dingtalk-automation-advanced-create-manager-20260421`
+- Base: `818bab3bd` from PR #1010
+- Package manager: `pnpm`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. Dependencies installed from the existing lockfile.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-client.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed. `3` files, `132` tests.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Existing Vite warnings remain:
+
+- `WorkflowDesigner.vue` is both dynamically and statically imported.
+- Some chunks exceed `500 kB` after minification.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Regression Coverage
+
+- `MetaAutomationManager` now verifies advanced DingTalk group creation posts the full `send_dingtalk_group_message` contract and inserts the normalized created rule into the UI list.
+- `MetaAutomationManager` now verifies advanced DingTalk person creation posts the full `send_dingtalk_person_message` contract and inserts the normalized created rule into the UI list.
+- The mock create response now uses `{ rule }`, matching the backend API response shape introduced by the contract PR.
+
+## Not Run
+
+- Backend tests were not rerun because this slice changes only frontend test coverage.
+- Browser E2E against a live server was not run in this worktree.


### PR DESCRIPTION
## Summary

- Add manager-level coverage for creating DingTalk group automation through the primary advanced rule editor flow.
- Add manager-level coverage for creating DingTalk person automation through the primary advanced rule editor flow.
- Make the manager test create mock return a backend-like `{ rule }` envelope so this path exercises the client response normalizer.
- Add development and verification notes.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-client.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

## Notes

Stacked on PR #1010 / `codex/dingtalk-automation-api-rule-contract-20260421`. This slice changes frontend tests/docs only.