### PR TITLE
fix(dingtalk): show readable forbidden errors

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -99,7 +99,7 @@ async function parseJson<T>(res: Response): Promise<T> {
   const body = raw ? safeParseJson(raw) : null
   if (!res.ok) {
     const payload = normalizeApiErrorPayload(body)
-    const error = new Error(firstFieldError(payload.fieldErrors) ?? payload.message ?? `API ${res.status}`) as Error & {
+    const error = new Error(firstFieldError(payload.fieldErrors) ?? payload.message ?? defaultApiErrorMessage(payload.code, res.status)) as Error & {
       status?: number
       code?: string
       fieldErrors?: Record<string, string>
@@ -134,6 +134,19 @@ function normalizeApiErrorPayload(body: unknown): ApiErrorPayload {
   if (error && typeof error === 'object') return error as ApiErrorPayload
   if (typeof record.message === 'string') return { message: record.message }
   return {}
+}
+
+function defaultApiErrorMessage(code: string | undefined, status: number): string {
+  switch (code) {
+    case 'FORBIDDEN':
+      return 'Insufficient permissions'
+    case 'UNAUTHENTICATED':
+      return 'Please sign in to continue.'
+    case 'VALIDATION_ERROR':
+      return 'Please check the submitted data and try again.'
+    default:
+      return `API ${status}`
+  }
 }
 
 function unwrapDataBody(body: unknown): unknown {

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -431,6 +431,29 @@ describe('MetaApiTokenManager', () => {
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/dingtalk-groups'))).toBe(false)
   })
 
+  it('shows readable permission errors when DingTalk group loading is forbidden', async () => {
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && url.includes('/tokens') && !url.includes('/rotate')) {
+        return okResponse({ tokens: [] })
+      }
+      if (method === 'GET' && url.includes('/webhooks') && !url.includes('/deliveries')) {
+        return okResponse({ webhooks: [] })
+      }
+      if (method === 'GET' && url.includes('/dingtalk-groups')) {
+        return new Response(JSON.stringify({ ok: false, error: { code: 'FORBIDDEN' } }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return okResponse({})
+    })
+    mount({ visible: true, client: new MultitableApiClient({ fetchFn }) })
+    await flushPromises()
+
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain('Insufficient permissions')
+  })
+
   it('masks DingTalk webhook access token in card display', async () => {
     const { client } = mockClient([], [], [], [fakeDingTalkGroup({
       webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=super-secret-token',

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -348,6 +348,34 @@ describe('MultitableApiClient', () => {
     })
   })
 
+  it('maps code-only forbidden responses to insufficient permissions', async () => {
+    const client = new MultitableApiClient({
+      fetchFn: vi.fn().mockResolvedValue(new Response(JSON.stringify({
+        ok: false,
+        error: { code: 'FORBIDDEN' },
+      }), { status: 403 })),
+    })
+
+    const error = await client.listDingTalkGroups('sheet_1').catch((err) => err)
+
+    expect(error.message).toBe('Insufficient permissions')
+    expect(error.status).toBe(403)
+    expect(error.code).toBe('FORBIDDEN')
+  })
+
+  it('preserves legacy string error payloads for permission failures', async () => {
+    const client = new MultitableApiClient({
+      fetchFn: vi.fn().mockResolvedValue(new Response(JSON.stringify({
+        error: 'Insufficient permissions',
+      }), { status: 403 })),
+    })
+
+    const error = await client.listDingTalkGroups('sheet_1').catch((err) => err)
+
+    expect(error.message).toBe('Insufficient permissions')
+    expect(error.status).toBe(403)
+  })
+
   it('prepares a person field preset', async () => {
     const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       ok: true,

--- a/docs/development/dingtalk-forbidden-error-copy-development-20260422.md
+++ b/docs/development/dingtalk-forbidden-error-copy-development-20260422.md
@@ -1,0 +1,44 @@
+# DingTalk Forbidden Error Copy Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-forbidden-error-copy-20260422`
+- Scope: frontend multitable API error handling
+
+## Goal
+
+Make code-only backend `FORBIDDEN` responses readable in the frontend.
+
+After the DingTalk Groups panel was gated by table automation permissions, stale or direct requests can still be denied by the backend. Some table-scoped endpoints return:
+
+```json
+{ "ok": false, "error": { "code": "FORBIDDEN" } }
+```
+
+Before this slice, `MultitableApiClient` surfaced that as `API 403`. The target behavior is `Insufficient permissions`, matching existing legacy string error envelopes.
+
+## Implementation
+
+- Added a `defaultApiErrorMessage()` helper in `MultitableApiClient`.
+- Preserved the existing error priority:
+  - first field-level validation error
+  - explicit backend `error.message`
+  - frontend code fallback
+  - generic `API {status}`
+- Mapped `FORBIDDEN` without a backend message to `Insufficient permissions`.
+- Added fallback copy for `UNAUTHENTICATED` and `VALIDATION_ERROR` while leaving unknown codes on the generic status fallback.
+- Added client tests using DingTalk group list requests because that is the current user-facing permission path.
+- Added a `MetaApiTokenManager` assertion that a forbidden DingTalk Groups preload shows the readable permission message in the alert.
+
+## Files
+
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+- `apps/web/tests/multitable-client.spec.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- This does not change backend authorization.
+- This does not change successful DingTalk group binding flows.
+- Existing string error envelopes such as `{ "error": "Insufficient permissions" }` remain preserved as-is.

--- a/docs/development/dingtalk-forbidden-error-copy-verification-20260422.md
+++ b/docs/development/dingtalk-forbidden-error-copy-verification-20260422.md
@@ -1,0 +1,36 @@
+# DingTalk Forbidden Error Copy Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-forbidden-error-copy-20260422`
+- Status: passed local validation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-api-token-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+rg -n "defaultApiErrorMessage|Insufficient permissions|FORBIDDEN|code-only forbidden|DingTalk group loading is forbidden" apps/web/src/multitable/api/client.ts apps/web/tests/multitable-client.spec.ts apps/web/tests/multitable-api-token-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-forbidden-error-copy-*.md
+git diff --check
+```
+
+## Expected Coverage
+
+- Code-only `FORBIDDEN` responses from DingTalk group list requests produce `Insufficient permissions`.
+- Legacy string error envelopes still produce the original string message.
+- `MetaApiTokenManager` shows `Insufficient permissions` when DingTalk group loading is denied.
+- Field-level errors remain higher priority than backend messages and code fallback.
+- Existing DingTalk Groups panel permission gating tests still pass.
+- Frontend build verifies TypeScript integration.
+
+## Results
+
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-api-token-manager.spec.ts --watch=false`: passed, 2 files and 37 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `rg -n "defaultApiErrorMessage|Insufficient permissions|FORBIDDEN|code-only forbidden|DingTalk group loading is forbidden" ...`: passed, expected frontend/test/doc references found.
+- `git diff --check`: passed.
+
+## Claude Code CLI
+
+- Local CLI check: `claude --version`
+- Version observed: `2.1.117 (Claude Code)`
+- A read-only `claude -p` attempt was made with `--max-budget-usd 0.25`; it exited with `Exceeded USD budget (0.25)` before returning analysis. Claude Code CLI did not edit files.

--- a/docs/development/dingtalk-forbidden-error-copy-verification-20260422.md
+++ b/docs/development/dingtalk-forbidden-error-copy-verification-20260422.md
@@ -34,3 +34,30 @@ git diff --check
 - Local CLI check: `claude --version`
 - Version observed: `2.1.117 (Claude Code)`
 - A read-only `claude -p` attempt was made with `--max-budget-usd 0.25`; it exited with `Exceeded USD budget (0.25)` before returning analysis. Claude Code CLI did not edit files.
+
+## Rebase Verification - 2026-04-22
+
+Rebased `codex/dingtalk-forbidden-error-copy-20260422` onto `origin/main@0c46bdeb6`
+after PR #1037 was squash-merged.
+
+```bash
+git rebase --onto origin/main origin/codex/dingtalk-forbidden-error-copy-base-20260422 HEAD
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-api-token-manager.spec.ts --watch=false
+rg -n "defaultApiErrorMessage|Insufficient permissions|FORBIDDEN|code-only forbidden|DingTalk group loading is forbidden" apps/web/src/multitable/api/client.ts apps/web/tests/multitable-client.spec.ts apps/web/tests/multitable-api-token-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-forbidden-error-copy-*.md
+git diff --check
+pnpm --filter @metasheet/web build
+git checkout -- plugins/ tools/
+```
+
+Results:
+
+- Rebase completed cleanly; replayed only the readable forbidden error copy commit on top of main.
+- `tests/multitable-client.spec.ts`: passed, 16 tests.
+- `tests/multitable-api-token-manager.spec.ts`: passed, 21 tests.
+- Combined target suite: passed, 2 files and 37 tests.
+- `rg` frontend/test/doc check: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/web build`: passed.
+- Build warnings were limited to the existing `WorkflowDesigner.vue` mixed import warning and existing large chunk warnings.
+- PNPM install recreated tracked plugin/tool `node_modules` symlink noise; it was cleaned with `git checkout -- plugins/ tools/` before pushing.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -49,6 +49,7 @@ Notes:
 - this is a management-side page, not a normal end-user page
 - the DingTalk Groups tab is shown only to users who can manage automations on the current table
 - users without that permission can still use API tokens and webhooks, but the UI will not preload or expose table-scoped DingTalk group bindings
+- if a stale or direct DingTalk group binding request is still denied by the backend, the frontend reports `Insufficient permissions` instead of a generic `API 403`
 - the current model manually registers a group webhook; it does not auto-import your DingTalk groups
 
 ## B. Configure a DingTalk person notification rule

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -231,6 +231,7 @@ Authoring guardrail:
 
 - the DingTalk Groups management tab is visible only to users with table automation management permission
 - users without that permission do not trigger table-scoped DingTalk group binding requests from the frontend
+- code-only `FORBIDDEN` responses from table-scoped APIs are shown as `Insufficient permissions`, avoiding generic `API 403` copy
 - group-message and person-message automations disable save when the selected public form link cannot produce a working fill link
 - group-message and person-message automations disable save when the selected internal processing view is not in the current sheet
 - automation create/update APIs reject invalid public form or internal processing links before rules are saved


### PR DESCRIPTION
## Summary
- map code-only `FORBIDDEN` API responses to `Insufficient permissions` in `MultitableApiClient`
- keep field-level errors and explicit backend messages higher priority
- cover DingTalk group list 403 handling at client level and in `MetaApiTokenManager` alert rendering
- document the frontend behavior and add development/verification notes
- rebase onto `main@0c46bdeb6` after PR #1037 was squash-merged

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-api-token-manager.spec.ts --watch=false` (37 passed)
- `pnpm --filter @metasheet/web build`
- `rg -n "defaultApiErrorMessage|Insufficient permissions|FORBIDDEN|code-only forbidden|DingTalk group loading is forbidden" apps/web/src/multitable/api/client.ts apps/web/tests/multitable-client.spec.ts apps/web/tests/multitable-api-token-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-forbidden-error-copy-*.md`
- `git diff --check`

## Notes
- PNPM-created tracked plugin/tool node_modules symlink dirtiness was cleaned before pushing
- Vite build only reports existing WorkflowDesigner mixed import and large chunk warnings