### PR TITLE
feat(dingtalk): guard person recipient candidates

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -306,11 +306,15 @@
                 :key="personRecipientCandidateKey(candidate)"
                 class="meta-automation__recipient-option"
                 type="button"
+                :disabled="isInactivePersonRecipientCandidate(candidate)"
                 :data-automation-person-suggestion="personRecipientCandidateKey(candidate)"
                 @click="addDingTalkPersonRecipient(candidate)"
               >
                 <strong>{{ candidate.label }}</strong>
                 <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                <span>{{ personRecipientSubjectLabel(candidate) }}</span>
+                <span v-if="candidate.accessLevel">{{ personRecipientAccessLabel(candidate.accessLevel) }}</span>
+                <span v-if="isInactivePersonRecipientCandidate(candidate)">Inactive users cannot be added</span>
               </button>
             </div>
             <div v-else-if="dingtalkPersonUserSearch.trim()" class="meta-automation__hint">No matching users or member groups</div>
@@ -921,6 +925,22 @@ function personRecipientCandidateKey(candidate: MetaSheetPermissionCandidate) {
   return personRecipientDirectoryKey(candidate.subjectType === 'member-group' ? 'member-group' : 'user', candidate.subjectId)
 }
 
+function isPersonRecipientCandidate(candidate: MetaSheetPermissionCandidate): boolean {
+  return candidate.subjectType === 'user' || candidate.subjectType === 'member-group'
+}
+
+function isInactivePersonRecipientCandidate(candidate: MetaSheetPermissionCandidate): boolean {
+  return candidate.subjectType === 'user' && candidate.isActive === false
+}
+
+function personRecipientSubjectLabel(candidate: MetaSheetPermissionCandidate): string {
+  return candidate.subjectType === 'member-group' ? 'Member group' : 'User'
+}
+
+function personRecipientAccessLabel(accessLevel: MetaSheetPermissionCandidate['accessLevel']): string {
+  return accessLevel ? `Access: ${accessLevel}` : ''
+}
+
 function rememberDingTalkPersonSuggestions(items: MetaSheetPermissionCandidate[]) {
   const next = { ...dingtalkPersonUserDirectory.value }
   for (const item of items) {
@@ -950,6 +970,7 @@ const availableDingTalkPersonSuggestions = computed(() => {
   const selected = new Set(parseUserIdsText(draft.value.dingtalkPersonUserIds))
   const selectedGroups = new Set(parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds))
   return dingtalkPersonUserSuggestions.value.filter((candidate) => {
+    if (!isPersonRecipientCandidate(candidate)) return false
     if (candidate.subjectType === 'member-group') return !selectedGroups.has(candidate.subjectId)
     return !selected.has(candidate.subjectId)
   })
@@ -987,6 +1008,8 @@ async function loadDingTalkPersonSuggestions() {
 }
 
 function addDingTalkPersonRecipient(candidate: MetaSheetPermissionCandidate) {
+  if (!isPersonRecipientCandidate(candidate)) return
+  if (isInactivePersonRecipientCandidate(candidate)) return
   if (candidate.subjectType === 'member-group') {
     const ids = new Set(parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds))
     ids.add(candidate.subjectId)

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -448,11 +448,15 @@
                   :key="personRecipientCandidateKey(candidate)"
                   class="meta-rule-editor__recipient-option"
                   type="button"
+                  :disabled="isInactivePersonRecipientCandidate(candidate)"
                   :data-person-recipient-suggestion="personRecipientCandidateKey(candidate)"
                   @click="addPersonRecipient(action, candidate, idx)"
                 >
                   <strong>{{ candidate.label }}</strong>
                   <span>{{ candidate.subtitle || candidate.subjectId }}</span>
+                  <span>{{ personRecipientSubjectLabel(candidate) }}</span>
+                  <span v-if="candidate.accessLevel">{{ personRecipientAccessLabel(candidate.accessLevel) }}</span>
+                  <span v-if="isInactivePersonRecipientCandidate(candidate)">Inactive users cannot be added</span>
                 </button>
               </div>
               <div v-else-if="typeof action.config.userIdsSearch === 'string' && action.config.userIdsSearch.trim()" class="meta-rule-editor__hint">No matching users or member groups</div>
@@ -1100,6 +1104,22 @@ function personRecipientCandidateKey(candidate: MetaSheetPermissionCandidate) {
   return personRecipientDirectoryKey(candidate.subjectType === 'member-group' ? 'member-group' : 'user', candidate.subjectId)
 }
 
+function isPersonRecipientCandidate(candidate: MetaSheetPermissionCandidate): boolean {
+  return candidate.subjectType === 'user' || candidate.subjectType === 'member-group'
+}
+
+function isInactivePersonRecipientCandidate(candidate: MetaSheetPermissionCandidate): boolean {
+  return candidate.subjectType === 'user' && candidate.isActive === false
+}
+
+function personRecipientSubjectLabel(candidate: MetaSheetPermissionCandidate): string {
+  return candidate.subjectType === 'member-group' ? 'Member group' : 'User'
+}
+
+function personRecipientAccessLabel(accessLevel: MetaSheetPermissionCandidate['accessLevel']): string {
+  return accessLevel ? `Access: ${accessLevel}` : ''
+}
+
 function rememberPersonRecipientSuggestions(items: MetaSheetPermissionCandidate[]) {
   const next = { ...personRecipientDirectory.value }
   for (const item of items) {
@@ -1129,6 +1149,7 @@ function availablePersonRecipientSuggestions(idx: number, action: DraftAction) {
   const selected = new Set(parseUserIdsText(action.config.userIdsText))
   const selectedGroups = new Set(parseMemberGroupIdsText(action.config.memberGroupIdsText))
   return (personRecipientSuggestions.value[idx] ?? []).filter((candidate) => {
+    if (!isPersonRecipientCandidate(candidate)) return false
     if (candidate.subjectType === 'member-group') return !selectedGroups.has(candidate.subjectId)
     return !selected.has(candidate.subjectId)
   })
@@ -1169,6 +1190,8 @@ async function loadPersonRecipientSuggestions(idx: number, action: DraftAction) 
 }
 
 function addPersonRecipient(action: DraftAction, candidate: MetaSheetPermissionCandidate, idx: number) {
+  if (!isPersonRecipientCandidate(candidate)) return
+  if (isInactivePersonRecipientCandidate(candidate)) return
   if (candidate.subjectType === 'member-group') {
     const ids = new Set(parseMemberGroupIdsText(action.config.memberGroupIdsText))
     ids.add(candidate.subjectId)

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -1903,6 +1903,82 @@ describe('MetaAutomationManager', () => {
     expect(client.listFormShareCandidates).toHaveBeenCalledTimes(2)
   })
 
+  it('disables inactive DingTalk person user candidates and shows candidate status in the inline form', async () => {
+    const { client } = mockClient([])
+    client.listFormShareCandidates = vi.fn(async () => ({
+      items: [
+        {
+          subjectType: 'user',
+          subjectId: 'user_inactive',
+          label: 'Inactive User',
+          subtitle: 'inactive@example.com',
+          isActive: false,
+          accessLevel: 'read',
+        },
+        {
+          subjectType: 'member-group',
+          subjectId: 'group_1',
+          label: 'Sales Team',
+          subtitle: '3 members',
+          isActive: true,
+          accessLevel: 'write',
+        },
+        {
+          subjectType: 'role',
+          subjectId: 'role_admin',
+          label: 'Admins',
+          subtitle: 'Role',
+          isActive: true,
+          accessLevel: 'admin',
+        },
+      ],
+      total: 3,
+      limit: 8,
+      query: 'inactive',
+    }))
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const searchInput = container.querySelector('[data-automation-field="dingtalkPersonUserSearch"]') as HTMLInputElement
+    searchInput.value = 'inactive'
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const inactiveSuggestion = container.querySelector('[data-automation-person-suggestion="user:user_inactive"]') as HTMLButtonElement
+    expect(inactiveSuggestion.disabled).toBe(true)
+    expect(inactiveSuggestion.textContent).toContain('User')
+    expect(inactiveSuggestion.textContent).toContain('Access: read')
+    expect(inactiveSuggestion.textContent).toContain('Inactive users cannot be added')
+    expect(container.querySelector('[data-automation-person-suggestion="user:role_admin"]')).toBeNull()
+    expect(container.textContent).not.toContain('Admins')
+
+    inactiveSuggestion.click()
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    expect(userIdsInput.value).toBe('')
+
+    const groupSuggestion = container.querySelector('[data-automation-person-suggestion="member-group:group_1"]') as HTMLButtonElement
+    expect(groupSuggestion.disabled).toBe(false)
+    expect(groupSuggestion.textContent).toContain('Member group')
+    expect(groupSuggestion.textContent).toContain('Access: write')
+    groupSuggestion.click()
+    await flushPromises()
+
+    const memberGroupIdsInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    expect(memberGroupIdsInput.value).toBe('group_1')
+    expect(client.listFormShareCandidates).toHaveBeenCalledWith('sheet_1', { q: 'inactive', limit: 8 })
+  })
+
   it('opens DingTalk person delivery viewer for person message rules', async () => {
     const { client } = mockClient([
       fakeRule({

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1931,6 +1931,86 @@ describe('MetaAutomationRuleEditor', () => {
     expect(client.listFormShareCandidates).toHaveBeenCalledTimes(2)
   })
 
+  it('disables inactive DingTalk person user candidates and shows candidate status', async () => {
+    const client = {
+      ...mockClient(),
+      listFormShareCandidates: vi.fn(async () => ({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_inactive',
+            label: 'Inactive User',
+            subtitle: 'inactive@example.com',
+            isActive: false,
+            accessLevel: 'read',
+          },
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_1',
+            label: 'Sales Team',
+            subtitle: '3 members',
+            isActive: true,
+            accessLevel: 'write',
+          },
+          {
+            subjectType: 'role',
+            subjectId: 'role_admin',
+            label: 'Admins',
+            subtitle: 'Role',
+            isActive: true,
+            accessLevel: 'admin',
+          },
+        ],
+        total: 3,
+        limit: 8,
+        query: 'inactive',
+      })),
+    }
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const searchInput = container.querySelector('[data-field="dingtalkPersonUserSearch"]') as HTMLInputElement
+    searchInput.value = 'inactive'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const inactiveSuggestion = container.querySelector('[data-person-recipient-suggestion="user:user_inactive"]') as HTMLButtonElement
+    expect(inactiveSuggestion.disabled).toBe(true)
+    expect(inactiveSuggestion.textContent).toContain('User')
+    expect(inactiveSuggestion.textContent).toContain('Access: read')
+    expect(inactiveSuggestion.textContent).toContain('Inactive users cannot be added')
+    expect(container.querySelector('[data-person-recipient-suggestion="user:role_admin"]')).toBeNull()
+    expect(container.textContent).not.toContain('Admins')
+
+    inactiveSuggestion.click()
+    await flushPromises()
+
+    const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
+    expect(userIdsInput.value).toBe('')
+
+    const groupSuggestion = container.querySelector('[data-person-recipient-suggestion="member-group:group_1"]') as HTMLButtonElement
+    expect(groupSuggestion.disabled).toBe(false)
+    expect(groupSuggestion.textContent).toContain('Member group')
+    expect(groupSuggestion.textContent).toContain('Access: write')
+    groupSuggestion.click()
+    await flushPromises()
+
+    const memberGroupIdsInput = container.querySelector('[data-field="dingtalkPersonMemberGroupIds"]') as HTMLTextAreaElement
+    expect(memberGroupIdsInput.value).toBe('group_1')
+    expect(client.listFormShareCandidates).toHaveBeenCalledWith('sheet_1', { q: 'inactive', limit: 8 })
+  })
+
   it('applies DingTalk group message presets', async () => {
     const client = mockClient()
     const { container } = mount({

--- a/docs/development/dingtalk-person-recipient-candidate-status-development-20260422.md
+++ b/docs/development/dingtalk-person-recipient-candidate-status-development-20260422.md
@@ -1,0 +1,32 @@
+# DingTalk Person Recipient Candidate Status Development - 2026-04-22
+
+## Goal
+
+Continue the DingTalk person-message workflow by making local user and member-group recipient selection safer in the automation UI.
+
+## Implemented
+
+- Added candidate status details to DingTalk person recipient search results in both automation editors.
+- Show whether a candidate is a `User` or `Member group`.
+- Show the candidate access level when the backend returns one.
+- Disable inactive local user candidates so they cannot be added to `send_dingtalk_person_message` recipients.
+- Filter role candidates out of DingTalk person recipient search results because direct person delivery only supports local users and member groups.
+- Added defensive guards in the add-recipient handlers so inactive users and unsupported candidate types cannot be added programmatically.
+
+## Files
+
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `docs/development/dingtalk-person-recipient-candidate-status-development-20260422.md`
+- `docs/development/dingtalk-person-recipient-candidate-status-verification-20260422.md`
+
+## Behavior Notes
+
+- This is a frontend-only safety and clarity slice.
+- Existing manual ID entry is preserved.
+- Existing dynamic record recipient field paths are preserved.
+- Member groups remain selectable.
+- Inactive local users remain visible with an explanatory message, but their buttons are disabled.
+- Role candidates are hidden because they are not valid DingTalk person-message recipients.

--- a/docs/development/dingtalk-person-recipient-candidate-status-verification-20260422.md
+++ b/docs/development/dingtalk-person-recipient-candidate-status-verification-20260422.md
@@ -1,0 +1,44 @@
+# DingTalk Person Recipient Candidate Status Verification - 2026-04-22
+
+## Result
+
+Passed local verification for the scoped frontend tests, frontend build, and diff hygiene.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed, 1 test file, 60 tests.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed, 1 test file, 71 tests.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Observations
+
+- Frontend Vitest printed `WebSocket server error: Port is already in use` during the manager test run; the test file still passed.
+- Frontend build printed existing Vite warnings about a large chunk and `WorkflowDesigner.vue` being both dynamically and statically imported; build completed successfully.
+
+## Coverage Added
+
+- Advanced rule editor disables inactive user candidates in DingTalk person recipient search.
+- Inline automation form disables inactive user candidates in DingTalk person recipient search.
+- Both editors display candidate type and access level.
+- Both editors hide unsupported role candidates from DingTalk person recipient search.
+- Both editors still allow member-group candidates to populate `memberGroupIds`.


### PR DESCRIPTION
## Summary
- show candidate type and access level in DingTalk person recipient search results
- disable inactive local user candidates in both automation editors
- filter unsupported role candidates out of direct DingTalk person-message recipient search
- add defensive add-recipient guards and scoped tests
- add development and verification notes for this slice

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

Notes: the manager Vitest run printed a non-fatal `WebSocket server error: Port is already in use`; frontend build printed existing Vite chunk/import warnings and completed successfully.