### PR TITLE
feat(dingtalk): show internal link permission hint

### DIFF
--- a/docs/development/dingtalk-runtime-internal-link-permission-development-20260421.md
+++ b/docs/development/dingtalk-runtime-internal-link-permission-development-20260421.md
@@ -1,0 +1,46 @@
+# DingTalk Runtime Internal Link Permission Development
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-runtime-internal-link-permission-20260421`
+- Scope: backend DingTalk automation message runtime
+
+## Goal
+
+Make DingTalk group/person messages explicitly state that an internal processing link still requires local system access.
+
+This addresses the collaboration case where a DingTalk group can see the message, but recipients without local table/view permission must not be able to open the internal table.
+
+## Implementation
+
+- Added a runtime helper in `AutomationExecutor` for internal processing link permission text.
+- Appended `处理权限：需登录系统并具备该表格/视图访问权限` below generated `处理入口` links.
+- Applied the same message shape to:
+  - `send_dingtalk_group_message`
+  - `send_dingtalk_person_message`
+- Kept all existing permission enforcement unchanged. The link remains a normal internal multitable route protected by login and local ACL.
+- Updated backend unit tests to assert the runtime DingTalk markdown includes the permission line.
+- Updated DingTalk operations/capability docs so the documented behavior matches the delivered message.
+
+## Runtime Message Shape
+
+```markdown
+**快捷入口**
+- [填写入口](...)
+- 表单访问：钉钉登录 + 本地授权
+- 允许范围：1 个本地用户、1 个本地成员组通过钉钉校验后可填写
+- [处理入口](...)
+- 处理权限：需登录系统并具备该表格/视图访问权限
+```
+
+## Files
+
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- A table can still associate multiple DingTalk group destinations.
+- DingTalk group destination management remains governed by existing sheet automation permissions.
+- This slice does not add new access rules; it only makes the existing internal-link security boundary visible in delivered DingTalk messages.

--- a/docs/development/dingtalk-runtime-internal-link-permission-verification-20260421.md
+++ b/docs/development/dingtalk-runtime-internal-link-permission-verification-20260421.md
@@ -32,3 +32,27 @@ git diff --check
 - Local CLI check: `claude --version`
 - Version observed: `2.1.116 (Claude Code)`
 - Claude Code CLI was not allowed to edit files in this slice; implementation was done locally to keep the diff controlled.
+
+## Rebase Verification - 2026-04-22
+
+Rebased `codex/dingtalk-runtime-internal-link-permission-20260421` onto
+`origin/main@88c5c91cb` after PR #1033 was squash-merged.
+
+```bash
+git rebase --onto origin/main origin/codex/dingtalk-runtime-internal-link-permission-base-20260421 HEAD
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+rg -n "处理权限|describeDingTalkInternalViewRuntimeLines" packages/core-backend/src/multitable/automation-executor.ts packages/core-backend/tests/unit/automation-v1.test.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-runtime-internal-link-permission-*.md
+git diff --check
+pnpm --filter @metasheet/core-backend build
+git checkout -- plugins/ tools/
+```
+
+Results:
+
+- Rebase completed cleanly; replayed only the internal-link permission hint commit on top of main.
+- `tests/unit/automation-v1.test.ts`: passed, 119 tests.
+- `rg` runtime/test/doc check: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/core-backend build`: passed.
+- PNPM install recreated tracked plugin/tool `node_modules` symlink noise; it was cleaned with `git checkout -- plugins/ tools/` before pushing.

--- a/docs/development/dingtalk-runtime-internal-link-permission-verification-20260421.md
+++ b/docs/development/dingtalk-runtime-internal-link-permission-verification-20260421.md
@@ -1,0 +1,34 @@
+# DingTalk Runtime Internal Link Permission Verification
+
+- Date: 2026-04-21
+- Branch: `codex/dingtalk-runtime-internal-link-permission-20260421`
+- Status: passed local validation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+rg -n "处理权限|describeDingTalkInternalViewRuntimeLines" packages/core-backend/src/multitable/automation-executor.ts packages/core-backend/tests/unit/automation-v1.test.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-runtime-internal-link-permission-*.md
+git diff --check
+```
+
+## Expected Coverage
+
+- Group robot messages include the internal processing link permission text.
+- Person work notifications include the same internal processing link permission text.
+- Existing public-form runtime access/audience text remains covered in the same automation suite.
+- Backend build verifies TypeScript integration.
+
+## Results
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false`: passed, 1 file and 119 tests.
+- `pnpm --filter @metasheet/core-backend build`: passed.
+- `rg -n "处理权限|describeDingTalkInternalViewRuntimeLines" ...`: passed, expected runtime/test/doc references found.
+- `git diff --check`: passed.
+
+## Claude Code CLI
+
+- Local CLI check: `claude --version`
+- Version observed: `2.1.116 (Claude Code)`
+- Claude Code CLI was not allowed to edit files in this slice; implementation was done locally to keep the diff controlled.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -110,6 +110,7 @@ Automation authoring guardrail:
 - the message summary and rule card also show `Allowed audience`, derived from local allowlist users/member groups when the form is DingTalk-protected
 - the warning is advisory; runtime delivery still performs the backend validation before sending the link
 - runtime DingTalk messages include `表单访问` and `允许范围` lines below the public form fill link, so recipients can see the access mode before opening the form
+- runtime DingTalk messages include `处理权限` below internal processing links, so group recipients know the link still requires system login and table/view permission
 - automation create/update APIs reject invalid public form or internal processing links before saving
 - runtime delivery refuses non-form public views and expired public-form shares before sending DingTalk messages
 - runtime delivery refuses missing internal processing views before sending DingTalk messages
@@ -174,6 +175,7 @@ Remember:
 
 - public form link != internal table access
 - internal link still obeys local ACL
+- DingTalk recipients without local access can see the message but cannot use the internal processing link to open the table/view
 
 ## G. Delivery history and troubleshooting
 

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -105,6 +105,7 @@ Runtime guardrail:
 - DingTalk automation delivery only emits public-form links for same-sheet form views with active sharing
 - expired public-form sharing is rejected before sending the DingTalk message
 - runtime DingTalk messages append `表单访问` and `允许范围` below the fill link, reflecting public, DingTalk-bound, DingTalk-authorized, and local allowlist-constrained access
+- runtime DingTalk messages append `处理权限` below internal processing links, reminding recipients that the link requires system login and table/view permission
 
 ### 6. Protected public-form allowlists
 
@@ -234,6 +235,7 @@ Authoring guardrail:
 - group-message automations warn when the selected public form link is still fully public
 - group-message automations warn when a DingTalk-protected form has no allowed users or member groups
 - group-message and person-message automation previews show the selected public form access range before save
+- group-message and person-message runtime messages show the internal processing link permission requirement after delivery
 - the warnings direct owners toward DingTalk-protected access plus allowlists
 
 ## Current limitations

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -298,6 +298,10 @@ function describeDingTalkPublicFormRuntimeLines(publicForm: Record<string, unkno
   ]
 }
 
+function describeDingTalkInternalViewRuntimeLines(): string[] {
+  return ['- 处理权限：需登录系统并具备该表格/视图访问权限']
+}
+
 async function recordDingTalkGroupDelivery(
   queryFn: AutomationDeps['queryFn'],
   input: {
@@ -872,6 +876,7 @@ export class AutomationExecutor {
         return { actionType: 'send_dingtalk_person_message', status: 'failed', error: 'Internal view not found' }
       }
       linkLines.push(`- [处理入口](${buildAppLink(baseUrl, `/multitable/${context.sheetId}/${internalViewId}`, { recordId: context.recordId })})`)
+      linkLines.push(...describeDingTalkInternalViewRuntimeLines())
     }
 
     const templateData: Record<string, unknown> = {
@@ -1274,6 +1279,7 @@ export class AutomationExecutor {
         return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'Internal view not found' }
       }
       linkLines.push(`- [处理入口](${buildAppLink(baseUrl, `/multitable/${context.sheetId}/${internalViewId}`, { recordId: context.recordId })})`)
+      linkLines.push(...describeDingTalkInternalViewRuntimeLines())
     }
 
     const templateData: Record<string, unknown> = {

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -454,6 +454,7 @@ describe('AutomationExecutor', () => {
     expect(payload.markdown.text).toContain('/multitable/public-form/sheet_1/view_form?publicToken=public-token')
     expect(payload.markdown.text).toContain('表单访问：任何获得链接的人可填写')
     expect(payload.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
+    expect(payload.markdown.text).toContain('处理权限：需登录系统并具备该表格/视图访问权限')
     expect((queryFn.mock.calls[3]?.[0] as string) ?? '').toContain('INSERT INTO dingtalk_group_deliveries')
   })
 
@@ -897,6 +898,7 @@ describe('AutomationExecutor', () => {
     expect(payload.msg.markdown.text).toContain('表单访问：钉钉登录 + 本地授权')
     expect(payload.msg.markdown.text).toContain('允许范围：1 个本地用户、1 个本地成员组通过钉钉校验后可填写')
     expect(payload.msg.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
+    expect(payload.msg.markdown.text).toContain('处理权限：需登录系统并具备该表格/视图访问权限')
     const insertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
     expect(insertCalls).toHaveLength(2)
   })


### PR DESCRIPTION
## Summary
- add a runtime DingTalk message line under internal processing links: `处理权限：需登录系统并具备该表格/视图访问权限`
- apply the same hint to DingTalk group robot messages and person work notifications
- document the internal-link ACL behavior and add development/verification notes
- rebase onto `main@88c5c91cb` after PR #1033 was squash-merged

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false` (119 passed)
- `pnpm --filter @metasheet/core-backend build`
- `rg -n "处理权限|describeDingTalkInternalViewRuntimeLines" packages/core-backend/src/multitable/automation-executor.ts packages/core-backend/tests/unit/automation-v1.test.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-runtime-internal-link-permission-*.md`
- `git diff --check`

## Notes
- PNPM-created tracked plugin/tool node_modules symlink dirtiness was cleaned before pushing
- Claude Code CLI availability was checked earlier; no files were edited by Claude Code CLI