### PR TITLE
fix(collab): mint staging token from backend runtime

### DIFF
--- a/.github/workflows/yjs-staging-validation.yml
+++ b/.github/workflows/yjs-staging-validation.yml
@@ -44,6 +44,7 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
         run: |
           set -euo pipefail
 
@@ -70,7 +71,7 @@ jobs:
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
 
           token="$(
-            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'EOF'
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_COMPOSE_FILE='${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}' bash -s" <<'EOF'
           set -euo pipefail
           if [[ "${DEPLOY_PATH}" == /* ]]; then
             DEPLOY_REPO_PATH="${DEPLOY_PATH}"
@@ -80,60 +81,47 @@ jobs:
             DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"
           fi
           cd "${DEPLOY_REPO_PATH}"
-          python3 - <<'PY'
-          from pathlib import Path
-          import base64
-          import hashlib
-          import hmac
-          import json
-          import sys
-          import time
+          if docker compose version >/dev/null 2>&1; then
+            COMPOSE_CMD=(docker compose)
+          elif command -v docker-compose >/dev/null 2>&1; then
+            COMPOSE_CMD=(docker-compose)
+          else
+            echo "docker compose is not available" >&2
+            exit 125
+          fi
+          "${COMPOSE_CMD[@]}" -f "${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}" exec -T backend node - <<'NODE'
+          const crypto = require('node:crypto')
 
-          def strip_outer_quotes(value):
-              value = value.strip()
-              if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                  return value[1:-1]
-              return value
-
-          def base64url(raw):
-              return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
-
-          env_path = Path("docker/app.env")
-          if not env_path.exists():
-              raise SystemExit("docker/app.env not found")
-
-          values = {}
-          for line in env_path.read_text().splitlines():
-              stripped = line.strip()
-              if not stripped or stripped.startswith("#") or "=" not in stripped:
-                  continue
-              key, value = stripped.split("=", 1)
-              values[key] = strip_outer_quotes(value)
-
-          secret = values.get("JWT_SECRET", "")
-          if not secret:
-              raise SystemExit("JWT_SECRET missing from docker/app.env")
-
-          now = int(time.time())
-          header = {"alg": "HS256", "typ": "JWT"}
-          payload = {
-              "id": "admin",
-              "roles": ["admin"],
-              "perms": ["*:*"],
-              "iat": now,
-              "exp": now + 7200,
+          const secret = process.env.JWT_SECRET
+          if (!secret) {
+            console.error('JWT_SECRET missing from backend runtime env')
+            process.exit(2)
           }
-          signing_input = ".".join([
-              base64url(json.dumps(header, separators=(",", ":")).encode("utf-8")),
-              base64url(json.dumps(payload, separators=(",", ":")).encode("utf-8")),
-          ])
-          signature = hmac.new(
-              secret.encode("utf-8"),
-              signing_input.encode("ascii"),
-              hashlib.sha256,
-          ).digest()
-          print(f"{signing_input}.{base64url(signature)}")
-          PY
+
+          function base64url(input) {
+            return Buffer.from(input)
+              .toString('base64')
+              .replace(/\+/g, '-')
+              .replace(/\//g, '_')
+              .replace(/=/g, '')
+          }
+
+          const now = Math.floor(Date.now() / 1000)
+          const header = { alg: 'HS256', typ: 'JWT' }
+          const payload = {
+            id: 'admin',
+            roles: ['admin'],
+            perms: ['*:*'],
+            iat: now,
+            exp: now + 7200,
+          }
+          const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`
+          const signature = crypto.createHmac('sha256', secret).update(signingInput).digest('base64')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '')
+          console.log(`${signingInput}.${signature}`)
+          NODE
           EOF
           )"
 

--- a/docs/development/yjs-staging-enable-workflow-development-20260421.md
+++ b/docs/development/yjs-staging-enable-workflow-development-20260421.md
@@ -36,11 +36,11 @@ Updated `.github/workflows/yjs-staging-validation.yml` with a token resolution s
 
 1. Use `secrets.YJS_ADMIN_TOKEN` if present.
 2. Otherwise, use existing deploy SSH secrets to connect to the configured deploy host.
-3. Read remote `docker/app.env` on the host.
-4. Generate a short-lived HS256 admin JWT from the remote `JWT_SECRET`.
+3. Execute `node` inside the running backend container.
+4. Generate a short-lived HS256 admin JWT from the backend runtime `process.env.JWT_SECRET`.
 5. Mask the token and write it to `GITHUB_ENV` for the validation steps.
 
-This avoids copying the remote `JWT_SECRET` into GitHub repository secrets and avoids requiring a long-lived admin token.
+This avoids copying the remote `JWT_SECRET` into GitHub repository secrets, avoids requiring a long-lived admin token, and avoids host env-file versus container runtime secret drift.
 
 ## Security Notes
 
@@ -74,4 +74,3 @@ gh workflow run yjs-staging-validation.yml --repo zensgit/metasheet2 \
 - Does not change backend Yjs semantics.
 - Does not enable Yjs by default for all deploys.
 - Does not bypass admin auth on `/api/admin/yjs/status`.
-

--- a/docs/development/yjs-staging-enable-workflow-verification-20260421.md
+++ b/docs/development/yjs-staging-enable-workflow-verification-20260421.md
@@ -64,3 +64,22 @@ The real remote Yjs validation is intentionally not run before this PR is merged
 - The validation workflow changes must exist on the default branch before manual dispatch can use them.
 - The repository variables must be set before rebuilding the frontend image and reconciling backend runtime env.
 
+## Post-Merge Token Resolver Follow-Up
+
+Initial default-branch validation after PR #1025 proved the SSH resolver ran, but `/api/admin/yjs/status` rejected the generated token with `401 Invalid token`.
+
+Root cause: signing from host `docker/app.env` can drift from the running backend container's actual `JWT_SECRET`.
+
+Follow-up fix:
+
+- Generate the short-lived admin JWT by running `node` inside the `backend` container.
+- Read `process.env.JWT_SECRET` from the actual runtime env used by the API.
+- Keep token masking and `GITHUB_ENV` propagation unchanged.
+
+Re-run static checks:
+
+```text
+yaml ok
+bash syntax ok
+git diff --check clean
+```


### PR DESCRIPTION
## Summary

- Fixes the Yjs staging validation token resolver introduced in #1025.
- The first live run proved SSH token resolution executed, but `/api/admin/yjs/status` returned `401 Invalid token`.
- Root cause: signing from host `docker/app.env` can drift from the running backend container's effective `JWT_SECRET`.
- New behavior runs `node` inside the backend container and signs from `process.env.JWT_SECRET`, matching the API runtime.

## Verification

```bash
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/yjs-staging-validation.yml'); puts 'yaml ok'"
ruby -ryaml -e 'w=YAML.load_file(".github/workflows/yjs-staging-validation.yml"); w["jobs"]["validate"]["steps"].each_with_index { |s,i| next unless s["run"]; File.write("/tmp/yjs-step-#{i}.sh", s["run"]) }'
bash -n /tmp/yjs-step-1.sh
bash -n /tmp/yjs-step-4.sh
bash -n /tmp/yjs-step-5.sh
bash -n /tmp/yjs-step-6.sh
git diff --check
```

## Live evidence from failed run

Run: https://github.com/zensgit/metasheet2/actions/runs/24730152455

- `Resolve admin token`: success
- `Sanity — is Yjs even enabled?`: failed with `401 Invalid token`

## Post-merge plan

Re-run `yjs-staging-validation.yml` against 142 using the same pilot record.
