### PR TITLE
test(dingtalk): reject invalid person create configs

### DIFF
--- a/docs/development/dingtalk-person-create-config-reject-development-20260422.md
+++ b/docs/development/dingtalk-person-create-config-reject-development-20260422.md
@@ -1,0 +1,34 @@
+# DingTalk Person Create Config Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-person-create-config-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already had create coverage for valid top-level DingTalk person rules and extensive V1 `actions[]` rejection coverage. The remaining top-level create gap was invalid `send_dingtalk_person_message` action config.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with two `POST /api/multitable/sheets/:sheetId/automations` cases:
+
+- Rejects a top-level `send_dingtalk_person_message` rule when no effective recipient source exists.
+- Rejects a top-level `send_dingtalk_person_message` rule when executable templates are missing or blank.
+
+Both tests assert:
+
+- HTTP 400
+- `VALIDATION_ERROR`
+- the expected recipient/template validation message
+- `automationService.createRule` is not called
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users create a top-level DingTalk person automation rule, invalid recipient or template configuration is rejected before the rule is saved.

--- a/docs/development/dingtalk-person-create-config-reject-verification-20260422.md
+++ b/docs/development/dingtalk-person-create-config-reject-verification-20260422.md
@@ -1,0 +1,46 @@
+# DingTalk Person Create Config Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-person-create-config-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 23 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: identified the top-level `send_dingtalk_person_message` create path as the next uncovered route-level slice.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that invalid top-level `send_dingtalk_person_message` create configs are rejected before persistence:
+
+- missing recipient source returns `At least one local userId, memberGroupId, record recipient field path, or member group record field path is required`
+- blank title template returns `DingTalk titleTemplate is required`
+- `automationService.createRule` is not called
+
+## Claude Code CLI Review Summary
+
+Claude verified:
+
+- route validation runs before `automationService.createRule`
+- the recipient test isolates the no-effective-recipient branch
+- the template test isolates the `titleTemplate` validation branch
+- assertion strings match the validator source
+- only tests and documentation changed
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -304,6 +304,58 @@ describe('DingTalk automation link route validation', () => {
     })
   })
 
+  it('rejects a DingTalk person rule without an effective recipient before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify person',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: [],
+          memberGroupIds: [','],
+          userIdFieldPath: 'record.',
+          title: 'Please fill',
+          content: 'Open form',
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one local userId, memberGroupId, record recipient field path, or member group record field path is required',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects a DingTalk person rule without executable templates before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify person',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: ['user_1'],
+          titleTemplate: ' ',
+          bodyTemplate: 'Open form',
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'DingTalk titleTemplate is required',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
   it('returns a canonical camelCase automation rule response with V1 DingTalk actions', async () => {
     const { app } = await createApp()
 


### PR DESCRIPTION
## Summary
- add POST route-level rejection coverage for top-level `send_dingtalk_person_message` without an effective recipient source
- add POST route-level rejection coverage for top-level `send_dingtalk_person_message` without executable templates
- assert invalid create requests fail before `automationService.createRule`
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: top-level person create route gap confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-person-create-config-reject-development-20260422.md`
- `docs/development/dingtalk-person-create-config-reject-verification-20260422.md`