### PR TITLE
feat(dingtalk): show runtime form link audience

### DIFF
--- a/docs/development/dingtalk-runtime-link-audience-development-20260421.md
+++ b/docs/development/dingtalk-runtime-link-audience-development-20260421.md
@@ -1,0 +1,49 @@
+# DingTalk Runtime Link Audience Development
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-runtime-link-audience-20260421`
+- Scope: backend DingTalk automation message runtime
+
+## Goal
+
+Make the actual DingTalk group/person message show the public-form access mode and local allowlist audience beside the fill link.
+
+Before this slice, the editor and rule cards could show `Public form access` and `Allowed audience`, but the message sent to DingTalk only included `填写入口` and `处理入口` links.
+
+## Implementation
+
+- Added runtime helpers in `AutomationExecutor` to describe public-form access modes.
+- Appended `表单访问` under the generated `填写入口` link.
+- Appended `允许范围` for DingTalk-protected forms, including:
+  - all bound DingTalk local users
+  - all authorized DingTalk local users
+  - local allowlist user/member-group counts
+- Reused the same parsed public-form config already loaded for runtime link validation.
+- Updated backend unit tests for group robot messages and person work notifications.
+- Updated DingTalk operations/capability docs to state that runtime messages now include access/audience text.
+
+## Runtime Message Shape
+
+For a public form:
+
+```markdown
+**快捷入口**
+- [填写入口](...)
+- 表单访问：任何获得链接的人可填写
+```
+
+For a DingTalk-protected form with allowlists:
+
+```markdown
+**快捷入口**
+- [填写入口](...)
+- 表单访问：钉钉登录 + 本地授权
+- 允许范围：1 个本地用户、1 个本地成员组通过钉钉校验后可填写
+```
+
+## Files
+
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`

--- a/docs/development/dingtalk-runtime-link-audience-verification-20260421.md
+++ b/docs/development/dingtalk-runtime-link-audience-verification-20260421.md
@@ -1,0 +1,35 @@
+# DingTalk Runtime Link Audience Verification
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-runtime-link-audience-20260421`
+- Status: passed local validation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+rg -n "表单访问|允许范围|describeDingTalkPublicFormRuntimeLines|allowedUserIds|allowedMemberGroupIds" packages/core-backend/src/multitable/automation-executor.ts packages/core-backend/tests/unit/automation-v1.test.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-runtime-link-audience-*.md
+git diff --check
+```
+
+## Expected Coverage
+
+- Group robot messages include public-form access text for fully public links.
+- Group robot messages include DingTalk-bound access text and no-allowlist audience text.
+- Person work notifications include DingTalk-authorized access text and local allowlist counts.
+- Existing save/runtime link validation tests still pass.
+- Backend build verifies TypeScript integration.
+
+## Results
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`: passed, 2 files and 131 tests.
+- `pnpm --filter @metasheet/core-backend build`: passed.
+- `rg -n "表单访问|允许范围|describeDingTalkPublicFormRuntimeLines|allowedUserIds|allowedMemberGroupIds" ...`: passed, expected runtime/test/doc references found.
+- `git diff --check`: passed.
+
+## Claude Code CLI
+
+- Local CLI exists at `/Users/chouhua/.local/bin/claude`.
+- Version checked: `2.1.116 (Claude Code)`.
+- A read-only `claude -p` attempt was made with a strict `--max-budget-usd 0.05`; it exited before producing analysis because the budget was too low. No files were modified by Claude Code CLI.

--- a/docs/development/dingtalk-runtime-link-audience-verification-20260421.md
+++ b/docs/development/dingtalk-runtime-link-audience-verification-20260421.md
@@ -33,3 +33,29 @@ git diff --check
 - Local CLI exists at `/Users/chouhua/.local/bin/claude`.
 - Version checked: `2.1.116 (Claude Code)`.
 - A read-only `claude -p` attempt was made with a strict `--max-budget-usd 0.05`; it exited before producing analysis because the budget was too low. No files were modified by Claude Code CLI.
+
+## Rebase Verification - 2026-04-22
+
+Rebased `codex/dingtalk-runtime-link-audience-20260421` onto `origin/main@f4ba4111c`
+after PR #1031 was squash-merged.
+
+```bash
+git rebase --onto origin/main origin/codex/dingtalk-runtime-link-audience-base-20260421 HEAD
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+rg -n "表单访问|允许范围|describeDingTalkPublicFormRuntimeLines|allowedUserIds|allowedMemberGroupIds" packages/core-backend/src/multitable/automation-executor.ts packages/core-backend/tests/unit/automation-v1.test.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-runtime-link-audience-*.md
+git diff --check
+pnpm --filter @metasheet/core-backend build
+git checkout -- plugins/ tools/
+```
+
+Results:
+
+- Rebase completed cleanly; replayed only the runtime link audience commit on top of main.
+- `tests/unit/automation-v1.test.ts`: passed.
+- `tests/unit/dingtalk-automation-link-validation.test.ts`: passed.
+- Combined target suite: passed, 2 files and 131 tests.
+- `rg` runtime/test/doc check: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/core-backend build`: passed.
+- PNPM install recreated tracked plugin/tool `node_modules` symlink noise; it was cleaned with `git checkout -- plugins/ tools/` before pushing.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -109,6 +109,7 @@ Automation authoring guardrail:
 - the message summary and rule card show `Public form access`, including fully public, bound DingTalk users, authorized DingTalk users, and allowlist-constrained states
 - the message summary and rule card also show `Allowed audience`, derived from local allowlist users/member groups when the form is DingTalk-protected
 - the warning is advisory; runtime delivery still performs the backend validation before sending the link
+- runtime DingTalk messages include `表单访问` and `允许范围` lines below the public form fill link, so recipients can see the access mode before opening the form
 - automation create/update APIs reject invalid public form or internal processing links before saving
 - runtime delivery refuses non-form public views and expired public-form shares before sending DingTalk messages
 - runtime delivery refuses missing internal processing views before sending DingTalk messages
@@ -149,6 +150,7 @@ Behavior:
 - without an allowlist, `Bound DingTalk users only` admits all bound DingTalk local users and `Authorized DingTalk users only` admits all locally authorized DingTalk users
 - the form share manager shows `Local allowlist limits` so owners can confirm whether no local limit is set or how many local users/member groups can fill after DingTalk checks
 - the automation editor and rule cards show the same local allowlist audience as `Allowed audience`, so authors can verify it without reopening the form share manager
+- the actual DingTalk message uses the same access-mode and local allowlist data in its runtime `允许范围` text
 
 Important rule:
 

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -104,6 +104,7 @@ Runtime guardrail:
 
 - DingTalk automation delivery only emits public-form links for same-sheet form views with active sharing
 - expired public-form sharing is rejected before sending the DingTalk message
+- runtime DingTalk messages append `表单访问` and `允许范围` below the fill link, reflecting public, DingTalk-bound, DingTalk-authorized, and local allowlist-constrained access
 
 ### 6. Protected public-form allowlists
 

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -250,6 +250,54 @@ function buildAppLink(baseUrl: string, path: string, search?: Record<string, str
   return url.toString()
 }
 
+function normalizePublicFormAccessMode(value: unknown): 'public' | 'dingtalk' | 'dingtalk_granted' {
+  return value === 'dingtalk' || value === 'dingtalk_granted' ? value : 'public'
+}
+
+function countStringIds(value: unknown): number {
+  if (!Array.isArray(value)) return 0
+  return new Set(
+    value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  ).size
+}
+
+function describeLocalAllowlistCount(userCount: number, memberGroupCount: number): string {
+  const parts: string[] = []
+  if (userCount > 0) parts.push(`${userCount} 个本地用户`)
+  if (memberGroupCount > 0) parts.push(`${memberGroupCount} 个本地成员组`)
+  return parts.join('、')
+}
+
+function describeDingTalkPublicFormRuntimeLines(publicForm: Record<string, unknown>): string[] {
+  const accessMode = normalizePublicFormAccessMode(publicForm.accessMode)
+  if (accessMode === 'public') {
+    return ['- 表单访问：任何获得链接的人可填写']
+  }
+
+  const userCount = countStringIds(publicForm.allowedUserIds)
+  const memberGroupCount = countStringIds(publicForm.allowedMemberGroupIds)
+  const modeLabel = accessMode === 'dingtalk_granted'
+    ? '钉钉登录 + 本地授权'
+    : '钉钉登录 + 绑定本地用户'
+  if (userCount === 0 && memberGroupCount === 0) {
+    const audience = accessMode === 'dingtalk_granted'
+      ? '所有已授权钉钉的本地用户可填写'
+      : '所有已绑定钉钉的本地用户可填写'
+    return [
+      `- 表单访问：${modeLabel}`,
+      `- 允许范围：${audience}`,
+    ]
+  }
+
+  return [
+    `- 表单访问：${modeLabel}`,
+    `- 允许范围：${describeLocalAllowlistCount(userCount, memberGroupCount)}通过钉钉校验后可填写`,
+  ]
+}
+
 async function recordDingTalkGroupDelivery(
   queryFn: AutomationDeps['queryFn'],
   input: {
@@ -779,16 +827,19 @@ export class AutomationExecutor {
 
       const viewConfig = parseViewConfig(publicView.config)
       const publicForm = viewConfig?.publicForm
-      const publicToken = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
-        ? typeof (publicForm as Record<string, unknown>).publicToken === 'string'
-          ? ((publicForm as Record<string, unknown>).publicToken as string).trim()
+      const publicFormRecord = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
+        ? publicForm as Record<string, unknown>
+        : null
+      const publicToken = publicFormRecord
+        ? typeof publicFormRecord.publicToken === 'string'
+          ? publicFormRecord.publicToken.trim()
           : ''
         : ''
-      const enabled = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
-        ? (publicForm as Record<string, unknown>).enabled === true
+      const enabled = publicFormRecord
+        ? publicFormRecord.enabled === true
         : false
 
-      if (!enabled || !publicToken) {
+      if (!publicFormRecord || !enabled || !publicToken) {
         return {
           actionType: 'send_dingtalk_person_message',
           status: 'failed',
@@ -796,9 +847,7 @@ export class AutomationExecutor {
         }
       }
       const expiryMs = parsePublicFormExpiryMs(
-        publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
-          ? (publicForm as Record<string, unknown>).expiresAt ?? (publicForm as Record<string, unknown>).expiresOn
-          : undefined,
+        publicFormRecord.expiresAt ?? publicFormRecord.expiresOn,
       )
       if (expiryMs !== null && Date.now() >= expiryMs) {
         return {
@@ -809,6 +858,7 @@ export class AutomationExecutor {
       }
 
       linkLines.push(`- [填写入口](${buildAppLink(baseUrl, `/multitable/public-form/${context.sheetId}/${publicFormViewId}`, { publicToken })})`)
+      linkLines.push(...describeDingTalkPublicFormRuntimeLines(publicFormRecord))
     }
 
     if (internalViewId && baseUrl) {
@@ -1179,16 +1229,19 @@ export class AutomationExecutor {
 
       const viewConfig = parseViewConfig(publicView.config)
       const publicForm = viewConfig?.publicForm
-      const publicToken = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
-        ? typeof (publicForm as Record<string, unknown>).publicToken === 'string'
-          ? ((publicForm as Record<string, unknown>).publicToken as string).trim()
+      const publicFormRecord = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
+        ? publicForm as Record<string, unknown>
+        : null
+      const publicToken = publicFormRecord
+        ? typeof publicFormRecord.publicToken === 'string'
+          ? publicFormRecord.publicToken.trim()
           : ''
         : ''
-      const enabled = publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
-        ? (publicForm as Record<string, unknown>).enabled === true
+      const enabled = publicFormRecord
+        ? publicFormRecord.enabled === true
         : false
 
-      if (!enabled || !publicToken) {
+      if (!publicFormRecord || !enabled || !publicToken) {
         return {
           actionType: 'send_dingtalk_group_message',
           status: 'failed',
@@ -1196,9 +1249,7 @@ export class AutomationExecutor {
         }
       }
       const expiryMs = parsePublicFormExpiryMs(
-        publicForm && typeof publicForm === 'object' && !Array.isArray(publicForm)
-          ? (publicForm as Record<string, unknown>).expiresAt ?? (publicForm as Record<string, unknown>).expiresOn
-          : undefined,
+        publicFormRecord.expiresAt ?? publicFormRecord.expiresOn,
       )
       if (expiryMs !== null && Date.now() >= expiryMs) {
         return {
@@ -1209,6 +1260,7 @@ export class AutomationExecutor {
       }
 
       linkLines.push(`- [填写入口](${buildAppLink(baseUrl, `/multitable/public-form/${context.sheetId}/${publicFormViewId}`, { publicToken })})`)
+      linkLines.push(...describeDingTalkPublicFormRuntimeLines(publicFormRecord))
     }
 
     if (internalViewId && baseUrl) {

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -452,6 +452,7 @@ describe('AutomationExecutor', () => {
     expect(payload.markdown.title).toBe('Record Incident ready')
     expect(payload.markdown.text).toContain('Status: open')
     expect(payload.markdown.text).toContain('/multitable/public-form/sheet_1/view_form?publicToken=public-token')
+    expect(payload.markdown.text).toContain('表单访问：任何获得链接的人可填写')
     expect(payload.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
     expect((queryFn.mock.calls[3]?.[0] as string) ?? '').toContain('INSERT INTO dingtalk_group_deliveries')
   })
@@ -654,7 +655,7 @@ describe('AutomationExecutor', () => {
         rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
       })
       .mockResolvedValueOnce({
-        rows: [{ id: 'view_form', sheet_id: 'sheet_1', config: { publicForm: { enabled: true, publicToken: 'public-token' } } }],
+        rows: [{ id: 'view_form', sheet_id: 'sheet_1', config: { publicForm: { enabled: true, publicToken: 'public-token', accessMode: 'dingtalk' } } }],
       })
       .mockResolvedValueOnce({ rows: [{ id: 'view_grid' }] })
       .mockRejectedValueOnce(new Error('delivery history unavailable'))
@@ -688,6 +689,10 @@ describe('AutomationExecutor', () => {
     expect(result.status).toBe('success')
     expect(fetchFn).toHaveBeenCalledTimes(1)
     expect(queryFn).toHaveBeenCalledTimes(4)
+    const [, sendInit] = fetchFn.mock.calls[0] as [string, RequestInit]
+    const payload = JSON.parse(sendInit.body as string)
+    expect(payload.markdown.text).toContain('表单访问：钉钉登录 + 绑定本地用户')
+    expect(payload.markdown.text).toContain('允许范围：所有已绑定钉钉的本地用户可填写')
   })
 
   it('fails send_dingtalk_group_message when destination is missing', async () => {
@@ -827,7 +832,19 @@ describe('AutomationExecutor', () => {
 
     const queryFn = vi.fn()
       .mockResolvedValueOnce({
-        rows: [{ id: 'view_form', sheet_id: 'sheet_1', config: { publicForm: { enabled: true, publicToken: 'public-token' } } }],
+        rows: [{
+          id: 'view_form',
+          sheet_id: 'sheet_1',
+          config: {
+            publicForm: {
+              enabled: true,
+              publicToken: 'public-token',
+              accessMode: 'dingtalk_granted',
+              allowedUserIds: ['user_1'],
+              allowedMemberGroupIds: ['group_1'],
+            },
+          },
+        }],
       })
       .mockResolvedValueOnce({ rows: [{ id: 'view_grid' }] })
       .mockResolvedValueOnce({
@@ -877,6 +894,8 @@ describe('AutomationExecutor', () => {
     const payload = JSON.parse(sendInit.body as string)
     expect(payload.userid_list).toBe('dt-user-1,dt-user-2')
     expect(payload.msg.markdown.text).toContain('/multitable/public-form/sheet_1/view_form?publicToken=public-token')
+    expect(payload.msg.markdown.text).toContain('表单访问：钉钉登录 + 本地授权')
+    expect(payload.msg.markdown.text).toContain('允许范围：1 个本地用户、1 个本地成员组通过钉钉校验后可填写')
     expect(payload.msg.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
     const insertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
     expect(insertCalls).toHaveLength(2)


### PR DESCRIPTION
## Summary
- append public-form access text to runtime DingTalk group/person messages below the generated fill link
- include local allowlist audience text for DingTalk-bound and DingTalk-authorized forms
- cover public, DingTalk-bound without allowlist, and DingTalk-authorized with local allowlist in backend automation tests
- update DingTalk admin/capability docs plus development and verification notes
- rebase onto `main@f4ba4111c` after PR #1031 was squash-merged

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false` (131 passed)
- `pnpm --filter @metasheet/core-backend build`
- `rg -n "表单访问|允许范围|describeDingTalkPublicFormRuntimeLines|allowedUserIds|allowedMemberGroupIds" packages/core-backend/src/multitable/automation-executor.ts packages/core-backend/tests/unit/automation-v1.test.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-runtime-link-audience-*.md`
- `git diff --check`

## Notes
- PNPM-created tracked plugin/tool node_modules symlink dirtiness was cleaned before pushing
- Claude Code CLI was not used to edit files; the earlier read-only budget-capped attempt produced no analysis