### PR TITLE
test(dingtalk): reject invalid update configs

### DIFF
--- a/docs/development/dingtalk-update-config-reject-development-20260422.md
+++ b/docs/development/dingtalk-update-config-reject-development-20260422.md
@@ -1,0 +1,38 @@
+# DingTalk Update Config Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-update-config-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already rejects invalid V1 DingTalk actions on update. The remaining top-level update gaps were direct `actionConfig` validation for:
+
+- `send_dingtalk_group_message` without an effective destination source.
+- `send_dingtalk_person_message` without executable message templates.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with two `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId` cases:
+
+- Rejects a top-level `send_dingtalk_group_message` action when updated `actionConfig` has no effective destination.
+- Rejects a top-level `send_dingtalk_person_message` action when updated `actionConfig` has a blank `titleTemplate`.
+
+The tests assert:
+
+- HTTP 400
+- `VALIDATION_ERROR`
+- the expected destination/template validation message
+- `automationService.getRule` is called to merge the existing rule state
+- `automationService.updateRule` is not called
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users update a top-level DingTalk automation rule, invalid group destinations and invalid person message templates are rejected before the rule is saved.

--- a/docs/development/dingtalk-update-config-reject-verification-20260422.md
+++ b/docs/development/dingtalk-update-config-reject-verification-20260422.md
@@ -1,0 +1,44 @@
+# DingTalk Update Config Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-update-config-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 25 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: identified the top-level group update missing-destination path as the next uncovered route-level slice.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that invalid top-level DingTalk update configs are rejected before persistence:
+
+- missing group destination returns `At least one DingTalk destination or record destination field path is required`
+- blank `titleTemplate` returns `DingTalk titleTemplate is required`
+- `automationService.getRule` is called before validation so the route validates merged update state
+- `automationService.updateRule` is not called
+
+## Claude Code CLI Review Summary
+
+- Confirmed both PATCH route tests validate before `automationService.updateRule`.
+- Confirmed assertion messages match the validator source.
+- Confirmed no production source changed.
+- Confirmed the development and verification docs accurately describe the test-only scope.
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -970,6 +970,67 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.updateRule).not.toHaveBeenCalled()
   })
 
+  it('rejects a DingTalk group action without an effective destination on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'send_dingtalk_group_message',
+      action_config: {
+        destinationId: 'group_1',
+        titleTemplate: 'Old title',
+        bodyTemplate: 'Old body',
+      },
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actionConfig: {
+          destinationIds: [],
+          destinationIdFieldPath: 'record., ,',
+          titleTemplate: 'New title',
+          bodyTemplate: 'New body',
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one DingTalk destination or record destination field path is required',
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects a DingTalk person action without executable templates on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'send_dingtalk_person_message',
+      action_config: {
+        userIds: ['user_1'],
+        titleTemplate: 'Old title',
+        bodyTemplate: 'Old body',
+      },
+    }))
+    const { app } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actionConfig: {
+          userIds: ['user_1'],
+          titleTemplate: ' ',
+          bodyTemplate: 'New body',
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'DingTalk titleTemplate is required',
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
   it('does not revalidate DingTalk links for enable-only updates', async () => {
     const automationService = createMockAutomationService(makeAutomationRule({
       action_config: {


### PR DESCRIPTION
## Summary
- add PATCH route-level rejection coverage for top-level `send_dingtalk_group_message` without an effective destination source
- add PATCH route-level rejection coverage for top-level `send_dingtalk_person_message` without executable templates
- assert invalid update requests fail after merged-state lookup and before `automationService.updateRule`
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: top-level group update missing-destination path confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-update-config-reject-development-20260422.md`
- `docs/development/dingtalk-update-config-reject-verification-20260422.md`