### PR TITLE
feat(approval): wire any-mode aggregation runtime

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -106,6 +106,9 @@ function mockVersionDetail(templateId: string, versionId: string): ApprovalTempl
 function mockApproval(index: number): UnifiedApprovalDTO {
   const statuses: ApprovalStatus[] = ['pending', 'approved', 'rejected', 'revoked', 'cancelled']
   const status = statuses[index % statuses.length]
+  // Surface an any-mode fixture on a stable slot so dev-mode always exercises the UI branch.
+  const isAnyModeFixture = index % 5 === 1
+  const baseAssignmentNodeKey = isAnyModeFixture ? 'approval_any' : 'approval_1'
   return {
     id: `apv_${index}`,
     sourceSystem: 'platform',
@@ -124,22 +127,49 @@ function mockApproval(index: number): UnifiedApprovalDTO {
     publishedDefinitionId: 'def_1',
     requestNo: `AP-${String(100000 + index)}`,
     formSnapshot: { fld_reason: '出差报销', fld_amount: 5000, fld_type: 'reimbursement' },
-    currentNodeKey: status === 'pending' ? 'approval_1' : null,
-    assignments: status === 'pending' ? [{
-      id: `asgn_${index}`,
-      type: 'approval',
-      assigneeId: 'user_current',
-      sourceStep: 1,
-      nodeKey: 'approval_1',
-      isActive: true,
-      metadata: {},
-    }] : [],
+    currentNodeKey: status === 'pending' ? baseAssignmentNodeKey : null,
+    assignments: status === 'pending'
+      ? (isAnyModeFixture
+        ? [
+          {
+            id: `asgn_${index}_a`,
+            type: 'approval',
+            assigneeId: 'user_current',
+            sourceStep: 1,
+            nodeKey: baseAssignmentNodeKey,
+            isActive: true,
+            metadata: {},
+          },
+          {
+            id: `asgn_${index}_b`,
+            type: 'approval',
+            assigneeId: 'user_other',
+            sourceStep: 1,
+            nodeKey: baseAssignmentNodeKey,
+            isActive: true,
+            metadata: {},
+          },
+        ]
+        : [
+          {
+            id: `asgn_${index}`,
+            type: 'approval',
+            assigneeId: 'user_current',
+            sourceStep: 1,
+            nodeKey: baseAssignmentNodeKey,
+            isActive: true,
+            metadata: {},
+          },
+        ])
+      : [],
     createdAt: new Date(Date.now() - index * 86400000).toISOString(),
     updatedAt: new Date(Date.now() - index * 3600000).toISOString(),
   }
 }
 
 function mockHistory(approvalId: string): UnifiedApprovalHistoryDTO[] {
+  // Dev-mode fixture: preserve the existing workflow story then append an any-mode (或签)
+  // completion event so the timeline exercises the first-wins aggregateCancelled path.
   return [
     {
       id: 'hist_1',
@@ -195,6 +225,39 @@ function mockHistory(approvalId: string): UnifiedApprovalHistoryDTO[] {
       toStatus: 'approved',
       occurredAt: new Date().toISOString(),
       metadata: { nodeKey: 'approval_1' },
+    },
+    {
+      id: 'hist_6',
+      action: 'approve',
+      actorId: 'user_7',
+      actorName: '赵六',
+      comment: '先行审批',
+      fromStatus: 'pending',
+      toStatus: 'approved',
+      occurredAt: new Date().toISOString(),
+      metadata: {
+        nodeKey: 'approval_any',
+        approvalMode: 'any',
+        aggregateComplete: true,
+        aggregateCancelled: ['user_8'],
+      },
+    },
+    {
+      id: 'hist_7',
+      action: 'sign',
+      actorId: 'system',
+      actorName: '系统',
+      comment: null,
+      fromStatus: 'pending',
+      toStatus: 'approved',
+      occurredAt: new Date().toISOString(),
+      metadata: {
+        nodeKey: 'approval_any',
+        autoCancelled: true,
+        aggregateMode: 'any',
+        aggregateCancelledBy: 'user_7',
+        cancelledAssignees: ['user_8'],
+      },
     },
   ]
 }

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -103,8 +103,17 @@
                   <span v-if="item.metadata?.approvalMode" class="approval-detail__meta-badge">
                     审批模式: {{ approvalModeLabel(item.metadata.approvalMode as string) }}
                   </span>
-                  <span v-if="item.metadata?.aggregateComplete" class="approval-detail__meta-badge approval-detail__meta-badge--complete">
+                  <span v-if="item.metadata?.aggregateComplete && item.metadata?.approvalMode === 'all'" class="approval-detail__meta-badge approval-detail__meta-badge--complete">
                     会签完成
+                  </span>
+                  <span v-if="item.metadata?.aggregateComplete && item.metadata?.approvalMode === 'any'" class="approval-detail__meta-badge approval-detail__meta-badge--complete">
+                    或签完成
+                  </span>
+                  <span v-if="cancelledAssigneesLabel(item.metadata)" class="approval-detail__meta-badge approval-detail__meta-badge--cancelled">
+                    {{ cancelledAssigneesLabel(item.metadata) }}
+                  </span>
+                  <span v-if="item.action === 'sign' && item.metadata?.autoCancelled" class="approval-detail__meta-badge approval-detail__meta-badge--cancelled">
+                    （已被 {{ item.metadata?.aggregateCancelledBy || '发起人' }} 的决定覆盖）
                   </span>
                   <span v-if="item.action === 'return' && item.metadata?.targetNodeKey" class="approval-detail__meta-badge approval-detail__meta-badge--return">
                     退回至: {{ nodeLabel(item.metadata.targetNodeKey as string) }}
@@ -392,6 +401,7 @@ function statusLabel(status: string) {
 
 function actionLabel(action: string, metadata?: Record<string, unknown>) {
   if (action === 'approve' && metadata?.autoApproved) return '自动通过'
+  if (action === 'sign' && metadata?.autoCancelled) return '自动失效'
   const map: Record<string, string> = {
     created: '发起',
     approve: '通过',
@@ -400,6 +410,7 @@ function actionLabel(action: string, metadata?: Record<string, unknown>) {
     revoke: '撤回',
     comment: '评论',
     return: '退回',
+    sign: '签字',
   }
   return map[action] ?? action
 }
@@ -436,12 +447,33 @@ function timelineIcon(action: string, metadata?: Record<string, unknown>) {
 
 function hasTimelineMetadata(metadata?: Record<string, unknown>): boolean {
   if (!metadata) return false
-  return !!(metadata.autoApproved || metadata.approvalMode || metadata.aggregateComplete || metadata.nodeKey || metadata.targetNodeKey)
+  return !!(
+    metadata.autoApproved
+    || metadata.approvalMode
+    || metadata.aggregateComplete
+    || metadata.aggregateCancelled
+    || metadata.autoCancelled
+    || metadata.aggregateCancelledBy
+    || metadata.nodeKey
+    || metadata.targetNodeKey
+  )
 }
 
 function approvalModeLabel(mode: string): string {
   const map: Record<string, string> = { single: '单人', all: '会签', any: '或签' }
   return map[mode] ?? mode
+}
+
+/**
+ * Builds a muted note listing sibling approvers whose active assignments were cancelled by
+ * an any-mode (或签) first-wins resolution. Returns empty string when metadata carries no
+ * aggregateCancelled list or when the list is empty — callers `v-if` on the truthy string.
+ */
+function cancelledAssigneesLabel(metadata?: Record<string, unknown>): string {
+  if (!metadata) return ''
+  const cancelled = metadata.aggregateCancelled
+  if (!Array.isArray(cancelled) || cancelled.length === 0) return ''
+  return `其他审批人已失效: ${cancelled.map((id) => String(id)).join(', ')}`
 }
 
 function nodeLabel(nodeKey: string): string {

--- a/docs/development/approval-wave2-wp1-runtime-development-20260420.md
+++ b/docs/development/approval-wave2-wp1-runtime-development-20260420.md
@@ -1,0 +1,175 @@
+# Approval Wave 2 WP1 - Any-mode (或签) Runtime Wiring
+
+- Date: 2026-04-20
+- Branch: `codex/approval-wave2-wp1-runtime-202605`
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/wp1`
+- Base: `origin/main` @ `0756ff61d`
+
+## Scope
+
+Deliver end-to-end `approvalMode='any'` (或签 / first-wins aggregation) on top of Pack 1A.
+Pack 1A already shipped `'all'` (会签), `targetNodeKey` return, empty-assignee `auto-approve`,
+and the `aggregateComplete` metadata flag. The `'any'` literal was present in the
+`ApprovalMode` union but the route handler's approve path fell through to the generic
+"deactivate all, resolve next node" branch, which worked visibly but left no audit trail
+for sibling cancellations and did not surface the aggregation mode to downstream consumers.
+
+## Design decisions
+
+### Who owns `aggregateCancelled`?
+
+The executor stays pure - it has no DB knowledge and no actor context (except for
+`buildTransferAssignments`, which is isolated). The route handler already computes
+`remainingAssignments = currentNodeAssignments - actorAssignments` for all-mode; we reuse
+the same pattern to derive `aggregateCancelledAssigneeIds` from the DB-authoritative
+active assignments, not from the static config's `assigneeIds`. This correctly accounts
+for prior transfers: if `approver-a` transferred to `approver-z`, the DB row for
+`approver-z` is the one that gets cancelled when a sibling wins.
+
+To let the route branch cleanly, the resolution now carries:
+
+```ts
+interface ApprovalGraphResolution {
+  // ...
+  aggregateMode: 'single' | 'all' | 'any' | null
+  aggregateComplete: boolean
+}
+```
+
+- `resolveAfterApprove` sets both from the node being resolved away from
+  (`aggregateMode` = that node's mode, `aggregateComplete` = true).
+- `resolveInitialState` and `resolveReturnToNode` set `aggregateMode: null` and
+  `aggregateComplete: false` (they do not represent aggregation completion events).
+
+### Audit trail shape
+
+For an any-mode resolution with siblings `approver-b, approver-c`, first approver
+`approver-a`:
+
+1. `approver-a`'s assignment row: deactivated via the existing
+   `deactivateActorAssignmentsAtNode` helper. No `aggregateCancelled*` metadata on
+   the actor's own row.
+2. Sibling rows (`approver-b`, `approver-c`): deactivated via a targeted UPDATE that
+   merges `aggregateCancelledBy`, `aggregateCancelledAt`, `aggregateMode: 'any'`
+   into their existing `metadata` JSONB.
+3. Approval record (`action='approve'`): includes `approvalMode: 'any'`,
+   `aggregateComplete: true`, and the new `aggregateCancelled: [<sibling ids>]` array.
+4. One aggregated sign record (`action='sign', actorId='system'`) with metadata
+   `{ autoCancelled: true, aggregateMode: 'any', aggregateCancelledBy,
+   cancelledAssignees: [...] }`. Single row per event rather than one-per-sibling -
+   keeps the timeline compact and matches the existing auto-approval record pattern.
+
+The sign action is already whitelisted in the `approval_records_action_check`
+constraint (see pack 1A test helper) so no migration was needed.
+
+### Sibling re-approval rejection
+
+When `approver-b` tries to approve after `approver-a` has won, the existing
+`actorCanAct` guard returns **403 APPROVAL_ASSIGNMENT_REQUIRED** because
+`approver-b`'s row is no longer active. The task doc asked for 403 or 409;
+we test for the actual current behavior (403).
+
+### Parallel gateway (deferred)
+
+The plan calls out parallel gateway (多分支并发审批) as a follow-up slice.
+True parallel fan-out requires multi-currentNodeKey state, concurrent branch
+completion tracking, and merge synchronization - none of which the current
+`ApprovalGraphResolution.currentNodeKey: string | null` shape supports.
+That is WP2 scope; this PR only adds any-mode first-wins on a single node.
+
+## Files changed
+
+### Backend
+
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+  - `ApprovalGraphResolution` extended with `aggregateMode` and `aggregateComplete`.
+  - `resolveFromNode` now accepts a completion context and threads it into every
+    return shape.
+  - `resolveAfterApprove` records `aggregateMode`/`aggregateComplete: true` derived
+    from the current node.
+  - `getApprovalNodeAssigneeIds()` added as a small accessor for callers that need
+    the static configured list (kept unused in-route; retained for future WP2 use).
+
+- `packages/core-backend/src/services/ApprovalProductService.ts` (dispatchAction approve path,
+  around line 1252 onward)
+  - Added an `approvalMode === 'any'` branch that:
+    - Deactivates the actor's assignment via the existing helper.
+    - Computes `aggregateCancelledAssigneeIds` from sibling active assignments.
+    - Updates sibling rows with the new metadata merge SQL.
+  - Kept the `'all'` short-circuit and the `else` (single / default) blanket deactivation.
+  - Added `aggregateCancelled: string[]` to the approve record metadata when applicable.
+  - Added the aggregated `action='sign'` audit record insertion.
+
+### OpenAPI
+
+- `packages/openapi/src/base.yml` - documented new optional metadata keys on
+  `ApprovalAssignmentDTO.metadata`. No endpoint shape changes.
+
+### Tests
+
+- `packages/core-backend/tests/unit/approval-graph-executor.test.ts`
+  - Added an any-mode test verifying `aggregateMode`, `aggregateComplete`,
+    and `getApprovalNodeAssigneeIds()`.
+- `packages/core-backend/tests/integration/approval-wp1-any-mode.api.test.ts`
+  - New integration test covering first-wins resolution, sibling cancellation
+    metadata, the 403 re-approval path, and timeline history content.
+
+### Frontend
+
+- `apps/web/src/views/approval/ApprovalDetailView.vue`
+  - Timeline rendering: differentiated `会签完成` vs `或签完成` badges.
+  - Added `aggregateCancelled` assignee list badge and the
+    `已被 {approver} 的决定覆盖` muted note for `action='sign'` auto-cancel rows.
+  - `hasTimelineMetadata()` extended to include the new keys.
+  - `actionLabel()` now maps `'sign'` to `签字` (or `自动失效` when `autoCancelled`).
+
+- `apps/web/src/approvals/api.ts`
+  - `mockApproval()` emits an any-mode assignment shape on `index % 5 === 1`.
+  - `mockHistory()` appends an any-mode approve event plus the matching sign
+    audit row so the dev-mode timeline always exercises the new UI branch.
+
+## Data shape - aggregateCancelled flow
+
+```
+DB approval_assignments row (sibling):
+  is_active: false
+  metadata: {
+    aggregateCancelledBy: "approver-a",
+    aggregateCancelledAt: "2026-04-20T12:32:23.123Z",
+    aggregateMode: "any"
+  }
+
+DB approval_records row (approve):
+  action: "approve"
+  actor_id: "approver-a"
+  to_status: "approved"
+  metadata: {
+    nodeKey: "approval_any",
+    nextNodeKey: null,
+    approvalMode: "any",
+    aggregateComplete: true,
+    aggregateCancelled: ["approver-b"]
+  }
+
+DB approval_records row (sign audit):
+  action: "sign"
+  actor_id: "system"
+  to_status: "approved"
+  metadata: {
+    nodeKey: "approval_any",
+    autoCancelled: true,
+    aggregateMode: "any",
+    aggregateCancelledBy: "approver-a",
+    cancelledAssignees: ["approver-b"]
+  }
+```
+
+## Follow-ups
+
+- **Parallel gateway** (WP2): multi-branch fan-out + merge join.
+- **Assignee name resolution on the cancelled note**: the UI currently renders the raw
+  userId; once the approval store exposes a userId -> display-name map in detail view,
+  swap `cancelledAssigneesLabel` to use the display name.
+- **Quorum / majority voting**: possible extension of any-mode where N-of-M approvals
+  are required. Not in WP1 scope; would need both an executor policy knob and a
+  new aggregation state machine.

--- a/docs/development/approval-wave2-wp1-runtime-verification-20260420.md
+++ b/docs/development/approval-wave2-wp1-runtime-verification-20260420.md
@@ -169,7 +169,7 @@ Follow-up proposal (do NOT include in this PR, scope creep): wrap `ensureApprova
 
 After the DingTalk/Yjs queue landed, this branch was advanced again from `origin/main@c4093dcb8` to `origin/main@81edca7d9`. Rebase used `git rebase --autostash origin/main`, preserved the verification MD changes, and completed with no conflicts.
 
-Post-latest-main HEAD: `f2c030f33`.
+Post-latest-main feature HEAD before this verification doc commit: `f2c030f33`.
 
 ### Commands run (2026-04-21, .worktrees/wp1)
 

--- a/docs/development/approval-wave2-wp1-runtime-verification-20260420.md
+++ b/docs/development/approval-wave2-wp1-runtime-verification-20260420.md
@@ -202,3 +202,40 @@ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-
 | Executor unit | PASS | 8/8 |
 
 The BPMN/EventBus/Automation startup diagnostics in the integration logs are expected for this local partial-schema test database; the server continues in degraded mode and the targeted approval tests pass.
+
+---
+
+## CI correction — 2026-04-21
+
+After PR opening, CI exposed two packaging issues that local focused verification did not catch:
+
+1. `contracts (openapi)` failed because generated OpenAPI dist files were not rebuilt after `packages/openapi/src/base.yml` changed.
+2. `test (18.x)` picked up `tests/integration/approval-wp1-any-mode.api.test.ts` through the default Vitest include set and failed in the no-Postgres CI environment.
+
+Fix:
+
+- Rebuilt OpenAPI dist with `pnpm exec tsx packages/openapi/tools/build.ts`.
+- Gated the WP1 DB-backed integration test with `describe.skip` when `DATABASE_URL` is not set. The integration test still runs normally under `vitest.integration.config.ts` when `DATABASE_URL` is provided.
+
+### Commands run
+
+```bash
+pnpm exec tsx packages/openapi/tools/build.ts
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+### Results
+
+| Step | Outcome | Counts |
+| ---- | ------- | ------ |
+| OpenAPI build | PASS | dist regenerated |
+| Default Vitest include without `DATABASE_URL` | PASS | 1 skipped |
+| DB-backed integration with `DATABASE_URL` | PASS | 1/1 |
+| tsc --noEmit | PASS | zero diagnostics |
+
+Note: running `scripts/ops/attendance-run-gate-contract-case.sh openapi` before committing regenerated dist still reports expected local git drift. CI should validate the committed dist after this correction lands on the PR branch.

--- a/docs/development/approval-wave2-wp1-runtime-verification-20260420.md
+++ b/docs/development/approval-wave2-wp1-runtime-verification-20260420.md
@@ -1,0 +1,106 @@
+# Approval Wave 2 WP1 - Verification
+
+- Date: 2026-04-20
+- Branch: `codex/approval-wave2-wp1-runtime-202605`
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/wp1`
+
+## Environment
+
+- Node / pnpm: repo-standard (pnpm 10.33.0 reported by install).
+- Postgres: local `postgresql@15` on 127.0.0.1:5432, db `postgres`, user `chouhua`.
+- DATABASE_URL: `postgresql://chouhua@127.0.0.1:5432/postgres`
+
+## Commands and results
+
+### 1. Backend typecheck
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: PASS (no output, exit 0).
+
+### 2. New any-mode integration test
+
+```bash
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts run \
+  tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot
+```
+
+Result: PASS. `Test Files 1 passed (1) / Tests 1 passed (1)` - duration ~2.79s.
+
+Note on log noise: pre-existing `bpmn_process_definitions`, `event_types`, and
+`automation_rules` tables are not materialized by the lightweight integration
+bootstrap and trigger expected "degraded mode" warnings. These are unrelated to
+the approval runtime and do not affect the approval test outcome (the Pack 1A
+test suite shows the same warnings).
+
+### 3. Pack 1A regression
+
+```bash
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts run \
+  tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+```
+
+Result: PASS. `Test Files 1 passed (1) / Tests 3 passed (3)` - duration ~2.49s.
+
+### 4. Approval executor unit tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-graph-executor.test.ts --reporter=dot
+```
+
+Result: PASS. `Test Files 1 passed (1) / Tests 8 passed (8)` (the new
+`tags resolveAfterApprove resolutions with the resolved-away node aggregate mode`
+case plus the 7 pre-existing ones).
+
+### 5. Full core-backend unit suite
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
+```
+
+Result: PASS. `Test Files 113 passed (113) / Tests 1454 passed (1454)`.
+
+### 6. Frontend typecheck
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: PASS (no output, exit 0).
+
+### 7. Frontend related-test smoke
+
+```bash
+cd apps/web && pnpm exec vitest run \
+  tests/plmApprovalHistoryDisplay.spec.ts tests/approval-e2e-lifecycle.spec.ts \
+  --reporter=dot
+```
+
+Result: PASS. `Test Files 2 passed (2) / Tests 46 passed (46)`.
+
+The `apps/web/tests/approval-center.spec.ts` suite fails on both the WP1 branch
+and `origin/main` with the same 5 errors - pre-existing baseline failure
+unrelated to this PR's changes.
+
+## Summary
+
+| Step | Outcome | Counts |
+| ---- | ------- | ------ |
+| 1. Backend tsc | PASS | - |
+| 2. New any-mode integration | PASS | 1/1 |
+| 3. Pack 1A regression | PASS | 3/3 |
+| 4. Executor unit tests | PASS | 8/8 |
+| 5. Core-backend unit suite | PASS | 1454/1454 |
+| 6. Frontend vue-tsc | PASS | - |
+| 7. Frontend approval smoke | PASS | 46/46 |
+
+All required verification commands pass. Pack 1A behavior is preserved.

--- a/docs/development/approval-wave2-wp1-runtime-verification-20260420.md
+++ b/docs/development/approval-wave2-wp1-runtime-verification-20260420.md
@@ -104,3 +104,101 @@ unrelated to this PR's changes.
 | 7. Frontend approval smoke | PASS | 46/46 |
 
 All required verification commands pass. Pack 1A behavior is preserved.
+
+---
+
+## Rebase verification — 2026-04-21
+
+Branch rebased from base `0756ff61d` onto latest `origin/main@c4093dcb8` (+21 commits upstream, no business-file overlap with this branch). Rebase was pure fast-forward with no merge conflict; business diff unchanged (9 files, +1032 / −22).
+
+Post-rebase HEAD: `02dcceda2`.
+
+### Commands run (2026-04-21, .worktrees/wp1)
+
+```bash
+git -C .worktrees/wp1 checkout -- plugins/ tools/   # clean dirty pnpm symlinks (26 entries)
+git -C .worktrees/wp1 fetch origin main
+git -C .worktrees/wp1 rebase origin/main             # no conflicts
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+
+# Run separately to avoid vitest file-parallel DDL race (see note below)
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts --reporter=dot
+```
+
+### Results
+
+| Step | Outcome | Counts |
+| ---- | ------- | ------ |
+| tsc --noEmit | PASS | zero diagnostics |
+| vue-tsc --noEmit | PASS | zero diagnostics |
+| any-mode integration (alone) | PASS | 1/1 |
+| Pack 1A regression (alone) | PASS | 3/3 |
+| Executor unit | PASS | 8/8 |
+
+### Concurrency note (follow-up)
+
+When both `approval-wp1-any-mode.api.test.ts` and `approval-pack1a-lifecycle.api.test.ts` are passed to a single `vitest run` invocation, vitest runs the two files in parallel workers. Both fixtures call an `ensureApprovalTables()` that performs non-atomic `DROP ... IF EXISTS` + `ADD CONSTRAINT` / `CREATE UNIQUE INDEX IF NOT EXISTS` against the shared schema, creating a race window where the second file's `ADD CONSTRAINT` / `CREATE INDEX` fails with `42710` (duplicate_object) or `23505` (pg_class unique violation).
+
+Workaround for this rebase verification: run the two integration files in separate `vitest run` invocations — both then pass (1/1 + 3/3).
+
+Follow-up proposal (do NOT include in this PR, scope creep): wrap `ensureApprovalTables()` in a `pg_advisory_xact_lock(hashtext('ensureApprovalTables'))` via a dedicated `pool.connect()` client + explicit `BEGIN/COMMIT`, so concurrent test files serialize on DDL. Pack 1A also benefits — that test was merged to main with the same fixture shape.
+
+### Baseline
+
+| Field | Value |
+| ----- | ----- |
+| Original base commit | `0756ff61d` |
+| Rebase target | `c4093dcb8` (origin/main, +21 commits) |
+| New branch HEAD | `02dcceda2` |
+| Upstream business-file overlap | none |
+| Rebase conflicts | none |
+
+---
+
+## Latest-main verification — 2026-04-21
+
+After the DingTalk/Yjs queue landed, this branch was advanced again from `origin/main@c4093dcb8` to `origin/main@81edca7d9`. Rebase used `git rebase --autostash origin/main`, preserved the verification MD changes, and completed with no conflicts.
+
+Post-latest-main HEAD: `f2c030f33`.
+
+### Commands run (2026-04-21, .worktrees/wp1)
+
+```bash
+git -C .worktrees/wp1 rebase --autostash origin/main
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts --reporter=dot
+```
+
+### Results
+
+| Step | Outcome | Counts |
+| ---- | ------- | ------ |
+| Rebase onto `81edca7d9` | PASS | zero conflicts |
+| tsc --noEmit | PASS | zero diagnostics |
+| vue-tsc --noEmit | PASS | zero diagnostics |
+| any-mode integration (alone) | PASS | 1/1 |
+| Pack 1A regression (alone) | PASS | 3/3 |
+| Executor unit | PASS | 8/8 |
+
+The BPMN/EventBus/Automation startup diagnostics in the integration logs are expected for this local partial-schema test database; the server continues in degraded mode and the targeted approval tests pass.

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -38,6 +38,19 @@ export interface ApprovalGraphResolution {
   assignments: ApprovalGraphAssignment[]
   ccEvents: ApprovalCcEvent[]
   autoApprovalEvents: ApprovalGraphAutoApprovalEvent[]
+  /**
+   * Aggregation mode of the node that was just resolved away from (by `resolveAfterApprove`).
+   * `null` for `resolveInitialState`, `resolveReturnToNode`, and non-approval advancement paths.
+   * Any-mode resolution carries `'any'`; all-mode carries `'all'` only when aggregation is complete
+   * (the route short-circuits incomplete all-mode before calling `resolveAfterApprove`).
+   */
+  aggregateMode: 'single' | 'all' | 'any' | null
+  /**
+   * Indicates that the previous node's aggregation requirement is satisfied and resolution advanced.
+   * Always `true` when `resolveAfterApprove` returns (incomplete aggregation never reaches here).
+   * `false` from the other entry points that do not represent an aggregation completion event.
+   */
+  aggregateComplete: boolean
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -312,10 +325,17 @@ export class ApprovalGraphExecutor {
     if (!start) {
       throw new Error('Runtime graph must contain a start node')
     }
-    return this.resolveFromNode(start.key)
+    return this.resolveFromNode(start.key, { aggregateMode: null, aggregateComplete: false })
   }
 
   resolveAfterApprove(currentNodeKey: string): ApprovalGraphResolution {
+    // The caller (ApprovalProductService) only reaches `resolveAfterApprove` after aggregation
+    // is satisfied for the current node. For 'any' mode that is on the first approver; for 'all'
+    // it is after the last approver; 'single' always satisfies on the sole approver. The resolution
+    // therefore carries `aggregateComplete: true` along with the current node's approval mode so
+    // downstream audit writers can distinguish `'any'` first-wins from `'all'` last-wins.
+    const aggregateMode = this.getApprovalMode(currentNodeKey)
+    const completionContext = { aggregateMode, aggregateComplete: true as const }
     const next = this.firstTargetForNode(currentNodeKey)
     if (!next) {
       return {
@@ -326,18 +346,24 @@ export class ApprovalGraphExecutor {
         assignments: [],
         ccEvents: [],
         autoApprovalEvents: [],
+        aggregateMode,
+        aggregateComplete: true,
       }
     }
-    return this.resolveFromNode(next)
+    return this.resolveFromNode(next, completionContext)
   }
 
   getApprovalMode(nodeKey: string): ApprovalMode {
     return normalizeApprovalMode(this.getApprovalNodeConfig(nodeKey).approvalMode)
   }
 
+  getApprovalNodeAssigneeIds(nodeKey: string): string[] {
+    return [...this.getApprovalNodeConfig(nodeKey).assigneeIds]
+  }
+
   resolveReturnToNode(targetNodeKey: string): ApprovalGraphResolution {
     this.getApprovalNodeConfig(targetNodeKey)
-    return this.resolveFromNode(targetNodeKey)
+    return this.resolveFromNode(targetNodeKey, { aggregateMode: null, aggregateComplete: false })
   }
 
   listVisitedApprovalNodeKeysUntil(currentNodeKey: string): string[] {
@@ -405,7 +431,10 @@ export class ApprovalGraphExecutor {
     }]
   }
 
-  private resolveFromNode(nodeKey: string): ApprovalGraphResolution {
+  private resolveFromNode(
+    nodeKey: string,
+    context: { aggregateMode: 'single' | 'all' | 'any' | null; aggregateComplete: boolean },
+  ): ApprovalGraphResolution {
     const ccEvents: ApprovalCcEvent[] = []
     const autoApprovalEvents: ApprovalGraphAutoApprovalEvent[] = []
     let currentKey: string | null = nodeKey
@@ -477,6 +506,8 @@ export class ApprovalGraphExecutor {
           })),
           ccEvents,
           autoApprovalEvents,
+          aggregateMode: context.aggregateMode,
+          aggregateComplete: context.aggregateComplete,
         }
       }
 
@@ -489,6 +520,8 @@ export class ApprovalGraphExecutor {
           assignments: [],
           ccEvents,
           autoApprovalEvents,
+          aggregateMode: context.aggregateMode,
+          aggregateComplete: context.aggregateComplete,
         }
       }
 
@@ -503,6 +536,8 @@ export class ApprovalGraphExecutor {
       assignments: [],
       ccEvents,
       autoApprovalEvents,
+      aggregateMode: context.aggregateMode,
+      aggregateComplete: context.aggregateComplete,
     }
   }
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1250,6 +1250,12 @@ export class ApprovalProductService {
       }
 
       const approvalMode = executor.getApprovalMode(currentNodeKey)
+      // Approval aggregation semantics:
+      //   'all'    (会签): deactivate only the actor's assignment, short-circuit if siblings remain.
+      //   'any'    (或签): first approver wins — deactivate siblings with an audit trail
+      //                    (aggregateCancelledBy/aggregateCancelledAt metadata) + one 'sign' record.
+      //   'single' / default: exactly one assignee expected; blanket-deactivate all active rows.
+      let aggregateCancelledAssigneeIds: string[] = []
       if (approvalMode === 'all') {
         await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
         const remainingAssignments = currentNodeAssignments.length - actorAssignments.length
@@ -1281,6 +1287,32 @@ export class ApprovalProductService {
           await client.query('COMMIT')
           return (await this.getApproval(id))!
         }
+      } else if (approvalMode === 'any') {
+        // Deactivate actor's own assignment first.
+        await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
+        // Identify siblings (still-active, non-actor) whose assignments the first-wins aggregation cancels.
+        const siblingAssignments = currentNodeAssignments.filter((assignment) =>
+          !assignmentMatchesActor(assignment, actor.userId, actorRoles))
+        aggregateCancelledAssigneeIds = Array.from(
+          new Set(siblingAssignments.map((assignment) => assignment.assignee_id)),
+        )
+        if (siblingAssignments.length > 0) {
+          await client.query(
+            `UPDATE approval_assignments
+             SET is_active = FALSE,
+                 metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+                   'aggregateCancelledBy', $3::text,
+                   'aggregateCancelledAt', now()::text,
+                   'aggregateMode', 'any'
+                 ),
+                 updated_at = now()
+             WHERE instance_id = $1
+               AND node_key = $2
+               AND is_active = TRUE
+               AND id = ANY($4::uuid[])`,
+            [id, currentNodeKey, actor.userId, siblingAssignments.map((assignment) => assignment.id)],
+          )
+        }
       } else {
         await this.deactivateAllActiveAssignments(client, id)
       }
@@ -1305,6 +1337,15 @@ export class ApprovalProductService {
         ],
       )
       await this.insertAssignments(client, id, resolution.assignments)
+      const approveRecordMetadata: Record<string, unknown> = {
+        nodeKey: currentNodeKey,
+        nextNodeKey: resolution.currentNodeKey,
+        approvalMode,
+        aggregateComplete: true,
+      }
+      if (approvalMode === 'any' && aggregateCancelledAssigneeIds.length > 0) {
+        approveRecordMetadata.aggregateCancelled = aggregateCancelledAssigneeIds
+      }
       await this.insertApprovalRecord(client, id, {
         action: 'approve',
         actorId: actor.userId,
@@ -1314,13 +1355,29 @@ export class ApprovalProductService {
         toStatus: resolution.status,
         fromVersion: instance.version,
         toVersion: nextVersion,
-        metadata: {
-          nodeKey: currentNodeKey,
-          nextNodeKey: resolution.currentNodeKey,
-          approvalMode,
-          aggregateComplete: true,
-        },
+        metadata: approveRecordMetadata,
       }, actor)
+      if (approvalMode === 'any' && aggregateCancelledAssigneeIds.length > 0) {
+        // One 'sign' audit row describing the aggregation cancellation — lets the timeline UI
+        // render a muted "已被 {approver} 的决定覆盖" line without mining assignment metadata.
+        await this.insertApprovalRecord(client, id, {
+          action: 'sign',
+          actorId: 'system',
+          actorName: 'System',
+          comment: null,
+          fromStatus: instance.status,
+          toStatus: resolution.status,
+          fromVersion: instance.version,
+          toVersion: nextVersion,
+          metadata: {
+            nodeKey: currentNodeKey,
+            autoCancelled: true,
+            aggregateMode: 'any',
+            aggregateCancelledBy: actor.userId,
+            cancelledAssignees: aggregateCancelledAssigneeIds,
+          },
+        })
+      }
       await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
       await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
 

--- a/packages/core-backend/tests/integration/approval-wp1-any-mode.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp1-any-mode.api.test.ts
@@ -1,0 +1,499 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+
+type JsonRecord = Record<string, unknown>
+
+type ApprovalRecordRow = {
+  action: string
+  actor_id: string | null
+  to_status: string
+  metadata: JsonRecord
+}
+
+type ApprovalAssignmentRow = {
+  assignee_id: string
+  is_active: boolean
+  metadata: JsonRecord | null
+}
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+/**
+ * The schema bootstrap mirrors approval-pack1a-lifecycle.api.test.ts. Keeping the
+ * duplication localized (rather than extracting to a shared helper) matches how the
+ * existing suite is structured and avoids cross-file test coupling.
+ */
+async function ensureApprovalTables() {
+  const pool = poolManager.get()
+  await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS approval_instances (
+      id TEXT PRIMARY KEY,
+      status TEXT NOT NULL,
+      version INTEGER NOT NULL DEFAULT 0,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS source_system TEXT`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS external_approval_id TEXT`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS workflow_key TEXT`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS business_key TEXT`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS title TEXT`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS requester_snapshot JSONB`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS subject_snapshot JSONB`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS policy_snapshot JSONB`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS metadata JSONB`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS current_step INTEGER`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS total_steps INTEGER`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS source_updated_at TIMESTAMPTZ`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS last_synced_at TIMESTAMPTZ`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS sync_status TEXT`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS sync_error TEXT`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS template_id UUID`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS template_version_id UUID`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS published_definition_id UUID`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS request_no TEXT`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS form_snapshot JSONB`)
+  await pool.query(`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS current_node_key TEXT`)
+  await pool.query(`
+    UPDATE approval_instances
+    SET source_system = COALESCE(source_system, 'platform'),
+        requester_snapshot = COALESCE(requester_snapshot, '{}'::jsonb),
+        subject_snapshot = COALESCE(subject_snapshot, '{}'::jsonb),
+        policy_snapshot = COALESCE(policy_snapshot, '{}'::jsonb),
+        metadata = COALESCE(metadata, '{}'::jsonb),
+        current_step = COALESCE(current_step, 0),
+        total_steps = COALESCE(total_steps, 0),
+        sync_status = COALESCE(sync_status, 'ok')
+  `)
+  await pool.query(`ALTER TABLE approval_instances ALTER COLUMN source_system SET DEFAULT 'platform'`)
+  await pool.query(`ALTER TABLE approval_instances ALTER COLUMN requester_snapshot SET DEFAULT '{}'::jsonb`)
+  await pool.query(`ALTER TABLE approval_instances ALTER COLUMN subject_snapshot SET DEFAULT '{}'::jsonb`)
+  await pool.query(`ALTER TABLE approval_instances ALTER COLUMN policy_snapshot SET DEFAULT '{}'::jsonb`)
+  await pool.query(`ALTER TABLE approval_instances ALTER COLUMN metadata SET DEFAULT '{}'::jsonb`)
+  await pool.query(`ALTER TABLE approval_instances ALTER COLUMN current_step SET DEFAULT 0`)
+  await pool.query(`ALTER TABLE approval_instances ALTER COLUMN total_steps SET DEFAULT 0`)
+  await pool.query(`ALTER TABLE approval_instances ALTER COLUMN sync_status SET DEFAULT 'ok'`)
+  await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_instances_source_external ON approval_instances(source_system, external_approval_id) WHERE external_approval_id IS NOT NULL`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_instances_status_updated ON approval_instances(status, updated_at DESC)`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_instances_source_status ON approval_instances(source_system, status, updated_at DESC)`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_instances_workflow_business ON approval_instances(workflow_key, business_key)`)
+  await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_instances_request_no ON approval_instances(request_no) WHERE request_no IS NOT NULL`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_instances_template_status ON approval_instances(template_id, status, updated_at DESC)`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_instances_published_definition ON approval_instances(published_definition_id)`)
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS approval_records (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      instance_id TEXT NOT NULL REFERENCES approval_instances(id) ON DELETE CASCADE,
+      action TEXT NOT NULL,
+      actor_id TEXT,
+      actor_name TEXT,
+      comment TEXT NULL,
+      reason TEXT NULL,
+      from_status TEXT NULL,
+      to_status TEXT NOT NULL,
+      version INT NULL,
+      from_version INT NULL,
+      to_version INT NOT NULL DEFAULT 0,
+      target_user_id TEXT NULL,
+      target_step_id TEXT NULL,
+      attachments JSONB DEFAULT '[]'::jsonb,
+      metadata JSONB DEFAULT '{}'::jsonb,
+      ip_address INET,
+      user_agent TEXT,
+      platform TEXT DEFAULT 'web',
+      occurred_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS actor_name TEXT`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS reason TEXT`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS version INT`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS from_version INT`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS to_version INT NOT NULL DEFAULT 0`)
+  await pool.query(`ALTER TABLE approval_records ALTER COLUMN to_version SET DEFAULT 0`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS target_user_id TEXT`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS target_step_id TEXT`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS attachments JSONB DEFAULT '[]'::jsonb`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'::jsonb`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS ip_address INET`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS user_agent TEXT`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS platform TEXT DEFAULT 'web'`)
+  await pool.query(`ALTER TABLE approval_records ADD COLUMN IF NOT EXISTS occurred_at TIMESTAMPTZ NOT NULL DEFAULT now()`)
+  await pool.query(`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`)
+  await pool.query(`
+    ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc'))
+  `)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance ON approval_records(instance_id)`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance_action_time ON approval_records(instance_id, action, occurred_at DESC)`)
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS approval_assignments (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      instance_id TEXT NOT NULL REFERENCES approval_instances(id) ON DELETE CASCADE,
+      assignment_type TEXT NOT NULL CHECK (assignment_type IN ('user', 'role', 'source_queue')),
+      assignee_id TEXT NOT NULL,
+      source_step INTEGER NOT NULL DEFAULT 0,
+      is_active BOOLEAN NOT NULL DEFAULT TRUE,
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `)
+  await pool.query(`ALTER TABLE approval_assignments ADD COLUMN IF NOT EXISTS node_key TEXT`)
+  await pool.query(`
+    DO $$
+    DECLARE
+      record_row RECORD;
+    BEGIN
+      FOR record_row IN
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid = 'approval_assignments'::regclass
+          AND contype = 'u'
+      LOOP
+        EXECUTE format('ALTER TABLE approval_assignments DROP CONSTRAINT IF EXISTS %I', record_row.conname);
+      END LOOP;
+    END $$;
+  `)
+  await pool.query(`DROP INDEX IF EXISTS idx_approval_assignments_active_unique`)
+  await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_assignments_active_unique ON approval_assignments(instance_id, assignment_type, assignee_id) WHERE is_active = TRUE`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_assignments_lookup ON approval_assignments(assignment_type, assignee_id, is_active)`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_assignments_instance ON approval_assignments(instance_id, is_active)`)
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS approval_templates (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      key TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      description TEXT,
+      status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'archived')),
+      active_version_id UUID,
+      latest_version_id UUID,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS approval_template_versions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      template_id UUID NOT NULL REFERENCES approval_templates(id) ON DELETE CASCADE,
+      version INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'archived')),
+      form_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
+      approval_graph JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (template_id, version)
+    )
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS approval_published_definitions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      template_id UUID NOT NULL REFERENCES approval_templates(id) ON DELETE CASCADE,
+      template_version_id UUID NOT NULL REFERENCES approval_template_versions(id) ON DELETE CASCADE,
+      runtime_graph JSONB NOT NULL DEFAULT '{}'::jsonb,
+      is_active BOOLEAN NOT NULL DEFAULT TRUE,
+      published_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `)
+  await pool.query(`
+    DO $$
+    BEGIN
+      ALTER TABLE approval_templates
+        ADD CONSTRAINT approval_templates_active_version_fk
+        FOREIGN KEY (active_version_id) REFERENCES approval_template_versions(id) ON DELETE SET NULL;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+  `)
+  await pool.query(`
+    DO $$
+    BEGIN
+      ALTER TABLE approval_templates
+        ADD CONSTRAINT approval_templates_latest_version_fk
+        FOREIGN KEY (latest_version_id) REFERENCES approval_template_versions(id) ON DELETE SET NULL;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+  `)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_templates_status_updated ON approval_templates(status, updated_at DESC)`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_template_versions_template ON approval_template_versions(template_id, version DESC)`)
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_approval_published_definitions_template_version ON approval_published_definitions(template_version_id, published_at DESC)`)
+  await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_published_definitions_active_template ON approval_published_definitions(template_id) WHERE is_active = TRUE`)
+
+  await pool.query(`CREATE SEQUENCE IF NOT EXISTS approval_request_no_seq START WITH 100001 INCREMENT BY 1`)
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: {
+    method?: string
+    body?: unknown
+  } = {},
+) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+  return response
+}
+
+function buildFormSchema() {
+  return {
+    fields: [
+      {
+        id: 'reason',
+        type: 'text',
+        label: '事由',
+        required: true,
+      },
+    ],
+  }
+}
+
+function buildAnyModeGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_any',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a', 'approver-b'],
+          approvalMode: 'any',
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-any', source: 'start', target: 'approval_any' },
+      { key: 'edge-any-end', source: 'approval_any', target: 'end' },
+    ],
+  }
+}
+
+describe('Approval Wave 2 WP1 any-mode (或签) API', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+
+  beforeAll(async () => {
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+
+    await ensureApprovalTables()
+
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [],
+    })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool.query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+    } catch {
+      // Ignore cleanup failures — the top-level describe restart clears everything on rerun.
+    }
+
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  it('advances an any-mode approval on the first approver and cancels siblings with audit metadata', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-any')
+    const requesterToken = await authToken(baseUrl, 'requester-any')
+    const approverAToken = await authToken(baseUrl, 'approver-a')
+    const approverBToken = await authToken(baseUrl, 'approver-b')
+    const templateKey = `approval-wp1-any-${Date.now()}`
+
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Any Mode Template',
+        description: 'approvalMode=any integration',
+        formSchema: buildFormSchema(),
+        approvalGraph: buildAnyModeGraph(),
+      },
+    })
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status).toBe(200)
+
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: {
+        templateId: template.id,
+        formData: { reason: 'any-mode request' },
+      },
+    })
+    expect(createResponse.status).toBe(201)
+    const createdApproval = await createResponse.json() as {
+      id: string
+      status: string
+      currentNodeKey: string | null
+      assignments: Array<{ assigneeId: string; isActive: boolean; nodeKey?: string | null }>
+    }
+    createdApprovalIds.add(createdApproval.id)
+    expect(createdApproval.status).toBe('pending')
+    expect(createdApproval.currentNodeKey).toBe('approval_any')
+    expect(
+      createdApproval.assignments
+        .filter((assignment) => assignment.isActive)
+        .map((assignment) => assignment.assigneeId)
+        .sort(),
+    ).toEqual(['approver-a', 'approver-b'])
+
+    const approveResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, approverAToken, {
+      method: 'POST',
+      body: {
+        action: 'approve',
+        comment: 'approver-a wins',
+      },
+    })
+    expect(approveResponse.status).toBe(200)
+    const completedApproval = await approveResponse.json() as {
+      status: string
+      currentNodeKey: string | null
+      assignments: Array<{ assigneeId: string; isActive: boolean; metadata?: JsonRecord }>
+    }
+    expect(completedApproval.status).toBe('approved')
+    expect(completedApproval.currentNodeKey).toBeNull()
+    expect(completedApproval.assignments.filter((assignment) => assignment.isActive)).toHaveLength(0)
+
+    const pool = poolManager.get()
+    const assignmentResult = await pool.query<ApprovalAssignmentRow>(
+      `SELECT assignee_id, is_active, metadata
+       FROM approval_assignments
+       WHERE instance_id = $1
+       ORDER BY assignee_id ASC`,
+      [createdApproval.id],
+    )
+    const approverBRow = assignmentResult.rows.find((row) => row.assignee_id === 'approver-b')
+    expect(approverBRow).toBeTruthy()
+    expect(approverBRow?.is_active).toBe(false)
+    expect(approverBRow?.metadata).toMatchObject({
+      aggregateCancelledBy: 'approver-a',
+      aggregateMode: 'any',
+    })
+    expect(typeof (approverBRow?.metadata as JsonRecord | undefined)?.aggregateCancelledAt).toBe('string')
+
+    const approverARow = assignmentResult.rows.find((row) => row.assignee_id === 'approver-a')
+    expect(approverARow?.is_active).toBe(false)
+    // approver-a's own row should NOT carry aggregateCancelledBy — that metadata is reserved for siblings.
+    expect((approverARow?.metadata as JsonRecord | undefined)?.aggregateCancelledBy).toBeUndefined()
+
+    const approveRecordsResult = await pool.query<ApprovalRecordRow>(
+      `SELECT action, actor_id, to_status, metadata
+       FROM approval_records
+       WHERE instance_id = $1 AND action = 'approve'
+       ORDER BY to_version ASC, created_at ASC`,
+      [createdApproval.id],
+    )
+    expect(approveRecordsResult.rows).toHaveLength(1)
+    expect(approveRecordsResult.rows[0]?.actor_id).toBe('approver-a')
+    expect(approveRecordsResult.rows[0]?.to_status).toBe('approved')
+    expect(approveRecordsResult.rows[0]?.metadata).toMatchObject({
+      nodeKey: 'approval_any',
+      nextNodeKey: null,
+      approvalMode: 'any',
+      aggregateComplete: true,
+      aggregateCancelled: ['approver-b'],
+    })
+
+    const signRecordsResult = await pool.query<ApprovalRecordRow>(
+      `SELECT action, actor_id, to_status, metadata
+       FROM approval_records
+       WHERE instance_id = $1 AND action = 'sign'
+       ORDER BY created_at ASC`,
+      [createdApproval.id],
+    )
+    expect(signRecordsResult.rows).toHaveLength(1)
+    expect(signRecordsResult.rows[0]?.actor_id).toBe('system')
+    expect(signRecordsResult.rows[0]?.metadata).toMatchObject({
+      nodeKey: 'approval_any',
+      autoCancelled: true,
+      aggregateMode: 'any',
+      aggregateCancelledBy: 'approver-a',
+      cancelledAssignees: ['approver-b'],
+    })
+
+    // approver-b attempting to approve afterward should be rejected — the active assignment is gone.
+    const lateApproveResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, approverBToken, {
+      method: 'POST',
+      body: {
+        action: 'approve',
+        comment: 'too late',
+      },
+    })
+    expect(lateApproveResponse.status).toBe(403)
+    const errorPayload = await lateApproveResponse.json() as { error?: { code?: string } }
+    expect(errorPayload.error?.code).toBe('APPROVAL_ASSIGNMENT_REQUIRED')
+
+    const timelineResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/history`, approverAToken)
+    expect(timelineResponse.status).toBe(200)
+    const timelinePayload = await timelineResponse.json() as {
+      ok: boolean
+      data: { items: Array<{ action: string; metadata?: JsonRecord }> }
+    }
+    const actions = timelinePayload.data.items.map((item) => item.action)
+    expect(actions).toContain('approve')
+    expect(actions).toContain('sign')
+  })
+})

--- a/packages/core-backend/tests/integration/approval-wp1-any-mode.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp1-any-mode.api.test.ts
@@ -3,6 +3,8 @@ import net from 'net'
 import { MetaSheetServer } from '../../src/index'
 import { poolManager } from '../../src/integration/db/connection-pool'
 
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
 type JsonRecord = Record<string, unknown>
 
 type ApprovalRecordRow = {
@@ -302,7 +304,7 @@ function buildAnyModeGraph() {
   }
 }
 
-describe('Approval Wave 2 WP1 any-mode (或签) API', () => {
+describeIfDatabase('Approval Wave 2 WP1 any-mode (或签) API', () => {
   let server: MetaSheetServer | undefined
   let baseUrl = ''
   const createdTemplateIds = new Set<string>()

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -184,6 +184,42 @@ describe('ApprovalGraphExecutor', () => {
     ])
   })
 
+  it('tags resolveAfterApprove resolutions with the resolved-away node aggregate mode', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'any_review',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: ['approver-a', 'approver-b'],
+            approvalMode: 'any',
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-any', source: 'start', target: 'any_review' },
+        { key: 'edge-any-end', source: 'any_review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+
+    const initial = executor.resolveInitialState()
+    expect(initial.aggregateMode).toBeNull()
+    expect(initial.aggregateComplete).toBe(false)
+    expect(executor.getApprovalMode('any_review')).toBe('any')
+    expect(executor.getApprovalNodeAssigneeIds('any_review')).toEqual(['approver-a', 'approver-b'])
+
+    const completed = executor.resolveAfterApprove('any_review')
+    expect(completed.status).toBe('approved')
+    expect(completed.aggregateMode).toBe('any')
+    expect(completed.aggregateComplete).toBe(true)
+  })
+
   it('lists the visited approval nodes for return validation on the active path', () => {
     const runtimeGraph: RuntimeGraph = {
       nodes: [

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2487,6 +2487,14 @@ components:
           type: boolean
         metadata:
           type: object
+          description: >
+            Runtime-populated metadata. Optional keys written by the approval
+            executor:
+              - `aggregateCancelledBy` (string): userId of the approver whose any-mode (或签)
+                first-wins decision deactivated this sibling assignment.
+              - `aggregateCancelledAt` (string, ISO-8601): timestamp when the cancellation fired.
+              - `aggregateMode` ('any'): aggregation mode that triggered the cancellation;
+                present alongside `aggregateCancelledBy` on cancelled sibling assignments.
           additionalProperties: true
       required:
         - id

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3606,6 +3606,7 @@
           },
           "metadata": {
             "type": "object",
+            "description": "Runtime-populated metadata. Optional keys written by the approval executor:\n  - `aggregateCancelledBy` (string): userId of the approver whose any-mode (或签)\n    first-wins decision deactivated this sibling assignment.\n  - `aggregateCancelledAt` (string, ISO-8601): timestamp when the cancellation fired.\n  - `aggregateMode` ('any'): aggregation mode that triggered the cancellation;\n    present alongside `aggregateCancelledBy` on cancelled sibling assignments.\n",
             "additionalProperties": true
           }
         },

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2487,6 +2487,14 @@ components:
           type: boolean
         metadata:
           type: object
+          description: >
+            Runtime-populated metadata. Optional keys written by the approval
+            executor:
+              - `aggregateCancelledBy` (string): userId of the approver whose any-mode (或签)
+                first-wins decision deactivated this sibling assignment.
+              - `aggregateCancelledAt` (string, ISO-8601): timestamp when the cancellation fired.
+              - `aggregateMode` ('any'): aggregation mode that triggered the cancellation;
+                present alongside `aggregateCancelledBy` on cancelled sibling assignments.
           additionalProperties: true
       required:
         - id

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2350,6 +2350,13 @@ components:
           type: boolean
         metadata:
           type: object
+          description: |
+            Runtime-populated metadata. Optional keys written by the approval executor:
+              - `aggregateCancelledBy` (string): userId of the approver whose any-mode (或签)
+                first-wins decision deactivated this sibling assignment.
+              - `aggregateCancelledAt` (string, ISO-8601): timestamp when the cancellation fired.
+              - `aggregateMode` ('any'): aggregation mode that triggered the cancellation;
+                present alongside `aggregateCancelledBy` on cancelled sibling assignments.
           additionalProperties: true
       required: [id, type, assigneeId, sourceStep, isActive, metadata]
     UnifiedApprovalDTO:


### PR DESCRIPTION
## Summary

- Adds approval Wave 2 WP1 any-mode (`approvalMode=any`) aggregation through executor, API, OpenAPI metadata, and approval detail UI.
- Preserves Pack 1A all-mode behavior and adds runtime coverage for first-approver-wins cancellation semantics.
- Keeps the parallel gateway/fork-list work explicitly out of scope.
- CI correction included: generated OpenAPI dist is committed, and the DB-backed integration test is skipped in default no-DB Vitest jobs unless `DATABASE_URL` is set.

## Verification

Latest-main verification on `origin/main@81edca7d9`:

```bash
git -C .worktrees/wp1 rebase --autostash origin/main
pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
pnpm --filter @metasheet/web exec vue-tsc --noEmit

DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
    tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot

DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
    tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot

pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts --reporter=dot
pnpm exec tsx packages/openapi/tools/build.ts
pnpm --filter @metasheet/core-backend exec vitest run tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot
./scripts/ops/attendance-run-gate-contract-case.sh openapi
```

Results:

- Backend `tsc --noEmit`: PASS, zero diagnostics
- Web `vue-tsc --noEmit`: PASS, zero diagnostics
- `approval-wp1-any-mode.api.test.ts` with DB: PASS, 1/1
- `approval-pack1a-lifecycle.api.test.ts`: PASS, 3/3
- `approval-graph-executor.test.ts`: PASS, 8/8
- default Vitest include without `DATABASE_URL`: PASS, 1 skipped
- OpenAPI build + attendance openapi contract gate: PASS

Verification MD: `docs/development/approval-wave2-wp1-runtime-verification-20260420.md`.

## Notes

The two approval integration files are intentionally run in separate Vitest invocations. Running both files in one invocation exposes a pre-existing shared-schema DDL race in `ensureApprovalTables()`; the verification MD records the follow-up proposal to serialize fixture DDL with `pg_advisory_xact_lock`.
