### PR TITLE
docs(dingtalk): clarify form share allowlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ MetaSheet V2 is a collaborative spreadsheet platform built on a modern microkern
 - **📊 Project Status?** → [Development Status](claudedocs/DEVELOPMENT_STATUS.md) (comprehensive overview)
 - **🔌 Need API Reference?** → [API Documentation](claudedocs/API_DOCUMENTATION.md) (complete API guide)
 - **🧭 Attendance Rule Examples?** → [Custom Rule Templates](docs/ATTENDANCE_CUSTOM_RULE_TEMPLATES.md)
+- **🔔 DingTalk forms and notifications?** → [DingTalk Admin Operations Guide](docs/dingtalk-admin-operations-guide-20260420.md)
 
 ### Prerequisites
 
@@ -221,6 +222,7 @@ OUT_DIR=artifacts
 
 - **[Feature Migration Assessment](claudedocs/FEATURE_MIGRATION_ASSESSMENT.md)** - Feature completeness analysis and migration recommendations
 - **[Phase 5 Completion Guide](claudedocs/PHASE5_COMPLETION_GUIDE.md)** - Phase 5 execution steps and checklist
+- **[DingTalk Admin Operations Guide](docs/dingtalk-admin-operations-guide-20260420.md)** - DingTalk group/person messages, public form access modes, and local user/member-group allowlists
 
 ### 🔧 Observability Documentation
 

--- a/apps/web/src/multitable/components/MetaFormShareManager.vue
+++ b/apps/web/src/multitable/components/MetaFormShareManager.vue
@@ -92,7 +92,9 @@
                     </button>
                   </span>
                 </div>
-                <div v-else class="meta-form-share__empty">No user allowlist. Any DingTalk user matching the selected access mode can fill this form.</div>
+                <div v-else class="meta-form-share__empty">
+                  No local user allowlist configured. Access is still gated by the selected DingTalk mode; add local users or member groups to narrow who can fill this form.
+                </div>
               </div>
 
               <div class="meta-form-share__allowlist-subsection">
@@ -119,7 +121,9 @@
                     </button>
                   </span>
                 </div>
-                <div v-else class="meta-form-share__empty">No member-group allowlist configured.</div>
+                <div v-else class="meta-form-share__empty">
+                  No local member-group allowlist configured. Add a local member group to let its members fill this form.
+                </div>
               </div>
 
               <div class="meta-form-share__allowlist-subsection">

--- a/apps/web/tests/multitable-form-share-manager.spec.ts
+++ b/apps/web/tests/multitable-form-share-manager.spec.ts
@@ -197,9 +197,27 @@ describe('MetaFormShareManager', () => {
     mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
     await flushPromises()
 
-    expect(document.querySelector('[data-form-share-allowlist-search]')).toBeTruthy()
+    const search = document.querySelector('[data-form-share-allowlist-search]') as HTMLInputElement
+    expect(search).toBeTruthy()
+    expect(search.placeholder).toBe('Search local users or member groups')
+    expect(document.body.textContent).toContain('The form opens only after DingTalk sign-in, and the user must already be bound to a local account.')
+    expect(document.body.textContent).toContain('Allowed system users and member groups')
+    expect(document.body.textContent).toContain('DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.')
+    expect(document.body.textContent).toContain('No local user allowlist configured. Access is still gated by the selected DingTalk mode; add local users or member groups to narrow who can fill this form.')
+    expect(document.body.textContent).toContain('No local member-group allowlist configured. Add a local member group to let its members fill this form.')
     expect(document.querySelector('[data-form-share-add-subject="user:user_1"]')).toBeTruthy()
     expect(document.querySelector('[data-form-share-add-subject="member-group:group_ops"]')).toBeTruthy()
+  })
+
+  it('explains DingTalk delivery still uses local allowlists for granted mode', async () => {
+    const { client } = mockClient(fakeConfig({ accessMode: 'dingtalk_granted' }))
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    expect(document.querySelector('[data-form-share-allowlist-search]')).toBeTruthy()
+    expect(document.body.textContent).toContain('The form opens only for DingTalk-bound users whose DingTalk grant is enabled by an administrator.')
+    expect(document.body.textContent).toContain('DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.')
+    expect(document.body.textContent).toContain('No local user allowlist configured. Access is still gated by the selected DingTalk mode; add local users or member groups to narrow who can fill this form.')
   })
 
   it('adds an allowed user through the allowlist controls', async () => {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -69,6 +69,7 @@
 |------|------|
 | [attendance-plugin-design-20260119.md](./attendance-plugin-design-20260119.md) | 考勤插件设计说明 |
 | [attendance-plugin-development-report-20260120.md](./attendance-plugin-development-report-20260120.md) | 考勤插件开发报告 (2026-01-20) |
+| [dingtalk-admin-operations-guide-20260420.md](./dingtalk-admin-operations-guide-20260420.md) | 钉钉群/个人通知、公开表单访问模式、指定本地用户或成员组填写 |
 
 **Phase 1 验证明细（2025-12-21/22）**:
 - `docs/phase1-stabilization-summary-2025-12-21.md`

--- a/docs/development/dingtalk-form-share-guidance-development-20260421.md
+++ b/docs/development/dingtalk-form-share-guidance-development-20260421.md
@@ -1,0 +1,37 @@
+# DingTalk Form Share Guidance Development
+
+Date: 2026-04-21
+
+## Scope
+
+This change improves the discoverability and frontend guidance for using DingTalk-protected public forms with local user/member-group allowlists.
+
+## Changes
+
+- Clarified the form share manager empty allowlist messages:
+  - no local user allowlist means the selected DingTalk mode still gates access
+  - adding local users or member groups narrows who can fill the form
+  - no local member-group allowlist suggests adding a local member group for group-based filling
+- Extended `multitable-form-share-manager.spec.ts` to lock the key DingTalk allowlist guidance:
+  - DingTalk is only the sign-in and delivery channel
+  - allowlists target local users and member groups
+  - both `dingtalk` and `dingtalk_granted` access modes show allowlist controls
+- Added DingTalk operations guide links to:
+  - `README.md`
+  - `docs/INDEX.md`
+- Added a quick entry section to `docs/dingtalk-admin-operations-guide-20260420.md` for:
+  - DingTalk group notification rules
+  - public form sharing
+  - protected allowlists for selected users/member groups
+
+## User Impact
+
+Table owners now get clearer frontend guidance that sending a form link through DingTalk does not mean raw DingTalk group membership controls filling permissions. Filling permissions are narrowed by the system's local users and member groups after the selected DingTalk protection mode is satisfied.
+
+## Files
+
+- `apps/web/src/multitable/components/MetaFormShareManager.vue`
+- `apps/web/tests/multitable-form-share-manager.spec.ts`
+- `README.md`
+- `docs/INDEX.md`
+- `docs/dingtalk-admin-operations-guide-20260420.md`

--- a/docs/development/dingtalk-form-share-guidance-verification-20260421.md
+++ b/docs/development/dingtalk-form-share-guidance-verification-20260421.md
@@ -23,3 +23,39 @@ git diff --check
 - An initial test assertion attempted to find the search placeholder in `document.body.textContent`; the test was corrected to assert the input `placeholder` attribute instead.
 - Vite build retained existing warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and chunks larger than 500 kB. These are unrelated to this DingTalk form-share guidance change.
 - Local tracked `node_modules` symlink dirtiness from PNPM install remains unstaged.
+
+## Rebase Verification - 2026-04-22
+
+- Previous stack base: `e1789d8a4e3d8b4658f61447f8b986e18573c561`
+- New base: `origin/main@6cd6bc3da4eb607cbb0718ac57cbf0e15147d578`
+- Rebase command: `git rebase --onto origin/main origin/codex/dingtalk-form-share-guidance-base-20260421 HEAD`
+- Result: clean rebase, no conflicts.
+
+Commands rerun after rebase:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
+rg -n "dingtalk-admin-operations-guide-20260420|DingTalk Admin|DingTalk forms and notifications|Allowed system users and member groups|No local user allowlist|Quick entry|Scenario 2" README.md docs/INDEX.md docs/dingtalk-admin-operations-guide-20260420.md apps/web/src/multitable/components/MetaFormShareManager.vue apps/web/tests/multitable-form-share-manager.spec.ts
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+Results:
+
+```text
+MetaFormShareManager
+Test Files  1 passed (1)
+Tests       14 passed (14)
+
+Documentation and frontend guidance search
+passed
+
+Frontend build
+passed
+
+git diff --check
+passed
+```
+
+Build note: the existing `WorkflowDesigner.vue` mixed static/dynamic import warning and large chunk warning remain unchanged and unrelated to this PR.

--- a/docs/development/dingtalk-form-share-guidance-verification-20260421.md
+++ b/docs/development/dingtalk-form-share-guidance-verification-20260421.md
@@ -1,0 +1,25 @@
+# DingTalk Form Share Guidance Verification
+
+Date: 2026-04-21
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+rg -n "dingtalk-admin-operations-guide-20260420|DingTalk Admin|DingTalk forms and notifications|Allowed system users and member groups|No local user allowlist|Quick entry|Scenario 2" README.md docs/INDEX.md docs/dingtalk-admin-operations-guide-20260420.md apps/web/src/multitable/components/MetaFormShareManager.vue apps/web/tests/multitable-form-share-manager.spec.ts
+git diff --check
+```
+
+## Results
+
+- `tests/multitable-form-share-manager.spec.ts`: passed, 14 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- Documentation and frontend guidance search: passed.
+- `git diff --check`: passed.
+
+## Observations
+
+- An initial test assertion attempted to find the search placeholder in `document.body.textContent`; the test was corrected to assert the input `placeholder` attribute instead.
+- Vite build retained existing warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and chunks larger than 500 kB. These are unrelated to this DingTalk form-share guidance change.
+- Local tracked `node_modules` symlink dirtiness from PNPM install remains unstaged.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -15,6 +15,12 @@ This guide explains the management-side UI flow for:
 
 It does not cover end-user filling behavior beyond the links they receive.
 
+## Quick entry
+
+- Send a table-triggered message to a DingTalk group: see [C. Configure a DingTalk group notification rule](#c-configure-a-dingtalk-group-notification-rule).
+- Send a form link that users can fill: see [D. Configure a public form](#d-configure-a-public-form).
+- Send to a DingTalk group while only selected local users or member groups can fill: see [E. Configure protected public-form allowlists](#e-configure-protected-public-form-allowlists) and [Scenario 2](#scenario-2-broadcast-to-a-group-but-only-selected-users-can-fill).
+
 ## Before you start
 
 You need all of the following:


### PR DESCRIPTION
## Summary

Replay of the DingTalk form-share guidance slice onto current main after PR #1026 merged.

- Clarifies that DingTalk protected form sharing still uses local user/member-group allowlists.
- Adds/updates guidance in MetaFormShareManager, README, docs index, and DingTalk admin operations guide.
- Rebased from stack base e1789d8a4e3d8b4658f61447f8b986e18573c561 onto main 6cd6bc3da4eb607cbb0718ac57cbf0e15147d578.

## Verification

- pnpm install --frozen-lockfile -> passed
- pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false -> 1 file / 14 tests passed
- documentation/frontend guidance rg check -> passed
- pnpm --filter @metasheet/web build -> passed, existing Vite warnings only
- git diff --check -> passed

## Notes

This PR now targets main directly. Rebase verification was appended to docs/development/dingtalk-form-share-guidance-verification-20260421.md.