### PR TITLE
feat(approval): add sourceSystem filter for unified inbox

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -278,6 +278,13 @@ export interface ApprovalListQuery {
   search?: string
   page?: number
   pageSize?: number
+  /**
+   * Wave 2 WP2: drives the unified Inbox source filter tab.
+   *   - 'all'      → mixed feed (platform + PLM)
+   *   - 'platform' → platform-owned only
+   *   - 'plm'      → PLM-mirrored only
+   */
+  sourceSystem?: 'all' | 'platform' | 'plm'
 }
 
 // ---------------------------------------------------------------------------
@@ -346,6 +353,7 @@ export async function listApprovals(
   if (query?.search) params.set('search', query.search)
   if (query?.page) params.set('page', String(query.page))
   if (query?.pageSize) params.set('pageSize', String(query.pageSize))
+  if (query?.sourceSystem) params.set('sourceSystem', query.sourceSystem)
   const qs = params.toString()
   return apiGet(`/api/approvals${qs ? `?${qs}` : ''}`)
 }

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -27,6 +27,17 @@
           <el-option label="已驳回" value="rejected" />
           <el-option label="已撤回" value="revoked" />
         </el-select>
+        <el-select
+          v-model="sourceSystemFilter"
+          placeholder="来源系统"
+          style="width: 140px; margin-left: 12px"
+          data-testid="approval-source-filter"
+          @change="handleSearch"
+        >
+          <el-option label="全部来源" value="all" />
+          <el-option label="平台审批" value="platform" />
+          <el-option label="PLM 审批" value="plm" />
+        </el-select>
         <el-button
           v-if="canWrite"
           type="primary"
@@ -259,6 +270,9 @@ const { canWrite } = useApprovalPermissions()
 const activeTab = ref<'pending' | 'mine' | 'cc' | 'completed'>('pending')
 const searchText = ref('')
 const statusFilter = ref<ApprovalStatus | ''>('')
+// Wave 2 WP2: source filter driving the `sourceSystem` query param on /api/approvals.
+// Default 'all' surfaces the unified feed; switching narrows to platform or PLM-mirrored rows.
+const sourceSystemFilter = ref<'all' | 'platform' | 'plm'>('all')
 const currentPage = ref(1)
 const pageSize = ref(10)
 
@@ -301,6 +315,7 @@ function loadCurrentTab() {
     status: (statusFilter.value || undefined) as ApprovalStatus | undefined,
     page: currentPage.value,
     pageSize: pageSize.value,
+    sourceSystem: sourceSystemFilter.value,
   }
   switch (activeTab.value) {
     case 'pending': store.loadPending(query); break

--- a/apps/web/tests/approvalCenterSourceFilter.spec.ts
+++ b/apps/web/tests/approvalCenterSourceFilter.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * Wave 2 WP2 regression: ensure the ApprovalCenterView source filter maps
+ * 1:1 to the `sourceSystem` query arg on the underlying list call.
+ *
+ * The view delegates loading to the Pinia store's `load{Pending|Mine|Cc|Completed}`
+ * helpers — each accepts a query object that is forwarded verbatim to the
+ * `/api/approvals` URL builder in `approvals/api.ts`. Asserting the store spy
+ * argument is therefore equivalent to asserting the outgoing URL carries
+ * `sourceSystem=plm` (or `=all`, `=platform`).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: pushSpy,
+      back: vi.fn(),
+    }),
+    useRoute: () => ({
+      params: {},
+      query: {},
+      path: '/approvals',
+      meta: {},
+    }),
+  }
+})
+
+const mockPendingApprovals = ref<any[]>([])
+const mockMyApprovals = ref<any[]>([])
+const mockCcApprovals = ref<any[]>([])
+const mockCompletedApprovals = ref<any[]>([])
+const mockLoading = ref(false)
+const mockError = ref<string | null>(null)
+const loadPendingSpy = vi.fn().mockResolvedValue(undefined)
+const loadMineSpy = vi.fn().mockResolvedValue(undefined)
+const loadCcSpy = vi.fn().mockResolvedValue(undefined)
+const loadCompletedSpy = vi.fn().mockResolvedValue(undefined)
+
+// `useApprovalPermissions` touches localStorage on setup; the jsdom env
+// provided by vitest does not always expose it depending on invocation path.
+// Stub it so the view can mount cleanly in the unit-style spec.
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({
+    canWrite: ref(true),
+    canAct: ref(true),
+    canRead: ref(true),
+  }),
+}))
+
+vi.mock('../src/approvals/store', () => ({
+  useApprovalStore: () => ({
+    get approvals() { return [] },
+    get pendingApprovals() { return mockPendingApprovals.value },
+    get myApprovals() { return mockMyApprovals.value },
+    get ccApprovals() { return mockCcApprovals.value },
+    get completedApprovals() { return mockCompletedApprovals.value },
+    get activeApproval() { return null },
+    get history() { return [] },
+    get loading() { return mockLoading.value },
+    get error() { return mockError.value },
+    get totalPending() { return mockPendingApprovals.value.length },
+    get totalMine() { return mockMyApprovals.value.length },
+    get totalCc() { return mockCcApprovals.value.length },
+    get totalCompleted() { return mockCompletedApprovals.value.length },
+    get pendingCount() { return mockPendingApprovals.value.length },
+    approvalById: () => undefined,
+    loadPending: loadPendingSpy,
+    loadMine: loadMineSpy,
+    loadCc: loadCcSpy,
+    loadCompleted: loadCompletedSpy,
+    loadDetail: vi.fn(),
+    loadHistory: vi.fn(),
+    submitApproval: vi.fn(),
+    executeAction: vi.fn(),
+  }),
+}))
+
+// Minimal Element Plus stubs: the select component needs to expose
+// `modelValue` plumbing so we can drive the filter change event.
+const ElTabs = defineComponent({
+  name: 'ElTabs',
+  props: { modelValue: String },
+  emits: ['update:modelValue', 'tab-change'],
+  render() {
+    return h('div', { 'data-el-tabs': this.modelValue }, this.$slots.default?.())
+  },
+})
+
+const ElTabPane = defineComponent({
+  name: 'ElTabPane',
+  props: { label: String, name: String },
+  render() {
+    return h('div', { 'data-tab-pane': this.name, 'data-tab-label': this.label }, this.$slots.default?.())
+  },
+})
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: Array, loading: Boolean, stripe: Boolean, highlightCurrentRow: Boolean },
+  emits: ['row-click'],
+  render() {
+    return h('div', { 'data-el-table': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number], minWidth: [String, Number], fixed: String },
+  render() {
+    return h('div', { 'data-column': this.prop || this.label })
+  },
+})
+
+const ElTag = defineComponent({
+  name: 'ElTag',
+  props: { type: String, size: String },
+  render() {
+    return h('span', { 'data-el-tag': this.type }, this.$slots.default?.())
+  },
+})
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: String, placeholder: String, clearable: Boolean },
+  emits: ['update:modelValue', 'clear'],
+  render() {
+    return h('input', { 'data-el-input': 'true' })
+  },
+})
+
+/**
+ * Preserve the same reactivity contract as el-select: emit
+ * `update:modelValue` + `change` on value mutation. We expose the
+ * attribute via `data-testid` so the test can locate the source filter
+ * without depending on the stub's internal order in the DOM tree.
+ */
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: {
+    modelValue: [String, Array],
+    placeholder: String,
+    clearable: Boolean,
+  },
+  emits: ['update:modelValue', 'change'],
+  setup(props, { emit, slots, attrs }) {
+    return () => h(
+      'select',
+      {
+        ...attrs,
+        'data-el-select': 'true',
+        value: props.modelValue as string | undefined,
+        onChange: (event: Event) => {
+          const value = (event.target as HTMLSelectElement).value
+          emit('update:modelValue', value)
+          emit('change', value)
+        },
+      },
+      slots.default?.(),
+    )
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() {
+    return h('option', { value: this.value }, this.label)
+  },
+})
+
+const ElPagination = defineComponent({
+  name: 'ElPagination',
+  props: { background: Boolean, layout: String, total: Number, currentPage: Number, pageSize: Number },
+  emits: ['update:currentPage'],
+  render() {
+    return h('div', { 'data-el-pagination': 'true' })
+  },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String },
+  emits: ['click'],
+  render() {
+    return h('button', { 'data-el-button': this.type || 'default' }, this.$slots.default?.())
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, type: String, showIcon: Boolean, closable: Boolean },
+  render() {
+    return h('div', { 'data-el-alert': this.type }, this.title)
+  },
+})
+
+const ElEmpty = defineComponent({
+  name: 'ElEmpty',
+  props: { description: String, imageSize: Number },
+  render() {
+    return h('div', { 'data-el-empty': 'true' }, this.description)
+  },
+})
+
+const stubDirective = { mounted() {}, updated() {} }
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('ApprovalCenterView source filter (Wave 2 WP2)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    mockPendingApprovals.value = []
+    mockMyApprovals.value = []
+    mockCcApprovals.value = []
+    mockCompletedApprovals.value = []
+    mockLoading.value = false
+    mockError.value = null
+    loadPendingSpy.mockClear()
+    loadMineSpy.mockClear()
+    loadCcSpy.mockClear()
+    loadCompletedSpy.mockClear()
+    pushSpy.mockClear()
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalCenterView } = await import('../src/views/approval/ApprovalCenterView.vue')
+    const Host = defineComponent({
+      setup() {
+        return () => h(ApprovalCenterView as any)
+      },
+    })
+    app = createApp(Host)
+    app.component('ElTabs', ElTabs)
+    app.component('ElTabPane', ElTabPane)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElInput', ElInput)
+    app.component('ElSelect', ElSelect)
+    app.component('ElOption', ElOption)
+    app.component('ElPagination', ElPagination)
+    app.component('ElButton', ElButton)
+    app.component('ElAlert', ElAlert)
+    app.component('ElEmpty', ElEmpty)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  it('defaults the source filter to "all" on mount', async () => {
+    await mountView()
+
+    expect(loadPendingSpy).toHaveBeenCalledTimes(1)
+    const [firstCallQuery] = loadPendingSpy.mock.calls[0] ?? []
+    expect(firstCallQuery).toMatchObject({ sourceSystem: 'all' })
+  })
+
+  it('renders the source filter dropdown with all three options', async () => {
+    await mountView()
+
+    const filter = container!.querySelector('[data-testid="approval-source-filter"]')
+    expect(filter).toBeTruthy()
+
+    const options = filter!.querySelectorAll('option')
+    const values = Array.from(options).map((option) => option.getAttribute('value'))
+    expect(values).toEqual(expect.arrayContaining(['all', 'platform', 'plm']))
+  })
+
+  it('propagates sourceSystem=plm to the store when the filter switches to PLM', async () => {
+    await mountView()
+
+    const filter = container!.querySelector('[data-testid="approval-source-filter"]') as HTMLSelectElement
+    expect(filter).toBeTruthy()
+
+    filter.value = 'plm'
+    filter.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const [latestQuery] = loadPendingSpy.mock.calls.at(-1) ?? []
+    expect(latestQuery).toMatchObject({ sourceSystem: 'plm' })
+  })
+
+  it('propagates sourceSystem=platform when the filter switches to platform', async () => {
+    await mountView()
+
+    const filter = container!.querySelector('[data-testid="approval-source-filter"]') as HTMLSelectElement
+    expect(filter).toBeTruthy()
+
+    filter.value = 'platform'
+    filter.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const [latestQuery] = loadPendingSpy.mock.calls.at(-1) ?? []
+    expect(latestQuery).toMatchObject({ sourceSystem: 'platform' })
+  })
+})

--- a/docs/development/approval-wave2-wp2-inbox-development-20260421.md
+++ b/docs/development/approval-wave2-wp2-inbox-development-20260421.md
@@ -1,0 +1,113 @@
+# Approval Wave 2 WP2 — Unified Inbox with PLM Integration (Development)
+
+- Date: 2026-04-21
+- Branch: `codex/approval-wave2-wp2-inbox-20260421`
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/wp2-inbox`
+- Baseline: `origin/main@6c5c652d1`
+- Scope: Roadmap WP2 acceptance criterion #1 — unified `/api/approvals` feed with `sourceSystem` filter across platform and PLM, matching entry in
+  `docs/development/approval-mvp-feishu-gap-matrix-20260411.md` ("审批中心/Inbox — 跨系统统一 Inbox").
+
+## Recon findings (what was already working)
+
+1. `ApprovalBridgeService.listApprovals` already supported filtering by `sourceSystem` —
+   `packages/core-backend/src/services/ApprovalBridgeService.ts:226-229` appends
+   `WHERE source_system = $n` when the caller passes the option. No change needed in the service.
+2. `ApprovalBridgeService.upsertPlmMirror` already writes `source_system='plm'` via
+   `bridge.externalSystem` (`packages/core-backend/src/services/ApprovalBridgeService.ts:694`, paired with
+   `packages/core-backend/src/federation/plm-approval-bridge.ts:82` where the field is hard-coded to `'plm'`).
+   The data contract is correct — no mutation of the bridge's write path is required.
+3. The LIST route accepted the `sourceSystem` query parameter as a pass-through string
+   (`packages/core-backend/src/routes/approvals.ts:306`) and forwarded it into the service, so new-PLM rows
+   inserted through the bridge were already reachable via `?sourceSystem=plm`.
+
+## Recon findings (what was missing)
+
+1. `sourceSystem=all` was not translated — the route passed the literal `'all'` downstream, producing
+   `WHERE source_system = 'all'` in SQL and matching zero rows. The acceptance criterion requires `all`
+   to mean "mixed feed".
+2. The route had no whitelist; any string value would be forwarded verbatim (zero rows for anything
+   other than the valid trio) with no 400. We want the contract explicit.
+3. The frontend `ApprovalListQuery` type and URL builder (`apps/web/src/approvals/api.ts`) did not
+   carry a `sourceSystem` field at all, so the store could not propagate a filter even if the UI were
+   extended.
+4. `ApprovalCenterView.vue` had no source filter control. The toolbar only exposed search + status.
+
+## Scope decisions
+
+- Route-layer change kept to whitelist + `'all'` translation. Did not touch `ApprovalBridgeService`
+  semantics (see follow-ups for the tab × source collision).
+- Did NOT introduce a data-migration to backfill `source_system` on historical rows — per task scope,
+  only new PLM events flow through the bridge.
+- Did NOT modify the approval core engine (`ApprovalGraphExecutor.ts`), PLM data model, or the AfterSales
+  bridge.
+- Did NOT add an attendance source tab — that is a later WP2 slice.
+- Chose a dropdown (not a second tab row) because the four Inbox tabs already consume horizontal space
+  and the source filter has only three values; the dropdown matches the existing status-filter visual
+  language.
+
+## File changes
+
+### Backend
+
+- `packages/core-backend/src/routes/approvals.ts:298-385`
+  - `GET /api/approvals` now validates `sourceSystem` against `['platform', 'plm', 'all']` (400
+    `APPROVAL_SOURCE_SYSTEM_INVALID` for unknown values).
+  - `'all'` translates to `undefined` at the service layer so no `WHERE` clause is appended.
+  - Preserves the legacy default: when the client omits `sourceSystem` but sends a `tab`, the
+    effective filter stays `'platform'` to keep tab semantics backwards-compatible.
+  - Documented the translation rules inline.
+
+### Frontend
+
+- `apps/web/src/approvals/api.ts:279-296`
+  - `ApprovalListQuery.sourceSystem?: 'all' | 'platform' | 'plm'`.
+- `apps/web/src/approvals/api.ts:353` (URL builder)
+  - Appends `sourceSystem` to `URLSearchParams` when set.
+- `apps/web/src/views/approval/ApprovalCenterView.vue`
+  - Added `sourceSystemFilter = ref<'all'|'platform'|'plm'>('all')` state and an `<el-select>`
+    dropdown (testid `approval-source-filter`) in the toolbar with the three options.
+  - Wired the value into `loadCurrentTab`'s query object so the store receives `sourceSystem` on every
+    tab load / page change / status change.
+
+### Tests
+
+- `packages/core-backend/tests/unit/plm-approval-bridge.test.ts`
+  - Extended with a dedicated WP2-labelled case asserting
+    `toPlatformApprovalBridgeRecord(...).externalSystem === 'plm'` for both a minimal and a fully
+    populated source payload. This pins the bridge write contract that downstream powers the unified
+    Inbox `sourceSystem=plm` filter.
+- `packages/core-backend/tests/integration/approval-wp2-source-filter.api.test.ts`
+  - Seeds one platform + one PLM row via raw INSERT (schema bootstrap mirrors the pattern from
+    `approval-pack1a-lifecycle.api.test.ts`).
+  - Four cases: `sourceSystem=all` → both rows, `=platform` → platform only, `=plm` → PLM only,
+    `=bogus` → 400.
+  - Pre-connects the DI-resolved PLM adapter in `beforeAll` so the test-env HTTP client falls into
+    mock mode and the route's `syncPlmApprovals` call is a no-op (see follow-up about injecting a
+    dedicated stub).
+- `apps/web/tests/approvalCenterSourceFilter.spec.ts`
+  - Mocks the store and `useApprovalPermissions` (the latter works around a baseline localStorage
+    issue in the existing `approval-center.spec.ts` that our spec also encounters).
+  - Drives the `ElSelect` stub with a real `change` event, asserts the latest `loadPending` spy call
+    carries `{ sourceSystem: 'plm' }` or `'platform'` respectively.
+  - Also covers the `'all'` default on mount.
+
+## Follow-ups (documented, not implemented)
+
+- Tab × source collision: `ApprovalBridgeService.listApprovals` hard-adds
+  `COALESCE(source_system,'platform')='platform'` when `tab && actorId` are set
+  (`packages/core-backend/src/services/ApprovalBridgeService.ts:264`). Passing `tab=pending &
+  sourceSystem=plm` therefore returns zero rows. The WP2 acceptance does not require composing these,
+  and the frontend currently serves tabs + filter independently for platform; a proper cross-product
+  needs a deeper refactor (likely when attendance is added). Document-only for now.
+- Attendance source: not yet in `approval_instances`. When added, extend the whitelist in the route
+  and the `ApprovalListQuery` literal, and surface a fourth option in the dropdown.
+- PLM adapter in integration tests: the current pattern (pre-connect to force mock mode) depends on
+  `IPLMAdapter` accepting a no-URL config path. If PLM env vars leak into CI (PLM_BASE_URL, etc.), the
+  adapter will try a real HTTP call and the test would regress. A future hardening: inject a
+  dedicated stub adapter via the `approvalsRouter({ plmAdapter })` option and skip the DI round-trip.
+- Historical PLM backfill: new events flow through the bridge and carry `source_system='plm'`; legacy
+  rows (if any) retain `NULL` or `'platform'`. Out of scope for this slice per the task.
+
+## Verification summary
+
+See `approval-wave2-wp2-inbox-verification-20260421.md` for exact commands and pass/fail counts.

--- a/docs/development/approval-wave2-wp2-inbox-verification-20260421.md
+++ b/docs/development/approval-wave2-wp2-inbox-verification-20260421.md
@@ -1,0 +1,167 @@
+# Approval Wave 2 WP2 — Unified Inbox (Verification)
+
+- Date: 2026-04-21
+- Branch: `codex/approval-wave2-wp2-inbox-20260421`
+- Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/wp2-inbox`
+- Baseline: `origin/main@6c5c652d1`
+
+## Environment
+
+- macOS, Node via pnpm workspace at repo root.
+- Postgres: `postgresql://chouhua@127.0.0.1:5432/postgres` (integration DB).
+- PLM env vars: unset → adapter operates in mock mode after `connect()`.
+
+## Commands executed
+
+### 1. Typechecks
+
+```
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+# exit 0, no errors
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+# exit 0, no errors
+```
+
+### 2a. Bridge write-path unit test
+
+```
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/plm-approval-bridge.test.ts --reporter=dot
+```
+
+Result: `Test Files 1 passed (1)`, `Tests 4 passed (4)`. Includes the extended WP2 case pinning
+`externalSystem='plm'` on every bridged record.
+
+### 2. New integration test
+
+```
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 \
+PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest \
+    --config vitest.integration.config.ts run \
+    tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot
+```
+
+Result: `Test Files 1 passed (1)`, `Tests 4 passed (4)`, duration ~2.5s.
+
+Covered cases:
+- `sourceSystem=all` → mixed feed includes both the seeded platform and PLM rows.
+- `sourceSystem=platform` → exactly one row (platform) returned.
+- `sourceSystem=plm` → exactly one row (PLM) returned.
+- `sourceSystem=bogus` → HTTP 400 with code `APPROVAL_SOURCE_SYSTEM_INVALID`.
+
+### 3. Backend neighbour regressions
+
+```
+DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts run \
+  tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot
+# Test Files 1 passed (1), Tests 1 passed (1)
+
+DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts run \
+  tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+# Test Files 1 passed (1), Tests 3 passed (3)
+```
+
+### 4. New frontend spec
+
+```
+pnpm --filter @metasheet/web exec vitest run \
+  tests/approvalCenterSourceFilter.spec.ts --reporter=dot
+```
+
+Result: `Test Files 1 passed (1)`, `Tests 4 passed (4)`, duration ~0.4s. Non-fatal
+`[Vue warn] Failed to resolve component: el-icon` appears (matches existing specs; the
+icon component is intentionally not stubbed and does not affect behaviour).
+
+Covered cases:
+- Default mount call carries `sourceSystem: 'all'`.
+- Dropdown exposes options for `all`, `platform`, `plm`.
+- Switching to `plm` triggers a reload with `sourceSystem: 'plm'`.
+- Switching to `platform` triggers a reload with `sourceSystem: 'platform'`.
+
+### 5. Frontend neighbour regression
+
+```
+pnpm --filter @metasheet/web exec vitest run \
+  tests/approval-e2e-permissions.spec.ts --reporter=dot
+```
+
+Result: `Test Files 1 passed (1)`, `Tests 37 passed (37)`, duration ~0.9s. No regression.
+
+## Baseline notes
+
+- The pre-existing `apps/web/tests/approval-center.spec.ts` fails on `origin/main@6c5c652d1`
+  (verified with `git stash`) because `useApprovalPermissions` reads `localStorage` during setup
+  and the jsdom environment isn't always primed in time. The new `approvalCenterSourceFilter.spec.ts`
+  works around this by mocking `useApprovalPermissions`. Fixing the neighbour spec is out of scope
+  for WP2 — documenting here for a subsequent DX ticket.
+
+## Summary
+
+All new tests pass (4 integration + 4 frontend = 8). All neighbour regressions pass
+(1 + 3 backend integration, 37 frontend permissions spec). Typechecks clean on both
+workspaces.
+
+## Rebase verification - 2026-04-22
+
+Rebased onto `origin/main@9f07a1a408faa761adc2e746b86ef5905c9f2735`.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-approval-bridge.test.ts --reporter=dot
+pnpm --filter @metasheet/web exec vitest run tests/approvalCenterSourceFilter.spec.ts tests/approval-e2e-permissions.spec.ts --reporter=dot
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-wp1-any-mode.api.test.ts --reporter=dot
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check origin/main...HEAD
+```
+
+Result:
+
+- Core backend typecheck: passed.
+- Web typecheck: passed.
+- PLM bridge unit regression: passed, 1 file / 4 tests.
+- Frontend source filter + permissions regression: passed, 2 files / 41 tests.
+- WP2 source filter integration: passed, 1 file / 4 tests.
+- WP1 neighbour integration: passed, 1 file / 1 test.
+- Pack 1A neighbour integration: passed, 1 file / 3 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Non-fatal existing Vue `el-icon` warning and degraded-mode backend startup logs appeared; assertions passed and exit code was 0.
+
+## Post-fixture-lock rebase verification - 2026-04-22
+
+After PRs #1066, #1067, and #1068 merged, this branch was rebased onto `origin/main@b2c3545e5246c8738d4b0b9c5ab945e63a4aa319`. The WP2 integration test was updated to reuse the shared `ensureApprovalSchemaReady()` helper introduced by #1067 instead of carrying a duplicate inline DDL bootstrap.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp2-source-filter.api.test.ts \
+    tests/integration/approval-wp1-any-mode.api.test.ts \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-approval-bridge.test.ts --reporter=dot
+pnpm --filter @metasheet/web exec vitest run tests/approvalCenterSourceFilter.spec.ts tests/approval-e2e-permissions.spec.ts --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check origin/main...HEAD
+```
+
+Result:
+
+- Core backend typecheck: passed.
+- Web typecheck: passed.
+- Combined approval integration run: passed, 3 files / 8 tests.
+- PLM bridge unit regression: passed, 1 file / 4 tests.
+- Frontend source filter + permissions regression: passed, 2 files / 41 tests.
+- Backend build: passed.
+- `git diff --check`: passed.
+- Non-fatal existing Vue `el-icon` warning and degraded-mode backend startup logs appeared; assertions passed and exit code was 0.

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -303,7 +303,24 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         )
       }
 
-      const sourceSystem = typeof req.query.sourceSystem === 'string' ? req.query.sourceSystem : undefined
+      // Wave 2 WP2: `sourceSystem` drives the unified Inbox filter.
+      //   - 'all'      → mixed feed across platform + plm (no filter)
+      //   - 'platform' → platform-owned approvals only
+      //   - 'plm'      → plm-mirrored approvals only
+      //   - undefined  → legacy behaviour (tab-driven default to 'platform')
+      const rawSourceSystem = typeof req.query.sourceSystem === 'string' ? req.query.sourceSystem.trim() : ''
+      if (rawSourceSystem && !['platform', 'plm', 'all'].includes(rawSourceSystem)) {
+        return res.status(400).json(
+          approvalErrorResponse(
+            'APPROVAL_SOURCE_SYSTEM_INVALID',
+            "sourceSystem must be one of 'platform', 'plm', or 'all'",
+          ),
+        )
+      }
+      const sourceSystem = rawSourceSystem === 'all' || rawSourceSystem === ''
+        ? undefined
+        : (rawSourceSystem as 'platform' | 'plm')
+      const sourceSystemProvided = rawSourceSystem !== ''
       const status = typeof req.query.status === 'string' ? req.query.status : undefined
       const workflowKey = typeof req.query.workflowKey === 'string' ? req.query.workflowKey : undefined
       const businessKey = typeof req.query.businessKey === 'string' ? req.query.businessKey : undefined
@@ -345,8 +362,16 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         })
       }
 
+      // Determine the effective filter.
+      //   - Explicit 'platform' | 'plm'  → honour it verbatim
+      //   - Explicit 'all'               → unified feed (sourceSystem is undefined here)
+      //   - Not provided                 → preserve legacy default (tabs imply platform)
+      const effectiveSourceSystem = sourceSystemProvided
+        ? sourceSystem
+        : (tab ? 'platform' : undefined)
+
       const result = await bridgeService.listApprovals({
-        sourceSystem: sourceSystem ?? (tab ? 'platform' : undefined),
+        sourceSystem: effectiveSourceSystem,
         status,
         workflowKey,
         businessKey,

--- a/packages/core-backend/tests/integration/approval-wp2-source-filter.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp2-source-filter.api.test.ts
@@ -1,0 +1,199 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { randomUUID } from 'node:crypto'
+import { MetaSheetServer } from '../../src/index'
+import { IPLMAdapter } from '../../src/di/identifiers'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+type UnifiedApprovalDTO = {
+  id: string
+  sourceSystem: string | null
+  title: string | null
+  status: string
+}
+
+type ListResponse = {
+  data: UnifiedApprovalDTO[]
+  total: number
+}
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function getJson<T>(baseUrl: string, path: string, token: string): Promise<T> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as T
+}
+
+describeIfDatabase('Approval Wave 2 WP2 sourceSystem filter', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const suiteSuffix = randomUUID().slice(0, 8)
+  const platformInstanceId = `apv_wp2_platform_${suiteSuffix}`
+  const plmExternalId = `wp2_plm_${suiteSuffix}`
+  const plmInstanceId = `plm:${plmExternalId}`
+  const createdIds = [platformInstanceId, plmInstanceId]
+  // Keep workflow keys stable but collision-free so the filter test is unaffected
+  // by any rows other integration suites may have left behind.
+  const platformWorkflowKey = `wp2-platform-${suiteSuffix}`
+  const plmWorkflowKey = `wp2-plm-${suiteSuffix}`
+
+  beforeAll(async () => {
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+
+    await ensureApprovalSchemaReady()
+
+    const pool = poolManager.get()
+
+    // Seed: one platform-owned approval.
+    await pool.query(
+      `INSERT INTO approval_instances
+         (id, status, version, source_system, workflow_key, business_key, title,
+          requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+          current_step, total_steps, sync_status, created_at, updated_at)
+       VALUES ($1, 'pending', 0, 'platform', $2, $3, $4,
+               '{"id":"requester-platform","name":"平台发起人"}'::jsonb,
+               '{}'::jsonb, '{}'::jsonb, '{}'::jsonb,
+               0, 0, 'ok', now(), now())`,
+      [platformInstanceId, platformWorkflowKey, `platform:wp2:${suiteSuffix}`, `WP2 platform approval ${suiteSuffix}`],
+    )
+
+    // Seed: one PLM-mirrored approval (matching the bridge's write shape).
+    await pool.query(
+      `INSERT INTO approval_instances
+         (id, status, version, source_system, external_approval_id, workflow_key, business_key, title,
+          requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+          current_step, total_steps, sync_status, created_at, updated_at)
+       VALUES ($1, 'pending', 0, 'plm', $2, $3, $4, $5,
+               '{"id":"plm-requester","name":"PLM 发起人"}'::jsonb,
+               '{"productNumber":"P-001","productName":"产品"}'::jsonb,
+               '{"rejectCommentRequired":true,"sourceOfTruth":"plm"}'::jsonb,
+               '{"source_type":"eco","source_stage":"review","source_version":0}'::jsonb,
+               0, 0, 'ok', now(), now())`,
+      [plmInstanceId, plmExternalId, plmWorkflowKey, `plm:wp2:${suiteSuffix}`, `WP2 PLM approval ${suiteSuffix}`],
+    )
+
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [],
+    })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    // The route force-syncs PLM on `sourceSystem=plm`. No PLM URL is configured in
+    // the test environment, so connect() puts the adapter in mock mode (returns
+    // empty approvals) and the sync becomes a no-op that leaves our seeded row
+    // untouched.
+    const injector = (server as unknown as { injector?: { get: (id: unknown) => unknown } }).injector
+    if (injector) {
+      const plmAdapter = injector.get(IPLMAdapter) as { connect?: () => Promise<void> }
+      if (typeof plmAdapter.connect === 'function') {
+        await plmAdapter.connect()
+      }
+    }
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [createdIds])
+      await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [createdIds])
+      await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [createdIds])
+    } catch {
+      // cleanup failures shouldn't mask the test result
+    }
+
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  it('returns a unified feed when sourceSystem=all', async () => {
+    const token = await authToken(baseUrl, `wp2-actor-${suiteSuffix}`)
+    const payload = await getJson<ListResponse>(
+      baseUrl,
+      `/api/approvals?sourceSystem=all&workflowKey=${encodeURIComponent(platformWorkflowKey)}`,
+      token,
+    )
+    const platformRow = payload.data.find((row) => row.id === platformInstanceId)
+    expect(platformRow).toBeTruthy()
+    expect(platformRow?.sourceSystem).toBe('platform')
+
+    // The PLM row shares suiteSuffix via workflow_key; query again narrowing to that key.
+    const plmPayload = await getJson<ListResponse>(
+      baseUrl,
+      `/api/approvals?sourceSystem=all&workflowKey=${encodeURIComponent(plmWorkflowKey)}`,
+      token,
+    )
+    const plmRow = plmPayload.data.find((row) => row.id === plmInstanceId)
+    expect(plmRow).toBeTruthy()
+    expect(plmRow?.sourceSystem).toBe('plm')
+
+    // Direct assertion: without workflow_key narrowing, the two rows tagged with our
+    // suite-specific business keys must both appear when sourceSystem=all.
+    const unified = await getJson<ListResponse>(baseUrl, '/api/approvals?sourceSystem=all&limit=200', token)
+    const ourRows = unified.data.filter((row) => createdIds.includes(row.id))
+    expect(ourRows).toHaveLength(2)
+    expect(new Set(ourRows.map((row) => row.sourceSystem))).toEqual(new Set(['platform', 'plm']))
+  })
+
+  it('scopes the feed to platform rows when sourceSystem=platform', async () => {
+    const token = await authToken(baseUrl, `wp2-actor-${suiteSuffix}`)
+    const payload = await getJson<ListResponse>(
+      baseUrl,
+      `/api/approvals?sourceSystem=platform&workflowKey=${encodeURIComponent(platformWorkflowKey)}`,
+      token,
+    )
+    expect(payload.total).toBe(1)
+    expect(payload.data).toHaveLength(1)
+    expect(payload.data[0]?.id).toBe(platformInstanceId)
+    expect(payload.data[0]?.sourceSystem).toBe('platform')
+  })
+
+  it('scopes the feed to plm rows when sourceSystem=plm', async () => {
+    const token = await authToken(baseUrl, `wp2-actor-${suiteSuffix}`)
+    const payload = await getJson<ListResponse>(
+      baseUrl,
+      `/api/approvals?sourceSystem=plm&workflowKey=${encodeURIComponent(plmWorkflowKey)}`,
+      token,
+    )
+    expect(payload.total).toBe(1)
+    expect(payload.data).toHaveLength(1)
+    expect(payload.data[0]?.id).toBe(plmInstanceId)
+    expect(payload.data[0]?.sourceSystem).toBe('plm')
+  })
+
+  it('rejects unknown sourceSystem values with a 400', async () => {
+    const token = await authToken(baseUrl, `wp2-actor-${suiteSuffix}`)
+    const response = await fetch(`${baseUrl}/api/approvals?sourceSystem=bogus`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(response.status).toBe(400)
+    const payload = await response.json() as { error?: { code?: string } }
+    expect(payload.error?.code).toBe('APPROVAL_SOURCE_SYSTEM_INVALID')
+  })
+})

--- a/packages/core-backend/tests/unit/plm-approval-bridge.test.ts
+++ b/packages/core-backend/tests/unit/plm-approval-bridge.test.ts
@@ -74,4 +74,31 @@ describe('PLM approval bridge mapping', () => {
   it('requires a source id', () => {
     expect(() => toPlatformApprovalBridgeRecord({ id: '' })).toThrow('PLM approval bridge requires a source id')
   })
+
+  // Wave 2 WP2 contract: the bridge must pin externalSystem='plm' on every
+  // record because ApprovalBridgeService.upsertPlmMirror forwards this value
+  // as the `source_system` column on INSERT. The unified Inbox filter
+  // (sourceSystem=plm) relies on every bridged row carrying this literal.
+  it('Wave 2 WP2: pins externalSystem to the "plm" literal for every bridged record', () => {
+    const minimal = toPlatformApprovalBridgeRecord({ id: 'eco-wp2-min' })
+    expect(minimal.externalSystem).toBe('plm')
+
+    const complete = toPlatformApprovalBridgeRecord({
+      id: 'eco-wp2-full',
+      title: 'ECO-WP2',
+      status: 'approved',
+      type: 'eco',
+      stage: 'review',
+      product_id: 'prod-wp2',
+      product_number: 'PN-WP2',
+      product_name: 'Module',
+      requester_id: 'user-wp2',
+      requester_name: 'Tester',
+      created_at: '2026-04-21T00:00:00.000Z',
+      updated_at: '2026-04-21T01:00:00.000Z',
+      version: 3,
+    })
+    expect(complete.externalSystem).toBe('plm')
+    expect(complete.policy.sourceOfTruth).toBe('plm')
+  })
 })


### PR DESCRIPTION
## Summary
- Adds sourceSystem filtering for /api/approvals so platform and PLM approvals can share the inbox.
- Wires ApprovalCenterView to pass all/platform/plm source filters.
- Extends PLM bridge and backend integration coverage.
- Rebased after #1067/#1068 and updated WP2 integration to reuse ensureApprovalSchemaReady(), avoiding a duplicate approval DDL bootstrap.

## Verification
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-wp2-source-filter.api.test.ts tests/integration/approval-wp1-any-mode.api.test.ts tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-approval-bridge.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vitest run tests/approvalCenterSourceFilter.spec.ts tests/approval-e2e-permissions.spec.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check origin/main...HEAD