### PR TITLE
feat(dingtalk): validate group robot webhooks

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -206,6 +206,13 @@
             <p id="dingtalk-group-webhook-help" class="meta-api-mgr__help" data-dingtalk-group-webhook-help="true">
               Paste the robot webhook from the target DingTalk group robot settings. After saving, this destination appears in this table's automation rule editor. The access token is stored for delivery but masked in this UI.
             </p>
+            <p
+              v-if="dingTalkGroupWebhookValidationMessage && dingTalkGroupDraft.webhookUrl.trim()"
+              class="meta-api-mgr__help meta-api-mgr__help--error"
+              data-dingtalk-group-webhook-error="true"
+            >
+              {{ dingTalkGroupWebhookValidationMessage }}
+            </p>
             <label class="meta-api-mgr__label">Secret (optional)</label>
             <input
               v-model="dingTalkGroupDraft.secret"
@@ -217,6 +224,13 @@
             />
             <p id="dingtalk-group-secret-help" class="meta-api-mgr__help" data-dingtalk-group-secret-help="true">
               Fill this only when the DingTalk robot uses signature security. Leave empty for robots without a SEC secret.
+            </p>
+            <p
+              v-if="dingTalkGroupSecretValidationMessage"
+              class="meta-api-mgr__help meta-api-mgr__help--error"
+              data-dingtalk-group-secret-error="true"
+            >
+              {{ dingTalkGroupSecretValidationMessage }}
             </p>
             <label class="meta-api-mgr__checkbox-label">
               <input
@@ -392,6 +406,7 @@ const dingTalkGroups = ref<DingTalkGroupDestination[]>([])
 const dingTalkGroupsLoading = ref(false)
 const showDingTalkGroupForm = ref(false)
 const editingDingTalkGroupId = ref<string | null>(null)
+const editingDingTalkGroupOriginal = ref<{ webhookUrl: string; secret: string } | null>(null)
 const dingTalkDeliveriesGroupId = ref<string | null>(null)
 const dingTalkDeliveriesLoading = ref(false)
 const dingTalkDeliveries = ref<DingTalkGroupDelivery[]>([])
@@ -412,8 +427,25 @@ const canSaveWebhook = computed(() => {
   return webhookDraft.value.name.trim() && webhookDraft.value.url.startsWith('https://') && webhookDraft.value.events.length > 0
 })
 
+const dingTalkGroupWebhookChanged = computed(() => {
+  if (!editingDingTalkGroupId.value) return true
+  return dingTalkGroupDraft.value.webhookUrl.trim() !== (editingDingTalkGroupOriginal.value?.webhookUrl ?? '').trim()
+})
+const dingTalkGroupSecretChanged = computed(() => {
+  if (!editingDingTalkGroupId.value) return true
+  return dingTalkGroupDraft.value.secret.trim() !== (editingDingTalkGroupOriginal.value?.secret ?? '').trim()
+})
+const dingTalkGroupWebhookValidationMessage = computed(() =>
+  dingTalkGroupWebhookChanged.value ? validateDingTalkGroupWebhookUrl(dingTalkGroupDraft.value.webhookUrl) : '',
+)
+const dingTalkGroupSecretValidationMessage = computed(() =>
+  dingTalkGroupSecretChanged.value ? validateDingTalkGroupSecret(dingTalkGroupDraft.value.secret) : '',
+)
 const canSaveDingTalkGroup = computed(() => {
-  return canManageDingTalkGroups.value && dingTalkGroupDraft.value.name.trim() && dingTalkGroupDraft.value.webhookUrl.trim().startsWith('https://')
+  return canManageDingTalkGroups.value
+    && dingTalkGroupDraft.value.name.trim()
+    && !dingTalkGroupWebhookValidationMessage.value
+    && !dingTalkGroupSecretValidationMessage.value
 })
 
 function formatDate(iso: string): string {
@@ -439,6 +471,32 @@ function maskDingTalkWebhookUrl(url: string): string {
   } catch {
     return String(url || '').replace(/([?&](?:access_token|timestamp|sign)=)[^&]+/gi, '$1***')
   }
+}
+
+function validateDingTalkGroupWebhookUrl(value: string): string {
+  const webhookUrl = value.trim()
+  if (!webhookUrl) return 'Webhook URL is required'
+  let parsed: URL
+  try {
+    parsed = new URL(webhookUrl)
+  } catch {
+    return 'Webhook URL is not a valid URL'
+  }
+  if (parsed.protocol !== 'https:') return 'DingTalk robot webhook URL must use HTTPS'
+  if (parsed.hostname !== 'oapi.dingtalk.com' || parsed.pathname !== '/robot/send') {
+    return 'Use the DingTalk group robot webhook from https://oapi.dingtalk.com/robot/send'
+  }
+  if (!parsed.searchParams.get('access_token')?.trim()) {
+    return 'DingTalk group robot webhook must include access_token'
+  }
+  return ''
+}
+
+function validateDingTalkGroupSecret(value: string): string {
+  const secret = value.trim()
+  if (!secret) return ''
+  if (!secret.startsWith('SEC')) return 'DingTalk robot secret must start with SEC'
+  return ''
 }
 
 // ---- Token actions ----
@@ -666,6 +724,7 @@ function clearDingTalkGroupState() {
   dingTalkGroups.value = []
   showDingTalkGroupForm.value = false
   editingDingTalkGroupId.value = null
+  editingDingTalkGroupOriginal.value = null
   dingTalkDeliveriesRequestToken += 1
   dingTalkDeliveriesGroupId.value = null
   dingTalkDeliveriesLoading.value = false
@@ -678,6 +737,7 @@ function clearDingTalkGroupState() {
 function openDingTalkGroupForm() {
   if (!canManageDingTalkGroups.value) return
   editingDingTalkGroupId.value = null
+  editingDingTalkGroupOriginal.value = null
   dingTalkGroupDraft.value = {
     name: '',
     webhookUrl: '',
@@ -690,6 +750,10 @@ function openDingTalkGroupForm() {
 function openEditDingTalkGroup(group: DingTalkGroupDestination) {
   if (!canManageDingTalkGroups.value) return
   editingDingTalkGroupId.value = group.id
+  editingDingTalkGroupOriginal.value = {
+    webhookUrl: group.webhookUrl,
+    secret: group.secret ?? '',
+  }
   dingTalkGroupDraft.value = {
     name: group.name,
     webhookUrl: group.webhookUrl,
@@ -702,6 +766,7 @@ function openEditDingTalkGroup(group: DingTalkGroupDestination) {
 function cancelDingTalkGroupForm() {
   showDingTalkGroupForm.value = false
   editingDingTalkGroupId.value = null
+  editingDingTalkGroupOriginal.value = null
 }
 
 async function onSaveDingTalkGroup() {
@@ -709,17 +774,23 @@ async function onSaveDingTalkGroup() {
   busy.value = true
   error.value = null
   try {
-    const createInput = {
-      name: dingTalkGroupDraft.value.name.trim(),
-      webhookUrl: dingTalkGroupDraft.value.webhookUrl.trim(),
-      secret: dingTalkGroupDraft.value.secret || undefined,
-      enabled: dingTalkGroupDraft.value.enabled,
-    }
+    const name = dingTalkGroupDraft.value.name.trim()
+    const webhookUrl = dingTalkGroupDraft.value.webhookUrl.trim()
+    const secret = dingTalkGroupDraft.value.secret.trim()
     if (editingDingTalkGroupId.value) {
-      await props.client.updateDingTalkGroup(editingDingTalkGroupId.value, createInput, props.sheetId)
+      const updateInput: { name: string; webhookUrl?: string; secret?: string; enabled: boolean } = {
+        name,
+        enabled: dingTalkGroupDraft.value.enabled,
+      }
+      if (dingTalkGroupWebhookChanged.value) updateInput.webhookUrl = webhookUrl
+      if (dingTalkGroupSecretChanged.value) updateInput.secret = secret || ''
+      await props.client.updateDingTalkGroup(editingDingTalkGroupId.value, updateInput, props.sheetId)
     } else {
       await props.client.createDingTalkGroup({
-        ...createInput,
+        name,
+        webhookUrl,
+        secret: secret || undefined,
+        enabled: dingTalkGroupDraft.value.enabled,
         sheetId: props.sheetId,
       })
     }
@@ -1022,6 +1093,10 @@ watch(canManageDingTalkGroups, (canManage) => {
   font-size: 12px;
   line-height: 1.45;
   color: #64748b;
+}
+
+.meta-api-mgr__help--error {
+  color: #b91c1c;
 }
 
 .meta-api-mgr__checkboxes {

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -527,6 +527,85 @@ describe('MetaApiTokenManager', () => {
     })
   })
 
+  it('disables DingTalk group save for invalid robot webhook settings', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const newBtn = document.querySelector('[data-dingtalk-group-new]') as HTMLButtonElement
+    newBtn.click()
+    await flushPromises()
+
+    const nameInput = document.querySelector('[data-dingtalk-group-name]') as HTMLInputElement
+    nameInput.value = 'Support group'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const urlInput = document.querySelector('[data-dingtalk-group-webhook-url]') as HTMLInputElement
+    urlInput.value = 'https://example.com/hook'
+    urlInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = document.querySelector('[data-dingtalk-group-save]') as HTMLButtonElement
+    expect(document.querySelector('[data-dingtalk-group-webhook-error]')?.textContent).toContain('https://oapi.dingtalk.com/robot/send')
+    expect(saveBtn.disabled).toBe(true)
+
+    urlInput.value = 'https://oapi.dingtalk.com/robot/send?access_token=test-token'
+    urlInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const secretInput = document.querySelector('[data-dingtalk-group-secret]') as HTMLInputElement
+    secretInput.value = 'bad-secret'
+    secretInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(document.querySelector('[data-dingtalk-group-secret-error]')?.textContent).toContain('must start with SEC')
+    expect(saveBtn.disabled).toBe(true)
+    expect(fetchFn.mock.calls.some((c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/dingtalk-groups'))).toBe(false)
+  })
+
+  it('omits unchanged legacy DingTalk webhook settings when editing metadata', async () => {
+    const legacyGroup = fakeDingTalkGroup({
+      webhookUrl: 'https://example.com/legacy-hook',
+      secret: 'legacy-secret',
+    })
+    const { client, fetchFn } = mockClient([], [], [], [legacyGroup])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const editBtn = document.querySelector('[data-dingtalk-group-edit]') as HTMLButtonElement
+    editBtn.click()
+    await flushPromises()
+
+    const nameInput = document.querySelector('[data-dingtalk-group-name]') as HTMLInputElement
+    nameInput.value = 'Legacy group renamed'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = document.querySelector('[data-dingtalk-group-save]') as HTMLButtonElement
+    expect(document.querySelector('[data-dingtalk-group-webhook-error]')).toBeNull()
+    expect(document.querySelector('[data-dingtalk-group-secret-error]')).toBeNull()
+    expect(saveBtn.disabled).toBe(false)
+
+    saveBtn.click()
+    await flushPromises()
+
+    const updateCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'PATCH' && c[0].includes('/dingtalk-groups/'),
+    )
+    expect(updateCalls.length).toBe(1)
+    expect(JSON.parse(updateCalls[0][1]?.body as string)).toEqual({
+      name: 'Legacy group renamed',
+      enabled: true,
+    })
+  })
+
   it('tests a DingTalk group destination', async () => {
     const { client, fetchFn } = mockClient([], [], [], [fakeDingTalkGroup()])
     mount({ visible: true, client })

--- a/docs/development/dingtalk-group-webhook-validation-development-20260422.md
+++ b/docs/development/dingtalk-group-webhook-validation-development-20260422.md
@@ -1,0 +1,46 @@
+# DingTalk Group Webhook Validation Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-webhook-validation-20260422`
+- Scope: DingTalk group destination validation
+
+## Goal
+
+Make DingTalk group destinations a stricter standard feature by preventing generic webhooks from being saved as DingTalk group robot targets.
+
+The expected target is a DingTalk group robot webhook copied from the DingTalk group robot settings. It must use the standard `https://oapi.dingtalk.com/robot/send` endpoint and include an `access_token`.
+
+## Implementation
+
+- Added backend normalization and validation for DingTalk group destination webhooks.
+- Required DingTalk group webhook URLs to use:
+  - `https:` protocol
+  - `oapi.dingtalk.com` host
+  - `/robot/send` path
+  - non-empty `access_token` query parameter
+- Added optional secret normalization and validation:
+  - trim whitespace
+  - require `SEC...` prefix when a secret is provided
+- Updated REST error mapping so validation failures return `400`.
+- Added frontend save-time validation with inline error text.
+- Disabled save when a new or changed webhook/secret is invalid.
+- Preserved legacy edit compatibility:
+  - unchanged legacy webhook/secret values are not resubmitted during metadata-only edits
+  - backend update validation still runs when webhook/secret fields are changed
+- Updated DingTalk docs with the enforced webhook and secret rules.
+
+## Files
+
+- `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+- `packages/core-backend/src/routes/api-tokens.ts`
+- `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- This does not change the DingTalk sending payload or delivery history schema.
+- Existing valid DingTalk robot webhooks continue to work.
+- Private or proxy DingTalk robot hosts are not supported by this standard validation rule.

--- a/docs/development/dingtalk-group-webhook-validation-verification-20260422.md
+++ b/docs/development/dingtalk-group-webhook-validation-verification-20260422.md
@@ -1,0 +1,51 @@
+# DingTalk Group Webhook Validation Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-webhook-validation-20260422`
+- Status: passed local validation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+rg -n "normalizeDingTalkRobotWebhookUrl|DingTalk robot webhook URL must use HTTPS|DingTalk group webhook URL must include access_token|DingTalk robot secret must start with SEC|data-dingtalk-group-webhook-error|validateDingTalkGroupWebhookUrl|standard group robot webhook URLs|access_token" packages/core-backend/src/multitable/dingtalk-group-destination-service.ts packages/core-backend/src/routes/api-tokens.ts packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts apps/web/src/multitable/components/MetaApiTokenManager.vue apps/web/tests/multitable-api-token-manager.spec.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md
+git diff --check
+claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only review. Inspect current git diff for DingTalk group robot webhook validation in backend/frontend/tests/docs. Do not modify files. Report concrete blockers only; if none, say no blocking issues and mention any small risks."
+claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only re-review after fixes. Inspect current git diff for DingTalk group robot webhook validation and legacy edit compatibility. Do not modify files. Report concrete blockers only; if none, say no blocking issues."
+```
+
+## Expected Coverage
+
+- Backend accepts valid DingTalk group robot webhook URLs.
+- Backend rejects:
+  - non-HTTPS robot URLs
+  - non-DingTalk hosts
+  - wrong paths
+  - missing `access_token`
+  - invalid signed robot secrets
+- Backend trims valid `SEC...` secrets before persistence.
+- Frontend disables save and shows inline errors for invalid webhook/secret inputs.
+- Frontend does not resubmit unchanged legacy webhook/secret values during metadata-only edits.
+- Docs describe the enforced standard webhook and secret rules.
+- TypeScript builds pass for frontend and backend.
+
+## Results
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false`: passed, 1 file and 16 tests.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false`: passed, 1 file and 23 tests.
+- `pnpm --filter @metasheet/core-backend build`: passed.
+- `pnpm --filter @metasheet/web build`: passed with existing Vite chunk/dynamic import warnings.
+- `rg -n "normalizeDingTalkRobotWebhookUrl|DingTalk robot webhook URL must use HTTPS|DingTalk group webhook URL must include access_token|DingTalk robot secret must start with SEC|data-dingtalk-group-webhook-error|validateDingTalkGroupWebhookUrl|standard group robot webhook URLs|access_token" ...`: passed, expected frontend/backend/test/doc references found.
+- `git diff --check`: passed.
+- Claude Code CLI re-review after the legacy edit fix: passed, no blocking issues.
+
+## Claude Code CLI
+
+- Local CLI check: `claude --version`
+- Version observed: `2.1.117 (Claude Code)`
+- Read-only review was executed with `Read,Grep,Glob` tools.
+- Claude reported no blocking issues and noted a legacy edit compatibility risk. That risk was addressed by omitting unchanged webhook/secret fields from metadata-only edits and adding a regression test.
+- A second read-only re-review after that fix reported no blocking issues.

--- a/docs/development/dingtalk-group-webhook-validation-verification-20260422.md
+++ b/docs/development/dingtalk-group-webhook-validation-verification-20260422.md
@@ -49,3 +49,15 @@ claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only re-review afte
 - Read-only review was executed with `Read,Grep,Glob` tools.
 - Claude reported no blocking issues and noted a legacy edit compatibility risk. That risk was addressed by omitting unchanged webhook/secret fields from metadata-only edits and adding a regression test.
 - A second read-only re-review after that fix reported no blocking issues.
+
+## Main rebase verification - 2026-04-22
+
+- Rebased only the webhook validation slice onto `origin/main@9c57caf1b6ba` after PR #1040 was squash-merged.
+- Rebased branch HEAD: `503453ff80cc`.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false`: passed, 1 file and 16 tests.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false`: passed, 1 file and 23 tests. The run printed a non-fatal local WebSocket port-in-use message and exited successfully.
+- `rg -n "normalizeDingTalkRobotWebhookUrl|DingTalk robot webhook URL must use HTTPS|DingTalk group webhook URL must include access_token|DingTalk robot secret must start with SEC|data-dingtalk-group-webhook-error|validateDingTalkGroupWebhookUrl|standard group robot webhook URLs|omits unchanged legacy DingTalk webhook settings|access_token" ...`: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/core-backend build`: passed.
+- `pnpm --filter @metasheet/web build`: passed. Vite emitted only existing chunk-size and mixed static/dynamic import warnings.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -52,6 +52,7 @@ Notes:
 - if a stale or direct DingTalk group binding request is still denied by the backend, the frontend reports `Insufficient permissions` instead of a generic `API 403`
 - the DingTalk Groups tab explains that groups created there are bound to the current table, one table can have multiple groups, and automations can choose one or more groups as send targets
 - registering a DingTalk group destination does not import DingTalk group members and does not grant or control public form access
+- DingTalk group destination webhooks must be standard group robot URLs from `https://oapi.dingtalk.com/robot/send` and include an `access_token`; optional signature secrets must start with `SEC`
 - the current model manually registers a group webhook; it does not auto-import your DingTalk groups
 
 ## B. Configure a DingTalk person notification rule

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -234,6 +234,7 @@ Authoring guardrail:
 - code-only `FORBIDDEN` responses from table-scoped APIs are shown as `Insufficient permissions`, avoiding generic `API 403` copy
 - the DingTalk Groups tab describes table-scoped binding, that one table can have multiple groups, and that automations can choose one or more groups
 - the DingTalk Groups form clarifies that the webhook comes from the target group robot, that `SEC...` is only for signed robots, and that registering a destination does not import DingTalk group members or grant form access
+- DingTalk group destination create/update enforces standard group robot webhook URLs from `https://oapi.dingtalk.com/robot/send` with a non-empty `access_token`; optional signature secrets must start with `SEC`
 - dynamic `Record group field paths` must resolve to DingTalk group destination IDs, not local user fields, member group IDs, or DingTalk group names
 - group-message and person-message automations disable save when the selected public form link cannot produce a working fill link
 - group-message and person-message automations disable save when the selected internal processing view is not in the current sheet

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -19,6 +19,8 @@ import type {
 
 const logger = new Logger('DingTalkGroupDestinationService')
 const DINGTALK_REQUEST_TIMEOUT_MS = 5_000
+const DINGTALK_ROBOT_WEBHOOK_HOST = 'oapi.dingtalk.com'
+const DINGTALK_ROBOT_WEBHOOK_PATH = '/robot/send'
 
 type DingTalkGroupDestinationRow = {
   id: string
@@ -37,6 +39,39 @@ type DingTalkGroupDestinationRow = {
 
 function generateId(): string {
   return randomBytes(16).toString('hex')
+}
+
+function normalizeDingTalkRobotWebhookUrl(value: string | undefined): string {
+  const webhookUrl = value?.trim()
+  if (!webhookUrl) throw new Error('Webhook URL is required')
+
+  let parsed: URL
+  try {
+    parsed = new URL(webhookUrl)
+  } catch {
+    throw new Error('Webhook URL is not a valid URL')
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('DingTalk robot webhook URL must use HTTPS')
+  }
+  if (parsed.hostname !== DINGTALK_ROBOT_WEBHOOK_HOST || parsed.pathname !== DINGTALK_ROBOT_WEBHOOK_PATH) {
+    throw new Error(`DingTalk group webhook URL must be a DingTalk robot URL from https://${DINGTALK_ROBOT_WEBHOOK_HOST}${DINGTALK_ROBOT_WEBHOOK_PATH}`)
+  }
+  if (!parsed.searchParams.get('access_token')?.trim()) {
+    throw new Error('DingTalk group webhook URL must include access_token')
+  }
+
+  return parsed.toString()
+}
+
+function normalizeDingTalkRobotSecret(value: string | undefined): string | undefined {
+  const secret = value?.trim()
+  if (!secret) return undefined
+  if (!secret.startsWith('SEC')) {
+    throw new Error('DingTalk robot secret must start with SEC')
+  }
+  return secret
 }
 
 function rowToDestination(row: DingTalkGroupDestinationRow): DingTalkGroupDestination {
@@ -111,19 +146,10 @@ export class DingTalkGroupDestinationService {
 
   async createDestination(userId: string, input: DingTalkGroupDestinationCreateInput): Promise<DingTalkGroupDestination> {
     const name = input.name?.trim()
-    const webhookUrl = input.webhookUrl?.trim()
+    const webhookUrl = normalizeDingTalkRobotWebhookUrl(input.webhookUrl)
+    const secret = normalizeDingTalkRobotSecret(input.secret)
     const sheetId = typeof input.sheetId === 'string' && input.sheetId.trim() ? input.sheetId.trim() : null
     if (!name) throw new Error('Destination name is required')
-    if (!webhookUrl) throw new Error('Webhook URL is required')
-    try {
-      const parsed = new URL(webhookUrl)
-      if (process.env.NODE_ENV === 'production' && parsed.protocol !== 'https:') {
-        throw new Error('Webhook URL must use HTTPS in production')
-      }
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('HTTPS')) throw error
-      throw new Error('Webhook URL is not a valid URL')
-    }
 
     const id = generateId()
     const enabled = input.enabled ?? true
@@ -133,7 +159,7 @@ export class DingTalkGroupDestinationService {
       id,
       name,
       webhook_url: webhookUrl,
-      secret: input.secret ?? null,
+      secret: secret ?? null,
       enabled,
       sheet_id: sheetId,
       created_by: userId,
@@ -145,7 +171,7 @@ export class DingTalkGroupDestinationService {
       id,
       name,
       webhookUrl,
-      secret: input.secret,
+      secret,
       enabled,
       ...(sheetId ? { sheetId } : {}),
       createdBy: userId,
@@ -225,20 +251,9 @@ export class DingTalkGroupDestinationService {
       updates.name = name
     }
     if (input.webhookUrl !== undefined) {
-      const webhookUrl = input.webhookUrl.trim()
-      if (!webhookUrl) throw new Error('Webhook URL is required')
-      try {
-        const parsed = new URL(webhookUrl)
-        if (process.env.NODE_ENV === 'production' && parsed.protocol !== 'https:') {
-          throw new Error('Webhook URL must use HTTPS in production')
-        }
-      } catch (error) {
-        if (error instanceof Error && error.message.includes('HTTPS')) throw error
-        throw new Error('Webhook URL is not a valid URL')
-      }
-      updates.webhook_url = webhookUrl
+      updates.webhook_url = normalizeDingTalkRobotWebhookUrl(input.webhookUrl)
     }
-    if (input.secret !== undefined) updates.secret = input.secret || null
+    if (input.secret !== undefined) updates.secret = normalizeDingTalkRobotSecret(input.secret) ?? null
     if (input.enabled !== undefined) updates.enabled = input.enabled
 
     await this.db.updateTable('dingtalk_group_destinations')

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -118,6 +118,8 @@ function serviceErrorResponse(res: Response, err: unknown, action: string): void
     message.includes('required')
     || message.includes('valid URL')
     || message.includes('HTTPS')
+    || message.includes('DingTalk robot')
+    || message.includes('DingTalk group webhook')
     || message.includes('At least one scope')
   ) {
     status = 400

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -105,25 +105,59 @@ describe('DingTalkGroupDestinationService', () => {
   })
 
   test('creates and lists destinations', async () => {
-    const { db } = createMockDb()
+    const { db, roots } = createMockDb()
     const service = new DingTalkGroupDestinationService(db, vi.fn())
 
     const created = await service.createDestination('user_1', {
       name: ' Ops DingTalk Group ',
       webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
-      secret: 'SEC123',
+      secret: ' SEC123 ',
       sheetId: 'sheet_1',
     })
 
     expect(created.name).toBe('Ops DingTalk Group')
+    expect(created.secret).toBe('SEC123')
     expect(created.enabled).toBe(true)
     expect(created.sheetId).toBe('sheet_1')
+    const insertChain = roots.insertInto.mock.results[0]?.value as MockChain | undefined
+    const values = insertChain?.values?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(values?.secret).toBe('SEC123')
 
     executeQueue.push([destinationRow({ sheet_id: 'sheet_1' }), destinationRow({ id: 'dt_legacy', sheet_id: null })])
     const listed = await service.listDestinations('user_1', 'sheet_1')
     expect(listed).toHaveLength(2)
     expect(listed[0].name).toBe('Ops DingTalk Group')
     expect(listed[0].sheetId).toBe('sheet_1')
+  })
+
+  test.each([
+    ['http://oapi.dingtalk.com/robot/send?access_token=test-token', 'HTTPS'],
+    ['https://example.com/robot/send?access_token=test-token', 'DingTalk robot URL'],
+    ['https://oapi.dingtalk.com/wrong?access_token=test-token', 'DingTalk robot URL'],
+    ['https://oapi.dingtalk.com/robot/send', 'access_token'],
+  ])('rejects invalid DingTalk robot webhook URL on create: %s', async (webhookUrl, expectedMessage) => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    await expect(service.createDestination('user_1', {
+      name: 'Ops DingTalk Group',
+      webhookUrl,
+    })).rejects.toThrow(expectedMessage)
+
+    expect(roots.insertInto).not.toHaveBeenCalled()
+  })
+
+  test('rejects invalid DingTalk robot secret on create', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    await expect(service.createDestination('user_1', {
+      name: 'Ops DingTalk Group',
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+      secret: 'bad-secret',
+    })).rejects.toThrow('DingTalk robot secret must start with SEC')
+
+    expect(roots.insertInto).not.toHaveBeenCalled()
   })
 
   test('shared sheet destinations can be managed by non-owners on the same sheet', async () => {
@@ -168,6 +202,19 @@ describe('DingTalkGroupDestinationService', () => {
     expect(updated.name).toBe('Updated group')
     expect(updated.enabled).toBe(false)
     expect(updated.webhookUrl).toContain('access_token=next')
+  })
+
+  test('rejects invalid DingTalk robot webhook URL on update', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeTakeFirstQueue.push(destinationRow())
+
+    await expect(service.updateDestination('dt_1', 'user_1', {
+      webhookUrl: 'https://example.com/hook',
+    })).rejects.toThrow('DingTalk robot URL')
+
+    expect(roots.updateTable).not.toHaveBeenCalled()
   })
 
   test('lists deliveries for a destination', async () => {


### PR DESCRIPTION
## Summary
- Enforce standard DingTalk group robot webhook URLs for group destinations: `https://oapi.dingtalk.com/robot/send` with non-empty `access_token`.
- Validate optional signed robot secrets with `SEC...` prefix and trim valid secrets before persistence.
- Add frontend save-time validation and inline errors for invalid webhook/secret inputs.
- Preserve metadata-only edits for legacy destinations by omitting unchanged webhook/secret fields.
- Update DingTalk docs and add development/verification notes.

## Verification
- Rebased only this webhook validation slice onto `origin/main@9c57caf1b6ba` after PR #1040 squash merge.
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false` -> 16/16 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false` -> 23/23 passed; non-fatal local WebSocket port-in-use message, exit 0
- `rg -n "normalizeDingTalkRobotWebhookUrl|DingTalk robot webhook URL must use HTTPS|DingTalk group webhook URL must include access_token|DingTalk robot secret must start with SEC|data-dingtalk-group-webhook-error|validateDingTalkGroupWebhookUrl|standard group robot webhook URLs|omits unchanged legacy DingTalk webhook settings|access_token" ...` -> passed
- `git diff --check` -> passed
- `pnpm --filter @metasheet/core-backend build` -> passed
- `pnpm --filter @metasheet/web build` -> passed with existing Vite warnings only
- Claude Code CLI read-only review and re-review: no blocking issues

## Notes
- No migration or delivery payload changes.
