### PR TITLE
docs(dingtalk): explain group binding scope

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -176,6 +176,11 @@
 
         <!-- ===== DINGTALK GROUPS TAB ===== -->
         <template v-if="canManageDingTalkGroups && activeTab === 'dingtalk-groups'">
+          <section class="meta-api-mgr__notice" data-dingtalk-groups-scope-note="true">
+            <strong>Table-scoped DingTalk groups</strong>
+            <span>Groups created here are bound to this table. You can add multiple groups and choose one or more in automations.</span>
+          </section>
+
           <section v-if="showDingTalkGroupForm" class="meta-api-mgr__form" data-dingtalk-group-form="true">
             <div class="meta-api-mgr__form-title">
               {{ editingDingTalkGroupId ? 'Edit DingTalk Group' : 'New DingTalk Group' }}
@@ -922,6 +927,9 @@ watch(canManageDingTalkGroups, (canManage) => {
   background: #eff6ff;
   color: #1e3a8a;
   border: 1px solid #bfdbfe;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .meta-api-mgr__empty {

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -405,7 +405,10 @@ describe('MetaApiTokenManager', () => {
   // ---- DingTalk group tests ----
 
   it('switches to DingTalk groups tab', async () => {
-    const { client, fetchFn } = mockClient([], [], [], [fakeDingTalkGroup()])
+    const { client, fetchFn } = mockClient([], [], [], [
+      fakeDingTalkGroup(),
+      fakeDingTalkGroup({ id: 'dt_2', name: 'QA DingTalk Group' }),
+    ])
     mount({ visible: true, client })
     await flushPromises()
 
@@ -414,7 +417,11 @@ describe('MetaApiTokenManager', () => {
     await flushPromises()
 
     const cards = document.querySelectorAll('[data-dingtalk-group-id]')
-    expect(cards.length).toBe(1)
+    expect(cards.length).toBe(2)
+    const scopeNote = document.querySelector('[data-dingtalk-groups-scope-note]') as HTMLElement
+    expect(scopeNote?.textContent).toContain('bound to this table')
+    expect(scopeNote?.textContent).toContain('add multiple groups')
+    expect(scopeNote?.textContent).toContain('choose one or more in automations')
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups?sheetId=sheet_1'))).toBe(true)
   })
 

--- a/docs/development/dingtalk-group-scope-guidance-development-20260422.md
+++ b/docs/development/dingtalk-group-scope-guidance-development-20260422.md
@@ -1,0 +1,35 @@
+# DingTalk Group Scope Guidance Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-scope-guidance-20260422`
+- Scope: frontend DingTalk group destination guidance
+
+## Goal
+
+Make the DingTalk Groups management tab explain how group bindings relate to the current table.
+
+Users asked whether a table can bind DingTalk groups from the frontend and whether one table can associate with multiple groups. The underlying implementation already supports table-scoped DingTalk group destinations and automation rules can choose one or more groups. This slice makes that model visible in the manager UI.
+
+## Implementation
+
+- Added a guidance note at the top of the DingTalk Groups tab.
+- Reused the existing `meta-api-mgr__notice` visual style.
+- The note states:
+  - groups created here are bound to the current table
+  - multiple groups can be added
+  - automations can choose one or more groups as send targets
+- Updated the existing DingTalk Groups component test to assert the guidance is present.
+- Updated the DingTalk operations and capability docs.
+
+## Files
+
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- This does not change backend APIs, migrations, or permissions.
+- Authorized users can still create multiple DingTalk group destinations for one table.
+- Low-permission users still do not see the DingTalk Groups tab, as implemented in the previous slice.

--- a/docs/development/dingtalk-group-scope-guidance-verification-20260422.md
+++ b/docs/development/dingtalk-group-scope-guidance-verification-20260422.md
@@ -1,0 +1,37 @@
+# DingTalk Group Scope Guidance Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-scope-guidance-20260422`
+- Status: passed local validation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+rg -n "data-dingtalk-groups-scope-note|Table-scoped DingTalk groups|bound to this table|add multiple groups|choose one or more in automations|one table can have multiple groups|dt_2" apps/web/src/multitable/components/MetaApiTokenManager.vue apps/web/tests/multitable-api-token-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-group-scope-guidance-*.md
+git diff --check
+```
+
+## Expected Coverage
+
+- DingTalk Groups tab renders scope guidance for users who can manage automations.
+- The guidance explains table-scoped binding.
+- The guidance explains multi-group support for one table.
+- The DingTalk Groups tab can render multiple group destination cards for the same table.
+- The guidance explains automations can choose one or more groups.
+- Existing DingTalk Groups happy path tests still pass.
+- Frontend build verifies Vue and TypeScript integration.
+
+## Results
+
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false`: passed, 1 file and 21 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `rg -n "data-dingtalk-groups-scope-note|Table-scoped DingTalk groups|bound to this table|add multiple groups|choose one or more in automations|one table can have multiple groups|dt_2" ...`: passed, expected frontend/test/doc references found.
+- `git diff --check`: passed.
+
+## Claude Code CLI
+
+- Local CLI check: `claude --version`
+- Version observed: `2.1.117 (Claude Code)`
+- A read-only `claude -p` run was attempted with `--tools ""`. It could not inspect files in its session and did not edit files.

--- a/docs/development/dingtalk-group-scope-guidance-verification-20260422.md
+++ b/docs/development/dingtalk-group-scope-guidance-verification-20260422.md
@@ -35,3 +35,13 @@ git diff --check
 - Local CLI check: `claude --version`
 - Version observed: `2.1.117 (Claude Code)`
 - A read-only `claude -p` run was attempted with `--tools ""`. It could not inspect files in its session and did not edit files.
+
+## Rebase verification - 2026-04-22
+
+- Rebased onto `origin/main@f5bea874b6fd` after PR #1038 was merged.
+- Rebased branch HEAD: `ee117ff82d53`.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false`: passed, 1 file and 21 tests.
+- `rg -n "data-dingtalk-groups-scope-note|Table-scoped DingTalk groups|bound to this table|add multiple groups|choose one or more in automations|one table can have multiple groups|dt_2" ...`: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/web build`: passed. Vite emitted only existing chunk-size and mixed static/dynamic import warnings.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -50,6 +50,7 @@ Notes:
 - the DingTalk Groups tab is shown only to users who can manage automations on the current table
 - users without that permission can still use API tokens and webhooks, but the UI will not preload or expose table-scoped DingTalk group bindings
 - if a stale or direct DingTalk group binding request is still denied by the backend, the frontend reports `Insufficient permissions` instead of a generic `API 403`
+- the DingTalk Groups tab explains that groups created there are bound to the current table, one table can have multiple groups, and automations can choose one or more groups as send targets
 - the current model manually registers a group webhook; it does not auto-import your DingTalk groups
 
 ## B. Configure a DingTalk person notification rule

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -232,6 +232,7 @@ Authoring guardrail:
 - the DingTalk Groups management tab is visible only to users with table automation management permission
 - users without that permission do not trigger table-scoped DingTalk group binding requests from the frontend
 - code-only `FORBIDDEN` responses from table-scoped APIs are shown as `Insufficient permissions`, avoiding generic `API 403` copy
+- the DingTalk Groups tab describes table-scoped binding, that one table can have multiple groups, and that automations can choose one or more groups
 - group-message and person-message automations disable save when the selected public form link cannot produce a working fill link
 - group-message and person-message automations disable save when the selected internal processing view is not in the current sheet
 - automation create/update APIs reject invalid public form or internal processing links before rules are saved


### PR DESCRIPTION
## Summary
- Add DingTalk Groups tab guidance explaining that group destinations are scoped to the current table.
- Document that one table can register multiple DingTalk groups and automations can choose one or more destinations.
- Extend the token manager component test to render multiple group destinations and assert the scope guidance.

## Verification
- Rebased onto `origin/main@f5bea874b6fd` after PR #1038 merge.
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false` -> 21/21 passed
- `rg -n "data-dingtalk-groups-scope-note|Table-scoped DingTalk groups|bound to this table|add multiple groups|choose one or more in automations|one table can have multiple groups|dt_2" ...` -> passed
- `git diff --check` -> passed
- `pnpm --filter @metasheet/web build` -> passed with existing Vite warnings only

## Notes
- Docs-only/UX-copy follow-up after the DingTalk group permission panel wiring.
- No backend or data model changes.
