### PR TITLE
feat(dingtalk): show automation card access summary

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -601,7 +601,11 @@
             {{ describeTrigger(rule) }} &rarr; {{ describeAction(rule) }}
           </div>
           <div v-if="dingTalkCardLinks(rule).length" class="meta-automation__card-links">
-            <template v-for="link in dingTalkCardLinks(rule)" :key="link.key">
+            <div
+              v-for="link in dingTalkCardLinks(rule)"
+              :key="link.key"
+              class="meta-automation__card-link-item"
+            >
               <a
                 v-if="link.href"
                 class="meta-automation__btn meta-automation__btn-link"
@@ -621,7 +625,14 @@
               >
                 {{ link.label }}
               </button>
-            </template>
+              <span
+                v-if="link.accessSummary"
+                class="meta-automation__card-link-access"
+                :data-automation-card-link-access="link.key"
+              >
+                {{ link.accessSummary }}
+              </span>
+            </div>
           </div>
           <div v-if="ruleStats[rule.id]" class="meta-automation__card-stats">
             <span class="meta-automation__stat meta-automation__stat--success">{{ ruleStats[rule.id].success }} ok</span>
@@ -840,6 +851,7 @@ interface DingTalkCardLink {
   label: string
   href?: string
   viewId?: string
+  accessSummary?: string
 }
 
 function parseUserIdsText(value: string): string[] {
@@ -1091,6 +1103,7 @@ function dingTalkCardLinks(rule: AutomationRule): DingTalkCardLink[] {
           key,
           label: `Open public form: ${viewSummaryName(publicFormViewId, publicFormViewId)}`,
           href: buildPublicFormHref(publicFormViewId, publicToken),
+          accessSummary: describeDingTalkPublicFormLinkAccess(publicFormViewId, formViews.value),
         })
       }
     }
@@ -1997,6 +2010,22 @@ watch(
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 2px;
+}
+
+.meta-automation__card-link-item {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.meta-automation__card-link-access {
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 8px;
 }
 
 .meta-automation__card-actions {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -226,6 +226,21 @@ const viewsWithProtectedPublicFormAllowlist = [
   },
 ]
 
+const viewsWithGrantedPublicFormAllowlist = [
+  views[0],
+  {
+    ...views[1],
+    config: {
+      publicForm: {
+        enabled: true,
+        publicToken: 'pub_view_form',
+        accessMode: 'dingtalk_granted',
+        allowedUserIds: ['user_1'],
+      },
+    },
+  },
+]
+
 describe('MetaAutomationManager', () => {
   const originalClipboard = navigator.clipboard
 
@@ -294,6 +309,8 @@ describe('MetaAutomationManager', () => {
     expect(publicLink.textContent).toContain('Open public form: Public Form')
     expect(publicLink.getAttribute('href')).toBe(`${window.location.origin}/multitable/public-form/sheet_1/view_form?publicToken=pub_view_form`)
     expect(publicLink.getAttribute('target')).toBe('_blank')
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.textContent)
+      .toContain('Fully public; anyone with the link can submit')
 
     const internalLink = container.querySelector('[data-automation-card-link="internal-view:view_grid"]') as HTMLButtonElement
     expect(internalLink).not.toBeNull()
@@ -339,6 +356,44 @@ describe('MetaAutomationManager', () => {
     expect(desc?.textContent).toContain('Send DingTalk person message')
     expect(desc?.textContent).toContain('Public form: Public Form')
     expect(desc?.textContent).toContain('Internal processing: Grid')
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.textContent)
+      .toContain('Fully public; anyone with the link can submit')
+  })
+
+  it('shows DingTalk-bound public form access on rule card links', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          publicFormViewId: 'view_form',
+        },
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views: viewsWithProtectedPublicFormAllowlist, client })
+    await flushPromises()
+
+    expect(container.querySelector('[data-automation-card-link="public-form:view_form"]')).not.toBeNull()
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.textContent)
+      .toContain('DingTalk-bound users in allowlist can submit')
+  })
+
+  it('shows DingTalk-authorized public form access on rule card links', async () => {
+    const { client } = mockClient([
+      fakeRule({
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: ['user_1'],
+          publicFormViewId: 'view_form',
+        },
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views: viewsWithGrantedPublicFormAllowlist, client })
+    await flushPromises()
+
+    expect(container.querySelector('[data-automation-card-link="public-form:view_form"]')).not.toBeNull()
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.textContent)
+      .toContain('Authorized DingTalk users in allowlist can submit')
   })
 
   it('does not render a public form card link when sharing is missing a public token', async () => {

--- a/docs/development/dingtalk-automation-card-access-summary-development-20260421.md
+++ b/docs/development/dingtalk-automation-card-access-summary-development-20260421.md
@@ -1,0 +1,50 @@
+# DingTalk Automation Card Access Summary Development 2026-04-21
+
+## Scope
+
+本次开发继续完善钉钉自动化规则卡片体验，在上一层“卡片可点击打开公开表单/内部视图”的基础上，增加公开表单访问策略提示。
+
+目标是让表格持有者在自动化规则列表里直接判断：
+
+- 该钉钉消息里的公开表单是否完全公开。
+- 是否仅允许已绑定钉钉的系统用户填写。
+- 是否仅允许管理员授权过的钉钉用户填写。
+- 是否叠加了系统用户或成员组 allowlist。
+
+## Implementation
+
+### Rule Card UI
+
+`apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+- 将规则卡片里的钉钉入口改为每个入口一个 `meta-automation__card-link-item`。
+- 公开表单入口继续使用上一层实现的 `<a target="_blank">` 打开公开表单。
+- 内部处理入口继续使用按钮触发 `router.push()`。
+- 仅公开表单入口渲染访问策略说明：
+  - 使用 `describeDingTalkPublicFormLinkAccess(publicFormViewId, formViews.value)`。
+  - 通过 `data-automation-card-link-access="public-form:<viewId>"` 暴露稳定测试选择器。
+- 新增 `accessSummary?: string` 到 `DingTalkCardLink`，不影响内部视图入口。
+
+### Access Text
+
+访问策略文案复用既有 helper，不新增第二套文案：
+
+- `Fully public; anyone with the link can submit`
+- `All bound DingTalk users can submit`
+- `DingTalk-bound users in allowlist can submit`
+- `All authorized DingTalk users can submit`
+- `Authorized DingTalk users in allowlist can submit`
+
+## Tests
+
+`apps/web/tests/multitable-automation-manager.spec.ts`
+
+- 默认公开表单入口展示 fully public 策略。
+- 钉钉群规则卡片入口展示 `DingTalk-bound users in allowlist can submit`。
+- 钉钉个人规则卡片入口展示 `Authorized DingTalk users in allowlist can submit`。
+- 缺少 public token 的公开表单仍不渲染可点击公开入口。
+
+## Follow-up
+
+- 当前策略提示只展示在自动化规则列表卡片；规则编辑器预览区已有公开表单访问摘要。
+- 后续如果需要更强提醒，可按 access mode 给 badge 增加 warning/protected 视觉状态。

--- a/docs/development/dingtalk-automation-card-access-summary-verification-20260421.md
+++ b/docs/development/dingtalk-automation-card-access-summary-verification-20260421.md
@@ -1,0 +1,48 @@
+# DingTalk Automation Card Access Summary Verification 2026-04-21
+
+## Local Environment
+
+- Worktree: `.worktrees/dingtalk-automation-card-access-summary-20260421`
+- Base: `codex/dingtalk-automation-link-card-actions-20260421`
+- Package manager: `pnpm`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+```text
+MetaAutomationManager
+Test Files  1 passed (1)
+Tests       67 passed (67)
+
+MetaAutomationManager + MetaAutomationRuleEditor
+Test Files  2 passed (2)
+Tests       121 passed (121)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+## Covered Cases
+
+- 公开表单卡片入口旁显示 `Fully public; anyone with the link can submit`。
+- 钉钉绑定用户 allowlist 模式显示 `DingTalk-bound users in allowlist can submit`。
+- 钉钉授权用户 allowlist 模式显示 `Authorized DingTalk users in allowlist can submit`。
+- 缺少 `publicToken` 的公开表单不渲染可点击入口。
+- 内部处理入口仍走 `AppRouteNames.MULTITABLE` 导航。
+
+## Notes
+
+- `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
+- `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。

--- a/docs/development/dingtalk-automation-card-access-summary-verification-20260421.md
+++ b/docs/development/dingtalk-automation-card-access-summary-verification-20260421.md
@@ -46,3 +46,30 @@ passed
 
 - `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
 - `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。
+
+## Rebase Verification - 2026-04-22
+
+The PR branch was rebased from the old PR #1018 base commit `4ff636c6088b5e065cd9b4741b4ad7981b17e870` to `origin/main@d62a4fe3` after PR #1018 was merged.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check origin/main...HEAD
+```
+
+Results:
+
+- `MetaAutomationManager`: `1` file, `67` tests passed.
+- `MetaAutomationManager + MetaAutomationRuleEditor`: `2` files, `121` tests passed.
+- `@metasheet/web` build passed with the existing Vite warnings about `WorkflowDesigner.vue` mixed static/dynamic import and large chunks over `500 kB`.
+- `git diff --check origin/main...HEAD` passed.
+
+Notes:
+
+- The rebase used `git rebase --onto origin/main 4ff636c6088b5e065cd9b4741b4ad7981b17e870 HEAD` so only the #1019 change was replayed on top of the merged #1018 mainline.
+- The post-rebase diff remains limited to `MetaAutomationManager.vue`, `multitable-automation-manager.spec.ts`, and the two DingTalk automation card access summary notes.
+- `pnpm install` produced local plugin/tool `node_modules` symlink modifications in the temporary worktree; those are generated dependency artifacts and were not staged.


### PR DESCRIPTION
## Summary

- Show the public form access policy next to DingTalk automation card links.
- Reuse the existing `describeDingTalkPublicFormLinkAccess()` helper so card text stays aligned with public form access validation.
- Cover fully public, DingTalk-bound allowlist, and DingTalk-authorized allowlist states in manager tests.
- Add development and verification notes, including the 2026-04-22 rebase verification.

## Verification

Initial verification:

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false` → 67 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 121 passed
- `pnpm --filter @metasheet/web build`
- `git diff --check`

Rebase verification on `origin/main@d62a4fe3`:

- `pnpm install --frozen-lockfile` → passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false` → 67 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 121 passed
- `pnpm --filter @metasheet/web build` → passed with existing Vite warnings
- `git diff --check origin/main...HEAD` → passed

## Notes

Originally stacked on PR #1018. After #1018 merged, this branch was replayed onto `main` using `git rebase --onto origin/main 4ff636c6088b5e065cd9b4741b4ad7981b17e870 HEAD` so the PR now contains only the card-access-summary slice.
