### PR TITLE
test(dingtalk): reject invalid v1 person update recipients

### DIFF
--- a/docs/development/dingtalk-v1-person-update-recipient-reject-development-20260422.md
+++ b/docs/development/dingtalk-v1-person-update-recipient-reject-development-20260422.md
@@ -1,0 +1,34 @@
+# DingTalk V1 Person Update Recipient Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-update-recipient-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already had update coverage for top-level `actionConfig` recipient rejection and V1 `actions[]` link rejection. The remaining update-route gap was V1 `actions[]` person actions without an effective recipient source.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with one `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId` case:
+
+- Rejects a V1 `send_dingtalk_person_message` action when `userIds`, `memberGroupIds`, and record field paths do not resolve to an effective recipient source.
+
+The test asserts:
+
+- HTTP 400
+- `VALIDATION_ERROR`
+- the expected recipient validation message
+- `automationService.getRule` is called to validate the merged next state
+- `automationService.updateRule` is not called
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users edit an automation rule that sends DingTalk person messages through V1 `actions[]`, updates with no effective recipient source are rejected before the rule is saved.

--- a/docs/development/dingtalk-v1-person-update-recipient-reject-verification-20260422.md
+++ b/docs/development/dingtalk-v1-person-update-recipient-reject-verification-20260422.md
@@ -1,0 +1,45 @@
+# DingTalk V1 Person Update Recipient Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-update-recipient-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 17 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: requested this update-route V1 `actions[]` recipient rejection slice.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that V1 `send_dingtalk_person_message` updates without an effective recipient are rejected before persistence:
+
+- invalid recipient source returns `At least one local userId, memberGroupId, record recipient field path, or member group record field path is required`
+- `automationService.getRule` is called to validate the merged next state
+- `automationService.updateRule` is not called
+
+## Claude Code CLI Review Summary
+
+Claude verified:
+
+- the new PATCH test exercises V1 `actions[]` `send_dingtalk_person_message`
+- the route calls `getRule`, validates the merged next state, and does not call `updateRule`
+- the expected recipient validation message matches the validator source
+- only tests and documentation changed
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -720,6 +720,45 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.updateRule).not.toHaveBeenCalled()
   })
 
+  it('rejects a V1 DingTalk person action without an effective recipient on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'notify',
+      action_config: {},
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          titleTemplate: 'Old title',
+          bodyTemplate: 'Old body',
+        },
+      }],
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: [],
+            memberGroupIds: [','],
+            userIdFieldPath: 'record.',
+            title: 'Please fill',
+            content: 'Open form',
+          },
+        }],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required',
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
   it('validates merged DingTalk action config on automation update', async () => {
     const automationService = createMockAutomationService(makeAutomationRule({
       action_type: 'send_dingtalk_person_message',


### PR DESCRIPTION
## Summary
- add PATCH route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` without an effective recipient source
- assert invalid updates load the existing rule for merged-state validation and fail before `automationService.updateRule`
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: update-route V1 actions[] recipient rejection slice confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-person-update-recipient-reject-development-20260422.md`
- `docs/development/dingtalk-v1-person-update-recipient-reject-verification-20260422.md`