### PR TITLE
test(dingtalk): guard granted person form routes

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -1,0 +1,109 @@
+# DingTalk Feature Plan And TODO
+
+- Date: 2026-04-22
+- Goal: table trigger -> DingTalk group/person message -> form fill or internal processing -> permission-safe completion
+- Delivery mode: small stacked PRs; each implementation PR must include development and verification notes
+- Current base: continue after the DingTalk validation and granted-form guard stack through PR #1062
+
+## Guiding Decisions
+
+- Build the DingTalk group workflow first, then complete direct DingTalk person messaging.
+- Treat DingTalk as the sign-in and delivery channel; the source of fill permission remains local users and member groups.
+- Allow one table to associate with multiple DingTalk groups.
+- Allow DingTalk-synced users without email to be manually created as local users by an administrator.
+- Keep row, column, and cell-level assigned filling out of this phase; handle that as a later permission design after form-level authorization is stable.
+- Use Claude Code CLI for read-only review only; do not let it mutate repository files.
+
+## P0: Stabilize Current PR Stack
+
+- [ ] Confirm PR #1055 through #1062 have green CI.
+- [ ] Merge or promote the stack in order, keeping the already verified semantics unchanged.
+- [ ] Resolve stack conflicts without reverting unrelated user or dependency changes.
+- [ ] After every promotion, run the targeted backend gates:
+  - `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
+  - `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false`
+  - `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false`
+  - `pnpm --filter @metasheet/core-backend build`
+  - `git diff --check`
+
+## P1: DingTalk Group Standard Workflow
+
+- [ ] Backend: verify table-scoped DingTalk group destinations support multiple groups per table.
+- [ ] Backend: verify create, update, delete, list, test-send, and delivery history routes enforce automation/write permissions.
+- [ ] Backend: verify webhook URLs and robot secrets are redacted in responses, logs, and delivery diagnostics.
+- [ ] Frontend: expose DingTalk group binding in the table integration or existing API token manager surface.
+- [ ] Frontend: let users add, edit, delete, and test-send DingTalk group robot destinations.
+- [ ] Frontend: show that group binding does not import DingTalk group members and does not grant form fill permission by itself.
+- [ ] Automation UI: let users choose a bound DingTalk group for `send_dingtalk_group_message`.
+- [ ] Automation UI: let users include public form and internal processing links in group messages.
+- [ ] Runtime: confirm a group message link opens the form and permission checks still gate access.
+
+## P2: Form Access And Assigned Fillers
+
+- [ ] Form share UI: support `public`, `dingtalk`, and `dingtalk_granted` access modes.
+- [ ] Form share UI: allow table owners to choose allowed local users and member groups for DingTalk-protected modes.
+- [ ] Form share UI: explain that only selected local users/member groups can fill when allowlists are configured.
+- [ ] Backend: keep `dingtalk_granted` submit guard before record insert.
+- [ ] Backend: reject inactive allowed users and invalid member groups when saving form access settings.
+- [ ] Automation UI: display the selected form access level before saving a DingTalk action.
+- [ ] Runtime copy: show clear errors for auth required, DingTalk binding required, grant required, and not in allowlist.
+
+## P3: DingTalk Person Messaging And User Sync
+
+- [ ] Backend: keep `send_dingtalk_person_message` support for static `userIds`.
+- [ ] Backend: keep `send_dingtalk_person_message` support for `memberGroupIds`.
+- [ ] Backend: keep dynamic recipient field paths for local users and member groups.
+- [ ] Frontend: expose person recipient picker for local users and member groups.
+- [ ] Frontend: warn when selected recipients are not bound to DingTalk.
+- [ ] Directory sync: show synced DingTalk accounts without matched local users.
+- [ ] Directory sync: support admin-triggered local user creation without email.
+- [ ] Directory sync: bind newly created local users to the DingTalk external identity.
+- [ ] Delivery history: record person send success, failure, and skipped-unbound reasons.
+
+## P4: Documentation And Remote Smoke
+
+- [ ] Add an administrator guide for DingTalk app credentials, group robot binding, directory sync, and no-email user creation.
+- [ ] Add a user guide for table group binding, automation messages, public form links, and form access levels.
+- [ ] Add troubleshooting notes for webhook signature failures, unbound users, missing grants, no-email users, and links that cannot be opened.
+- [ ] Remote smoke: create a table and form view.
+- [ ] Remote smoke: bind at least two DingTalk groups to the table.
+- [ ] Remote smoke: set the form to `dingtalk_granted`.
+- [ ] Remote smoke: send a group message with a form link.
+- [ ] Remote smoke: verify an authorized user can open and submit.
+- [ ] Remote smoke: verify an unauthorized user cannot submit and no record is inserted.
+- [ ] Remote smoke: verify delivery history records group and person sends.
+
+## Suggested Parallel Lanes
+
+- Lane A: backend group destination, automation action, delivery history, and route tests.
+- Lane B: frontend group binding, automation editor, form link selection, and UI tests.
+- Lane C: form access UI, allowlist guidance, forbidden copy, and submit guard tests.
+- Lane D: directory sync, no-email local user creation, quick bind, person recipient UI, and person delivery history.
+- Lane E: docs, smoke checklist, PR stack tracking, and read-only Claude CLI review.
+
+## Acceptance Criteria
+
+- A table owner can bind multiple DingTalk groups to one table.
+- A table owner can create an automation that sends a DingTalk group message containing a form link.
+- A user can click the DingTalk message and open the form when local permission allows it.
+- A user without required binding, grant, or allowlist membership cannot submit the form.
+- An administrator can create and bind a no-email local user from a synced DingTalk account.
+- A table owner can select local users or member groups for direct DingTalk person messages.
+- Delivery history exposes success, failure, and skipped recipient states without leaking secrets.
+
+## Standard Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-delivery-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts tests/unit/dingtalk-person-delivery-service.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+pnpm lint
+pnpm type-check
+git diff --check
+```

--- a/docs/development/dingtalk-feature-plan-and-todo-development-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-development-20260422.md
@@ -1,0 +1,32 @@
+# DingTalk Feature Plan And TODO Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-feature-plan-todo-20260422`
+- Scope: planning and execution tracking documentation
+
+## Context
+
+The DingTalk work now spans group robot delivery, direct person delivery, DingTalk-protected public forms, directory sync, no-email local user creation, and remote smoke validation. A single actionable TODO document is needed so parallel implementation lanes can proceed without rediscovering the same decisions.
+
+## Changes
+
+Added `docs/development/dingtalk-feature-plan-and-todo-20260422.md` with:
+
+- P0 stack stabilization tasks.
+- P1 DingTalk group standard workflow tasks.
+- P2 form access and assigned filler tasks.
+- P3 direct person messaging and DingTalk user sync tasks.
+- P4 documentation and remote smoke tasks.
+- Parallel lane ownership guidance.
+- Acceptance criteria and standard verification commands.
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend behavior changes.
+- No database migration changes.
+
+## Expected Effect
+
+Future DingTalk PRs can be cut from this plan as small, independently verifiable slices, while preserving the product decisions already made: group first, person second, and local users/member groups as the source of fill permission.

--- a/docs/development/dingtalk-feature-plan-and-todo-verification-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-verification-20260422.md
@@ -1,0 +1,29 @@
+# DingTalk Feature Plan And TODO Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-feature-plan-todo-20260422`
+- Scope: planning and execution tracking documentation
+
+## Verification Commands
+
+```bash
+git diff --check
+```
+
+## Results
+
+- `git diff --check`: passed.
+- Repository change scope: documentation-only.
+- Existing unrelated local `node_modules` dirty files remain unstaged and were not modified by this patch.
+
+## Review Checklist
+
+- The TODO document identifies P0 through P4 execution phases.
+- The TODO document keeps group messaging before direct person messaging.
+- The TODO document states DingTalk is a delivery/sign-in channel, not the source of fill permission.
+- The TODO document includes backend, frontend, user sync, docs, and remote smoke work.
+- The TODO document includes concrete verification commands for follow-up implementation PRs.
+
+## Residual Risk
+
+This is a documentation-only patch. It creates the execution plan but does not implement runtime functionality.

--- a/docs/development/dingtalk-person-granted-form-route-success-development-20260422.md
+++ b/docs/development/dingtalk-person-granted-form-route-success-development-20260422.md
@@ -1,0 +1,43 @@
+# DingTalk Person Granted Form Route Success Development
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-person-granted-form-guard-20260422`
+- Scope: backend route-level integration and public form submit guard coverage
+
+## Context
+
+Group automation creation already had route-level coverage for public forms protected by `accessMode: dingtalk_granted`. The next missing product paths were direct DingTalk person delivery, V1 `actions[]` delivery, and the submit-time security guard: a rule sends a message to selected local users, those users are bound to DingTalk, and the linked form still rejects bound users who have not been granted access.
+
+## Changes
+
+Updated `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts` with one `POST /api/multitable/sheets/:sheetId/automations` success case:
+
+- Adds a granted public form fixture with `publicForm.accessMode: dingtalk_granted` and `allowedUserIds`.
+- Creates a top-level `send_dingtalk_person_message` rule referencing the granted form and an internal processing view.
+- Verifies the route persists the selected `userIds`.
+- Verifies legacy `title` and `content` are normalized to `titleTemplate` and `bodyTemplate`.
+- Verifies route-level link validation queries `meta_views`.
+
+Added a second automation route success case for V1 `actions[]`:
+
+- Creates a `notify` rule containing `actions: [{ type: 'send_dingtalk_person_message' }]`.
+- References the same `dingtalk_granted` form view and internal processing view.
+- Verifies normalized templates and view ids are persisted inside `actions[].config`.
+
+Updated `packages/core-backend/tests/integration/public-form-flow.test.ts` with one `POST /api/multitable/views/:viewId/submit` denial case:
+
+- Uses `accessMode: dingtalk_granted` with an authenticated, DingTalk-bound user.
+- Leaves `hasDingTalkGrant` false.
+- Verifies the submit route returns `DINGTALK_GRANT_REQUIRED`.
+- Verifies the rejected submit does not execute `INSERT INTO meta_records`.
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No API contract changes.
+- No frontend changes.
+- No database migration changes.
+
+## Expected Product Effect
+
+The backend route contract now covers the intended direct-person flow, the V1 multi-action flow, and the submit guard: a table owner can configure an automation that sends a DingTalk message to selected users, while the linked form remains restricted to users with the required DingTalk grant.

--- a/docs/development/dingtalk-person-granted-form-route-success-verification-20260422.md
+++ b/docs/development/dingtalk-person-granted-form-route-success-verification-20260422.md
@@ -1,0 +1,61 @@
+# DingTalk Person Granted Form Route Success Verification
+
+- Date: 2026-04-22
+- Branch: `codex/dingtalk-person-granted-form-guard-20260422`
+- Scope: backend route-level integration and public form submit guard coverage
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+git diff --check
+/Users/chouhua/.local/bin/claude -p --tools Read,Grep,Glob --max-budget-usd 1.5 "Read-only review current git diff ..."
+```
+
+## Results
+
+- DingTalk automation route integration test: passed, 32 tests.
+- Public form flow integration test: passed, 18 tests.
+- Link validation unit test: passed, 12 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Parallel read-only agent review: identified the V1 `actions[]` granted-form route gap and the submit-time no-grant denial gap; both were covered in this patch.
+- Claude Code CLI read-only review: no blockers.
+
+## Expected Assertions
+
+The new integration coverage confirms that valid DingTalk person automation creation accepts a DingTalk-authorized public form:
+
+- response is HTTP 200 with `ok: true`
+- `automationService.createRule` receives `actionType: send_dingtalk_person_message`
+- persisted `actionConfig.userIds` includes the selected local user
+- legacy `title` and `content` are normalized to `titleTemplate` and `bodyTemplate`
+- persisted `actionConfig.publicFormViewId` references the granted form view
+- `meta_views` is queried for route-level link validation
+
+It also confirms the same granted form works through V1 `actions[]`:
+
+- `automationService.createRule` receives `actionType: notify`
+- persisted `actions[].type` is `send_dingtalk_person_message`
+- persisted `actions[].config.publicFormViewId` references the granted form view
+- `actions[].config.titleTemplate` and `bodyTemplate` are normalized from legacy input
+
+The new public form coverage confirms that the submit route rejects bound but ungranted users:
+
+- response is HTTP 403
+- `error.code` is `DINGTALK_GRANT_REQUIRED`
+- rejected submit does not execute `INSERT INTO meta_records`
+
+## Residual Risk
+
+This is a test-only patch. It verifies existing route validation behavior but does not change runtime logic.
+
+## Claude Code CLI Review Summary
+
+- Confirmed direct person and V1 `actions[]` automation tests correctly exercise `dingtalk_granted` public forms.
+- Confirmed submit denial uses `hasDingTalkBinding: true` and `hasDingTalkGrant: false`, matching the `DINGTALK_GRANT_REQUIRED` branch.
+- Confirmed the no-insert assertion is valid because the submit route returns before record creation.
+- Confirmed docs accurately describe the test-only scope.

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -355,6 +355,64 @@ describe('DingTalk automation link route validation', () => {
     })
   })
 
+  it('persists a DingTalk person rule when public form access requires DingTalk authorization', async () => {
+    const { app, mockPool, automationService } = await createApp({
+      queryHandler: createDingTalkLinkQueryHandler([
+        ...makeViewRows(),
+        {
+          id: GRANTED_FORM_VIEW_ID,
+          sheet_id: SHEET_ID,
+          type: 'form',
+          config: {
+            publicForm: {
+              enabled: true,
+              publicToken: 'pub_granted_token',
+              accessMode: 'dingtalk_granted',
+              allowedUserIds: ['user_1'],
+            },
+          },
+        },
+      ]),
+    })
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Notify granted person',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: {
+          userIds: ['user_1'],
+          title: 'Please fill',
+          content: 'Open form',
+          publicFormViewId: GRANTED_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        },
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
+      actionType: 'send_dingtalk_person_message',
+      actionConfig: expect.objectContaining({
+        userIds: ['user_1'],
+        titleTemplate: 'Please fill',
+        bodyTemplate: 'Open form',
+        publicFormViewId: GRANTED_FORM_VIEW_ID,
+        internalViewId: INTERNAL_VIEW_ID,
+      }),
+    }))
+    expect(res.body.data.rule.actionConfig).toEqual(expect.objectContaining({
+      userIds: ['user_1'],
+      titleTemplate: 'Please fill',
+      bodyTemplate: 'Open form',
+      publicFormViewId: GRANTED_FORM_VIEW_ID,
+      internalViewId: INTERNAL_VIEW_ID,
+    }))
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('FROM meta_views'))).toBe(true)
+  })
+
   it('rejects a DingTalk person rule without an effective recipient before persisting the rule', async () => {
     const { app, automationService } = await createApp()
 
@@ -534,6 +592,79 @@ describe('DingTalk automation link route validation', () => {
         }),
       }),
     ])
+  })
+
+  it('persists a V1 DingTalk person action when public form access requires DingTalk authorization', async () => {
+    const { app, mockPool, automationService } = await createApp({
+      queryHandler: createDingTalkLinkQueryHandler([
+        ...makeViewRows(),
+        {
+          id: GRANTED_FORM_VIEW_ID,
+          sheet_id: SHEET_ID,
+          type: 'form',
+          config: {
+            publicForm: {
+              enabled: true,
+              publicToken: 'pub_granted_token',
+              accessMode: 'dingtalk_granted',
+              allowedUserIds: ['user_1'],
+            },
+          },
+        },
+      ]),
+    })
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Advanced granted person rule',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'notify',
+        actionConfig: {},
+        conditions: { conjunction: 'AND', conditions: [] },
+        actions: [{
+          type: 'send_dingtalk_person_message',
+          config: {
+            userIds: ['user_1'],
+            title: 'Please fill',
+            content: 'Open form',
+            publicFormViewId: GRANTED_FORM_VIEW_ID,
+            internalViewId: INTERNAL_VIEW_ID,
+          },
+        }],
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
+      actionType: 'notify',
+      actions: [
+        expect.objectContaining({
+          type: 'send_dingtalk_person_message',
+          config: expect.objectContaining({
+            userIds: ['user_1'],
+            titleTemplate: 'Please fill',
+            bodyTemplate: 'Open form',
+            publicFormViewId: GRANTED_FORM_VIEW_ID,
+            internalViewId: INTERNAL_VIEW_ID,
+          }),
+        }),
+      ],
+    }))
+    expect(res.body.data.rule.actions).toEqual([
+      expect.objectContaining({
+        type: 'send_dingtalk_person_message',
+        config: expect.objectContaining({
+          userIds: ['user_1'],
+          titleTemplate: 'Please fill',
+          bodyTemplate: 'Open form',
+          publicFormViewId: GRANTED_FORM_VIEW_ID,
+          internalViewId: INTERNAL_VIEW_ID,
+        }),
+      }),
+    ])
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('FROM meta_views'))).toBe(true)
   })
 
   it('rejects an invalid public form link in a V1 DingTalk person action before persisting the rule', async () => {

--- a/packages/core-backend/tests/integration/public-form-flow.test.ts
+++ b/packages/core-backend/tests/integration/public-form-flow.test.ts
@@ -291,6 +291,28 @@ describe('Public form flow', () => {
     expect(res.body.error?.code).toBe('DINGTALK_GRANT_REQUIRED')
   })
 
+  test('dingtalk-granted form rejects submit from a bound user without grant', async () => {
+    const { app, mockPool } = await createApp({
+      queryHandler: buildQueryHandler(VALID_TOKEN, {
+        accessMode: 'dingtalk_granted',
+        hasDingTalkBinding: true,
+        hasDingTalkGrant: false,
+      }),
+      user: { id: 'user_bound' },
+    })
+
+    const res = await request(app)
+      .post(`/api/multitable/views/${TEST_VIEW_ID}/submit?publicToken=${VALID_TOKEN}`)
+      .send({
+        publicToken: VALID_TOKEN,
+        data: { fld_1: 'Alice', fld_2: 'alice@test.com' },
+      })
+
+    expect(res.status).toBe(403)
+    expect(res.body.error?.code).toBe('DINGTALK_GRANT_REQUIRED')
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO meta_records'))).toBe(false)
+  })
+
   test('dingtalk-protected form rejects a bound user outside the allowlist', async () => {
     const { app } = await createApp({
       queryHandler: buildQueryHandler(VALID_TOKEN, {


### PR DESCRIPTION
## Summary
- Add route-level coverage for direct DingTalk person automation using a `dingtalk_granted` public form.
- Add V1 `actions[]` coverage for DingTalk person automation using a `dingtalk_granted` public form.
- Add public form submit guard coverage proving a bound but ungranted user gets `DINGTALK_GRANT_REQUIRED` and no record insert occurs.
- Add development and verification docs for this slice.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false` (32 passed)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false` (18 passed)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-automation-link-validation.test.ts --watch=false` (12 passed)
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- Claude Code CLI read-only review: no blockers

## Notes
- Test-only patch; no runtime behavior, API contract, frontend, or migration changes.
- Existing local `node_modules` dirty files were not staged or committed.