### PR TITLE
feat(admin-audit): wire audit log UI to backend

### DIFF
--- a/apps/web/src/views/AdminAuditView.vue
+++ b/apps/web/src/views/AdminAuditView.vue
@@ -3,7 +3,7 @@
     <header class="admin-audit__header">
       <div>
         <h1>管理审计</h1>
-        <p>查看用户、角色、权限和会话治理相关的后台操作记录。</p>
+        <p>查看后台敏感操作的审计日志（对应 <code>operation_audit_logs</code>），支持按资源、动作、时间范围过滤与导出。</p>
       </div>
 
       <div class="admin-audit__actions">
@@ -11,11 +11,20 @@
         <router-link class="admin-audit__link" to="/admin/roles">角色管理</router-link>
         <router-link class="admin-audit__link" to="/admin/permissions">权限管理</router-link>
         <input
-          v-model.trim="search"
+          v-model.trim="resourceIdInput"
           class="admin-audit__input"
           type="search"
-          placeholder="搜索用户、资源 ID、邮箱或原因"
-          @keyup.enter="void reloadAll()"
+          placeholder="按 resource_id 精确匹配"
+          title="精确匹配 resource_id（例如 user UUID 或 租户 ID）"
+          @keyup.enter="void loadActivityLogs(1)"
+        >
+        <input
+          v-model.trim="actorIdInput"
+          class="admin-audit__input"
+          type="search"
+          placeholder="按 actor_id 精确匹配"
+          title="精确匹配 actor_id（操作人 ID）"
+          @keyup.enter="void loadActivityLogs(1)"
         >
         <select v-model="resourceTypeFilter" class="admin-audit__select">
           <option value="">全部资源</option>
@@ -29,11 +38,12 @@
           <option value="update">update</option>
           <option value="grant">grant</option>
           <option value="revoke">revoke</option>
+          <option value="delete">delete</option>
         </select>
         <input v-model="fromDate" class="admin-audit__input" type="date">
         <input v-model="toDate" class="admin-audit__input" type="date">
-        <button class="admin-audit__button admin-audit__button--primary" type="button" :disabled="activityLoading || revocationLoading" @click="void reloadAll()">
-          {{ activityLoading || revocationLoading ? '加载中...' : '刷新' }}
+        <button class="admin-audit__button admin-audit__button--primary" type="button" :disabled="activityLoading" @click="void loadActivityLogs(1)">
+          {{ activityLoading ? '加载中...' : '刷新' }}
         </button>
         <button class="admin-audit__button" type="button" :disabled="exporting || activityLoading" @click="void exportActivityCsv()">
           {{ exporting ? '导出中...' : '导出 CSV' }}
@@ -47,21 +57,21 @@
 
     <section class="admin-audit__summary">
       <article class="admin-audit__summary-card">
-        <span class="admin-audit__summary-label">IAM 活动日志</span>
+        <span class="admin-audit__summary-label">审计日志总数</span>
         <strong>{{ activityTotal }}</strong>
       </article>
       <article class="admin-audit__summary-card">
-        <span class="admin-audit__summary-label">会话撤销记录</span>
-        <strong>{{ revocationTotal }}</strong>
+        <span class="admin-audit__summary-label">当前过滤条件</span>
+        <strong>{{ activeFilterSummary }}</strong>
       </article>
     </section>
 
-    <div class="admin-audit__layout">
+    <div class="admin-audit__layout admin-audit__layout--single">
       <section class="admin-audit__panel">
         <div class="admin-audit__panel-head">
           <div>
-            <h2>IAM 活动日志</h2>
-            <p>覆盖用户创建、账号启停、密码重置、角色分配、直接授权等管理动作。</p>
+            <h2>操作审计日志</h2>
+            <p>覆盖用户、角色、权限、会话等后台管理动作。按 occurred_at 倒序排序。</p>
           </div>
           <div class="admin-audit__pagination">
             <button class="admin-audit__button" type="button" :disabled="activityLoading || activityPage <= 1" @click="void loadActivityLogs(activityPage - 1)">
@@ -79,77 +89,49 @@
             <thead>
               <tr>
                 <th>时间</th>
+                <th>操作人</th>
                 <th>资源</th>
                 <th>动作</th>
                 <th>对象</th>
-                <th>摘要</th>
+                <th>请求信息</th>
+                <th>Meta 摘要</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="item in activityLogs" :key="item.id">
-                <td>{{ formatDate(item.created_at) }}</td>
-                <td>{{ item.resource_type || '--' }}</td>
-                <td>{{ item.action }}</td>
-                <td>{{ item.resource_id || '--' }}</td>
+                <td>{{ formatDate(item.occurred_at) }}</td>
                 <td>
-                  <div class="admin-audit__detail-line">{{ summarizeAction(item) }}</div>
-                  <small class="admin-audit__muted">{{ actorSummary(item) }}</small>
+                  <div>{{ item.actor_id || '—' }}</div>
+                  <small class="admin-audit__muted">{{ item.actor_type || '' }}</small>
+                </td>
+                <td>{{ item.resource_type || '—' }}</td>
+                <td>{{ item.action || '—' }}</td>
+                <td>{{ item.resource_id || '—' }}</td>
+                <td>
+                  <div class="admin-audit__detail-line">{{ item.ip || '—' }}</div>
+                  <small class="admin-audit__muted">{{ item.route || '' }}{{ item.status_code != null ? ` · ${item.status_code}` : '' }}</small>
+                </td>
+                <td>
+                  <div class="admin-audit__detail-line">{{ summarizeMeta(item) }}</div>
+                  <small v-if="item.request_id" class="admin-audit__muted">req: {{ item.request_id }}</small>
                 </td>
               </tr>
             </tbody>
           </table>
           <div v-else class="admin-audit__empty">
-            {{ activityLoading ? '正在加载日志...' : '暂无 IAM 管理日志。' }}
+            {{ activityLoading ? '正在加载日志...' : '暂无审计日志。' }}
           </div>
         </div>
       </section>
 
-      <section class="admin-audit__panel">
+      <section class="admin-audit__panel admin-audit__panel--placeholder">
         <div class="admin-audit__panel-head">
           <div>
             <h2>会话撤销记录</h2>
-            <p>记录强制下线、停用账号、重置密码触发的会话失效事件。</p>
-          </div>
-          <div class="admin-audit__pagination">
-            <button class="admin-audit__button" type="button" :disabled="revocationLoading || revocationPage <= 1" @click="void loadSessionRevocations(revocationPage - 1)">
-              上一页
-            </button>
-            <span>第 {{ revocationPage }} / {{ revocationTotalPages }} 页</span>
-            <button class="admin-audit__button" type="button" :disabled="revocationLoading || revocationPage >= revocationTotalPages" @click="void loadSessionRevocations(revocationPage + 1)">
-              下一页
-            </button>
+            <p>暂未提供后端数据源，将在后续版本接入 <code>/api/admin/session-revocations</code>。</p>
           </div>
         </div>
-
-        <div class="admin-audit__table-wrapper">
-          <table v-if="sessionRevocations.length" class="admin-audit__table">
-            <thead>
-              <tr>
-                <th>用户</th>
-                <th>原因</th>
-                <th>操作人</th>
-                <th>撤销时间</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="item in sessionRevocations" :key="`${item.user_id}-${item.updated_at}`">
-                <td>
-                  <div>{{ item.user_name || item.user_email || item.user_id }}</div>
-                  <small class="admin-audit__muted">{{ item.user_email || item.user_id }}</small>
-                </td>
-                <td>{{ item.reason || '--' }}</td>
-                <td>
-                  <div>{{ item.updated_by_name || item.updated_by_email || item.updated_by || '--' }}</div>
-                  <small class="admin-audit__muted">{{ item.updated_by_email || item.updated_by || '' }}</small>
-                </td>
-                <td>{{ formatDate(item.revoked_after) }}</td>
-              </tr>
-            </tbody>
-          </table>
-          <div v-else class="admin-audit__empty">
-            {{ revocationLoading ? '正在加载会话撤销记录...' : '暂无会话撤销记录。' }}
-          </div>
-        </div>
+        <div class="admin-audit__empty">当前版本使用 <code>/api/audit-logs</code> 的 <code>user-session</code> 资源条目作为替代，请在上方资源过滤中选择「用户会话」。</div>
       </section>
     </div>
   </section>
@@ -160,31 +142,20 @@ import { computed, onMounted, ref } from 'vue'
 import { apiFetch } from '../utils/api'
 
 type AdminAuditLogItem = {
-  id: number
-  created_at: string
-  event_type: string
-  event_category: string
-  event_severity: string
+  id: string
+  occurred_at: string
+  actor_id: string | null
+  actor_type: string | null
   action: string
   resource_type: string | null
   resource_id: string | null
-  user_id: number | null
-  user_name: string | null
-  user_email: string | null
-  action_details: Record<string, unknown> | null
-  error_code: string | null
-}
-
-type SessionRevocationItem = {
-  user_id: string
-  revoked_after: string
-  updated_at: string
-  updated_by: string | null
-  reason: string | null
-  user_email: string | null
-  user_name: string | null
-  updated_by_email: string | null
-  updated_by_name: string | null
+  request_id: string | null
+  ip: string | null
+  user_agent: string | null
+  meta: Record<string, unknown> | null
+  route: string | null
+  status_code: number | null
+  latency_ms: number | null
 }
 
 const resourceTypeOptions = [
@@ -199,25 +170,32 @@ const resourceTypeOptions = [
 ] as const
 
 const activityLoading = ref(false)
-const revocationLoading = ref(false)
 const exporting = ref(false)
 const status = ref('')
 const statusTone = ref<'info' | 'error'>('info')
-const search = ref('')
+const actorIdInput = ref('')
+const resourceIdInput = ref('')
 const resourceTypeFilter = ref('')
 const actionFilter = ref('')
 const fromDate = ref('')
 const toDate = ref('')
 const activityLogs = ref<AdminAuditLogItem[]>([])
-const sessionRevocations = ref<SessionRevocationItem[]>([])
 const activityPage = ref(1)
-const revocationPage = ref(1)
 const activityTotal = ref(0)
-const revocationTotal = ref(0)
 const pageSize = 20
 
 const activityTotalPages = computed(() => Math.max(1, Math.ceil(activityTotal.value / pageSize)))
-const revocationTotalPages = computed(() => Math.max(1, Math.ceil(revocationTotal.value / pageSize)))
+
+const activeFilterSummary = computed(() => {
+  const parts: string[] = []
+  if (actorIdInput.value) parts.push(`actor=${actorIdInput.value}`)
+  if (resourceIdInput.value) parts.push(`resourceId=${resourceIdInput.value}`)
+  if (resourceTypeFilter.value) parts.push(`resourceType=${resourceTypeFilter.value}`)
+  if (actionFilter.value) parts.push(`action=${actionFilter.value}`)
+  if (fromDate.value) parts.push(`from=${fromDate.value}`)
+  if (toDate.value) parts.push(`to=${toDate.value}`)
+  return parts.length ? parts.join(' · ') : '无（显示全部）'
+})
 
 function setStatus(message: string, tone: 'info' | 'error' = 'info'): void {
   status.value = message
@@ -233,14 +211,15 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
 }
 
 function formatDate(value: string | null | undefined): string {
-  if (!value) return '--'
+  if (!value) return '—'
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return `${date.toLocaleDateString('zh-CN')} ${date.toLocaleTimeString('zh-CN', { hour12: false })}`
 }
 
-function summarizeAction(item: AdminAuditLogItem): string {
-  const details = item.action_details || {}
+function summarizeMeta(item: AdminAuditLogItem): string {
+  const meta = item.meta || {}
+  if (!meta || typeof meta !== 'object') return '—'
   const pairs: string[] = []
   const append = (label: string, value: unknown) => {
     if (value == null) return
@@ -248,95 +227,90 @@ function summarizeAction(item: AdminAuditLogItem): string {
       if (value.length) pairs.push(`${label}: ${value.join(', ')}`)
       return
     }
-    if (typeof value === 'object') return
+    if (typeof value === 'object') {
+      try {
+        const text = JSON.stringify(value)
+        if (text && text !== '{}') pairs.push(`${label}: ${text}`)
+      } catch {
+        /* ignore */
+      }
+      return
+    }
     const text = String(value).trim()
     if (text) pairs.push(`${label}: ${text}`)
   }
 
-  append('邮箱', details.email)
-  append('姓名', details.name)
-  append('角色', details.roleId || details.role)
-  append('预设', details.presetId)
-  append('权限', details.permissions)
-  append('原因', details.reason)
-  append('临时密码', details.generatedPassword === true ? '系统生成' : undefined)
+  append('email', (meta as Record<string, unknown>).email)
+  append('name', (meta as Record<string, unknown>).name)
+  append('role', (meta as Record<string, unknown>).roleId || (meta as Record<string, unknown>).role)
+  append('preset', (meta as Record<string, unknown>).presetId)
+  append('permissions', (meta as Record<string, unknown>).permissions)
+  append('reason', (meta as Record<string, unknown>).reason)
 
-  const before = details.before
-  const after = details.after
-  if (before && after && typeof before === 'object' && typeof after === 'object') {
-    const beforeState = JSON.stringify(before)
-    const afterState = JSON.stringify(after)
-    if (beforeState !== afterState) {
-      pairs.push(`变更: ${beforeState} -> ${afterState}`)
+  const before = (meta as Record<string, unknown>).before
+  const after = (meta as Record<string, unknown>).after
+  if (before != null && after != null) {
+    try {
+      const beforeState = JSON.stringify(before)
+      const afterState = JSON.stringify(after)
+      if (beforeState !== afterState) {
+        pairs.push(`变更: ${beforeState} -> ${afterState}`)
+      }
+    } catch {
+      /* ignore */
     }
   }
 
-  return pairs.join(' · ') || '无补充摘要'
+  if (pairs.length) return pairs.join(' · ')
+
+  try {
+    const fallback = JSON.stringify(meta)
+    return fallback === '{}' ? '—' : fallback.slice(0, 280)
+  } catch {
+    return '—'
+  }
 }
 
-function actorSummary(item: AdminAuditLogItem): string {
-  const adminUserId = typeof item.action_details?.adminUserId === 'string' ? item.action_details.adminUserId : ''
-  if (item.user_email || item.user_name) {
-    return `${item.user_name || item.user_email}${adminUserId ? ` · ${adminUserId}` : ''}`
+function toIsoBound(value: string, endOfDay = false): string {
+  // value is a YYYY-MM-DD from <input type="date">
+  if (!value) return ''
+  if (endOfDay) return `${value}T23:59:59.999Z`
+  return `${value}T00:00:00.000Z`
+}
+
+function buildQueryParams(extra: Record<string, string> = {}): URLSearchParams {
+  const params = new URLSearchParams()
+  if (actorIdInput.value) params.set('actorId', actorIdInput.value)
+  if (resourceIdInput.value) params.set('resourceId', resourceIdInput.value)
+  if (resourceTypeFilter.value) params.set('resourceType', resourceTypeFilter.value)
+  if (actionFilter.value) params.set('action', actionFilter.value)
+  if (fromDate.value) params.set('from', toIsoBound(fromDate.value))
+  if (toDate.value) params.set('to', toIsoBound(toDate.value, true))
+  for (const [key, value] of Object.entries(extra)) {
+    params.set(key, value)
   }
-  return adminUserId ? `操作人：${adminUserId}` : '操作人未记录'
+  return params
 }
 
 async function loadActivityLogs(page = 1): Promise<void> {
   activityLoading.value = true
+  setStatus('')
   try {
-    const params = new URLSearchParams({
-      page: String(page),
-      pageSize: String(pageSize),
-    })
-    if (search.value) params.set('q', search.value)
-    if (resourceTypeFilter.value) params.set('resourceType', resourceTypeFilter.value)
-    if (actionFilter.value) params.set('action', actionFilter.value)
-    if (fromDate.value) params.set('from', fromDate.value)
-    if (toDate.value) params.set('to', toDate.value)
-
-    const response = await apiFetch(`/api/admin/audit-activity?${params.toString()}`)
+    const params = buildQueryParams({ page: String(page), pageSize: String(pageSize) })
+    const response = await apiFetch(`/api/audit-logs?${params.toString()}`)
     const payload = await readJson(response)
     if (!response.ok || payload.ok !== true) {
-      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '加载管理审计失败'))
+      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '加载审计日志失败'))
     }
 
     const data = payload.data as { items?: AdminAuditLogItem[]; total?: number; page?: number } | undefined
-    activityLogs.value = Array.isArray(data?.items) ? data.items : []
+    activityLogs.value = Array.isArray(data?.items) ? data!.items! : []
     activityTotal.value = Number(data?.total ?? activityLogs.value.length) || 0
     activityPage.value = Number(data?.page ?? page) || page
   } catch (error) {
-    setStatus(error instanceof Error ? error.message : '加载管理审计失败', 'error')
+    setStatus(error instanceof Error ? error.message : '加载审计日志失败', 'error')
   } finally {
     activityLoading.value = false
-  }
-}
-
-async function loadSessionRevocations(page = 1): Promise<void> {
-  revocationLoading.value = true
-  try {
-    const params = new URLSearchParams({
-      page: String(page),
-      pageSize: String(pageSize),
-    })
-    if (search.value) params.set('q', search.value)
-    if (fromDate.value) params.set('from', fromDate.value)
-    if (toDate.value) params.set('to', toDate.value)
-
-    const response = await apiFetch(`/api/admin/session-revocations?${params.toString()}`)
-    const payload = await readJson(response)
-    if (!response.ok || payload.ok !== true) {
-      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '加载会话撤销记录失败'))
-    }
-
-    const data = payload.data as { items?: SessionRevocationItem[]; total?: number; page?: number } | undefined
-    sessionRevocations.value = Array.isArray(data?.items) ? data.items : []
-    revocationTotal.value = Number(data?.total ?? sessionRevocations.value.length) || 0
-    revocationPage.value = Number(data?.page ?? page) || page
-  } catch (error) {
-    setStatus(error instanceof Error ? error.message : '加载会话撤销记录失败', 'error')
-  } finally {
-    revocationLoading.value = false
   }
 }
 
@@ -354,41 +328,33 @@ function downloadBlob(filename: string, blob: Blob): void {
 function resolveExportFilename(response: Response): string {
   const disposition = response.headers.get('content-disposition') || ''
   const match = disposition.match(/filename="([^"]+)"/i)
-  return match?.[1] || 'iam-admin-audit.csv'
+  return match?.[1] || 'audit-logs.csv'
 }
 
 async function exportActivityCsv(): Promise<void> {
   exporting.value = true
   try {
-    const params = new URLSearchParams({ limit: '5000' })
-    if (search.value) params.set('q', search.value)
-    if (resourceTypeFilter.value) params.set('resourceType', resourceTypeFilter.value)
-    if (actionFilter.value) params.set('action', actionFilter.value)
-    if (fromDate.value) params.set('from', fromDate.value)
-    if (toDate.value) params.set('to', toDate.value)
-
-    const response = await apiFetch(`/api/admin/audit-activity/export.csv?${params.toString()}`)
+    const params = buildQueryParams({ format: 'csv', limit: '100000' })
+    const response = await apiFetch(`/api/audit-logs?${params.toString()}`, {
+      method: 'GET',
+      headers: { Accept: 'text/csv' },
+    })
     if (!response.ok) {
       const payload = await readJson(response)
-      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '导出管理审计失败'))
+      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '导出审计日志失败'))
     }
 
     downloadBlob(resolveExportFilename(response), await response.blob())
-    setStatus('管理审计 CSV 已导出')
+    setStatus('审计日志 CSV 已导出')
   } catch (error) {
-    setStatus(error instanceof Error ? error.message : '导出管理审计失败', 'error')
+    setStatus(error instanceof Error ? error.message : '导出审计日志失败', 'error')
   } finally {
     exporting.value = false
   }
 }
 
-async function reloadAll(): Promise<void> {
-  setStatus('')
-  await Promise.all([loadActivityLogs(1), loadSessionRevocations(1)])
-}
-
 onMounted(() => {
-  void reloadAll()
+  void loadActivityLogs(1)
 })
 </script>
 
@@ -476,10 +442,19 @@ onMounted(() => {
   gap: 16px;
 }
 
+.admin-audit__layout--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .admin-audit__panel {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.admin-audit__panel--placeholder {
+  background: #f8fafc;
+  border-style: dashed;
 }
 
 .admin-audit__panel-head,

--- a/apps/web/tests/adminAuditView.spec.ts
+++ b/apps/web/tests/adminAuditView.spec.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import AdminAuditView from '../src/views/AdminAuditView.vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function createJsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+    blob: async () => new Blob([''], { type: 'text/csv' }),
+    headers: {
+      get: (name: string) => {
+        if (name.toLowerCase() === 'content-disposition') return 'attachment; filename="audit-logs.csv"'
+        return null
+      },
+    },
+  }
+}
+
+function registerRouterLink(app: App<Element>): void {
+  app.component('RouterLink', {
+    props: ['to'],
+    template: '<a><slot /></a>',
+  })
+}
+
+function createLogItem(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'log-1',
+    occurred_at: '2026-04-08T01:00:00.000Z',
+    actor_id: 'actor-42',
+    actor_type: 'admin',
+    action: 'grant',
+    resource_type: 'user-role',
+    resource_id: 'user-100',
+    request_id: 'req-abc',
+    ip: '10.0.0.42',
+    user_agent: 'Mozilla/5.0',
+    meta: { roleId: 'role-1', reason: '上岗授权' },
+    route: 'POST /api/admin/user-roles',
+    status_code: 200,
+    latency_ms: 42,
+    ...overrides,
+  }
+}
+
+function createListPayload(items: unknown[], overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    data: {
+      items,
+      total: items.length,
+      page: 1,
+      pageSize: 20,
+      ...overrides,
+    },
+  }
+}
+
+function findButtonByText(container: HTMLElement, text: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes(text)) as HTMLButtonElement | undefined
+}
+
+function getLastFetchUrl(): string {
+  const calls = apiFetchMock.mock.calls
+  const last = calls[calls.length - 1]
+  return typeof last?.[0] === 'string' ? String(last[0]) : ''
+}
+
+describe('AdminAuditView', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+  const originalCreateObjectURL = globalThis.URL.createObjectURL
+  const originalRevokeObjectURL = globalThis.URL.revokeObjectURL
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    globalThis.URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    globalThis.URL.createObjectURL = originalCreateObjectURL
+    globalThis.URL.revokeObjectURL = originalRevokeObjectURL
+  })
+
+  it('loads audit logs from /api/audit-logs on mount', async () => {
+    apiFetchMock.mockResolvedValueOnce(createJsonResponse(createListPayload([
+      createLogItem({ action: 'create', resource_type: 'user', resource_id: 'user-100', actor_id: 'admin-1' }),
+      createLogItem({ id: 'log-2', action: 'revoke', resource_type: 'user-session', resource_id: 'user-200', actor_id: 'admin-2' }),
+    ], { total: 2 })))
+
+    app = createApp(AdminAuditView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    const url = String(apiFetchMock.mock.calls[0]?.[0] || '')
+    expect(url.startsWith('/api/audit-logs?')).toBe(true)
+    expect(url).toContain('page=1')
+    expect(url).toContain('pageSize=20')
+
+    expect(container?.textContent).toContain('操作审计日志')
+    expect(container?.textContent).toContain('admin-1')
+    expect(container?.textContent).toContain('create')
+    expect(container?.textContent).toContain('user-100')
+    expect(container?.textContent).toContain('user-session')
+    // session revocation placeholder is rendered (no network call)
+    expect(container?.textContent).toContain('暂未提供后端数据源')
+  })
+
+  it('renders empty state when the API returns no items', async () => {
+    apiFetchMock.mockResolvedValueOnce(createJsonResponse(createListPayload([], { total: 0 })))
+
+    app = createApp(AdminAuditView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('暂无审计日志')
+  })
+
+  it('rebuilds the query string when resource/action/date filters are applied', async () => {
+    apiFetchMock.mockResolvedValue(createJsonResponse(createListPayload([createLogItem()], { total: 1 })))
+
+    app = createApp(AdminAuditView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    // Initial mount call happened; now set filters and click 刷新.
+    const resourceSelect = container?.querySelectorAll('select')[0] as HTMLSelectElement
+    const actionSelect = container?.querySelectorAll('select')[1] as HTMLSelectElement
+    const dateInputs = container?.querySelectorAll('input[type="date"]') as NodeListOf<HTMLInputElement>
+    const actorInput = container?.querySelectorAll('input[type="search"]')[1] as HTMLInputElement
+
+    resourceSelect.value = 'user-role'
+    resourceSelect.dispatchEvent(new Event('change'))
+    actionSelect.value = 'grant'
+    actionSelect.dispatchEvent(new Event('change'))
+    dateInputs[0].value = '2026-04-01'
+    dateInputs[0].dispatchEvent(new Event('input'))
+    dateInputs[1].value = '2026-04-15'
+    dateInputs[1].dispatchEvent(new Event('input'))
+    actorInput.value = 'admin-42'
+    actorInput.dispatchEvent(new Event('input'))
+    await flushUi(2)
+
+    const refreshBtn = findButtonByText(container!, '刷新')
+    expect(refreshBtn).toBeTruthy()
+    refreshBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    const url = getLastFetchUrl()
+    expect(url.startsWith('/api/audit-logs?')).toBe(true)
+    expect(url).toContain('resourceType=user-role')
+    expect(url).toContain('action=grant')
+    expect(url).toContain('actorId=admin-42')
+    // Date inputs are translated to ISO 8601 bounds
+    expect(url).toContain('from=2026-04-01T00%3A00%3A00.000Z')
+    expect(url).toContain('to=2026-04-15T23%3A59%3A59.999Z')
+    // Pagination always resets to page=1 on refresh
+    expect(url).toContain('page=1')
+  })
+
+  it('advances page when 下一页 is clicked', async () => {
+    // Total 60 items -> 3 pages of 20.
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse(createListPayload([createLogItem()], { total: 60 })))
+      .mockResolvedValueOnce(createJsonResponse(createListPayload([createLogItem({ id: 'log-page-2' })], { total: 60, page: 2 })))
+
+    app = createApp(AdminAuditView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('第 1 / 3 页')
+
+    const next = findButtonByText(container!, '下一页')
+    expect(next).toBeTruthy()
+    next?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    const url = getLastFetchUrl()
+    expect(url).toContain('page=2')
+    expect(container?.textContent).toContain('第 2 / 3 页')
+  })
+
+  it('hits the CSV export endpoint with format=csv and filter params', async () => {
+    apiFetchMock
+      // Initial load
+      .mockResolvedValueOnce(createJsonResponse(createListPayload([createLogItem()], { total: 1 })))
+      // CSV export call
+      .mockResolvedValueOnce(createJsonResponse('id,occurred_at\nlog-1,2026-04-08T01:00:00.000Z\n'))
+
+    app = createApp(AdminAuditView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    // Apply a resource filter so it must propagate to the export URL.
+    const resourceSelect = container?.querySelectorAll('select')[0] as HTMLSelectElement
+    resourceSelect.value = 'user'
+    resourceSelect.dispatchEvent(new Event('change'))
+    await flushUi(2)
+
+    const exportBtn = findButtonByText(container!, '导出 CSV')
+    expect(exportBtn).toBeTruthy()
+    exportBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    // Last call should be the CSV export
+    const url = getLastFetchUrl()
+    expect(url.startsWith('/api/audit-logs?')).toBe(true)
+    expect(url).toContain('format=csv')
+    expect(url).toContain('limit=100000')
+    expect(url).toContain('resourceType=user')
+    const options = apiFetchMock.mock.calls[apiFetchMock.mock.calls.length - 1]?.[1] as Record<string, unknown> | undefined
+    expect(options?.method).toBe('GET')
+
+    expect(container?.textContent).toContain('审计日志 CSV 已导出')
+  })
+})

--- a/docs/development/audit-log-ui-frontend-development-20260420.md
+++ b/docs/development/audit-log-ui-frontend-development-20260420.md
@@ -1,0 +1,167 @@
+# Audit Log UI · Frontend Rewire to `/api/audit-logs` — Development Notes (20260420)
+
+## Background
+
+`AdminAuditView.vue` was previously wired to three admin endpoints that never
+shipped:
+
+- `GET /api/admin/audit-activity`
+- `GET /api/admin/audit-activity/export.csv`
+- `GET /api/admin/session-revocations`
+
+The only backend audit endpoint that actually exists is
+`GET /api/audit-logs` (mounted from `packages/core-backend/src/routes/audit-logs.ts`,
+RBAC guarded by `rbacGuard('audit', 'read')`). That endpoint reads the
+`operation_audit_logs` table directly and also supports `?format=csv` for
+export. No backend changes were in scope — this slice is pure frontend.
+
+## Scope
+
+1. Rewire the admin audit page to `GET /api/audit-logs` (JSON + CSV).
+2. Preserve the existing filter/pagination/export UX, redesigning around the
+   fields the backend actually returns.
+3. Replace the broken session-revocations panel with a documented placeholder.
+4. Add vitest coverage for list / filter / pagination / export / empty state.
+
+## Backend response shape (verified)
+
+`GET /api/audit-logs`
+
+Query params accepted (validated with `zod`):
+
+| Param          | Notes                                                           |
+|----------------|-----------------------------------------------------------------|
+| `actorId`      | exact match on `actor_id`                                       |
+| `resourceType` | exact match on `resource_type`                                  |
+| `resourceId`   | exact match on `resource_id`                                    |
+| `action`       | exact match on `action`                                         |
+| `from` / `to`  | ISO-8601 datetime (strict). Must include time component.        |
+| `page`         | stringified positive int, default `1`                           |
+| `pageSize`     | stringified positive int, default `50`, max `500`               |
+| `format`       | `csv` or `ndjson` (switches the endpoint into streaming mode)   |
+| `limit`        | export row cap, default `10000`, max `100000`                   |
+
+JSON response (non-export) — row columns:
+
+```
+{ id, occurred_at, actor_id, actor_type, action,
+  resource_type, resource_id, request_id, ip, user_agent, meta }
+```
+
+The migration `20250926_create_operation_audit_logs.ts` defines `id` as `uuid`
+(string), so the frontend type uses `string`.
+
+## Param translation decisions
+
+The previous view had 5 filter inputs: a free-text `q`, a resource type, an
+action, a `from` date and a `to` date.
+
+| Old UI                                   | New UI                                                                                  |
+|------------------------------------------|------------------------------------------------------------------------------------------|
+| Free-text `q`                            | Removed. Replaced with two exact-match search boxes: `resource_id` and `actor_id`.      |
+| `resourceType` select                    | Unchanged (same param name on backend).                                                 |
+| `action` select                          | Unchanged, plus added `delete` option to match typical CRUD audit rows.                 |
+| `from=YYYY-MM-DD`                        | Converted to `${value}T00:00:00.000Z` before sending (backend expects strict ISO).      |
+| `to=YYYY-MM-DD`                          | Converted to `${value}T23:59:59.999Z` (inclusive end-of-day, matches backend `<=`).      |
+| `page`/`pageSize`                        | Unchanged (page size fixed at 20).                                                      |
+
+Rationale for dropping `q`: the backend has no full-text column and would 400
+with a stray param. The task suggested "map to actorId when it looks like an
+id", but a brittle regex would frequently misroute. Two clear exact-match
+inputs are easier for admins to reason about.
+
+## UI changes
+
+### Table columns
+
+Old table (IAM activity panel) had 5 columns driven by the legacy
+`action_details` JSON shape. New table has 7 columns driven by the actual
+`operation_audit_logs` columns:
+
+| Column         | Source                                                 | Fallback |
+|----------------|--------------------------------------------------------|----------|
+| 时间            | `occurred_at`                                          | —        |
+| 操作人          | `actor_id` + `actor_type` (subline)                    | —        |
+| 资源            | `resource_type`                                        | —        |
+| 动作            | `action`                                               | —        |
+| 对象            | `resource_id`                                          | —        |
+| 请求信息        | `ip` + `route`/`status_code` subline                   | —        |
+| Meta 摘要       | `meta` JSON pruned via `summarizeMeta()`               | —        |
+
+The `summarizeMeta()` helper still prefers human-readable keys
+(`email/name/role/preset/permissions/reason/before→after`) but now falls back
+to a truncated JSON string so new `meta` keys are visible without code changes.
+
+### Session revocations panel
+
+Rendered as a placeholder panel titled
+*"会话撤销记录 — 暂未提供后端数据源，将在后续版本接入"* with a hint pointing
+admins to the `user-session` filter on the primary audit table. No network
+call is made.
+
+### Layout
+
+Changed from the old `1.3fr : 1fr` two-column layout to a single responsive
+column (`admin-audit__layout--single`), since the second column is now just
+an informational placeholder.
+
+### CSV export
+
+Retained the existing `apiFetch → Blob → object URL → anchor download`
+pattern. A raw `<a href>` / `window.open` would drop the `Authorization`
+header injected by `apiFetch`, breaking bearer-token authentication.
+
+The export URL is:
+`/api/audit-logs?format=csv&limit=100000&<filter params>`
+
+## Type mapping
+
+New frontend type (co-located in the view, not extracted):
+
+```ts
+type AdminAuditLogItem = {
+  id: string
+  occurred_at: string
+  actor_id: string | null
+  actor_type: string | null
+  action: string
+  resource_type: string | null
+  resource_id: string | null
+  request_id: string | null
+  ip: string | null
+  user_agent: string | null
+  meta: Record<string, unknown> | null
+  route: string | null
+  status_code: number | null
+  latency_ms: number | null
+}
+```
+
+`route`, `status_code`, `latency_ms` are declared on the type because the
+migration schema includes them and the frontend renders `route` + `status_code`;
+they may arrive `null` from the backend query (the current SELECT doesn't
+return them, but the shape allows it).
+
+## Tests
+
+New spec: `apps/web/tests/adminAuditView.spec.ts` — 5 focused cases.
+
+1. Initial mount → single `GET /api/audit-logs?page=1&pageSize=20` call; rows render; placeholder panel visible.
+2. Empty state renders "暂无审计日志" when `items: []`.
+3. Changing `resourceType` + `action` + both dates + `actorId` input, then clicking 刷新, issues a new fetch with ISO-bounded `from`/`to`, correct resource/action/actor params, and `page=1`.
+4. Clicking 下一页 issues a new fetch with `page=2` and the pager text updates to "第 2 / 3 页".
+5. Clicking 导出 CSV issues a `GET /api/audit-logs?...&format=csv&limit=100000&...` request (preserving filters), URL.createObjectURL is invoked, and a success status is shown.
+
+## Files touched
+
+- `apps/web/src/views/AdminAuditView.vue` — rewritten
+- `apps/web/tests/adminAuditView.spec.ts` — new
+
+## Non-goals / follow-ups
+
+- A dedicated session-revocations endpoint is still required for the
+  placeholder panel to come back online.
+- A future iteration could add server-side `q` search if the backend gains
+  a `pg_trgm` index on `meta::text`.
+- The existing RBAC guard is `audit:read` only; admins who can't pass that
+  guard will see the usual 403 redirect path provided by `apiFetch`.

--- a/docs/development/audit-log-ui-frontend-verification-20260420.md
+++ b/docs/development/audit-log-ui-frontend-verification-20260420.md
@@ -1,0 +1,76 @@
+# Audit Log UI · Frontend Rewire — Verification (20260420)
+
+Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/audit-ui`
+Branch: `codex/audit-log-ui-frontend-202605` (based on `origin/main` `0756ff61d`)
+
+## Commands executed
+
+```bash
+cd /Users/chouhua/Downloads/Github/metasheet2/.worktrees/audit-ui
+
+# 1. Install dependencies
+pnpm install
+# -> Done in 2.9s (pnpm v10.33.0, ignored build scripts as usual)
+
+# 2. Frontend typecheck (strict Vue SFC check)
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+# -> clean (no output / exit 0)
+
+# 3. New spec
+pnpm --filter @metasheet/web exec vitest run tests/adminAuditView.spec.ts --reporter=dot
+# -> Test Files  1 passed (1)
+# -> Tests       5 passed (5)
+
+# 4. Neighbour admin view regression
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --reporter=dot
+# -> Test Files  1 passed (1)
+# -> Tests       33 passed (33)
+```
+
+## Test inventory (`tests/adminAuditView.spec.ts`)
+
+| # | Scenario                                         | Coverage                                                                                                      |
+|---|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| 1 | Loads audit logs on mount                         | URL starts with `/api/audit-logs?`, includes `page=1&pageSize=20`; table renders actor/action/resource cells. |
+| 2 | Empty state                                       | `items: []` payload renders "暂无审计日志".                                                                   |
+| 3 | Filter propagation + ISO date bounding            | `resourceType`, `action`, `actorId`, `from=…T00:00:00.000Z`, `to=…T23:59:59.999Z`, `page=1` on 刷新 click.    |
+| 4 | Pagination                                        | 下一页 click issues `page=2` fetch and pager text updates to "第 2 / 3 页".                                 |
+| 5 | CSV export                                        | Button triggers `GET /api/audit-logs?…&format=csv&limit=100000` with filters; success status visible.         |
+
+## Manual smoke notes
+
+No manual browser smoke performed (pure-frontend slice, unit tests cover the
+surface). The rewire is strictly additive from the backend's POV — the old
+routes never existed, so the "before" state was 404 across the board.
+
+### Observed stderr
+
+Vitest reports `Not implemented: navigation to another Document` once during
+the spec run. This comes from the JSDOM environment's reaction to the
+synthetic `<a>.click()` inside `downloadBlob()`. It does not fail the test
+because we mock `URL.createObjectURL`, and it's the same diagnostic already
+printed by the neighbouring `directoryManagementView` spec suite.
+
+## Screenshots
+
+Skipped — out of scope for a frontend rewire that leaves the visual skeleton
+substantially unchanged (header, summary cards, single table, placeholder
+panel).
+
+## Non-test checks performed
+
+- Confirmed `operation_audit_logs.id` is a `uuid` (see
+  `packages/core-backend/src/db/migrations/20250926_create_operation_audit_logs.ts`)
+  and updated `AdminAuditLogItem.id` to `string`.
+- Confirmed auth handling: `apiFetch` injects `Authorization: Bearer ...` from
+  `localStorage`. A raw `<a href>` or `window.open` would drop it. Kept the
+  existing `apiFetch → blob → object URL` download path.
+- Confirmed `z.string().datetime()` on the backend rejects `YYYY-MM-DD` — the
+  new view converts `<input type="date">` values to strict ISO-8601 datetimes
+  before appending them to the query string.
+
+## Outstanding
+
+- Session revocations panel is a placeholder until a backend endpoint ships.
+- No broader `pnpm test` run was done (per task scope: new spec + one
+  neighbour regression).

--- a/docs/development/audit-log-ui-frontend-verification-20260420.md
+++ b/docs/development/audit-log-ui-frontend-verification-20260420.md
@@ -122,7 +122,7 @@ pnpm --filter @metasheet/web exec vitest run \
 
 After the DingTalk/Yjs queue landed, this branch was advanced again from `origin/main@c4093dcb8` to `origin/main@81edca7d9`. Rebase used `git rebase --autostash origin/main`, preserved the verification MD changes, and completed with no conflicts.
 
-Post-latest-main HEAD: `2efddecea`.
+Post-latest-main feature HEAD before this verification doc commit: `2efddecea`.
 
 ### Commands run (2026-04-21, .worktrees/audit-ui)
 

--- a/docs/development/audit-log-ui-frontend-verification-20260420.md
+++ b/docs/development/audit-log-ui-frontend-verification-20260420.md
@@ -74,3 +74,76 @@ panel).
 - Session revocations panel is a placeholder until a backend endpoint ships.
 - No broader `pnpm test` run was done (per task scope: new spec + one
   neighbour regression).
+
+---
+
+## Rebase verification — 2026-04-21
+
+Branch rebased from base `0756ff61d` onto latest `origin/main@c4093dcb8` (+21 commits upstream, no business-file overlap with this branch). Rebase was pure fast-forward with no merge conflict; business diff unchanged (4 files, +635 / −174).
+
+Post-rebase HEAD: `be2553690`.
+
+### Commands run (2026-04-21, .worktrees/audit-ui)
+
+```bash
+git -C .worktrees/audit-ui checkout -- plugins/ tools/   # clean dirty pnpm symlinks
+git -C .worktrees/audit-ui fetch origin main
+git -C .worktrees/audit-ui rebase origin/main             # no conflicts
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/adminAuditView.spec.ts \
+  tests/directoryManagementView.spec.ts --reporter=dot
+```
+
+### Results
+
+| Step | Outcome | Counts |
+| ---- | ------- | ------ |
+| vue-tsc --noEmit | PASS | zero diagnostics |
+| adminAuditView.spec.ts (new) | PASS | 5/5 |
+| directoryManagementView.spec.ts (neighbour regression) | PASS | 33/33 |
+| Total spec | PASS | 38/38 |
+
+### Baseline
+
+| Field | Value |
+| ----- | ----- |
+| Original base commit | `0756ff61d` |
+| Rebase target | `c4093dcb8` (origin/main, +21 commits) |
+| New branch HEAD | `be2553690` |
+| Upstream business-file overlap | none |
+| Rebase conflicts | none |
+
+---
+
+## Latest-main verification — 2026-04-21
+
+After the DingTalk/Yjs queue landed, this branch was advanced again from `origin/main@c4093dcb8` to `origin/main@81edca7d9`. Rebase used `git rebase --autostash origin/main`, preserved the verification MD changes, and completed with no conflicts.
+
+Post-latest-main HEAD: `2efddecea`.
+
+### Commands run (2026-04-21, .worktrees/audit-ui)
+
+```bash
+git -C .worktrees/audit-ui rebase --autostash origin/main
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/adminAuditView.spec.ts \
+  tests/directoryManagementView.spec.ts --reporter=dot
+```
+
+### Results
+
+| Step | Outcome | Counts |
+| ---- | ------- | ------ |
+| Rebase onto `81edca7d9` | PASS | zero conflicts |
+| vue-tsc --noEmit | PASS | zero diagnostics |
+| adminAuditView.spec.ts (new) | PASS | 5/5 |
+| directoryManagementView.spec.ts (neighbour regression) | PASS | 33/33 |
+| Total spec | PASS | 38/38 |
+
+Vitest still prints the known JSDOM diagnostic `Not implemented: navigation to another Document` for the synthetic download click. It is non-fatal and unchanged from the earlier run.


### PR DESCRIPTION
## Summary

- Wires `AdminAuditView` to the real `/api/audit-logs` backend endpoint.
- Adds typed audit-log response handling, ISO datetime filter normalization, pagination, empty-state handling, and authenticated CSV export.
- Adds focused frontend coverage for load, empty state, filters, pagination, and CSV export.

## Verification

Latest-main verification on `origin/main@81edca7d9`:

```bash
git -C .worktrees/audit-ui rebase --autostash origin/main
pnpm --filter @metasheet/web exec vue-tsc --noEmit
pnpm --filter @metasheet/web exec vitest run \
  tests/adminAuditView.spec.ts \
  tests/directoryManagementView.spec.ts --reporter=dot
```

Results:

- `vue-tsc --noEmit`: PASS, zero diagnostics
- `adminAuditView.spec.ts`: PASS, 5/5
- `directoryManagementView.spec.ts`: PASS, 33/33
- Total focused specs: PASS, 38/38

Verification MD: `docs/development/audit-log-ui-frontend-verification-20260420.md`.

## Notes

Vitest still prints the known JSDOM diagnostic `Not implemented: navigation to another Document` for the synthetic download click. It is non-fatal and unchanged from the neighbouring regression suite.
