### PR TITLE
fix(dingtalk): reject inactive form allowlist users

### DIFF
--- a/docs/development/dingtalk-form-allowlist-active-users-development-20260422.md
+++ b/docs/development/dingtalk-form-allowlist-active-users-development-20260422.md
@@ -1,0 +1,33 @@
+# DingTalk Form Allowlist Active Users Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-form-allowlist-active-users-20260422`
+- Scope: backend protected public-form allowlist validation
+
+## Goal
+
+Close the backend/API gap for DingTalk-protected public-form allowlists.
+
+The frontend allowlist picker already marks inactive local users as unavailable. Before this slice, a direct API caller could still patch a protected form share config with an inactive local user ID in `allowedUserIds`.
+
+## Implementation
+
+- Updated the `PATCH /api/multitable/sheets/:sheetId/views/:viewId/form-share` route to load `users.is_active` while validating `allowedUserIds`.
+- Kept the existing unknown-user rejection behavior.
+- Added a new validation error for inactive allowed users:
+  - `Inactive allowed users: <ids>`
+- Added integration coverage for rejecting inactive local users before the form share config is persisted.
+- Updated DingTalk operations and capability docs to document the active-user constraint.
+
+## Files
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/integration/public-form-flow.test.ts`
+- `docs/dingtalk-admin-operations-guide-20260420.md`
+- `docs/dingtalk-capability-guide-20260420.md`
+
+## Notes
+
+- This does not change public-form submission semantics.
+- This does not change member-group allowlists.
+- This aligns direct API behavior with the existing frontend picker guardrail.

--- a/docs/development/dingtalk-form-allowlist-active-users-verification-20260422.md
+++ b/docs/development/dingtalk-form-allowlist-active-users-verification-20260422.md
@@ -1,0 +1,62 @@
+# DingTalk Form Allowlist Active Users Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-form-allowlist-active-users-20260422`
+
+## Local Verification
+
+Passed:
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false`
+  - Result: passed, 1 file and 17 tests.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false`
+  - Result: passed, 1 file and 15 tests.
+  - Notes: Vitest printed a non-failing WebSocket port-in-use warning.
+- `pnpm --filter @metasheet/core-backend build`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.
+
+## Expected Assertions
+
+- Protected form-share updates reject inactive local users in `allowedUserIds`.
+- Unknown allowed-user validation remains unchanged.
+- Existing protected public-form allowlist updates still pass.
+- Frontend form-share manager behavior remains compatible with the backend constraint.
+
+## Claude Code CLI
+
+Passed:
+
+- Command: `/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."`
+- Result: no blockers.
+- Findings:
+  - PATCH inactive-user rejection preserves the existing unknown-user path.
+  - Inactive users are rejected after existence validation, so they are not mislabeled as unknown users.
+  - Clearing allowlists still works because validation only runs when `allowedUserIds` is non-empty.
+  - Existing happy-path test mocks cover the widened `SELECT id, is_active` query shape.
+  - Non-blocking note: one defensive inactive-row filter is redundant but harmless.
+
+## Main Rebase Verification - 2026-04-22
+
+Rebased the single #1046 slice onto `origin/main` at `15f06cc3d15c9a7b2b0f012013f739fa95af0e2b`.
+
+Scope after rebase:
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/integration/public-form-flow.test.ts`
+- DingTalk admin/capability docs and this development/verification note.
+
+Passed:
+
+- `pnpm install --frozen-lockfile`
+  - Result: passed.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false`
+  - Result: passed, 1 file and 17 tests.
+- `pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false`
+  - Result: passed, 1 file and 15 tests.
+  - Notes: Vitest printed a non-failing WebSocket port-in-use warning.
+- `pnpm --filter @metasheet/core-backend build`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -157,6 +157,7 @@ Behavior:
 - the visitor must pass the selected DingTalk protection mode first
 - the system then resolves the local user
 - the local user must be directly allowed or belong to an allowed member group
+- allowed local users must exist and be active; inactive users are rejected when saving the allowlist
 - without an allowlist, `Bound DingTalk users only` admits all bound DingTalk local users and `Authorized DingTalk users only` admits all locally authorized DingTalk users
 - the form share manager shows `Local allowlist limits` so owners can confirm whether no local limit is set or how many local users/member groups can fill after DingTalk checks
 - the automation editor and rule cards show the same local allowlist audience as `Allowed audience`, so authors can verify it without reopening the form share manager

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -119,6 +119,7 @@ This enables the precise model:
 - send a form link to a DingTalk group or DingTalk user
 - only selected local users or local member groups can fill it
 - DingTalk verifies identity, but local allowlists decide access
+- backend form-share updates reject inactive local users in `allowedUserIds`, matching the frontend allowlist picker
 
 ### 7. Internal processing links
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5580,7 +5580,7 @@ export function univerMetaRouter(): Router {
       }
       if (allowedUserIds.length > 0) {
         const userCheck = await pool.query(
-          'SELECT id FROM users WHERE id = ANY($1::text[])',
+          'SELECT id, is_active FROM users WHERE id = ANY($1::text[])',
           [allowedUserIds],
         )
         const existingUserIds = new Set(
@@ -5593,6 +5593,19 @@ export function univerMetaRouter(): Router {
             error: {
               code: 'VALIDATION_ERROR',
               message: `Unknown allowed users: ${missingUserIds.join(', ')}`,
+            },
+          })
+        }
+        const inactiveUserIds = (userCheck.rows as Array<{ id: string; is_active?: boolean | null }>)
+          .filter((entry) => entry.is_active === false)
+          .map((entry) => String(entry.id))
+          .filter((userId) => allowedUserIds.includes(userId))
+        if (inactiveUserIds.length > 0) {
+          return res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: `Inactive allowed users: ${inactiveUserIds.join(', ')}`,
             },
           })
         }

--- a/packages/core-backend/tests/integration/public-form-flow.test.ts
+++ b/packages/core-backend/tests/integration/public-form-flow.test.ts
@@ -483,6 +483,54 @@ describe('Public form flow', () => {
     expect(patchResponse.body.error?.message).toMatch(/require a DingTalk-protected access mode/i)
   })
 
+  test('form share config rejects inactive allowed users', async () => {
+    const storedConfig = {
+      publicForm: {
+        enabled: true,
+        publicToken: VALID_TOKEN,
+        accessMode: 'dingtalk',
+      },
+    }
+    const { app } = await createApp({
+      user: { id: 'admin_1', perms: ['multitable:write'] },
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1')) {
+          return {
+            rows: [{
+              id: TEST_VIEW_ID,
+              sheet_id: TEST_SHEET_ID,
+              name: 'Public Form View',
+              type: 'form',
+              filter_info: {},
+              sort_info: {},
+              group_info: {},
+              hidden_field_ids: [],
+              config: storedConfig,
+            }],
+          }
+        }
+        if (sql.includes('SELECT id, is_active FROM users WHERE id = ANY')) {
+          const ids = Array.isArray(params?.[0]) ? (params?.[0] as string[]) : []
+          return {
+            rows: ids.map((id) => ({ id, is_active: id !== 'user_inactive' })),
+            rowCount: ids.length,
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const patchResponse = await request(app)
+      .patch(`/api/multitable/sheets/${TEST_SHEET_ID}/views/${TEST_VIEW_ID}/form-share`)
+      .send({ allowedUserIds: ['user_inactive'] })
+      .expect(400)
+
+    expect(patchResponse.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'Inactive allowed users: user_inactive',
+    })
+  })
+
   test('rate limit exceeded -> 429 with Retry-After header', async () => {
     const { app } = await createApp({
       queryHandler: buildQueryHandler(VALID_TOKEN),


### PR DESCRIPTION
## Summary
- reject inactive local users when saving DingTalk-protected public-form `allowedUserIds`
- preserve existing unknown-user rejection and existing allowlist behavior
- add public-form integration coverage for direct API attempts to persist inactive users
- document the active-user allowlist constraint and add development/verification MDs

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-form-allowlist-active-users-development-20260422.md`
- `docs/development/dingtalk-form-allowlist-active-users-verification-20260422.md`