### PR TITLE
feat(infra): add Redis runtime stores for token bucket and circuit breaker

### DIFF
--- a/docs/development/collab-infra-redis-runtime-development-20260420.md
+++ b/docs/development/collab-infra-redis-runtime-development-20260420.md
@@ -1,0 +1,165 @@
+# Redis runtime adapters for TokenBucket and CircuitBreaker — development log
+
+- **Date**: 2026-04-20
+- **Branch**: `codex/collab-infra-redis-runtime-202605`
+- **Worktree**: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/redis`
+- **Base commit**: `0756ff61d` (`fix(collab): YjsRecordBridge re-registers observer when Y.Doc is recreated (P1)`)
+
+## Scope
+
+Add Redis-backed storage adapters for two pieces of gateway runtime state so multi-replica deployments can share it:
+
+1. **TokenBucketRateLimiter** — per-key bucket balance.
+2. **CircuitBreaker** — per-circuit state + rolling event window.
+
+The work is strictly additive: every existing caller continues to run against the in-process defaults with no code changes. Callers that need cluster-wide coordination opt in by constructing the limiter / breaker with a `store` parameter.
+
+Webhook deliveries are already Postgres-persisted (`multitable_webhook_deliveries`) so no Redis work was needed there. `AutomationScheduler` was deferred — it needs a richer leader-election story plus queue semantics, which justify a separate slice rather than bolting onto the current in-memory scheduler.
+
+## Rationale
+
+- **Multi-replica correctness.** The existing Map/field storage is per-process, so three API-gateway pods would each maintain their own rate-limit counter and their own CircuitBreaker state. Under load this amplifies allowed traffic by `Npods` and desynchronises circuit trips.
+- **Graceful degradation.** Following the `packages/core-backend/src/middleware/rate-limiter.ts` precedent, Redis is opt-in and failures must not take the service down. The new interfaces are unreachable from default paths; a caller wanting Redis wires it explicitly and is expected to wrap store calls in its own fallback logic (mirror of `createRateLimiter`'s pattern).
+
+## Files added
+
+| Path | Purpose |
+| --- | --- |
+| `packages/core-backend/src/integration/rate-limiting/token-bucket-store.ts` | `TokenBucketStore` interface + `MemoryTokenBucketStore` default. |
+| `packages/core-backend/src/integration/rate-limiting/redis-token-bucket-store.ts` | Lua-backed Redis implementation + pure-JS twin for tests. |
+| `packages/core-backend/src/gateway/circuit-breaker-store.ts` | `CircuitBreakerStore` + `CircuitBreakerThresholds` + `MemoryCircuitBreakerStore`. |
+| `packages/core-backend/src/gateway/redis-circuit-breaker-store.ts` | Four Lua scripts (success/failure/check/transition) + JS twins. |
+| `packages/core-backend/tests/unit/redis-token-bucket-store.test.ts` | 11 unit tests (pure-JS transitions, dispatch path, NOSCRIPT recovery). |
+| `packages/core-backend/tests/unit/redis-circuit-breaker-store.test.ts` | 13 unit tests (state-machine twins, memory store cycle, Redis dispatch). |
+
+## Files modified (additive only)
+
+- `packages/core-backend/src/integration/rate-limiting/token-bucket.ts`:
+  - Accepts optional `store?: TokenBucketStore` as a second constructor argument.
+  - Adds `consumeAsync(key, tokens)` which delegates to the store when one is attached. The original sync `consume()` is untouched.
+- `packages/core-backend/src/gateway/CircuitBreaker.ts`:
+  - Accepts optional `CircuitBreakerRuntimeOptions` (`{ store?, id? }`) as a second constructor argument. Default callers (`new CircuitBreaker(config)` and every `createXxxCircuitBreaker()` factory) continue to work unchanged.
+  - Adds `refreshSharedState()` and `reportToStore(success)` hooks for callers who wish to synchronize with a shared store before/after `execute`.
+- `packages/core-backend/src/integration/rate-limiting/index.ts` and `packages/core-backend/src/gateway/index.ts`:
+  - Re-export the new types / Lua sources / JS twins.
+
+## Interface definitions
+
+### `TokenBucketStore`
+
+```ts
+export interface ConsumeResult {
+  allowed: boolean
+  tokensRemaining: number
+  retryAfterMs: number
+}
+
+export interface TokenBucketStore {
+  consume(
+    key: string,
+    capacity: number,
+    refillRate: number,
+    tokens: number,
+  ): Promise<ConsumeResult>
+}
+```
+
+### `CircuitBreakerStore`
+
+```ts
+export interface CircuitBreakerThresholds {
+  errorThreshold: number
+  volumeThreshold: number
+  windowSizeMs: number
+  resetTimeoutMs: number
+}
+
+export interface CircuitBreakerSnapshot {
+  state: CircuitState
+  windowRequests: number
+  windowFailures: number
+  lastTransitionAt: number
+  nextAttemptAt: number
+}
+
+export interface CircuitBreakerStore {
+  getSnapshot(id): Promise<CircuitBreakerSnapshot>
+  recordSuccess(id, thresholds): Promise<CircuitBreakerSnapshot>
+  recordFailure(id, thresholds): Promise<CircuitBreakerSnapshot>
+  transitionTo(id, newState, thresholds): Promise<CircuitBreakerSnapshot>
+  checkAndUpdate(id, thresholds): Promise<CircuitBreakerSnapshot>
+}
+```
+
+The store is intentionally *smart*: record-methods take the breaker's thresholds and atomically perform `record + maybe-transition` so replicas cannot disagree about when to open/close a circuit. The alternative (dumb storage with business logic outside Redis) reintroduces the cross-replica race we are trying to eliminate.
+
+## Lua script excerpts
+
+### Token bucket (`TOKEN_BUCKET_LUA`)
+
+```lua
+local data = redis.call('HMGET', key, 'tokens', 'lastRefill')
+local tokens = tonumber(data[1])
+local lastRefill = tonumber(data[2])
+
+if tokens == nil then
+  tokens = capacity
+  lastRefill = nowMs
+end
+
+local elapsed = nowMs - lastRefill
+if elapsed < 0 then elapsed = 0 end
+local refill = (elapsed / 1000.0) * refillRate
+if refill > 0 then
+  tokens = math.min(capacity, tokens + refill)
+  lastRefill = nowMs
+end
+
+local allowed = 0
+if tokens >= requested then
+  tokens = tokens - requested
+  allowed = 1
+end
+
+redis.call('HMSET', key, 'tokens', tokens, 'lastRefill', lastRefill)
+redis.call('EXPIRE', key, ttlSeconds)
+
+-- returns { allowed, tostring(tokens), tostring(retryAfterMs) }
+```
+
+### Circuit breaker — record-failure decision (`CIRCUIT_RECORD_FAILURE_LUA`, condensed)
+
+```lua
+if state == 'HALF_OPEN' then
+  state = 'OPEN'; lastAt = nowMs; nextAt = nowMs + resetTimeoutMs
+elseif state == 'CLOSED' then
+  local total, failures = #kept, count_failures(kept)
+  local rate = (failures / total) * 100
+  if total >= volume and rate >= errorThreshold then
+    state = 'OPEN'; lastAt = nowMs; nextAt = nowMs + resetTimeoutMs
+  end
+end
+```
+
+The four scripts (`SUCCESS`, `FAILURE`, `CHECK_AND_UPDATE`, `TRANSITION`) all share a small header that loads and saves the hash layout, so behavior stays consistent.
+
+## Testing strategy
+
+Unit tests exercise **pure-JS twins** (`applyTokenBucketScript`, `applyRecordFailureScript`, etc.) that mirror the Lua transformations one-for-one. The advantage:
+
+1. No Redis server needed in CI.
+2. No Lua interpreter shim to maintain.
+3. The same JS function is used by the mock-Redis shim in the dispatch tests, so `evalsha` / `eval` / `NOSCRIPT` recovery is covered against realistic script output.
+
+The `MemoryCircuitBreakerStore` also serves as an executable specification of the expected Redis behavior: the full `CLOSED → OPEN → HALF_OPEN → CLOSED` cycle is asserted there, and the Redis-backed test runs the same set of assertions through the shim, verifying the Lua twins produce identical results.
+
+## Why `CircuitBreaker` + `TokenBucket` and not `AutomationScheduler`?
+
+- Both TB and CB are **stateless** between requests (the only "state" is the counter/window itself) and **hot-path**: they are consulted on every gateway request. Moving them to Redis immediately benefits any horizontally-scaled deployment.
+- `AutomationScheduler` has durable-queue semantics, leader election, retry/back-off and idempotency requirements that deserve a separate design (BullMQ or similar) rather than a thin store adapter. Rolling it into this slice would have balloon the surface area and muddled the review.
+
+## Follow-ups (explicitly out of scope)
+
+- Wire Redis store selection into `APIGateway`'s internal `CircuitBreaker` map (currently constructs `new CircuitBreaker(config)` without the runtime options).
+- Admin UI to inspect global circuit state across replicas.
+- Automation queue migration (separate ticket).

--- a/docs/development/collab-infra-redis-runtime-development-20260420.md
+++ b/docs/development/collab-infra-redis-runtime-development-20260420.md
@@ -153,6 +153,17 @@ Unit tests exercise **pure-JS twins** (`applyTokenBucketScript`, `applyRecordFai
 
 The `MemoryCircuitBreakerStore` also serves as an executable specification of the expected Redis behavior: the full `CLOSED → OPEN → HALF_OPEN → CLOSED` cycle is asserted there, and the Redis-backed test runs the same set of assertions through the shim, verifying the Lua twins produce identical results.
 
+### Live Redis smoke addendum — 2026-04-21
+
+Reviewer feedback correctly pointed out that the unit tests prove the JS twin and mocked dispatch semantics, but not a real Redis server's Lua execution path. This branch now includes `packages/core-backend/tests/integration/redis-runtime-stores.integration.test.ts`.
+
+Design of the live smoke:
+
+- The suite is gated by `REDIS_URL`; without a real Redis URL it is skipped, so normal CI remains infrastructure-neutral.
+- The token bucket case runs real Redis `SCRIPT LOAD` + `EVALSHA`, validates burst exhaustion and TTL, then runs `SCRIPT FLUSH` and verifies `NOSCRIPT` recovery through the same store instance.
+- The circuit breaker case runs real Redis Lua through `RedisCircuitBreakerStore`, drives `CLOSED -> OPEN`, validates persisted window counters and TTL, then runs `SCRIPT FLUSH` and verifies `NOSCRIPT` recovery via `checkAndUpdate`.
+- The test uses a unique key prefix per case and deletes matching keys after each run, avoiding `FLUSHDB` against a shared Redis.
+
 ## Why `CircuitBreaker` + `TokenBucket` and not `AutomationScheduler`?
 
 - Both TB and CB are **stateless** between requests (the only "state" is the counter/window itself) and **hot-path**: they are consulted on every gateway request. Moving them to Redis immediately benefits any horizontally-scaled deployment.

--- a/docs/development/collab-infra-redis-runtime-verification-20260420.md
+++ b/docs/development/collab-infra-redis-runtime-verification-20260420.md
@@ -1,0 +1,70 @@
+# Redis runtime adapters — verification log
+
+- **Date**: 2026-04-20
+- **Branch**: `codex/collab-infra-redis-runtime-202605`
+- **Worktree**: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/redis`
+- **Scope**: verify that the Redis-backed TokenBucketStore and CircuitBreakerStore adapters typecheck, pass their new unit tests, and do not regress the existing rate-limiter tests.
+
+All commands were executed from the worktree root.
+
+## 1. TypeScript typecheck (core-backend)
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: **PASS** — zero diagnostics emitted.
+
+## 2. New unit tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/redis-token-bucket-store.test.ts \
+  tests/unit/redis-circuit-breaker-store.test.ts \
+  --reporter=dot
+```
+
+```
+ Test Files  2 passed (2)
+      Tests  25 passed (25)
+```
+
+Breakdown:
+
+| File | Tests | Coverage highlights |
+| --- | --- | --- |
+| `redis-token-bucket-store.test.ts` | 11 | initial consume, refill/clamp, reject with retryAfterMs, burst exhaustion, refillRate=0, parallel consume atomicity, SCRIPT LOAD + EVALSHA caching, NOSCRIPT recovery, EVAL fallback, prefix/TTL argument wiring, Lua source asserts. |
+| `redis-circuit-breaker-store.test.ts` | 14 | CLOSED→OPEN threshold, CLOSED stays below volume, OPEN→HALF_OPEN via `checkAndUpdate`, HALF_OPEN success→CLOSED (window cleared), HALF_OPEN failure→OPEN, explicit transitions, `MemoryCircuitBreakerStore` full cycle, admin force open/close, Redis dispatch for failure flip, NOSCRIPT recovery, cooldown-driven transition via Redis, HALF_OPEN flip paths through Redis, `getSnapshot` is a pure HMGET read (no window trim). |
+
+## 3. Regression — existing rate-limiter tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/rate-limiter.test.ts --reporter=dot
+```
+
+```
+ Test Files  1 passed (1)
+      Tests  15 passed (15)
+```
+
+## 4. Regression — existing TokenBucket behaviour
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run src/tests/rate-limiting.test.ts --reporter=dot
+```
+
+```
+ Test Files  1 passed (1)
+      Tests  36 passed (36)
+```
+
+Log output confirmed the new constructor seam is exercised — new logs include `"store":"memory-sync"` showing that unchanged callers continue to use the in-process path.
+
+## Summary
+
+- Typecheck: PASS
+- New adapter tests: 25 / 25 PASS
+- Existing rate-limiter tests: 15 / 15 PASS
+- Existing TokenBucket rate-limiting tests: 36 / 36 PASS
+
+No live Redis server was required or started. All Redis behaviour is exercised through (a) pure-JS twins of the Lua scripts, (b) an in-memory Redis shim that routes `eval` / `evalsha` / `script LOAD` through those twins.

--- a/docs/development/collab-infra-redis-runtime-verification-20260420.md
+++ b/docs/development/collab-infra-redis-runtime-verification-20260420.md
@@ -68,3 +68,109 @@ Log output confirmed the new constructor seam is exercised — new logs include 
 - Existing TokenBucket rate-limiting tests: 36 / 36 PASS
 
 No live Redis server was required or started. All Redis behaviour is exercised through (a) pure-JS twins of the Lua scripts, (b) an in-memory Redis shim that routes `eval` / `evalsha` / `script LOAD` through those twins.
+
+---
+
+## Rebase verification — 2026-04-21
+
+Branch rebased from base `0756ff61d` onto latest `origin/main@c4093dcb8` (+21 commits upstream, no business-file overlap with this branch). Rebase was pure fast-forward with no merge conflict; business diff unchanged (12 files, +2218 / −4).
+
+Post-rebase HEAD: `4565e44a6`.
+
+### Commands run (2026-04-21, .worktrees/redis)
+
+```bash
+git -C .worktrees/redis checkout -- plugins/ tools/   # clean dirty pnpm symlinks
+git -C .worktrees/redis fetch origin main
+git -C .worktrees/redis rebase origin/main             # no conflicts
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/redis-token-bucket-store.test.ts \
+  tests/unit/redis-circuit-breaker-store.test.ts \
+  tests/unit/rate-limiter.test.ts --reporter=dot
+```
+
+### Results
+
+| Step | Outcome | Counts |
+| ---- | ------- | ------ |
+| tsc --noEmit | PASS | zero diagnostics |
+| redis-token-bucket-store | PASS | 11/11 |
+| redis-circuit-breaker-store | PASS | 14/14 |
+| rate-limiter (existing regression) | PASS | 15/15 |
+| Total unit | PASS | 40/40 |
+
+### Live-Redis smoke — PASS
+
+```bash
+docker run -d --name ms2-redis-smoke-<timestamp> -p 127.0.0.1:6389:6379 redis:7
+REDIS_URL=redis://127.0.0.1:6389 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot
+docker rm -f ms2-redis-smoke-<timestamp>
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       2 passed (2)
+```
+
+This is stronger than the originally proposed smoke command: the original command still executed mocked/fake Redis unit tests. The new integration suite connects to a real Redis 7 container, executes the Lua scripts through Redis `SCRIPT LOAD` / `EVALSHA`, validates TTL-backed state, and verifies `NOSCRIPT` recovery after `SCRIPT FLUSH`.
+
+This PR exposes adapter seams only — APIGateway's internal `new CircuitBreaker(config)` wiring is NOT switched to Redis yet. That is an explicit follow-up.
+
+### Baseline
+
+| Field | Value |
+| ----- | ----- |
+| Original base commit | `0756ff61d` |
+| Rebase target | `c4093dcb8` (origin/main, +21 commits) |
+| New branch HEAD | `4565e44a6` |
+| Upstream business-file overlap | none |
+| Rebase conflicts | none |
+
+---
+
+## Latest-main verification — 2026-04-21
+
+After the DingTalk/Yjs queue landed, this branch was advanced again from `origin/main@c4093dcb8` to `origin/main@81edca7d9`. Rebase used `git rebase --autostash origin/main`, preserved the verification MD changes, and completed with no conflicts.
+
+Post-latest-main HEAD before the live-smoke test/doc addendum: `215d11c72`.
+
+### Commands run (2026-04-21, .worktrees/redis)
+
+```bash
+git -C .worktrees/redis rebase --autostash origin/main
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/redis-token-bucket-store.test.ts \
+  tests/unit/redis-circuit-breaker-store.test.ts \
+  tests/unit/rate-limiter.test.ts --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot
+
+docker run -d --name ms2-redis-smoke-<timestamp> -p 127.0.0.1:6389:6379 redis:7
+REDIS_URL=redis://127.0.0.1:6389 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot
+docker rm -f ms2-redis-smoke-<timestamp>
+```
+
+### Results
+
+| Step | Outcome | Counts |
+| ---- | ------- | ------ |
+| Rebase onto `81edca7d9` | PASS | zero conflicts |
+| tsc --noEmit | PASS | zero diagnostics |
+| redis-token-bucket-store | PASS | 11/11 |
+| redis-circuit-breaker-store | PASS | 14/14 |
+| rate-limiter (existing regression) | PASS | 15/15 |
+| Redis runtime integration without `REDIS_URL` | PASS | 2 skipped |
+| Live Redis 7 integration smoke | PASS | 2/2 |
+
+Live Redis smoke validates real Lua execution for both Redis-backed stores, including `SCRIPT FLUSH` / `NOSCRIPT` recovery. This removes the previous "pending manual smoke" caveat.

--- a/packages/core-backend/src/gateway/CircuitBreaker.ts
+++ b/packages/core-backend/src/gateway/CircuitBreaker.ts
@@ -1,4 +1,8 @@
 import { EventEmitter } from 'events'
+import type {
+  CircuitBreakerStore,
+  CircuitBreakerThresholds,
+} from './circuit-breaker-store'
 
 export interface CircuitBreakerConfig {
   timeout?: number         // Request timeout in ms
@@ -34,6 +38,17 @@ interface RequestRecord {
   error?: Error
 }
 
+export interface CircuitBreakerRuntimeOptions {
+  /**
+   * Optional pluggable store for cross-process state (typically
+   * `RedisCircuitBreakerStore`). When omitted, the breaker behaves
+   * exactly like the legacy in-process implementation.
+   */
+  store?: CircuitBreakerStore
+  /** Circuit identifier when using a shared store. Default: 'default'. */
+  id?: string
+}
+
 export class CircuitBreaker extends EventEmitter {
   private config: Required<CircuitBreakerConfig>
   private state: CircuitState = CircuitState.CLOSED
@@ -43,8 +58,13 @@ export class CircuitBreaker extends EventEmitter {
   private halfOpenRequests: number = 0
   private metrics: CircuitMetrics
   private cleanupTimer: NodeJS.Timeout
+  private readonly store: CircuitBreakerStore | null
+  private readonly circuitId: string
 
-  constructor(config: CircuitBreakerConfig = {}) {
+  constructor(
+    config: CircuitBreakerConfig = {},
+    runtime: CircuitBreakerRuntimeOptions = {},
+  ) {
     super()
 
     this.config = {
@@ -55,6 +75,9 @@ export class CircuitBreaker extends EventEmitter {
       windowSize: config.windowSize || 10000,
       halfOpenRequests: config.halfOpenRequests || 3
     }
+
+    this.store = runtime.store ?? null
+    this.circuitId = runtime.id ?? 'default'
 
     this.metrics = {
       requests: 0,
@@ -69,6 +92,56 @@ export class CircuitBreaker extends EventEmitter {
 
     // Clean up old records periodically
     this.cleanupTimer = setInterval(() => this.cleanupWindow(), 1000)
+  }
+
+  private thresholds(): CircuitBreakerThresholds {
+    return {
+      errorThreshold: this.config.errorThreshold,
+      volumeThreshold: this.config.volumeThreshold,
+      windowSizeMs: this.config.windowSize,
+      resetTimeoutMs: this.config.resetTimeout,
+    }
+  }
+
+  /**
+   * Read (and possibly refresh) the circuit state via the configured
+   * store. Returns the in-process state when no store is attached.
+   */
+  async refreshSharedState(): Promise<CircuitState> {
+    if (!this.store) return this.state
+    const snap = await this.store.checkAndUpdate(
+      this.circuitId,
+      this.thresholds(),
+    )
+    if (snap.state !== this.state) {
+      const from = this.state
+      this.state = snap.state
+      this.stateChangedAt = new Date(snap.lastTransitionAt || Date.now())
+      this.metrics.state = snap.state
+      this.metrics.stateChangedAt = this.stateChangedAt
+      this.metrics.nextAttempt =
+        snap.nextAttemptAt > 0 ? new Date(snap.nextAttemptAt) : undefined
+      this.emit('stateChange', { from, to: snap.state })
+    }
+    return this.state
+  }
+
+  /** Record a success/failure through the shared store (no-op if none). */
+  async reportToStore(success: boolean): Promise<void> {
+    if (!this.store) return
+    const snap = success
+      ? await this.store.recordSuccess(this.circuitId, this.thresholds())
+      : await this.store.recordFailure(this.circuitId, this.thresholds())
+    if (snap.state !== this.state) {
+      const from = this.state
+      this.state = snap.state
+      this.stateChangedAt = new Date(snap.lastTransitionAt || Date.now())
+      this.metrics.state = snap.state
+      this.metrics.stateChangedAt = this.stateChangedAt
+      this.metrics.nextAttempt =
+        snap.nextAttemptAt > 0 ? new Date(snap.nextAttemptAt) : undefined
+      this.emit('stateChange', { from, to: snap.state })
+    }
   }
 
   async execute<T>(fn: () => Promise<T>): Promise<T> {

--- a/packages/core-backend/src/gateway/circuit-breaker-store.ts
+++ b/packages/core-backend/src/gateway/circuit-breaker-store.ts
@@ -1,0 +1,251 @@
+/**
+ * Pluggable storage backend for CircuitBreaker.
+ *
+ * The existing in-process `CircuitBreaker` uses a private field for state
+ * and a `RequestRecord[]` rolling window. Both are lost on process restart
+ * and cannot be shared between API-gateway replicas. This store abstracts
+ * "what state am I in? how many failures have I seen lately?" so callers
+ * can opt into a Redis-backed, cluster-wide circuit.
+ *
+ * The interface is deliberately "smart": record-methods take the CB
+ * thresholds and perform the record + maybe-transition step atomically in
+ * Lua. Otherwise multiple replicas could race and disagree about state.
+ */
+
+import { CircuitState } from './CircuitBreaker'
+
+export interface CircuitBreakerThresholds {
+  /** Error percentage that triggers CLOSED -> OPEN. */
+  errorThreshold: number
+  /** Minimum requests required before errorThreshold is evaluated. */
+  volumeThreshold: number
+  /** Rolling window size in milliseconds. */
+  windowSizeMs: number
+  /** Cooldown in ms before OPEN is eligible to transition to HALF_OPEN. */
+  resetTimeoutMs: number
+}
+
+export interface CircuitBreakerSnapshot {
+  state: CircuitState
+  /** Total requests observed within the rolling window. */
+  windowRequests: number
+  /** Failed requests observed within the rolling window. */
+  windowFailures: number
+  /** Epoch-ms of the last state transition. */
+  lastTransitionAt: number
+  /** Epoch-ms when OPEN is eligible to become HALF_OPEN (0 when N/A). */
+  nextAttemptAt: number
+}
+
+export interface CircuitBreakerStore {
+  /**
+   * Read the current snapshot for the circuit. Implementations should
+   * lazily initialize an empty (CLOSED) entry when none exists.
+   */
+  getSnapshot(id: string): Promise<CircuitBreakerSnapshot>
+
+  /**
+   * Record a successful request and return the resulting snapshot.
+   * Must atomically transition HALF_OPEN → CLOSED when the error rate
+   * within the window drops below the threshold.
+   */
+  recordSuccess(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot>
+
+  /**
+   * Record a failed request and return the resulting snapshot.
+   * Must atomically transition:
+   *  - CLOSED → OPEN when the window meets volume & error thresholds.
+   *  - HALF_OPEN → OPEN on any failure.
+   */
+  recordFailure(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot>
+
+  /**
+   * Explicitly move to a new state (admin actions: `reset`, `forceOpen`).
+   */
+  transitionTo(
+    id: string,
+    state: CircuitState,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot>
+
+  /**
+   * Convenience: read snapshot and, if the breaker is OPEN and the
+   * cooldown has elapsed, atomically move it to HALF_OPEN.
+   *
+   * Used on the hot path at the start of `execute()`.
+   */
+  checkAndUpdate(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot>
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation — equivalent to the behaviour already inlined
+// in `CircuitBreaker` for the default case, but accessible via the store
+// interface so tests and alternate backends share the same contract.
+// ---------------------------------------------------------------------------
+
+interface MemoryEntry {
+  state: CircuitState
+  /** Per-request log within the rolling window. */
+  events: { at: number; success: boolean }[]
+  lastTransitionAt: number
+  nextAttemptAt: number
+}
+
+export class MemoryCircuitBreakerStore implements CircuitBreakerStore {
+  private readonly entries = new Map<string, MemoryEntry>()
+
+  async getSnapshot(id: string): Promise<CircuitBreakerSnapshot> {
+    const entry = this.getOrCreate(id)
+    return this.snapshot(entry)
+  }
+
+  async recordSuccess(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot> {
+    const nowMs = Math.floor(Date.now())
+    const entry = this.getOrCreate(id)
+    this.trimWindow(entry, thresholds.windowSizeMs, nowMs)
+    entry.events.push({ at: nowMs, success: true })
+
+    if (entry.state === CircuitState.HALF_OPEN) {
+      const { errorRate } = this.windowStats(entry)
+      if (errorRate < thresholds.errorThreshold) {
+        this.setState(entry, CircuitState.CLOSED, thresholds, nowMs)
+      }
+    }
+
+    return this.snapshot(entry)
+  }
+
+  async recordFailure(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot> {
+    const nowMs = Math.floor(Date.now())
+    const entry = this.getOrCreate(id)
+    this.trimWindow(entry, thresholds.windowSizeMs, nowMs)
+    entry.events.push({ at: nowMs, success: false })
+
+    if (entry.state === CircuitState.HALF_OPEN) {
+      // Any failure during probe re-opens the circuit.
+      this.setState(entry, CircuitState.OPEN, thresholds, nowMs)
+    } else if (entry.state === CircuitState.CLOSED) {
+      const { totalRequests, errorRate } = this.windowStats(entry)
+      if (
+        totalRequests >= thresholds.volumeThreshold &&
+        errorRate >= thresholds.errorThreshold
+      ) {
+        this.setState(entry, CircuitState.OPEN, thresholds, nowMs)
+      }
+    }
+
+    return this.snapshot(entry)
+  }
+
+  async transitionTo(
+    id: string,
+    state: CircuitState,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot> {
+    const nowMs = Math.floor(Date.now())
+    const entry = this.getOrCreate(id)
+    this.setState(entry, state, thresholds, nowMs)
+    return this.snapshot(entry)
+  }
+
+  async checkAndUpdate(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot> {
+    const nowMs = Math.floor(Date.now())
+    const entry = this.getOrCreate(id)
+    this.trimWindow(entry, thresholds.windowSizeMs, nowMs)
+
+    if (
+      entry.state === CircuitState.OPEN &&
+      entry.nextAttemptAt > 0 &&
+      nowMs >= entry.nextAttemptAt
+    ) {
+      this.setState(entry, CircuitState.HALF_OPEN, thresholds, nowMs)
+    }
+
+    return this.snapshot(entry)
+  }
+
+  /** Test hook — forget all circuits. */
+  reset(): void {
+    this.entries.clear()
+  }
+
+  private getOrCreate(id: string): MemoryEntry {
+    let entry = this.entries.get(id)
+    if (!entry) {
+      entry = {
+        state: CircuitState.CLOSED,
+        events: [],
+        lastTransitionAt: Math.floor(Date.now()),
+        nextAttemptAt: 0,
+      }
+      this.entries.set(id, entry)
+    }
+    return entry
+  }
+
+  private trimWindow(entry: MemoryEntry, windowSizeMs: number, nowMs: number): void {
+    const cutoff = nowMs - windowSizeMs
+    if (entry.events.length === 0 || entry.events[0].at >= cutoff) return
+    entry.events = entry.events.filter(e => e.at >= cutoff)
+  }
+
+  private windowStats(entry: MemoryEntry): {
+    totalRequests: number
+    failures: number
+    errorRate: number
+  } {
+    const totalRequests = entry.events.length
+    const failures = entry.events.reduce(
+      (acc, e) => (e.success ? acc : acc + 1),
+      0,
+    )
+    const errorRate = totalRequests > 0 ? (failures / totalRequests) * 100 : 0
+    return { totalRequests, failures, errorRate }
+  }
+
+  private setState(
+    entry: MemoryEntry,
+    state: CircuitState,
+    thresholds: CircuitBreakerThresholds,
+    nowMs: number,
+  ): void {
+    if (entry.state === state) return
+    entry.state = state
+    entry.lastTransitionAt = nowMs
+    entry.nextAttemptAt =
+      state === CircuitState.OPEN ? nowMs + thresholds.resetTimeoutMs : 0
+    if (state === CircuitState.CLOSED) {
+      // Fresh window on close so past failures don't immediately re-open.
+      entry.events = []
+    }
+  }
+
+  private snapshot(entry: MemoryEntry): CircuitBreakerSnapshot {
+    const { totalRequests, failures } = this.windowStats(entry)
+    return {
+      state: entry.state,
+      windowRequests: totalRequests,
+      windowFailures: failures,
+      lastTransitionAt: entry.lastTransitionAt,
+      nextAttemptAt: entry.nextAttemptAt,
+    }
+  }
+}

--- a/packages/core-backend/src/gateway/index.ts
+++ b/packages/core-backend/src/gateway/index.ts
@@ -216,4 +216,36 @@ export type {
 
 export type { RateLimitConfig } from './RateLimiter'
 export { CircuitState } from './CircuitBreaker'
-export type { CircuitBreakerConfig } from './CircuitBreaker'
+export type {
+  CircuitBreakerConfig,
+  CircuitBreakerRuntimeOptions
+} from './CircuitBreaker'
+
+// Pluggable storage backends (memory default, optional Redis)
+export {
+  MemoryCircuitBreakerStore
+} from './circuit-breaker-store'
+export type {
+  CircuitBreakerStore,
+  CircuitBreakerThresholds,
+  CircuitBreakerSnapshot
+} from './circuit-breaker-store'
+
+export {
+  RedisCircuitBreakerStore,
+  CIRCUIT_RECORD_SUCCESS_LUA,
+  CIRCUIT_RECORD_FAILURE_LUA,
+  CIRCUIT_CHECK_AND_UPDATE_LUA,
+  CIRCUIT_TRANSITION_LUA,
+  applyRecordSuccessScript,
+  applyRecordFailureScript,
+  applyCheckAndUpdateScript,
+  applyTransitionScript,
+  emptyCircuitState
+} from './redis-circuit-breaker-store'
+
+export type {
+  RedisCircuitBreakerStoreOptions,
+  RedisCircuitClient,
+  CircuitScriptState
+} from './redis-circuit-breaker-store'

--- a/packages/core-backend/src/gateway/redis-circuit-breaker-store.ts
+++ b/packages/core-backend/src/gateway/redis-circuit-breaker-store.ts
@@ -1,0 +1,569 @@
+/**
+ * Redis-backed CircuitBreaker store (Sprint 6 / Redis runtime).
+ *
+ * State layout per circuit (`{prefix}{id}`):
+ *   HASH fields:
+ *     state             'CLOSED' | 'OPEN' | 'HALF_OPEN'
+ *     lastTransitionAt  epoch-ms
+ *     nextAttemptAt     epoch-ms (0 when not OPEN)
+ *     events            JSON array of { at, success } within the window
+ *
+ * Storing the event window as JSON inside the hash keeps the Lua scripts
+ * self-contained; capacity is bounded by `volumeThreshold`-order values
+ * so the payload stays small. This mirrors the in-process rolling window
+ * the existing CircuitBreaker maintains.
+ *
+ * Every mutating call goes through a Lua script so record + transition
+ * happens atomically across replicas.
+ */
+
+import { CircuitState } from './CircuitBreaker'
+import type {
+  CircuitBreakerSnapshot,
+  CircuitBreakerStore,
+  CircuitBreakerThresholds,
+} from './circuit-breaker-store'
+
+// ---------------------------------------------------------------------------
+// Lua helpers reused by all scripts.
+// ---------------------------------------------------------------------------
+
+const LUA_HEADER = `
+local key = KEYS[1]
+
+local function load_state()
+  local data = redis.call('HMGET', key, 'state', 'lastTransitionAt', 'nextAttemptAt', 'events')
+  local state = data[1] or 'CLOSED'
+  local lastAt = tonumber(data[2]) or 0
+  local nextAt = tonumber(data[3]) or 0
+  local events = data[4]
+  return state, lastAt, nextAt, events
+end
+
+local function save_state(state, lastAt, nextAt, events)
+  redis.call('HMSET', key, 'state', state, 'lastTransitionAt', lastAt, 'nextAttemptAt', nextAt, 'events', events)
+end
+`
+
+// ---------------------------------------------------------------------------
+// Public Lua sources (exported for inspection / tests).
+//
+// recordSuccess / recordFailure take (errorThreshold, volumeThreshold,
+// windowSizeMs, resetTimeoutMs, nowMs, ttlSeconds) as ARGV.
+// ---------------------------------------------------------------------------
+
+export const CIRCUIT_RECORD_SUCCESS_LUA = (
+  LUA_HEADER +
+  `
+local errorThreshold = tonumber(ARGV[1])
+local _volume = tonumber(ARGV[2]) -- unused on success path, kept for symmetry
+local windowSizeMs = tonumber(ARGV[3])
+local _reset = tonumber(ARGV[4])
+local nowMs = tonumber(ARGV[5])
+local ttlSeconds = tonumber(ARGV[6])
+
+local state, lastAt, nextAt, events = load_state()
+if lastAt == 0 then lastAt = nowMs end
+
+-- append + trim window
+local list = cjson.decode(events or '[]')
+local cutoff = nowMs - windowSizeMs
+local kept = {}
+for _, ev in ipairs(list) do
+  if ev.at >= cutoff then table.insert(kept, ev) end
+end
+table.insert(kept, { at = nowMs, success = true })
+
+if state == 'HALF_OPEN' then
+  local total = #kept
+  local failures = 0
+  for _, ev in ipairs(kept) do
+    if not ev.success then failures = failures + 1 end
+  end
+  local rate = 0
+  if total > 0 then rate = (failures / total) * 100 end
+  if rate < errorThreshold then
+    state = 'CLOSED'
+    lastAt = nowMs
+    nextAt = 0
+    kept = {} -- fresh window
+  end
+end
+
+save_state(state, lastAt, nextAt, cjson.encode(kept))
+redis.call('EXPIRE', key, ttlSeconds)
+
+local total = #kept
+local failures = 0
+for _, ev in ipairs(kept) do
+  if not ev.success then failures = failures + 1 end
+end
+return { state, tostring(total), tostring(failures), tostring(lastAt), tostring(nextAt) }
+`
+).trim()
+
+export const CIRCUIT_RECORD_FAILURE_LUA = (
+  LUA_HEADER +
+  `
+local errorThreshold = tonumber(ARGV[1])
+local volume = tonumber(ARGV[2])
+local windowSizeMs = tonumber(ARGV[3])
+local resetTimeoutMs = tonumber(ARGV[4])
+local nowMs = tonumber(ARGV[5])
+local ttlSeconds = tonumber(ARGV[6])
+
+local state, lastAt, nextAt, events = load_state()
+if lastAt == 0 then lastAt = nowMs end
+
+local list = cjson.decode(events or '[]')
+local cutoff = nowMs - windowSizeMs
+local kept = {}
+for _, ev in ipairs(list) do
+  if ev.at >= cutoff then table.insert(kept, ev) end
+end
+table.insert(kept, { at = nowMs, success = false })
+
+if state == 'HALF_OPEN' then
+  state = 'OPEN'
+  lastAt = nowMs
+  nextAt = nowMs + resetTimeoutMs
+elseif state == 'CLOSED' then
+  local total = #kept
+  local failures = 0
+  for _, ev in ipairs(kept) do
+    if not ev.success then failures = failures + 1 end
+  end
+  local rate = 0
+  if total > 0 then rate = (failures / total) * 100 end
+  if total >= volume and rate >= errorThreshold then
+    state = 'OPEN'
+    lastAt = nowMs
+    nextAt = nowMs + resetTimeoutMs
+  end
+end
+
+save_state(state, lastAt, nextAt, cjson.encode(kept))
+redis.call('EXPIRE', key, ttlSeconds)
+
+local total = #kept
+local failures = 0
+for _, ev in ipairs(kept) do
+  if not ev.success then failures = failures + 1 end
+end
+return { state, tostring(total), tostring(failures), tostring(lastAt), tostring(nextAt) }
+`
+).trim()
+
+export const CIRCUIT_CHECK_AND_UPDATE_LUA = (
+  LUA_HEADER +
+  `
+local windowSizeMs = tonumber(ARGV[3])
+local nowMs = tonumber(ARGV[5])
+local ttlSeconds = tonumber(ARGV[6])
+
+local state, lastAt, nextAt, events = load_state()
+if lastAt == 0 then lastAt = nowMs end
+
+local list = cjson.decode(events or '[]')
+local cutoff = nowMs - windowSizeMs
+local kept = {}
+for _, ev in ipairs(list) do
+  if ev.at >= cutoff then table.insert(kept, ev) end
+end
+
+if state == 'OPEN' and nextAt > 0 and nowMs >= nextAt then
+  state = 'HALF_OPEN'
+  lastAt = nowMs
+  nextAt = 0
+end
+
+save_state(state, lastAt, nextAt, cjson.encode(kept))
+redis.call('EXPIRE', key, ttlSeconds)
+
+local total = #kept
+local failures = 0
+for _, ev in ipairs(kept) do
+  if not ev.success then failures = failures + 1 end
+end
+return { state, tostring(total), tostring(failures), tostring(lastAt), tostring(nextAt) }
+`
+).trim()
+
+export const CIRCUIT_TRANSITION_LUA = (
+  LUA_HEADER +
+  `
+local newState = ARGV[1]
+local resetTimeoutMs = tonumber(ARGV[4])
+local nowMs = tonumber(ARGV[5])
+local ttlSeconds = tonumber(ARGV[6])
+
+local state, lastAt, nextAt, events = load_state()
+if state == newState then
+  local list = cjson.decode(events or '[]')
+  local total = #list
+  local failures = 0
+  for _, ev in ipairs(list) do
+    if not ev.success then failures = failures + 1 end
+  end
+  return { state, tostring(total), tostring(failures), tostring(lastAt), tostring(nextAt) }
+end
+
+state = newState
+lastAt = nowMs
+if newState == 'OPEN' then
+  nextAt = nowMs + resetTimeoutMs
+else
+  nextAt = 0
+end
+
+local keptStr = '[]'
+if newState == 'CLOSED' then
+  keptStr = '[]'
+elseif events ~= nil then
+  keptStr = events
+end
+
+save_state(state, lastAt, nextAt, keptStr)
+redis.call('EXPIRE', key, ttlSeconds)
+
+local list = cjson.decode(keptStr)
+local total = #list
+local failures = 0
+for _, ev in ipairs(list) do
+  if not ev.success then failures = failures + 1 end
+end
+return { state, tostring(total), tostring(failures), tostring(lastAt), tostring(nextAt) }
+`
+).trim()
+
+// ---------------------------------------------------------------------------
+// Pure-JS twins used by unit tests (and to sanity-check the Lua above).
+// Each helper mutates a plain object mirroring the Redis hash layout.
+// ---------------------------------------------------------------------------
+
+export interface CircuitScriptState {
+  state: CircuitState
+  lastTransitionAt: number
+  nextAttemptAt: number
+  events: { at: number; success: boolean }[]
+}
+
+export function emptyCircuitState(): CircuitScriptState {
+  return {
+    state: CircuitState.CLOSED,
+    lastTransitionAt: 0,
+    nextAttemptAt: 0,
+    events: [],
+  }
+}
+
+function trim(state: CircuitScriptState, windowSizeMs: number, nowMs: number): void {
+  const cutoff = nowMs - windowSizeMs
+  if (state.events.length === 0) return
+  state.events = state.events.filter(ev => ev.at >= cutoff)
+}
+
+function windowStats(state: CircuitScriptState): {
+  totalRequests: number
+  failures: number
+  errorRate: number
+} {
+  const totalRequests = state.events.length
+  const failures = state.events.reduce(
+    (acc, ev) => (ev.success ? acc : acc + 1),
+    0,
+  )
+  const errorRate = totalRequests > 0 ? (failures / totalRequests) * 100 : 0
+  return { totalRequests, failures, errorRate }
+}
+
+export function applyRecordSuccessScript(
+  state: CircuitScriptState,
+  thresholds: CircuitBreakerThresholds,
+  nowMs: number,
+): CircuitScriptState {
+  if (state.lastTransitionAt === 0) state.lastTransitionAt = nowMs
+  trim(state, thresholds.windowSizeMs, nowMs)
+  state.events.push({ at: nowMs, success: true })
+
+  if (state.state === CircuitState.HALF_OPEN) {
+    const { errorRate } = windowStats(state)
+    if (errorRate < thresholds.errorThreshold) {
+      state.state = CircuitState.CLOSED
+      state.lastTransitionAt = nowMs
+      state.nextAttemptAt = 0
+      state.events = []
+    }
+  }
+  return state
+}
+
+export function applyRecordFailureScript(
+  state: CircuitScriptState,
+  thresholds: CircuitBreakerThresholds,
+  nowMs: number,
+): CircuitScriptState {
+  if (state.lastTransitionAt === 0) state.lastTransitionAt = nowMs
+  trim(state, thresholds.windowSizeMs, nowMs)
+  state.events.push({ at: nowMs, success: false })
+
+  if (state.state === CircuitState.HALF_OPEN) {
+    state.state = CircuitState.OPEN
+    state.lastTransitionAt = nowMs
+    state.nextAttemptAt = nowMs + thresholds.resetTimeoutMs
+  } else if (state.state === CircuitState.CLOSED) {
+    const { totalRequests, errorRate } = windowStats(state)
+    if (
+      totalRequests >= thresholds.volumeThreshold &&
+      errorRate >= thresholds.errorThreshold
+    ) {
+      state.state = CircuitState.OPEN
+      state.lastTransitionAt = nowMs
+      state.nextAttemptAt = nowMs + thresholds.resetTimeoutMs
+    }
+  }
+  return state
+}
+
+export function applyCheckAndUpdateScript(
+  state: CircuitScriptState,
+  thresholds: CircuitBreakerThresholds,
+  nowMs: number,
+): CircuitScriptState {
+  if (state.lastTransitionAt === 0) state.lastTransitionAt = nowMs
+  trim(state, thresholds.windowSizeMs, nowMs)
+  if (
+    state.state === CircuitState.OPEN &&
+    state.nextAttemptAt > 0 &&
+    nowMs >= state.nextAttemptAt
+  ) {
+    state.state = CircuitState.HALF_OPEN
+    state.lastTransitionAt = nowMs
+    state.nextAttemptAt = 0
+  }
+  return state
+}
+
+export function applyTransitionScript(
+  state: CircuitScriptState,
+  newState: CircuitState,
+  thresholds: CircuitBreakerThresholds,
+  nowMs: number,
+): CircuitScriptState {
+  if (state.state === newState) return state
+  state.state = newState
+  state.lastTransitionAt = nowMs
+  state.nextAttemptAt =
+    newState === CircuitState.OPEN ? nowMs + thresholds.resetTimeoutMs : 0
+  if (newState === CircuitState.CLOSED) state.events = []
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Redis client shape — narrow enough for ioredis + a test shim.
+// ---------------------------------------------------------------------------
+
+export interface RedisCircuitClient {
+  evalsha(
+    sha1: string,
+    numKeys: number,
+    ...keysAndArgs: (string | number)[]
+  ): Promise<unknown>
+  eval(
+    script: string,
+    numKeys: number,
+    ...keysAndArgs: (string | number)[]
+  ): Promise<unknown>
+  script(subcommand: 'LOAD', script: string): Promise<string>
+  /** Read a set of hash fields. Must return one entry per field, or null. */
+  hmget(key: string, ...fields: string[]): Promise<(string | null)[]>
+}
+
+export interface RedisCircuitBreakerStoreOptions {
+  redis: RedisCircuitClient
+  /** Prefix applied to every circuit key. Default: `cb:`. */
+  keyPrefix?: string
+  /** TTL (seconds) applied whenever the hash is touched. Default: 3600. */
+  ttlSeconds?: number
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+function parseSnapshot(raw: unknown): CircuitBreakerSnapshot {
+  if (!Array.isArray(raw) || raw.length < 5) {
+    throw new Error(
+      `[RedisCircuitBreakerStore] unexpected Lua result: ${JSON.stringify(raw)}`,
+    )
+  }
+  const stateStr = String(raw[0])
+  const state: CircuitState =
+    stateStr === CircuitState.OPEN
+      ? CircuitState.OPEN
+      : stateStr === CircuitState.HALF_OPEN
+        ? CircuitState.HALF_OPEN
+        : CircuitState.CLOSED
+  return {
+    state,
+    windowRequests: Number(String(raw[1])),
+    windowFailures: Number(String(raw[2])),
+    lastTransitionAt: Number(String(raw[3])),
+    nextAttemptAt: Number(String(raw[4])),
+  }
+}
+
+function isNoScriptError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return /NOSCRIPT/i.test(message)
+}
+
+export class RedisCircuitBreakerStore implements CircuitBreakerStore {
+  private readonly redis: RedisCircuitClient
+  private readonly keyPrefix: string
+  private readonly ttlSeconds: number
+  private shaCache: Record<string, string | null> = {
+    success: null,
+    failure: null,
+    check: null,
+    transition: null,
+  }
+
+  constructor(options: RedisCircuitBreakerStoreOptions) {
+    this.redis = options.redis
+    this.keyPrefix = options.keyPrefix ?? 'cb:'
+    this.ttlSeconds = options.ttlSeconds ?? 3600
+  }
+
+  async getSnapshot(id: string): Promise<CircuitBreakerSnapshot> {
+    // Pure read: HMGET the hash and decode locally. No Lua, no trimming,
+    // no state transitions — `getSnapshot` must not mutate the circuit
+    // (the MemoryCircuitBreakerStore contract is also read-only).
+    const redisKey = this.keyPrefix + id
+    const fields = await this.redis.hmget(
+      redisKey,
+      'state',
+      'lastTransitionAt',
+      'nextAttemptAt',
+      'events',
+    )
+    const [stateRaw, lastAtRaw, nextAtRaw, eventsRaw] = fields
+    const stateStr = stateRaw ?? CircuitState.CLOSED
+    const state: CircuitState =
+      stateStr === CircuitState.OPEN
+        ? CircuitState.OPEN
+        : stateStr === CircuitState.HALF_OPEN
+          ? CircuitState.HALF_OPEN
+          : CircuitState.CLOSED
+
+    let windowRequests = 0
+    let windowFailures = 0
+    if (eventsRaw) {
+      try {
+        const list = JSON.parse(eventsRaw) as { at: number; success: boolean }[]
+        windowRequests = list.length
+        windowFailures = list.reduce(
+          (acc, ev) => (ev.success ? acc : acc + 1),
+          0,
+        )
+      } catch {
+        // Corrupt payload — treat as empty window rather than crash.
+      }
+    }
+
+    return {
+      state,
+      windowRequests,
+      windowFailures,
+      lastTransitionAt: Number(lastAtRaw ?? 0) || 0,
+      nextAttemptAt: Number(nextAtRaw ?? 0) || 0,
+    }
+  }
+
+  async recordSuccess(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot> {
+    return this.run('success', CIRCUIT_RECORD_SUCCESS_LUA, id, [
+      thresholds.errorThreshold,
+      thresholds.volumeThreshold,
+      thresholds.windowSizeMs,
+      thresholds.resetTimeoutMs,
+      Math.floor(Date.now()),
+      this.ttlSeconds,
+    ])
+  }
+
+  async recordFailure(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot> {
+    return this.run('failure', CIRCUIT_RECORD_FAILURE_LUA, id, [
+      thresholds.errorThreshold,
+      thresholds.volumeThreshold,
+      thresholds.windowSizeMs,
+      thresholds.resetTimeoutMs,
+      Math.floor(Date.now()),
+      this.ttlSeconds,
+    ])
+  }
+
+  async transitionTo(
+    id: string,
+    state: CircuitState,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot> {
+    return this.run('transition', CIRCUIT_TRANSITION_LUA, id, [
+      state,
+      thresholds.volumeThreshold,
+      thresholds.windowSizeMs,
+      thresholds.resetTimeoutMs,
+      Math.floor(Date.now()),
+      this.ttlSeconds,
+    ])
+  }
+
+  async checkAndUpdate(
+    id: string,
+    thresholds: CircuitBreakerThresholds,
+  ): Promise<CircuitBreakerSnapshot> {
+    return this.run('check', CIRCUIT_CHECK_AND_UPDATE_LUA, id, [
+      thresholds.errorThreshold,
+      thresholds.volumeThreshold,
+      thresholds.windowSizeMs,
+      thresholds.resetTimeoutMs,
+      Math.floor(Date.now()),
+      this.ttlSeconds,
+    ])
+  }
+
+  private async run(
+    slot: keyof typeof this.shaCache,
+    source: string,
+    id: string,
+    args: (string | number)[],
+  ): Promise<CircuitBreakerSnapshot> {
+    const redisKey = this.keyPrefix + id
+
+    const cached = this.shaCache[slot]
+    if (cached) {
+      try {
+        const raw = await this.redis.evalsha(cached, 1, redisKey, ...args)
+        return parseSnapshot(raw)
+      } catch (err) {
+        if (!isNoScriptError(err)) throw err
+        this.shaCache[slot] = null
+      }
+    }
+
+    try {
+      const sha = await this.redis.script('LOAD', source)
+      this.shaCache[slot] = sha
+      const raw = await this.redis.evalsha(sha, 1, redisKey, ...args)
+      return parseSnapshot(raw)
+    } catch {
+      const raw = await this.redis.eval(source, 1, redisKey, ...args)
+      return parseSnapshot(raw)
+    }
+  }
+}

--- a/packages/core-backend/src/integration/rate-limiting/index.ts
+++ b/packages/core-backend/src/integration/rate-limiting/index.ts
@@ -15,6 +15,29 @@ export type {
   RateLimitResult
 } from './token-bucket'
 
+// Pluggable storage backends (memory default, optional Redis)
+export {
+  MemoryTokenBucketStore
+} from './token-bucket-store'
+
+export type {
+  TokenBucketStore,
+  ConsumeResult
+} from './token-bucket-store'
+
+export {
+  RedisTokenBucketStore,
+  TOKEN_BUCKET_LUA,
+  applyTokenBucketScript
+} from './redis-token-bucket-store'
+
+export type {
+  RedisTokenBucketStoreOptions,
+  RedisScriptClient,
+  ApplyTokenBucketArgs,
+  ApplyTokenBucketResult
+} from './redis-token-bucket-store'
+
 // Message Rate Limiter (MessageBus integration)
 export {
   MessageRateLimiter,

--- a/packages/core-backend/src/integration/rate-limiting/redis-token-bucket-store.ts
+++ b/packages/core-backend/src/integration/rate-limiting/redis-token-bucket-store.ts
@@ -1,0 +1,270 @@
+/**
+ * Redis-backed Token Bucket store (Sprint 6 / Redis runtime).
+ *
+ * Atomically consumes tokens from a bucket stored in Redis using a Lua
+ * script. The script reads current `tokens` + `lastRefill`, refills based
+ * on elapsed time, decrements by the requested count (when enough are
+ * available), writes the new state back, and refreshes the TTL.
+ *
+ * The limiter itself continues to default to the in-process MemoryStore;
+ * callers explicitly opt into Redis by constructing
+ * `TokenBucketRateLimiter` with `{ store: new RedisTokenBucketStore(...) }`.
+ *
+ * Graceful degradation: if the Redis call throws, the caller is expected
+ * to fall back to memory — see `message-rate-limiter.ts` for the pattern.
+ */
+
+import type { TokenBucketStore, ConsumeResult } from './token-bucket-store'
+
+// ---------------------------------------------------------------------------
+// Shared Lua script source.
+// Exported so unit tests can assert the contents (and so the pure-JS twin
+// below stays in sync).
+//
+// KEYS[1]      bucket key
+// ARGV[1]      bucket capacity          (number)
+// ARGV[2]      tokensPerSecond          (number)
+// ARGV[3]      tokensRequested          (number)
+// ARGV[4]      nowMs                    (integer, ms since epoch)
+// ARGV[5]      ttlSeconds               (integer)
+//
+// HASH fields stored at KEYS[1]:
+//   tokens           current token balance (float serialised as string)
+//   lastRefill       timestamp in ms of the most recent refill
+// ---------------------------------------------------------------------------
+export const TOKEN_BUCKET_LUA = `
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refillRate = tonumber(ARGV[2])
+local requested = tonumber(ARGV[3])
+local nowMs = tonumber(ARGV[4])
+local ttlSeconds = tonumber(ARGV[5])
+
+local data = redis.call('HMGET', key, 'tokens', 'lastRefill')
+local tokens = tonumber(data[1])
+local lastRefill = tonumber(data[2])
+
+if tokens == nil then
+  tokens = capacity
+  lastRefill = nowMs
+end
+
+local elapsed = nowMs - lastRefill
+if elapsed < 0 then elapsed = 0 end
+local refill = (elapsed / 1000.0) * refillRate
+if refill > 0 then
+  tokens = math.min(capacity, tokens + refill)
+  lastRefill = nowMs
+end
+
+local allowed = 0
+if tokens >= requested then
+  tokens = tokens - requested
+  allowed = 1
+end
+
+redis.call('HMSET', key, 'tokens', tokens, 'lastRefill', lastRefill)
+redis.call('EXPIRE', key, ttlSeconds)
+
+local retryAfterMs = 0
+if allowed == 0 then
+  local deficit = requested - tokens
+  if refillRate > 0 then
+    retryAfterMs = math.ceil((deficit / refillRate) * 1000)
+  else
+    retryAfterMs = -1
+  end
+end
+
+return { allowed, tostring(tokens), tostring(retryAfterMs) }
+`.trim()
+
+// ---------------------------------------------------------------------------
+// Pure-JS twin used by tests so we never need to run a real Lua VM.
+// Mirrors the Lua transformation exactly — same formulas, same rounding.
+// ---------------------------------------------------------------------------
+
+export interface ApplyTokenBucketArgs {
+  /** Previous bucket state; undefined when the key does not yet exist. */
+  state: { tokens: number; lastRefill: number } | undefined
+  capacity: number
+  refillRate: number
+  requested: number
+  nowMs: number
+}
+
+export interface ApplyTokenBucketResult {
+  allowed: boolean
+  tokens: number
+  lastRefill: number
+  retryAfterMs: number
+}
+
+/**
+ * Deterministic JS equivalent of TOKEN_BUCKET_LUA — used by unit tests
+ * and (optionally) by a future non-Redis code-path that wants the same
+ * semantics without a network call.
+ */
+export function applyTokenBucketScript(args: ApplyTokenBucketArgs): ApplyTokenBucketResult {
+  const { capacity, refillRate, requested } = args
+  const nowMs = Math.floor(args.nowMs)
+
+  let tokens: number
+  let lastRefill: number
+
+  if (!args.state) {
+    tokens = capacity
+    lastRefill = nowMs
+  } else {
+    tokens = args.state.tokens
+    lastRefill = args.state.lastRefill
+  }
+
+  let elapsed = nowMs - lastRefill
+  if (elapsed < 0) elapsed = 0
+
+  const refill = (elapsed / 1000) * refillRate
+  if (refill > 0) {
+    tokens = Math.min(capacity, tokens + refill)
+    lastRefill = nowMs
+  }
+
+  let allowed = false
+  if (tokens >= requested) {
+    tokens = tokens - requested
+    allowed = true
+  }
+
+  let retryAfterMs = 0
+  if (!allowed) {
+    const deficit = requested - tokens
+    retryAfterMs =
+      refillRate > 0 ? Math.ceil((deficit / refillRate) * 1000) : -1
+  }
+
+  return { allowed, tokens, lastRefill, retryAfterMs }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ioredis-compatible client shape (eval/evalsha/script).
+// Keeping this narrow means tests can provide a tiny shim without pulling
+// in ioredis at all.
+// ---------------------------------------------------------------------------
+
+export interface RedisScriptClient {
+  evalsha(
+    sha1: string,
+    numKeys: number,
+    ...keysAndArgs: (string | number)[]
+  ): Promise<unknown>
+  eval(
+    script: string,
+    numKeys: number,
+    ...keysAndArgs: (string | number)[]
+  ): Promise<unknown>
+  script(subcommand: 'LOAD', script: string): Promise<string>
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface RedisTokenBucketStoreOptions {
+  /** ioredis-compatible client exposing eval/evalsha/script. */
+  redis: RedisScriptClient
+  /** Key prefix used to namespace bucket keys. Default: `tb:` */
+  keyPrefix?: string
+  /** TTL (seconds) used when touching the bucket hash. Default: 3600. */
+  ttlSeconds?: number
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+function parseLuaResult(raw: unknown): ConsumeResult {
+  // Lua returns [allowed(int), tokens(string), retryAfterMs(string)]
+  if (!Array.isArray(raw) || raw.length < 3) {
+    throw new Error(
+      `[RedisTokenBucketStore] unexpected Lua return shape: ${JSON.stringify(raw)}`,
+    )
+  }
+  const allowed = Number(raw[0]) === 1
+  const tokens = Number(String(raw[1]))
+  const retryAfterMs = Number(String(raw[2]))
+  return {
+    allowed,
+    tokensRemaining: tokens,
+    retryAfterMs,
+  }
+}
+
+export class RedisTokenBucketStore implements TokenBucketStore {
+  private readonly redis: RedisScriptClient
+  private readonly keyPrefix: string
+  private readonly ttlSeconds: number
+  private scriptSha: string | null = null
+
+  constructor(options: RedisTokenBucketStoreOptions) {
+    this.redis = options.redis
+    this.keyPrefix = options.keyPrefix ?? 'tb:'
+    this.ttlSeconds = options.ttlSeconds ?? 3600
+  }
+
+  /** The Lua source this store runs on Redis. */
+  get luaSource(): string {
+    return TOKEN_BUCKET_LUA
+  }
+
+  async consume(
+    key: string,
+    capacity: number,
+    refillRate: number,
+    tokens: number,
+  ): Promise<ConsumeResult> {
+    const nowMs = Math.floor(Date.now())
+    const redisKey = this.keyPrefix + key
+    const args: (string | number)[] = [
+      capacity,
+      refillRate,
+      tokens,
+      nowMs,
+      this.ttlSeconds,
+    ]
+
+    // Fast path: run cached sha.
+    if (this.scriptSha) {
+      try {
+        const raw = await this.redis.evalsha(this.scriptSha, 1, redisKey, ...args)
+        return parseLuaResult(raw)
+      } catch (err) {
+        // NOSCRIPT happens when Redis has been flushed/restarted.
+        // Re-load and retry once below.
+        if (!isNoScriptError(err)) throw err
+        this.scriptSha = null
+      }
+    }
+
+    // Load + fall back to EVAL to guarantee progress on first call.
+    try {
+      this.scriptSha = await this.redis.script('LOAD', TOKEN_BUCKET_LUA)
+      const raw = await this.redis.evalsha(
+        this.scriptSha,
+        1,
+        redisKey,
+        ...args,
+      )
+      return parseLuaResult(raw)
+    } catch (err) {
+      // If SCRIPT LOAD itself fails (e.g. cluster mode quirk), fall back
+      // to inline EVAL — slower but always correct.
+      const raw = await this.redis.eval(TOKEN_BUCKET_LUA, 1, redisKey, ...args)
+      return parseLuaResult(raw)
+    }
+  }
+}
+
+function isNoScriptError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return /NOSCRIPT/i.test(message)
+}

--- a/packages/core-backend/src/integration/rate-limiting/token-bucket-store.ts
+++ b/packages/core-backend/src/integration/rate-limiting/token-bucket-store.ts
@@ -1,0 +1,103 @@
+/**
+ * Pluggable storage backend for the Token Bucket rate limiter.
+ *
+ * The in-process `TokenBucketRateLimiter` continues to use its own Map
+ * for the zero-dependency sync `consume()` path. This store abstraction
+ * is additive: callers who need cross-process coordination (multi-node
+ * web tier, sidecars, etc.) inject a store — typically
+ * `RedisTokenBucketStore` — and call the limiter's async variant.
+ *
+ * Keeping this as a narrow interface makes unit tests trivial: mock the
+ * store, no Redis connection needed.
+ */
+
+export interface ConsumeResult {
+  /** Whether the requested tokens were available and have been debited. */
+  allowed: boolean
+  /** Tokens left in the bucket after this call (post-decrement). */
+  tokensRemaining: number
+  /** Estimated time until the requested token count can be served (ms). */
+  retryAfterMs: number
+}
+
+export interface TokenBucketStore {
+  /**
+   * Atomically refill the bucket based on elapsed wall-clock time and,
+   * if enough tokens are available, decrement by `tokens`.
+   *
+   * Implementations must clamp the post-refill balance at `capacity`.
+   */
+  consume(
+    key: string,
+    capacity: number,
+    refillRate: number,
+    tokens: number,
+  ): Promise<ConsumeResult>
+}
+
+// ---------------------------------------------------------------------------
+// Memory implementation — functionally equivalent to the existing inline
+// Map-based behaviour in `TokenBucketRateLimiter.consume`, but exposed
+// through the `TokenBucketStore` interface so callers can swap it with
+// Redis without touching business logic.
+// ---------------------------------------------------------------------------
+
+interface MemoryBucket {
+  tokens: number
+  lastRefill: number
+}
+
+export class MemoryTokenBucketStore implements TokenBucketStore {
+  private readonly buckets = new Map<string, MemoryBucket>()
+
+  async consume(
+    key: string,
+    capacity: number,
+    refillRate: number,
+    tokens: number,
+  ): Promise<ConsumeResult> {
+    const nowMs = Math.floor(Date.now())
+    let bucket = this.buckets.get(key)
+
+    if (!bucket) {
+      bucket = { tokens: capacity, lastRefill: nowMs }
+      this.buckets.set(key, bucket)
+    }
+
+    const elapsed = Math.max(0, nowMs - bucket.lastRefill)
+    const refill = (elapsed / 1000) * refillRate
+    if (refill > 0) {
+      bucket.tokens = Math.min(capacity, bucket.tokens + refill)
+      bucket.lastRefill = nowMs
+    }
+
+    let allowed = false
+    if (bucket.tokens >= tokens) {
+      bucket.tokens -= tokens
+      allowed = true
+    }
+
+    let retryAfterMs = 0
+    if (!allowed) {
+      const deficit = tokens - bucket.tokens
+      retryAfterMs =
+        refillRate > 0 ? Math.ceil((deficit / refillRate) * 1000) : -1
+    }
+
+    return {
+      allowed,
+      tokensRemaining: bucket.tokens,
+      retryAfterMs,
+    }
+  }
+
+  /** Clear all buckets. Exposed primarily for tests. */
+  reset(): void {
+    this.buckets.clear()
+  }
+
+  /** Number of active buckets. Exposed primarily for tests. */
+  get size(): number {
+    return this.buckets.size
+  }
+}

--- a/packages/core-backend/src/integration/rate-limiting/token-bucket.ts
+++ b/packages/core-backend/src/integration/rate-limiting/token-bucket.ts
@@ -11,6 +11,7 @@
 
 import { Logger } from '../../core/logger'
 import { coreMetrics } from '../metrics/metrics'
+import type { TokenBucketStore, ConsumeResult } from './token-bucket-store'
 
 const logger = new Logger('TokenBucketRateLimiter')
 
@@ -67,8 +68,15 @@ export class TokenBucketRateLimiter {
   private readonly config: Required<RateLimiterConfig>
   private readonly buckets: Map<string, TokenBucket> = new Map()
   private cleanupInterval: NodeJS.Timeout | null = null
+  /**
+   * Optional pluggable store. When provided, `consumeAsync()` routes
+   * through it (typically Redis) for cross-process coordination. The
+   * legacy synchronous `consume()` API continues to use the in-process
+   * Map so no existing caller needs to change.
+   */
+  private readonly store: TokenBucketStore | null
 
-  constructor(config: RateLimiterConfig = {}) {
+  constructor(config: RateLimiterConfig = {}, store?: TokenBucketStore) {
     const tokensPerSecond = config.tokensPerSecond ?? 1000
 
     this.config = {
@@ -79,13 +87,52 @@ export class TokenBucketRateLimiter {
       bucketIdleTimeoutMs: config.bucketIdleTimeoutMs ?? 300000
     }
 
+    this.store = store ?? null
+
     // Start cleanup interval
     this.startCleanupInterval()
 
     logger.info('TokenBucketRateLimiter initialized', {
       tokensPerSecond: this.config.tokensPerSecond,
-      bucketCapacity: this.config.bucketCapacity
+      bucketCapacity: this.config.bucketCapacity,
+      store: this.store ? this.store.constructor?.name ?? 'custom' : 'memory-sync'
     })
+  }
+
+  /**
+   * Asynchronous consume path. When a `TokenBucketStore` was provided to
+   * the constructor, the call is dispatched through it (enabling Redis
+   * or other cross-process storage). When no store was configured, this
+   * method delegates to the synchronous in-process implementation so
+   * existing metrics and stats remain consistent.
+   */
+  async consumeAsync(key: string, tokens = 1): Promise<RateLimitResult> {
+    if (!this.store) {
+      return this.consume(key, tokens)
+    }
+
+    const raw: ConsumeResult = await this.store.consume(
+      key,
+      this.config.bucketCapacity,
+      this.config.tokensPerSecond,
+      tokens,
+    )
+
+    if (this.config.enableMetrics) {
+      coreMetrics.increment(
+        raw.allowed ? 'rate_limit_allowed' : 'rate_limit_rejected',
+        { key },
+      )
+      if (!raw.allowed) coreMetrics.increment('rate_limit_total_rejected')
+    }
+
+    return {
+      allowed: raw.allowed,
+      tokensRemaining: raw.tokensRemaining,
+      bucketCapacity: this.config.bucketCapacity,
+      retryAfterMs: raw.allowed ? 0 : Math.max(0, raw.retryAfterMs),
+      key,
+    }
   }
 
   /**

--- a/packages/core-backend/tests/integration/redis-runtime-stores.integration.test.ts
+++ b/packages/core-backend/tests/integration/redis-runtime-stores.integration.test.ts
@@ -1,0 +1,97 @@
+import Redis from 'ioredis'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import { CircuitState } from '../../src/gateway/CircuitBreaker'
+import {
+  RedisCircuitBreakerStore,
+  type RedisCircuitClient,
+} from '../../src/gateway/redis-circuit-breaker-store'
+import {
+  RedisTokenBucketStore,
+  type RedisScriptClient,
+} from '../../src/integration/rate-limiting/redis-token-bucket-store'
+
+const redisUrl = process.env.REDIS_URL
+const describeIfRedis = redisUrl ? describe : describe.skip
+
+describeIfRedis('Redis runtime stores live smoke', () => {
+  let redis: Redis
+  let prefix: string
+
+  beforeAll(async () => {
+    redis = new Redis(redisUrl!, {
+      lazyConnect: true,
+      maxRetriesPerRequest: 1,
+      enableOfflineQueue: false,
+    })
+    await redis.connect()
+    await redis.ping()
+  })
+
+  afterEach(async () => {
+    if (!redis || !prefix) return
+    const keys = await redis.keys(`${prefix}*`)
+    if (keys.length) await redis.del(...keys)
+  })
+
+  afterAll(async () => {
+    await redis?.quit()
+  })
+
+  it('executes token bucket Lua against a real Redis server and recovers after SCRIPT FLUSH', async () => {
+    prefix = `ms2:tb:${Date.now()}:${Math.random().toString(16).slice(2)}:`
+    const store = new RedisTokenBucketStore({
+      redis: redis as RedisScriptClient,
+      keyPrefix: prefix,
+      ttlSeconds: 60,
+    })
+
+    await expect(store.consume('user-a', 2, 0, 1)).resolves.toMatchObject({
+      allowed: true,
+      tokensRemaining: 1,
+    })
+    await expect(store.consume('user-a', 2, 0, 1)).resolves.toMatchObject({
+      allowed: true,
+      tokensRemaining: 0,
+    })
+    await expect(store.consume('user-a', 2, 0, 1)).resolves.toMatchObject({
+      allowed: false,
+      retryAfterMs: -1,
+    })
+    await expect(redis.ttl(`${prefix}user-a`)).resolves.toBeGreaterThan(0)
+
+    await redis.script('FLUSH')
+    await expect(store.consume('user-b', 1, 0, 1)).resolves.toMatchObject({
+      allowed: true,
+      tokensRemaining: 0,
+    })
+  })
+
+  it('executes circuit-breaker Lua against a real Redis server and recovers after SCRIPT FLUSH', async () => {
+    prefix = `ms2:cb:${Date.now()}:${Math.random().toString(16).slice(2)}:`
+    const store = new RedisCircuitBreakerStore({
+      redis: redis as RedisCircuitClient,
+      keyPrefix: prefix,
+      ttlSeconds: 60,
+    })
+    const thresholds = {
+      errorThreshold: 50,
+      volumeThreshold: 3,
+      windowSizeMs: 10_000,
+      resetTimeoutMs: 2_000,
+    }
+
+    await store.recordFailure('svc-a', thresholds)
+    await store.recordFailure('svc-a', thresholds)
+    const opened = await store.recordFailure('svc-a', thresholds)
+    expect(opened.state).toBe(CircuitState.OPEN)
+    expect(opened.windowRequests).toBe(3)
+    expect(opened.windowFailures).toBe(3)
+    await expect(redis.ttl(`${prefix}svc-a`)).resolves.toBeGreaterThan(0)
+
+    await redis.script('FLUSH')
+    const afterFlush = await store.checkAndUpdate('svc-a', thresholds)
+    expect(afterFlush.state).toBe(CircuitState.OPEN)
+    expect(afterFlush.windowFailures).toBe(3)
+  })
+})

--- a/packages/core-backend/tests/unit/redis-circuit-breaker-store.test.ts
+++ b/packages/core-backend/tests/unit/redis-circuit-breaker-store.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Unit tests for the Redis-backed CircuitBreaker store.
+ *
+ * Same approach as the token-bucket tests: we don't spin up a Redis
+ * server. The core transition logic is exercised through the pure-JS
+ * twins (`applyRecordSuccessScript`, etc.), and the dispatch layer is
+ * checked via a small Redis shim that runs those twins against an
+ * in-memory state map.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import { CircuitState } from '../../src/gateway/CircuitBreaker'
+import {
+  MemoryCircuitBreakerStore,
+} from '../../src/gateway/circuit-breaker-store'
+import type {
+  CircuitBreakerThresholds,
+} from '../../src/gateway/circuit-breaker-store'
+import {
+  CIRCUIT_RECORD_FAILURE_LUA,
+  CIRCUIT_RECORD_SUCCESS_LUA,
+  CIRCUIT_CHECK_AND_UPDATE_LUA,
+  RedisCircuitBreakerStore,
+  applyCheckAndUpdateScript,
+  applyRecordFailureScript,
+  applyRecordSuccessScript,
+  applyTransitionScript,
+  emptyCircuitState,
+  type CircuitScriptState,
+  type RedisCircuitClient,
+} from '../../src/gateway/redis-circuit-breaker-store'
+
+const defaultThresholds: CircuitBreakerThresholds = {
+  errorThreshold: 50,
+  volumeThreshold: 5,
+  windowSizeMs: 10_000,
+  resetTimeoutMs: 2_000,
+}
+
+// ---------------------------------------------------------------------------
+// Pure-JS twin tests
+// ---------------------------------------------------------------------------
+
+describe('circuit-breaker script twins', () => {
+  it('CLOSED → OPEN after failure threshold is reached', () => {
+    const state: CircuitScriptState = emptyCircuitState()
+    let now = 1_000_000
+    for (let i = 0; i < 5; i++) {
+      applyRecordFailureScript(state, defaultThresholds, now++)
+    }
+    expect(state.state).toBe(CircuitState.OPEN)
+    expect(state.nextAttemptAt).toBe(now - 1 + defaultThresholds.resetTimeoutMs)
+  })
+
+  it('CLOSED stays CLOSED below the volume threshold', () => {
+    const state: CircuitScriptState = emptyCircuitState()
+    // Only 4 failures but threshold=5 -> still CLOSED
+    for (let i = 0; i < 4; i++) {
+      applyRecordFailureScript(state, defaultThresholds, 1_000_000 + i)
+    }
+    expect(state.state).toBe(CircuitState.CLOSED)
+  })
+
+  it('OPEN → HALF_OPEN after reset timeout via checkAndUpdate', () => {
+    const state: CircuitScriptState = emptyCircuitState()
+    // Force OPEN
+    for (let i = 0; i < 5; i++) {
+      applyRecordFailureScript(state, defaultThresholds, 1_000_000 + i)
+    }
+    expect(state.state).toBe(CircuitState.OPEN)
+
+    // Before cooldown — still OPEN
+    applyCheckAndUpdateScript(state, defaultThresholds, 1_000_500)
+    expect(state.state).toBe(CircuitState.OPEN)
+
+    // After cooldown
+    applyCheckAndUpdateScript(state, defaultThresholds, state.nextAttemptAt + 1)
+    expect(state.state).toBe(CircuitState.HALF_OPEN)
+  })
+
+  it('HALF_OPEN success → CLOSED and clears the window (when errorRate drops below threshold)', () => {
+    // With a relaxed threshold one success is enough to close the circuit.
+    const relaxed: CircuitBreakerThresholds = {
+      ...defaultThresholds,
+      errorThreshold: 80,
+    }
+    const state = emptyCircuitState()
+    state.state = CircuitState.HALF_OPEN
+    state.events = [{ at: 999_000, success: false }]
+
+    applyRecordSuccessScript(state, relaxed, 1_000_000)
+    expect(state.state).toBe(CircuitState.CLOSED)
+    expect(state.events).toHaveLength(0)
+  })
+
+  it('HALF_OPEN failure → OPEN immediately', () => {
+    const state: CircuitScriptState = emptyCircuitState()
+    state.state = CircuitState.HALF_OPEN
+    state.lastTransitionAt = 900_000
+
+    applyRecordFailureScript(state, defaultThresholds, 1_000_000)
+    expect(state.state).toBe(CircuitState.OPEN)
+    expect(state.nextAttemptAt).toBe(1_000_000 + defaultThresholds.resetTimeoutMs)
+  })
+
+  it('explicit transition clears window on CLOSE and sets nextAttempt on OPEN', () => {
+    const state: CircuitScriptState = emptyCircuitState()
+    state.events = [{ at: 1, success: false }]
+
+    applyTransitionScript(state, CircuitState.OPEN, defaultThresholds, 2_000_000)
+    expect(state.state).toBe(CircuitState.OPEN)
+    expect(state.nextAttemptAt).toBe(2_000_000 + defaultThresholds.resetTimeoutMs)
+
+    applyTransitionScript(state, CircuitState.CLOSED, defaultThresholds, 2_001_000)
+    expect(state.state).toBe(CircuitState.CLOSED)
+    expect(state.nextAttemptAt).toBe(0)
+    expect(state.events).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// MemoryCircuitBreakerStore — sanity check (shared interface surface)
+// ---------------------------------------------------------------------------
+
+describe('MemoryCircuitBreakerStore', () => {
+  let store: MemoryCircuitBreakerStore
+  beforeEach(() => {
+    store = new MemoryCircuitBreakerStore()
+  })
+
+  it('full cycle CLOSED → OPEN → HALF_OPEN → CLOSED', async () => {
+    const id = 'svc'
+    const now = vi.spyOn(Date, 'now')
+
+    // Drive into OPEN
+    now.mockReturnValue(1_000_000)
+    for (let i = 0; i < 5; i++) {
+      await store.recordFailure(id, defaultThresholds)
+    }
+    expect((await store.getSnapshot(id)).state).toBe(CircuitState.OPEN)
+
+    // Cooldown hasn't elapsed
+    now.mockReturnValue(1_000_500)
+    expect((await store.checkAndUpdate(id, defaultThresholds)).state).toBe(
+      CircuitState.OPEN,
+    )
+
+    // After cooldown → HALF_OPEN
+    now.mockReturnValue(1_000_000 + defaultThresholds.resetTimeoutMs + 1)
+    expect((await store.checkAndUpdate(id, defaultThresholds)).state).toBe(
+      CircuitState.HALF_OPEN,
+    )
+
+    // Successful probe → CLOSED
+    await store.recordSuccess(id, {
+      ...defaultThresholds,
+      errorThreshold: 100, // ensure 1 success brings rate < threshold
+    })
+    expect((await store.getSnapshot(id)).state).toBe(CircuitState.CLOSED)
+
+    now.mockRestore()
+  })
+
+  it('explicit transitionTo lets admin force open/close', async () => {
+    await store.transitionTo('svc', CircuitState.OPEN, defaultThresholds)
+    expect((await store.getSnapshot('svc')).state).toBe(CircuitState.OPEN)
+
+    await store.transitionTo('svc', CircuitState.CLOSED, defaultThresholds)
+    const snap = await store.getSnapshot('svc')
+    expect(snap.state).toBe(CircuitState.CLOSED)
+    expect(snap.nextAttemptAt).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RedisCircuitBreakerStore — mocked Redis dispatch
+// ---------------------------------------------------------------------------
+
+function createFakeCircuitRedis(): RedisCircuitClient & {
+  _calls: { method: string; args: unknown[] }[]
+  _store: Map<string, CircuitScriptState>
+  _scripts: Map<string, string>
+} {
+  const hashes = new Map<string, CircuitScriptState>()
+  const scripts = new Map<string, string>()
+  const calls: { method: string; args: unknown[] }[] = []
+
+  // Map each known Lua script to the corresponding JS twin.
+  const runScript = (
+    source: string,
+    key: string,
+    args: (string | number)[],
+  ): (string | number)[] => {
+    const state = hashes.get(key) ?? emptyCircuitState()
+    const thresholds: CircuitBreakerThresholds = {
+      errorThreshold: Number(args[0]),
+      volumeThreshold: Number(args[1]),
+      windowSizeMs: Number(args[2]),
+      resetTimeoutMs: Number(args[3]),
+    }
+    const nowMs = Number(args[4])
+
+    if (source === CIRCUIT_RECORD_SUCCESS_LUA) {
+      applyRecordSuccessScript(state, thresholds, nowMs)
+    } else if (source === CIRCUIT_RECORD_FAILURE_LUA) {
+      applyRecordFailureScript(state, thresholds, nowMs)
+    } else if (source === CIRCUIT_CHECK_AND_UPDATE_LUA) {
+      applyCheckAndUpdateScript(state, thresholds, nowMs)
+    } else {
+      // transition (ARGV[1] is the target state)
+      const newState = String(args[0]) as CircuitState
+      applyTransitionScript(state, newState, thresholds, nowMs)
+    }
+
+    hashes.set(key, state)
+    const failures = state.events.reduce(
+      (acc, e) => (e.success ? acc : acc + 1),
+      0,
+    )
+    return [
+      state.state,
+      String(state.events.length),
+      String(failures),
+      String(state.lastTransitionAt),
+      String(state.nextAttemptAt),
+    ]
+  }
+
+  return {
+    _calls: calls,
+    _store: hashes,
+    _scripts: scripts,
+    async evalsha(sha: string, numKeys: number, ...rest: (string | number)[]) {
+      calls.push({ method: 'evalsha', args: [sha, numKeys, ...rest] })
+      const source = scripts.get(sha)
+      if (!source) throw new Error('NOSCRIPT No matching script.')
+      const [key, ...scriptArgs] = rest
+      return runScript(source, String(key), scriptArgs)
+    },
+    async eval(source: string, numKeys: number, ...rest: (string | number)[]) {
+      calls.push({ method: 'eval', args: [source, numKeys, ...rest] })
+      const [key, ...scriptArgs] = rest
+      return runScript(source, String(key), scriptArgs)
+    },
+    async script(subcommand: 'LOAD', source: string) {
+      calls.push({ method: 'script', args: [subcommand, source] })
+      const sha = `sha-${scripts.size + 1}`
+      scripts.set(sha, source)
+      return sha
+    },
+    async hmget(key: string, ...fields: string[]): Promise<(string | null)[]> {
+      calls.push({ method: 'hmget', args: [key, ...fields] })
+      const entry = hashes.get(key)
+      if (!entry) return fields.map(() => null)
+      return fields.map(field => {
+        switch (field) {
+          case 'state':
+            return entry.state
+          case 'lastTransitionAt':
+            return String(entry.lastTransitionAt)
+          case 'nextAttemptAt':
+            return String(entry.nextAttemptAt)
+          case 'events':
+            return JSON.stringify(entry.events)
+          default:
+            return null
+        }
+      })
+    },
+  }
+}
+
+describe('RedisCircuitBreakerStore', () => {
+  let redis: ReturnType<typeof createFakeCircuitRedis>
+  let store: RedisCircuitBreakerStore
+
+  beforeEach(() => {
+    redis = createFakeCircuitRedis()
+    store = new RedisCircuitBreakerStore({ redis, keyPrefix: 'cb:test:' })
+  })
+
+  it('records failures through Lua and flips CLOSED → OPEN', async () => {
+    for (let i = 0; i < 5; i++) {
+      await store.recordFailure('svc', defaultThresholds)
+    }
+    const snap = await store.getSnapshot('svc')
+    expect(snap.state).toBe(CircuitState.OPEN)
+    expect(snap.nextAttemptAt).toBeGreaterThan(0)
+  })
+
+  it('recovers from NOSCRIPT by reloading the appropriate script', async () => {
+    await store.recordFailure('svc', defaultThresholds)
+    // Flush script cache to force NOSCRIPT
+    redis._scripts.clear()
+    await store.recordFailure('svc', defaultThresholds)
+
+    const scriptLoads = redis._calls.filter(c => c.method === 'script').length
+    // At least one load per script type we've exercised.
+    expect(scriptLoads).toBeGreaterThanOrEqual(2)
+  })
+
+  it('checkAndUpdate moves OPEN → HALF_OPEN when cooldown elapses', async () => {
+    const nowSpy = vi.spyOn(Date, 'now')
+    nowSpy.mockReturnValue(1_000_000)
+
+    for (let i = 0; i < 5; i++) {
+      await store.recordFailure('svc', defaultThresholds)
+    }
+    expect((await store.getSnapshot('svc')).state).toBe(CircuitState.OPEN)
+
+    // advance past cooldown
+    nowSpy.mockReturnValue(1_000_000 + defaultThresholds.resetTimeoutMs + 1)
+    const snap = await store.checkAndUpdate('svc', defaultThresholds)
+    expect(snap.state).toBe(CircuitState.HALF_OPEN)
+
+    nowSpy.mockRestore()
+  })
+
+  it('HALF_OPEN failure immediately reopens', async () => {
+    await store.transitionTo('svc', CircuitState.HALF_OPEN, defaultThresholds)
+    await store.recordFailure('svc', defaultThresholds)
+    const snap = await store.getSnapshot('svc')
+    expect(snap.state).toBe(CircuitState.OPEN)
+  })
+
+  it('HALF_OPEN success returns to CLOSED', async () => {
+    await store.transitionTo('svc', CircuitState.HALF_OPEN, defaultThresholds)
+    await store.recordSuccess('svc', {
+      ...defaultThresholds,
+      errorThreshold: 100,
+    })
+    const snap = await store.getSnapshot('svc')
+    expect(snap.state).toBe(CircuitState.CLOSED)
+  })
+
+  it('getSnapshot is a pure read and does not trim the event window', async () => {
+    for (let i = 0; i < 3; i++) {
+      await store.recordFailure('svc', defaultThresholds)
+    }
+    // Pre-read
+    const before = await store.getSnapshot('svc')
+    expect(before.windowRequests).toBe(3)
+    expect(before.windowFailures).toBe(3)
+
+    // Multiple getSnapshot calls must NOT mutate the window.
+    for (let i = 0; i < 5; i++) {
+      await store.getSnapshot('svc')
+    }
+    const after = await store.getSnapshot('svc')
+    expect(after.windowRequests).toBe(3)
+    expect(after.windowFailures).toBe(3)
+
+    // And getSnapshot must NOT write any script (it's plain HMGET).
+    const hmgets = redis._calls.filter(c => c.method === 'hmget').length
+    expect(hmgets).toBeGreaterThan(0)
+  })
+})

--- a/packages/core-backend/tests/unit/redis-token-bucket-store.test.ts
+++ b/packages/core-backend/tests/unit/redis-token-bucket-store.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Unit tests for the Redis-backed Token Bucket store.
+ *
+ * We don't need a real Redis here: the store's core logic lives in the
+ * Lua script, and the store file exports a pure-JS twin
+ * (`applyTokenBucketScript`) that mirrors it exactly. Tests exercise that
+ * twin for deterministic refill/burst behaviour, plus a small shim for
+ * the eval/evalsha/script dispatch path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import {
+  RedisTokenBucketStore,
+  TOKEN_BUCKET_LUA,
+  applyTokenBucketScript,
+  type RedisScriptClient,
+} from '../../src/integration/rate-limiting/redis-token-bucket-store'
+import {
+  MemoryTokenBucketStore,
+} from '../../src/integration/rate-limiting/token-bucket-store'
+
+// ---------------------------------------------------------------------------
+// Pure-JS Lua twin
+// ---------------------------------------------------------------------------
+
+describe('applyTokenBucketScript (pure-JS twin of TOKEN_BUCKET_LUA)', () => {
+  it('initial consume on missing key returns capacity - requested', () => {
+    const out = applyTokenBucketScript({
+      state: undefined,
+      capacity: 10,
+      refillRate: 1,
+      requested: 3,
+      nowMs: 1_000_000,
+    })
+    expect(out.allowed).toBe(true)
+    expect(out.tokens).toBe(7)
+    expect(out.lastRefill).toBe(1_000_000)
+    expect(out.retryAfterMs).toBe(0)
+  })
+
+  it('refills tokens based on elapsed time and clamps at capacity', () => {
+    const out = applyTokenBucketScript({
+      state: { tokens: 2, lastRefill: 1_000_000 },
+      capacity: 10,
+      refillRate: 5, // 5 tokens / second
+      requested: 1,
+      nowMs: 1_010_000, // 10 seconds later → would refill by 50, clamp at 10
+    })
+    expect(out.allowed).toBe(true)
+    expect(out.tokens).toBe(9) // 10 - 1
+    expect(out.lastRefill).toBe(1_010_000)
+  })
+
+  it('rejects when bucket is empty and reports retryAfterMs', () => {
+    const out = applyTokenBucketScript({
+      state: { tokens: 0, lastRefill: 2_000_000 },
+      capacity: 5,
+      refillRate: 2, // 2/s
+      requested: 3,
+      nowMs: 2_000_000, // no elapsed time
+    })
+    expect(out.allowed).toBe(false)
+    expect(out.tokens).toBe(0)
+    // deficit = 3 - 0 = 3; 3/2 * 1000 = 1500
+    expect(out.retryAfterMs).toBe(1500)
+  })
+
+  it('exhausts bucket in a burst then refuses subsequent requests', () => {
+    let state: { tokens: number; lastRefill: number } | undefined
+    const capacity = 4
+    const nowMs = 3_000_000
+    const results = [] as boolean[]
+    for (let i = 0; i < 6; i++) {
+      const r = applyTokenBucketScript({
+        state,
+        capacity,
+        refillRate: 1,
+        requested: 1,
+        nowMs,
+      })
+      state = { tokens: r.tokens, lastRefill: r.lastRefill }
+      results.push(r.allowed)
+    }
+    expect(results.slice(0, 4)).toEqual([true, true, true, true])
+    expect(results.slice(4)).toEqual([false, false])
+  })
+
+  it('handles refillRate=0 as a never-refilling bucket', () => {
+    const out = applyTokenBucketScript({
+      state: { tokens: 0, lastRefill: 1_000_000 },
+      capacity: 10,
+      refillRate: 0,
+      requested: 1,
+      nowMs: 2_000_000,
+    })
+    expect(out.allowed).toBe(false)
+    expect(out.retryAfterMs).toBe(-1) // signals "never"
+  })
+
+  it('parallel consumes on memory store are serialised (atomicity surrogate)', async () => {
+    const store = new MemoryTokenBucketStore()
+    const capacity = 3
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        store.consume('k', capacity, 0, 1),
+      ),
+    )
+    const allowed = results.filter(r => r.allowed).length
+    const rejected = results.filter(r => !r.allowed).length
+    expect(allowed).toBe(3)
+    expect(rejected).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Redis dispatch path — verify SCRIPT LOAD → EVALSHA → NOSCRIPT recovery
+// ---------------------------------------------------------------------------
+
+function createFakeRedis(opts: { scriptLoadReturns?: string } = {}): RedisScriptClient & {
+  _calls: { method: string; args: unknown[] }[]
+  _loadedSha: string | null
+  _scriptCache: Map<string, string>
+  _flushScripts: () => void
+} {
+  const loadedSha = opts.scriptLoadReturns ?? 'sha-fake-1'
+  const calls: { method: string; args: unknown[] }[] = []
+  const scriptCache = new Map<string, string>() // sha -> source
+
+  const runScript = (
+    source: string,
+    _numKeys: number,
+    key: string,
+    ...args: (string | number)[]
+  ) => {
+    // Execute via the JS twin so tests get realistic output.
+    const [capacity, refillRate, requested, nowMs] = args.map(Number)
+    const out = applyTokenBucketScript({
+      state: undefined, // test harness doesn't persist
+      capacity,
+      refillRate,
+      requested,
+      nowMs,
+    })
+    // Redis returns numbers as integers and strings as strings
+    return [out.allowed ? 1 : 0, String(out.tokens), String(out.retryAfterMs)]
+  }
+
+  return {
+    _calls: calls,
+    _loadedSha: loadedSha,
+    _scriptCache: scriptCache,
+    _flushScripts() {
+      scriptCache.clear()
+    },
+    async evalsha(sha: string, numKeys: number, ...rest: (string | number)[]) {
+      calls.push({ method: 'evalsha', args: [sha, numKeys, ...rest] })
+      const source = scriptCache.get(sha)
+      if (!source) {
+        const err = new Error(
+          'NOSCRIPT No matching script. Please use EVAL.',
+        )
+        throw err
+      }
+      return runScript(source, numKeys, String(rest[0]), ...rest.slice(1) as (string | number)[])
+    },
+    async eval(source: string, numKeys: number, ...rest: (string | number)[]) {
+      calls.push({ method: 'eval', args: [source, numKeys, ...rest] })
+      return runScript(source, numKeys, String(rest[0]), ...rest.slice(1) as (string | number)[])
+    },
+    async script(subcommand: 'LOAD', source: string) {
+      calls.push({ method: 'script', args: [subcommand, source] })
+      scriptCache.set(loadedSha, source)
+      return loadedSha
+    },
+  }
+}
+
+describe('RedisTokenBucketStore', () => {
+  let redis: ReturnType<typeof createFakeRedis>
+  let store: RedisTokenBucketStore
+
+  beforeEach(() => {
+    redis = createFakeRedis()
+    store = new RedisTokenBucketStore({ redis, keyPrefix: 't:', ttlSeconds: 60 })
+  })
+
+  it('loads the script on first call, then uses EVALSHA thereafter', async () => {
+    const r1 = await store.consume('user-1', 5, 1, 1)
+    expect(r1.allowed).toBe(true)
+
+    // First call: SCRIPT LOAD + EVALSHA
+    const methods = redis._calls.map(c => c.method)
+    expect(methods.slice(0, 2)).toEqual(['script', 'evalsha'])
+
+    const r2 = await store.consume('user-1', 5, 1, 1)
+    expect(r2.allowed).toBe(true)
+    // Second call: just EVALSHA (no new script load)
+    expect(redis._calls[redis._calls.length - 1].method).toBe('evalsha')
+    expect(redis._calls.filter(c => c.method === 'script').length).toBe(1)
+  })
+
+  it('handles NOSCRIPT by reloading the script', async () => {
+    await store.consume('user-1', 5, 1, 1) // loads + evalsha OK
+
+    // Simulate Redis flushing scripts
+    redis._flushScripts()
+
+    const r = await store.consume('user-1', 5, 1, 1)
+    expect(r.allowed).toBe(true)
+
+    // We should see: evalsha (NOSCRIPT) → script LOAD → evalsha
+    const methods = redis._calls.map(c => c.method)
+    // Count two script loads (initial + reload) and at least three evalshas
+    expect(methods.filter(m => m === 'script').length).toBe(2)
+    expect(methods.filter(m => m === 'evalsha').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('falls back to plain EVAL when SCRIPT LOAD throws', async () => {
+    // Force SCRIPT LOAD to fail (but still log the attempt)
+    const originalScript = redis.script.bind(redis)
+    redis.script = async (...args: Parameters<typeof originalScript>) => {
+      redis._calls.push({ method: 'script', args })
+      throw new Error('cluster: CROSSSLOT')
+    }
+
+    const r = await store.consume('user-2', 5, 1, 1)
+    expect(r.allowed).toBe(true)
+
+    const methods = redis._calls.map(c => c.method)
+    expect(methods).toContain('script')
+    expect(methods).toContain('eval')
+  })
+
+  it('propagates the bucket key with the configured prefix and TTL arg', async () => {
+    await store.consume('user-xyz', 10, 2, 1)
+    const evalsha = redis._calls.find(c => c.method === 'evalsha')!
+    const args = evalsha.args as (string | number)[]
+    // sha, numKeys, key, capacity, refillRate, requested, nowMs, ttlSeconds
+    expect(args[1]).toBe(1) // numKeys
+    expect(args[2]).toBe('t:user-xyz')
+    expect(Number(args[3])).toBe(10) // capacity
+    expect(Number(args[4])).toBe(2) // refillRate
+    expect(Number(args[5])).toBe(1) // requested
+    expect(Number(args[7])).toBe(60) // ttl
+  })
+
+  it('exports the Lua script source containing the atomic EXPIRE and HMSET calls', () => {
+    expect(TOKEN_BUCKET_LUA).toMatch(/HMSET/)
+    expect(TOKEN_BUCKET_LUA).toMatch(/EXPIRE/)
+    expect(TOKEN_BUCKET_LUA).toMatch(/redis\.call/)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds Redis-backed runtime stores for TokenBucket and CircuitBreaker with narrow store interfaces and memory defaults preserved.
- Uses Lua for atomic token consumption and circuit state transitions, plus JS twins for deterministic unit coverage.
- Adds a `REDIS_URL`-gated live Redis integration smoke that exercises real Redis 7 `SCRIPT LOAD` / `EVALSHA`, TTL-backed state, and `SCRIPT FLUSH` / `NOSCRIPT` recovery.

## Verification

Latest-main verification on `origin/main@81edca7d9`:

```bash
git -C .worktrees/redis rebase --autostash origin/main
pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/redis-token-bucket-store.test.ts \
  tests/unit/redis-circuit-breaker-store.test.ts \
  tests/unit/rate-limiter.test.ts --reporter=dot
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot
```

Live Redis smoke:

```bash
docker run -d --name ms2-redis-smoke-<timestamp> -p 127.0.0.1:6389:6379 redis:7
REDIS_URL=redis://127.0.0.1:6389 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot
docker rm -f ms2-redis-smoke-<timestamp>
```

Results:

- Backend `tsc --noEmit`: PASS, zero diagnostics
- Redis token bucket unit: PASS, 11/11
- Redis circuit breaker unit: PASS, 14/14
- Existing rate limiter regression: PASS, 15/15
- Redis integration without `REDIS_URL`: PASS, 2 skipped
- Live Redis 7 integration smoke: PASS, 2/2

Verification MD: `docs/development/collab-infra-redis-runtime-verification-20260420.md`.

## Notes

This PR is an adapter/seam slice only. APIGateway's internal `new CircuitBreaker(config)` wiring is not switched to Redis yet; that remains an explicit follow-up.
