### PR TITLE
feat(dingtalk): add automation card link actions

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -600,6 +600,29 @@
           <div class="meta-automation__card-desc">
             {{ describeTrigger(rule) }} &rarr; {{ describeAction(rule) }}
           </div>
+          <div v-if="dingTalkCardLinks(rule).length" class="meta-automation__card-links">
+            <template v-for="link in dingTalkCardLinks(rule)" :key="link.key">
+              <a
+                v-if="link.href"
+                class="meta-automation__btn meta-automation__btn-link"
+                :href="link.href"
+                target="_blank"
+                rel="noopener noreferrer"
+                :data-automation-card-link="link.key"
+              >
+                {{ link.label }}
+              </a>
+              <button
+                v-else
+                class="meta-automation__btn meta-automation__btn-link"
+                type="button"
+                :data-automation-card-link="link.key"
+                @click="openInternalView(link.viewId ?? '')"
+              >
+                {{ link.label }}
+              </button>
+            </template>
+          </div>
           <div v-if="ruleStats[rule.id]" class="meta-automation__card-stats">
             <span class="meta-automation__stat meta-automation__stat--success">{{ ruleStats[rule.id].success }} ok</span>
             <span class="meta-automation__stat meta-automation__stat--failed">{{ ruleStats[rule.id].failed }} fail</span>
@@ -677,6 +700,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
 import type {
   AutomationExecution,
   AutomationRule,
@@ -687,6 +711,7 @@ import type {
   MetaSheetPermissionCandidate,
   MetaView,
 } from '../types'
+import { AppRouteNames } from '../../router/types'
 import { useMultitableAutomations } from '../composables/useMultitableAutomations'
 import type { MultitableApiClient } from '../api/client'
 import MetaAutomationRuleEditor from './MetaAutomationRuleEditor.vue'
@@ -729,6 +754,8 @@ const emit = defineEmits<{
   (e: 'close'): void
   (e: 'updated'): void
 }>()
+
+const router = useRouter()
 
 type AutomationTestRunState = {
   status: 'running' | 'success' | 'failed' | 'skipped'
@@ -807,6 +834,13 @@ const formViews = computed(() => (props.views ?? []).filter((view) =>
   view.type === 'form' && (!view.sheetId || view.sheetId === props.sheetId),
 ))
 const internalViews = computed(() => (props.views ?? []).filter((view) => !view.sheetId || view.sheetId === props.sheetId))
+
+interface DingTalkCardLink {
+  key: string
+  label: string
+  href?: string
+  viewId?: string
+}
 
 function parseUserIdsText(value: string): string[] {
   return value
@@ -1015,6 +1049,80 @@ function internalViewLinkBlockingErrors(value: unknown) {
 
 function publicFormAccessSummary(value: unknown) {
   return describeDingTalkPublicFormLinkAccess(value, formViews.value)
+}
+
+function readPublicFormToken(view: MetaView): string {
+  const publicForm = view.config?.publicForm
+  if (!publicForm || typeof publicForm !== 'object' || Array.isArray(publicForm)) return ''
+  const token = (publicForm as Record<string, unknown>).publicToken
+  return typeof token === 'string' ? token.trim() : ''
+}
+
+function buildPublicFormHref(viewId: string, publicToken: string): string {
+  return `${window.location.origin}/multitable/public-form/${props.sheetId}/${viewId}?publicToken=${encodeURIComponent(publicToken)}`
+}
+
+function dingTalkActionConfigs(rule: AutomationRule): Record<string, unknown>[] {
+  const actionTypes: AutomationActionType[] = ['send_dingtalk_group_message', 'send_dingtalk_person_message']
+  const configs = (rule.actions ?? [])
+    .filter((action) => actionTypes.includes(action.type))
+    .map((action) => action.config)
+  if (!configs.length && actionTypes.includes(rule.actionType)) {
+    configs.push(rule.actionConfig)
+  }
+  return configs
+}
+
+function dingTalkCardLinks(rule: AutomationRule): DingTalkCardLink[] {
+  const seen = new Set<string>()
+  const links: DingTalkCardLink[] = []
+
+  for (const actionConfig of dingTalkActionConfigs(rule)) {
+    const publicFormViewId = typeof actionConfig.publicFormViewId === 'string'
+      ? actionConfig.publicFormViewId.trim()
+      : ''
+    if (publicFormViewId && !listDingTalkPublicFormLinkBlockingErrors(publicFormViewId, formViews.value).length) {
+      const view = formViews.value.find((item) => item.id === publicFormViewId)
+      const publicToken = view ? readPublicFormToken(view) : ''
+      const key = `public-form:${publicFormViewId}`
+      if (view && publicToken && !seen.has(key)) {
+        seen.add(key)
+        links.push({
+          key,
+          label: `Open public form: ${viewSummaryName(publicFormViewId, publicFormViewId)}`,
+          href: buildPublicFormHref(publicFormViewId, publicToken),
+        })
+      }
+    }
+
+    const internalViewId = typeof actionConfig.internalViewId === 'string'
+      ? actionConfig.internalViewId.trim()
+      : ''
+    if (internalViewId && !listDingTalkInternalViewLinkBlockingErrors(internalViewId, internalViews.value).length) {
+      const key = `internal-view:${internalViewId}`
+      if (!seen.has(key)) {
+        seen.add(key)
+        links.push({
+          key,
+          label: `Open internal view: ${viewSummaryName(internalViewId, internalViewId)}`,
+          viewId: internalViewId,
+        })
+      }
+    }
+  }
+
+  return links
+}
+
+function openInternalView(viewId: string) {
+  if (!viewId) return
+  void router.push({
+    name: AppRouteNames.MULTITABLE,
+    params: {
+      sheetId: props.sheetId,
+      viewId,
+    },
+  })
 }
 
 function copyPreviewText(key: string, text: string) {
@@ -1884,6 +1992,13 @@ watch(
   color: #475569;
 }
 
+.meta-automation__card-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 2px;
+}
+
 .meta-automation__card-actions {
   display: flex;
   gap: 8px;
@@ -1899,6 +2014,10 @@ watch(
   color: #0f172a;
   font-size: 13px;
   cursor: pointer;
+}
+
+.meta-automation__btn-link {
+  text-decoration: none;
 }
 
 .meta-automation__btn:disabled {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1,11 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 
+const routerPushMock = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}))
+
 function flushPromises() {
   return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
 }
 import MetaAutomationManager from '../src/multitable/components/MetaAutomationManager.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
+import { AppRouteNames } from '../src/router/types'
 import type { AutomationRule, DingTalkGroupDelivery, DingTalkPersonDelivery } from '../src/multitable/types'
 
 function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
@@ -221,6 +230,7 @@ describe('MetaAutomationManager', () => {
   const originalClipboard = navigator.clipboard
 
   beforeEach(() => {
+    routerPushMock.mockClear()
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: {
@@ -278,6 +288,26 @@ describe('MetaAutomationManager', () => {
     expect(desc?.textContent).toContain('Send DingTalk group message')
     expect(desc?.textContent).toContain('Public form: Public Form')
     expect(desc?.textContent).toContain('Internal processing: Grid')
+
+    const publicLink = container.querySelector('[data-automation-card-link="public-form:view_form"]') as HTMLAnchorElement
+    expect(publicLink).not.toBeNull()
+    expect(publicLink.textContent).toContain('Open public form: Public Form')
+    expect(publicLink.getAttribute('href')).toBe(`${window.location.origin}/multitable/public-form/sheet_1/view_form?publicToken=pub_view_form`)
+    expect(publicLink.getAttribute('target')).toBe('_blank')
+
+    const internalLink = container.querySelector('[data-automation-card-link="internal-view:view_grid"]') as HTMLButtonElement
+    expect(internalLink).not.toBeNull()
+    expect(internalLink.textContent).toContain('Open internal view: Grid')
+    internalLink.click()
+    await flushPromises()
+
+    expect(routerPushMock).toHaveBeenCalledWith({
+      name: AppRouteNames.MULTITABLE,
+      params: {
+        sheetId: 'sheet_1',
+        viewId: 'view_grid',
+      },
+    })
   })
 
   it('describes V1 multi-action DingTalk person rules in the list', async () => {
@@ -309,6 +339,24 @@ describe('MetaAutomationManager', () => {
     expect(desc?.textContent).toContain('Send DingTalk person message')
     expect(desc?.textContent).toContain('Public form: Public Form')
     expect(desc?.textContent).toContain('Internal processing: Grid')
+  })
+
+  it('does not render a public form card link when sharing is missing a public token', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          publicFormViewId: 'view_form',
+          internalViewId: 'view_grid',
+        },
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views: viewsWithMissingPublicToken, client })
+    await flushPromises()
+
+    expect(container.querySelector('[data-automation-card-link="public-form:view_form"]')).toBeNull()
+    expect(container.querySelector('[data-automation-card-link="internal-view:view_grid"]')).not.toBeNull()
   })
 
   it('shows empty state when no rules', async () => {

--- a/docs/development/dingtalk-automation-link-card-actions-development-20260421.md
+++ b/docs/development/dingtalk-automation-link-card-actions-development-20260421.md
@@ -1,0 +1,42 @@
+# DingTalk Automation Link Card Actions Development 2026-04-21
+
+## Scope
+
+本次开发基于钉钉自动化规则的列表摘要能力，继续补齐规则卡片上的可点击入口：
+
+- 在自动化规则卡片中展示钉钉公开表单入口。
+- 在自动化规则卡片中展示内部处理视图入口。
+- 公开表单入口复用现有公开表单 URL：`/multitable/public-form/:sheetId/:viewId?publicToken=...`。
+- 内部处理入口复用现有 multitable 路由：`AppRouteNames.MULTITABLE`。
+- 公开表单缺失 `publicToken`、未启用、过期或不是当前表单视图时，不渲染可点击公开表单入口。
+
+## Implementation
+
+### Rule Card Links
+
+`apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+- 新增 `dingTalkCardLinks(rule)`，从 V1 `rule.actions` 和 legacy `rule.actionConfig` 中提取 `send_dingtalk_group_message` / `send_dingtalk_person_message` 的 `publicFormViewId` 与 `internalViewId`。
+- 使用已有的 `listDingTalkPublicFormLinkBlockingErrors()` 校验公开表单视图，避免在配置不可用时给用户展示不可用链接。
+- 使用已有的 `listDingTalkInternalViewLinkBlockingErrors()` 校验内部处理视图是否属于当前表格上下文。
+- 公开表单链接读取视图配置里的 `config.publicForm.publicToken`，拼接绝对 URL，点击后新窗口打开。
+- 内部视图入口使用 `router.push({ name: AppRouteNames.MULTITABLE, params: { sheetId, viewId } })`，保持 SPA 内部导航。
+- 使用 `public-form:<viewId>` / `internal-view:<viewId>` 去重，避免一个规则多个钉钉动作重复渲染相同入口。
+
+### UI
+
+- 在规则描述下方新增 `meta-automation__card-links` 区块。
+- 公开表单使用 `<a target="_blank" rel="noopener noreferrer">`。
+- 内部处理使用按钮触发 router 导航。
+- 新增 `data-automation-card-link` 测试选择器，方便后续 E2E 直接定位。
+
+## Behavior
+
+- 用户在自动化管理列表中可以直接打开配置好的“公开表单填写页”。
+- 用户在自动化管理列表中可以直接跳转到配置好的“内部处理视图”。
+- 如果公开表单未生成有效 token，规则描述仍保留文本摘要，但不会展示可点击公开入口，避免误导用户。
+
+## Follow-up
+
+- 本次只解决管理后台规则卡片的快速入口；钉钉群消息中的链接生成仍沿用后端 executor 的既有逻辑。
+- 后续可在卡片入口旁补充权限状态提示，例如“仅绑定钉钉用户可填写”或“需授权后填写”。

--- a/docs/development/dingtalk-automation-link-card-actions-verification-20260421.md
+++ b/docs/development/dingtalk-automation-link-card-actions-verification-20260421.md
@@ -48,3 +48,30 @@ passed
 
 - `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
 - `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。
+
+## Rebase Verification - 2026-04-22
+
+The PR branch was rebased from the old PR #1017 base commit `19065c74960afaf1f78495901c80b81a29251d41` to `origin/main@680f3ee8` after PR #1017 was merged.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check origin/main...HEAD
+```
+
+Results:
+
+- `MetaAutomationManager`: `1` file, `65` tests passed.
+- `MetaAutomationManager + MetaAutomationRuleEditor`: `2` files, `119` tests passed.
+- `@metasheet/web` build passed with the existing Vite warnings about `WorkflowDesigner.vue` mixed static/dynamic import and large chunks over `500 kB`.
+- `git diff --check origin/main...HEAD` passed.
+
+Notes:
+
+- The rebase used `git rebase --onto origin/main 19065c74960afaf1f78495901c80b81a29251d41 HEAD` so only the #1018 change was replayed on top of the merged #1017 mainline.
+- The post-rebase diff remains limited to `MetaAutomationManager.vue`, `multitable-automation-manager.spec.ts`, and the two DingTalk link card action notes.
+- `pnpm install` produced local plugin/tool `node_modules` symlink modifications in the temporary worktree; those are generated dependency artifacts and were not staged.

--- a/docs/development/dingtalk-automation-link-card-actions-verification-20260421.md
+++ b/docs/development/dingtalk-automation-link-card-actions-verification-20260421.md
@@ -1,0 +1,50 @@
+# DingTalk Automation Link Card Actions Verification 2026-04-21
+
+## Local Environment
+
+- Worktree: `.worktrees/dingtalk-automation-link-card-actions-20260421`
+- Base: `codex/dingtalk-automation-link-summary-20260421`
+- Package manager: `pnpm`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+```text
+MetaAutomationManager
+Test Files  1 passed (1)
+Tests       65 passed (65)
+
+MetaAutomationManager + MetaAutomationRuleEditor
+Test Files  2 passed (2)
+Tests       119 passed (119)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+## Covered Cases
+
+- V1 多动作钉钉群规则列表展示公开表单与内部处理摘要。
+- 钉钉群规则卡片渲染 `Open public form: Public Form` 链接。
+- 公开表单链接包含 `/multitable/public-form/sheet_1/view_form?publicToken=pub_view_form`。
+- 公开表单链接使用新窗口打开。
+- 钉钉群规则卡片渲染 `Open internal view: Grid` 按钮。
+- 点击内部处理按钮后触发 `router.push({ name: AppRouteNames.MULTITABLE, params: { sheetId, viewId } })`。
+- 当公开表单缺失 `publicToken` 时，不渲染公开表单可点击入口。
+
+## Notes
+
+- `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
+- `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。


### PR DESCRIPTION
## Summary

- Add clickable DingTalk action entries on automation rule cards for configured public form and internal processing views.
- Reuse the existing public form URL contract and multitable SPA route for internal view navigation.
- Hide public form card links when sharing is missing a usable public token or fails existing link validation.
- Add development and verification notes, including the 2026-04-22 rebase verification.

## Verification

Initial verification:

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false` → 65 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 119 passed
- `pnpm --filter @metasheet/web build`
- `git diff --check`

Rebase verification on `origin/main@680f3ee8`:

- `pnpm install --frozen-lockfile` → passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false` → 65 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 119 passed
- `pnpm --filter @metasheet/web build` → passed with existing Vite warnings
- `git diff --check origin/main...HEAD` → passed

## Notes

Originally stacked on PR #1017. After #1017 merged, this branch was replayed onto `main` using `git rebase --onto origin/main 19065c74960afaf1f78495901c80b81a29251d41 HEAD` so the PR now contains only the link-card-actions slice.
