### PR TITLE
test(dingtalk): allow granted form automation links

### DIFF
--- a/docs/development/dingtalk-granted-form-route-success-development-20260422.md
+++ b/docs/development/dingtalk-granted-form-route-success-development-20260422.md
@@ -1,0 +1,29 @@
+# DingTalk Granted Form Route Success Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-granted-form-route-success-20260422`
+- Scope: backend route-level integration coverage
+
+## Context
+
+Unit coverage already allows DingTalk-protected public forms, including `accessMode: dingtalk_granted`. The route integration suite only persisted automation rules that referenced default public forms. The missing route-level proof was that a DingTalk automation can be saved with a public form link that requires DingTalk authorization.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with one `POST /api/multitable/sheets/:sheetId/automations` success case:
+
+- Adds a form view fixture with `publicForm.accessMode: dingtalk_granted`.
+- Creates a top-level `send_dingtalk_group_message` rule referencing that granted form and an internal processing view.
+- Verifies the route persists normalized `titleTemplate` and `bodyTemplate`.
+- Verifies route-level link validation queries `meta_views`.
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+Automation setup can reference DingTalk-authorized public forms, supporting the intended flow where only authorized DingTalk-bound users can open and fill the form.

--- a/docs/development/dingtalk-granted-form-route-success-verification-20260422.md
+++ b/docs/development/dingtalk-granted-form-route-success-verification-20260422.md
@@ -1,0 +1,44 @@
+# DingTalk Granted Form Route Success Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-granted-form-route-success-20260422`
+- Scope: backend route-level integration coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- Route integration test: passed, 30 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: identified DingTalk-authorized public form route success as the next uncovered route-level slice.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that valid DingTalk group automation creation accepts a DingTalk-authorized public form:
+
+- response is HTTP 200 with `ok: true`
+- `automationService.createRule` receives normalized `titleTemplate` and `bodyTemplate`
+- persisted `actionConfig` references `publicFormViewId: view_form_granted`
+- `meta_views` is queried for route-level link validation
+
+## Claude Code CLI Review Summary
+
+- Confirmed the POST route test exercises link validation and persistence for a `dingtalk_granted` public form.
+- Confirmed `automationService.createRule` receives normalized templates and the granted form view id.
+- Confirmed no production source changed.
+- Confirmed docs accurately describe the test-only scope.
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -12,6 +12,7 @@ type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<Q
 const SHEET_ID = 'sheet_dingtalk_links'
 const OTHER_SHEET_ID = 'sheet_other'
 const VALID_FORM_VIEW_ID = 'view_form_valid'
+const GRANTED_FORM_VIEW_ID = 'view_form_granted'
 const DISABLED_FORM_VIEW_ID = 'view_form_disabled'
 const EXPIRED_FORM_VIEW_ID = 'view_form_expired'
 const OTHER_SHEET_FORM_VIEW_ID = 'view_form_other_sheet'
@@ -259,6 +260,56 @@ describe('DingTalk automation link route validation', () => {
         internalViewId: INTERNAL_VIEW_ID,
       }),
     }))
+  })
+
+  it('persists a DingTalk group rule when public form access requires DingTalk authorization', async () => {
+    const { app, mockPool, automationService } = await createApp({
+      queryHandler: createDingTalkLinkQueryHandler([
+        ...makeViewRows(),
+        {
+          id: GRANTED_FORM_VIEW_ID,
+          sheet_id: SHEET_ID,
+          type: 'form',
+          config: {
+            publicForm: {
+              enabled: true,
+              publicToken: 'pub_granted_token',
+              accessMode: 'dingtalk_granted',
+              allowedUserIds: ['user_1'],
+            },
+          },
+        },
+      ]),
+    })
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify granted group',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'group_1',
+          title: 'Please fill',
+          content: 'Open form',
+          publicFormViewId: GRANTED_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        },
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
+      actionType: 'send_dingtalk_group_message',
+      actionConfig: expect.objectContaining({
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+        publicFormViewId: GRANTED_FORM_VIEW_ID,
+        internalViewId: INTERNAL_VIEW_ID,
+      }),
+    }))
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('FROM meta_views'))).toBe(true)
   })
 
   it('persists a DingTalk person rule when public form and internal links are valid', async () => {


### PR DESCRIPTION
## Summary
- add POST route-level success coverage for `send_dingtalk_group_message` using a public form with `accessMode: dingtalk_granted`
- assert the route persists normalized templates and the granted form view id
- assert the success path reaches `meta_views` link validation
- add development and verification reports

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- parallel read-only agent review: DingTalk-authorized public form route success path confirmed
- Claude Code CLI read-only review: no blockers

## Docs
- `docs/development/dingtalk-granted-form-route-success-development-20260422.md`
- `docs/development/dingtalk-granted-form-route-success-verification-20260422.md`