### PR TITLE
fix(collab): complete Yjs sync handshake

### DIFF
--- a/apps/web/src/multitable/composables/useYjsDocument.ts
+++ b/apps/web/src/multitable/composables/useYjsDocument.ts
@@ -22,13 +22,23 @@ function handleSyncMessage(
   if (messageType === MSG_SYNC) {
     const encoder = encoding.createEncoder()
     encoding.writeVarUint(encoder, MSG_SYNC)
-    syncProtocol.readSyncMessage(decoder, encoder, doc, 'server')
+    syncProtocol.readSyncMessage(decoder, encoder, doc, 'remote')
 
     const reply = encoding.toUint8Array(encoder)
     if (reply.length > 1) {
       socket.emit('yjs:message', { recordId, data: Array.from(reply) })
     }
   }
+}
+
+function sendSyncStep1(doc: Y.Doc, socket: Socket, recordId: string): void {
+  const encoder = encoding.createEncoder()
+  encoding.writeVarUint(encoder, MSG_SYNC)
+  syncProtocol.writeSyncStep1(encoder, doc)
+  socket.emit('yjs:message', {
+    recordId,
+    data: Array.from(encoding.toUint8Array(encoder)),
+  })
 }
 
 /**
@@ -125,6 +135,7 @@ export function useYjsDocument(recordId: Ref<string | null>, options: UseYjsDocu
 
     const yDoc = new Y.Doc()
     doc.value = yDoc
+    let requestedServerState = false
 
     socket = socketIO('/yjs', {
       transports: ['websocket'],
@@ -142,6 +153,10 @@ export function useYjsDocument(recordId: Ref<string | null>, options: UseYjsDocu
         if (rid2 !== currentRecordId) return
         const message = new Uint8Array(data)
         handleSyncMessage(yDoc, socket!, rid2, message)
+        if (!requestedServerState) {
+          requestedServerState = true
+          sendSyncStep1(yDoc, socket!, rid2)
+        }
         synced.value = true
       },
     )

--- a/apps/web/tests/multitable-yjs-cell-binding.spec.ts
+++ b/apps/web/tests/multitable-yjs-cell-binding.spec.ts
@@ -182,6 +182,7 @@ describe('useYjsCellBinding', () => {
     await flushUi()
 
     expect(activeRef?.value).toBe(true)
+    expect(emitMock.mock.calls.some((call) => call[0] === 'yjs:update')).toBe(false)
 
     // Writing via setText should fire a yjs:update emit (Y.Doc 'update' path).
     setText('hello')

--- a/apps/web/tests/yjs-document-invalidation.spec.ts
+++ b/apps/web/tests/yjs-document-invalidation.spec.ts
@@ -126,4 +126,52 @@ describe('useYjsDocument invalidation event', () => {
     expect(api.connected.value).toBe(true)
     expect(api.error.value).toBeNull()
   })
+
+  it('requests server state after the server sync step and does not echo remote sync updates', async () => {
+    const { api } = mountDocument('rec_1')
+    await flushUi()
+
+    handlers.get('connect')?.()
+    await flushUi()
+    expect(emitMock).toHaveBeenCalledWith('yjs:subscribe', { recordId: 'rec_1' })
+
+    const Y = await import('yjs')
+    const syncProtocol = await import('y-protocols/sync')
+    const encodingModule = await import('lib0/encoding')
+
+    const serverDoc = new Y.Doc()
+    const fields = serverDoc.getMap('fields')
+    const seededText = new Y.Text()
+    seededText.insert(0, 'from-server')
+    fields.set('fld_title', seededText)
+
+    const step1Encoder = encodingModule.createEncoder()
+    encodingModule.writeVarUint(step1Encoder, 0)
+    syncProtocol.writeSyncStep1(step1Encoder, serverDoc)
+    handlers.get('yjs:message')?.({
+      recordId: 'rec_1',
+      data: Array.from(encodingModule.toUint8Array(step1Encoder)),
+    })
+    await flushUi()
+
+    const emittedMessages = emitMock.mock.calls.filter((call) => call[0] === 'yjs:message')
+    expect(emittedMessages.length).toBeGreaterThanOrEqual(2)
+    expect(emitMock.mock.calls.some((call) => call[0] === 'yjs:update')).toBe(false)
+
+    const step2Encoder = encodingModule.createEncoder()
+    encodingModule.writeVarUint(step2Encoder, 0)
+    syncProtocol.writeSyncStep2(step2Encoder, serverDoc)
+    handlers.get('yjs:message')?.({
+      recordId: 'rec_1',
+      data: Array.from(encodingModule.toUint8Array(step2Encoder)),
+    })
+    await flushUi()
+
+    const clientText = api.doc.value?.getMap('fields').get('fld_title')
+    expect(clientText).toBeInstanceOf(Y.Text)
+    expect((clientText as { toString(): string }).toString()).toBe('from-server')
+    expect(emitMock.mock.calls.some((call) => call[0] === 'yjs:update')).toBe(false)
+
+    serverDoc.destroy()
+  })
 })

--- a/packages/core-backend/scripts/ops/yjs-node-client.mjs
+++ b/packages/core-backend/scripts/ops/yjs-node-client.mjs
@@ -59,11 +59,42 @@ function handleIncomingMessage(doc, socket, message) {
   if (messageType !== MSG_SYNC) return
   const encoder = encoding.createEncoder()
   encoding.writeVarUint(encoder, MSG_SYNC)
-  syncProtocol.readSyncMessage(decoder, encoder, doc, 'server')
+  syncProtocol.readSyncMessage(decoder, encoder, doc, 'remote')
   const reply = encoding.toUint8Array(encoder)
   if (reply.length > 1) {
     socket.emit('yjs:message', { recordId: RECORD_ID, data: Array.from(reply) })
   }
+}
+
+function sendSyncStep1(doc, socket) {
+  const encoder = encoding.createEncoder()
+  encoding.writeVarUint(encoder, MSG_SYNC)
+  syncProtocol.writeSyncStep1(encoder, doc)
+  socket.emit('yjs:message', { recordId: RECORD_ID, data: Array.from(encoding.toUint8Array(encoder)) })
+}
+
+async function waitForYTextField(doc, fieldId, timeoutMs = 5000) {
+  const fields = doc.getMap('fields')
+  const current = fields.get(fieldId)
+  if (current instanceof Y.Text) return current
+
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      fields.unobserve(observer)
+      reject(new Error(`timed out waiting for server-seeded Y.Text field ${fieldId}`))
+    }, timeoutMs)
+
+    const observer = (event) => {
+      if (!event.keysChanged.has(fieldId)) return
+      const next = fields.get(fieldId)
+      if (!(next instanceof Y.Text)) return
+      clearTimeout(timer)
+      fields.unobserve(observer)
+      resolve(next)
+    }
+
+    fields.observe(observer)
+  })
 }
 
 async function run() {
@@ -99,9 +130,14 @@ async function run() {
   log('  socket connected:', socket.id)
 
   socket.on('yjs:error', (err) => log('  yjs:error', err))
+  let requestedServerState = false
   socket.on('yjs:message', ({ recordId, data }) => {
     if (recordId !== RECORD_ID) return
     handleIncomingMessage(doc, socket, new Uint8Array(data))
+    if (!requestedServerState) {
+      requestedServerState = true
+      sendSyncStep1(doc, socket)
+    }
   })
   socket.on('yjs:update', ({ recordId, data }) => {
     if (recordId !== RECORD_ID) return
@@ -126,12 +162,7 @@ async function run() {
   log('  activeSocketCount:', midStatus.socket.activeSocketCount, `(expected: ${preStatus.socket.activeSocketCount + 1})`)
 
   log('\n  Injecting Y.Text edit via Y.Map("fields")')
-  const fields = doc.getMap('fields')
-  let yText = fields.get(FIELD_ID)
-  if (!(yText instanceof Y.Text)) {
-    yText = new Y.Text()
-    fields.set(FIELD_ID, yText)
-  }
+  const yText = await waitForYTextField(doc, FIELD_ID)
   const stamp = `YJS-NODE-${new Date().toISOString().slice(11, 19)}`
   doc.transact(() => {
     yText.delete(0, yText.length)

--- a/packages/core-backend/scripts/ops/yjs-node-client.mjs
+++ b/packages/core-backend/scripts/ops/yjs-node-client.mjs
@@ -198,7 +198,9 @@ async function run() {
 
   log('\n=== RESULT ===')
   const ok = {
-    connected: midStatus.sync.activeDocCount > preStatus.sync.activeDocCount,
+    connected:
+      midStatus.sync.activeDocCount >= preStatus.sync.activeDocCount
+      && midStatus.socket.activeSocketCount > preStatus.socket.activeSocketCount,
     flushed: postFlushStatus.bridge.flushSuccessCount > preStatus.bridge.flushSuccessCount,
     noFailures: postFlushStatus.bridge.flushFailureCount === preStatus.bridge.flushFailureCount,
     bridgedToDB: postTitle === stamp,

--- a/packages/core-backend/src/collab/yjs-record-bridge.ts
+++ b/packages/core-backend/src/collab/yjs-record-bridge.ts
@@ -194,18 +194,21 @@ export class YjsRecordBridge {
 
     // Fire and forget — errors logged, not thrown
     this.executePatch(recordId, fields, primaryActorId, actorIds)
-      .then(() => { this._flushSuccessCount++ })
+      .then((applied) => {
+        if (applied) this._flushSuccessCount++
+      })
       .catch((err) => {
         this._flushFailureCount++
         console.error(`[yjs-bridge] Failed to flush patch for record ${recordId}:`, err)
       })
   }
 
-  private async executePatch(recordId: string, fields: Record<string, unknown>, primaryActorId: string, allActorIds: string[]): Promise<void> {
+  private async executePatch(recordId: string, fields: Record<string, unknown>, primaryActorId: string, allActorIds: string[]): Promise<boolean> {
     const input = await this.getWriteInput(recordId, fields, primaryActorId, allActorIds)
-    if (!input) return // record context not available (e.g., deleted)
+    if (!input) return false // record context not available (e.g., deleted)
 
-    await this.recordWriteService.patchRecords(input)
+    const result = await this.recordWriteService.patchRecords(input)
+    return result.updated.length > 0
   }
 
   /**

--- a/packages/core-backend/tests/unit/yjs-poc.test.ts
+++ b/packages/core-backend/tests/unit/yjs-poc.test.ts
@@ -503,6 +503,36 @@ describe('YjsRecordBridge', () => {
     bridge.destroy()
     doc.destroy()
   })
+
+  it('does not count a skipped write input as a successful flush', async () => {
+    const { YjsRecordBridge } = await import('../../src/collab/yjs-record-bridge')
+
+    const doc = new Y.Doc()
+    const fields = doc.getMap('fields')
+    const textField = new Y.Text()
+    fields.set('fld_name', textField)
+
+    const mockPatchRecords = vi.fn().mockResolvedValue({ updated: [{ recordId: 'rec1', version: 2 }] })
+    const mockGetWriteInput = vi.fn().mockResolvedValue(null)
+
+    const bridge = new YjsRecordBridge({} as any, { patchRecords: mockPatchRecords } as any, mockGetWriteInput, {
+      mergeWindowMs: 10,
+      maxDelayMs: 50,
+    })
+
+    bridge.observe('rec1', doc)
+    textField.insert(0, 'hello')
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(mockGetWriteInput).toHaveBeenCalledTimes(1)
+    expect(mockPatchRecords).not.toHaveBeenCalled()
+    expect(bridge.getMetrics().flushSuccessCount).toBe(0)
+    expect(bridge.getMetrics().flushFailureCount).toBe(0)
+
+    bridge.destroy()
+    doc.destroy()
+  })
 })
 
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- complete the Yjs sync handshake by requesting server state from clients after the server sync step
- apply sync-protocol messages with remote origin so seeded server updates are not echoed back as local edits
- make the staging node validator wait for server-seeded Y.Text instead of creating an empty field
- stop counting skipped bridge write inputs as successful flushes

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/yjs-document-invalidation.spec.ts tests/multitable-yjs-cell-binding.spec.ts --reporter=verbose
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/yjs-poc.test.ts tests/unit/yjs-hardening.test.ts --reporter=verbose
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/yjs-poc.test.ts tests/unit/yjs-hardening.test.ts tests/unit/yjs-rest-invalidation.test.ts tests/unit/yjs-awareness.test.ts tests/unit/admin-yjs-status-routes.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- pnpm --filter @metasheet/core-backend exec tsc -p tsconfig.json --noEmit
- Yjs Staging Validation run 24732394563 passed Run A and Run B against 142 staging
