### PR TITLE
test(dingtalk): cover v1 person link route success

### DIFF
--- a/docs/development/dingtalk-v1-person-link-route-success-development-20260422.md
+++ b/docs/development/dingtalk-v1-person-link-route-success-development-20260422.md
@@ -1,0 +1,37 @@
+# DingTalk V1 Person Link Route Success Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-link-route-success-20260422`
+- Scope: backend route-level V1 DingTalk person action coverage
+
+## Goal
+
+Close the remaining route-level success coverage gap for V1 automation rules that store DingTalk person messaging inside `actions[]`.
+
+The previous slice covered top-level `send_dingtalk_person_message` create with valid public-form and internal-processing links. This slice covers the advanced/V1 shape where the top-level action is `notify` and the DingTalk person message lives in the multi-action list.
+
+## Implementation
+
+- Added an integration test for `POST /api/multitable/sheets/:sheetId/automations`.
+- The test creates a V1 rule with:
+  - `actionType: notify`
+  - `actions[]` containing `send_dingtalk_person_message`
+  - `userIds`
+  - legacy `title` / `content` input
+  - valid `publicFormViewId`
+  - valid `internalViewId`
+- The test asserts:
+  - route returns success
+  - `createRule` receives top-level `notify`
+  - `actions[0].config` is normalized to `titleTemplate` / `bodyTemplate`
+  - public form and internal view IDs are preserved
+  - the response rule returns canonical camelCase `actions[]`
+
+## Files
+
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+
+## Notes
+
+- This is a coverage-only change.
+- No runtime, API contract, database, or frontend behavior changes are intended.

--- a/docs/development/dingtalk-v1-person-link-route-success-verification-20260422.md
+++ b/docs/development/dingtalk-v1-person-link-route-success-verification-20260422.md
@@ -1,0 +1,57 @@
+# DingTalk V1 Person Link Route Success Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-link-route-success-20260422`
+
+## Local Verification
+
+Passed:
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
+  - Result: passed, 1 file and 12 tests.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
+  - Result: passed, 2 files and 24 tests.
+- `pnpm --filter @metasheet/core-backend build`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.
+
+## Expected Assertions
+
+- V1 `actions[]` DingTalk person-message automation create succeeds when public form and internal links are valid.
+- V1 person-message create uses the same backend normalization and link validation path as V1 group-message create.
+- Legacy `title` / `content` fields inside `actions[]` normalize to `titleTemplate` / `bodyTemplate`.
+- Existing invalid group/person link validation route tests still pass.
+
+## Claude Code CLI
+
+Passed:
+
+- Command: `/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."`
+- Result: no blockers.
+- Findings:
+  - The new test covers V1 `actionType: notify` with `actions[]` containing `send_dingtalk_person_message`.
+  - Existing `meta_views` test fixtures resolve both valid public-form and internal-processing links before persistence.
+  - The test asserts `title` / `content` normalization to `titleTemplate` / `bodyTemplate`.
+  - No production code change is required.
+  - Development documentation accurately describes the coverage-only scope.
+
+## Main Rebase Verification - 2026-04-22
+
+Rebased the single #1048 slice onto `origin/main` at `9a8f5e28bf3087b6eba96bf9af6ef78f44340d85`.
+
+Scope after rebase:
+
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+- This development/verification note.
+
+Passed:
+
+- `pnpm install --frozen-lockfile`
+  - Result: passed.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
+  - Result: passed, 2 files and 24 tests.
+- `pnpm --filter @metasheet/core-backend build`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -374,6 +374,65 @@ describe('DingTalk automation link route validation', () => {
     expect(res.body.data.rule).not.toHaveProperty('action_type')
   })
 
+  it('persists a V1 DingTalk person action when public form and internal links are valid', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Advanced person rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        conditions: { conjunction: 'AND', conditions: [] },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: ['user_1'],
+            title: 'Please fill',
+            content: 'Open form',
+            publicFormViewId: VALID_FORM_VIEW_ID,
+            internalViewId: INTERNAL_VIEW_ID,
+          },
+        }],
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
+      actionType: 'notify',
+      actions: [
+        expect.objectContaining({
+          type: 'send_dingtalk_person_message',
+          config: expect.objectContaining({
+            userIds: ['user_1'],
+            titleTemplate: 'Please fill',
+            bodyTemplate: 'Open form',
+            publicFormViewId: VALID_FORM_VIEW_ID,
+            internalViewId: INTERNAL_VIEW_ID,
+          }),
+        }),
+      ],
+    }))
+    expect(res.body.data.rule).toMatchObject({
+      actionType: 'notify',
+      conditions: { conjunction: 'AND', conditions: [] },
+    })
+    expect(res.body.data.rule.actions).toEqual([
+      expect.objectContaining({
+        type: 'send_dingtalk_person_message',
+        config: expect.objectContaining({
+          userIds: ['user_1'],
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+          publicFormViewId: VALID_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        }),
+      }),
+    ])
+  })
+
   it('rejects a DingTalk group rule without an effective destination before persisting the rule', async () => {
     const { app, automationService } = await createApp()
 


### PR DESCRIPTION
## Summary
- add backend route-level coverage for V1 `actions[]` containing `send_dingtalk_person_message` with valid public-form and internal-processing links
- assert `title`/`content` normalize to `titleTemplate`/`bodyTemplate` inside the V1 action config before persistence
- confirm the response rule keeps canonical camelCase `actions[]`
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-person-link-route-success-development-20260422.md`
- `docs/development/dingtalk-v1-person-link-route-success-verification-20260422.md`