### PR TITLE
test(dingtalk): reject invalid v1 group create destinations

### DIFF
--- a/docs/development/dingtalk-v1-group-create-destination-reject-development-20260422.md
+++ b/docs/development/dingtalk-v1-group-create-destination-reject-development-20260422.md
@@ -1,0 +1,34 @@
+# DingTalk V1 Group Create Destination Reject Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-group-create-destination-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already rejects invalid top-level DingTalk group create configs and invalid V1 DingTalk group update configs. The remaining create-side V1 gap was `actions[]` `send_dingtalk_group_message` with no effective destination source.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with one `POST /api/multitable/sheets/:sheetId/automations` case:
+
+- Rejects a V1 `send_dingtalk_group_message` action when created `actions[]` has no effective destination.
+
+The test asserts:
+
+- HTTP 400
+- `VALIDATION_ERROR`
+- `At least one DingTalk destination or record destination field path is required`
+- `automationService.createRule` is not called
+- no `meta_views` link validation query is made after config validation fails
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users create a V1 DingTalk group automation action, invalid destination configuration is rejected before the rule is saved or link validation runs.

--- a/docs/development/dingtalk-v1-group-create-destination-reject-verification-20260422.md
+++ b/docs/development/dingtalk-v1-group-create-destination-reject-verification-20260422.md
@@ -1,0 +1,43 @@
+# DingTalk V1 Group Create Destination Reject Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-group-create-destination-reject-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 27 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: identified the V1 group create missing-destination path as the next uncovered route-level slice.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that invalid V1 DingTalk group create configs are rejected before persistence:
+
+- missing group destination returns `At least one DingTalk destination or record destination field path is required`
+- `automationService.createRule` is not called
+- no `meta_views` query is made after config validation fails
+
+## Claude Code CLI Review Summary
+
+- Confirmed route validation runs before `automationService.createRule`.
+- Confirmed the failing config does not reach `meta_views` link validation.
+- Confirmed assertion messages match the validator source.
+- Confirmed no production source changed.
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -688,6 +688,40 @@ describe('DingTalk automation link route validation', () => {
     expect(automationService.createRule).not.toHaveBeenCalled()
   })
 
+  it('rejects a V1 DingTalk group action without an effective destination before persisting the rule', async () => {
+    const { app, mockPool, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Multi action group rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        actions: [
+          {
+            type: 'send_dingtalk_group_message',
+            config: {
+              destinationIds: [],
+              destinationIdFieldPath: 'record., ,',
+              title: 'Please fill',
+              content: 'Open form',
+              publicFormViewId: VALID_FORM_VIEW_ID,
+            },
+          },
+        ],
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'At least one DingTalk destination or record destination field path is required',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('FROM meta_views'))).toBe(false)
+  })
+
   it('validates V1 actions on automation create', async () => {
     const { app, automationService } = await createApp()
 


### PR DESCRIPTION
## Summary
- add POST route-level rejection coverage for V1 `actions[]` `send_dingtalk_group_message` without an effective destination source
- assert invalid V1 group creates fail before `automationService.createRule`
- assert config validation fails before `meta_views` link validation queries run
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: V1 group create missing-destination path confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-group-create-destination-reject-development-20260422.md`
- `docs/development/dingtalk-v1-group-create-destination-reject-verification-20260422.md`