### PR TITLE
feat(dingtalk): expose quick form access levels

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -260,7 +260,14 @@
                 </button>
               </div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
-              <div><strong>Public form access:</strong> {{ publicFormAccessSummary(draft.publicFormViewId) }}</div>
+              <div
+                class="meta-automation__public-form-access"
+                :class="`meta-automation__public-form-access--${publicFormAccessLevel(draft.publicFormViewId)}`"
+                data-automation-public-form-access="group"
+                :data-access-level="publicFormAccessLevel(draft.publicFormViewId)"
+              >
+                <strong>Public form access:</strong> {{ publicFormAccessSummary(draft.publicFormViewId) }}
+              </div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
             </div>
           </template>
@@ -541,7 +548,14 @@
                 </button>
               </div>
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
-              <div><strong>Public form access:</strong> {{ publicFormAccessSummary(draft.dingtalkPersonPublicFormViewId) }}</div>
+              <div
+                class="meta-automation__public-form-access"
+                :class="`meta-automation__public-form-access--${publicFormAccessLevel(draft.dingtalkPersonPublicFormViewId)}`"
+                data-automation-public-form-access="person"
+                :data-access-level="publicFormAccessLevel(draft.dingtalkPersonPublicFormViewId)"
+              >
+                <strong>Public form access:</strong> {{ publicFormAccessSummary(draft.dingtalkPersonPublicFormViewId) }}
+              </div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
             </div>
           </template>
@@ -2054,6 +2068,36 @@ watch(
 }
 
 .meta-automation__card-link-access--unavailable {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.meta-automation__public-form-access {
+  border-radius: 8px;
+  padding: 6px 8px;
+}
+
+.meta-automation__public-form-access--none {
+  background: #f8fafc;
+  color: #475569;
+}
+
+.meta-automation__public-form-access--public {
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.meta-automation__public-form-access--dingtalk {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.meta-automation__public-form-access--dingtalk_granted {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.meta-automation__public-form-access--unavailable {
   background: #fef2f2;
   color: #b91c1c;
 }

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1073,6 +1073,7 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
     expect(container.querySelector('[data-automation-summary="group"]')?.textContent).toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('public')
   })
 
   it('warns when a DingTalk group message uses a protected public form without an allowlist in the inline form', async () => {
@@ -1102,6 +1103,7 @@ describe('MetaAutomationManager', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
     expect(container.textContent).toContain('add allowed users or member groups')
+    expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('dingtalk')
   })
 
   it('does not warn when a DingTalk group message uses a protected public form with an allowlist in the inline form', async () => {
@@ -1132,6 +1134,7 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
     expect(container.textContent).not.toContain('is fully public')
     expect(container.querySelector('[data-automation-summary="group"]')?.textContent).toContain('DingTalk-bound users in allowlist can submit')
+    expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('dingtalk')
   })
 
   it('warns when a DingTalk person message selects a public form without a token in the inline form', async () => {
@@ -1154,6 +1157,7 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is missing a public token')
+    expect(container.querySelector('[data-automation-public-form-access="person"]')?.getAttribute('data-access-level')).toBe('unavailable')
   })
 
   it('disables creating a DingTalk person automation when the selected public form link cannot work', async () => {
@@ -2229,6 +2233,7 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
     expect(summary?.textContent).toContain('Public Form')
     expect(summary?.textContent).toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-automation-public-form-access="person"]')?.getAttribute('data-access-level')).toBe('public')
     expect(summary?.textContent).toContain('No internal link')
   })
 

--- a/docs/development/dingtalk-quick-form-access-level-development-20260421.md
+++ b/docs/development/dingtalk-quick-form-access-level-development-20260421.md
@@ -1,0 +1,29 @@
+# DingTalk Quick Form Access Level Development
+
+Date: 2026-04-21
+
+## Scope
+
+This change finishes the DingTalk public-form access state surface for the legacy quick automation form in `MetaAutomationManager`.
+
+## Changes
+
+- Added `data-automation-public-form-access="group"` and `data-access-level` to the DingTalk group quick-form public form access preview.
+- Added `data-automation-public-form-access="person"` and `data-access-level` to the DingTalk person quick-form public form access preview.
+- Reused the existing `publicFormAccessLevel()` helper so quick form, automation cards, and advanced rule editor use the same access-level semantics.
+- Added visual states for quick-form access summaries:
+  - `none`
+  - `public`
+  - `dingtalk`
+  - `dingtalk_granted`
+  - `unavailable`
+- Extended manager tests to assert the emitted access level for group and person quick-form flows.
+
+## User Impact
+
+When a table owner configures a DingTalk group or DingTalk person automation from the quick form, the UI now exposes the selected public form's permission state as structured DOM state and styled status text. This makes it clearer whether the DingTalk message link is fully public, DingTalk-bound, authorization-gated, unavailable, or not selected.
+
+## Notes
+
+- No backend schema or API changes were required.
+- `pnpm install --frozen-lockfile` creates local tracked `node_modules` symlink dirtiness in plugin/tool packages in this repository. Those generated workspace artifacts are intentionally excluded from the commit.

--- a/docs/development/dingtalk-quick-form-access-level-verification-20260421.md
+++ b/docs/development/dingtalk-quick-form-access-level-verification-20260421.md
@@ -29,3 +29,40 @@ git diff --check
 - The combined Vitest run printed `WebSocket server error: Port is already in use`, but all requested test files passed and the command exited successfully.
 - Vite build retained existing warnings about a mixed dynamic/static import for `WorkflowDesigner.vue` and chunks larger than 500 kB. These warnings are unrelated to this DingTalk quick-form access-level change.
 - Local PNPM install produced tracked `node_modules` symlink dirtiness under plugin/tool package folders. Those generated artifacts were not staged.
+
+## Rebase Verification - 2026-04-22
+
+- Previous stack base: `6b641b9b3826f240928fec69849a19db241b8aa1`
+- New base: `origin/main@a21fc740c52c0498f9eb381778894cd0478e631e`
+- Rebase command: `git rebase --onto origin/main origin/codex/dingtalk-quick-form-access-level-base-20260421 HEAD`
+- Result: clean rebase, no conflicts.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+Results:
+
+```text
+MetaAutomationManager
+Test Files  1 passed (1)
+Tests       67 passed (67)
+
+DingTalk public form helper + automation adjacent tests
+Test Files  3 passed (3)
+Tests       129 passed (129)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+Build note: the existing `WorkflowDesigner.vue` mixed static/dynamic import warning and large chunk warning remain unchanged and unrelated to this PR.

--- a/docs/development/dingtalk-quick-form-access-level-verification-20260421.md
+++ b/docs/development/dingtalk-quick-form-access-level-verification-20260421.md
@@ -1,0 +1,31 @@
+# DingTalk Quick Form Access Level Verification
+
+Date: 2026-04-21
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`: passed.
+- `tests/multitable-automation-manager.spec.ts`: passed, 67 tests.
+- Combined DingTalk public form regression:
+  - `tests/dingtalk-public-form-link-warnings.spec.ts`: passed, 7 tests.
+  - `tests/multitable-automation-manager.spec.ts`: passed, 67 tests.
+  - `tests/multitable-automation-rule-editor.spec.ts`: passed, 55 tests.
+  - Total: 129 tests passed.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Observations
+
+- The combined Vitest run printed `WebSocket server error: Port is already in use`, but all requested test files passed and the command exited successfully.
+- Vite build retained existing warnings about a mixed dynamic/static import for `WorkflowDesigner.vue` and chunks larger than 500 kB. These warnings are unrelated to this DingTalk quick-form access-level change.
+- Local PNPM install produced tracked `node_modules` symlink dirtiness under plugin/tool package folders. Those generated artifacts were not staged.


### PR DESCRIPTION
## Summary

Replay of the DingTalk quick-form access-level slice onto current main after PR #1022 merged.

- Exposes structured data-access-level state on DingTalk group/person quick-form public-form access previews.
- Reuses the existing public-form access helper semantics used by automation cards/editor.
- Rebased from stack base 6b641b9b3826f240928fec69849a19db241b8aa1 onto main a21fc740c52c0498f9eb381778894cd0478e631e.

## Verification

- pnpm install --frozen-lockfile -> passed
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false -> 1 file / 67 tests passed
- pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false -> 3 files / 129 tests passed
- pnpm --filter @metasheet/web build -> passed, existing Vite warnings only
- git diff --check -> passed

## Notes

This PR now targets main directly. Rebase verification was appended to docs/development/dingtalk-quick-form-access-level-verification-20260421.md.