### PR TITLE
feat(dingtalk): show automation allowlist audience

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -268,6 +268,9 @@
               >
                 <strong>Public form access:</strong> {{ draftGroupPublicFormAccessState.summary }}
               </div>
+              <div data-automation-public-form-audience="group">
+                <strong>Allowed audience:</strong> {{ draftGroupPublicFormAccessState.audienceSummary }}
+              </div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
             </div>
           </template>
@@ -556,6 +559,9 @@
               >
                 <strong>Public form access:</strong> {{ draftPersonPublicFormAccessState.summary }}
               </div>
+              <div data-automation-public-form-audience="person">
+                <strong>Allowed audience:</strong> {{ draftPersonPublicFormAccessState.audienceSummary }}
+              </div>
               <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
             </div>
           </template>
@@ -647,6 +653,13 @@
                 :data-access-level="link.accessLevel"
               >
                 {{ link.accessSummary }}
+              </span>
+              <span
+                v-if="link.audienceSummary"
+                class="meta-automation__card-link-audience"
+                :data-automation-card-link-audience="link.key"
+              >
+                Allowed audience: {{ link.audienceSummary }}
               </span>
             </div>
           </div>
@@ -875,6 +888,7 @@ interface DingTalkCardLink {
   href?: string
   viewId?: string
   accessSummary?: string
+  audienceSummary?: string
   accessLevel?: DingTalkPublicFormLinkAccessLevel
 }
 
@@ -1126,6 +1140,7 @@ function dingTalkCardLinks(rule: AutomationRule): DingTalkCardLink[] {
           label: `Open public form: ${viewSummaryName(publicFormViewId, publicFormViewId)}`,
           href: buildPublicFormHref(publicFormViewId, publicToken),
           accessSummary: accessState.summary,
+          audienceSummary: accessState.audienceSummary,
           accessLevel: accessState.level,
         })
       }
@@ -2069,6 +2084,15 @@ watch(
 .meta-automation__card-link-access--unavailable {
   background: #fef2f2;
   color: #b91c1c;
+}
+
+.meta-automation__card-link-audience {
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 8px;
 }
 
 .meta-automation__public-form-access {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -351,6 +351,13 @@
                 >
                   <strong>Access:</strong> {{ accessState.summary }}
                 </div>
+                <div
+                  v-if="accessState.hasSelection"
+                  class="meta-rule-editor__hint meta-rule-editor__access-audience"
+                  :data-field="`groupPublicFormAudienceSummary-${idx}`"
+                >
+                  <strong>Allowed audience:</strong> {{ accessState.audienceSummary }}
+                </div>
               </template>
               <label class="meta-rule-editor__label">Internal processing view (optional)</label>
               <select
@@ -398,6 +405,7 @@
                 </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Public form access:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
+                <div><strong>Allowed audience:</strong> {{ publicFormAccessState(action.config.publicFormViewId).audienceSummary }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
             </div>
@@ -654,6 +662,13 @@
                 >
                   <strong>Access:</strong> {{ accessState.summary }}
                 </div>
+                <div
+                  v-if="accessState.hasSelection"
+                  class="meta-rule-editor__hint meta-rule-editor__access-audience"
+                  :data-field="`personPublicFormAudienceSummary-${idx}`"
+                >
+                  <strong>Allowed audience:</strong> {{ accessState.audienceSummary }}
+                </div>
               </template>
               <label class="meta-rule-editor__label">Internal processing view (optional)</label>
               <select
@@ -702,6 +717,7 @@
                 </div>
                 <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
                 <div><strong>Public form access:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
+                <div><strong>Allowed audience:</strong> {{ publicFormAccessState(action.config.publicFormViewId).audienceSummary }}</div>
                 <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
               </div>
             </div>
@@ -1695,6 +1711,13 @@ function onTestRun() {
 
 .meta-rule-editor__access-summary {
   border-radius: 8px;
+  padding: 6px 8px;
+}
+
+.meta-rule-editor__access-audience {
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #475569;
   padding: 6px 8px;
 }
 

--- a/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
@@ -19,6 +19,7 @@ export type DingTalkPublicFormLinkAccessLevel =
   | 'dingtalk_granted'
 
 export interface DingTalkPublicFormLinkAccessState {
+  audienceSummary: string
   hasSelection: boolean
   level: DingTalkPublicFormLinkAccessLevel
   summary: string
@@ -50,6 +51,63 @@ function normalizeAccessMode(value: unknown): 'public' | 'dingtalk' | 'dingtalk_
 
 function hasAllowlistIds(value: unknown): boolean {
   return Array.isArray(value) && value.some((item) => typeof item === 'string' && item.trim())
+}
+
+function countAllowlistIds(value: unknown): number {
+  if (!Array.isArray(value)) return 0
+  return new Set(
+    value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean),
+  ).size
+}
+
+function describeAllowlistCounts(userCount: number, memberGroupCount: number): string {
+  const parts: string[] = []
+  if (userCount > 0) {
+    parts.push(`${userCount} ${userCount === 1 ? 'local user' : 'local users'}`)
+  }
+  if (memberGroupCount > 0) {
+    parts.push(`${memberGroupCount} ${memberGroupCount === 1 ? 'local member group' : 'local member groups'}`)
+  }
+  return parts.join(' and ')
+}
+
+export function describeDingTalkPublicFormLinkAudience(
+  viewId: unknown,
+  views: readonly DingTalkPublicFormLinkView[],
+  optionsOrNowMs?: number | DingTalkPublicFormLinkWarningOptions,
+): string {
+  const options = normalizeWarningOptions(optionsOrNowMs)
+  const nowMs = options.nowMs ?? Date.now()
+  const id = typeof viewId === 'string' ? viewId.trim() : ''
+  if (!id) return 'No public form link'
+
+  const view = views.find((item) => item.id === id)
+  if (!view || view.type !== 'form') return 'Allowed audience unavailable'
+
+  const publicForm = isRecord(view.config?.publicForm) ? view.config.publicForm : null
+  if (!publicForm || publicForm.enabled !== true) return 'Allowed audience unavailable'
+
+  const publicToken = typeof publicForm.publicToken === 'string' ? publicForm.publicToken.trim() : ''
+  if (!publicToken) return 'Allowed audience unavailable'
+
+  const expiryMs = parseExpiryMs(publicForm.expiresAt ?? publicForm.expiresOn)
+  if (expiryMs !== null && nowMs >= expiryMs) return 'Allowed audience unavailable'
+
+  const accessMode = normalizeAccessMode(publicForm.accessMode)
+  if (accessMode === 'public') return 'Anyone with the link can submit'
+
+  const userCount = countAllowlistIds(publicForm.allowedUserIds)
+  const memberGroupCount = countAllowlistIds(publicForm.allowedMemberGroupIds)
+  if (userCount === 0 && memberGroupCount === 0) {
+    return accessMode === 'dingtalk_granted'
+      ? 'No local allowlist limits are set; all authorized DingTalk users can submit'
+      : 'No local allowlist limits are set; all bound DingTalk users can submit'
+  }
+
+  return `${describeAllowlistCounts(userCount, memberGroupCount)} can submit after DingTalk checks`
 }
 
 export function describeDingTalkPublicFormLinkAccess(
@@ -124,6 +182,7 @@ export function getDingTalkPublicFormLinkAccessState(
   const stableOptions = { ...options, nowMs: options.nowMs ?? Date.now() }
   const id = typeof viewId === 'string' ? viewId.trim() : ''
   return {
+    audienceSummary: describeDingTalkPublicFormLinkAudience(id, views, stableOptions),
     hasSelection: Boolean(id),
     level: getDingTalkPublicFormLinkAccessLevel(id, views, stableOptions),
     summary: describeDingTalkPublicFormLinkAccess(id, views, stableOptions),

--- a/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   describeDingTalkPublicFormLinkAccess,
+  describeDingTalkPublicFormLinkAudience,
   getDingTalkPublicFormLinkAccessLevel,
   getDingTalkPublicFormLinkAccessState,
   listDingTalkPublicFormLinkBlockingErrors,
@@ -160,6 +161,20 @@ describe('dingtalk public form link warnings', () => {
     expect(describeDingTalkPublicFormLinkAccess('missing_view', views, nowMs)).toBe('View unavailable in this sheet')
   })
 
+  it('describes selected public form audience for DingTalk message summaries', () => {
+    expect(describeDingTalkPublicFormLinkAudience('', views, nowMs)).toBe('No public form link')
+    expect(describeDingTalkPublicFormLinkAudience('view_form_enabled', views, nowMs)).toBe('Anyone with the link can submit')
+    expect(describeDingTalkPublicFormLinkAudience('view_form_protected', views, nowMs))
+      .toBe('No local allowlist limits are set; all bound DingTalk users can submit')
+    expect(describeDingTalkPublicFormLinkAudience('view_form_granted_without_allowlist', views, nowMs))
+      .toBe('No local allowlist limits are set; all authorized DingTalk users can submit')
+    expect(describeDingTalkPublicFormLinkAudience('view_form_protected_allowed_user', views, nowMs))
+      .toBe('1 local user can submit after DingTalk checks')
+    expect(describeDingTalkPublicFormLinkAudience('view_form_granted_allowed_group', views, nowMs))
+      .toBe('1 local member group can submit after DingTalk checks')
+    expect(describeDingTalkPublicFormLinkAudience('missing_view', views, nowMs)).toBe('Allowed audience unavailable')
+  })
+
   it('returns stable access levels for automation badges', () => {
     expect(getDingTalkPublicFormLinkAccessLevel('', views, nowMs)).toBe('none')
     expect(getDingTalkPublicFormLinkAccessLevel('view_form_enabled', views, nowMs)).toBe('public')
@@ -178,26 +193,31 @@ describe('dingtalk public form link warnings', () => {
 
   it('returns stable access state for automation summaries', () => {
     expect(getDingTalkPublicFormLinkAccessState('   ', views, nowMs)).toEqual({
+      audienceSummary: 'No public form link',
       hasSelection: false,
       level: 'none',
       summary: 'No public form link',
     })
     expect(getDingTalkPublicFormLinkAccessState('view_form_enabled', views, nowMs)).toEqual({
+      audienceSummary: 'Anyone with the link can submit',
       hasSelection: true,
       level: 'public',
       summary: 'Fully public; anyone with the link can submit',
     })
     expect(getDingTalkPublicFormLinkAccessState('view_form_protected_allowed_user', views, nowMs)).toEqual({
+      audienceSummary: '1 local user can submit after DingTalk checks',
       hasSelection: true,
       level: 'dingtalk',
       summary: 'DingTalk-bound users in allowlist can submit',
     })
     expect(getDingTalkPublicFormLinkAccessState('view_form_granted_allowed_group', views, nowMs)).toEqual({
+      audienceSummary: '1 local member group can submit after DingTalk checks',
       hasSelection: true,
       level: 'dingtalk_granted',
       summary: 'Authorized DingTalk users in allowlist can submit',
     })
     expect(getDingTalkPublicFormLinkAccessState('missing_view', views, nowMs)).toEqual({
+      audienceSummary: 'Allowed audience unavailable',
       hasSelection: true,
       level: 'unavailable',
       summary: 'View unavailable in this sheet',

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -313,6 +313,8 @@ describe('MetaAutomationManager', () => {
       .toContain('Fully public; anyone with the link can submit')
     expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
       .toBe('public')
+    expect(container.querySelector('[data-automation-card-link-audience="public-form:view_form"]')?.textContent)
+      .toContain('Allowed audience: Anyone with the link can submit')
 
     const internalLink = container.querySelector('[data-automation-card-link="internal-view:view_grid"]') as HTMLButtonElement
     expect(internalLink).not.toBeNull()
@@ -362,6 +364,8 @@ describe('MetaAutomationManager', () => {
       .toContain('Fully public; anyone with the link can submit')
     expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
       .toBe('public')
+    expect(container.querySelector('[data-automation-card-link-audience="public-form:view_form"]')?.textContent)
+      .toContain('Allowed audience: Anyone with the link can submit')
   })
 
   it('shows DingTalk-bound public form access on rule card links', async () => {
@@ -382,6 +386,8 @@ describe('MetaAutomationManager', () => {
       .toContain('DingTalk-bound users in allowlist can submit')
     expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
       .toBe('dingtalk')
+    expect(container.querySelector('[data-automation-card-link-audience="public-form:view_form"]')?.textContent)
+      .toContain('Allowed audience: 1 local member group can submit after DingTalk checks')
   })
 
   it('shows DingTalk-authorized public form access on rule card links', async () => {
@@ -402,6 +408,8 @@ describe('MetaAutomationManager', () => {
       .toContain('Authorized DingTalk users in allowlist can submit')
     expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
       .toBe('dingtalk_granted')
+    expect(container.querySelector('[data-automation-card-link-audience="public-form:view_form"]')?.textContent)
+      .toContain('Allowed audience: 1 local user can submit after DingTalk checks')
   })
 
   it('does not render a public form card link when sharing is missing a public token', async () => {
@@ -1073,6 +1081,8 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
     expect(container.querySelector('[data-automation-summary="group"]')?.textContent).toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-automation-public-form-audience="group"]')?.textContent)
+      .toContain('Anyone with the link can submit')
     expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('public')
     expect(container.querySelector('[data-automation-public-form-access="group"]')?.classList.contains('meta-automation__public-form-access--public')).toBe(true)
   })
@@ -1104,6 +1114,8 @@ describe('MetaAutomationManager', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
     expect(container.textContent).toContain('add allowed users or member groups')
+    expect(container.querySelector('[data-automation-public-form-audience="group"]')?.textContent)
+      .toContain('No local allowlist limits are set; all bound DingTalk users can submit')
     expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('dingtalk')
     expect(container.querySelector('[data-automation-public-form-access="group"]')?.classList.contains('meta-automation__public-form-access--dingtalk')).toBe(true)
   })
@@ -1136,6 +1148,8 @@ describe('MetaAutomationManager', () => {
     expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
     expect(container.textContent).not.toContain('is fully public')
     expect(container.querySelector('[data-automation-summary="group"]')?.textContent).toContain('DingTalk-bound users in allowlist can submit')
+    expect(container.querySelector('[data-automation-public-form-audience="group"]')?.textContent)
+      .toContain('1 local member group can submit after DingTalk checks')
     expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('dingtalk')
   })
 
@@ -1159,6 +1173,8 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is missing a public token')
+    expect(container.querySelector('[data-automation-public-form-audience="person"]')?.textContent)
+      .toContain('Allowed audience unavailable')
     expect(container.querySelector('[data-automation-public-form-access="person"]')?.getAttribute('data-access-level')).toBe('unavailable')
     expect(container.querySelector('[data-automation-public-form-access="person"]')?.classList.contains('meta-automation__public-form-access--unavailable')).toBe(true)
   })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -790,6 +790,8 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Public form sharing is disabled for "Public Form"')
     expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
       .toBe('unavailable')
+    expect(container.querySelector('[data-field="groupPublicFormAudienceSummary-0"]')?.textContent)
+      .toContain('Allowed audience unavailable')
   })
 
   it('disables saving a DingTalk group message when the selected public form link cannot work', async () => {
@@ -864,9 +866,13 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
     expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.textContent)
       .toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-field="groupPublicFormAudienceSummary-0"]')?.textContent)
+      .toContain('Anyone with the link can submit')
     expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
       .toBe('public')
     expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('Allowed audience:')
+    expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('Anyone with the link can submit')
   })
 
   it('warns when a DingTalk group message uses a protected public form without an allowlist', async () => {
@@ -892,6 +898,10 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
     expect(container.textContent).toContain('add allowed users or member groups')
+    expect(container.querySelector('[data-field="groupPublicFormAudienceSummary-0"]')?.textContent)
+      .toContain('No local allowlist limits are set; all bound DingTalk users can submit')
+    expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent)
+      .toContain('No local allowlist limits are set; all bound DingTalk users can submit')
   })
 
   it('does not warn when a DingTalk group message uses a protected public form with an allowlist', async () => {
@@ -919,9 +929,13 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).not.toContain('is fully public')
     expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.textContent)
       .toContain('DingTalk-bound users in allowlist can submit')
+    expect(container.querySelector('[data-field="groupPublicFormAudienceSummary-0"]')?.textContent)
+      .toContain('1 local user can submit after DingTalk checks')
     expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
       .toBe('dingtalk')
     expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('DingTalk-bound users in allowlist can submit')
+    expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent)
+      .toContain('1 local user can submit after DingTalk checks')
   })
 
   it('does not render access badges for whitespace-only public form ids', async () => {
@@ -951,6 +965,8 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.querySelector('[data-field="groupPublicFormAccessSummary-0"]')).toBeNull()
     expect(container.querySelector('[data-field="personPublicFormAccessSummary-1"]')).toBeNull()
+    expect(container.querySelector('[data-field="groupPublicFormAudienceSummary-0"]')).toBeNull()
+    expect(container.querySelector('[data-field="personPublicFormAudienceSummary-1"]')).toBeNull()
     expect(container.querySelector('[data-field="groupMessageSummary"]')?.textContent).toContain('No public form link')
     expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent).toContain('No public form link')
   })
@@ -978,10 +994,14 @@ describe('MetaAutomationRuleEditor', () => {
 
     expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.textContent)
       .toContain('Authorized DingTalk users in allowlist can submit')
+    expect(container.querySelector('[data-field="personPublicFormAudienceSummary-0"]')?.textContent)
+      .toContain('1 local user can submit after DingTalk checks')
     expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
       .toBe('dingtalk_granted')
     expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent)
       .toContain('Authorized DingTalk users in allowlist can submit')
+    expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent)
+      .toContain('1 local user can submit after DingTalk checks')
   })
 
   it('emits DingTalk person action config with optional links', async () => {
@@ -1029,6 +1049,8 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent).toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent).toContain('Allowed audience:')
+    expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent).toContain('Anyone with the link can submit')
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
     expect(saveBtn.disabled).toBe(false)
@@ -1132,6 +1154,8 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.textContent).toContain('Public form sharing is disabled for "Public Form"')
     expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
       .toBe('unavailable')
+    expect(container.querySelector('[data-field="personPublicFormAudienceSummary-0"]')?.textContent)
+      .toContain('Allowed audience unavailable')
     expect(saveBtn.disabled).toBe(true)
     saveBtn.click()
     await flushPromises()

--- a/docs/development/dingtalk-automation-allowlist-audience-development-20260421.md
+++ b/docs/development/dingtalk-automation-allowlist-audience-development-20260421.md
@@ -1,0 +1,40 @@
+# DingTalk Automation Allowlist Audience Development
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-automation-allowlist-audience-20260421`
+- Scope: automation editor and automation manager DingTalk public-form link summaries
+
+## Goal
+
+Make DingTalk automation authors see both:
+
+- `Public form access`: the DingTalk protection mode for the selected public form.
+- `Allowed audience`: the local allowlist scope that can submit after DingTalk checks.
+
+This keeps the group-message flow clear when a form is broadcast to a DingTalk group but only selected local users or local member groups may fill it.
+
+## Implementation
+
+- Added public-form audience derivation to `DingTalkPublicFormLinkAccessState`.
+- Added audience text for public, unavailable, DingTalk-bound, DingTalk-authorized, and allowlist-constrained public forms.
+- Displayed `Allowed audience` in the inline automation manager message summaries for group and person DingTalk actions.
+- Displayed `Allowed audience` on automation manager rule card public-form link chips.
+- Displayed `Allowed audience` beside public-form selectors and in message previews in `MetaAutomationRuleEditor`.
+- Updated the DingTalk admin operations guide to document that automation summaries use the same local allowlist counts as the form share manager.
+
+## Behavior
+
+- Fully public forms show `Anyone with the link can submit`.
+- DingTalk-protected forms without local allowlists show that all bound or authorized DingTalk local users can submit.
+- DingTalk-protected forms with local allowlists show local user/member-group counts, for example `1 local user can submit after DingTalk checks`.
+- Missing, disabled, expired, non-form, or tokenless public-form selections show `Allowed audience unavailable`.
+
+## Files
+
+- `apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/dingtalk-public-form-link-warnings.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`

--- a/docs/development/dingtalk-automation-allowlist-audience-verification-20260421.md
+++ b/docs/development/dingtalk-automation-allowlist-audience-verification-20260421.md
@@ -33,3 +33,31 @@ git diff --check
 ## Notes
 
 - Existing `node_modules` symlink changes from local dependency installation are intentionally excluded from this validation scope.
+
+## Rebase Verification - 2026-04-22
+
+Rebased `codex/dingtalk-automation-allowlist-audience-20260421` onto
+`origin/main@0c86ecaa4` after PR #1029 was squash-merged.
+
+```bash
+git rebase --onto origin/main origin/codex/dingtalk-automation-allowlist-audience-base-20260421 HEAD
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+rg -n "Allowed audience|audienceSummary|data-automation-public-form-audience|data-automation-card-link-audience|allowedUserIds|allowedMemberGroupIds" apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts apps/web/tests/dingtalk-public-form-link-warnings.spec.ts apps/web/tests/multitable-automation-manager.spec.ts apps/web/tests/multitable-automation-rule-editor.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/development/dingtalk-automation-allowlist-audience-*.md
+git diff --check
+pnpm --filter @metasheet/web build
+git checkout -- plugins/ tools/
+```
+
+Results:
+
+- Rebase completed cleanly; replayed only the automation allowlist audience commit on top of main.
+- `tests/dingtalk-public-form-link-warnings.spec.ts`: passed, 9 tests.
+- `tests/multitable-automation-manager.spec.ts`: passed, 67 tests.
+- `tests/multitable-automation-rule-editor.spec.ts`: passed, 56 tests.
+- Combined target suite: passed, 3 files and 132 tests.
+- `rg` guidance/search check: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/web build`: passed.
+- Build warnings were limited to the existing `WorkflowDesigner.vue` mixed import warning and existing large chunk warnings.
+- PNPM install recreated tracked plugin/tool `node_modules` symlink noise; it was cleaned with `git checkout -- plugins/ tools/` before pushing.

--- a/docs/development/dingtalk-automation-allowlist-audience-verification-20260421.md
+++ b/docs/development/dingtalk-automation-allowlist-audience-verification-20260421.md
@@ -1,0 +1,35 @@
+# DingTalk Automation Allowlist Audience Verification
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-automation-allowlist-audience-20260421`
+- Status: passed local validation
+
+## Local Validation Plan
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+rg -n "Allowed audience|audienceSummary|data-automation-public-form-audience|data-automation-card-link-audience|allowedUserIds|allowedMemberGroupIds" apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts apps/web/tests/dingtalk-public-form-link-warnings.spec.ts apps/web/tests/multitable-automation-manager.spec.ts apps/web/tests/multitable-automation-rule-editor.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/development/dingtalk-automation-allowlist-audience-*.md
+git diff --check
+```
+
+## Results
+
+- `pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false`: passed, 3 files and 132 tests.
+- `pnpm --filter @metasheet/web build`: passed. Vite reported the existing large-chunk and mixed static/dynamic import warnings.
+- `rg -n "Allowed audience|audienceSummary|data-automation-public-form-audience|data-automation-card-link-audience|allowedUserIds|allowedMemberGroupIds" ...`: passed, expected implementation/test/doc references found.
+- `git diff --check`: passed.
+
+## Expected Coverage
+
+- Utility tests cover public, unavailable, DingTalk-bound, DingTalk-authorized, and allowlist-constrained audience summaries.
+- Automation manager tests cover inline group/person summaries and rule-card public-form audience chips.
+- Rule editor tests cover public-form selector audience badges and message summary previews.
+- Build verifies Vue/TypeScript integration.
+- `git diff --check` verifies whitespace safety.
+
+## Notes
+
+- Existing `node_modules` symlink changes from local dependency installation are intentionally excluded from this validation scope.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -106,7 +106,8 @@ Automation authoring guardrail:
 - if a selected internal processing view is no longer in the current sheet, the automation editor warns and disables save
 - if a DingTalk group rule links to a fully public form, the automation editor warns that anyone with the message link can submit
 - if a DingTalk group rule links to a DingTalk-protected form without allowed users or member groups, the editor warns that all bound or authorized DingTalk users can submit
-- the message summary shows `Public form access`, including fully public, bound DingTalk users, authorized DingTalk users, and allowlist-constrained states
+- the message summary and rule card show `Public form access`, including fully public, bound DingTalk users, authorized DingTalk users, and allowlist-constrained states
+- the message summary and rule card also show `Allowed audience`, derived from local allowlist users/member groups when the form is DingTalk-protected
 - the warning is advisory; runtime delivery still performs the backend validation before sending the link
 - automation create/update APIs reject invalid public form or internal processing links before saving
 - runtime delivery refuses non-form public views and expired public-form shares before sending DingTalk messages
@@ -147,6 +148,7 @@ Behavior:
 - the local user must be directly allowed or belong to an allowed member group
 - without an allowlist, `Bound DingTalk users only` admits all bound DingTalk local users and `Authorized DingTalk users only` admits all locally authorized DingTalk users
 - the form share manager shows `Local allowlist limits` so owners can confirm whether no local limit is set or how many local users/member groups can fill after DingTalk checks
+- the automation editor and rule cards show the same local allowlist audience as `Allowed audience`, so authors can verify it without reopening the form share manager
 
 Important rule:
 
@@ -219,7 +221,7 @@ Authoring guardrail:
 
 - if the selected form is still fully public, the DingTalk group rule editor warns before save
 - if the selected protected form has no allowed users or member groups, the DingTalk group rule editor warns before save
-- check `Public form access` in the automation message summary and `Local allowlist limits` in form sharing before saving
+- check `Public form access` and `Allowed audience` in the automation message summary, plus `Local allowlist limits` in form sharing before saving
 - switch the form to `Bound DingTalk users only` or `Authorized DingTalk users only` before relying on allowlists
 
 ### Scenario 3: Notify specific staff only
@@ -258,7 +260,7 @@ Current gaps to be aware of:
 - DingTalk group roster is not auto-imported
 - row/field-specific fill assignment is not yet first-class
 - precise protected-form allowlists depend on local user/member-group governance, not raw DingTalk identities
-- the allowlist audience summary is derived from local allowlist users/groups; it does not infer or sync DingTalk group members
+- `Allowed audience` and `Local allowlist limits` are derived from local allowlist users/groups; they do not infer or sync DingTalk group members
 
 ## K. Operational recommendations
 


### PR DESCRIPTION
## Summary
- add DingTalk public-form `Allowed audience` derivation for automation summaries
- show local allowlist audience in automation manager inline summaries, rule card link chips, and rule editor previews
- update DingTalk admin/development/verification docs for the allowlist audience behavior
- rebase onto `main@0c86ecaa4` after PR #1029 was squash-merged

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` (132 passed)
- `rg -n "Allowed audience|audienceSummary|data-automation-public-form-audience|data-automation-card-link-audience|allowedUserIds|allowedMemberGroupIds" apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts apps/web/tests/dingtalk-public-form-link-warnings.spec.ts apps/web/tests/multitable-automation-manager.spec.ts apps/web/tests/multitable-automation-rule-editor.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/development/dingtalk-automation-allowlist-audience-*.md`
- `git diff --check`
- `pnpm --filter @metasheet/web build`

## Notes
- no backend API or schema changes
- PNPM-created tracked plugin/tool node_modules symlink dirtiness was cleaned before pushing
- Vite build only reports existing WorkflowDesigner mixed import and large chunk warnings