### PR TITLE
test(dingtalk): normalize v1 actions on update

### DIFF
--- a/docs/development/dingtalk-v1-actions-update-normalize-development-20260422.md
+++ b/docs/development/dingtalk-v1-actions-update-normalize-development-20260422.md
@@ -1,0 +1,29 @@
+# DingTalk V1 Actions Update Normalize Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-actions-update-normalize-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+The automation route already covered V1 `actions[]` normalization on create and several update rejection paths. The remaining update-side gap was a successful V1 DingTalk group action update using legacy `title` and `content` fields.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with one `PATCH /api/multitable/sheets/:sheetId/automations/:ruleId` success case:
+
+- Updates a V1 `send_dingtalk_group_message` action with legacy `title` and `content`.
+- Verifies the route normalizes them to `titleTemplate` and `bodyTemplate` before calling `automationService.updateRule`.
+- Verifies the response includes the normalized action config.
+- Verifies valid public form and internal links are checked on the success path.
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+When users update a V1 DingTalk group automation action through legacy title/content fields, the route-level contract preserves normalized executable templates before saving the rule.

--- a/docs/development/dingtalk-v1-actions-update-normalize-verification-20260422.md
+++ b/docs/development/dingtalk-v1-actions-update-normalize-verification-20260422.md
@@ -1,0 +1,46 @@
+# DingTalk V1 Actions Update Normalize Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-v1-actions-update-normalize-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 28 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: identified V1 `actions[]` update success normalization as the next uncovered route-level slice.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that valid V1 DingTalk group updates normalize legacy template fields before persistence:
+
+- response is HTTP 200 with `ok: true`
+- `automationService.getRule` is called before merged-state validation
+- `automationService.updateRule` receives `titleTemplate` and `bodyTemplate`
+- response actions include the normalized templates
+- `meta_views` is queried for valid public form and internal link validation
+
+## Claude Code CLI Review Summary
+
+- Confirmed the PATCH success test exercises route-level V1 `actions[]` normalization.
+- Confirmed `automationService.updateRule` receives normalized `titleTemplate` and `bodyTemplate`.
+- Confirmed the response includes normalized action config.
+- Confirmed the success path reaches `meta_views` link validation.
+- Confirmed no production source changed.
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route normalization behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -1074,6 +1074,67 @@ describe('DingTalk automation link route validation', () => {
     expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('FROM meta_views'))).toBe(false)
   })
 
+  it('normalizes V1 DingTalk group action templates on automation update', async () => {
+    const automationService = createMockAutomationService(makeAutomationRule({
+      action_type: 'notify',
+      action_config: {},
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'group_1',
+          titleTemplate: 'Old title',
+          bodyTemplate: 'Old body',
+        },
+      }],
+    }))
+    const { app, mockPool } = await createApp({ automationService })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: {
+            destinationId: 'group_1',
+            title: 'Please fill',
+            content: 'Open form',
+            publicFormViewId: VALID_FORM_VIEW_ID,
+            internalViewId: INTERNAL_VIEW_ID,
+          },
+        }],
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.getRule).toHaveBeenCalledWith(RULE_ID)
+    expect(automationService.updateRule).toHaveBeenCalledWith(RULE_ID, SHEET_ID, expect.objectContaining({
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          type: 'send_dingtalk_group_message',
+          config: expect.objectContaining({
+            destinationId: 'group_1',
+            titleTemplate: 'Please fill',
+            bodyTemplate: 'Open form',
+            publicFormViewId: VALID_FORM_VIEW_ID,
+            internalViewId: INTERNAL_VIEW_ID,
+          }),
+        }),
+      ]),
+    }))
+    expect(res.body.data.rule.actions).toEqual([
+      expect.objectContaining({
+        type: 'send_dingtalk_group_message',
+        config: expect.objectContaining({
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+          publicFormViewId: VALID_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        }),
+      }),
+    ])
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('FROM meta_views'))).toBe(true)
+  })
+
   it('rejects a DingTalk person action without executable templates on automation update', async () => {
     const automationService = createMockAutomationService(makeAutomationRule({
       action_type: 'send_dingtalk_person_message',


### PR DESCRIPTION
## Summary
- add PATCH route-level success coverage for V1 `actions[]` `send_dingtalk_group_message`
- assert legacy `title` and `content` are normalized to `titleTemplate` and `bodyTemplate` before `automationService.updateRule`
- assert the serialized response includes the normalized action config
- assert the success path reaches `meta_views` link validation
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: V1 actions update success normalization path confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-v1-actions-update-normalize-development-20260422.md`
- `docs/development/dingtalk-v1-actions-update-normalize-verification-20260422.md`