### PR TITLE
test(dingtalk): reject invalid v1 person update links

### DIFF
--- a/docs/development/dingtalk-v1-person-update-link-reject-development-20260422.md
+++ b/docs/development/dingtalk-v1-person-update-link-reject-development-20260422.md
@@ -1,0 +1,35 @@
+# DingTalk V1 Person Update Link Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-update-link-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already covered invalid V1 `actions[]` DingTalk person links on create. The remaining route-level gap was update behavior: editing an existing automation rule with invalid V1 person action links should be rejected before persistence.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with two `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId` cases:
+
+- Rejects a V1 `send_dingtalk_person_message` action with an invalid public-form link.
+- Rejects a V1 `send_dingtalk_person_message` action with an invalid internal-processing link.
+
+Both tests assert:
+
+- HTTP 400
+- `VALIDATION_ERROR`
+- the expected link-validation message
+- `automationService.getRule` is called to merge and validate the next state
+- `automationService.updateRule` is not called
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users edit an automation rule that sends DingTalk person messages through V1 `actions[]`, invalid public-form or internal links are rejected before the updated rule is saved.

--- a/docs/development/dingtalk-v1-person-update-link-reject-verification-20260422.md
+++ b/docs/development/dingtalk-v1-person-update-link-reject-verification-20260422.md
@@ -1,0 +1,77 @@
+# DingTalk V1 Person Update Link Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-update-link-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 16 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: recommended this update-route V1 `actions[]` rejection slice.
+- Claude Code CLI read-only review: no blockers.
+
+## Stack Rebase Verification - 2026-04-22
+
+Rebased onto the cleaned `codex/dingtalk-v1-person-link-reject-20260422` branch so this patch only carries the update-route rejection slice on top of the create-route rejection coverage.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+- Combined DingTalk link validation regression: passed, 28 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Remaining local dirt after dependency install was limited to pnpm-linked `plugins/*/node_modules/*` and `tools/cli/node_modules/*`; it was cleared before push.
+
+## Main Rebase Verification - 2026-04-22
+
+After PR #1050 merged, this patch was rebased from the stacked branch onto `origin/main@3adfcf788645cbb62605438c348dc55792f2fb4b`.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+- Combined DingTalk link validation regression: passed, 28 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Final diff against main is limited to the update-route rejection tests and two development/verification docs.
+
+## Expected Assertions
+
+The new integration coverage confirms that invalid V1 `send_dingtalk_person_message` links are rejected on automation update before persistence:
+
+- invalid public-form links return `Selected public form view is not shared`
+- invalid internal links return `Internal processing view not found`
+- `automationService.getRule` is called to validate the merged next state
+- `automationService.updateRule` is not called for either invalid request
+
+## Claude Code CLI Review Summary
+
+Claude verified:
+
+- both new PATCH cases send V1 `actions[]` with `send_dingtalk_person_message`
+- the route loads and validates the merged next state before `updateRule`
+- validation messages match the link validator source
+- only tests and documentation changed
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -642,6 +642,84 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.updateRule).not.toHaveBeenCalled()
   })
 
+  it('rejects an invalid public form link in a V1 DingTalk person action on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'notify',
+      action_config: {},
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          titleTemplate: 'Old title',
+          bodyTemplate: 'Old body',
+          publicFormViewId: VALID_FORM_VIEW_ID,
+        },
+      }],
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: ['user_1'],
+            title: 'Please fill',
+            content: 'Open form',
+            publicFormViewId: DISABLED_FORM_VIEW_ID,
+          },
+        }],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: `Selected public form view is not shared: ${DISABLED_FORM_VIEW_ID}`,
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid internal link in a V1 DingTalk person action on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'notify',
+      action_config: {},
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          titleTemplate: 'Old title',
+          bodyTemplate: 'Old body',
+          internalViewId: INTERNAL_VIEW_ID,
+        },
+      }],
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: ['user_1'],
+            title: 'Please process',
+            content: 'Open internal link',
+            internalViewId: MISSING_INTERNAL_VIEW_ID,
+          },
+        }],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: `Internal processing view not found: ${MISSING_INTERNAL_VIEW_ID}`,
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
   it('validates merged DingTalk action config on automation update', async () => {
     const automationService = createMockAutomationService(makeAutomationRule({
       action_type: 'send_dingtalk_person_message',


### PR DESCRIPTION
## Summary
- add PATCH route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` with an invalid public-form link
- add PATCH route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` with an invalid internal-processing link
- assert invalid updates load the existing rule for merged-state validation and fail before `automationService.updateRule`
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: update-route V1 actions[] rejection slice confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-person-update-link-reject-development-20260422.md`
- `docs/development/dingtalk-v1-person-update-link-reject-verification-20260422.md`