### PR TITLE
fix(dingtalk): guard group runtime webhooks

### DIFF
--- a/docs/development/dingtalk-group-runtime-webhook-guard-development-20260422.md
+++ b/docs/development/dingtalk-group-runtime-webhook-guard-development-20260422.md
@@ -1,0 +1,41 @@
+# DingTalk Group Runtime Webhook Guard Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-runtime-webhook-guard-20260422`
+- Scope: DingTalk group runtime delivery guard
+
+## Goal
+
+Close the runtime gap for DingTalk group destinations.
+
+The previous slice enforced standard DingTalk robot webhook URLs during create/update. This slice also validates stored webhook URLs before manual test sends and automation sends, so legacy non-DingTalk URLs cannot be used as outbound targets.
+
+## Implementation
+
+- Moved DingTalk robot webhook normalization into the shared DingTalk robot integration module.
+- Reused the same standard webhook rules across write-time and runtime paths:
+  - `https:` protocol
+  - `oapi.dingtalk.com` host
+  - `/robot/send` path
+  - non-empty `access_token`
+  - optional `SEC...` signed robot secret
+- Updated `DingTalkGroupDestinationService.testSend` to validate the stored webhook inside the existing failure-handling path before `fetch`.
+- Updated automation group-message execution to pre-validate all selected destinations before any outbound send.
+- When any selected destination has an invalid legacy webhook, automation fails before sending to any destination and records failed delivery diagnostics for the invalid destinations.
+- Updated DingTalk docs to clarify that test sends and automation sends re-check stored webhook URLs.
+
+## Files
+
+- `packages/core-backend/src/integrations/dingtalk/robot.ts`
+- `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+- `packages/core-backend/tests/unit/automation-v1.test.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- No database migration or payload schema changed.
+- Valid DingTalk robot destinations continue to send normally.
+- Legacy invalid destinations can still be renamed in the manager from the previous slice, but cannot test-send or automation-send until the webhook is corrected.

--- a/docs/development/dingtalk-group-runtime-webhook-guard-verification-20260422.md
+++ b/docs/development/dingtalk-group-runtime-webhook-guard-verification-20260422.md
@@ -40,3 +40,14 @@ claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only review. Inspec
 - Version observed: `2.1.117 (Claude Code)`
 - Read-only review was executed with `Read,Grep,Glob` tools.
 - Claude reported no blocking issues. It noted a non-blocking clarity risk around a raw webhook fallback in the send loop; that fallback was removed and the automation target test still passed.
+
+## Stack rebase verification - 2026-04-22
+
+- Rebased onto `origin/codex/dingtalk-group-webhook-validation-20260422@34c83aa01d6a` after PR #1041 was replayed onto `main`.
+- Rebased branch HEAD: `8eb4a487844f`.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false`: passed, 1 file and 17 tests.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false`: passed, 1 file and 121 tests.
+- `rg -n "normalizeDingTalkRobotWebhookUrl|normalizeDingTalkRobotSecret|testSend rejects legacy invalid webhook URL without fetch|fails send_dingtalk_group_message for legacy invalid webhook without fetch|validates all DingTalk group webhooks before sending any destination|re-check|re-validate stored webhook" ...`: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/core-backend build`: passed.

--- a/docs/development/dingtalk-group-runtime-webhook-guard-verification-20260422.md
+++ b/docs/development/dingtalk-group-runtime-webhook-guard-verification-20260422.md
@@ -51,3 +51,13 @@ claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only review. Inspec
 - `rg -n "normalizeDingTalkRobotWebhookUrl|normalizeDingTalkRobotSecret|testSend rejects legacy invalid webhook URL without fetch|fails send_dingtalk_group_message for legacy invalid webhook without fetch|validates all DingTalk group webhooks before sending any destination|re-check|re-validate stored webhook" ...`: passed.
 - `git diff --check`: passed.
 - `pnpm --filter @metasheet/core-backend build`: passed.
+
+## Main rebase verification - 2026-04-22
+
+- Rebased directly onto `origin/main@c8aa605ea735` after PR #1041 was squash-merged.
+- Rebased branch HEAD: `67e0221e5f4e`.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false`: passed, 1 file and 17 tests.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false`: passed, 1 file and 121 tests.
+- `rg -n "normalizeDingTalkRobotWebhookUrl|normalizeDingTalkRobotSecret|testSend rejects legacy invalid webhook URL without fetch|fails send_dingtalk_group_message for legacy invalid webhook without fetch|validates all DingTalk group webhooks before sending any destination|re-check|re-validate stored webhook" ...`: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/core-backend build`: passed.

--- a/docs/development/dingtalk-group-runtime-webhook-guard-verification-20260422.md
+++ b/docs/development/dingtalk-group-runtime-webhook-guard-verification-20260422.md
@@ -1,0 +1,42 @@
+# DingTalk Group Runtime Webhook Guard Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-runtime-webhook-guard-20260422`
+- Status: passed local validation
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+rg -n "normalizeDingTalkRobotWebhookUrl|normalizeDingTalkRobotSecret|testSend rejects legacy invalid webhook URL without fetch|fails send_dingtalk_group_message for legacy invalid webhook without fetch|validates all DingTalk group webhooks before sending any destination|re-check|re-validate stored webhook" packages/core-backend/src/integrations/dingtalk/robot.ts packages/core-backend/src/multitable/dingtalk-group-destination-service.ts packages/core-backend/src/multitable/automation-executor.ts packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts packages/core-backend/tests/unit/automation-v1.test.ts docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/development/dingtalk-group-runtime-webhook-guard-*.md
+git diff --check
+claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 "Read-only review. Inspect current git diff for DingTalk group runtime webhook guard. Focus on testSend and automation group sends not fetching legacy invalid webhook URLs. Do not modify files. Report concrete blockers only; if none, say no blocking issues."
+```
+
+## Expected Coverage
+
+- `testSend` rejects legacy invalid stored webhook URLs before `fetch`.
+- `testSend` records failed delivery diagnostics and marks the destination test status as failed.
+- Automation group sends reject legacy invalid stored webhook URLs before `fetch`.
+- Automation pre-validates all selected destinations before sending any valid destination.
+- Existing valid DingTalk group sends still pass.
+- Shared robot webhook normalization remains used by create/update and runtime paths.
+- Backend TypeScript build passes.
+
+## Results
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false`: passed, 1 file and 17 tests.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false`: passed, 1 file and 121 tests.
+- `pnpm --filter @metasheet/core-backend build`: passed.
+- `rg -n "normalizeDingTalkRobotWebhookUrl|normalizeDingTalkRobotSecret|testSend rejects legacy invalid webhook URL without fetch|fails send_dingtalk_group_message for legacy invalid webhook without fetch|validates all DingTalk group webhooks before sending any destination|re-check|re-validate stored webhook" ...`: passed, expected backend/test/doc references found.
+- `git diff --check`: passed.
+- `claude -p --tools Read,Grep,Glob --max-budget-usd 0.75 ...`: passed as read-only review, no blocking issues reported.
+
+## Claude Code CLI
+
+- Local CLI check: `claude --version`
+- Version observed: `2.1.117 (Claude Code)`
+- Read-only review was executed with `Read,Grep,Glob` tools.
+- Claude reported no blocking issues. It noted a non-blocking clarity risk around a raw webhook fallback in the send loop; that fallback was removed and the automation target test still passed.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -53,6 +53,7 @@ Notes:
 - the DingTalk Groups tab explains that groups created there are bound to the current table, one table can have multiple groups, and automations can choose one or more groups as send targets
 - registering a DingTalk group destination does not import DingTalk group members and does not grant or control public form access
 - DingTalk group destination webhooks must be standard group robot URLs from `https://oapi.dingtalk.com/robot/send` and include an `access_token`; optional signature secrets must start with `SEC`
+- test sends and automation sends re-check the stored webhook before delivery, so legacy non-DingTalk URLs are blocked before any outbound request
 - the current model manually registers a group webhook; it does not auto-import your DingTalk groups
 
 ## B. Configure a DingTalk person notification rule

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -235,6 +235,7 @@ Authoring guardrail:
 - the DingTalk Groups tab describes table-scoped binding, that one table can have multiple groups, and that automations can choose one or more groups
 - the DingTalk Groups form clarifies that the webhook comes from the target group robot, that `SEC...` is only for signed robots, and that registering a destination does not import DingTalk group members or grant form access
 - DingTalk group destination create/update enforces standard group robot webhook URLs from `https://oapi.dingtalk.com/robot/send` with a non-empty `access_token`; optional signature secrets must start with `SEC`
+- DingTalk group test sends and automation sends re-validate stored webhook URLs before delivery, preventing legacy non-DingTalk URLs from being fetched
 - dynamic `Record group field paths` must resolve to DingTalk group destination IDs, not local user fields, member group IDs, or DingTalk group names
 - group-message and person-message automations disable save when the selected public form link cannot produce a working fill link
 - group-message and person-message automations disable save when the selected internal processing view is not in the current sheet

--- a/packages/core-backend/src/integrations/dingtalk/robot.ts
+++ b/packages/core-backend/src/integrations/dingtalk/robot.ts
@@ -15,6 +15,9 @@ interface DingTalkRobotResponse {
 
 export class DingTalkRobotResponseError extends Error {}
 
+const DINGTALK_ROBOT_WEBHOOK_HOST = 'oapi.dingtalk.com'
+const DINGTALK_ROBOT_WEBHOOK_PATH = '/robot/send'
+
 export function buildDingTalkMarkdown(subject: string, content: string): DingTalkRobotPayload {
   const title = subject.trim() || 'MetaSheet Notification'
   const body = content.trim() || title
@@ -25,6 +28,39 @@ export function buildDingTalkMarkdown(subject: string, content: string): DingTal
       text: `### ${title}\n\n${body}`,
     },
   }
+}
+
+export function normalizeDingTalkRobotWebhookUrl(value: string | undefined): string {
+  const webhookUrl = value?.trim()
+  if (!webhookUrl) throw new Error('Webhook URL is required')
+
+  let parsed: URL
+  try {
+    parsed = new URL(webhookUrl)
+  } catch {
+    throw new Error('Webhook URL is not a valid URL')
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('DingTalk robot webhook URL must use HTTPS')
+  }
+  if (parsed.hostname !== DINGTALK_ROBOT_WEBHOOK_HOST || parsed.pathname !== DINGTALK_ROBOT_WEBHOOK_PATH) {
+    throw new Error(`DingTalk group webhook URL must be a DingTalk robot URL from https://${DINGTALK_ROBOT_WEBHOOK_HOST}${DINGTALK_ROBOT_WEBHOOK_PATH}`)
+  }
+  if (!parsed.searchParams.get('access_token')?.trim()) {
+    throw new Error('DingTalk group webhook URL must include access_token')
+  }
+
+  return parsed.toString()
+}
+
+export function normalizeDingTalkRobotSecret(value: string | undefined): string | undefined {
+  const secret = value?.trim()
+  if (!secret) return undefined
+  if (!secret.startsWith('SEC')) {
+    throw new Error('DingTalk robot secret must start with SEC')
+  }
+  return secret
 }
 
 export function buildSignedDingTalkWebhookUrl(baseUrl: string, secret?: string): string {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -16,6 +16,8 @@ import type { EventBus } from '../integration/events/event-bus'
 import {
   buildDingTalkMarkdown,
   buildSignedDingTalkWebhookUrl,
+  normalizeDingTalkRobotSecret,
+  normalizeDingTalkRobotWebhookUrl,
   validateDingTalkRobotResponse,
 } from '../integrations/dingtalk/robot'
 import type {
@@ -1299,6 +1301,56 @@ export class AutomationExecutor {
       .filter((destination): destination is NonNullable<typeof destination> => Boolean(destination))
     const successfulDestinations: Array<{ id: string; name: string }> = []
     const failedDestinations: Array<{ id: string; name: string; error: string }> = []
+    const runtimeWebhookByDestinationId = new Map<string, { webhookUrl: string; secret?: string }>()
+
+    for (const destination of orderedDestinations) {
+      try {
+        runtimeWebhookByDestinationId.set(destination.id, {
+          webhookUrl: normalizeDingTalkRobotWebhookUrl(destination.webhook_url),
+          secret: normalizeDingTalkRobotSecret(destination.secret ?? undefined),
+        })
+      } catch (err) {
+        failedDestinations.push({
+          id: destination.id,
+          name: destination.name,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+
+    if (failedDestinations.length) {
+      await Promise.all(failedDestinations.map((destination) =>
+        recordDingTalkGroupDeliverySafely(this.deps.queryFn, {
+          destinationId: destination.id,
+          sourceType: 'automation',
+          subject: renderedTitle,
+          content: bodyWithLinks,
+          success: false,
+          httpStatus: null,
+          responseBody: null,
+          errorMessage: destination.error,
+          automationRuleId: context.ruleId,
+          recordId: context.recordId,
+          initiatedBy: context.actorId ?? null,
+        }),
+      ))
+      return {
+        actionType: 'send_dingtalk_group_message',
+        status: 'failed',
+        error: `${failedDestinations.length} of ${orderedDestinations.length} DingTalk destinations failed validation: ${failedDestinations.map((destination) => `${destination.name} (${destination.error})`).join('; ')}`,
+        output: {
+          staticDestinationCount: staticDestinationIds.length,
+          dynamicDestinationCount: recordDestinationIds.length,
+          destinationIds: orderedDestinations.map((destination) => destination.id),
+          destinationNames: orderedDestinations.map((destination) => destination.name),
+          destinationFieldPath: destinationFieldPaths[0] ?? null,
+          destinationFieldPaths,
+          sentCount: 0,
+          failedDestinationIds: failedDestinations.map((destination) => destination.id),
+          linkCount: linkLines.length,
+        },
+      }
+    }
 
     for (const destination of orderedDestinations) {
       let deliveryRecorded = false
@@ -1307,8 +1359,12 @@ export class AutomationExecutor {
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS)
       try {
+        const runtimeWebhook = runtimeWebhookByDestinationId.get(destination.id)
+        if (!runtimeWebhook) {
+          throw new Error(`DingTalk destination ${destination.name || destination.id} was not validated before send`)
+        }
         const response = await (this.deps.fetchFn ?? globalThis.fetch)(
-          buildSignedDingTalkWebhookUrl(destination.webhook_url, destination.secret ?? undefined),
+          buildSignedDingTalkWebhookUrl(runtimeWebhook.webhookUrl, runtimeWebhook.secret),
           {
             method: 'POST',
             headers: {

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -6,6 +6,8 @@ import { nowTimestamp } from '../db/type-helpers'
 import {
   buildDingTalkMarkdown,
   buildSignedDingTalkWebhookUrl,
+  normalizeDingTalkRobotSecret,
+  normalizeDingTalkRobotWebhookUrl,
   validateDingTalkRobotResponse,
 } from '../integrations/dingtalk/robot'
 import { maskDingTalkWebhookUrl } from '../integrations/dingtalk/runtime-policy'
@@ -19,8 +21,6 @@ import type {
 
 const logger = new Logger('DingTalkGroupDestinationService')
 const DINGTALK_REQUEST_TIMEOUT_MS = 5_000
-const DINGTALK_ROBOT_WEBHOOK_HOST = 'oapi.dingtalk.com'
-const DINGTALK_ROBOT_WEBHOOK_PATH = '/robot/send'
 
 type DingTalkGroupDestinationRow = {
   id: string
@@ -39,39 +39,6 @@ type DingTalkGroupDestinationRow = {
 
 function generateId(): string {
   return randomBytes(16).toString('hex')
-}
-
-function normalizeDingTalkRobotWebhookUrl(value: string | undefined): string {
-  const webhookUrl = value?.trim()
-  if (!webhookUrl) throw new Error('Webhook URL is required')
-
-  let parsed: URL
-  try {
-    parsed = new URL(webhookUrl)
-  } catch {
-    throw new Error('Webhook URL is not a valid URL')
-  }
-
-  if (parsed.protocol !== 'https:') {
-    throw new Error('DingTalk robot webhook URL must use HTTPS')
-  }
-  if (parsed.hostname !== DINGTALK_ROBOT_WEBHOOK_HOST || parsed.pathname !== DINGTALK_ROBOT_WEBHOOK_PATH) {
-    throw new Error(`DingTalk group webhook URL must be a DingTalk robot URL from https://${DINGTALK_ROBOT_WEBHOOK_HOST}${DINGTALK_ROBOT_WEBHOOK_PATH}`)
-  }
-  if (!parsed.searchParams.get('access_token')?.trim()) {
-    throw new Error('DingTalk group webhook URL must include access_token')
-  }
-
-  return parsed.toString()
-}
-
-function normalizeDingTalkRobotSecret(value: string | undefined): string | undefined {
-  const secret = value?.trim()
-  if (!secret) return undefined
-  if (!secret.startsWith('SEC')) {
-    throw new Error('DingTalk robot secret must start with SEC')
-  }
-  return secret
 }
 
 function rowToDestination(row: DingTalkGroupDestinationRow): DingTalkGroupDestination {
@@ -286,12 +253,15 @@ export class DingTalkGroupDestinationService {
     const subject = input.subject?.trim() || 'MetaSheet DingTalk group test'
     const content = input.content?.trim() || 'This is a standard DingTalk group destination test message.'
     const payload = buildDingTalkMarkdown(subject, content)
-    const signedUrl = buildSignedDingTalkWebhookUrl(row.webhook_url, row.secret ?? undefined)
     let deliveryRecorded = false
     let responseStatus: number | null = null
     let responseBody: string | null = null
 
     try {
+      const signedUrl = buildSignedDingTalkWebhookUrl(
+        normalizeDingTalkRobotWebhookUrl(row.webhook_url),
+        normalizeDingTalkRobotSecret(row.secret ?? undefined),
+      )
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), DINGTALK_REQUEST_TIMEOUT_MS)
       let response: Response

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -552,6 +552,97 @@ describe('AutomationExecutor', () => {
     expect(insertCalls).toHaveLength(2)
   })
 
+  it('fails send_dingtalk_group_message for legacy invalid webhook without fetch', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Legacy Group', webhook_url: 'https://example.com/hook', secret: null, enabled: true }],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('DingTalk robot URL')
+    expect(result.steps[0].output).toEqual(expect.objectContaining({
+      sentCount: 0,
+      failedDestinationIds: ['dt_1'],
+    }))
+    expect(fetchFn).not.toHaveBeenCalled()
+    const insertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_group_deliveries'))
+    expect(insertCalls).toHaveLength(1)
+    expect(insertCalls[0]?.[1]?.[8]).toContain('DingTalk robot URL')
+  })
+
+  it('validates all DingTalk group webhooks before sending any destination', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 'dt_valid', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true },
+          { id: 'dt_legacy', name: 'Legacy Group', webhook_url: 'https://example.com/hook', secret: null, enabled: true },
+        ],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationIds: ['dt_valid', 'dt_legacy'],
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('1 of 2 DingTalk destinations failed validation')
+    expect(result.steps[0].output).toEqual(expect.objectContaining({
+      sentCount: 0,
+      failedDestinationIds: ['dt_legacy'],
+    }))
+    expect(fetchFn).not.toHaveBeenCalled()
+    const insertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_group_deliveries'))
+    expect(insertCalls).toHaveLength(1)
+    expect(insertCalls[0]?.[1]?.[1]).toBe('dt_legacy')
+  })
+
   it('executes send_dingtalk_group_message with dynamic record destinations', async () => {
     const queryFn = vi.fn()
       .mockResolvedValueOnce({

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -276,6 +276,30 @@ describe('DingTalkGroupDestinationService', () => {
     expect(setArg?.last_test_error).toBeNull()
   })
 
+  test('testSend rejects legacy invalid webhook URL without fetch', async () => {
+    const { db, roots } = createMockDb()
+    const fetchFn = vi.fn(async () => new Response(
+      JSON.stringify({ errcode: 0, errmsg: 'ok' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    const service = new DingTalkGroupDestinationService(db, fetchFn as typeof fetch)
+
+    executeTakeFirstQueue.push(destinationRow({ webhook_url: 'https://example.com/hook' }))
+    await expect(service.testSend('dt_1', 'user_1', {})).rejects.toThrow('DingTalk robot URL')
+
+    expect(fetchFn).not.toHaveBeenCalled()
+    expect(roots.insertInto).toHaveBeenCalledWith('dingtalk_group_deliveries')
+    const insertChain = roots.insertInto.mock.results[0]?.value as MockChain | undefined
+    const deliveryValues = insertChain?.values?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(deliveryValues?.success).toBe(false)
+    expect(deliveryValues?.http_status).toBeNull()
+    expect(deliveryValues?.error_message).toContain('DingTalk robot URL')
+    const updateChain = roots.updateTable.mock.results[0]?.value as MockChain | undefined
+    const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(setArg?.last_test_status).toBe('failed')
+    expect(setArg?.last_test_error).toContain('DingTalk robot URL')
+  })
+
   test('testSend allows shared destination access for non-owner on the same sheet', async () => {
     const { db } = createMockDb()
     const fetchFn = vi.fn(async () => new Response(


### PR DESCRIPTION
## Summary
- Extract shared DingTalk robot webhook/secret normalization for destination write-time and runtime paths.
- Re-check stored group robot webhook and secret during manual test sends, recording a failed test result before any outbound request for invalid legacy rows.
- Pre-validate all selected DingTalk group destinations before automation delivery so a single invalid legacy destination fails the action without partial sends.
- Update DingTalk capability/admin docs plus development and verification reports.

## Verification
- Rebased directly onto `origin/main@c8aa605ea735` after PR #1041 squash merge.
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts --watch=false` -> 17/17 passed
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false` -> 121/121 passed
- `rg -n "normalizeDingTalkRobotWebhookUrl|normalizeDingTalkRobotSecret|testSend rejects legacy invalid webhook URL without fetch|fails send_dingtalk_group_message for legacy invalid webhook without fetch|validates all DingTalk group webhooks before sending any destination|re-check|re-validate stored webhook" ...` -> passed
- `git diff --check` -> passed
- `pnpm --filter @metasheet/core-backend build` -> passed
- Claude Code CLI read-only review: no blocking issues; removed the non-blocking raw webhook fallback it pointed out and reran the automation target tests.
