### PR TITLE
fix(dingtalk): redact group robot credentials

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -219,11 +219,12 @@
               class="meta-api-mgr__input"
               type="text"
               placeholder="SEC..."
+              :disabled="dingTalkGroupDraft.clearSecret"
               aria-describedby="dingtalk-group-secret-help"
               data-dingtalk-group-secret="true"
             />
             <p id="dingtalk-group-secret-help" class="meta-api-mgr__help" data-dingtalk-group-secret-help="true">
-              Fill this only when the DingTalk robot uses signature security. Leave empty for robots without a SEC secret.
+              {{ dingTalkGroupSecretHelpText }}
             </p>
             <p
               v-if="dingTalkGroupSecretValidationMessage"
@@ -232,6 +233,18 @@
             >
               {{ dingTalkGroupSecretValidationMessage }}
             </p>
+            <label
+              v-if="editingDingTalkGroupOriginal?.hasSecret"
+              class="meta-api-mgr__checkbox-label"
+              data-dingtalk-group-clear-secret-row="true"
+            >
+              <input
+                v-model="dingTalkGroupDraft.clearSecret"
+                type="checkbox"
+                data-dingtalk-group-clear-secret="true"
+              />
+              Clear saved SEC secret
+            </label>
             <label class="meta-api-mgr__checkbox-label">
               <input
                 v-model="dingTalkGroupDraft.enabled"
@@ -286,6 +299,7 @@
             </div>
             <div class="meta-api-mgr__card-meta">
               <span>Webhook: {{ maskDingTalkWebhookUrl(group.webhookUrl) }}</span>
+              <span>Secret: {{ group.hasSecret ? 'configured' : 'not configured' }}</span>
               <span>{{ group.sheetId ? 'Shared with this sheet' : 'Private legacy group' }}</span>
               <span>Created: {{ formatDate(group.createdAt) }}</span>
               <span v-if="group.lastTestedAt">Last test: {{ formatDate(group.lastTestedAt) }}</span>
@@ -406,7 +420,7 @@ const dingTalkGroups = ref<DingTalkGroupDestination[]>([])
 const dingTalkGroupsLoading = ref(false)
 const showDingTalkGroupForm = ref(false)
 const editingDingTalkGroupId = ref<string | null>(null)
-const editingDingTalkGroupOriginal = ref<{ webhookUrl: string; secret: string } | null>(null)
+const editingDingTalkGroupOriginal = ref<{ webhookUrl: string; hasSecret: boolean } | null>(null)
 const dingTalkDeliveriesGroupId = ref<string | null>(null)
 const dingTalkDeliveriesLoading = ref(false)
 const dingTalkDeliveries = ref<DingTalkGroupDelivery[]>([])
@@ -415,6 +429,7 @@ const dingTalkGroupDraft = ref({
   name: '',
   webhookUrl: '',
   secret: '',
+  clearSecret: false,
   enabled: true,
 })
 
@@ -433,14 +448,21 @@ const dingTalkGroupWebhookChanged = computed(() => {
 })
 const dingTalkGroupSecretChanged = computed(() => {
   if (!editingDingTalkGroupId.value) return true
-  return dingTalkGroupDraft.value.secret.trim() !== (editingDingTalkGroupOriginal.value?.secret ?? '').trim()
+  if (dingTalkGroupDraft.value.clearSecret) return true
+  return Boolean(dingTalkGroupDraft.value.secret.trim())
 })
 const dingTalkGroupWebhookValidationMessage = computed(() =>
   dingTalkGroupWebhookChanged.value ? validateDingTalkGroupWebhookUrl(dingTalkGroupDraft.value.webhookUrl) : '',
 )
 const dingTalkGroupSecretValidationMessage = computed(() =>
-  dingTalkGroupSecretChanged.value ? validateDingTalkGroupSecret(dingTalkGroupDraft.value.secret) : '',
+  dingTalkGroupDraft.value.clearSecret ? '' : dingTalkGroupSecretChanged.value ? validateDingTalkGroupSecret(dingTalkGroupDraft.value.secret) : '',
 )
+const dingTalkGroupSecretHelpText = computed(() => {
+  if (editingDingTalkGroupOriginal.value?.hasSecret) {
+    return 'A SEC secret is already saved. Leave blank to keep it, enter a new SEC secret to replace it, or clear it below.'
+  }
+  return 'Fill this only when the DingTalk robot uses signature security. Leave empty for robots without a SEC secret.'
+})
 const canSaveDingTalkGroup = computed(() => {
   return canManageDingTalkGroups.value
     && dingTalkGroupDraft.value.name.trim()
@@ -742,6 +764,7 @@ function openDingTalkGroupForm() {
     name: '',
     webhookUrl: '',
     secret: '',
+    clearSecret: false,
     enabled: true,
   }
   showDingTalkGroupForm.value = true
@@ -752,12 +775,13 @@ function openEditDingTalkGroup(group: DingTalkGroupDestination) {
   editingDingTalkGroupId.value = group.id
   editingDingTalkGroupOriginal.value = {
     webhookUrl: group.webhookUrl,
-    secret: group.secret ?? '',
+    hasSecret: group.hasSecret === true || Boolean(group.secret),
   }
   dingTalkGroupDraft.value = {
     name: group.name,
     webhookUrl: group.webhookUrl,
-    secret: group.secret ?? '',
+    secret: '',
+    clearSecret: false,
     enabled: group.enabled,
   }
   showDingTalkGroupForm.value = true
@@ -783,7 +807,11 @@ async function onSaveDingTalkGroup() {
         enabled: dingTalkGroupDraft.value.enabled,
       }
       if (dingTalkGroupWebhookChanged.value) updateInput.webhookUrl = webhookUrl
-      if (dingTalkGroupSecretChanged.value) updateInput.secret = secret || ''
+      if (dingTalkGroupDraft.value.clearSecret) {
+        updateInput.secret = ''
+      } else if (secret) {
+        updateInput.secret = secret
+      }
       await props.client.updateDingTalkGroup(editingDingTalkGroupId.value, updateInput, props.sheetId)
     } else {
       await props.client.createDingTalkGroup({

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -797,6 +797,7 @@ export interface DingTalkGroupDestination {
   name: string
   webhookUrl: string
   secret?: string
+  hasSecret?: boolean
   enabled: boolean
   sheetId?: string
   createdBy: string

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -82,6 +82,7 @@ function fakeDingTalkGroup(overrides: Partial<DingTalkGroupDestination> = {}): D
     id: 'dt_1',
     name: 'Ops DingTalk Group',
     webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+    hasSecret: false,
     enabled: true,
     sheetId: 'sheet_1',
     createdBy: 'user_1',
@@ -569,7 +570,7 @@ describe('MetaApiTokenManager', () => {
   it('omits unchanged legacy DingTalk webhook settings when editing metadata', async () => {
     const legacyGroup = fakeDingTalkGroup({
       webhookUrl: 'https://example.com/legacy-hook',
-      secret: 'legacy-secret',
+      hasSecret: true,
     })
     const { client, fetchFn } = mockClient([], [], [], [legacyGroup])
     mount({ visible: true, client })
@@ -603,6 +604,48 @@ describe('MetaApiTokenManager', () => {
     expect(JSON.parse(updateCalls[0][1]?.body as string)).toEqual({
       name: 'Legacy group renamed',
       enabled: true,
+    })
+  })
+
+  it('does not prefill saved DingTalk group secret and can clear it explicitly', async () => {
+    const signedGroup = fakeDingTalkGroup({
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=***',
+      hasSecret: true,
+    })
+    const { client, fetchFn } = mockClient([], [], [], [signedGroup])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const editBtn = document.querySelector('[data-dingtalk-group-edit]') as HTMLButtonElement
+    editBtn.click()
+    await flushPromises()
+
+    const secretInput = document.querySelector('[data-dingtalk-group-secret]') as HTMLInputElement
+    expect(secretInput.value).toBe('')
+    expect(document.querySelector('[data-dingtalk-group-secret-help]')?.textContent).toContain('already saved')
+
+    const clearSecret = document.querySelector('[data-dingtalk-group-clear-secret]') as HTMLInputElement
+    expect(clearSecret).toBeTruthy()
+    clearSecret.checked = true
+    clearSecret.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = document.querySelector('[data-dingtalk-group-save]') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const updateCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'PATCH' && c[0].includes('/dingtalk-groups/'),
+    )
+    expect(updateCalls.length).toBe(1)
+    expect(JSON.parse(updateCalls[0][1]?.body as string)).toEqual({
+      name: 'Ops DingTalk Group',
+      enabled: true,
+      secret: '',
     })
   })
 

--- a/docs/development/dingtalk-group-credential-redaction-development-20260422.md
+++ b/docs/development/dingtalk-group-credential-redaction-development-20260422.md
@@ -1,0 +1,46 @@
+# DingTalk Group Credential Redaction Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-credential-redaction-20260422`
+- Scope: DingTalk group destination API/UI credential hygiene
+
+## Goal
+
+Prevent saved DingTalk group robot credentials from being reflected back to the browser after creation.
+
+Robot webhook `access_token` values and optional `SEC...` secrets are delivery credentials. Runtime delivery still needs the stored values, but management UI list/edit responses should not expose them.
+
+## Implementation
+
+- Added a DingTalk group destination API response serializer.
+- The serializer:
+  - masks `access_token`, `timestamp`, and `sign` query parameters in `webhookUrl`
+  - omits the saved `secret` field from API responses
+  - exposes `hasSecret` so the UI can show and preserve signed-robot state without revealing the secret
+- Applied the serializer to DingTalk group list/create/update API responses.
+- Extended frontend DingTalk group destination types with `hasSecret`.
+- Updated the DingTalk Groups manager UI:
+  - card metadata shows whether a secret is configured
+  - editing no longer pre-fills a saved secret
+  - leaving the secret field blank keeps the existing secret
+  - entering a new `SEC...` value replaces it
+  - checking `Clear saved SEC secret` sends `secret: ''`
+- Updated operating/capability docs to describe the redaction behavior.
+
+## Files
+
+- `packages/core-backend/src/multitable/dingtalk-group-destination-response.ts`
+- `packages/core-backend/src/routes/api-tokens.ts`
+- `packages/core-backend/src/multitable/dingtalk-group-destinations.ts`
+- `packages/core-backend/tests/unit/dingtalk-group-destination-response.test.ts`
+- `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/tests/multitable-api-token-manager.spec.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- No database migration is required.
+- Runtime automation delivery and manual test sends still use the raw DB values internally.
+- This slice does not change generic webhook management; it is scoped to DingTalk group robot destinations.

--- a/docs/development/dingtalk-group-credential-redaction-verification-20260422.md
+++ b/docs/development/dingtalk-group-credential-redaction-verification-20260422.md
@@ -1,0 +1,42 @@
+# DingTalk Group Credential Redaction Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-group-credential-redaction-20260422`
+
+## Local Verification
+
+Passed:
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-response.test.ts tests/unit/dingtalk-group-destination-service.test.ts --watch=false`
+  - 2 files passed
+  - 19 tests passed
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false`
+  - 1 file passed
+  - 24 tests passed
+- `pnpm --filter @metasheet/core-backend build`
+  - passed
+- `pnpm --filter @metasheet/web build`
+  - passed
+  - Vite reported existing chunk-size/dynamic-import warnings only
+- `git diff --check`
+  - passed
+
+## Expected Assertions
+
+- API response serializer masks DingTalk robot webhook query credentials.
+- API response serializer omits the saved `SEC` secret and returns `hasSecret`.
+- Existing service behavior for create/list/test-send remains intact.
+- Frontend manager does not prefill a saved secret during edit.
+- Frontend manager can explicitly clear a saved secret by sending `secret: ''`.
+- Frontend manager still omits unchanged webhook/secret fields when editing metadata only.
+
+## Claude Code CLI
+
+Read-only review passed with no blockers.
+
+The first run used a `0.75 USD` budget and exited with `Exceeded USD budget`. A second short-prompt run with a `1.5 USD` budget completed and confirmed:
+
+- list/create/update DingTalk group destination API responses route through the redaction serializer
+- raw `access_token`, `timestamp`, `sign`, URL password, and saved `SEC` secret are not reflected to the browser by those responses
+- frontend editing does not prefill saved secrets
+- frontend keep/replace/clear behavior is correctly encoded in the PATCH payload

--- a/docs/development/dingtalk-group-credential-redaction-verification-20260422.md
+++ b/docs/development/dingtalk-group-credential-redaction-verification-20260422.md
@@ -40,3 +40,15 @@ The first run used a `0.75 USD` budget and exited with `Exceeded USD budget`. A 
 - raw `access_token`, `timestamp`, `sign`, URL password, and saved `SEC` secret are not reflected to the browser by those responses
 - frontend editing does not prefill saved secrets
 - frontend keep/replace/clear behavior is correctly encoded in the PATCH payload
+
+## Main rebase verification - 2026-04-22
+
+- Rebased only the credential redaction slice onto `origin/main@21683ef3c42b` after PR #1043 was squash-merged.
+- Rebased branch HEAD: `8de603836acb`.
+- `pnpm install --frozen-lockfile`: passed.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-response.test.ts tests/unit/dingtalk-group-destination-service.test.ts --watch=false`: passed, 2 files and 19 tests.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false`: passed, 1 file and 24 tests. The run printed a non-fatal local WebSocket port-in-use message and exited successfully.
+- `rg -n "serializeDingTalkGroupDestination|maskDingTalkRobotWebhookUrl|hasSecret|access_token=\\*\\*\\*|does not prefill saved secrets|explicitly clear|redact|credential|secret" ...`: passed.
+- `git diff --check`: passed.
+- `pnpm --filter @metasheet/core-backend build`: passed.
+- `pnpm --filter @metasheet/web build`: passed. Vite emitted only existing chunk-size and mixed static/dynamic import warnings.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -53,6 +53,8 @@ Notes:
 - the DingTalk Groups tab explains that groups created there are bound to the current table, one table can have multiple groups, and automations can choose one or more groups as send targets
 - registering a DingTalk group destination does not import DingTalk group members and does not grant or control public form access
 - DingTalk group destination webhooks must be standard group robot URLs from `https://oapi.dingtalk.com/robot/send` and include an `access_token`; optional signature secrets must start with `SEC`
+- after saving, the management API and UI show only a masked webhook URL plus whether a `SEC` secret is configured; the raw `access_token` and secret are not returned to the browser
+- when editing a signed robot destination, leave the secret field blank to keep the existing secret, enter a new `SEC...` value to replace it, or choose clear to remove it
 - test sends and automation sends re-check the stored webhook before delivery, so legacy non-DingTalk URLs are blocked before any outbound request
 - the current model manually registers a group webhook; it does not auto-import your DingTalk groups
 

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -235,6 +235,8 @@ Authoring guardrail:
 - the DingTalk Groups tab describes table-scoped binding, that one table can have multiple groups, and that automations can choose one or more groups
 - the DingTalk Groups form clarifies that the webhook comes from the target group robot, that `SEC...` is only for signed robots, and that registering a destination does not import DingTalk group members or grant form access
 - DingTalk group destination create/update enforces standard group robot webhook URLs from `https://oapi.dingtalk.com/robot/send` with a non-empty `access_token`; optional signature secrets must start with `SEC`
+- DingTalk group destination API responses redact the robot `access_token`/signature query parameters and omit the saved `SEC` secret, exposing only a `hasSecret` flag for editing state
+- signed robot destinations can keep the existing secret by leaving the edit field blank, replace it with a new `SEC...` value, or explicitly clear it
 - DingTalk group test sends and automation sends re-validate stored webhook URLs before delivery, preventing legacy non-DingTalk URLs from being fetched
 - dynamic `Record group field paths` must resolve to DingTalk group destination IDs, not local user fields, member group IDs, or DingTalk group names
 - group-message and person-message automations disable save when the selected public form link cannot produce a working fill link

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-response.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-response.ts
@@ -1,0 +1,17 @@
+import { maskDingTalkWebhookUrl } from '../integrations/dingtalk/runtime-policy'
+import type { DingTalkGroupDestination } from './dingtalk-group-destinations'
+
+export type DingTalkGroupDestinationResponse = Omit<DingTalkGroupDestination, 'secret'> & {
+  hasSecret: boolean
+}
+
+export function toDingTalkGroupDestinationResponse(
+  destination: DingTalkGroupDestination,
+): DingTalkGroupDestinationResponse {
+  const { secret: _secret, ...rest } = destination
+  return {
+    ...rest,
+    webhookUrl: maskDingTalkWebhookUrl(destination.webhookUrl),
+    hasSecret: Boolean(destination.secret),
+  }
+}

--- a/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
@@ -3,6 +3,7 @@ export interface DingTalkGroupDestination {
   name: string
   webhookUrl: string
   secret?: string
+  hasSecret?: boolean
   enabled: boolean
   sheetId?: string
   createdBy: string

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -12,6 +12,7 @@ import { authenticate } from '../middleware/auth'
 import { ApiTokenService } from '../multitable/api-token-service'
 import { ALL_API_TOKEN_SCOPES } from '../multitable/api-tokens'
 import { DingTalkGroupDestinationService } from '../multitable/dingtalk-group-destination-service'
+import { toDingTalkGroupDestinationResponse } from '../multitable/dingtalk-group-destination-response'
 import { resolveSheetCapabilitiesForUser } from '../multitable/sheet-capabilities'
 import { WebhookService } from '../multitable/webhook-service'
 import { ALL_WEBHOOK_EVENT_TYPES } from '../multitable/webhooks'
@@ -320,7 +321,7 @@ export function apiTokensRouter(): Router {
     const sheetId = getSheetId(req.query.sheetId)
     if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
     const destinations = await dingTalkGroupDestinationService.listDestinations(userId, sheetId || undefined)
-    res.json({ ok: true, data: { destinations } })
+    res.json({ ok: true, data: { destinations: destinations.map(toDingTalkGroupDestinationResponse) } })
   })
 
   router.post('/api/multitable/dingtalk-groups', async (req: Request, res: Response) => {
@@ -340,7 +341,7 @@ export function apiTokensRouter(): Router {
         enabled: input.enabled,
         sheetId: sheetId || undefined,
       })
-      res.status(201).json({ ok: true, data: destination })
+      res.status(201).json({ ok: true, data: toDingTalkGroupDestinationResponse(destination) })
     } catch (err) {
       if (err instanceof z.ZodError) {
         zodError(res, err)
@@ -367,7 +368,7 @@ export function apiTokensRouter(): Router {
         secret: input.secret,
         enabled: input.enabled,
       }, sheetId || undefined)
-      res.json({ ok: true, data: destination })
+      res.json({ ok: true, data: toDingTalkGroupDestinationResponse(destination) })
     } catch (err) {
       if (err instanceof z.ZodError) {
         zodError(res, err)

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-response.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-response.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { toDingTalkGroupDestinationResponse } from '../../src/multitable/dingtalk-group-destination-response'
+import type { DingTalkGroupDestination } from '../../src/multitable/dingtalk-group-destinations'
+
+function destination(overrides: Partial<DingTalkGroupDestination> = {}): DingTalkGroupDestination {
+  return {
+    id: 'dt_1',
+    name: 'Ops DingTalk Group',
+    webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=secret-token&timestamp=123&sign=abc',
+    secret: 'SECsecret',
+    enabled: true,
+    sheetId: 'sheet_1',
+    createdBy: 'user_1',
+    createdAt: '2026-04-22T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('toDingTalkGroupDestinationResponse', () => {
+  it('masks webhook credentials and omits the saved robot secret', () => {
+    const response = toDingTalkGroupDestinationResponse(destination())
+
+    expect(response.webhookUrl).toContain('access_token=***')
+    expect(response.webhookUrl).toContain('timestamp=***')
+    expect(response.webhookUrl).toContain('sign=***')
+    expect(response.webhookUrl).not.toContain('secret-token')
+    expect(response.hasSecret).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(response, 'secret')).toBe(false)
+  })
+
+  it('reports hasSecret=false when no SEC secret is saved', () => {
+    const response = toDingTalkGroupDestinationResponse(destination({ secret: undefined }))
+
+    expect(response.hasSecret).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(response, 'secret')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add a DingTalk group destination response serializer that masks robot webhook credential query params and omits saved SEC secrets from list/create/update API responses.
- Expose `hasSecret` for UI state without reflecting the raw secret.
- Update the DingTalk Groups manager so edit forms do not prefill saved secrets, while supporting keep, replace, and explicit clear flows.
- Update DingTalk admin/capability docs plus development and verification reports.

## Verification
- Rebased only this credential redaction slice onto `origin/main@21683ef3c42b` after PR #1043 squash merge.
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-response.test.ts tests/unit/dingtalk-group-destination-service.test.ts --watch=false` -> 19/19 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false` -> 24/24 passed; non-fatal local WebSocket port-in-use message, exit 0
- `rg -n "serializeDingTalkGroupDestination|maskDingTalkRobotWebhookUrl|hasSecret|access_token=\\*\\*\\*|does not prefill saved secrets|explicitly clear|redact|credential|secret" ...` -> passed
- `git diff --check` -> passed
- `pnpm --filter @metasheet/core-backend build` -> passed
- `pnpm --filter @metasheet/web build` -> passed with existing Vite warnings only
- Claude Code CLI read-only review: no blocking issues. First run exceeded the 0.75 USD budget; second short-prompt run with 1.5 USD completed successfully.
