### PR TITLE
feat(dingtalk): summarize form share allowlist audience

### DIFF
--- a/apps/web/src/multitable/components/MetaFormShareManager.vue
+++ b/apps/web/src/multitable/components/MetaFormShareManager.vue
@@ -54,6 +54,14 @@
                   <p class="meta-form-share__hint">
                     DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.
                   </p>
+                  <p
+                    class="meta-form-share__allowlist-summary"
+                    data-form-share-allowlist-summary="true"
+                    :data-user-count="allowedUserCount"
+                    :data-member-group-count="allowedMemberGroupCount"
+                  >
+                    {{ allowlistAudienceSummary }}
+                  </p>
                 </div>
               </div>
 
@@ -289,6 +297,24 @@ const accessModeHint = computed(() => {
 
 const allowedUsers = computed(() => config.value?.allowedUsers ?? [])
 const allowedMemberGroups = computed(() => config.value?.allowedMemberGroups ?? [])
+const allowedUserCount = computed(() => config.value?.allowedUserIds?.length ?? allowedUsers.value.length)
+const allowedMemberGroupCount = computed(() => config.value?.allowedMemberGroupIds?.length ?? allowedMemberGroups.value.length)
+const allowlistAudienceSummary = computed(() => {
+  const userCount = allowedUserCount.value
+  const memberGroupCount = allowedMemberGroupCount.value
+  if (userCount === 0 && memberGroupCount === 0) {
+    return 'No local allowlist limits are set; all users allowed by the selected DingTalk mode can fill this form.'
+  }
+
+  const parts: string[] = []
+  if (userCount > 0) {
+    parts.push(`${userCount} ${userCount === 1 ? 'local user' : 'local users'}`)
+  }
+  if (memberGroupCount > 0) {
+    parts.push(`${memberGroupCount} ${memberGroupCount === 1 ? 'local member group' : 'local member groups'}`)
+  }
+  return `Local allowlist limits: ${parts.join(' and ')} can fill after passing the selected DingTalk mode.`
+})
 const selectedSubjectKeys = computed(() => new Set([
   ...allowedUsers.value.map((user) => `user:${user.subjectId}`),
   ...allowedMemberGroups.value.map((group) => `member-group:${group.subjectId}`),
@@ -651,6 +677,17 @@ watch(candidateQuery, () => {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.meta-form-share__allowlist-summary {
+  align-self: flex-start;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 999px;
+  color: #1d4ed8;
+  font-size: 12px;
+  margin: 0;
+  padding: 4px 10px;
 }
 
 .meta-form-share__chip-list {

--- a/apps/web/tests/multitable-form-share-manager.spec.ts
+++ b/apps/web/tests/multitable-form-share-manager.spec.ts
@@ -198,8 +198,13 @@ describe('MetaFormShareManager', () => {
     await flushPromises()
 
     const search = document.querySelector('[data-form-share-allowlist-search]') as HTMLInputElement
+    const summary = document.querySelector('[data-form-share-allowlist-summary]') as HTMLElement
     expect(search).toBeTruthy()
     expect(search.placeholder).toBe('Search local users or member groups')
+    expect(summary).toBeTruthy()
+    expect(summary.getAttribute('data-user-count')).toBe('0')
+    expect(summary.getAttribute('data-member-group-count')).toBe('0')
+    expect(summary.textContent).toContain('No local allowlist limits are set; all users allowed by the selected DingTalk mode can fill this form.')
     expect(document.body.textContent).toContain('The form opens only after DingTalk sign-in, and the user must already be bound to a local account.')
     expect(document.body.textContent).toContain('Allowed system users and member groups')
     expect(document.body.textContent).toContain('DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.')
@@ -214,10 +219,31 @@ describe('MetaFormShareManager', () => {
     mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
     await flushPromises()
 
+    const summary = document.querySelector('[data-form-share-allowlist-summary]') as HTMLElement
     expect(document.querySelector('[data-form-share-allowlist-search]')).toBeTruthy()
+    expect(summary).toBeTruthy()
+    expect(summary.textContent).toContain('No local allowlist limits are set; all users allowed by the selected DingTalk mode can fill this form.')
     expect(document.body.textContent).toContain('The form opens only for DingTalk-bound users whose DingTalk grant is enabled by an administrator.')
     expect(document.body.textContent).toContain('DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.')
     expect(document.body.textContent).toContain('No local user allowlist configured. Access is still gated by the selected DingTalk mode; add local users or member groups to narrow who can fill this form.')
+  })
+
+  it('summarizes the configured local allowlist audience', async () => {
+    const { client } = mockClient(fakeConfig({
+      accessMode: 'dingtalk',
+      allowedUserIds: ['user_1'],
+      allowedUsers: [{ subjectType: 'user', subjectId: 'user_1', label: 'Alice', subtitle: 'alice@test.local', isActive: true }],
+      allowedMemberGroupIds: ['group_ops'],
+      allowedMemberGroups: [{ subjectType: 'member-group', subjectId: 'group_ops', label: 'Ops', subtitle: 'Operations', isActive: true }],
+    }))
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const summary = document.querySelector('[data-form-share-allowlist-summary]') as HTMLElement
+    expect(summary).toBeTruthy()
+    expect(summary.getAttribute('data-user-count')).toBe('1')
+    expect(summary.getAttribute('data-member-group-count')).toBe('1')
+    expect(summary.textContent).toContain('Local allowlist limits: 1 local user and 1 local member group can fill after passing the selected DingTalk mode.')
   })
 
   it('adds an allowed user through the allowlist controls', async () => {

--- a/docs/development/dingtalk-form-share-audience-summary-development-20260421.md
+++ b/docs/development/dingtalk-form-share-audience-summary-development-20260421.md
@@ -1,0 +1,34 @@
+# DingTalk Form Share Audience Summary Development
+
+Date: 2026-04-21
+
+## Scope
+
+This change adds a read-only local allowlist audience summary to the form share manager for DingTalk-protected public forms.
+
+## Changes
+
+- Added `data-form-share-allowlist-summary` in `MetaFormShareManager`.
+- Added structured count attributes:
+  - `data-user-count`
+  - `data-member-group-count`
+- Added `allowlistAudienceSummary` derived from `allowedUserIds` and `allowedMemberGroupIds`, falling back to resolved subject lists when needed.
+- Added UI copy for:
+  - no local allowlist limits
+  - local user count
+  - local member-group count
+- Added a compact visual style for the summary badge.
+- Extended form-share tests to cover:
+  - no local allowlist limits
+  - DingTalk granted mode
+  - one local user plus one local member group
+- Updated the DingTalk operations guide to tell owners to check `Local allowlist limits` before relying on selected-user filling.
+
+## User Impact
+
+When a table owner protects a public form with DingTalk, the form share manager now shows whether access is still broad after the DingTalk check or narrowed to specific local users/member groups. This reduces the chance of assuming DingTalk group membership itself defines who can fill the form.
+
+## Notes
+
+- No backend API or schema changes were required.
+- The summary is derived from form share config only; it does not infer DingTalk group roster membership.

--- a/docs/development/dingtalk-form-share-audience-summary-verification-20260421.md
+++ b/docs/development/dingtalk-form-share-audience-summary-verification-20260421.md
@@ -1,0 +1,24 @@
+# DingTalk Form Share Audience Summary Verification
+
+Date: 2026-04-21
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+rg -n "Local allowlist limits|No local allowlist limits|data-form-share-allowlist-summary|DingTalk group roster|allowlist audience|allowedUserIds|allowedMemberGroupIds" apps/web/src/multitable/components/MetaFormShareManager.vue apps/web/tests/multitable-form-share-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md
+git diff --check
+```
+
+## Results
+
+- `tests/multitable-form-share-manager.spec.ts`: passed, 15 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `rg` guidance/search check: passed.
+- `git diff --check`: passed.
+
+## Observations
+
+- Vite build retained existing warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and chunks larger than 500 kB. These are unrelated to this DingTalk audience-summary change.
+- Local tracked `node_modules` symlink dirtiness from PNPM install remains unstaged.

--- a/docs/development/dingtalk-form-share-audience-summary-verification-20260421.md
+++ b/docs/development/dingtalk-form-share-audience-summary-verification-20260421.md
@@ -22,3 +22,28 @@ git diff --check
 
 - Vite build retained existing warnings about mixed dynamic/static import of `WorkflowDesigner.vue` and chunks larger than 500 kB. These are unrelated to this DingTalk audience-summary change.
 - Local tracked `node_modules` symlink dirtiness from PNPM install remains unstaged.
+
+## Rebase Verification - 2026-04-22
+
+Rebased `codex/dingtalk-form-share-audience-summary-20260421` onto `origin/main@10bd32cc6`
+after PR #1027 was squash-merged.
+
+```bash
+git rebase --onto origin/main origin/codex/dingtalk-form-share-audience-summary-base-20260421 HEAD
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
+rg -n "Local allowlist limits|No local allowlist limits|data-form-share-allowlist-summary|DingTalk group roster|allowlist audience|allowedUserIds|allowedMemberGroupIds" apps/web/src/multitable/components/MetaFormShareManager.vue apps/web/tests/multitable-form-share-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md
+git diff --check
+pnpm --filter @metasheet/web build
+git checkout -- plugins/ tools/
+```
+
+Results:
+
+- Rebase completed cleanly; replayed only the audience-summary commit on top of main.
+- `tests/multitable-form-share-manager.spec.ts`: passed, 15 tests.
+- `rg` guidance/search check: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/web build`: passed.
+- Build warnings were limited to the existing `WorkflowDesigner.vue` mixed import warning and existing large chunk warnings.
+- PNPM install recreated tracked plugin/tool `node_modules` symlink noise; it was cleaned with `git checkout -- plugins/ tools/` before pushing.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -146,6 +146,7 @@ Behavior:
 - the system then resolves the local user
 - the local user must be directly allowed or belong to an allowed member group
 - without an allowlist, `Bound DingTalk users only` admits all bound DingTalk local users and `Authorized DingTalk users only` admits all locally authorized DingTalk users
+- the form share manager shows `Local allowlist limits` so owners can confirm whether no local limit is set or how many local users/member groups can fill after DingTalk checks
 
 Important rule:
 
@@ -218,7 +219,7 @@ Authoring guardrail:
 
 - if the selected form is still fully public, the DingTalk group rule editor warns before save
 - if the selected protected form has no allowed users or member groups, the DingTalk group rule editor warns before save
-- check `Public form access` in the automation message summary before saving
+- check `Public form access` in the automation message summary and `Local allowlist limits` in form sharing before saving
 - switch the form to `Bound DingTalk users only` or `Authorized DingTalk users only` before relying on allowlists
 
 ### Scenario 3: Notify specific staff only
@@ -257,6 +258,7 @@ Current gaps to be aware of:
 - DingTalk group roster is not auto-imported
 - row/field-specific fill assignment is not yet first-class
 - precise protected-form allowlists depend on local user/member-group governance, not raw DingTalk identities
+- the allowlist audience summary is derived from local allowlist users/groups; it does not infer or sync DingTalk group members
 
 ## K. Operational recommendations
 


### PR DESCRIPTION
## Summary
- add a local allowlist audience summary to DingTalk-protected form sharing
- expose structured user/member-group counts via `data-form-share-allowlist-summary`
- cover empty and configured allowlist summaries in form-share tests
- document checking `Local allowlist limits` before relying on selected-user filling
- add development and verification docs
- rebase onto `main@10bd32cc6` after PR #1027 was squash-merged

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false` (15 passed)
- `rg -n "Local allowlist limits|No local allowlist limits|data-form-share-allowlist-summary|DingTalk group roster|allowlist audience|allowedUserIds|allowedMemberGroupIds" apps/web/src/multitable/components/MetaFormShareManager.vue apps/web/tests/multitable-form-share-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md`
- `git diff --check`
- `pnpm --filter @metasheet/web build`

## Notes
- no backend API or schema changes
- PNPM-created tracked plugin/tool node_modules symlink dirtiness was cleaned before pushing
- Vite build only reports existing WorkflowDesigner mixed import and large chunk warnings