### PR TITLE
test(dingtalk): reject invalid v1 person links

### DIFF
--- a/docs/development/dingtalk-v1-person-link-reject-development-20260422.md
+++ b/docs/development/dingtalk-v1-person-link-reject-development-20260422.md
@@ -1,0 +1,41 @@
+# DingTalk V1 Person Link Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-link-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The DingTalk automation route already had coverage for:
+
+- top-level person message success with valid public-form and internal links
+- V1 `actions[]` person message success with valid public-form and internal links
+- V1 person message rejection when no effective recipient exists
+- V1 group message rejection when a public-form link is invalid
+
+The missing route-level gap was V1 `actions[]` with `send_dingtalk_person_message` carrying invalid links.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with two route-level rejection cases:
+
+- Invalid public form link in a V1 DingTalk person action.
+- Invalid internal processing link in a V1 DingTalk person action.
+
+Both tests assert:
+
+- the API returns HTTP 400
+- the response uses `VALIDATION_ERROR`
+- the expected link-validation message is returned
+- `automationService.createRule` is not called
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users configure a table automation that sends a DingTalk person message from V1 `actions[]`, invalid form/internal links are rejected before the automation rule can be persisted.

--- a/docs/development/dingtalk-v1-person-link-reject-verification-20260422.md
+++ b/docs/development/dingtalk-v1-person-link-reject-verification-20260422.md
@@ -1,0 +1,65 @@
+# DingTalk V1 Person Link Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-link-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 14 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: recommended the same placement, payload shape, and assertions used by this patch.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that invalid V1 `send_dingtalk_person_message` links are rejected before persistence:
+
+- invalid public-form links return `Selected public form view is not shared`
+- invalid internal links return `Internal processing view not found`
+- `automationService.createRule` is not called for either invalid request
+
+## Claude Code CLI Review Summary
+
+Claude verified:
+
+- both new tests exercise V1 `actions[]` `send_dingtalk_person_message`
+- `validateDingTalkAutomationLinks` runs before `automationService.createRule`
+- validation messages match source behavior
+- only tests and documentation changed
+
+## Residual Risk
+
+This is a test-only patch. It verifies the existing route validation behavior but does not change runtime logic.
+
+## Main Rebase Verification - 2026-04-22
+
+Rebased the single #1050 slice onto `origin/main` at `9cd7481b18cd7e732998407d05118c05ecdaa7b7`.
+
+Scope after rebase:
+
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+- This development/verification note.
+
+Passed:
+
+- `pnpm install --frozen-lockfile`
+  - Result: passed.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
+  - Result: passed, 2 files and 26 tests.
+- `pnpm --filter @metasheet/core-backend build`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -433,6 +433,66 @@ describe('DingTalk automation link route validation', () => {
     ])
   })
 
+  it('rejects an invalid public form link in a V1 DingTalk person action before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Advanced person rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: ['user_1'],
+            title: 'Please fill',
+            content: 'Open form',
+            publicFormViewId: DISABLED_FORM_VIEW_ID,
+          },
+        }],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: `Selected public form view is not shared: ${DISABLED_FORM_VIEW_ID}`,
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid internal link in a V1 DingTalk person action before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Advanced person rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: ['user_1'],
+            title: 'Please process',
+            content: 'Open internal link',
+            internalViewId: MISSING_INTERNAL_VIEW_ID,
+          },
+        }],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: `Internal processing view not found: ${MISSING_INTERNAL_VIEW_ID}`,
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
   it('rejects a DingTalk group rule without an effective destination before persisting the rule', async () => {
     const { app, automationService } = await createApp()
 


### PR DESCRIPTION
## Summary
- add route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` with an invalid public-form link
- add route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` with an invalid internal-processing link
- assert both invalid requests fail before `automationService.createRule` is called
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: placement/payload/assertions confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-person-link-reject-development-20260422.md`
- `docs/development/dingtalk-v1-person-link-reject-verification-20260422.md`