### PR TITLE
feat(dingtalk): gate group bindings by automation permission

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -2,7 +2,7 @@
   <div v-if="visible" class="meta-api-mgr__overlay" @click.self="$emit('close')">
     <div class="meta-api-mgr">
       <div class="meta-api-mgr__header">
-        <h4 class="meta-api-mgr__title">API Tokens, Webhooks &amp; DingTalk Groups</h4>
+        <h4 class="meta-api-mgr__title">{{ managerTitle }}</h4>
         <button class="meta-api-mgr__close" type="button" @click="$emit('close')">&times;</button>
       </div>
 
@@ -26,6 +26,7 @@
           Webhooks
         </button>
         <button
+          v-if="canManageDingTalkGroups"
           role="tab"
           :aria-selected="activeTab === 'dingtalk-groups'"
           class="meta-api-mgr__tab"
@@ -38,6 +39,14 @@
 
       <div class="meta-api-mgr__body">
         <div v-if="error" class="meta-api-mgr__error" role="alert">{{ error }}</div>
+        <div
+          v-if="!canManageDingTalkGroups"
+          class="meta-api-mgr__notice"
+          role="note"
+          data-dingtalk-groups-permission-note="true"
+        >
+          DingTalk group bindings require automation management permission for this table.
+        </div>
 
         <!-- ===== TOKENS TAB ===== -->
         <template v-if="activeTab === 'tokens'">
@@ -166,7 +175,7 @@
         </template>
 
         <!-- ===== DINGTALK GROUPS TAB ===== -->
-        <template v-if="activeTab === 'dingtalk-groups'">
+        <template v-if="canManageDingTalkGroups && activeTab === 'dingtalk-groups'">
           <section v-if="showDingTalkGroupForm" class="meta-api-mgr__form" data-dingtalk-group-form="true">
             <div class="meta-api-mgr__form-title">
               {{ editingDingTalkGroupId ? 'Edit DingTalk Group' : 'New DingTalk Group' }}
@@ -328,11 +337,14 @@ import type {
 } from '../types'
 import type { MultitableApiClient } from '../api/client'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   visible: boolean
   sheetId?: string
   client?: MultitableApiClient
-}>()
+  canManageAutomation?: boolean
+}>(), {
+  canManageAutomation: true,
+})
 
 const emit = defineEmits<{
   (e: 'close'): void
@@ -377,12 +389,17 @@ const dingTalkGroupDraft = ref({
   enabled: true,
 })
 
+const canManageDingTalkGroups = computed(() => props.canManageAutomation !== false)
+const managerTitle = computed(() => canManageDingTalkGroups.value
+  ? 'API Tokens, Webhooks & DingTalk Groups'
+  : 'API Tokens & Webhooks')
+
 const canSaveWebhook = computed(() => {
   return webhookDraft.value.name.trim() && webhookDraft.value.url.startsWith('https://') && webhookDraft.value.events.length > 0
 })
 
 const canSaveDingTalkGroup = computed(() => {
-  return dingTalkGroupDraft.value.name.trim() && dingTalkGroupDraft.value.webhookUrl.trim().startsWith('https://')
+  return canManageDingTalkGroups.value && dingTalkGroupDraft.value.name.trim() && dingTalkGroupDraft.value.webhookUrl.trim().startsWith('https://')
 })
 
 function formatDate(iso: string): string {
@@ -615,6 +632,11 @@ async function onViewDeliveries(webhookId: string) {
 // ---- DingTalk group actions ----
 async function loadDingTalkGroups() {
   if (!props.client) return
+  if (!canManageDingTalkGroups.value) {
+    clearDingTalkGroupState()
+    dingTalkGroupsLoading.value = false
+    return
+  }
   dingTalkGroupsLoading.value = true
   error.value = null
   try {
@@ -626,7 +648,21 @@ async function loadDingTalkGroups() {
   }
 }
 
+function clearDingTalkGroupState() {
+  dingTalkGroups.value = []
+  showDingTalkGroupForm.value = false
+  editingDingTalkGroupId.value = null
+  dingTalkDeliveriesRequestToken += 1
+  dingTalkDeliveriesGroupId.value = null
+  dingTalkDeliveriesLoading.value = false
+  dingTalkDeliveries.value = []
+  if (activeTab.value === 'dingtalk-groups') {
+    activeTab.value = 'tokens'
+  }
+}
+
 function openDingTalkGroupForm() {
+  if (!canManageDingTalkGroups.value) return
   editingDingTalkGroupId.value = null
   dingTalkGroupDraft.value = {
     name: '',
@@ -638,6 +674,7 @@ function openDingTalkGroupForm() {
 }
 
 function openEditDingTalkGroup(group: DingTalkGroupDestination) {
+  if (!canManageDingTalkGroups.value) return
   editingDingTalkGroupId.value = group.id
   dingTalkGroupDraft.value = {
     name: group.name,
@@ -654,7 +691,7 @@ function cancelDingTalkGroupForm() {
 }
 
 async function onSaveDingTalkGroup() {
-  if (!props.client || busy.value || !canSaveDingTalkGroup.value) return
+  if (!props.client || busy.value || !canManageDingTalkGroups.value || !canSaveDingTalkGroup.value) return
   busy.value = true
   error.value = null
   try {
@@ -682,7 +719,7 @@ async function onSaveDingTalkGroup() {
 }
 
 async function onToggleDingTalkGroup(group: DingTalkGroupDestination) {
-  if (!props.client || busy.value) return
+  if (!props.client || busy.value || !canManageDingTalkGroups.value) return
   busy.value = true
   error.value = null
   try {
@@ -696,7 +733,7 @@ async function onToggleDingTalkGroup(group: DingTalkGroupDestination) {
 }
 
 async function onTestDingTalkGroup(groupId: string) {
-  if (!props.client || busy.value) return
+  if (!props.client || busy.value || !canManageDingTalkGroups.value) return
   busy.value = true
   error.value = null
   try {
@@ -713,7 +750,7 @@ async function onTestDingTalkGroup(groupId: string) {
 }
 
 async function loadDingTalkDeliveries(groupId: string) {
-  if (!props.client) return
+  if (!props.client || !canManageDingTalkGroups.value) return
   const requestToken = ++dingTalkDeliveriesRequestToken
   dingTalkDeliveriesGroupId.value = groupId
   dingTalkDeliveriesLoading.value = true
@@ -738,7 +775,7 @@ async function loadDingTalkDeliveries(groupId: string) {
 }
 
 async function onViewDingTalkDeliveries(groupId: string) {
-  if (!props.client) return
+  if (!props.client || !canManageDingTalkGroups.value) return
   if (dingTalkDeliveriesGroupId.value === groupId) {
     dingTalkDeliveriesRequestToken += 1
     dingTalkDeliveriesGroupId.value = null
@@ -750,7 +787,7 @@ async function onViewDingTalkDeliveries(groupId: string) {
 }
 
 async function onDeleteDingTalkGroup(groupId: string) {
-  if (!props.client || busy.value) return
+  if (!props.client || busy.value || !canManageDingTalkGroups.value) return
   busy.value = true
   error.value = null
   try {
@@ -782,6 +819,15 @@ watch(
   },
   { immediate: true },
 )
+
+watch(canManageDingTalkGroups, (canManage) => {
+  if (!props.visible) return
+  if (canManage) {
+    void loadDingTalkGroups()
+  } else {
+    clearDingTalkGroupState()
+  }
+})
 </script>
 
 <style scoped>
@@ -867,6 +913,15 @@ watch(
   font-size: 13px;
   background: #fef2f2;
   color: #b91c1c;
+}
+
+.meta-api-mgr__notice {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  background: #eff6ff;
+  color: #1e3a8a;
+  border: 1px solid #bfdbfe;
 }
 
 .meta-api-mgr__empty {

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -304,6 +304,7 @@
       :visible="showApiTokenManager"
       :sheet-id="workbench.activeSheetId.value"
       :client="workbench.client"
+      :can-manage-automation="caps.canManageAutomation.value"
       @close="showApiTokenManager = false"
     />
   </div>

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -418,6 +418,19 @@ describe('MetaApiTokenManager', () => {
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups?sheetId=sheet_1'))).toBe(true)
   })
 
+  it('hides DingTalk group management without automation permission', async () => {
+    const { client, fetchFn } = mockClient([], [], [], [fakeDingTalkGroup()])
+    mount({ visible: true, client, canManageAutomation: false })
+    await flushPromises()
+
+    const title = document.querySelector('.meta-api-mgr__title')
+    expect(title?.textContent).toBe('API Tokens & Webhooks')
+    const tabLabels = Array.from(document.querySelectorAll('[role="tab"]')).map((tab) => tab.textContent?.trim())
+    expect(tabLabels).toEqual(['API Tokens', 'Webhooks'])
+    expect(document.querySelector('[data-dingtalk-groups-permission-note]')?.textContent).toContain('DingTalk group bindings require automation management permission')
+    expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/dingtalk-groups'))).toBe(false)
+  })
+
   it('masks DingTalk webhook access token in card display', async () => {
     const { client } = mockClient([], [], [], [fakeDingTalkGroup({
       webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=super-secret-token',

--- a/docs/development/dingtalk-group-permission-panel-development-20260422.md
+++ b/docs/development/dingtalk-group-permission-panel-development-20260422.md
@@ -1,0 +1,39 @@
+# DingTalk Group Permission Panel Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-permission-panel-20260422`
+- Scope: frontend DingTalk group destination management
+
+## Goal
+
+Align the DingTalk Groups management UI with the existing backend permission boundary.
+
+Before this slice, the `API Tokens, Webhooks & DingTalk Groups` modal always exposed the DingTalk Groups tab and preloaded `/api/multitable/dingtalk-groups?sheetId=...`. For users without table automation management permission, the backend correctly returned 403, but the frontend still looked actionable and could show a generic error.
+
+## Implementation
+
+- Added `canManageAutomation` to `MetaApiTokenManager`.
+- Passed `caps.canManageAutomation.value` from `MultitableWorkbench`.
+- Defaulted `canManageAutomation` to `true` for standalone component compatibility.
+- When permission is unavailable:
+  - the modal title downgrades to `API Tokens & Webhooks`
+  - the DingTalk Groups tab is hidden
+  - the component does not preload DingTalk group destinations
+  - a permission note explains that DingTalk group bindings require table automation management permission
+  - any stale DingTalk group state is cleared
+- Guarded DingTalk group mutation/read-detail handlers against programmatic invocation when permission is unavailable.
+- Updated component tests to prove low-permission users do not trigger DingTalk group API calls.
+
+## Files
+
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- This does not change backend RBAC. The server remains the source of truth.
+- This improves the frontend affordance so ordinary table users do not see a group-binding tab they cannot use.
+- A table can still have multiple DingTalk group destinations when managed by an authorized user.

--- a/docs/development/dingtalk-group-permission-panel-verification-20260422.md
+++ b/docs/development/dingtalk-group-permission-panel-verification-20260422.md
@@ -1,0 +1,35 @@
+# DingTalk Group Permission Panel Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-permission-panel-20260422`
+- Status: passed local validation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+rg -n "canManageAutomation|canManageDingTalkGroups|data-dingtalk-groups-permission-note|DingTalk group bindings require automation management permission" apps/web/src/multitable/components/MetaApiTokenManager.vue apps/web/src/multitable/views/MultitableWorkbench.vue apps/web/tests/multitable-api-token-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-group-permission-panel-*.md
+git diff --check
+```
+
+## Expected Coverage
+
+- Existing DingTalk Groups happy paths remain enabled by default.
+- Users without `canManageAutomation` do not see the DingTalk Groups tab.
+- Users without `canManageAutomation` do not trigger `/dingtalk-groups` requests when opening the modal.
+- Workbench passes the current table automation capability into the manager.
+- Frontend build verifies Vue and TypeScript integration.
+
+## Results
+
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false`: passed, 1 file and 20 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `rg -n "canManageAutomation|canManageDingTalkGroups|data-dingtalk-groups-permission-note|DingTalk group bindings require automation management permission" ...`: passed, expected frontend/test/doc references found.
+- `git diff --check`: passed.
+
+## Claude Code CLI
+
+- Local CLI check: `claude --version`
+- Version observed: `2.1.116 (Claude Code)`
+- A read-only `claude -p` review was run for this slice. It suggested a frontend-only permission disclosure and no backend RBAC changes. Claude Code CLI did not edit files.

--- a/docs/development/dingtalk-group-permission-panel-verification-20260422.md
+++ b/docs/development/dingtalk-group-permission-panel-verification-20260422.md
@@ -33,3 +33,28 @@ git diff --check
 - Local CLI check: `claude --version`
 - Version observed: `2.1.116 (Claude Code)`
 - A read-only `claude -p` review was run for this slice. It suggested a frontend-only permission disclosure and no backend RBAC changes. Claude Code CLI did not edit files.
+
+## Rebase Verification - 2026-04-22
+
+Rebased `codex/dingtalk-group-permission-panel-20260422` onto `origin/main@131df2aaf`
+after PR #1034 was squash-merged.
+
+```bash
+git rebase --onto origin/main origin/codex/dingtalk-group-permission-panel-base-20260422 HEAD
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+rg -n "canManageAutomation|canManageDingTalkGroups|data-dingtalk-groups-permission-note|DingTalk group bindings require automation management permission" apps/web/src/multitable/components/MetaApiTokenManager.vue apps/web/src/multitable/views/MultitableWorkbench.vue apps/web/tests/multitable-api-token-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-group-permission-panel-*.md
+git diff --check
+pnpm --filter @metasheet/web build
+git checkout -- plugins/ tools/
+```
+
+Results:
+
+- Rebase completed cleanly; replayed only the group permission panel commit on top of main.
+- `tests/multitable-api-token-manager.spec.ts`: passed, 20 tests.
+- `rg` frontend/test/doc check: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/web build`: passed.
+- Build warnings were limited to the existing `WorkflowDesigner.vue` mixed import warning and existing large chunk warnings.
+- PNPM install recreated tracked plugin/tool `node_modules` symlink noise; it was cleaned with `git checkout -- plugins/ tools/` before pushing.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -47,6 +47,8 @@ Management-side UI path:
 Notes:
 
 - this is a management-side page, not a normal end-user page
+- the DingTalk Groups tab is shown only to users who can manage automations on the current table
+- users without that permission can still use API tokens and webhooks, but the UI will not preload or expose table-scoped DingTalk group bindings
 - the current model manually registers a group webhook; it does not auto-import your DingTalk groups
 
 ## B. Configure a DingTalk person notification rule

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -229,6 +229,8 @@ This is the preferred implementation for:
 
 Authoring guardrail:
 
+- the DingTalk Groups management tab is visible only to users with table automation management permission
+- users without that permission do not trigger table-scoped DingTalk group binding requests from the frontend
 - group-message and person-message automations disable save when the selected public form link cannot produce a working fill link
 - group-message and person-message automations disable save when the selected internal processing view is not in the current sheet
 - automation create/update APIs reject invalid public form or internal processing links before rules are saved


### PR DESCRIPTION
## Summary
- pass `canManageAutomation` from `MultitableWorkbench` into `MetaApiTokenManager`
- hide the DingTalk Groups tab and skip `/dingtalk-groups` preloading when the user cannot manage automations for the table
- keep API tokens and webhooks usable, with a clear DingTalk group permission note
- add frontend coverage and update DingTalk docs plus development/verification notes
- rebase onto `main@131df2aaf` after PR #1034 was squash-merged

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false` (20 passed)
- `pnpm --filter @metasheet/web build`
- `rg -n "canManageAutomation|canManageDingTalkGroups|data-dingtalk-groups-permission-note|DingTalk group bindings require automation management permission" apps/web/src/multitable/components/MetaApiTokenManager.vue apps/web/src/multitable/views/MultitableWorkbench.vue apps/web/tests/multitable-api-token-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-group-permission-panel-*.md`
- `git diff --check`

## Notes
- PNPM-created tracked plugin/tool node_modules symlink dirtiness was cleaned before pushing
- Vite build only reports existing WorkflowDesigner mixed import and large chunk warnings