### PR TITLE
fix(dingtalk): stabilize public form access state

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -262,11 +262,11 @@
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
               <div
                 class="meta-automation__public-form-access"
-                :class="`meta-automation__public-form-access--${publicFormAccessLevel(draft.publicFormViewId)}`"
+                :class="`meta-automation__public-form-access--${draftGroupPublicFormAccessState.level}`"
                 data-automation-public-form-access="group"
-                :data-access-level="publicFormAccessLevel(draft.publicFormViewId)"
+                :data-access-level="draftGroupPublicFormAccessState.level"
               >
-                <strong>Public form access:</strong> {{ publicFormAccessSummary(draft.publicFormViewId) }}
+                <strong>Public form access:</strong> {{ draftGroupPublicFormAccessState.summary }}
               </div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
             </div>
@@ -550,11 +550,11 @@
               <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
               <div
                 class="meta-automation__public-form-access"
-                :class="`meta-automation__public-form-access--${publicFormAccessLevel(draft.dingtalkPersonPublicFormViewId)}`"
+                :class="`meta-automation__public-form-access--${draftPersonPublicFormAccessState.level}`"
                 data-automation-public-form-access="person"
-                :data-access-level="publicFormAccessLevel(draft.dingtalkPersonPublicFormViewId)"
+                :data-access-level="draftPersonPublicFormAccessState.level"
               >
-                <strong>Public form access:</strong> {{ publicFormAccessSummary(draft.dingtalkPersonPublicFormViewId) }}
+                <strong>Public form access:</strong> {{ draftPersonPublicFormAccessState.summary }}
               </div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
             </div>
@@ -760,8 +760,7 @@ import {
   listDingTalkPersonRecipientFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
-  describeDingTalkPublicFormLinkAccess,
-  getDingTalkPublicFormLinkAccessLevel,
+  getDingTalkPublicFormLinkAccessState,
   type DingTalkPublicFormLinkAccessLevel,
   listDingTalkPublicFormLinkBlockingErrors,
   listDingTalkPublicFormLinkWarnings,
@@ -863,6 +862,12 @@ const formViews = computed(() => (props.views ?? []).filter((view) =>
   view.type === 'form' && (!view.sheetId || view.sheetId === props.sheetId),
 ))
 const internalViews = computed(() => (props.views ?? []).filter((view) => !view.sheetId || view.sheetId === props.sheetId))
+const draftGroupPublicFormAccessState = computed(() =>
+  getDingTalkPublicFormLinkAccessState(draft.value.publicFormViewId, formViews.value),
+)
+const draftPersonPublicFormAccessState = computed(() =>
+  getDingTalkPublicFormLinkAccessState(draft.value.dingtalkPersonPublicFormViewId, formViews.value),
+)
 
 interface DingTalkCardLink {
   key: string
@@ -1044,8 +1049,9 @@ const dingTalkGroupSummary = computed(() => {
 })
 
 function viewSummaryName(viewId: string, fallback: string) {
-  if (!viewId) return fallback
-  return (props.views ?? []).find((view) => view.id === viewId)?.name ?? viewId
+  const id = viewId.trim()
+  if (!id) return fallback
+  return (props.views ?? []).find((view) => view.id === id)?.name ?? id
 }
 
 function templatePreviewText(value: string, fallback: string) {
@@ -1076,14 +1082,6 @@ function internalViewLinkWarnings(value: unknown) {
 
 function internalViewLinkBlockingErrors(value: unknown) {
   return listDingTalkInternalViewLinkBlockingErrors(value, internalViews.value)
-}
-
-function publicFormAccessSummary(value: unknown) {
-  return describeDingTalkPublicFormLinkAccess(value, formViews.value)
-}
-
-function publicFormAccessLevel(value: unknown) {
-  return getDingTalkPublicFormLinkAccessLevel(value, formViews.value)
 }
 
 function readPublicFormToken(view: MetaView): string {
@@ -1121,13 +1119,14 @@ function dingTalkCardLinks(rule: AutomationRule): DingTalkCardLink[] {
       const publicToken = view ? readPublicFormToken(view) : ''
       const key = `public-form:${publicFormViewId}`
       if (view && publicToken && !seen.has(key)) {
+        const accessState = getDingTalkPublicFormLinkAccessState(publicFormViewId, formViews.value)
         seen.add(key)
         links.push({
           key,
           label: `Open public form: ${viewSummaryName(publicFormViewId, publicFormViewId)}`,
           href: buildPublicFormHref(publicFormViewId, publicToken),
-          accessSummary: describeDingTalkPublicFormLinkAccess(publicFormViewId, formViews.value),
-          accessLevel: publicFormAccessLevel(publicFormViewId),
+          accessSummary: accessState.summary,
+          accessLevel: accessState.level,
         })
       }
     }

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -338,15 +338,20 @@
               >
                 {{ warning }}
               </div>
-              <div
-                v-if="action.config.publicFormViewId"
-                class="meta-rule-editor__hint meta-rule-editor__access-summary"
-                :class="`meta-rule-editor__access-summary--${publicFormAccessLevel(action.config.publicFormViewId)}`"
-                :data-field="`groupPublicFormAccessSummary-${idx}`"
-                :data-access-level="publicFormAccessLevel(action.config.publicFormViewId)"
+              <template
+                v-for="accessState in [publicFormAccessState(action.config.publicFormViewId)]"
+                :key="`group-public-form-access-${idx}`"
               >
-                <strong>Access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}
-              </div>
+                <div
+                  v-if="accessState.hasSelection"
+                  class="meta-rule-editor__hint meta-rule-editor__access-summary"
+                  :class="`meta-rule-editor__access-summary--${accessState.level}`"
+                  :data-field="`groupPublicFormAccessSummary-${idx}`"
+                  :data-access-level="accessState.level"
+                >
+                  <strong>Access:</strong> {{ accessState.summary }}
+                </div>
+              </template>
               <label class="meta-rule-editor__label">Internal processing view (optional)</label>
               <select
                 v-model="action.config.internalViewId"
@@ -392,7 +397,7 @@
                   </button>
                 </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
-                <div><strong>Public form access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}</div>
+                <div><strong>Public form access:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
             </div>
@@ -636,15 +641,20 @@
               >
                 {{ warning }}
               </div>
-              <div
-                v-if="action.config.publicFormViewId"
-                class="meta-rule-editor__hint meta-rule-editor__access-summary"
-                :class="`meta-rule-editor__access-summary--${publicFormAccessLevel(action.config.publicFormViewId)}`"
-                :data-field="`personPublicFormAccessSummary-${idx}`"
-                :data-access-level="publicFormAccessLevel(action.config.publicFormViewId)"
+              <template
+                v-for="accessState in [publicFormAccessState(action.config.publicFormViewId)]"
+                :key="`person-public-form-access-${idx}`"
               >
-                <strong>Access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}
-              </div>
+                <div
+                  v-if="accessState.hasSelection"
+                  class="meta-rule-editor__hint meta-rule-editor__access-summary"
+                  :class="`meta-rule-editor__access-summary--${accessState.level}`"
+                  :data-field="`personPublicFormAccessSummary-${idx}`"
+                  :data-access-level="accessState.level"
+                >
+                  <strong>Access:</strong> {{ accessState.summary }}
+                </div>
+              </template>
               <label class="meta-rule-editor__label">Internal processing view (optional)</label>
               <select
                 v-model="action.config.internalViewId"
@@ -691,7 +701,7 @@
                   </button>
                 </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
-                <div><strong>Public form access:</strong> {{ publicFormAccessSummary(action.config.publicFormViewId) }}</div>
+                <div><strong>Public form access:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
             </div>
@@ -780,8 +790,7 @@ import {
   listDingTalkPersonRecipientFieldPathWarnings,
 } from '../utils/dingtalkRecipientFieldWarnings'
 import {
-  describeDingTalkPublicFormLinkAccess,
-  getDingTalkPublicFormLinkAccessLevel,
+  getDingTalkPublicFormLinkAccessState,
   listDingTalkPublicFormLinkBlockingErrors,
   listDingTalkPublicFormLinkWarnings,
 } from '../utils/dingtalkPublicFormLinkWarnings'
@@ -1237,7 +1246,7 @@ function removePersonRecipientGroup(action: DraftAction, groupId: string) {
 }
 
 function viewSummaryName(viewId: unknown, fallback: string) {
-  const id = typeof viewId === 'string' ? viewId : ''
+  const id = typeof viewId === 'string' ? viewId.trim() : ''
   if (!id) return fallback
   return (props.views ?? []).find((view) => view.id === id)?.name ?? id
 }
@@ -1271,12 +1280,8 @@ function internalViewLinkBlockingErrors(value: unknown) {
   return listDingTalkInternalViewLinkBlockingErrors(value, internalViews.value)
 }
 
-function publicFormAccessSummary(value: unknown) {
-  return describeDingTalkPublicFormLinkAccess(value, formViews.value)
-}
-
-function publicFormAccessLevel(value: unknown) {
-  return getDingTalkPublicFormLinkAccessLevel(value, formViews.value)
+function publicFormAccessState(value: unknown) {
+  return getDingTalkPublicFormLinkAccessState(value, formViews.value)
 }
 
 function isDingTalkActionType(value: unknown): boolean {

--- a/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
@@ -18,6 +18,12 @@ export type DingTalkPublicFormLinkAccessLevel =
   | 'dingtalk'
   | 'dingtalk_granted'
 
+export interface DingTalkPublicFormLinkAccessState {
+  hasSelection: boolean
+  level: DingTalkPublicFormLinkAccessLevel
+  summary: string
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -107,6 +113,21 @@ export function getDingTalkPublicFormLinkAccessLevel(
   if (expiryMs !== null && nowMs >= expiryMs) return 'unavailable'
 
   return normalizeAccessMode(publicForm.accessMode)
+}
+
+export function getDingTalkPublicFormLinkAccessState(
+  viewId: unknown,
+  views: readonly DingTalkPublicFormLinkView[],
+  optionsOrNowMs?: number | DingTalkPublicFormLinkWarningOptions,
+): DingTalkPublicFormLinkAccessState {
+  const options = normalizeWarningOptions(optionsOrNowMs)
+  const stableOptions = { ...options, nowMs: options.nowMs ?? Date.now() }
+  const id = typeof viewId === 'string' ? viewId.trim() : ''
+  return {
+    hasSelection: Boolean(id),
+    level: getDingTalkPublicFormLinkAccessLevel(id, views, stableOptions),
+    summary: describeDingTalkPublicFormLinkAccess(id, views, stableOptions),
+  }
 }
 
 export function listDingTalkPublicFormLinkBlockingErrors(

--- a/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   describeDingTalkPublicFormLinkAccess,
   getDingTalkPublicFormLinkAccessLevel,
+  getDingTalkPublicFormLinkAccessState,
   listDingTalkPublicFormLinkBlockingErrors,
   listDingTalkPublicFormLinkWarnings,
 } from '../src/multitable/utils/dingtalkPublicFormLinkWarnings'
@@ -173,6 +174,34 @@ describe('dingtalk public form link warnings', () => {
     expect(getDingTalkPublicFormLinkAccessLevel('view_form_missing_token', views, nowMs)).toBe('unavailable')
     expect(getDingTalkPublicFormLinkAccessLevel('view_form_expired', views, nowMs)).toBe('unavailable')
     expect(getDingTalkPublicFormLinkAccessLevel('view_form_expires_on', views, nowMs)).toBe('unavailable')
+  })
+
+  it('returns stable access state for automation summaries', () => {
+    expect(getDingTalkPublicFormLinkAccessState('   ', views, nowMs)).toEqual({
+      hasSelection: false,
+      level: 'none',
+      summary: 'No public form link',
+    })
+    expect(getDingTalkPublicFormLinkAccessState('view_form_enabled', views, nowMs)).toEqual({
+      hasSelection: true,
+      level: 'public',
+      summary: 'Fully public; anyone with the link can submit',
+    })
+    expect(getDingTalkPublicFormLinkAccessState('view_form_protected_allowed_user', views, nowMs)).toEqual({
+      hasSelection: true,
+      level: 'dingtalk',
+      summary: 'DingTalk-bound users in allowlist can submit',
+    })
+    expect(getDingTalkPublicFormLinkAccessState('view_form_granted_allowed_group', views, nowMs)).toEqual({
+      hasSelection: true,
+      level: 'dingtalk_granted',
+      summary: 'Authorized DingTalk users in allowlist can submit',
+    })
+    expect(getDingTalkPublicFormLinkAccessState('missing_view', views, nowMs)).toEqual({
+      hasSelection: true,
+      level: 'unavailable',
+      summary: 'View unavailable in this sheet',
+    })
   })
 
   it('separates blocking link errors from advisory access warnings', () => {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1074,6 +1074,7 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
     expect(container.querySelector('[data-automation-summary="group"]')?.textContent).toContain('Fully public; anyone with the link can submit')
     expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('public')
+    expect(container.querySelector('[data-automation-public-form-access="group"]')?.classList.contains('meta-automation__public-form-access--public')).toBe(true)
   })
 
   it('warns when a DingTalk group message uses a protected public form without an allowlist in the inline form', async () => {
@@ -1104,6 +1105,7 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
     expect(container.textContent).toContain('add allowed users or member groups')
     expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('dingtalk')
+    expect(container.querySelector('[data-automation-public-form-access="group"]')?.classList.contains('meta-automation__public-form-access--dingtalk')).toBe(true)
   })
 
   it('does not warn when a DingTalk group message uses a protected public form with an allowlist in the inline form', async () => {
@@ -1158,6 +1160,7 @@ describe('MetaAutomationManager', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is missing a public token')
     expect(container.querySelector('[data-automation-public-form-access="person"]')?.getAttribute('data-access-level')).toBe('unavailable')
+    expect(container.querySelector('[data-automation-public-form-access="person"]')?.classList.contains('meta-automation__public-form-access--unavailable')).toBe(true)
   })
 
   it('disables creating a DingTalk person automation when the selected public form link cannot work', async () => {
@@ -2234,6 +2237,7 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Public Form')
     expect(summary?.textContent).toContain('Fully public; anyone with the link can submit')
     expect(container.querySelector('[data-automation-public-form-access="person"]')?.getAttribute('data-access-level')).toBe('public')
+    expect(container.querySelector('[data-automation-public-form-access="person"]')?.classList.contains('meta-automation__public-form-access--public')).toBe(true)
     expect(summary?.textContent).toContain('No internal link')
   })
 

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -924,6 +924,37 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('DingTalk-bound users in allowlist can submit')
   })
 
+  it('does not render access badges for whitespace-only public form ids', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      rule: fakeRule({
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: { publicFormViewId: '   ', destinationId: 'dt_1', titleTemplate: 'Ticket', bodyTemplate: 'Please fill' },
+        actions: [
+          {
+            type: 'send_dingtalk_group_message',
+            config: { publicFormViewId: '   ', destinationId: 'dt_1', titleTemplate: 'Ticket', bodyTemplate: 'Please fill' },
+          },
+          {
+            type: 'send_dingtalk_person_message',
+            config: { publicFormViewId: '\n\t', userIds: ['user_1'], titleTemplate: 'Ticket', bodyTemplate: 'Please fill' },
+          },
+        ],
+      }),
+    })
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')).toBeNull()
+    expect(container.querySelector('[data-field="personPublicFormAccessSummary-1"]')).toBeNull()
+    expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('No public form link')
+    expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent).toContain('No public form link')
+  })
+
   it('shows DingTalk-authorized public form access next to the person form selector', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/docs/development/dingtalk-public-form-access-state-development-20260421.md
+++ b/docs/development/dingtalk-public-form-access-state-development-20260421.md
@@ -1,0 +1,29 @@
+# DingTalk Public Form Access State Development
+
+Date: 2026-04-21
+
+## Scope
+
+This change stabilizes DingTalk public-form access rendering across the quick automation manager, advanced rule editor, and automation card link generation.
+
+## Changes
+
+- Added `getDingTalkPublicFormLinkAccessState()` to return `hasSelection`, `level`, and `summary` from one stable timestamp.
+- Updated quick group/person automation summaries to use computed access states instead of separately deriving CSS class, data attributes, and summary text.
+- Updated automation card public-form links to use the shared access state for summary and access level.
+- Updated advanced rule editor group/person access summaries to use one derived access state per rendered selector.
+- Trimmed public-form view ids before rendering view names, so whitespace-only ids show as `No public form link`.
+- Suppressed advanced editor access badges when a stale public-form id is whitespace-only.
+
+## User Impact
+
+The UI now renders DingTalk form-link permission state consistently. A public-form link cannot show one level in CSS and another in `data-access-level` during expiry boundary renders, and stale whitespace ids no longer produce a misleading empty access badge.
+
+## Files
+
+- `apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/dingtalk-public-form-link-warnings.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`

--- a/docs/development/dingtalk-public-form-access-state-verification-20260421.md
+++ b/docs/development/dingtalk-public-form-access-state-verification-20260421.md
@@ -24,3 +24,35 @@ git diff --check
 
 - Vite build retained existing warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and chunks larger than 500 kB. These are unrelated to this DingTalk access-state change.
 - The worktree still has local tracked `node_modules` symlink dirtiness from the earlier `pnpm install --frozen-lockfile`; those generated artifacts were not staged.
+
+## Rebase Verification - 2026-04-22
+
+- Previous stack base: `edba6ef7c71bd8f133e2bf0aa18ed62d6a28214b`
+- New base: `origin/main@b5981d67d7255b0ecaef820f5e115b017322652b`
+- Rebase command: `git rebase --onto origin/main origin/codex/dingtalk-public-form-access-state-base-20260421 HEAD`
+- Result: clean rebase, no conflicts.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+Results:
+
+```text
+DingTalk public-form access regression tests
+Test Files  3 passed (3)
+Tests       131 passed (131)
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+Build note: the existing `WorkflowDesigner.vue` mixed static/dynamic import warning and large chunk warning remain unchanged and unrelated to this PR.

--- a/docs/development/dingtalk-public-form-access-state-verification-20260421.md
+++ b/docs/development/dingtalk-public-form-access-state-verification-20260421.md
@@ -1,0 +1,26 @@
+# DingTalk Public Form Access State Verification
+
+Date: 2026-04-21
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+- DingTalk public-form access regression tests: passed.
+  - `tests/dingtalk-public-form-link-warnings.spec.ts`: 8 tests passed.
+  - `tests/multitable-automation-manager.spec.ts`: 67 tests passed.
+  - `tests/multitable-automation-rule-editor.spec.ts`: 56 tests passed.
+  - Total: 131 tests passed.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check`: passed.
+
+## Observations
+
+- Vite build retained existing warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and chunks larger than 500 kB. These are unrelated to this DingTalk access-state change.
+- The worktree still has local tracked `node_modules` symlink dirtiness from the earlier `pnpm install --frozen-lockfile`; those generated artifacts were not staged.


### PR DESCRIPTION
## Summary

Replay of the DingTalk public-form access state stabilization slice onto current main after PR #1024 merged.

- Stabilizes public-form access state semantics across helper, manager, and rule editor.
- Keeps the scope to DingTalk public-form state rendering and tests.
- Rebased from stack base edba6ef7c71bd8f133e2bf0aa18ed62d6a28214b onto main b5981d67d7255b0ecaef820f5e115b017322652b.

## Verification

- pnpm install --frozen-lockfile -> passed
- pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false -> 3 files / 131 tests passed
- pnpm --filter @metasheet/web build -> passed, existing Vite warnings only
- git diff --check -> passed

## Notes

This PR now targets main directly. Rebase verification was appended to docs/development/dingtalk-public-form-access-state-verification-20260421.md.