### PR TITLE
feat(dingtalk): clarify group destination setup

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -179,6 +179,7 @@
           <section class="meta-api-mgr__notice" data-dingtalk-groups-scope-note="true">
             <strong>Table-scoped DingTalk groups</strong>
             <span>Groups created here are bound to this table. You can add multiple groups and choose one or more in automations.</span>
+            <span>Register DingTalk robot webhooks as send destinations for this table. This does not import DingTalk group members or control form access.</span>
           </section>
 
           <section v-if="showDingTalkGroupForm" class="meta-api-mgr__form" data-dingtalk-group-form="true">
@@ -199,16 +200,24 @@
               class="meta-api-mgr__input"
               type="url"
               placeholder="https://oapi.dingtalk.com/robot/send?access_token=..."
+              aria-describedby="dingtalk-group-webhook-help"
               data-dingtalk-group-webhook-url="true"
             />
+            <p id="dingtalk-group-webhook-help" class="meta-api-mgr__help" data-dingtalk-group-webhook-help="true">
+              Paste the robot webhook from the target DingTalk group robot settings. After saving, this destination appears in this table's automation rule editor. The access token is stored for delivery but masked in this UI.
+            </p>
             <label class="meta-api-mgr__label">Secret (optional)</label>
             <input
               v-model="dingTalkGroupDraft.secret"
               class="meta-api-mgr__input"
               type="text"
               placeholder="SEC..."
+              aria-describedby="dingtalk-group-secret-help"
               data-dingtalk-group-secret="true"
             />
+            <p id="dingtalk-group-secret-help" class="meta-api-mgr__help" data-dingtalk-group-secret-help="true">
+              Fill this only when the DingTalk robot uses signature security. Leave empty for robots without a SEC secret.
+            </p>
             <label class="meta-api-mgr__checkbox-label">
               <input
                 v-model="dingTalkGroupDraft.enabled"
@@ -247,7 +256,7 @@
             class="meta-api-mgr__empty"
             data-dingtalk-groups-empty="true"
           >
-            No DingTalk groups yet.
+            No DingTalk group destinations yet. Add a group robot webhook before configuring group-message automations.
           </div>
           <div
             v-for="group in dingTalkGroups"
@@ -1006,6 +1015,13 @@ watch(canManageDingTalkGroups, (canManage) => {
   font-size: 13px;
   background: #fff;
   box-sizing: border-box;
+}
+
+.meta-api-mgr__help {
+  margin: -2px 0 2px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #64748b;
 }
 
 .meta-api-mgr__checkboxes {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -205,6 +205,9 @@
                   {{ destination.name }}
                 </option>
               </select>
+              <div class="meta-rule-editor__hint" data-field="dingtalkDestinationPickerHint">
+                Only DingTalk group destinations registered for this table are listed here.
+              </div>
               <div
                 v-if="selectedGroupDestinations(action).length"
                 class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
@@ -231,6 +234,9 @@
                 placeholder="record.opsDestinationId, record.escalationDestinationIds"
                 data-field="dingtalkDestinationFieldPath"
               />
+              <div class="meta-rule-editor__hint" data-field="dingtalkDestinationFieldPathHint">
+                Use record fields whose value is a DingTalk group destination ID, not a local user, member group, or DingTalk group name.
+              </div>
               <label class="meta-rule-editor__label">Pick group field</label>
               <select
                 class="meta-rule-editor__select"

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -422,6 +422,8 @@ describe('MetaApiTokenManager', () => {
     expect(scopeNote?.textContent).toContain('bound to this table')
     expect(scopeNote?.textContent).toContain('add multiple groups')
     expect(scopeNote?.textContent).toContain('choose one or more in automations')
+    expect(scopeNote?.textContent).toContain('does not import DingTalk group members')
+    expect(scopeNote?.textContent).toContain('control form access')
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups?sheetId=sheet_1'))).toBe(true)
   })
 
@@ -487,9 +489,19 @@ describe('MetaApiTokenManager', () => {
     dingTalkTab.click()
     await flushPromises()
 
+    expect(document.querySelector('[data-dingtalk-groups-empty]')?.textContent).toContain('Add a group robot webhook')
+
     const newBtn = document.querySelector('[data-dingtalk-group-new]') as HTMLButtonElement
     newBtn.click()
     await flushPromises()
+
+    const webhookHelp = document.querySelector('[data-dingtalk-group-webhook-help]') as HTMLElement
+    expect(webhookHelp?.textContent).toContain('DingTalk group robot settings')
+    expect(webhookHelp?.textContent).toContain("appears in this table's automation rule editor")
+    expect(webhookHelp?.textContent).toContain('masked in this UI')
+    const secretHelp = document.querySelector('[data-dingtalk-group-secret-help]') as HTMLElement
+    expect(secretHelp?.textContent).toContain('signature security')
+    expect(secretHelp?.textContent).toContain('without a SEC secret')
 
     const nameInput = document.querySelector('[data-dingtalk-group-name]') as HTMLInputElement
     nameInput.value = 'Support group'

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -503,6 +503,9 @@ describe('MetaAutomationRuleEditor', () => {
     actionSelect.dispatchEvent(new Event('change'))
     await flushPromises()
 
+    const pickerHint = container.querySelector('[data-field="dingtalkDestinationPickerHint"]')
+    expect(pickerHint?.textContent).toContain('registered for this table')
+
     const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
     destinationSelect.value = 'dt_1'
     destinationSelect.dispatchEvent(new Event('change'))
@@ -640,6 +643,12 @@ describe('MetaAutomationRuleEditor', () => {
     actionSelect.value = 'send_dingtalk_group_message'
     actionSelect.dispatchEvent(new Event('change'))
     await flushPromises()
+
+    const fieldPathHint = container.querySelector('[data-field="dingtalkDestinationFieldPathHint"]')
+    expect(fieldPathHint?.textContent).toContain('DingTalk group destination ID')
+    expect(fieldPathHint?.textContent).toContain('not a local user')
+    expect(fieldPathHint?.textContent).toContain('member group')
+    expect(fieldPathHint?.textContent).toContain('DingTalk group name')
 
     const destinationFieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
     destinationFieldInput.value = 'record.fld_2'

--- a/docs/development/dingtalk-group-form-help-development-20260422.md
+++ b/docs/development/dingtalk-group-form-help-development-20260422.md
@@ -1,0 +1,43 @@
+# DingTalk Group Form Help Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-form-help-20260422`
+- Scope: frontend DingTalk group destination guidance and automation authoring hints
+
+## Goal
+
+Make the DingTalk group binding flow clearer in the places where users configure it.
+
+This slice addresses a practical ambiguity: binding a DingTalk group in MetaSheet means registering a group robot webhook as a send destination for the current table. It does not sync DingTalk group members and does not grant or control public form access.
+
+## Implementation
+
+- Expanded the DingTalk Groups tab scope note to state that group destinations are table-scoped robot webhooks.
+- Clarified that registering a destination does not import DingTalk group members or control form access.
+- Added inline help under the DingTalk group webhook URL field:
+  - webhook comes from the target DingTalk group robot settings
+  - saved destinations appear in this table's automation rule editor
+  - access tokens are stored for delivery but masked in the UI
+- Added inline help under the optional secret field:
+  - `SEC...` is only needed for DingTalk robots using signature security
+  - the field should remain empty when no signature secret is configured
+- Improved the empty state to explain that a group robot webhook should be added before configuring group-message automations.
+- Added automation rule editor hints:
+  - static group picker lists only DingTalk group destinations registered for the current table
+  - dynamic record field paths must resolve to DingTalk group destination IDs, not local users, member groups, or DingTalk group names
+- Updated user/admin-facing DingTalk docs with the same model.
+
+## Files
+
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- This is a frontend and documentation clarity slice only.
+- No backend API, schema, migration, or permission behavior changed.
+- Existing table-scoped access control remains unchanged: only users with automation management permission can manage DingTalk group bindings.

--- a/docs/development/dingtalk-group-form-help-verification-20260422.md
+++ b/docs/development/dingtalk-group-form-help-verification-20260422.md
@@ -1,0 +1,41 @@
+# DingTalk Group Form Help Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-form-help-20260422`
+- Status: passed local validation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+rg -n "does not import DingTalk group members|control form access|target DingTalk group robot settings|appears in this table's automation rule editor|registered for this table|DingTalk group destination ID|No DingTalk group destinations yet|SEC secret" apps/web/src/multitable/components/MetaApiTokenManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue apps/web/tests/multitable-api-token-manager.spec.ts apps/web/tests/multitable-automation-rule-editor.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md
+git diff --check
+claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only review. Inspect the current git diff for DingTalk group form/help text changes in apps/web and docs. Do not modify files. Report only concrete risks or say no blocking issues."
+```
+
+## Expected Coverage
+
+- DingTalk Groups tab explains that table group bindings are robot webhook send destinations.
+- DingTalk Groups tab states the binding does not import group members or control form access.
+- The new group form explains where to get the webhook URL and how the access token is handled.
+- The optional `SEC...` field explains DingTalk signature-security usage.
+- Empty state tells users to add a group robot webhook before group-message automation.
+- Automation rule editor explains that the group picker is scoped to the current table.
+- Automation rule editor explains dynamic field paths must resolve to DingTalk group destination IDs.
+- Frontend build validates Vue and TypeScript integration.
+
+## Results
+
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false`: passed, 2 files and 77 tests.
+- `pnpm --filter @metasheet/web build`: passed.
+- `rg -n "does not import DingTalk group members|control form access|target DingTalk group robot settings|appears in this table's automation rule editor|registered for this table|DingTalk group destination ID|No DingTalk group destinations yet|SEC secret" ...`: passed, expected frontend/test/doc references found.
+- `git diff --check`: passed.
+- `claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 ...`: passed as read-only review, no blocking issues reported.
+
+## Claude Code CLI
+
+- Local CLI check: `claude --version`
+- Version observed: `2.1.117 (Claude Code)`
+- Read-only review was executed with `Read,Grep,Glob` tools.
+- Claude reported no blocking issues. Minor notes were copy redundancy and broader i18n consistency risks, which do not block this slice.

--- a/docs/development/dingtalk-group-form-help-verification-20260422.md
+++ b/docs/development/dingtalk-group-form-help-verification-20260422.md
@@ -49,3 +49,12 @@ claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only review. Inspec
 - `rg -n "does not import DingTalk group members|control form access|target DingTalk group robot settings|appears in this table's automation rule editor|registered for this table|DingTalk group destination ID|No DingTalk group destinations yet|SEC secret" ...`: passed.
 - `git diff --check`: passed.
 - `pnpm --filter @metasheet/web build`: passed. Vite emitted only existing chunk-size and mixed static/dynamic import warnings.
+
+## Main rebase verification - 2026-04-22
+
+- Rebased directly onto `origin/main@3c3dd1096f71` after PR #1039 was squash-merged.
+- Rebased branch HEAD: `2f1ba9c63f54`.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false`: passed, 2 files and 77 tests.
+- `rg -n "does not import DingTalk group members|control form access|target DingTalk group robot settings|appears in this table's automation rule editor|registered for this table|DingTalk group destination ID|No DingTalk group destinations yet|SEC secret" ...`: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/web build`: passed. Vite emitted only existing chunk-size and mixed static/dynamic import warnings.

--- a/docs/development/dingtalk-group-form-help-verification-20260422.md
+++ b/docs/development/dingtalk-group-form-help-verification-20260422.md
@@ -39,3 +39,13 @@ claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only review. Inspec
 - Version observed: `2.1.117 (Claude Code)`
 - Read-only review was executed with `Read,Grep,Glob` tools.
 - Claude reported no blocking issues. Minor notes were copy redundancy and broader i18n consistency risks, which do not block this slice.
+
+## Rebase verification - 2026-04-22
+
+- Rebased onto `origin/codex/dingtalk-group-scope-guidance-20260422@8f659abc396c` after PR #1039 was replayed onto `main`.
+- Rebased branch HEAD: `16a1aa78fa76`.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false`: passed, 2 files and 77 tests.
+- `rg -n "does not import DingTalk group members|control form access|target DingTalk group robot settings|appears in this table's automation rule editor|registered for this table|DingTalk group destination ID|No DingTalk group destinations yet|SEC secret" ...`: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/web build`: passed. Vite emitted only existing chunk-size and mixed static/dynamic import warnings.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -39,8 +39,8 @@ Management-side UI path:
 3. Go to the `DingTalk Groups` tab.
 4. Create a destination with:
    - group name
-   - webhook URL
-   - optional secret
+   - webhook URL from the target DingTalk group robot settings
+   - optional `SEC...` secret if the group robot uses signature security
    - enabled state
 5. Use `Test send` to verify delivery.
 
@@ -51,6 +51,7 @@ Notes:
 - users without that permission can still use API tokens and webhooks, but the UI will not preload or expose table-scoped DingTalk group bindings
 - if a stale or direct DingTalk group binding request is still denied by the backend, the frontend reports `Insufficient permissions` instead of a generic `API 403`
 - the DingTalk Groups tab explains that groups created there are bound to the current table, one table can have multiple groups, and automations can choose one or more groups as send targets
+- registering a DingTalk group destination does not import DingTalk group members and does not grant or control public form access
 - the current model manually registers a group webhook; it does not auto-import your DingTalk groups
 
 ## B. Configure a DingTalk person notification rule

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -233,6 +233,8 @@ Authoring guardrail:
 - users without that permission do not trigger table-scoped DingTalk group binding requests from the frontend
 - code-only `FORBIDDEN` responses from table-scoped APIs are shown as `Insufficient permissions`, avoiding generic `API 403` copy
 - the DingTalk Groups tab describes table-scoped binding, that one table can have multiple groups, and that automations can choose one or more groups
+- the DingTalk Groups form clarifies that the webhook comes from the target group robot, that `SEC...` is only for signed robots, and that registering a destination does not import DingTalk group members or grant form access
+- dynamic `Record group field paths` must resolve to DingTalk group destination IDs, not local user fields, member group IDs, or DingTalk group names
 - group-message and person-message automations disable save when the selected public form link cannot produce a working fill link
 - group-message and person-message automations disable save when the selected internal processing view is not in the current sheet
 - automation create/update APIs reject invalid public form or internal processing links before rules are saved


### PR DESCRIPTION
## Summary
- Clarify that table-scoped DingTalk groups are robot webhook send destinations, not DingTalk member sync or form-access grants.
- Add inline help for DingTalk group webhook URL and optional SEC signature secret.
- Add automation editor hints for table-scoped group picker and dynamic destination ID field paths.
- Update DingTalk docs and add development/verification notes.

## Verification
- Rebased directly onto `origin/main@3c3dd1096f71` after PR #1039 squash merge.
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` -> 77/77 passed
- `rg -n "does not import DingTalk group members|control form access|target DingTalk group robot settings|appears in this table's automation rule editor|registered for this table|DingTalk group destination ID|No DingTalk group destinations yet|SEC secret" ...` -> passed
- `git diff --check` -> passed
- `pnpm --filter @metasheet/web build` -> passed with existing Vite warnings only
- Claude Code CLI read-only review: no blocking issues

## Notes
- No backend API or migration changes.
- Follow-up UX copy on top of the DingTalk group scope guidance from #1039.
