### PR TITLE
feat(dingtalk): show editor access summary

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -338,6 +338,13 @@
               >
                 {{ warning }}
               </div>
+              <div
+                v-if="action.config.publicFormViewId"
+                class="meta-rule-editor__hint"
+                :data-field="`groupPublicFormAccessSummary-${idx}`"
+              >
+                <strong>Access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}
+              </div>
               <label class="meta-rule-editor__label">Internal processing view (optional)</label>
               <select
                 v-model="action.config.internalViewId"
@@ -626,6 +633,13 @@
                 class="meta-rule-editor__hint meta-rule-editor__hint--warning"
               >
                 {{ warning }}
+              </div>
+              <div
+                v-if="action.config.publicFormViewId"
+                class="meta-rule-editor__hint"
+                :data-field="`personPublicFormAccessSummary-${idx}`"
+              >
+                <strong>Access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}
               </div>
               <label class="meta-rule-editor__label">Internal processing view (optional)</label>
               <select

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -59,6 +59,21 @@ const viewsWithProtectedPublicFormAllowlist = [
   },
 ]
 
+const viewsWithGrantedPublicFormAllowlist = [
+  views[0],
+  {
+    ...views[1],
+    config: {
+      publicForm: {
+        enabled: true,
+        publicToken: 'pub_view_form',
+        accessMode: 'dingtalk_granted',
+        allowedUserIds: ['user_1'],
+      },
+    },
+  },
+]
+
 function mockClient() {
   return {
     listDingTalkGroups: vi.fn(async () => [
@@ -845,6 +860,8 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
+    expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.textContent)
+      .toContain('Fully public; anyone with the link can submit')
     expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('Fully public; anyone with the link can submit')
   })
 
@@ -896,7 +913,36 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
     expect(container.textContent).not.toContain('is fully public')
+    expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.textContent)
+      .toContain('DingTalk-bound users in allowlist can submit')
     expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('DingTalk-bound users in allowlist can submit')
+  })
+
+  it('shows DingTalk-authorized public form access next to the person form selector', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithGrantedPublicFormAllowlist,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.textContent)
+      .toContain('Authorized DingTalk users in allowlist can submit')
+    expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent)
+      .toContain('Authorized DingTalk users in allowlist can submit')
   })
 
   it('emits DingTalk person action config with optional links', async () => {

--- a/docs/development/dingtalk-automation-editor-access-summary-development-20260421.md
+++ b/docs/development/dingtalk-automation-editor-access-summary-development-20260421.md
@@ -1,0 +1,48 @@
+# DingTalk Automation Editor Access Summary Development 2026-04-21
+
+## Scope
+
+本次开发继续完善钉钉自动化标准功能，把公开表单访问策略从规则卡片进一步前移到高级自动化规则编辑器的钉钉动作配置区。
+
+目标：
+
+- 用户选择公开表单视图后，立即看到该表单的填写权限策略。
+- Group 和 Person 两类钉钉动作都保持一致体验。
+- 复用既有公开表单访问摘要 helper，不新增第二套权限文案。
+
+## Implementation
+
+### Advanced Rule Editor
+
+`apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+- 在 `send_dingtalk_group_message` 的 `Public form view` 下拉框下方新增 access summary。
+- 在 `send_dingtalk_person_message` 的 `Public form view` 下拉框下方新增 access summary。
+- 仅当 `publicFormViewId` 有值时显示该提示，未选择公开表单时不额外占位。
+- 访问策略继续调用 `publicFormAccessSummary(action.config.publicFormViewId)`，该函数内部复用 `describeDingTalkPublicFormLinkAccess()`。
+- 新增稳定测试选择器：
+  - `groupPublicFormAccessSummary-<idx>`
+  - `personPublicFormAccessSummary-<idx>`
+
+## Behavior
+
+选择公开表单后，用户可以直接在选择框附近看到：
+
+- `Fully public; anyone with the link can submit`
+- `DingTalk-bound users in allowlist can submit`
+- `Authorized DingTalk users in allowlist can submit`
+
+这不改变保存 payload，也不改变钉钉消息链接生成逻辑，只补充编辑时的权限可见性。
+
+## Tests
+
+`apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+- group 钉钉动作选择 fully public 表单后，选择框下方显示 fully public access summary。
+- group 钉钉动作选择 DingTalk-bound allowlist 表单后，选择框下方显示 bound allowlist access summary。
+- person 钉钉动作选择 DingTalk-authorized allowlist 表单后，选择框下方显示 authorized allowlist access summary。
+- 原有 Message summary 访问策略仍保留，防止 UI 前移破坏既有预览。
+
+## Follow-up
+
+- 当前提示为文本级别。后续可在公开/受控/授权三类策略上增加不同视觉等级，减少 fully public 表单被误用到钉钉群的风险。

--- a/docs/development/dingtalk-automation-editor-access-summary-verification-20260421.md
+++ b/docs/development/dingtalk-automation-editor-access-summary-verification-20260421.md
@@ -45,3 +45,30 @@ passed
 
 - `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
 - `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。
+
+## Rebase Verification - 2026-04-22
+
+The PR branch was rebased from the old PR #1019 base commit `64a4875f314fa70ad926576d698f3c03b4b53133` to `origin/main@26e97bd25` after PR #1019 was merged.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check origin/main...HEAD
+```
+
+Results:
+
+- `MetaAutomationRuleEditor`: `1` file, `55` tests passed.
+- `MetaAutomationManager + MetaAutomationRuleEditor`: `2` files, `122` tests passed.
+- `@metasheet/web` build passed with the existing Vite warnings about `WorkflowDesigner.vue` mixed static/dynamic import and large chunks over `500 kB`.
+- `git diff --check origin/main...HEAD` passed.
+
+Notes:
+
+- The rebase used `git rebase --onto origin/main 64a4875f314fa70ad926576d698f3c03b4b53133 HEAD` so only the #1020 change was replayed on top of the merged #1019 mainline.
+- The post-rebase diff remains limited to `MetaAutomationRuleEditor.vue`, `multitable-automation-rule-editor.spec.ts`, and the two DingTalk automation editor access summary notes.
+- `pnpm install` produced local plugin/tool `node_modules` symlink modifications in the temporary worktree; those are generated dependency artifacts and were not staged.

--- a/docs/development/dingtalk-automation-editor-access-summary-verification-20260421.md
+++ b/docs/development/dingtalk-automation-editor-access-summary-verification-20260421.md
@@ -1,0 +1,47 @@
+# DingTalk Automation Editor Access Summary Verification 2026-04-21
+
+## Local Environment
+
+- Worktree: `.worktrees/dingtalk-automation-editor-access-summary-20260421`
+- Base: `codex/dingtalk-automation-card-access-summary-20260421`
+- Package manager: `pnpm`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+```text
+MetaAutomationRuleEditor
+Test Files  1 passed (1)
+Tests       55 passed (55)
+
+MetaAutomationManager + MetaAutomationRuleEditor
+Test Files  2 passed (2)
+Tests       122 passed (122)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+## Covered Cases
+
+- Group 钉钉动作 public form selector 下方显示 fully public access summary。
+- Group 钉钉动作 public form selector 下方显示 DingTalk-bound allowlist access summary。
+- Person 钉钉动作 public form selector 下方显示 DingTalk-authorized allowlist access summary。
+- Message summary 中已有的 public form access summary 保持不变。
+
+## Notes
+
+- `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
+- `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。


### PR DESCRIPTION
## Summary

- Show public form access policy directly below the DingTalk group/person public form selectors in the advanced automation rule editor.
- Reuse the existing `publicFormAccessSummary()`/`describeDingTalkPublicFormLinkAccess()` path so the selector hint matches the message preview and rule-card text.
- Cover group fully-public, group DingTalk-bound allowlist, and person DingTalk-authorized allowlist states in RuleEditor tests.
- Add development and verification notes, including the 2026-04-22 rebase verification.

## Verification

Initial verification:

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` → 55 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 122 passed
- `pnpm --filter @metasheet/web build`
- `git diff --check`

Rebase verification on `origin/main@26e97bd25`:

- `pnpm install --frozen-lockfile` → passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` → 55 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` → 122 passed
- `pnpm --filter @metasheet/web build` → passed with existing Vite warnings
- `git diff --check origin/main...HEAD` → passed

## Notes

Originally stacked on PR #1019. After #1019 merged, this branch was replayed onto `main` using `git rebase --onto origin/main 64a4875f314fa70ad926576d698f3c03b4b53133 HEAD` so the PR now contains only the editor-access-summary slice.
