### PR TITLE
chore(onprem): harden env bootstrap for PM2 and env templates

### DIFF
--- a/docker/app.env.attendance-onprem.template
+++ b/docker/app.env.attendance-onprem.template
@@ -11,6 +11,9 @@ BCRYPT_SALT_ROUNDS=12
 POSTGRES_USER=metasheet
 POSTGRES_PASSWORD=change-me
 POSTGRES_DB=metasheet
+# If the target PostgreSQL does not have SSL enabled (typical for local / on-prem
+# dev), append `?sslmode=disable` to DATABASE_URL to avoid migrate.js failing
+# with "The server does not support SSL connections".
 DATABASE_URL=postgres://metasheet:change-me@127.0.0.1:5432/metasheet
 DB_SSL=false
 

--- a/docker/app.env.example
+++ b/docker/app.env.example
@@ -9,6 +9,9 @@ PRODUCT_MODE=platform
 # - onprem | hybrid | saas
 DEPLOYMENT_MODEL=onprem
 JWT_SECRET=change-me
+# If the target PostgreSQL does not have SSL enabled (typical for local / on-prem
+# dev), append `?sslmode=disable` to DATABASE_URL to avoid migrate.js failing
+# with "The server does not support SSL connections".
 DATABASE_URL=postgres://metasheet:change-me@postgres:5432/metasheet
 DB_SSL=false
 REDIS_HOST=redis

--- a/docker/app.env.multitable-onprem.template
+++ b/docker/app.env.multitable-onprem.template
@@ -11,6 +11,9 @@ JWT_SECRET=change-me
 POSTGRES_USER=metasheet
 POSTGRES_PASSWORD=change-me
 POSTGRES_DB=metasheet
+# If the target PostgreSQL does not have SSL enabled (typical for local / on-prem
+# dev), append `?sslmode=disable` to DATABASE_URL to avoid migrate.js failing
+# with "The server does not support SSL connections".
 DATABASE_URL=postgres://metasheet:change-me@127.0.0.1:5432/metasheet
 DB_SSL=false
 

--- a/docker/app.staging.env.example
+++ b/docker/app.staging.env.example
@@ -15,6 +15,9 @@ JWT_SECRET=change-me
 POSTGRES_USER=metasheet
 POSTGRES_PASSWORD=change-me
 POSTGRES_DB=metasheet
+# If the target PostgreSQL does not have SSL enabled (typical for local / on-prem
+# dev), append `?sslmode=disable` to DATABASE_URL to avoid migrate.js failing
+# with "The server does not support SSL connections".
 DATABASE_URL=postgres://metasheet:change-me@postgres:5432/metasheet
 DB_SSL=false
 

--- a/docs/development/onprem-bootstrap-harden-development-20260422.md
+++ b/docs/development/onprem-bootstrap-harden-development-20260422.md
@@ -1,0 +1,117 @@
+# On-Prem Bootstrap Hardening
+
+- **Branch**: `codex/harden-onprem-bootstrap-20260422`
+- **Date**: 2026-04-22
+- **Closes**: #517, #518
+
+## Scope
+
+Two operator-friction bugs surfaced during Pilot R1 on-prem validation
+(2026-03-20). Both are purely operational: no schema changes, no new
+dependencies, no behavior change when the bootstrap scripts are used as
+intended.
+
+### #517 — `DATABASE_URL` `sslmode=disable` not documented
+
+Local PostgreSQL typically does not enable SSL. When an operator copies
+one of the `docker/app.env.*.template` files verbatim and runs
+`migrate.js`, pg throws:
+
+```
+The server does not support SSL connections
+```
+
+None of the four templates mentioned the `?sslmode=disable` workaround.
+
+### #518 — `pm2 start ecosystem.config.cjs` loses `DATABASE_URL`
+
+The on-prem bootstrap scripts (`attendance-onprem-bootstrap.sh` etc.)
+`source docker/app.env` before invoking PM2. An operator running
+`pm2 start ecosystem.config.cjs` directly — e.g. via a Windows scheduled
+task or a fresh shell — skipped that step and the backend crash-looped:
+
+```
+Error: Secret not found for key: DATABASE_URL
+```
+
+The previous `ecosystem.config.cjs` only set `NODE_ENV`; every other
+variable was expected to already be in `process.env`.
+
+## Fixes
+
+### ecosystem.config.cjs — inline env loader (closes #518)
+
+`ecosystem.config.cjs` now reads `docker/app.env` at config-parse time
+and populates `process.env` (without overriding anything already set
+by the shell). PM2 forks the backend with those vars inherited, so
+both the bootstrap path and the direct `pm2 start` path produce the
+same runtime env.
+
+Why inline instead of `dotenv`:
+- Zero new dependencies — on-prem images stay lean.
+- The templates use a simple `KEY=value` shape that doesn't need `${var}`
+  expansion. A 30-line parser is enough and keeps the contract honest
+  (operators can still `source` the file from bash and get identical
+  results).
+
+Semantics (covered by tests):
+- Comments (`#`) and blank lines skipped.
+- `=` inside values preserved.
+- Single/double quotes around values stripped (bash-like).
+- Shell env wins over file values — a `DATABASE_URL=...` exported before
+  `pm2 start` is not overridden.
+- Missing file = silent no-op. Dev machines and CI (which never write
+  `docker/app.env`) are unaffected.
+
+### docker/app.env.*.template — sslmode note (closes #517)
+
+All four operator-facing env templates now explain the
+`?sslmode=disable` suffix on the `DATABASE_URL` line:
+
+```env
+# If the target PostgreSQL does not have SSL enabled (typical for local /
+# on-prem dev), append `?sslmode=disable` to DATABASE_URL to avoid
+# migrate.js failing with "The server does not support SSL connections".
+DATABASE_URL=postgres://metasheet:change-me@127.0.0.1:5432/metasheet
+```
+
+Touched templates:
+- `docker/app.env.example`
+- `docker/app.env.attendance-onprem.template`
+- `docker/app.env.multitable-onprem.template`
+- `docker/app.staging.env.example`
+
+## Tests
+
+New: `scripts/ops/ecosystem-env-loader.test.mjs` (Node built-in test
+runner). Spawns a fresh `node` child in a temp dir to exercise the
+exact code path PM2 takes when it `require`s the config. 7 cases:
+
+- populates `process.env` from `docker/app.env`
+- skips comments and blank lines
+- strips single/double quotes (bash-like)
+- preserves `=` inside values
+- preserves empty values
+- does NOT override shell env values
+- is a silent no-op when `docker/app.env` is missing
+
+Run:
+
+```bash
+node --test scripts/ops/ecosystem-env-loader.test.mjs
+```
+
+## Risk
+
+- **Bootstrap scripts path** — unchanged. `attendance-onprem-bootstrap.sh`
+  still `source`s the env file; the inline loader then finds every key
+  already in `process.env` and skips the assignment (shell wins).
+- **Missing env file** — in dev and CI there is no `docker/app.env`.
+  The `fs.existsSync` guard makes the loader a no-op, behavior unchanged.
+- **Format drift** — if someone starts using `${VAR}` expansion in the
+  templates, the inline parser will NOT expand it. Current templates do
+  not rely on expansion. If that need appears, switch to `dotenv-expand`
+  in a follow-up.
+- **PM2 config semantics** — the `env: { NODE_ENV: 'development' }` block
+  is unchanged. PM2 merges it on top of the inherited `process.env`,
+  so `NODE_ENV` still wins when you run with `--env production`.

--- a/docs/development/onprem-bootstrap-harden-verification-20260422.md
+++ b/docs/development/onprem-bootstrap-harden-verification-20260422.md
@@ -1,0 +1,92 @@
+# Verification — On-Prem Bootstrap Hardening
+
+- **Branch**: `codex/harden-onprem-bootstrap-20260422`
+- **Date**: 2026-04-22
+- **Development MD**: `onprem-bootstrap-harden-development-20260422.md`
+- **Closes**: #517, #518
+
+## Evidence matrix
+
+| Issue | Fix | Test(s) |
+|---|---|---|
+| #517 DATABASE_URL sslmode not documented | Added `?sslmode=disable` comment above `DATABASE_URL` in all four env templates | Visual diff on `docker/app.env.*.template` |
+| #518 `pm2 start` loses `DATABASE_URL` | Inline env loader at top of `ecosystem.config.cjs` reads `docker/app.env` into `process.env` | `scripts/ops/ecosystem-env-loader.test.mjs` (7 cases) |
+| #518 bootstrap scripts still win | Loader uses `if (!(key in process.env))` — shell-exported values are preserved | Loader test: "does NOT override values already present in the shell env" |
+| #518 dev/CI path | `fs.existsSync` guard — missing `docker/app.env` is a silent no-op | Loader test: "is a silent no-op when docker/app.env is missing" |
+
+## Test runs
+
+### Ecosystem env loader
+
+```
+node --test scripts/ops/ecosystem-env-loader.test.mjs
+```
+
+Result:
+
+```text
+✔ populates process.env from docker/app.env (27ms)
+✔ skips comments and blank lines without error (27ms)
+✔ strips single and double quotes from values (bash-like) (28ms)
+✔ preserves `=` characters inside values (27ms)
+✔ preserves empty values without crashing (28ms)
+✔ does NOT override values already present in the shell env (27ms)
+✔ is a silent no-op when docker/app.env is missing (27ms)
+✔ ecosystem.config.cjs env loader (196ms)
+ℹ tests 7
+ℹ pass 7
+ℹ fail 0
+```
+
+### Manual smoke — direct `pm2 start` path
+
+Before this change (reproducing #518 on bare shell):
+
+```bash
+# In a fresh shell with no sourced env
+node -e "require('./ecosystem.config.cjs'); console.log(process.env.DATABASE_URL)"
+# → undefined  (backend would crash-loop here)
+```
+
+After this change, with a populated `docker/app.env`:
+
+```bash
+cat > docker/app.env <<'EOF'
+DATABASE_URL=postgres://metasheet:change-me@127.0.0.1:5432/metasheet?sslmode=disable
+JWT_SECRET=dev-secret
+EOF
+
+node -e "require('./ecosystem.config.cjs'); console.log(process.env.DATABASE_URL)"
+# → postgres://metasheet:change-me@127.0.0.1:5432/metasheet?sslmode=disable
+```
+
+### Manual smoke — bootstrap-script path (unchanged contract)
+
+```bash
+# Simulate what attendance-onprem-bootstrap.sh does
+DATABASE_URL=postgres://shell-value node -e "
+  require('./ecosystem.config.cjs')
+  console.log(process.env.DATABASE_URL)
+"
+# → postgres://shell-value   (shell-sourced env wins; file would NOT override)
+```
+
+### Template doc
+
+```
+git diff main -- docker/app.env.example docker/app.env.attendance-onprem.template docker/app.env.multitable-onprem.template docker/app.staging.env.example
+```
+
+Shows the inserted comment block on all four files; no functional env
+values changed.
+
+## Rollback
+
+Both changes are inert when `docker/app.env` is missing, so rollback on
+a running stack is simply:
+
+1. `git revert` the PR commit.
+2. Rebuild & restart. The previous behavior (`pm2 start` fails without
+   `source`, templates silent on `sslmode`) returns.
+
+No schema migration, no data change.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,3 +1,56 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+// --- on-prem env bootstrap (issue #518) -------------------------------------
+//
+// The bootstrap scripts (`attendance-onprem-bootstrap.sh` etc.) normally
+// `source docker/app.env` before invoking PM2. Running `pm2 start
+// ecosystem.config.cjs` directly skipped that step and the backend crashed
+// in a restart loop with `Secret not found for key: DATABASE_URL`.
+//
+// This inline loader reads `docker/app.env` at config-parse time and
+// populates `process.env` (without overriding values already set by the
+// shell), so PM2 inherits the expected runtime env whether the operator
+// ran `bootstrap.sh` or called `pm2 start` directly.
+//
+// Zero extra deps — we intentionally do NOT pull in `dotenv` to keep the
+// on-prem image footprint small. The parser handles the `KEY=value` shape
+// used by all `docker/app.env.*.template` files:
+//   - lines starting with `#` are comments
+//   - blank lines are skipped
+//   - single or double quotes around the value are stripped
+//   - values are NOT subject to `${var}` expansion (bash would expand them
+//     in `source`, but the templates do not rely on expansion)
+// ---------------------------------------------------------------------------
+function loadOnPremEnvFile(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return
+    const content = fs.readFileSync(filePath, 'utf8')
+    for (const rawLine of content.split(/\r?\n/)) {
+      const line = rawLine.trim()
+      if (!line || line.startsWith('#')) continue
+      const eq = line.indexOf('=')
+      if (eq <= 0) continue
+      const key = line.slice(0, eq).trim()
+      let value = line.slice(eq + 1).trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      if (!(key in process.env)) {
+        process.env[key] = value
+      }
+    }
+  } catch {
+    // Best effort: if reading/parsing fails, fall back to the shell-sourced
+    // env path. Operators using the bootstrap scripts are unaffected.
+  }
+}
+
+loadOnPremEnvFile(path.join(__dirname, 'docker', 'app.env'))
+
 module.exports = {
   apps: [
     {

--- a/scripts/ops/ecosystem-env-loader.test.mjs
+++ b/scripts/ops/ecosystem-env-loader.test.mjs
@@ -1,0 +1,116 @@
+/**
+ * Tests for the inline env loader in `ecosystem.config.cjs` (issue #518).
+ *
+ * The loader reads `docker/app.env` at config-parse time so
+ * `pm2 start ecosystem.config.cjs` inherits the runtime env even when the
+ * operator did not first `source` the file via the bootstrap scripts.
+ *
+ * This test spawns a fresh Node child process with a temp cwd so the loader
+ * is exercised exactly as PM2 would parse it: a bare `require` of the config
+ * must populate `process.env` from the sibling `docker/app.env`.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(scriptDir, '..', '..')
+const ecosystemConfigPath = join(repoRoot, 'ecosystem.config.cjs')
+
+function runLoader({ envFile, childEnv = {} }) {
+  const sandbox = mkdtempSync(join(tmpdir(), 'ecosystem-env-loader-'))
+  try {
+    copyFileSync(ecosystemConfigPath, join(sandbox, 'ecosystem.config.cjs'))
+    if (envFile !== null) {
+      mkdirSync(join(sandbox, 'docker'), { recursive: true })
+      writeFileSync(join(sandbox, 'docker', 'app.env'), envFile, 'utf8')
+    }
+    const result = spawnSync(process.execPath, [
+      '-e',
+      `require('./ecosystem.config.cjs'); console.log(JSON.stringify({
+        DATABASE_URL: process.env.DATABASE_URL ?? null,
+        JWT_SECRET: process.env.JWT_SECRET ?? null,
+        EMPTY_VAL: process.env.EMPTY_VAL ?? null,
+        WITH_EQUALS: process.env.WITH_EQUALS ?? null,
+        OVERRIDE_ME: process.env.OVERRIDE_ME ?? null,
+        COMMENT_VAR: process.env.COMMENT_VAR ?? null,
+      }))`,
+    ], {
+      cwd: sandbox,
+      env: { ...process.env, ...childEnv },
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `loader crashed: stderr=${result.stderr}`)
+    return JSON.parse(result.stdout.trim().split('\n').pop())
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true })
+  }
+}
+
+describe('ecosystem.config.cjs env loader', () => {
+  it('populates process.env from docker/app.env', () => {
+    const out = runLoader({
+      envFile: 'DATABASE_URL=postgres://a/b?sslmode=disable\nJWT_SECRET=secret-value\n',
+    })
+    assert.equal(out.DATABASE_URL, 'postgres://a/b?sslmode=disable')
+    assert.equal(out.JWT_SECRET, 'secret-value')
+  })
+
+  it('skips comments and blank lines without error', () => {
+    const out = runLoader({
+      envFile: [
+        '# Comment line should be ignored',
+        '',
+        'DATABASE_URL=postgres://x/y',
+        '  # Indented comment',
+        'COMMENT_VAR=seen',
+      ].join('\n'),
+    })
+    assert.equal(out.DATABASE_URL, 'postgres://x/y')
+    assert.equal(out.COMMENT_VAR, 'seen')
+  })
+
+  it('strips single and double quotes from values (bash-like)', () => {
+    const out = runLoader({
+      envFile: 'JWT_SECRET="double-quoted"\nDATABASE_URL=\'single-quoted\'\n',
+    })
+    assert.equal(out.JWT_SECRET, 'double-quoted')
+    assert.equal(out.DATABASE_URL, 'single-quoted')
+  })
+
+  it('preserves `=` characters inside values', () => {
+    const out = runLoader({
+      envFile: 'WITH_EQUALS=a=b=c\n',
+    })
+    assert.equal(out.WITH_EQUALS, 'a=b=c')
+  })
+
+  it('preserves empty values without crashing', () => {
+    const out = runLoader({
+      envFile: 'EMPTY_VAL=\nDATABASE_URL=postgres://ok\n',
+    })
+    assert.equal(out.EMPTY_VAL, '')
+    assert.equal(out.DATABASE_URL, 'postgres://ok')
+  })
+
+  it('does NOT override values already present in the shell env', () => {
+    const out = runLoader({
+      envFile: 'OVERRIDE_ME=file-value\nDATABASE_URL=postgres://from-file\n',
+      childEnv: { OVERRIDE_ME: 'shell-wins' },
+    })
+    assert.equal(out.OVERRIDE_ME, 'shell-wins')
+    assert.equal(out.DATABASE_URL, 'postgres://from-file')
+  })
+
+  it('is a silent no-op when docker/app.env is missing', () => {
+    // The bootstrap scripts may have already exported env vars; missing file
+    // is the expected path in dev / CI, and the loader must not throw.
+    const out = runLoader({ envFile: null })
+    assert.equal(out.DATABASE_URL, null)
+    assert.equal(out.JWT_SECRET, null)
+  })
+})


### PR DESCRIPTION
## Summary

Closes two operator-friction bugs from Pilot R1 on-prem validation:

- **#518** — `pm2 start ecosystem.config.cjs` previously crash-looped with \`Secret not found for key: DATABASE_URL\` unless the operator first sourced \`docker/app.env\`. The config now reads the env file at config-parse time and populates \`process.env\` (without overriding shell-exported values), so both the bootstrap-script path and the direct \`pm2 start\` path produce the same runtime env. Zero new dependencies — an inline 30-line parser handles the KEY=value shape the templates already use.
- **#517** — All four \`docker/app.env.*.template\` files now document the \`?sslmode=disable\` suffix required when the target PostgreSQL does not enable SSL. Pure doc line above \`DATABASE_URL\`.

## What the loader guarantees (tests verify)

- Populates \`process.env\` from \`docker/app.env\` on \`require('./ecosystem.config.cjs')\`
- Skips \`#\` comments and blank lines
- Strips matching single / double quotes around values (bash-like)
- Preserves \`=\` characters inside values
- Preserves empty values without crashing
- **Does NOT override values already in the shell env** — bootstrap scripts that \`source\` first keep their precedence
- Silent no-op when \`docker/app.env\` is missing (dev / CI path)

## Test plan

- [x] \`node --test scripts/ops/ecosystem-env-loader.test.mjs\` — 7/7 passed (spawns a fresh node child per case, validates the exact path PM2 takes when \`require\`ing the config).
- [x] \`node -e \"require('./ecosystem.config.cjs')\"\` from a fresh shell — parses without error, no env file required.
- [x] Manual smoke: with \`docker/app.env\` present containing \`DATABASE_URL=...\`, direct \`pm2 start\` no longer loses the variable.

## Risk

- Bootstrap-script path unchanged — the loader skips keys already in \`process.env\`.
- Dev / CI unchanged — no \`docker/app.env\` file, \`fs.existsSync\` short-circuits.
- Templates ship the same default \`DATABASE_URL\` value; only added a comment.

No schema changes, no new dependencies.

## Docs

- \`docs/development/onprem-bootstrap-harden-development-20260422.md\`
- \`docs/development/onprem-bootstrap-harden-verification-20260422.md\`

Closes #517
Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)