### PR TITLE
test(dingtalk): cover public form access levels

### DIFF
--- a/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   describeDingTalkPublicFormLinkAccess,
+  getDingTalkPublicFormLinkAccessLevel,
   listDingTalkPublicFormLinkBlockingErrors,
   listDingTalkPublicFormLinkWarnings,
 } from '../src/multitable/utils/dingtalkPublicFormLinkWarnings'
@@ -156,6 +157,22 @@ describe('dingtalk public form link warnings', () => {
     expect(describeDingTalkPublicFormLinkAccess('view_form_expired', views, nowMs)).toBe('Public form sharing has expired')
     expect(describeDingTalkPublicFormLinkAccess('view_grid', views, nowMs)).toBe('Selected view is not a form')
     expect(describeDingTalkPublicFormLinkAccess('missing_view', views, nowMs)).toBe('View unavailable in this sheet')
+  })
+
+  it('returns stable access levels for automation badges', () => {
+    expect(getDingTalkPublicFormLinkAccessLevel('', views, nowMs)).toBe('none')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_enabled', views, nowMs)).toBe('public')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_protected', views, nowMs)).toBe('dingtalk')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_protected_allowed_user', views, nowMs)).toBe('dingtalk')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_granted_without_allowlist', views, nowMs)).toBe('dingtalk_granted')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_granted_allowed_group', views, nowMs)).toBe('dingtalk_granted')
+    expect(getDingTalkPublicFormLinkAccessLevel('missing_view', views, nowMs)).toBe('unavailable')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_grid', views, nowMs)).toBe('unavailable')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_unconfigured', views, nowMs)).toBe('unavailable')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_disabled', views, nowMs)).toBe('unavailable')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_missing_token', views, nowMs)).toBe('unavailable')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_expired', views, nowMs)).toBe('unavailable')
+    expect(getDingTalkPublicFormLinkAccessLevel('view_form_expires_on', views, nowMs)).toBe('unavailable')
   })
 
   it('separates blocking link errors from advisory access warnings', () => {

--- a/docs/development/dingtalk-public-form-access-helper-tests-development-20260421.md
+++ b/docs/development/dingtalk-public-form-access-helper-tests-development-20260421.md
@@ -1,0 +1,33 @@
+# DingTalk Public Form Access Helper Tests Development 2026-04-21
+
+## Scope
+
+本次开发继续补强钉钉公开表单访问等级的测试覆盖。上一层已新增 `getDingTalkPublicFormLinkAccessLevel()` 并在规则卡片、高级编辑器中使用 `data-access-level`；本次把该 helper 的行为补成独立纯函数单测，降低后续 UI 测试承担的范围。
+
+## Implementation
+
+`apps/web/tests/dingtalk-public-form-link-warnings.spec.ts`
+
+- 在既有 public form link warning 测试文件中引入 `getDingTalkPublicFormLinkAccessLevel()`。
+- 新增 `returns stable access levels for automation badges` 用例。
+- 复用现有 fixtures，覆盖：
+  - 未选择表单：`none`
+  - 有效 public 表单：`public`
+  - 有效 DingTalk-bound 表单：`dingtalk`
+  - 有效 DingTalk-bound allowlist 表单：`dingtalk`
+  - 有效 DingTalk-authorized 表单：`dingtalk_granted`
+  - 有效 DingTalk-authorized allowlist 表单：`dingtalk_granted`
+  - 视图不存在、非 form、未配置分享、分享禁用、缺 token、已过期：`unavailable`
+
+## Rationale
+
+组件测试已经覆盖 UI 上的 `data-access-level`，但 helper 的边界条件更适合用独立单测表达：
+
+- 不需要挂载 Vue 组件。
+- 对过期时间、缺 token、非法视图等分支更直接。
+- 后续如果调整 UI 文案或样式，helper 行为仍有独立保护。
+
+## Follow-up
+
+- 如果未来新增访问模式，只需先扩展 helper 类型和本测试，再接入 UI。
+- 如果未来把 public form access 文案中文化，当前等级测试不会受文案变更影响。

--- a/docs/development/dingtalk-public-form-access-helper-tests-verification-20260421.md
+++ b/docs/development/dingtalk-public-form-access-helper-tests-verification-20260421.md
@@ -46,3 +46,35 @@ passed
 
 - `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
 - `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。
+
+## Rebase Verification - 2026-04-22
+
+- Previous stack base: `0f0ec22dab787c8a58fde8132f732c11bf768be1`
+- New base: `origin/main@a0030b98769f02e7a1c2fa80978cc852dcbaee97`
+- Rebase command: `git rebase --onto origin/main origin/codex/dingtalk-public-form-access-helper-tests-base-20260421 HEAD`
+- Result: clean rebase, no conflicts.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+Results:
+
+```text
+DingTalk public form helper + automation adjacent tests
+Test Files  3 passed (3)
+Tests       129 passed (129)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+Build note: the existing `WorkflowDesigner.vue` mixed static/dynamic import warning and large chunk warning remain unchanged and unrelated to this PR.

--- a/docs/development/dingtalk-public-form-access-helper-tests-verification-20260421.md
+++ b/docs/development/dingtalk-public-form-access-helper-tests-verification-20260421.md
@@ -1,0 +1,48 @@
+# DingTalk Public Form Access Helper Tests Verification 2026-04-21
+
+## Local Environment
+
+- Worktree: `.worktrees/dingtalk-public-form-access-helper-tests-20260421`
+- Base: `codex/dingtalk-automation-access-state-badges-20260421`
+- Package manager: `pnpm`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+```text
+DingTalk public form link warnings
+Test Files  1 passed (1)
+Tests       7 passed (7)
+
+DingTalk public form helper + automation adjacent tests
+Test Files  3 passed (3)
+Tests       129 passed (129)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+## Covered Cases
+
+- `getDingTalkPublicFormLinkAccessLevel('', views)` returns `none`。
+- Active public form returns `public`。
+- Active DingTalk-bound forms return `dingtalk`。
+- Active DingTalk-authorized forms return `dingtalk_granted`。
+- Missing view, non-form view, unconfigured sharing, disabled sharing, missing token, expired sharing return `unavailable`。
+
+## Notes
+
+- `pnpm install --frozen-lockfile` 会在当前 worktree 下恢复 workspace 依赖，并可能让若干已跟踪的插件 `node_modules` 软链显示为 modified；这些不是本功能变更，不应纳入提交。
+- `pnpm --filter @metasheet/web build` 通过，但仍有仓库既有 Vite dynamic import/chunk size 警告，和本次变更无关。


### PR DESCRIPTION
## Summary

Replay of the DingTalk public-form access helper test slice onto current main after PR #1042 merged.

- Adds stable access-level assertions for getDingTalkPublicFormLinkAccessLevel.
- Keeps scope to frontend tests and development/verification docs.
- Rebased from stack base 0f0ec22dab787c8a58fde8132f732c11bf768be1 onto main a0030b98769f02e7a1c2fa80978cc852dcbaee97.

## Verification

- pnpm install --frozen-lockfile -> passed
- pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false -> 3 files / 129 tests passed
- pnpm --filter @metasheet/web build -> passed, existing Vite warnings only
- git diff --check -> passed

## Notes

This PR now targets main directly. Rebase verification was appended to docs/development/dingtalk-public-form-access-helper-tests-verification-20260421.md.