### PR TITLE
test(dingtalk): reject invalid v1 group update destinations

### DIFF
--- a/docs/development/dingtalk-v1-group-update-destination-reject-development-20260422.md
+++ b/docs/development/dingtalk-v1-group-update-destination-reject-development-20260422.md
@@ -1,0 +1,35 @@
+# DingTalk V1 Group Update Destination Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-group-update-destination-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already rejects invalid top-level DingTalk group update configs and invalid V1 DingTalk person update configs. The remaining route-level update gap was the V1 `actions[]` path for `send_dingtalk_group_message` when no effective group destination source is supplied.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with one `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId` case:
+
+- Rejects a V1 `send_dingtalk_group_message` action when updated `actions[]` has no effective destination.
+
+The test asserts:
+
+- HTTP 400
+- `VALIDATION_ERROR`
+- `At least one DingTalk destination or record destination field path is required`
+- `automationService.getRule` is called to load the existing rule state
+- `automationService.updateRule` is not called
+- no `meta_views` link validation query is made after config validation fails
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users update a V1 DingTalk group automation action, invalid destination configuration is rejected before the rule is saved or link validation runs.

--- a/docs/development/dingtalk-v1-group-update-destination-reject-verification-20260422.md
+++ b/docs/development/dingtalk-v1-group-update-destination-reject-verification-20260422.md
@@ -1,0 +1,44 @@
+# DingTalk V1 Group Update Destination Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-group-update-destination-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 26 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: identified the V1 group update missing-destination path as the next uncovered route-level slice.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that invalid V1 DingTalk group update configs are rejected before persistence:
+
+- missing group destination returns `At least one DingTalk destination or record destination field path is required`
+- `automationService.getRule` is called before validation
+- `automationService.updateRule` is not called
+- no `meta_views` query is made after config validation fails
+
+## Claude Code CLI Review Summary
+
+- Confirmed route validation runs after `automationService.getRule` and before `automationService.updateRule`.
+- Confirmed the failing config does not reach `meta_views` link validation.
+- Confirmed assertion messages match the validator source.
+- Confirmed no production source changed.
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -1001,6 +1001,45 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.updateRule).not.toHaveBeenCalled()
   })
 
+  it('rejects a V1 DingTalk group action without an effective destination on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'notify',
+      action_config: {},
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'group_1',
+          titleTemplate: 'Old title',
+          bodyTemplate: 'Old body',
+        },
+      }],
+    }))
+    const { app, mockPool } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationIds: [],
+            destinationIdFieldPath: 'record., ,',
+            title: 'Please fill',
+            content: 'Open form',
+          },
+        }],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one DingTalk destination or record destination field path is required',
+    })
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('FROM meta_views'))).toBe(false)
+  })
+
   it('rejects a DingTalk person action without executable templates on automation update', async () => {
     const automationService = createMockAutomationService(makeAutomationRule({
       action_type: 'send_dingtalk_person_message',


### PR DESCRIPTION
## Summary
- add PATCH route-level rejection coverage for V1 `actions[]` `send_dingtalk_group_message` without an effective destination source
- assert invalid V1 group updates fail after `automationService.getRule` and before `automationService.updateRule`
- assert config validation fails before `meta_views` link validation queries run
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: V1 group update missing-destination path confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-group-update-destination-reject-development-20260422.md`
- `docs/development/dingtalk-v1-group-update-destination-reject-verification-20260422.md`