### PR TITLE
fix(collab): sign staging token for real admin user

### DIFF
--- a/.github/workflows/yjs-staging-validation.yml
+++ b/.github/workflows/yjs-staging-validation.yml
@@ -89,38 +89,57 @@ jobs:
             echo "docker compose is not available" >&2
             exit 125
           fi
-          "${COMPOSE_CMD[@]}" -f "${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}" exec -T backend node - <<'NODE'
-          const crypto = require('node:crypto')
+          "${COMPOSE_CMD[@]}" -f "${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}" exec -T backend node --input-type=module - <<'NODE' | awk '/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/ { token = $0 } END { if (token) print token }'
+          import pg from 'pg'
+          import { authService } from '/app/packages/core-backend/dist/src/auth/AuthService.js'
 
-          const secret = process.env.JWT_SECRET
-          if (!secret) {
-            console.error('JWT_SECRET missing from backend runtime env')
+          const { Client } = pg
+          const databaseUrl = process.env.DATABASE_URL
+          if (!databaseUrl) {
+            console.error('DATABASE_URL missing from backend runtime env')
             process.exit(2)
           }
 
-          function base64url(input) {
-            return Buffer.from(input)
-              .toString('base64')
-              .replace(/\+/g, '-')
-              .replace(/\//g, '_')
-              .replace(/=/g, '')
-          }
+          const client = new Client({
+            connectionString: databaseUrl,
+            ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : false,
+          })
 
-          const now = Math.floor(Date.now() / 1000)
-          const header = { alg: 'HS256', typ: 'JWT' }
-          const payload = {
-            id: 'admin',
-            roles: ['admin'],
-            perms: ['*:*'],
-            iat: now,
-            exp: now + 7200,
+          try {
+            await client.connect()
+            const result = await client.query(`
+              SELECT u.id, u.email, u.username, u.name, u.mobile, u.role, u.permissions, u.is_active, u.must_change_password
+              FROM users u
+              LEFT JOIN user_roles ur ON ur.user_id = u.id AND ur.role_id = 'admin'
+              WHERE COALESCE(u.is_active, true) = true
+                AND COALESCE(u.must_change_password, false) = false
+                AND (u.role = 'admin' OR ur.user_id IS NOT NULL)
+              ORDER BY CASE WHEN u.id = 'admin' THEN 0 ELSE 1 END, u.created_at ASC
+              LIMIT 1
+            `)
+            const row = result.rows[0]
+            if (!row) {
+              console.error('No active admin user found for Yjs validation token')
+              process.exit(3)
+            }
+
+            const token = authService.createToken({
+              id: String(row.id),
+              email: typeof row.email === 'string' ? row.email : '',
+              username: row.username ?? null,
+              name: typeof row.name === 'string' && row.name.trim() ? row.name : 'Yjs Validation Admin',
+              mobile: row.mobile ?? null,
+              role: typeof row.role === 'string' && row.role.trim() ? row.role : 'admin',
+              permissions: Array.isArray(row.permissions) ? row.permissions : [],
+              is_active: row.is_active,
+              must_change_password: row.must_change_password,
+              created_at: new Date(),
+              updated_at: new Date(),
+            })
+            console.log(token)
+          } finally {
+            await client.end().catch(() => {})
           }
-          const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`
-          const signature = crypto.createHmac('sha256', secret).update(signingInput).digest('base64')
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=/g, '')
-          console.log(`${signingInput}.${signature}`)
           NODE
           EOF
           )"

--- a/docs/development/yjs-staging-enable-workflow-development-20260421.md
+++ b/docs/development/yjs-staging-enable-workflow-development-20260421.md
@@ -37,10 +37,11 @@ Updated `.github/workflows/yjs-staging-validation.yml` with a token resolution s
 1. Use `secrets.YJS_ADMIN_TOKEN` if present.
 2. Otherwise, use existing deploy SSH secrets to connect to the configured deploy host.
 3. Execute `node` inside the running backend container.
-4. Generate a short-lived HS256 admin JWT from the backend runtime `process.env.JWT_SECRET`.
-5. Mask the token and write it to `GITHUB_ENV` for the validation steps.
+4. Select a real active admin user from the deployment database.
+5. Generate a short-lived admin JWT through the app's own `authService.createToken()` path.
+6. Mask the token and write it to `GITHUB_ENV` for the validation steps.
 
-This avoids copying the remote `JWT_SECRET` into GitHub repository secrets, avoids requiring a long-lived admin token, and avoids host env-file versus container runtime secret drift.
+This avoids copying the remote `JWT_SECRET` into GitHub repository secrets, avoids requiring a long-lived admin token, avoids host env-file versus container runtime secret drift, and preserves the same user/RBAC checks used by normal API requests.
 
 ## Security Notes
 

--- a/docs/development/yjs-staging-enable-workflow-verification-20260421.md
+++ b/docs/development/yjs-staging-enable-workflow-verification-20260421.md
@@ -70,11 +70,20 @@ Initial default-branch validation after PR #1025 proved the SSH resolver ran, bu
 
 Root cause: signing from host `docker/app.env` can drift from the running backend container's actual `JWT_SECRET`.
 
-Follow-up fix:
+Follow-up fix, iteration 1:
 
 - Generate the short-lived admin JWT by running `node` inside the `backend` container.
 - Read `process.env.JWT_SECRET` from the actual runtime env used by the API.
 - Keep token masking and `GITHUB_ENV` propagation unchanged.
+
+Second default-branch validation still returned `401 Invalid token`, which showed that signing with the correct runtime secret is not sufficient: production-like auth does not trust arbitrary token claims, and it validates the user/RBAC state.
+
+Follow-up fix, iteration 2:
+
+- Run token generation inside the backend container.
+- Query the deployment database for a real active admin user.
+- Sign through the app's compiled `authService.createToken()` implementation.
+- Filter stdout to the JWT-shaped line before exporting `YJS_TOKEN`, so logger output cannot contaminate the token value.
 
 Re-run static checks:
 


### PR DESCRIPTION
## Summary

- Fixes the remaining `401 Invalid token` from live Yjs staging validation.
- The previous resolver signed inside the backend container but still minted arbitrary admin claims.
- Production-like auth does not trust arbitrary token claims; it verifies a real user and RBAC admin state.
- New resolver queries the deployment DB for an active admin user and signs through the app's compiled `authService.createToken()` path.
- It filters stdout to the JWT-shaped line before exporting `YJS_TOKEN`, so logger output cannot contaminate the token.

## Live failures driving this change

- https://github.com/zensgit/metasheet2/actions/runs/24730152455: host env token resolver ran, status returned `401 Invalid token`.
- https://github.com/zensgit/metasheet2/actions/runs/24730653023: backend runtime token resolver ran, status still returned `401 Invalid token`.

## Verification

```bash
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/yjs-staging-validation.yml'); puts 'yaml ok'"
ruby -ryaml -e 'w=YAML.load_file(".github/workflows/yjs-staging-validation.yml"); w["jobs"]["validate"]["steps"].each_with_index { |s,i| next unless s["run"]; File.write("/tmp/yjs-step-#{i}.sh", s["run"]) }'
bash -n /tmp/yjs-step-1.sh
bash -n /tmp/yjs-step-4.sh
bash -n /tmp/yjs-step-5.sh
bash -n /tmp/yjs-step-6.sh
git diff --check
```

## Post-merge plan

Re-run `yjs-staging-validation.yml` against 142 with the pilot record.
