### PR TITLE
test(dingtalk): reject invalid v1 person create configs

### DIFF
--- a/docs/development/dingtalk-v1-person-create-config-reject-development-20260422.md
+++ b/docs/development/dingtalk-v1-person-create-config-reject-development-20260422.md
@@ -1,0 +1,34 @@
+# DingTalk V1 Person Create Config Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-create-config-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already had create coverage for V1 `actions[]` DingTalk person invalid links and invalid recipients. The remaining create-route gap was invalid V1 action config shape and missing executable template fields.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with two `POST /api/multitable/sheets/:sheetId/automations` cases:
+
+- Rejects a V1 `send_dingtalk_person_message` action when `config` is not an object.
+- Rejects a V1 `send_dingtalk_person_message` action when executable templates are missing or blank.
+
+Both tests assert:
+
+- HTTP 400
+- `VALIDATION_ERROR`
+- the expected config/template validation message
+- `automationService.createRule` is not called
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users create an automation rule that sends DingTalk person messages through V1 `actions[]`, invalid action config payloads are rejected before the rule is saved.

--- a/docs/development/dingtalk-v1-person-create-config-reject-verification-20260422.md
+++ b/docs/development/dingtalk-v1-person-create-config-reject-verification-20260422.md
@@ -1,0 +1,45 @@
+# DingTalk V1 Person Create Config Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-person-create-config-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 21 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: confirmed the current worktree contains the requested create-route V1 `actions[]` config coverage.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that invalid V1 `send_dingtalk_person_message` action configs are rejected on create before persistence:
+
+- non-object config returns `DingTalk action config must be an object`
+- blank title template returns `DingTalk titleTemplate is required`
+- `automationService.createRule` is not called
+
+## Claude Code CLI Review Summary
+
+Claude verified:
+
+- both new POST cases exercise V1 `actions[]` `send_dingtalk_person_message`
+- route validation returns before `automationService.createRule`
+- config and template validation messages match the validator source
+- only tests and documentation changed
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -578,6 +578,64 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.createRule).not.toHaveBeenCalled()
   })
 
+  it('rejects a V1 DingTalk person action with a non-object config before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Multi action person rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        actions: [
+          {
+            type: 'send_dingtalk_person_message',
+            config: null,
+          },
+        ],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'DingTalk action config must be an object',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects a V1 DingTalk person action without executable templates before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Multi action person rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        actions: [
+          {
+            type: 'send_dingtalk_person_message',
+            config: {
+              userIds: ['user_1'],
+              titleTemplate: ' ',
+              bodyTemplate: 'Open form',
+            },
+          },
+        ],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'DingTalk titleTemplate is required',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
   it('validates V1 actions on automation create', async () => {
     const { app, automationService } = await createApp()
 


### PR DESCRIPTION
## Summary
- add POST route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` with a non-object config
- add POST route-level rejection coverage for V1 `actions[]` containing `send_dingtalk_person_message` without executable templates
- assert invalid create requests fail before `automationService.createRule`
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: requested create-route V1 actions[] config coverage confirmed in worktree
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-person-create-config-reject-development-20260422.md`
- `docs/development/dingtalk-v1-person-create-config-reject-verification-20260422.md`