### PR TITLE
fix(collab): pass Yjs frontend flag into GHCR build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,8 +40,11 @@ jobs:
           docker push ghcr.io/zensgit/metasheet2-backend:${{ github.sha }}
       
       - name: Build and push frontend
+        env:
+          VITE_ENABLE_YJS_COLLAB: ${{ vars.VITE_ENABLE_YJS_COLLAB || 'false' }}
         run: |
           docker build -f Dockerfile.frontend \
+            --build-arg VITE_ENABLE_YJS_COLLAB="${VITE_ENABLE_YJS_COLLAB}" \
             -t ghcr.io/zensgit/metasheet2-web:latest \
             -t ghcr.io/zensgit/metasheet2-web:${{ github.sha }} \
             .

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -2,6 +2,8 @@ FROM node:20-slim AS builder
 
 WORKDIR /app
 RUN corepack enable
+ARG VITE_ENABLE_YJS_COLLAB=false
+ENV VITE_ENABLE_YJS_COLLAB=$VITE_ENABLE_YJS_COLLAB
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY tsconfig.json ./

--- a/docs/development/yjs-frontend-ghcr-build-flag-development-20260421.md
+++ b/docs/development/yjs-frontend-ghcr-build-flag-development-20260421.md
@@ -1,0 +1,43 @@
+# Yjs Frontend GHCR Build Flag
+
+- Date: 2026-04-21
+- Branch: `codex/yjs-staging-build-flag-20260421`
+- Scope: allow the GHCR frontend image to be built with Yjs collaboration enabled for staging/internal rollout.
+
+## Problem
+
+The backend Yjs stack can be enabled at runtime with `ENABLE_YJS_COLLAB=true`, but the frontend editor path is guarded by the Vite build-time flag `VITE_ENABLE_YJS_COLLAB`.
+
+The GHCR frontend image was previously built without passing that flag into `Dockerfile.frontend`, so the deployed frontend stayed flag-off even when the backend was prepared for Yjs validation. This blocks staging two-browser/manual validation because the browser bundle never activates the Yjs cell binding path.
+
+## Change
+
+`Dockerfile.frontend` now accepts:
+
+```dockerfile
+ARG VITE_ENABLE_YJS_COLLAB=false
+ENV VITE_ENABLE_YJS_COLLAB=$VITE_ENABLE_YJS_COLLAB
+```
+
+`.github/workflows/docker-build.yml` now passes:
+
+```bash
+--build-arg VITE_ENABLE_YJS_COLLAB="${VITE_ENABLE_YJS_COLLAB}"
+```
+
+The workflow value comes from repository variable `VITE_ENABLE_YJS_COLLAB`, defaulting to `false`.
+
+## Behavior
+
+- Default push builds remain Yjs-off unless the repo variable is explicitly set.
+- Internal staging can opt in by setting repository variable `VITE_ENABLE_YJS_COLLAB=true` before publishing a new GHCR image.
+- Runtime backend gating remains separate and still requires `ENABLE_YJS_COLLAB=true` in the server env.
+
+## Rollout Requirements
+
+For a real Yjs staging rollout, both switches must be true:
+
+1. Frontend build-time: repository variable `VITE_ENABLE_YJS_COLLAB=true` before GHCR image build.
+2. Backend runtime: remote `docker/app.env` contains `ENABLE_YJS_COLLAB=true`.
+
+The Yjs staging workflow also needs repository secret `YJS_ADMIN_TOKEN` set to a non-expired admin JWT.

--- a/docs/development/yjs-frontend-ghcr-build-flag-verification-20260421.md
+++ b/docs/development/yjs-frontend-ghcr-build-flag-verification-20260421.md
@@ -1,0 +1,101 @@
+# Verification - Yjs Frontend GHCR Build Flag
+
+- Date: 2026-04-21
+- Branch: `codex/yjs-staging-build-flag-20260421`
+
+## Checks
+
+### Dockerfile / Workflow Wiring
+
+Expected:
+
+- `Dockerfile.frontend` defines `ARG VITE_ENABLE_YJS_COLLAB=false`.
+- `Dockerfile.frontend` exports the ARG as `ENV VITE_ENABLE_YJS_COLLAB`.
+- `.github/workflows/docker-build.yml` passes `--build-arg VITE_ENABLE_YJS_COLLAB=...` to the frontend image build.
+- Workflow value defaults to `false` when the repository variable is not set.
+
+### Frontend Build - Yjs Off
+
+Command:
+
+```bash
+VITE_ENABLE_YJS_COLLAB=false pnpm --filter @metasheet/web build
+```
+
+Result: **PASS**
+
+- Build exited `0`.
+- `2354 modules transformed`.
+- Output did not include `useYjsDocument-*`, `useYjsTextField-*`, or `yjs-*` chunks, matching the default Yjs-off behavior.
+
+### Frontend Build - Yjs On
+
+Command:
+
+```bash
+VITE_ENABLE_YJS_COLLAB=true pnpm --filter @metasheet/web build
+```
+
+Result: **PASS**
+
+- Build exited `0`.
+- `2354 modules transformed`.
+- Output included:
+  - `useYjsTextField-D2-i31UE.js`
+  - `useYjsDocument-o6U4Xo49.js`
+  - `yjs-BoMmO8v_.js`
+
+### Docker Build Smoke
+
+Command:
+
+```bash
+docker build -f Dockerfile.frontend \
+  --build-arg VITE_ENABLE_YJS_COLLAB=true \
+  -t metasheet2-web:yjs-build-flag-smoke .
+```
+
+Result: **PASS**
+
+- Docker build completed successfully.
+- The containerized frontend build output included the Yjs runtime chunks listed above.
+
+### Focused Frontend Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-yjs-cell-binding.spec.ts \
+  tests/yjs-document-invalidation.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       7 passed (7)
+```
+
+### Typecheck
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: **PASS**
+
+### Remote Staging Probe
+
+Observed against `http://142.171.239.56:8081` before this change is deployed:
+
+- `GET /` returns `200`.
+- `GET /api/health` returns `200`, `pluginsSummary.failed=0`.
+- `GET /api/plugins` returns `200`.
+- `GET /api/admin/yjs/status` returns `401` with the expired/manual token. The token provided earlier expired at `2026-04-21T14:08:17Z`.
+- Manual `Yjs Staging Validation` workflow run `24728341234` failed because repository secret `YJS_ADMIN_TOKEN` is not set.
+
+This confirms the current deployment is healthy as a general app deployment, but cannot complete Yjs staging E2E until credentials and feature flags are set.


### PR DESCRIPTION
## Summary

- Adds `VITE_ENABLE_YJS_COLLAB` as a `Dockerfile.frontend` build arg, defaulting to `false`.
- Passes the repo variable `VITE_ENABLE_YJS_COLLAB` from `.github/workflows/docker-build.yml` into the frontend GHCR build.
- Documents the staging rollout requirement: frontend build-time flag + backend runtime flag + non-expired `YJS_ADMIN_TOKEN` secret.

## Why

142 staging is on latest `main`, but the current frontend GHCR image is built without `VITE_ENABLE_YJS_COLLAB`, so browser Yjs cell binding cannot be activated even if backend Yjs is enabled. This keeps default builds safe while allowing internal staging to opt in explicitly.

## Verification

- `rg` wiring check for Dockerfile/workflow build arg: PASS
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-build.yml')"`: PASS
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-yjs-cell-binding.spec.ts tests/yjs-document-invalidation.spec.ts --reporter=dot`: 7/7 passed
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit`: PASS
- `VITE_ENABLE_YJS_COLLAB=false pnpm --filter @metasheet/web build`: PASS, no Yjs runtime chunks
- `VITE_ENABLE_YJS_COLLAB=true pnpm --filter @metasheet/web build`: PASS, includes `useYjsDocument-*`, `useYjsTextField-*`, and `yjs-*` chunks
- `docker build -f Dockerfile.frontend --build-arg VITE_ENABLE_YJS_COLLAB=true -t metasheet2-web:yjs-build-flag-smoke .`: PASS

## Remote staging notes

- Latest `main@6c5c652d1086674772ae78cc451f057563bb69b4` built and deployed successfully by Actions.
- `http://142.171.239.56:8081/api/health`: 200, `pluginsSummary.failed=0`.
- Manual Yjs staging workflow run `24728341234` failed before E2E because repository secret `YJS_ADMIN_TOKEN` is not set.
- The previously provided admin JWT is expired (`exp=2026-04-21T14:08:17Z`).
