### PR TITLE
test(dingtalk): cover person link route success

### DIFF
--- a/docs/development/dingtalk-person-link-route-success-development-20260422.md
+++ b/docs/development/dingtalk-person-link-route-success-development-20260422.md
@@ -1,0 +1,38 @@
+# DingTalk Person Link Route Success Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-person-link-route-success-20260422`
+- Scope: backend route-level DingTalk person automation coverage
+
+## Goal
+
+Close the backend route coverage gap for valid top-level DingTalk person-message automations that include both:
+
+- a public form link
+- an internal processing link
+
+Group-message route coverage already asserted this success path. Person-message validation shared the same backend link validation code, but only invalid person create/update cases were covered at the route level.
+
+## Implementation
+
+- Added an integration test for `POST /api/multitable/sheets/:sheetId/automations`.
+- The test creates a top-level `send_dingtalk_person_message` rule with:
+  - `userIds`
+  - legacy `title` / `content` input
+  - valid `publicFormViewId`
+  - valid `internalViewId`
+- The test asserts:
+  - route returns success
+  - `createRule` receives `send_dingtalk_person_message`
+  - `title` / `content` are normalized to `titleTemplate` / `bodyTemplate`
+  - public form and internal view IDs are preserved in the persisted action config
+  - the response rule is canonical camelCase
+
+## Files
+
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+
+## Notes
+
+- This is a coverage-only change.
+- No runtime, API contract, database, or frontend behavior changes are intended.

--- a/docs/development/dingtalk-person-link-route-success-verification-20260422.md
+++ b/docs/development/dingtalk-person-link-route-success-verification-20260422.md
@@ -1,0 +1,76 @@
+# DingTalk Person Link Route Success Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-person-link-route-success-20260422`
+
+## Local Verification
+
+Passed:
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
+  - Result: passed, 1 file and 11 tests.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
+  - Result: included in combined run below.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
+  - Result: passed, 2 files and 23 tests.
+- `pnpm --filter @metasheet/core-backend build`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.
+
+## Expected Assertions
+
+- Top-level DingTalk person-message automation create succeeds when public form and internal links are valid.
+- Person-message create uses the same backend link validation path as group-message create.
+- Legacy `title` / `content` fields normalize to `titleTemplate` / `bodyTemplate`.
+- Existing invalid group/person link validation route tests still pass.
+
+## Claude Code CLI
+
+Passed:
+
+- Command: `/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."`
+- Result: no blockers.
+- Findings:
+  - Route create flow runs DingTalk action normalization, config validation, and link validation before `createRule`.
+  - The new person-message success test reaches `createRule` only after valid `publicFormViewId` and `internalViewId` validation passes.
+  - No production code change is required.
+  - Development documentation accurately describes the coverage-only scope.
+
+## Stack Rebase Verification - 2026-04-22
+
+Rebased the single #1047 slice onto updated #1046 branch `origin/codex/dingtalk-form-allowlist-active-users-20260422` at `72b9a28f9ac70306a4e7c8880740873707cdd071`.
+
+Scope after rebase:
+
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+- This development/verification note.
+
+Passed:
+
+- `pnpm install --frozen-lockfile`
+  - Result: passed.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
+  - Result: passed, 2 files and 23 tests.
+- `pnpm --filter @metasheet/core-backend build`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.
+
+## Main Rebase Verification - 2026-04-22
+
+After PR #1046 was merged, rebased the single #1047 slice onto `origin/main` at `f7a69df4f0244b4463e4a941e87370296c119471`.
+
+Scope after rebase:
+
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+- This development/verification note.
+
+Passed:
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
+  - Result: passed, 2 files and 23 tests.
+- `pnpm --filter @metasheet/core-backend build`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -261,6 +261,49 @@ describe('DingTalk automation link route validation', () => {
     }))
   })
 
+  it('persists a DingTalk person rule when public form and internal links are valid', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify person',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: ['user_1'],
+          title: 'Please fill',
+          content: 'Open form',
+          publicFormViewId: VALID_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        },
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
+      actionType: 'send_dingtalk_person_message',
+      actionConfig: expect.objectContaining({
+        userIds: ['user_1'],
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+        publicFormViewId: VALID_FORM_VIEW_ID,
+        internalViewId: INTERNAL_VIEW_ID,
+      }),
+    }))
+    expect(res.body.data.rule).toMatchObject({
+      actionType: 'send_dingtalk_person_message',
+      actionConfig: expect.objectContaining({
+        userIds: ['user_1'],
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+        publicFormViewId: VALID_FORM_VIEW_ID,
+        internalViewId: INTERNAL_VIEW_ID,
+      }),
+    })
+  })
+
   it('returns a canonical camelCase automation rule response with V1 DingTalk actions', async () => {
     const { app } = await createApp()
 


### PR DESCRIPTION
## Summary
- add backend route-level coverage for top-level `send_dingtalk_person_message` creation with valid public-form and internal-processing links
- assert route normalization from `title`/`content` to `titleTemplate`/`bodyTemplate` before persistence
- confirm the response rule remains canonical camelCase
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-person-link-route-success-development-20260422.md`
- `docs/development/dingtalk-person-link-route-success-verification-20260422.md`