### PR TITLE
feat(dingtalk): warn person form access risks

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -503,7 +503,7 @@
               <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
             <div
-              v-for="warning in publicFormLinkWarnings(draft.dingtalkPersonPublicFormViewId)"
+              v-for="warning in publicFormLinkWarnings(draft.dingtalkPersonPublicFormViewId, true)"
               :key="`draft-person-public-form-${warning}`"
               class="meta-automation__hint meta-automation__hint--warning"
             >
@@ -1079,10 +1079,10 @@ function renderedTemplateExample(value: string, fallback: string) {
   return rendered || fallback
 }
 
-function publicFormLinkWarnings(value: unknown, warnWhenGroupAccessRisk = false) {
+function publicFormLinkWarnings(value: unknown, warnWhenDingTalkAccessRisk = false) {
   return listDingTalkPublicFormLinkWarnings(value, formViews.value, {
-    warnWhenFullyPublic: warnWhenGroupAccessRisk,
-    warnWhenProtectedWithoutAllowlist: warnWhenGroupAccessRisk,
+    warnWhenFullyPublic: warnWhenDingTalkAccessRisk,
+    warnWhenProtectedWithoutAllowlist: warnWhenDingTalkAccessRisk,
   })
 }
 

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -649,7 +649,7 @@
                 <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
               <div
-                v-for="warning in publicFormLinkWarnings(action.config.publicFormViewId)"
+                v-for="warning in publicFormLinkWarnings(action.config.publicFormViewId, true)"
                 :key="`person-public-form-${warning}`"
                 class="meta-rule-editor__hint meta-rule-editor__hint--warning"
               >
@@ -1283,10 +1283,10 @@ function renderedTemplateExample(value: unknown, fallback: string) {
   return rendered || fallback
 }
 
-function publicFormLinkWarnings(value: unknown, warnWhenGroupAccessRisk = false) {
+function publicFormLinkWarnings(value: unknown, warnWhenDingTalkAccessRisk = false) {
   return listDingTalkPublicFormLinkWarnings(value, formViews.value, {
-    warnWhenFullyPublic: warnWhenGroupAccessRisk,
-    warnWhenProtectedWithoutAllowlist: warnWhenGroupAccessRisk,
+    warnWhenFullyPublic: warnWhenDingTalkAccessRisk,
+    warnWhenProtectedWithoutAllowlist: warnWhenDingTalkAccessRisk,
   })
 }
 

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1153,6 +1153,65 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-automation-public-form-access="group"]')?.getAttribute('data-access-level')).toBe('dingtalk')
   })
 
+  it('warns when a DingTalk person message includes a fully public form link in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
+    expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
+    expect(container.querySelector('[data-automation-summary="person"]')?.textContent).toContain('Fully public; anyone with the link can submit')
+    expect(container.querySelector('[data-automation-public-form-audience="person"]')?.textContent)
+      .toContain('Anyone with the link can submit')
+    expect(container.querySelector('[data-automation-public-form-access="person"]')?.getAttribute('data-access-level')).toBe('public')
+  })
+
+  it('warns when a DingTalk person message uses a protected public form without an allowlist in the inline form', async () => {
+    const { client } = mockClient([])
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithProtectedPublicFormWithoutAllowlist,
+      client,
+    })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
+    expect(container.textContent).toContain('add allowed users or member groups')
+    expect(container.querySelector('[data-automation-public-form-audience="person"]')?.textContent)
+      .toContain('No local allowlist limits are set; all bound DingTalk users can submit')
+    expect(container.querySelector('[data-automation-public-form-access="person"]')?.getAttribute('data-access-level')).toBe('dingtalk')
+  })
+
   it('warns when a DingTalk person message selects a public form without a token in the inline form', async () => {
     const { client } = mockClient([])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views: viewsWithMissingPublicToken, client })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1013,6 +1013,64 @@ describe('MetaAutomationRuleEditor', () => {
       .toContain('1 local user can submit after DingTalk checks')
   })
 
+  it('warns when a DingTalk person message includes a fully public form link', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
+    expect(container.textContent).toContain('Use DingTalk-protected access and an allowlist')
+    expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.getAttribute('data-access-level'))
+      .toBe('public')
+    expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent)
+      .toContain('Fully public; anyone with the link can submit')
+  })
+
+  it('warns when a DingTalk person message uses a protected public form without an allowlist', async () => {
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views: viewsWithProtectedPublicFormWithoutAllowlist,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
+    publicFormSelect.value = 'view_form'
+    publicFormSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
+    expect(container.textContent).toContain('add allowed users or member groups')
+    expect(container.querySelector('[data-field="personPublicFormAudienceSummary-0"]')?.textContent)
+      .toContain('No local allowlist limits are set; all bound DingTalk users can submit')
+    expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent)
+      .toContain('No local allowlist limits are set; all bound DingTalk users can submit')
+  })
+
   it('emits DingTalk person action config with optional links', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/docs/development/dingtalk-person-form-risk-parity-development-20260422.md
+++ b/docs/development/dingtalk-person-form-risk-parity-development-20260422.md
@@ -1,0 +1,44 @@
+# DingTalk Person Form Risk Parity Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-person-form-risk-parity-20260422`
+- Scope: frontend DingTalk person-message public-form warnings
+
+## Goal
+
+Bring DingTalk person-message automation authoring to parity with group-message authoring for public-form access risk warnings.
+
+Before this slice, both group and person messages showed blocking errors for unusable public-form links, and both showed access/audience summaries. Only group messages showed advisory risk warnings for:
+
+- fully public form links
+- DingTalk-protected form links without local allowlists
+
+Person messages can also carry those links, so they should show the same warnings.
+
+## Implementation
+
+- Updated `MetaAutomationRuleEditor` person-message public-form warning call to enable DingTalk access-risk warnings.
+- Updated `MetaAutomationManager` inline person-message form warning call to enable the same access-risk warnings.
+- Renamed the local helper argument from group-specific wording to DingTalk access-risk wording.
+- Added tests for person-message fully public warnings in:
+  - advanced rule editor
+  - inline automation manager form
+- Added tests for person-message protected-without-allowlist warnings in:
+  - advanced rule editor
+  - inline automation manager form
+- Updated DingTalk admin and capability docs so warning behavior is described for group and person messages.
+
+## Files
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- This is advisory UI behavior only.
+- Save-blocking validation is unchanged and still only uses blocking public-form link errors.
+- Runtime delivery behavior is unchanged.

--- a/docs/development/dingtalk-person-form-risk-parity-verification-20260422.md
+++ b/docs/development/dingtalk-person-form-risk-parity-verification-20260422.md
@@ -33,3 +33,41 @@ Passed:
   - `MetaAutomationRuleEditor.vue` person path now mirrors group path for fully public and protected-without-allowlist advisory warnings.
   - `MetaAutomationManager.vue` inline person path now mirrors group path for the same warnings.
   - Save blocking remains tied to `publicFormLinkBlockingErrors`; advisory warnings do not block submit.
+
+## Stack Rebase Verification - 2026-04-22
+
+Base refreshed to `origin/codex/dingtalk-group-credential-redaction-20260422` at `61fc5161b2dd5bebc6eabc7268f434e29f9becea`.
+
+Passed:
+
+- `pnpm install --frozen-lockfile`
+  - Result: passed.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts tests/dingtalk-public-form-link-warnings.spec.ts --watch=false`
+  - Result: passed, 3 files and 136 tests.
+- `pnpm --filter @metasheet/web build`
+  - Result: passed.
+  - Notes: Vite reported existing non-failing dynamic-import and chunk-size warnings.
+- `git diff --check`
+  - Result: passed.
+
+Scope after rebase:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- DingTalk admin/capability docs and this development/verification note.
+
+## Main Rebase Verification - 2026-04-22
+
+After PR #1044 was merged, this branch was rebased from the stack base onto `origin/main` at `14a7d94188a6dec0cae147134cc708df7038f07c`.
+
+Passed:
+
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts tests/dingtalk-public-form-link-warnings.spec.ts --watch=false`
+  - Result: passed, 3 files and 136 tests.
+- `pnpm --filter @metasheet/web build`
+  - Result: passed.
+  - Notes: Vite reported existing non-failing dynamic-import and chunk-size warnings.
+- `git diff --check`
+  - Result: passed.

--- a/docs/development/dingtalk-person-form-risk-parity-verification-20260422.md
+++ b/docs/development/dingtalk-person-form-risk-parity-verification-20260422.md
@@ -1,0 +1,35 @@
+# DingTalk Person Form Risk Parity Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-person-form-risk-parity-20260422`
+
+## Local Verification
+
+Passed:
+
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts tests/dingtalk-public-form-link-warnings.spec.ts --watch=false`
+  - Result: passed, 3 files and 136 tests.
+- `pnpm --filter @metasheet/web build`
+  - Result: passed.
+  - Notes: Vite reported existing non-failing dynamic-import and chunk-size warnings.
+- `git diff --check`
+  - Result: passed.
+
+## Expected Assertions
+
+- Advanced rule editor warns when a DingTalk person message includes a fully public form link.
+- Advanced rule editor warns when a DingTalk person message uses a DingTalk-protected form without local allowlists.
+- Inline automation manager warns for the same two person-message risk cases.
+- Existing access summary and allowed-audience badges remain unchanged.
+- Save blocking still depends on blocking link errors, not advisory risk warnings.
+
+## Claude Code CLI
+
+Passed:
+
+- Command: `/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."`
+- Result: no blockers.
+- Findings:
+  - `MetaAutomationRuleEditor.vue` person path now mirrors group path for fully public and protected-without-allowlist advisory warnings.
+  - `MetaAutomationManager.vue` inline person path now mirrors group path for the same warnings.
+  - Save blocking remains tied to `publicFormLinkBlockingErrors`; advisory warnings do not block submit.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -113,8 +113,8 @@ Automation authoring guardrail:
 
 - if a selected public form view is not shared, has no public token, or has expired, the automation editor warns and disables save
 - if a selected internal processing view is no longer in the current sheet, the automation editor warns and disables save
-- if a DingTalk group rule links to a fully public form, the automation editor warns that anyone with the message link can submit
-- if a DingTalk group rule links to a DingTalk-protected form without allowed users or member groups, the editor warns that all bound or authorized DingTalk users can submit
+- if a DingTalk group or person rule links to a fully public form, the automation editor warns that anyone with the message link can submit
+- if a DingTalk group or person rule links to a DingTalk-protected form without allowed users or member groups, the editor warns that all bound or authorized DingTalk users can submit
 - the message summary and rule card show `Public form access`, including fully public, bound DingTalk users, authorized DingTalk users, and allowlist-constrained states
 - the message summary and rule card also show `Allowed audience`, derived from local allowlist users/member groups when the form is DingTalk-protected
 - the warning is advisory; runtime delivery still performs the backend validation before sending the link
@@ -232,8 +232,8 @@ Use:
 
 Authoring guardrail:
 
-- if the selected form is still fully public, the DingTalk group rule editor warns before save
-- if the selected protected form has no allowed users or member groups, the DingTalk group rule editor warns before save
+- if the selected form is still fully public, the DingTalk group/person rule editor warns before save
+- if the selected protected form has no allowed users or member groups, the DingTalk group/person rule editor warns before save
 - check `Public form access` and `Allowed audience` in the automation message summary, plus `Local allowlist limits` in form sharing before saving
 - switch the form to `Bound DingTalk users only` or `Authorized DingTalk users only` before relying on allowlists
 

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -242,8 +242,8 @@ Authoring guardrail:
 - group-message and person-message automations disable save when the selected public form link cannot produce a working fill link
 - group-message and person-message automations disable save when the selected internal processing view is not in the current sheet
 - automation create/update APIs reject invalid public form or internal processing links before rules are saved
-- group-message automations warn when the selected public form link is still fully public
-- group-message automations warn when a DingTalk-protected form has no allowed users or member groups
+- group-message and person-message automations warn when the selected public form link is still fully public
+- group-message and person-message automations warn when a DingTalk-protected form has no allowed users or member groups
 - group-message and person-message automation previews show the selected public form access range before save
 - group-message and person-message runtime messages show the internal processing link permission requirement after delivery
 - the warnings direct owners toward DingTalk-protected access plus allowlists


### PR DESCRIPTION
## Summary
- enable the same public-form access risk advisories for DingTalk person-message automations as group-message automations
- keep save-blocking behavior unchanged and tied only to blocking public-form link errors
- add advanced editor and inline manager tests for fully public and protected-without-allowlist person-message links
- update DingTalk capability/admin docs plus development and verification reports

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts tests/dingtalk-public-form-link-warnings.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-person-form-risk-parity-development-20260422.md`
- `docs/development/dingtalk-person-form-risk-parity-verification-20260422.md`