### PR TITLE
refactor(multitable): absorb route helpers into M0 modules

### DIFF
--- a/docs/development/multitable-m0-extraction-development-20260421.md
+++ b/docs/development/multitable-m0-extraction-development-20260421.md
@@ -1,0 +1,294 @@
+# Multitable M0 Extraction — Development Notes (2026-04-21)
+
+> Document type: development / status
+> Date: 2026-04-21
+> Branch: `codex/multitable-m0-extraction-20260421`
+> Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/multitable-m0`
+> Baseline: `6c5c652d1` (= `origin/main` HEAD)
+> Roadmap reference: `docs/development/multitable-service-extraction-roadmap-20260407.md` sections 5.1 and 10
+
+## TL;DR
+
+**Status: BLOCKED — extraction already landed on `main` via an unrelated track, but `univer-meta.ts` still holds divergent inline copies that cannot be removed as a "pure move."**
+
+The three target files the roadmap asks M0 to create (`packages/core-backend/src/multitable/{access,loaders,provisioning}.ts`) and the three target unit test files already exist on `origin/main` (HEAD = `6c5c652d1`). They were introduced incrementally by the after-sales installer track:
+
+| Commit | Subject |
+|---|---|
+| `2206cc45b` | `refactor(multitable): extract access and loader helpers` |
+| `9aa1b8725` | `feat(after-sales): add multitable provisioning views and install shell` |
+| `8da4c02c8` | `refactor(multitable): share provisioning field contracts` |
+| `3f3079490` | `refactor(multitable): hide physical id resolution behind provisioning helpers` |
+
+All are ancestors of `origin/main` at `6c5c652d1`.
+
+However, `packages/core-backend/src/routes/univer-meta.ts` still contains inline duplicate definitions of the same helpers, and their signatures have **drifted** from the extracted modules during the after-sales track's evolution. Replacing the route's inline copies with imports from the already-extracted modules would require either (a) **expanding** the existing modules' public signatures in a non-additive way, which breaks the "pure move, no behavior change" rule and the roadmap's section 10 constraint that after-sales remain the driver, or (b) **changing call sites** in `univer-meta.ts` to cope with narrower APIs, which is also not a pure move.
+
+No code was changed in this session. No commit was made. Per the task brief's "If blocked, STOP and report" clause, this MD documents the findings and defers to the user.
+
+---
+
+## 1. Files present at HEAD
+
+### 1.1 Target modules (already on `main`)
+
+- `packages/core-backend/src/multitable/access.ts` — exports `normalizePermissionCodes`, `resolveRequestAccess`, `hasPermission`, `deriveCapabilities`, `deriveFieldPermissions`, `deriveViewPermissions`, `deriveRowActions` plus type aliases. 156 lines.
+- `packages/core-backend/src/multitable/loaders.ts` — exports `loadSheetRow`, `loadFieldsForSheet`, `tryResolveView` plus type aliases. 95 lines.
+- `packages/core-backend/src/multitable/provisioning.ts` — exports `ensureLegacyBase`, `ensureSheet`, `ensureFields`, `createSheet`, `ensureView`, `createView`, `ensureObject`, ID helpers, and contract types. 417 lines.
+
+### 1.2 Target unit tests (already on `main`)
+
+- `packages/core-backend/tests/unit/multitable-access.test.ts` (3042 bytes)
+- `packages/core-backend/tests/unit/multitable-loaders.test.ts` (2664 bytes)
+- `packages/core-backend/tests/unit/multitable-provisioning.test.ts` (10514 bytes)
+
+### 1.3 Consumer of the already-extracted modules
+
+- `packages/core-backend/src/index.ts` imports provisioning helpers directly (line 49).
+- The after-sales installer relies on the current provisioning-module shapes.
+
+---
+
+## 2. Divergence catalog (route inline vs. module)
+
+`grep` targets run against `packages/core-backend/src/routes/univer-meta.ts`:
+
+| Helper | Inline location | Inline signature | Module signature | Diff |
+|---|---|---|---|---|
+| `ensureLegacyBase` | L3162 | `(query: QueryFn) => Promise<string>` | same | identical — safe delete |
+| `loadSheetRow` | L3310 | `(query: QueryFn, sheetId) => Promise<{id, baseId, name, description}\|null>` | `(query: MultitableLoaderQueryFn, sheetId) => Promise<MultitableSheetRow\|null>` | structurally compatible — safe delete if `QueryFn` and `MultitableLoaderQueryFn` are assignment-compatible |
+| `loadFieldsForSheet` | L3328 | `(query: QueryFn, sheetId) => Promise<UniverMetaField[]>` | `(pool: { query: MultitableLoaderQueryFn }, sheetId, cache?) => Promise<MultitableField[]>` | **arg shape differs**: inline takes `query` directly; module takes `{ query }` |
+| `tryResolveView` | L1803 | `(pool: { query: QueryFn }, viewId) => Promise<UniverMetaViewConfig\|null>` | `(pool: { query }, viewId, cache?) => Promise<MultitableViewConfig\|null>` | module uses caller-provided `cache`; inline uses module-level `metaViewConfigCache` — observable behavior different (cache isolation) |
+| `resolveRequestAccess` | L1939 | `(req) => Promise<{ userId, permissions, isAdminRole }>` | `(req) => Promise<{ permissions, isAdminRole }>` | **module drops `userId`**; many call sites in `univer-meta.ts` read `access.userId` (L2666, L2689, L2712, L2737, L2791, L2972, L3799, L3899, L4075, L8143, L8411) |
+| `deriveCapabilities` | L1972 | returns 10 fields incl. `canManageSheetAccess`, `canExport` | returns 8 fields | **module missing two capability fields**; call sites read `capabilities.canManageSheetAccess` at L2545, L2557, L2617; `canExport` at L2546, L2561 |
+| `ensureSheet` | not inline | n/a | `(input: { query, sheetId, baseId?, name, description? }) => Promise<MultitableProvisioningSheet>` | module-only; route uses raw `INSERT` at L3716, L5861 |
+| `ensureFields` | not inline | n/a | `(input: { query, sheetId, fields }) => Promise<MultitableProvisioningField[]>` | module-only; route uses raw `INSERT` at L3724, L4829 |
+
+### 2.1 Load-bearing evidence for blocker call
+
+Grep for `access.userId`, `canManageSheetAccess`, `canExport` against `univer-meta.ts`:
+
+- `access.userId` is read in at least 11 locations to gate 401 responses and to pass to sheet-permission scope loaders — dropping it from the return type is a compile-time break.
+- `canManageSheetAccess` and `canExport` are read by `serializeSheetCapabilitiesResponse` logic around L2545–L2617 — they are part of the REST response body and the permission-scope composition.
+
+Both are observable, non-trivial behaviors. Replacing the inline `deriveCapabilities` with the module version would change HTTP responses and would additionally fail TypeScript compilation at call sites.
+
+---
+
+## 3. Why pure-move extraction is not possible
+
+The task brief's rule 1 states:
+
+> **Pure move, no behavior change.** Signatures preserved, argument order preserved, return types preserved.
+
+Any of the three resolution paths conflicts with this rule or the task's scope:
+
+### 3.1 Path A — widen module APIs to match inline
+
+Add `userId` to `resolveRequestAccess` return; add `canManageSheetAccess`/`canExport` to `MultitableCapabilities`; accept `query: QueryFn` directly in `loadFieldsForSheet`; fall back to a module-level cache in `tryResolveView`.
+
+- Touches after-sales consumers via shared types, increases surface area, and is not "preserved signatures."
+- Is scope expansion that the user has not authorized.
+
+### 3.2 Path B — narrow route call sites to match module
+
+Change every `access.userId` read in `univer-meta.ts` to re-derive from `req.user`; delete `canManageSheetAccess`/`canExport` from the REST response; inject caches explicitly at every `tryResolveView` / `loadFieldsForSheet` call.
+
+- Changes observable REST response body (removes two capability fields).
+- Is a behavior change, not a pure move.
+
+### 3.3 Path C — leave inline copies, declare M0 done
+
+Because substance-wise the M0 deliverable (the three files + tests) is on `main`, one could argue M0 is already done and close this work.
+
+- This leaves `univer-meta.ts` with ~60 lines of dead-duplicate helpers and two signatures drifting from the extracted modules. Does not satisfy roadmap section 11's M0 "新功能通过 helper 接入" criterion — any new code added to `univer-meta.ts` still has the inline helpers as the path of least resistance.
+- Violates hard rule #2 from roadmap section 10: "不再往 `univer-meta.ts` 新增核心 SQL，除非只是转调新 helper."
+
+None of A/B/C is a safe, in-scope move. All require user sign-off.
+
+---
+
+## 4. What was done this session
+
+- Confirmed baseline at `6c5c652d1` on branch `codex/multitable-m0-extraction-20260421`.
+- `pnpm install --prefer-offline` — ok.
+- Read the full roadmap.
+- Read `packages/core-backend/src/routes/univer-meta.ts` (8714 lines) to locate every target helper.
+- Catalogued divergences between inline and module APIs (section 2).
+- Traced all call sites for `access.userId`, `canManageSheetAccess`, `canExport` to verify load-bearing usage.
+- No edits to any `.ts` file. No commit.
+
+---
+
+## 5. Follow-ups
+
+### 5.1 If user picks Path A (widen modules)
+
+Steps:
+
+1. Add `userId: string` to `resolveRequestAccess` return type.
+2. Add `canManageSheetAccess: boolean` and `canExport: boolean` to `MultitableCapabilities` in `multitable/access.ts`.
+3. Add an optional `cache?: Map<...>` parameter to `tryResolveView` and `loadFieldsForSheet` (already present for `tryResolveView`).
+4. Adapt `loadFieldsForSheet` to accept `(query: QueryFn, sheetId)` overload, or swap `univer-meta.ts` call sites to `{ query }`.
+5. Delete inline copies in `univer-meta.ts`.
+6. Add regression tests covering new capability fields.
+7. Audit after-sales installer for any assumption that the old return shapes are exhaustive.
+
+Risk: medium — touches the installer's type surface. Estimated diff: ~200 LoC across 4–5 files.
+
+### 5.2 If user picks Path B (narrow route)
+
+Steps:
+
+1. Replace each `access.userId` with `normalizeUserId(req)` local helper that re-reads from `req.user`.
+2. Remove `canManageSheetAccess` and `canExport` from route responses and update frontend consumers if any rely on them.
+3. Thread explicit caches at every existing call site.
+
+Risk: high — frontend consumer contracts may break. Not recommended without a wider spec.
+
+### 5.3 If user picks Path C (leave it)
+
+Steps:
+
+1. No code changes.
+2. Update roadmap section 5.1 to note M0 is done in substance and delete this bullet from future PR plans.
+3. Optionally add a `// TODO(multitable-m0): replace with multitable/access.resolveRequestAccess when signatures converge` comment on each inline helper.
+
+Risk: low — but leaves the technical debt the roadmap was created to eliminate.
+
+---
+
+## 6. Recommendation
+
+Path A with additive-only widening is the cleanest path to the roadmap's intent. It makes the inline helpers in `univer-meta.ts` genuinely replaceable by imports and does not break existing after-sales consumers because all added fields are strictly additive. It does cross the "pure move" boundary, so it needs the user's explicit sign-off to expand scope from "extract" to "reconcile."
+
+If Path A is approved, the corresponding commit message should be:
+
+```
+refactor(multitable): reconcile univer-meta helpers with shared modules
+
+Widens packages/core-backend/src/multitable/{access,loaders}.ts to cover
+the capability fields and return shape that univer-meta.ts call sites
+depend on (userId, canManageSheetAccess, canExport, direct QueryFn
+overload on loadFieldsForSheet). Removes the ~60 lines of duplicate
+inline helpers in univer-meta.ts; route now delegates to the shared
+modules.
+
+Closes the M0 gap documented in
+docs/development/multitable-service-extraction-roadmap-20260407.md
+where after-sales had already landed the shared modules but univer-meta.ts
+still carried divergent inline copies.
+```
+
+This is different from the "pure move" commit the task brief specified, so the brief itself would need an amendment.
+
+---
+
+## 7. References
+
+- Roadmap: `docs/development/multitable-service-extraction-roadmap-20260407.md`
+- Task brief: session instructions (M0 extraction, 2026-04-21)
+- Current file: `packages/core-backend/src/routes/univer-meta.ts` @ `6c5c652d1`
+- Target modules: `packages/core-backend/src/multitable/{access,loaders,provisioning}.ts` @ `6c5c652d1`
+- Target tests: `packages/core-backend/tests/unit/multitable-{access,loaders,provisioning}.test.ts` @ `6c5c652d1`
+
+---
+
+## Path A execution — 2026-04-21
+
+Path A (additive widening) approved by user and executed in the same worktree. All four modules widened additively; route-side inline duplicates removed; no external HTTP contract change.
+
+### Files touched
+
+- `packages/core-backend/src/multitable/access.ts` — widened
+- `packages/core-backend/src/multitable/loaders.ts` — widened
+- `packages/core-backend/src/routes/univer-meta.ts` — inline duplicates deleted; imports added
+- `packages/core-backend/tests/unit/multitable-access.test.ts` — existing assertions updated + 3 new cases
+- `packages/core-backend/tests/unit/multitable-loaders.test.ts` — 4 new cases covering new signatures
+
+No change to `provisioning.ts` — its `ensureLegacyBase` matched the inline version verbatim and simply needed re-wiring at the route.
+
+### Final widened signatures
+
+**`multitable/access.ts`**
+
+```ts
+export type MultitableCapabilities = {
+  canRead: boolean
+  canCreateRecord: boolean
+  canEditRecord: boolean
+  canDeleteRecord: boolean
+  canManageFields: boolean
+  canManageSheetAccess: boolean  // NEW
+  canManageViews: boolean
+  canComment: boolean
+  canManageAutomation: boolean
+  canExport: boolean  // NEW
+}
+
+export type ResolvedRequestAccess = {
+  userId: string  // NEW (now returned by resolveRequestAccess)
+  permissions: string[]
+  isAdminRole: boolean
+}
+
+export async function resolveRequestAccess(req: Request): Promise<ResolvedRequestAccess>
+export function deriveCapabilities(permissions: string[], isAdminRole: boolean): MultitableCapabilities
+// deriveCapabilities now populates canManageSheetAccess (gated by multitable:share
+// or admin) and canExport (== canRead, matching the inline route semantic).
+```
+
+**`multitable/loaders.ts`**
+
+```ts
+function normalizeQueryArg(
+  arg: MultitableLoaderQueryFn | { query: MultitableLoaderQueryFn },
+): MultitableLoaderQueryFn
+
+const DEFAULT_VIEW_CACHE = new Map<string, MultitableViewConfig>()
+
+// All three loader fns now accept EITHER a raw query fn OR a { query } wrapper
+export async function loadSheetRow(
+  poolOrQuery: MultitableLoaderQueryFn | { query: MultitableLoaderQueryFn },
+  sheetId: string,
+): Promise<MultitableSheetRow | null>
+
+export async function loadFieldsForSheet(
+  poolOrQuery: MultitableLoaderQueryFn | { query: MultitableLoaderQueryFn },
+  sheetId: string,
+  cache?: Map<string, MultitableField[]>,
+): Promise<MultitableField[]>
+
+// tryResolveView now falls back to DEFAULT_VIEW_CACHE when no cache supplied
+export async function tryResolveView(
+  poolOrQuery: MultitableLoaderQueryFn | { query: MultitableLoaderQueryFn },
+  viewId: string,
+  cache: Map<string, MultitableViewConfig> = DEFAULT_VIEW_CACHE,
+): Promise<MultitableViewConfig | null>
+```
+
+### Deleted inline implementations in `univer-meta.ts`
+
+Using the pre-edit line numbers from §4 of the recon:
+
+- L182  `type MultitableCapabilities = {...}` — 10-field type, replaced by import from `multitable/access`
+- L1803 `async function tryResolveView(pool, viewId)` — 25-line inline replaced with a 10-line wrapper that delegates to `tryResolveViewShared(pool, viewId, metaViewConfigCache)`; route-level cache preserved by explicit pass-through (advisor-recommended path over module-level fallback, to keep existing `metaViewConfigCache.set/delete` call sites at L1759/L1762/L5343/L5422/L5470/L5623/L5696 observably unchanged)
+- L1821 `type ResolvedRequestAccess = {...}` — replaced by import
+- L1829 `function normalizePermissionCodes` — removed (imported from `multitable/access`)
+- L1913 `async function resolveRequestAccess` — removed (imported)
+- L1940 `function hasPermission` — removed (imported)
+- L1946 `function deriveCapabilities` — removed (imported)
+- L3077 `async function ensureLegacyBase` — replaced with `const ensureLegacyBase = ensureLegacyBaseShared`
+- L3217 `async function loadSheetRow` — replaced with `const loadSheetRow = loadSheetRowShared`
+- L3235 `async function loadFieldsForSheet` — replaced with `const loadFieldsForSheet = loadFieldsForSheetShared`
+
+Net: `-168` / `+30` LoC at `univer-meta.ts`, `+21` LoC at `access.ts`, `+28` LoC at `loaders.ts`, `+129` LoC at the two unit tests.
+
+### Surprises and notes
+
+- **Five copies of `MultitableCapabilities` exist in the codebase** (access.ts, permission-derivation.ts, sheet-capabilities.ts, record-write-service.ts, and the now-deleted route copy). The task scope is `access.ts` only; the other three already carry the 10-field shape. Consolidating them is left for a later M-step.
+- **`UniverMetaViewConfig` (route, L115) and `MultitableViewConfig` (loaders.ts, L20) are structurally identical** but TypeScript treats `Map<K, A>` and `Map<K, B>` as invariant, so the cache pass-through uses a cast: `metaViewConfigCache as Map<string, SharedMultitableViewConfig>`. This is the only cast added; it is safe because every writer writes records that satisfy both types.
+- **`loadSheetFields` at L1787 (route) was NOT deleted.** It is a DIFFERENT function than `loadFieldsForSheet` — it uses the route-level `metaFieldCache` and is invoked at L4782 and L5809. It is not in the 6-line deletion catalog and is out of scope for M0.
+- `isAdmin` and `listUserPermissions` imports from `../rbac/service` are KEPT in `univer-meta.ts` because L2144/L2145 still call them directly from the candidate-resolution flow. They are no longer referenced by the deleted inline `resolveRequestAccess` (that logic now lives in `multitable/access.ts`).
+- `DEFAULT_BASE_ID` and `DEFAULT_BASE_NAME` module-level consts at route L144/L145 are now unused; kept because `tsconfig.json` does not set `noUnusedLocals` and removing them is orthogonal to this change.
+- **`DEFAULT_VIEW_CACHE` footgun (design note for the next agent).** `multitable/loaders.ts` now holds a module-level `DEFAULT_VIEW_CACHE: Map<string, MultitableViewConfig>` that `tryResolveView` falls back to when no cache is passed. The task brief explicitly requested this default. However: a future caller who forgets to pass a cache would silently share a process-global singleton with no invalidation hook. This is fine today because the sole route consumer explicitly passes `metaViewConfigCache`, but any downstream new caller needs to either own a cache or accept shared-global semantics. M1 should surface this by requiring the cache argument at each documented caller (or adding a `resetDefaultViewCache()` export).

--- a/docs/development/multitable-m0-extraction-verification-20260421.md
+++ b/docs/development/multitable-m0-extraction-verification-20260421.md
@@ -1,0 +1,231 @@
+# Multitable M0 Extraction — Verification Notes (2026-04-21)
+
+> Document type: verification / status
+> Date: 2026-04-21
+> Branch: `codex/multitable-m0-extraction-20260421`
+> Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/multitable-m0`
+> Baseline: `6c5c652d1` (= `origin/main` HEAD)
+
+## TL;DR
+
+- Outcome: **BLOCKED, no code changes, no commit.**
+- Reason: target files already exist on `main`; inline copies in `univer-meta.ts` have drifted and cannot be deleted as a "pure move" per the task brief's rule 1.
+- See companion document: `multitable-m0-extraction-development-20260421.md`.
+
+## 1. Baseline confirmation
+
+```
+$ git log --oneline -3
+6c5c652d1 feat(infra): add Redis runtime stores for token bucket and circuit breaker (#1016)
+c6caa537b feat(approval): wire any-mode aggregation runtime (#1015)
+bac834a6c feat(admin-audit): wire audit log UI to backend (#1014)
+
+$ git branch --show-current
+codex/multitable-m0-extraction-20260421
+
+$ git merge-base HEAD origin/main
+6c5c652d1086674772ae78cc451f057563bb69b4
+
+$ git merge-base --is-ancestor 2206cc45b origin/main && echo "ancestor"
+ancestor
+```
+
+Confirms:
+- HEAD = `origin/main` HEAD.
+- Historical commits `2206cc45b` (extract access and loader helpers), `9aa1b8725` (provisioning views and install shell), `8da4c02c8`, `3f3079490` are all ancestors of `origin/main`.
+- The M0 deliverables are already on `main`.
+
+## 2. Install
+
+```
+$ pnpm install --prefer-offline
+Done in 4.5s using pnpm v10.33.0
+```
+
+No errors. No deprecation flags relevant to this task.
+
+## 3. Target file inventory
+
+```
+$ ls packages/core-backend/src/multitable/
+access.ts
+loaders.ts
+provisioning.ts
+(and many others — field-codecs.ts, record-write-service.ts, etc.)
+
+$ ls packages/core-backend/tests/unit/multitable-*.test.ts
+multitable-access.test.ts
+multitable-loaders.test.ts
+multitable-provisioning.test.ts
+(and others)
+```
+
+All six artifacts the task brief asked to create already exist on `main`.
+
+## 4. Verification commands — NOT EXECUTED
+
+Per the task brief, verification should include:
+
+```
+# TypeScript check
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+
+# New unit tests (already exist on main, not introduced this session)
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-provisioning.test.ts \
+  tests/unit/multitable-loaders.test.ts \
+  tests/unit/multitable-access.test.ts --reporter=dot
+
+# Full core-backend unit suite — MUST pass (zero regressions)
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
+
+# Multitable integration smoke
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration --reporter=dot
+```
+
+Rationale for skipping: **no code was changed this session**, so these checks would only verify the state of `main` at `6c5c652d1`, not anything this session produced. Running them would consume time without answering the task's actual question, which is the blocker described in section 5. If the user selects Path A or Path B (see development MD section 5), the full verification battery becomes appropriate and should be run at that point.
+
+## 5. Blocker summary
+
+`packages/core-backend/src/routes/univer-meta.ts` contains inline duplicate helpers at:
+
+- L1803 `tryResolveView` — uses module-level cache, 2-arg signature
+- L1939 `resolveRequestAccess` — returns `{ userId, permissions, isAdminRole }`
+- L1972 `deriveCapabilities` — returns 10-field `MultitableCapabilities` including `canManageSheetAccess`, `canExport`
+- L3162 `ensureLegacyBase` — identical to module
+- L3310 `loadSheetRow` — identical shape to module
+- L3328 `loadFieldsForSheet` — takes `query: QueryFn` directly, not `{ query }`
+
+The module copies have **different** signatures:
+
+- `multitable/access.ts::resolveRequestAccess` returns `{ permissions, isAdminRole }` — **no `userId`**
+- `multitable/access.ts::MultitableCapabilities` has 8 fields — **missing `canManageSheetAccess` and `canExport`**
+- `multitable/loaders.ts::loadFieldsForSheet` takes `(pool: { query }, sheetId, cache?)`
+- `multitable/loaders.ts::tryResolveView` takes caller-provided cache
+
+Call-site evidence in `univer-meta.ts`:
+
+```
+$ grep -n 'access\.userId\|canManageSheetAccess\|canExport' packages/core-backend/src/routes/univer-meta.ts | wc -l
+18
+```
+
+18 call sites read these fields. Dropping them in favor of the module shapes would be a TypeScript break and an HTTP response contract change. Therefore a "pure move" as defined in the task brief's rule 1 is not achievable.
+
+## 6. What would need to happen to unblock
+
+User picks one of (Path A / Path B / Path C) described in
+`multitable-m0-extraction-development-20260421.md` section 5. Path A (additive widening of the shared modules, then delete inline duplicates) is recommended.
+
+## 7. Artifacts produced this session
+
+- `docs/development/multitable-m0-extraction-development-20260421.md`
+- `docs/development/multitable-m0-extraction-verification-20260421.md` (this file)
+
+No other files were created or modified. No commit.
+
+---
+
+## Path A execution — 2026-04-21
+
+Path A executed after sign-off. All verification gates green.
+
+### 1. TypeScript
+
+```
+$ pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+exit=0  (no output, no errors)
+
+$ pnpm --filter @metasheet/web exec vue-tsc --noEmit
+exit=0  (no output, no errors)
+```
+
+### 2. Multitable targeted unit tests
+
+```
+$ pnpm --filter @metasheet/core-backend exec vitest run \
+    tests/unit/multitable-provisioning.test.ts \
+    tests/unit/multitable-loaders.test.ts \
+    tests/unit/multitable-access.test.ts --reporter=dot
+
+ ✓ tests/unit/multitable-access.test.ts        (8 tests) 3ms   [was 5; +3]
+ ✓ tests/unit/multitable-provisioning.test.ts  (7 tests) 3ms   [unchanged]
+ ✓ tests/unit/multitable-loaders.test.ts       (7 tests) 2ms   [was 3; +4]
+
+ Test Files  3 passed (3)
+      Tests  22 passed (22)
+```
+
+### 3. Full core-backend unit suite
+
+```
+$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
+
+ Test Files  121 passed (121)
+      Tests  1568 passed (1568)
+   Duration  5.67s
+```
+
+Baseline at `6c5c652d1` (measured in-session via `git stash` of Path A source + test edits, then re-run):
+
+```
+ Test Files  121 passed (121)
+      Tests  1561 passed (1561)
+   Duration  5.84s
+```
+
+**Net delta: +7 new tests (3 access + 4 loader), 0 regressions, all 1561 baseline cases continue to pass.** Three `.toEqual`-on-exact-shape assertions inside the existing multitable-access tests were updated in-place to reflect the widened return shape of `resolveRequestAccess` (adds `userId`) and `deriveCapabilities` (adds `canManageSheetAccess`, `canExport`); those three assertions are counted within the baseline 1561 and are green post-widening.
+
+(Pre-existing `error: database "chouhua" does not exist` log lines are from `server-lifecycle.test.ts` and `plm-disable-routes.test.ts` driving degraded-mode init paths; they are not test failures — exit code is 0 and the test summary is all-green. Same behavior as on baseline.)
+
+### 4. Integration tests (optional, not run)
+
+The multitable routes do not have their own integration-level regression owned by M0; `approval-pack1a-lifecycle.api.test.ts` was the suggested spot-check in the brief. Skipped this session to keep scope minimal — the M0 change is module-surface and TypeScript-gated, and the full unit suite exercises every derivation path that the route wires. If a later gate requires it, run:
+
+```
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts run \
+  tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+```
+
+### 5. Behavioural invariants preserved
+
+- `resolveRequestAccess` return now includes `userId`. **11 existing `access.userId` reads in `univer-meta.ts` (L2582, L2604, L2627, …, L8326) continue to compile and behave identically** because the inline return shape already included `userId`; it has merely moved from the route's private `ResolvedRequestAccess` alias to the shared one.
+- `deriveCapabilities` on the same inputs produces the same 10-field object as before. Verified by test case `'grants every capability (including canManageSheetAccess and canExport) for admin role'` and `'derives full write capability set from multitable:write'` — both assertions are exact equality against the 10-field shape.
+- `metaViewConfigCache` is still written by `tryResolveView` (via the shared impl), and still invalidated by L1759/L1762 and written by L5343/L5422/L5470/L5623/L5696. The route wrapper passes the route's cache explicitly as the third arg to the shared function, so cache isolation and invalidation semantics are byte-for-byte identical to baseline.
+- `PUBLIC_FORM_CAPABILITIES` (L343, 10-field literal) still satisfies `MultitableCapabilities` — 10 declared fields match the widened type.
+
+### 6. Commit
+
+See commit at branch tip: `refactor(multitable): widen M0 modules to absorb route-side helpers`.
+No `--amend`. No `--no-verify`. No push.
+
+---
+
+## Rebase verification - 2026-04-22
+
+Rebased onto `origin/main@9f07a1a408faa761adc2e746b86ef5905c9f2735`.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-provisioning.test.ts \
+  tests/unit/multitable-loaders.test.ts \
+  tests/unit/multitable-access.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check origin/main...HEAD
+```
+
+Result:
+
+- Targeted multitable unit tests: passed, 3 files / 22 tests.
+- Core backend typecheck: passed.
+- Web typecheck: passed.
+- Full core-backend unit suite: passed, 123 files / 1587 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Pre-existing degraded-mode logs for missing local `chouhua` database appeared in lifecycle-related unit tests; assertions passed and exit code was 0.

--- a/packages/core-backend/src/multitable/access.ts
+++ b/packages/core-backend/src/multitable/access.ts
@@ -8,9 +8,11 @@ export type MultitableCapabilities = {
   canEditRecord: boolean
   canDeleteRecord: boolean
   canManageFields: boolean
+  canManageSheetAccess: boolean
   canManageViews: boolean
   canComment: boolean
   canManageAutomation: boolean
+  canExport: boolean
 }
 
 export type MultitableFieldPermission = {
@@ -37,9 +39,15 @@ export function normalizePermissionCodes(value: unknown): string[] {
     .filter((item) => item.length > 0)
 }
 
+export type ResolvedRequestAccess = {
+  userId: string
+  permissions: string[]
+  isAdminRole: boolean
+}
+
 export async function resolveRequestAccess(
   req: Request,
-): Promise<{ permissions: string[]; isAdminRole: boolean }> {
+): Promise<ResolvedRequestAccess> {
   const userId =
     req.user?.id?.toString() ??
     req.user?.sub?.toString() ??
@@ -54,18 +62,19 @@ export async function resolveRequestAccess(
   const isAdminRole = role === 'admin' || tokenRoles.includes('admin')
   const directPermissions = tokenPerms.length > 0 ? tokenPerms : resolvedPermissions
   if (!userId) {
-    return { permissions: directPermissions, isAdminRole }
+    return { userId, permissions: directPermissions, isAdminRole }
   }
 
   if (isAdminRole) {
-    return { permissions: directPermissions, isAdminRole: true }
+    return { userId, permissions: directPermissions, isAdminRole: true }
   }
 
   if (directPermissions.length > 0) {
-    return { permissions: directPermissions, isAdminRole: false }
+    return { userId, permissions: directPermissions, isAdminRole: false }
   }
 
   return {
+    userId,
     permissions: await listUserPermissions(userId),
     isAdminRole: await isAdmin(userId),
   }
@@ -86,6 +95,8 @@ export function deriveCapabilities(
     hasPermission(permissions, 'multitable:read') ||
     hasPermission(permissions, 'multitable:write')
   const canWrite = isAdminRole || hasPermission(permissions, 'multitable:write')
+  const canManageSheetAccess =
+    isAdminRole || hasPermission(permissions, 'multitable:share')
   const canComment =
     isAdminRole ||
     hasPermission(permissions, 'comments:write') ||
@@ -103,9 +114,11 @@ export function deriveCapabilities(
     canEditRecord: canWrite,
     canDeleteRecord: canWrite,
     canManageFields: canWrite,
+    canManageSheetAccess,
     canManageViews: canWrite,
     canComment,
     canManageAutomation,
+    canExport: canRead,
   }
 }
 

--- a/packages/core-backend/src/multitable/loaders.ts
+++ b/packages/core-backend/src/multitable/loaders.ts
@@ -29,10 +29,20 @@ export type MultitableViewConfig = {
   config?: Record<string, unknown>
 }
 
+function normalizeQueryArg(
+  arg: MultitableLoaderQueryFn | { query: MultitableLoaderQueryFn },
+): MultitableLoaderQueryFn {
+  if (typeof arg === 'function') return arg
+  return arg.query.bind(arg)
+}
+
+const DEFAULT_VIEW_CACHE = new Map<string, MultitableViewConfig>()
+
 export async function loadSheetRow(
-  query: MultitableLoaderQueryFn,
+  poolOrQuery: MultitableLoaderQueryFn | { query: MultitableLoaderQueryFn },
   sheetId: string,
 ): Promise<MultitableSheetRow | null> {
+  const query = normalizeQueryArg(poolOrQuery)
   const result = await query(
     'SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
     [sheetId],
@@ -48,14 +58,15 @@ export async function loadSheetRow(
 }
 
 export async function loadFieldsForSheet(
-  pool: { query: MultitableLoaderQueryFn },
+  poolOrQuery: MultitableLoaderQueryFn | { query: MultitableLoaderQueryFn },
   sheetId: string,
   cache?: Map<string, MultitableField[]>,
 ): Promise<MultitableField[]> {
   const cached = cache?.get(sheetId)
   if (cached) return cached
 
-  const fieldRes = await pool.query(
+  const query = normalizeQueryArg(poolOrQuery)
+  const fieldRes = await query(
     'SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC',
     [sheetId],
   )
@@ -65,14 +76,15 @@ export async function loadFieldsForSheet(
 }
 
 export async function tryResolveView(
-  pool: { query: MultitableLoaderQueryFn },
+  poolOrQuery: MultitableLoaderQueryFn | { query: MultitableLoaderQueryFn },
   viewId: string,
-  cache?: Map<string, MultitableViewConfig>,
+  cache: Map<string, MultitableViewConfig> = DEFAULT_VIEW_CACHE,
 ): Promise<MultitableViewConfig | null> {
-  const cached = cache?.get(viewId)
+  const cached = cache.get(viewId)
   if (cached) return cached
 
-  const result = await pool.query(
+  const query = normalizeQueryArg(poolOrQuery)
+  const result = await query(
     'SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1',
     [viewId],
   )
@@ -90,6 +102,6 @@ export async function tryResolveView(
     hiddenFieldIds: normalizeJsonArray(row.hidden_field_ids),
     config: normalizeJson(row.config),
   }
-  cache?.set(viewId, view)
+  cache.set(viewId, view)
   return view
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -19,6 +19,21 @@ import {
 import { rbacGuard, rbacGuardAny } from '../rbac/rbac'
 import { isAdmin, listUserPermissions } from '../rbac/service'
 import {
+  deriveCapabilities,
+  hasPermission,
+  normalizePermissionCodes,
+  resolveRequestAccess,
+  type MultitableCapabilities,
+  type ResolvedRequestAccess,
+} from '../multitable/access'
+import {
+  loadFieldsForSheet as loadFieldsForSheetShared,
+  loadSheetRow as loadSheetRowShared,
+  tryResolveView as tryResolveViewShared,
+  type MultitableViewConfig as SharedMultitableViewConfig,
+} from '../multitable/loaders'
+import { ensureLegacyBase as ensureLegacyBaseShared } from '../multitable/provisioning'
+import {
   queryRecordsWithCursor,
   buildRecordsCacheKey,
   type CursorPaginatedResult,
@@ -177,19 +192,6 @@ type UniverMetaBase = {
   color: string | null
   ownerId: string | null
   workspaceId: string | null
-}
-
-type MultitableCapabilities = {
-  canRead: boolean
-  canCreateRecord: boolean
-  canEditRecord: boolean
-  canDeleteRecord: boolean
-  canManageFields: boolean
-  canManageSheetAccess: boolean
-  canManageViews: boolean
-  canComment: boolean
-  canManageAutomation: boolean
-  canExport: boolean
 }
 
 type MultitableCapabilityOrigin = {
@@ -1800,48 +1802,20 @@ async function loadSheetFields(
   return fields
 }
 
-async function tryResolveView(pool: { query: QueryFn }, viewId: string): Promise<UniverMetaViewConfig | null> {
-  const cached = metaViewConfigCache.get(viewId)
-  if (cached) return cached
-
-  const result = await pool.query(
-    'SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1',
-    [viewId],
+async function tryResolveView(
+  pool: { query: QueryFn },
+  viewId: string,
+): Promise<UniverMetaViewConfig | null> {
+  return tryResolveViewShared(
+    pool as { query: QueryFn },
+    viewId,
+    metaViewConfigCache as Map<string, SharedMultitableViewConfig>,
   )
-  if (result.rows.length === 0) return null
-
-  const row: any = result.rows[0]
-  const view = {
-    id: String(row.id),
-    sheetId: String(row.sheet_id),
-    name: String(row.name),
-    type: String(row.type ?? 'grid'),
-    filterInfo: normalizeJson(row.filter_info),
-    sortInfo: normalizeJson(row.sort_info),
-    groupInfo: normalizeJson(row.group_info),
-    hiddenFieldIds: normalizeJsonArray(row.hidden_field_ids),
-    config: normalizeJson(row.config),
-  }
-  metaViewConfigCache.set(viewId, view)
-  return view
-}
-
-function normalizePermissionCodes(value: unknown): string[] {
-  if (!Array.isArray(value)) return []
-  return value
-    .map((item) => (typeof item === 'string' ? item.trim() : ''))
-    .filter((item) => item.length > 0)
 }
 
 function parseDingTalkAutomationDeliveryLimit(value: unknown): number {
   const raw = typeof value === 'string' ? Number(value) : undefined
   return Number.isFinite(raw) ? Math.min(Math.max(Math.floor(raw as number), 1), 200) : 50
-}
-
-type ResolvedRequestAccess = {
-  userId: string
-  permissions: string[]
-  isAdminRole: boolean
 }
 
 type SheetPermissionScope = {
@@ -1934,65 +1908,6 @@ const CANONICAL_SHEET_PERMISSION_CODE_BY_ACCESS_LEVEL: Record<MultitableSheetAcc
 
 function isSheetPermissionSubjectType(value: unknown): value is MultitableSheetPermissionSubjectType {
   return value === 'user' || value === 'role' || value === 'member-group'
-}
-
-async function resolveRequestAccess(req: Request): Promise<ResolvedRequestAccess> {
-  const userId = req.user?.id?.toString() ?? req.user?.sub?.toString() ?? req.user?.userId?.toString() ?? ''
-  const tokenRoles = normalizePermissionCodes(req.user?.roles)
-  const tokenPerms = normalizePermissionCodes(req.user?.perms)
-  const resolvedPermissions = normalizePermissionCodes((req.user as { permissions?: unknown } | undefined)?.permissions)
-  const role = typeof req.user?.role === 'string' ? req.user.role.trim() : ''
-  const isAdminRole = role === 'admin' || tokenRoles.includes('admin')
-  const directPermissions = tokenPerms.length > 0 ? tokenPerms : resolvedPermissions
-  if (!userId) {
-    return { userId, permissions: directPermissions, isAdminRole }
-  }
-
-  if (isAdminRole) {
-    return { userId, permissions: directPermissions, isAdminRole: true }
-  }
-
-  if (directPermissions.length > 0) {
-    return { userId, permissions: directPermissions, isAdminRole: false }
-  }
-
-  return {
-    userId,
-    permissions: await listUserPermissions(userId),
-    isAdminRole: await isAdmin(userId),
-  }
-}
-
-function hasPermission(permissions: string[], code: string): boolean {
-  if (permissions.includes(code)) return true
-  const [resource] = code.split(':')
-  return permissions.includes(`${resource}:*`) || permissions.includes('*:*')
-}
-
-function deriveCapabilities(permissions: string[], isAdminRole: boolean): MultitableCapabilities {
-  const canRead = isAdminRole || hasPermission(permissions, 'multitable:read') || hasPermission(permissions, 'multitable:write')
-  const canWrite = isAdminRole || hasPermission(permissions, 'multitable:write')
-  const canManageSheetAccess = isAdminRole || hasPermission(permissions, 'multitable:share')
-  const canComment = isAdminRole || hasPermission(permissions, 'comments:write') || hasPermission(permissions, 'comments:read')
-  const canManageAutomation =
-    isAdminRole ||
-    hasPermission(permissions, 'workflow:all') ||
-    hasPermission(permissions, 'workflow:write') ||
-    hasPermission(permissions, 'workflow:create') ||
-    hasPermission(permissions, 'workflow:execute')
-
-  return {
-    canRead,
-    canCreateRecord: canWrite,
-    canEditRecord: canWrite,
-    canDeleteRecord: canWrite,
-    canManageFields: canWrite,
-    canManageSheetAccess,
-    canManageViews: canWrite,
-    canComment,
-    canManageAutomation,
-    canExport: canRead,
-  }
 }
 
 function summarizeSheetPermissionCodes(codes: string[]): SheetPermissionScope {
@@ -3159,15 +3074,7 @@ function serializeBaseRow(row: any): UniverMetaBase {
   }
 }
 
-async function ensureLegacyBase(query: QueryFn): Promise<string> {
-  await query(
-    `INSERT INTO meta_bases (id, name, icon, color, owner_id, workspace_id)
-     VALUES ($1, $2, $3, $4, $5, $6)
-     ON CONFLICT (id) DO NOTHING`,
-    [DEFAULT_BASE_ID, DEFAULT_BASE_NAME, 'table', '#1677ff', null, null],
-  )
-  return DEFAULT_BASE_ID
-}
+const ensureLegacyBase = ensureLegacyBaseShared
 
 async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<PeopleSheetPreset> {
   const existingSheets = await query(
@@ -3307,31 +3214,8 @@ async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<
   }
 }
 
-async function loadSheetRow(
-  query: QueryFn,
-  sheetId: string,
-): Promise<{ id: string; baseId: string | null; name: string; description: string | null } | null> {
-  const result = await query(
-    'SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
-    [sheetId],
-  )
-  const row: any = result.rows[0]
-  if (!row) return null
-  return {
-    id: String(row.id),
-    baseId: typeof row.base_id === 'string' ? row.base_id : null,
-    name: String(row.name),
-    description: typeof row.description === 'string' ? row.description : null,
-  }
-}
-
-async function loadFieldsForSheet(query: QueryFn, sheetId: string): Promise<UniverMetaField[]> {
-  const result = await query(
-    'SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC',
-    [sheetId],
-  )
-  return result.rows.map((row: any) => serializeFieldRow(row))
-}
+const loadSheetRow = loadSheetRowShared
+const loadFieldsForSheet = loadFieldsForSheetShared
 
 async function ensureAttachmentIdsExist(
   query: QueryFn,

--- a/packages/core-backend/tests/unit/multitable-access.test.ts
+++ b/packages/core-backend/tests/unit/multitable-access.test.ts
@@ -38,6 +38,7 @@ describe('multitable access helper', () => {
     const result = await resolveRequestAccess(req)
 
     expect(result).toEqual({
+      userId: 'user_1',
       permissions: ['multitable:write'],
       isAdminRole: false,
     })
@@ -59,11 +60,26 @@ describe('multitable access helper', () => {
     const result = await resolveRequestAccess(req)
 
     expect(result).toEqual({
+      userId: 'user_2',
       permissions: ['comments:write'],
       isAdminRole: false,
     })
     expect(listUserPermissions).toHaveBeenCalledWith('user_2')
     expect(isAdmin).toHaveBeenCalledWith('user_2')
+  })
+
+  it('returns an empty userId when req.user has no identifier fields', async () => {
+    const req = { user: { roles: ['user'] } } as any
+
+    const result = await resolveRequestAccess(req)
+
+    expect(result).toEqual({
+      userId: '',
+      permissions: [],
+      isAdminRole: false,
+    })
+    expect(listUserPermissions).not.toHaveBeenCalled()
+    expect(isAdmin).not.toHaveBeenCalled()
   })
 
   it('derives full write capability set from multitable:write', () => {
@@ -73,9 +89,32 @@ describe('multitable access helper', () => {
       canEditRecord: true,
       canDeleteRecord: true,
       canManageFields: true,
+      canManageSheetAccess: false,
       canManageViews: true,
       canComment: false,
       canManageAutomation: false,
+      canExport: true,
+    })
+  })
+
+  it('propagates canManageSheetAccess when multitable:share is granted', () => {
+    const capabilities = deriveCapabilities(['multitable:read', 'multitable:share'], false)
+    expect(capabilities.canManageSheetAccess).toBe(true)
+    expect(capabilities.canExport).toBe(true)
+  })
+
+  it('grants every capability (including canManageSheetAccess and canExport) for admin role', () => {
+    expect(deriveCapabilities([], true)).toEqual({
+      canRead: true,
+      canCreateRecord: true,
+      canEditRecord: true,
+      canDeleteRecord: true,
+      canManageFields: true,
+      canManageSheetAccess: true,
+      canManageViews: true,
+      canComment: true,
+      canManageAutomation: true,
+      canExport: true,
     })
   })
 

--- a/packages/core-backend/tests/unit/multitable-loaders.test.ts
+++ b/packages/core-backend/tests/unit/multitable-loaders.test.ts
@@ -40,6 +40,22 @@ describe('multitable loaders helper', () => {
     })
   })
 
+  it('accepts a pool wrapper in addition to a raw query for loadSheetRow', async () => {
+    const pool = createPool((_sql, params) => {
+      expect(params).toEqual(['sheet_wrap'])
+      return [
+        { id: 'sheet_wrap', base_id: null, name: 'Wrapped', description: null },
+      ]
+    })
+
+    await expect(loadSheetRow(pool, 'sheet_wrap')).resolves.toEqual({
+      id: 'sheet_wrap',
+      baseId: null,
+      name: 'Wrapped',
+      description: null,
+    })
+  })
+
   it('loads fields and caches them', async () => {
     let calls = 0
     const cache = new Map<string, any[]>()
@@ -67,6 +83,27 @@ describe('multitable loaders helper', () => {
       type: 'select',
       options: [{ value: 'open' }],
     })
+  })
+
+  it('accepts a raw query for loadFieldsForSheet', async () => {
+    let calls = 0
+    const pool = createPool((_sql, params) => {
+      calls += 1
+      expect(params).toEqual(['sheet_raw'])
+      return [
+        {
+          id: 'fld_name',
+          name: 'Name',
+          type: 'string',
+          property: {},
+          order: 0,
+        },
+      ]
+    })
+
+    const result = await loadFieldsForSheet(pool.query, 'sheet_raw')
+    expect(calls).toBe(1)
+    expect(result[0]).toMatchObject({ id: 'fld_name', type: 'string' })
   })
 
   it('loads one view config and caches it', async () => {
@@ -100,5 +137,58 @@ describe('multitable loaders helper', () => {
       sheetId: 'sheet_ops',
       hiddenFieldIds: ['fld_hidden'],
     })
+  })
+
+  it('falls back to a module-level cache when no cache is supplied to tryResolveView', async () => {
+    let calls = 0
+    const pool = createPool((_sql, params) => {
+      calls += 1
+      expect(params).toEqual(['view_default_cache_probe'])
+      return [
+        {
+          id: 'view_default_cache_probe',
+          sheet_id: 'sheet_any',
+          name: 'Default Cache Probe',
+          type: 'grid',
+          filter_info: {},
+          sort_info: {},
+          group_info: {},
+          hidden_field_ids: [],
+          config: {},
+        },
+      ]
+    })
+
+    const first = await tryResolveView(pool, 'view_default_cache_probe')
+    const second = await tryResolveView(pool, 'view_default_cache_probe')
+
+    expect(calls).toBe(1)
+    expect(first).toBe(second)
+  })
+
+  it('accepts a raw query for tryResolveView', async () => {
+    let calls = 0
+    const cache = new Map<string, any>()
+    const pool = createPool((_sql, params) => {
+      calls += 1
+      expect(params).toEqual(['view_raw'])
+      return [
+        {
+          id: 'view_raw',
+          sheet_id: 'sheet_any',
+          name: 'Raw Query',
+          type: 'grid',
+          filter_info: {},
+          sort_info: {},
+          group_info: {},
+          hidden_field_ids: [],
+          config: {},
+        },
+      ]
+    })
+
+    const result = await tryResolveView(pool.query, 'view_raw', cache)
+    expect(calls).toBe(1)
+    expect(result).toMatchObject({ id: 'view_raw', sheetId: 'sheet_any' })
   })
 })


### PR DESCRIPTION
## Summary
- Widens multitable access/loaders module surfaces to match the route-side helper contracts.
- Removes duplicate inline helper logic from univer-meta.ts where the shared modules now preserve behavior.
- Adds targeted unit coverage for the widened access and loader helpers.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-provisioning.test.ts tests/unit/multitable-loaders.test.ts tests/unit/multitable-access.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check origin/main...HEAD