### PR TITLE
feat(dingtalk): add automation access state badges

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -628,7 +628,9 @@
               <span
                 v-if="link.accessSummary"
                 class="meta-automation__card-link-access"
+                :class="`meta-automation__card-link-access--${link.accessLevel ?? 'none'}`"
                 :data-automation-card-link-access="link.key"
+                :data-access-level="link.accessLevel"
               >
                 {{ link.accessSummary }}
               </span>
@@ -745,6 +747,8 @@ import {
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
   describeDingTalkPublicFormLinkAccess,
+  getDingTalkPublicFormLinkAccessLevel,
+  type DingTalkPublicFormLinkAccessLevel,
   listDingTalkPublicFormLinkBlockingErrors,
   listDingTalkPublicFormLinkWarnings,
 } from '../utils/dingtalkPublicFormLinkWarnings'
@@ -852,6 +856,7 @@ interface DingTalkCardLink {
   href?: string
   viewId?: string
   accessSummary?: string
+  accessLevel?: DingTalkPublicFormLinkAccessLevel
 }
 
 function parseUserIdsText(value: string): string[] {
@@ -1063,6 +1068,10 @@ function publicFormAccessSummary(value: unknown) {
   return describeDingTalkPublicFormLinkAccess(value, formViews.value)
 }
 
+function publicFormAccessLevel(value: unknown) {
+  return getDingTalkPublicFormLinkAccessLevel(value, formViews.value)
+}
+
 function readPublicFormToken(view: MetaView): string {
   const publicForm = view.config?.publicForm
   if (!publicForm || typeof publicForm !== 'object' || Array.isArray(publicForm)) return ''
@@ -1104,6 +1113,7 @@ function dingTalkCardLinks(rule: AutomationRule): DingTalkCardLink[] {
           label: `Open public form: ${viewSummaryName(publicFormViewId, publicFormViewId)}`,
           href: buildPublicFormHref(publicFormViewId, publicToken),
           accessSummary: describeDingTalkPublicFormLinkAccess(publicFormViewId, formViews.value),
+          accessLevel: publicFormAccessLevel(publicFormViewId),
         })
       }
     }
@@ -2026,6 +2036,26 @@ watch(
   font-size: 12px;
   line-height: 1;
   padding: 5px 8px;
+}
+
+.meta-automation__card-link-access--public {
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.meta-automation__card-link-access--dingtalk {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.meta-automation__card-link-access--dingtalk_granted {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.meta-automation__card-link-access--unavailable {
+  background: #fef2f2;
+  color: #b91c1c;
 }
 
 .meta-automation__card-actions {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -340,8 +340,10 @@
               </div>
               <div
                 v-if="action.config.publicFormViewId"
-                class="meta-rule-editor__hint"
+                class="meta-rule-editor__hint meta-rule-editor__access-summary"
+                :class="`meta-rule-editor__access-summary--${publicFormAccessLevel(action.config.publicFormViewId)}`"
                 :data-field="`groupPublicFormAccessSummary-${idx}`"
+                :data-access-level="publicFormAccessLevel(action.config.publicFormViewId)"
               >
                 <strong>Access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}
               </div>
@@ -636,8 +638,10 @@
               </div>
               <div
                 v-if="action.config.publicFormViewId"
-                class="meta-rule-editor__hint"
+                class="meta-rule-editor__hint meta-rule-editor__access-summary"
+                :class="`meta-rule-editor__access-summary--${publicFormAccessLevel(action.config.publicFormViewId)}`"
                 :data-field="`personPublicFormAccessSummary-${idx}`"
+                :data-access-level="publicFormAccessLevel(action.config.publicFormViewId)"
               >
                 <strong>Access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}
               </div>
@@ -777,6 +781,7 @@ import {
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
   describeDingTalkPublicFormLinkAccess,
+  getDingTalkPublicFormLinkAccessLevel,
   listDingTalkPublicFormLinkBlockingErrors,
   listDingTalkPublicFormLinkWarnings,
 } from '../utils/dingtalkPublicFormLinkWarnings'
@@ -1270,6 +1275,10 @@ function publicFormAccessSummary(value: unknown) {
   return describeDingTalkPublicFormLinkAccess(value, formViews.value)
 }
 
+function publicFormAccessLevel(value: unknown) {
+  return getDingTalkPublicFormLinkAccessLevel(value, formViews.value)
+}
+
 function isDingTalkActionType(value: unknown): boolean {
   return value === 'send_dingtalk_group_message' || value === 'send_dingtalk_person_message'
 }
@@ -1678,6 +1687,31 @@ function onTestRun() {
 
 .meta-rule-editor__section-title { font-size: 14px; font-weight: 600; color: #0f172a; }
 .meta-rule-editor__hint { font-weight: 400; color: #94a3b8; font-size: 12px; }
+
+.meta-rule-editor__access-summary {
+  border-radius: 8px;
+  padding: 6px 8px;
+}
+
+.meta-rule-editor__access-summary--public {
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.meta-rule-editor__access-summary--dingtalk {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.meta-rule-editor__access-summary--dingtalk_granted {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.meta-rule-editor__access-summary--unavailable {
+  background: #fef2f2;
+  color: #b91c1c;
+}
 
 .meta-rule-editor__label { font-size: 12px; font-weight: 600; color: #475569; margin-top: 4px; }
 

--- a/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
@@ -11,6 +11,13 @@ export interface DingTalkPublicFormLinkWarningOptions {
   warnWhenProtectedWithoutAllowlist?: boolean
 }
 
+export type DingTalkPublicFormLinkAccessLevel =
+  | 'none'
+  | 'unavailable'
+  | 'public'
+  | 'dingtalk'
+  | 'dingtalk_granted'
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -75,6 +82,31 @@ export function describeDingTalkPublicFormLinkAccess(
     return hasAllowlist ? 'Authorized DingTalk users in allowlist can submit' : 'All authorized DingTalk users can submit'
   }
   return 'Fully public; anyone with the link can submit'
+}
+
+export function getDingTalkPublicFormLinkAccessLevel(
+  viewId: unknown,
+  views: readonly DingTalkPublicFormLinkView[],
+  optionsOrNowMs?: number | DingTalkPublicFormLinkWarningOptions,
+): DingTalkPublicFormLinkAccessLevel {
+  const options = normalizeWarningOptions(optionsOrNowMs)
+  const nowMs = options.nowMs ?? Date.now()
+  const id = typeof viewId === 'string' ? viewId.trim() : ''
+  if (!id) return 'none'
+
+  const view = views.find((item) => item.id === id)
+  if (!view || view.type !== 'form') return 'unavailable'
+
+  const publicForm = isRecord(view.config?.publicForm) ? view.config.publicForm : null
+  if (!publicForm || publicForm.enabled !== true) return 'unavailable'
+
+  const publicToken = typeof publicForm.publicToken === 'string' ? publicForm.publicToken.trim() : ''
+  if (!publicToken) return 'unavailable'
+
+  const expiryMs = parseExpiryMs(publicForm.expiresAt ?? publicForm.expiresOn)
+  if (expiryMs !== null && nowMs >= expiryMs) return 'unavailable'
+
+  return normalizeAccessMode(publicForm.accessMode)
 }
 
 export function listDingTalkPublicFormLinkBlockingErrors(

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -311,6 +311,8 @@ describe('MetaAutomationManager', () => {
     expect(publicLink.getAttribute('target')).toBe('_blank')
     expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.textContent)
       .toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
+      .toBe('public')
 
     const internalLink = container.querySelector('[data-automation-card-link="internal-view:view_grid"]') as HTMLButtonElement
     expect(internalLink).not.toBeNull()
@@ -358,6 +360,8 @@ describe('MetaAutomationManager', () => {
     expect(desc?.textContent).toContain('Internal processing: Grid')
     expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.textContent)
       .toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
+      .toBe('public')
   })
 
   it('shows DingTalk-bound public form access on rule card links', async () => {
@@ -376,6 +380,8 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-automation-card-link="public-form:view_form"]')).not.toBeNull()
     expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.textContent)
       .toContain('DingTalk-bound users in allowlist can submit')
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
+      .toBe('dingtalk')
   })
 
   it('shows DingTalk-authorized public form access on rule card links', async () => {
@@ -394,6 +400,8 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-automation-card-link="public-form:view_form"]')).not.toBeNull()
     expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.textContent)
       .toContain('Authorized DingTalk users in allowlist can submit')
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
+      .toBe('dingtalk_granted')
   })
 
   it('does not render a public form card link when sharing is missing a public token', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -788,6 +788,8 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing is disabled for "Public Form"')
+    expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
+      .toBe('unavailable')
   })
 
   it('disables saving a DingTalk group message when the selected public form link cannot work', async () => {
@@ -862,6 +864,8 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
     expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.textContent)
       .toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
+      .toBe('public')
     expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('Fully public; anyone with the link can submit')
   })
 
@@ -915,6 +919,8 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).not.toContain('is fully public')
     expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.textContent)
       .toContain('DingTalk-bound users in allowlist can submit')
+    expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
+      .toBe('dingtalk')
     expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('DingTalk-bound users in allowlist can submit')
   })
 
@@ -941,6 +947,8 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.textContent)
       .toContain('Authorized DingTalk users in allowlist can submit')
+    expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
+      .toBe('dingtalk_granted')
     expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent)
       .toContain('Authorized DingTalk users in allowlist can submit')
   })
@@ -1091,6 +1099,8 @@ describe('MetaAutomationRuleEditor', () => {
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
     expect(container.textContent).toContain('Public form sharing is disabled for "Public Form"')
+    expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
+      .toBe('unavailable')
     expect(saveBtn.disabled).toBe(true)
     saveBtn.click()
     await flushPromises()

--- a/docs/development/dingtalk-automation-access-state-badges-development-20260421.md
+++ b/docs/development/dingtalk-automation-access-state-badges-development-20260421.md
@@ -1,0 +1,74 @@
+# DingTalk Automation Access State Badges Development 2026-04-21
+
+## Scope
+
+本次开发继续完善钉钉自动化公开表单权限可见性，在规则卡片和高级编辑器访问策略文案上增加语义等级。
+
+目标：
+
+- 让 UI 明确区分 `public`、`dingtalk`、`dingtalk_granted`、`unavailable`。
+- 让 E2E/回归测试可以通过稳定 `data-access-level` 判断公开表单访问状态。
+- 不把访问等级写入自动化规则 payload，保持它是由表单配置派生的 UI 状态。
+
+## Implementation
+
+### Shared Helper
+
+`apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts`
+
+- 新增 `DingTalkPublicFormLinkAccessLevel` 类型：
+  - `none`
+  - `unavailable`
+  - `public`
+  - `dingtalk`
+  - `dingtalk_granted`
+- 新增 `getDingTalkPublicFormLinkAccessLevel(viewId, views, options)`：
+  - 未选择表单返回 `none`。
+  - 视图不存在、非 form、未启用分享、缺少 public token、已过期，返回 `unavailable`。
+  - 有效表单按 `accessMode` 返回 `public`、`dingtalk` 或 `dingtalk_granted`。
+  - 非法 `accessMode` 继续按现有逻辑 fallback 为 `public`。
+
+### Rule Card
+
+`apps/web/src/multitable/components/MetaAutomationManager.vue`
+
+- 规则卡片公开表单 access badge 增加：
+  - `data-access-level`
+  - `meta-automation__card-link-access--public`
+  - `meta-automation__card-link-access--dingtalk`
+  - `meta-automation__card-link-access--dingtalk_granted`
+  - `meta-automation__card-link-access--unavailable`
+- 卡片可点击入口仍只在公开表单配置可用时渲染；不可用配置继续不展示可点击公开入口。
+
+### Advanced Rule Editor
+
+`apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+- Group/Person 两个 public form selector 下方的 access summary 增加：
+  - `data-access-level`
+  - `meta-rule-editor__access-summary--public`
+  - `meta-rule-editor__access-summary--dingtalk`
+  - `meta-rule-editor__access-summary--dingtalk_granted`
+  - `meta-rule-editor__access-summary--unavailable`
+- 不可用公开表单在编辑器中会显示 `unavailable`，并继续保留阻断保存的 warning。
+
+## Tests
+
+`apps/web/tests/multitable-automation-manager.spec.ts`
+
+- 规则卡片 fully public badge 输出 `data-access-level="public"`。
+- 规则卡片 DingTalk-bound allowlist badge 输出 `data-access-level="dingtalk"`。
+- 规则卡片 DingTalk-authorized allowlist badge 输出 `data-access-level="dingtalk_granted"`。
+
+`apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+- Group selector disabled public form 输出 `data-access-level="unavailable"`。
+- Group selector fully public 输出 `data-access-level="public"`。
+- Group selector DingTalk-bound allowlist 输出 `data-access-level="dingtalk"`。
+- Person selector DingTalk-authorized allowlist 输出 `data-access-level="dingtalk_granted"`。
+- Person selector disabled public form 输出 `data-access-level="unavailable"`。
+
+## Follow-up
+
+- 后续 E2E 可以直接断言 `data-access-level`，不需要解析英文文案。
+- 如果产品希望中文化，可只替换 summary 文案，等级字段和样式无需调整。

--- a/docs/development/dingtalk-automation-access-state-badges-verification-20260421.md
+++ b/docs/development/dingtalk-automation-access-state-badges-verification-20260421.md
@@ -44,3 +44,35 @@ passed
 
 - `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
 - `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。
+
+## Rebase Verification - 2026-04-22
+
+- Previous stack base: `33f35b64158ff4910f0c0b1224cc0550889a2d3d`
+- New base: `origin/main@3141c75871c69660ef8add9deee2f10fde229bff`
+- Rebase command: `git rebase --onto origin/main origin/codex/dingtalk-automation-access-state-badges-base-20260421 HEAD`
+- Result: clean rebase, no conflicts.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+Results:
+
+```text
+MetaAutomationManager + MetaAutomationRuleEditor
+Test Files  2 passed (2)
+Tests       122 passed (122)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+Build note: the existing `WorkflowDesigner.vue` mixed static/dynamic import warning and large chunk warning remain unchanged and unrelated to this PR.

--- a/docs/development/dingtalk-automation-access-state-badges-verification-20260421.md
+++ b/docs/development/dingtalk-automation-access-state-badges-verification-20260421.md
@@ -1,0 +1,46 @@
+# DingTalk Automation Access State Badges Verification 2026-04-21
+
+## Local Environment
+
+- Worktree: `.worktrees/dingtalk-automation-access-state-badges-20260421`
+- Base: `codex/dingtalk-automation-editor-access-summary-20260421`
+- Package manager: `pnpm`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+```text
+MetaAutomationManager + MetaAutomationRuleEditor
+Test Files  2 passed (2)
+Tests       122 passed (122)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+## Covered Cases
+
+- Rule card public form badge level: `public`。
+- Rule card DingTalk-bound badge level: `dingtalk`。
+- Rule card DingTalk-authorized badge level: `dingtalk_granted`。
+- Rule editor group disabled form level: `unavailable`。
+- Rule editor group public form level: `public`。
+- Rule editor group DingTalk-bound allowlist level: `dingtalk`。
+- Rule editor person DingTalk-authorized allowlist level: `dingtalk_granted`。
+- Rule editor person disabled form level: `unavailable`。
+
+## Notes
+
+- `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
+- `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。


### PR DESCRIPTION
## Summary

Replay of the DingTalk automation access state badges slice onto current main after PR #1020 merged.

- Adds visible access-state badges for automation cards/editor warnings.
- Keeps scope to frontend automation manager/editor utilities and tests.
- Rebased from stack base 33f35b64158ff4910f0c0b1224cc0550889a2d3d onto main 3141c75871c69660ef8add9deee2f10fde229bff.

## Verification

- pnpm install --frozen-lockfile -> passed
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false -> 2 files / 122 tests passed
- pnpm --filter @metasheet/web build -> passed, existing Vite warnings only
- git diff --check -> passed

## Notes

This PR now targets main directly. Rebase verification was appended to docs/development/dingtalk-automation-access-state-badges-verification-20260421.md.