### PR TITLE
test(dingtalk): reject invalid v1 person update configs

### DIFF
--- a/docs/development/dingtalk-v1-person-update-config-reject-development-20260422.md
+++ b/docs/development/dingtalk-v1-person-update-config-reject-development-20260422.md
@@ -1,0 +1,35 @@
+# DingTalk V1 Person Update Config Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-update-config-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already had update coverage for V1 `actions[]` DingTalk person invalid links and invalid recipients. The remaining update-route gap was invalid V1 action config shape and missing executable template fields.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with two `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId` cases:
+
+- Rejects a V1 `send_dingtalk_person_message` action when `config` is not an object.
+- Rejects a V1 `send_dingtalk_person_message` action when executable templates are missing or blank.
+
+Both tests assert:
+
+- HTTP 400
+- `VALIDATION_ERROR`
+- the expected config/template validation message
+- `automationService.getRule` is called to validate the merged next state
+- `automationService.updateRule` is not called
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users edit an automation rule that sends DingTalk person messages through V1 `actions[]`, invalid action config payloads are rejected before the rule is saved.

--- a/docs/development/dingtalk-v1-person-update-config-reject-verification-20260422.md
+++ b/docs/development/dingtalk-v1-person-update-config-reject-verification-20260422.md
@@ -1,0 +1,46 @@
+# DingTalk V1 Person Update Config Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-update-config-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 19 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: confirmed the config-shape and missing-template route-level gap and payloads.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that invalid V1 `send_dingtalk_person_message` action configs are rejected on update before persistence:
+
+- non-object config returns `DingTalk action config must be an object`
+- blank title template returns `DingTalk titleTemplate is required`
+- `automationService.getRule` is called to validate the merged next state
+- `automationService.updateRule` is not called
+
+## Claude Code CLI Review Summary
+
+Claude verified:
+
+- PATCH with `actions` triggers `getRule` and config validation before `updateRule`
+- `config: null` exercises `DingTalk action config must be an object`
+- whitespace-only `titleTemplate` exercises `DingTalk titleTemplate is required`
+- only tests and documentation changed
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -759,6 +759,76 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.updateRule).not.toHaveBeenCalled()
   })
 
+  it('rejects a V1 DingTalk person action with a non-object config on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'notify',
+      action_config: {},
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          titleTemplate: 'Old title',
+          bodyTemplate: 'Old body',
+        },
+      }],
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: null,
+        }],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'DingTalk action config must be an object',
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects a V1 DingTalk person action without executable templates on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'notify',
+      action_config: {},
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          titleTemplate: 'Old title',
+          bodyTemplate: 'Old body',
+        },
+      }],
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: ['user_1'],
+            titleTemplate: ' ',
+            bodyTemplate: 'Open form',
+          },
+        }],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'DingTalk titleTemplate is required',
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
   it('validates merged DingTalk action config on automation update', async () => {
     const automationService = createMockAutomationService(makeAutomationRule({
       action_type: 'send_dingtalk_person_message',


### PR DESCRIPTION
## Summary
- add PATCH route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` with a non-object config
- add PATCH route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` without executable templates
- assert invalid updates load the existing rule for merged-state validation and fail before `automationService.updateRule`
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: config-shape/template route-level gap confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-person-update-config-reject-development-20260422.md`
- `docs/development/dingtalk-v1-person-update-config-reject-verification-20260422.md`