### PR TITLE
feat(dingtalk): show automation link summary

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1589,14 +1589,28 @@ function describeActionType(actionType: AutomationActionType, actionConfig: Reco
     case 'send_webhook':
       return 'Send webhook'
     case 'send_dingtalk_group_message':
-      return 'Send DingTalk group message'
+      return `Send DingTalk group message${describeDingTalkActionLinks(actionConfig)}`
     case 'send_dingtalk_person_message':
-      return 'Send DingTalk person message'
+      return `Send DingTalk person message${describeDingTalkActionLinks(actionConfig)}`
     case 'lock_record':
       return 'Lock record'
     default:
       return String(actionType)
   }
+}
+
+function describeDingTalkActionLinks(actionConfig: Record<string, unknown>): string {
+  const publicFormViewId = typeof actionConfig.publicFormViewId === 'string'
+    ? actionConfig.publicFormViewId.trim()
+    : ''
+  const internalViewId = typeof actionConfig.internalViewId === 'string'
+    ? actionConfig.internalViewId.trim()
+    : ''
+  const parts = [
+    publicFormViewId ? `Public form: ${viewSummaryName(publicFormViewId, publicFormViewId)}` : '',
+    internalViewId ? `Internal processing: ${viewSummaryName(internalViewId, internalViewId)}` : '',
+  ].filter(Boolean)
+  return parts.length ? ` · ${parts.join(' · ')}` : ''
 }
 
 function ruleHasActionType(rule: AutomationRule, actionType: AutomationActionType): boolean {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -263,6 +263,8 @@ describe('MetaAutomationManager', () => {
               destinationId: 'dt_1',
               titleTemplate: 'Ticket {{recordId}}',
               bodyTemplate: 'Please fill {{record.status}}',
+              publicFormViewId: 'view_form',
+              internalViewId: 'view_grid',
             },
           },
         ],
@@ -274,6 +276,8 @@ describe('MetaAutomationManager', () => {
     const desc = container.querySelector('[data-automation-rule="rule_1"] .meta-automation__card-desc')
     expect(desc?.textContent).toContain('Send notification')
     expect(desc?.textContent).toContain('Send DingTalk group message')
+    expect(desc?.textContent).toContain('Public form: Public Form')
+    expect(desc?.textContent).toContain('Internal processing: Grid')
   })
 
   it('describes V1 multi-action DingTalk person rules in the list', async () => {
@@ -290,6 +294,8 @@ describe('MetaAutomationManager', () => {
               userIds: ['user_1'],
               titleTemplate: 'Ticket {{recordId}}',
               bodyTemplate: 'Please fill {{record.status}}',
+              publicFormViewId: 'view_form',
+              internalViewId: 'view_grid',
             },
           },
         ],
@@ -301,6 +307,8 @@ describe('MetaAutomationManager', () => {
     const desc = container.querySelector('[data-automation-rule="rule_1"] .meta-automation__card-desc')
     expect(desc?.textContent).toContain('Send notification')
     expect(desc?.textContent).toContain('Send DingTalk person message')
+    expect(desc?.textContent).toContain('Public form: Public Form')
+    expect(desc?.textContent).toContain('Internal processing: Grid')
   })
 
   it('shows empty state when no rules', async () => {

--- a/docs/development/dingtalk-automation-link-summary-development-20260421.md
+++ b/docs/development/dingtalk-automation-link-summary-development-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Automation Link Summary Development - 2026-04-21
+
+## Background
+
+Users can configure DingTalk group/person automation messages with a public form link and an internal processing view. The inline and advanced editors already preview those links while editing, but the automation rule list only showed the generic action text after saving.
+
+That made it hard to confirm from the rule card whether a DingTalk message opens the intended form or internal processing view.
+
+## Scope
+
+- Enhance the automation rule card action summary for DingTalk group messages.
+- Enhance the automation rule card action summary for DingTalk person messages.
+- Keep the change presentation-only; no API or persistence behavior changed.
+
+## Implementation
+
+- Updated `MetaAutomationManager.vue`.
+- Added `describeDingTalkActionLinks(actionConfig)` and reused existing `viewSummaryName()`.
+- DingTalk action summaries now append configured links:
+  - `Public form: <view name>`
+  - `Internal processing: <view name>`
+- If a link is not configured, the card remains concise and does not append an empty placeholder.
+
+## Tests
+
+- Updated `multitable-automation-manager.spec.ts`.
+- Existing V1 multi-action DingTalk group/person list tests now verify the rule card includes:
+  - base DingTalk action text
+  - public form view name
+  - internal processing view name
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+## Notes
+
+- This PR is stacked on the main-target advanced create manager coverage branch because it extends the same manager test area.
+- Dependency install produced tracked `node_modules` symlink changes in plugin/tool workspaces; those artifacts are intentionally excluded from the commit.

--- a/docs/development/dingtalk-automation-link-summary-verification-20260421.md
+++ b/docs/development/dingtalk-automation-link-summary-verification-20260421.md
@@ -1,0 +1,47 @@
+# DingTalk Automation Link Summary Verification - 2026-04-21
+
+## Environment
+
+- Worktree: `.worktrees/dingtalk-automation-link-summary-20260421`
+- Branch: `codex/dingtalk-automation-link-summary-20260421`
+- Base: `3c8841df` from PR #1013
+- Package manager: `pnpm`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. Dependencies installed from the existing lockfile.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed. `2` files, `118` tests.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Existing Vite warnings remain:
+
+- `WorkflowDesigner.vue` is both dynamically and statically imported.
+- Some chunks exceed `500 kB` after minification.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Regression Coverage
+
+- Rule list summaries for V1 DingTalk group actions now show `Public form: Public Form` and `Internal processing: Grid` when configured.
+- Rule list summaries for V1 DingTalk person actions now show `Public form: Public Form` and `Internal processing: Grid` when configured.
+
+## Not Run
+
+- Backend tests were not rerun because this slice changes only frontend display logic and frontend tests.
+- Browser E2E against a live server was not run in this worktree.

--- a/docs/development/dingtalk-automation-link-summary-verification-20260421.md
+++ b/docs/development/dingtalk-automation-link-summary-verification-20260421.md
@@ -45,3 +45,42 @@ Result: passed.
 
 - Backend tests were not rerun because this slice changes only frontend display logic and frontend tests.
 - Browser E2E against a live server was not run in this worktree.
+
+## Rebase Verification - 2026-04-22
+
+The PR branch was rebased from the old PR #1013 base commit `3c8841df` to `origin/main@036a61c64` after PR #1013 was merged.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. Dependencies were restored from the lockfile.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed. `2` files, `118` tests.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Existing Vite warnings remain:
+
+- `WorkflowDesigner.vue` is both dynamically and statically imported.
+- Some chunks exceed `500 kB` after minification.
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Result: passed.
+
+Notes:
+
+- The rebase used `git rebase --onto origin/main 3c8841df HEAD` so only the #1017 change was replayed on top of the merged #1013 mainline.
+- The post-rebase diff remains limited to `MetaAutomationManager.vue`, `multitable-automation-manager.spec.ts`, and the two DingTalk link summary notes.
+- `pnpm install` produced local plugin/tool `node_modules` symlink modifications in the temporary worktree; those are generated dependency artifacts and were not staged.


### PR DESCRIPTION
## Summary

- Show configured DingTalk public form and internal processing views in automation rule card summaries.
- Cover V1 DingTalk group and person actions in the manager rule list tests.
- Add development and verification notes, including the 2026-04-22 rebase verification.

## Verification

Initial verification:

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 118 passed
- `pnpm --filter @metasheet/web build`
- `git diff --check`

Rebase verification on `origin/main@036a61c64`:

- `pnpm install --frozen-lockfile` → passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 118 passed
- `pnpm --filter @metasheet/web build` → passed with existing Vite warnings
- `git diff --check origin/main...HEAD` → passed

## Notes

Originally stacked on PR #1013. After #1013 merged, this branch was replayed onto `main` using `git rebase --onto origin/main 3c8841df HEAD` so the PR now contains only the link-summary slice.
