### PR TITLE
feat(dingtalk): warn unlinked person recipients

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -502,6 +502,15 @@ function normalizeSheetPermissionCandidates(
         accessLevel: item?.accessLevel === 'read' || item?.accessLevel === 'write' || item?.accessLevel === 'write-own' || item?.accessLevel === 'admin'
           ? item.accessLevel
           : null,
+        dingtalkBound: typeof item?.dingtalkBound === 'boolean' || item?.dingtalkBound === null
+          ? item.dingtalkBound ?? null
+          : null,
+        dingtalkGrantEnabled: typeof item?.dingtalkGrantEnabled === 'boolean' || item?.dingtalkGrantEnabled === null
+          ? item.dingtalkGrantEnabled ?? null
+          : null,
+        dingtalkPersonDeliveryAvailable: typeof item?.dingtalkPersonDeliveryAvailable === 'boolean' || item?.dingtalkPersonDeliveryAvailable === null
+          ? item.dingtalkPersonDeliveryAvailable ?? null
+          : null,
       })
     }
   }

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -314,6 +314,7 @@
                 <span>{{ candidate.subtitle || candidate.subjectId }}</span>
                 <span>{{ personRecipientSubjectLabel(candidate) }}</span>
                 <span v-if="candidate.accessLevel">{{ personRecipientAccessLabel(candidate.accessLevel) }}</span>
+                <span v-if="personRecipientDingTalkStatusLabel(candidate.subjectType, candidate)">{{ personRecipientDingTalkStatusLabel(candidate.subjectType, candidate) }}</span>
                 <span v-if="isInactivePersonRecipientCandidate(candidate)">Inactive users cannot be added</span>
               </button>
             </div>
@@ -329,6 +330,7 @@
               >
                 <strong>{{ recipient.label }}</strong>
                 <span>{{ recipient.subtitle || recipient.id }}</span>
+                <span v-if="personRecipientDingTalkStatusLabel('user', recipient)">{{ personRecipientDingTalkStatusLabel('user', recipient) }}</span>
                 <em>Remove</em>
               </button>
             </div>
@@ -343,6 +345,7 @@
               >
                 <strong>{{ group.label }}</strong>
                 <span>{{ group.subtitle || group.id }}</span>
+                <span v-if="personRecipientDingTalkStatusLabel('member-group', group)">{{ personRecipientDingTalkStatusLabel('member-group', group) }}</span>
                 <em>Remove</em>
               </button>
             </div>
@@ -878,7 +881,16 @@ const dingtalkPersonUserSearch = ref('')
 const dingtalkPersonUserSearchLoading = ref(false)
 const dingtalkPersonUserSearchError = ref('')
 const dingtalkPersonUserSuggestions = ref<MetaSheetPermissionCandidate[]>([])
-const dingtalkPersonUserDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
+
+type DingTalkPersonRecipientDirectoryEntry = {
+  label: string
+  subtitle?: string
+  dingtalkBound?: boolean | null
+  dingtalkGrantEnabled?: boolean | null
+  dingtalkPersonDeliveryAvailable?: boolean | null
+}
+
+const dingtalkPersonUserDirectory = ref<Record<string, DingTalkPersonRecipientDirectoryEntry>>({})
 const copiedPreviewKey = ref('')
 let dingtalkPersonSuggestionLoadId = 0
 let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
@@ -941,29 +953,62 @@ function personRecipientAccessLabel(accessLevel: MetaSheetPermissionCandidate['a
   return accessLevel ? `Access: ${accessLevel}` : ''
 }
 
+function personRecipientDingTalkStatusLabel(
+  subjectType: MetaSheetPermissionCandidate['subjectType'],
+  status: Pick<MetaSheetPermissionCandidate, 'dingtalkBound' | 'dingtalkGrantEnabled' | 'dingtalkPersonDeliveryAvailable'>,
+): string {
+  if (subjectType === 'member-group') return 'Member group members are checked individually for DingTalk delivery'
+  if (subjectType !== 'user') return ''
+  if (status.dingtalkPersonDeliveryAvailable === false) return 'No DingTalk delivery link; person message will skip until linked'
+  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === true) return 'DingTalk direct message ready; form authorization enabled'
+  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === false) return 'DingTalk direct message ready; form authorization not enabled'
+  if (status.dingtalkBound === false) return 'Not bound to DingTalk; person message may skip until linked'
+  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === true) return 'DingTalk bound; form authorization enabled'
+  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === false) return 'DingTalk bound; form authorization not enabled'
+  return ''
+}
+
 function rememberDingTalkPersonSuggestions(items: MetaSheetPermissionCandidate[]) {
   const next = { ...dingtalkPersonUserDirectory.value }
   for (const item of items) {
     if (item.subjectType !== 'user' && item.subjectType !== 'member-group') continue
-    next[personRecipientDirectoryKey(item.subjectType, item.subjectId)] = { label: item.label, subtitle: item.subtitle ?? undefined }
+    next[personRecipientDirectoryKey(item.subjectType, item.subjectId)] = {
+      label: item.label,
+      subtitle: item.subtitle ?? undefined,
+      dingtalkBound: item.dingtalkBound ?? null,
+      dingtalkGrantEnabled: item.dingtalkGrantEnabled ?? null,
+      dingtalkPersonDeliveryAvailable: item.dingtalkPersonDeliveryAvailable ?? null,
+    }
   }
   dingtalkPersonUserDirectory.value = next
 }
 
 const selectedDingTalkPersonRecipients = computed(() =>
-  parseUserIdsText(draft.value.dingtalkPersonUserIds).map((id) => ({
-    id,
-    label: dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('user', id)]?.label ?? id,
-    subtitle: dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('user', id)]?.subtitle,
-  })),
+  parseUserIdsText(draft.value.dingtalkPersonUserIds).map((id) => {
+    const directoryEntry = dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('user', id)]
+    return {
+      id,
+      label: directoryEntry?.label ?? id,
+      subtitle: directoryEntry?.subtitle,
+      dingtalkBound: directoryEntry?.dingtalkBound ?? null,
+      dingtalkGrantEnabled: directoryEntry?.dingtalkGrantEnabled ?? null,
+      dingtalkPersonDeliveryAvailable: directoryEntry?.dingtalkPersonDeliveryAvailable ?? null,
+    }
+  }),
 )
 
 const selectedDingTalkPersonMemberGroups = computed(() =>
-  parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds).map((id) => ({
-    id,
-    label: dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('member-group', id)]?.label ?? id,
-    subtitle: dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('member-group', id)]?.subtitle,
-  })),
+  parseMemberGroupIdsText(draft.value.dingtalkPersonMemberGroupIds).map((id) => {
+    const directoryEntry = dingtalkPersonUserDirectory.value[personRecipientDirectoryKey('member-group', id)]
+    return {
+      id,
+      label: directoryEntry?.label ?? id,
+      subtitle: directoryEntry?.subtitle,
+      dingtalkBound: directoryEntry?.dingtalkBound ?? null,
+      dingtalkGrantEnabled: directoryEntry?.dingtalkGrantEnabled ?? null,
+      dingtalkPersonDeliveryAvailable: directoryEntry?.dingtalkPersonDeliveryAvailable ?? null,
+    }
+  }),
 )
 
 const availableDingTalkPersonSuggestions = computed(() => {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -456,6 +456,7 @@
                   <span>{{ candidate.subtitle || candidate.subjectId }}</span>
                   <span>{{ personRecipientSubjectLabel(candidate) }}</span>
                   <span v-if="candidate.accessLevel">{{ personRecipientAccessLabel(candidate.accessLevel) }}</span>
+                  <span v-if="personRecipientDingTalkStatusLabel(candidate.subjectType, candidate)">{{ personRecipientDingTalkStatusLabel(candidate.subjectType, candidate) }}</span>
                   <span v-if="isInactivePersonRecipientCandidate(candidate)">Inactive users cannot be added</span>
                 </button>
               </div>
@@ -471,6 +472,7 @@
                 >
                   <strong>{{ recipient.label }}</strong>
                   <span>{{ recipient.subtitle || recipient.id }}</span>
+                  <span v-if="personRecipientDingTalkStatusLabel('user', recipient)">{{ personRecipientDingTalkStatusLabel('user', recipient) }}</span>
                   <em>Remove</em>
                 </button>
               </div>
@@ -485,6 +487,7 @@
                 >
                   <strong>{{ group.label }}</strong>
                   <span>{{ group.subtitle || group.id }}</span>
+                  <span v-if="personRecipientDingTalkStatusLabel('member-group', group)">{{ personRecipientDingTalkStatusLabel('member-group', group) }}</span>
                   <em>Remove</em>
                 </button>
               </div>
@@ -901,7 +904,16 @@ const dingTalkDestinationsError = ref('')
 const personRecipientSuggestions = ref<Record<number, MetaSheetPermissionCandidate[]>>({})
 const personRecipientLoading = ref<Record<number, boolean>>({})
 const personRecipientErrors = ref<Record<number, string>>({})
-const personRecipientDirectory = ref<Record<string, { label: string; subtitle?: string }>>({})
+
+type PersonRecipientDirectoryEntry = {
+  label: string
+  subtitle?: string
+  dingtalkBound?: boolean | null
+  dingtalkGrantEnabled?: boolean | null
+  dingtalkPersonDeliveryAvailable?: boolean | null
+}
+
+const personRecipientDirectory = ref<Record<string, PersonRecipientDirectoryEntry>>({})
 const copiedPreviewKey = ref('')
 let personRecipientSuggestionLoadId = 0
 let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
@@ -1120,29 +1132,62 @@ function personRecipientAccessLabel(accessLevel: MetaSheetPermissionCandidate['a
   return accessLevel ? `Access: ${accessLevel}` : ''
 }
 
+function personRecipientDingTalkStatusLabel(
+  subjectType: MetaSheetPermissionCandidate['subjectType'],
+  status: Pick<MetaSheetPermissionCandidate, 'dingtalkBound' | 'dingtalkGrantEnabled' | 'dingtalkPersonDeliveryAvailable'>,
+): string {
+  if (subjectType === 'member-group') return 'Member group members are checked individually for DingTalk delivery'
+  if (subjectType !== 'user') return ''
+  if (status.dingtalkPersonDeliveryAvailable === false) return 'No DingTalk delivery link; person message will skip until linked'
+  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === true) return 'DingTalk direct message ready; form authorization enabled'
+  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === false) return 'DingTalk direct message ready; form authorization not enabled'
+  if (status.dingtalkBound === false) return 'Not bound to DingTalk; person message may skip until linked'
+  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === true) return 'DingTalk bound; form authorization enabled'
+  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === false) return 'DingTalk bound; form authorization not enabled'
+  return ''
+}
+
 function rememberPersonRecipientSuggestions(items: MetaSheetPermissionCandidate[]) {
   const next = { ...personRecipientDirectory.value }
   for (const item of items) {
     if (item.subjectType !== 'user' && item.subjectType !== 'member-group') continue
-    next[personRecipientDirectoryKey(item.subjectType, item.subjectId)] = { label: item.label, subtitle: item.subtitle ?? undefined }
+    next[personRecipientDirectoryKey(item.subjectType, item.subjectId)] = {
+      label: item.label,
+      subtitle: item.subtitle ?? undefined,
+      dingtalkBound: item.dingtalkBound ?? null,
+      dingtalkGrantEnabled: item.dingtalkGrantEnabled ?? null,
+      dingtalkPersonDeliveryAvailable: item.dingtalkPersonDeliveryAvailable ?? null,
+    }
   }
   personRecipientDirectory.value = next
 }
 
 function selectedPersonRecipients(action: DraftAction) {
-  return parseUserIdsText(action.config.userIdsText).map((id) => ({
-    id,
-    label: personRecipientDirectory.value[personRecipientDirectoryKey('user', id)]?.label ?? id,
-    subtitle: personRecipientDirectory.value[personRecipientDirectoryKey('user', id)]?.subtitle,
-  }))
+  return parseUserIdsText(action.config.userIdsText).map((id) => {
+    const directoryEntry = personRecipientDirectory.value[personRecipientDirectoryKey('user', id)]
+    return {
+      id,
+      label: directoryEntry?.label ?? id,
+      subtitle: directoryEntry?.subtitle,
+      dingtalkBound: directoryEntry?.dingtalkBound ?? null,
+      dingtalkGrantEnabled: directoryEntry?.dingtalkGrantEnabled ?? null,
+      dingtalkPersonDeliveryAvailable: directoryEntry?.dingtalkPersonDeliveryAvailable ?? null,
+    }
+  })
 }
 
 function selectedPersonRecipientGroups(action: DraftAction) {
-  return parseMemberGroupIdsText(action.config.memberGroupIdsText).map((id) => ({
-    id,
-    label: personRecipientDirectory.value[personRecipientDirectoryKey('member-group', id)]?.label ?? id,
-    subtitle: personRecipientDirectory.value[personRecipientDirectoryKey('member-group', id)]?.subtitle,
-  }))
+  return parseMemberGroupIdsText(action.config.memberGroupIdsText).map((id) => {
+    const directoryEntry = personRecipientDirectory.value[personRecipientDirectoryKey('member-group', id)]
+    return {
+      id,
+      label: directoryEntry?.label ?? id,
+      subtitle: directoryEntry?.subtitle,
+      dingtalkBound: directoryEntry?.dingtalkBound ?? null,
+      dingtalkGrantEnabled: directoryEntry?.dingtalkGrantEnabled ?? null,
+      dingtalkPersonDeliveryAvailable: directoryEntry?.dingtalkPersonDeliveryAvailable ?? null,
+    }
+  })
 }
 
 function availablePersonRecipientSuggestions(idx: number, action: DraftAction) {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -214,6 +214,9 @@ export interface MetaSheetPermissionCandidate {
   subtitle?: string | null
   isActive: boolean
   accessLevel?: MetaSheetPermissionAccessLevel | null
+  dingtalkBound?: boolean | null
+  dingtalkGrantEnabled?: boolean | null
+  dingtalkPersonDeliveryAvailable?: boolean | null
 }
 
 export interface MetaFieldPermissionEntry {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -157,9 +157,36 @@ function mockClient(
   const client = new MultitableApiClient({ fetchFn })
   client.listFormShareCandidates = vi.fn(async () => ({
     items: [
-      { subjectType: 'user', subjectId: 'user_1', label: 'Lin Lan', subtitle: 'lin@example.com', isActive: true },
-      { subjectType: 'user', subjectId: 'user_2', label: 'Zhao Ming', subtitle: 'zhao@example.com', isActive: true },
-      { subjectType: 'member-group', subjectId: 'group_1', label: 'Sales Team', subtitle: '3 members', isActive: true },
+      {
+        subjectType: 'user',
+        subjectId: 'user_1',
+        label: 'Lin Lan',
+        subtitle: 'lin@example.com',
+        isActive: true,
+        dingtalkBound: true,
+        dingtalkGrantEnabled: true,
+        dingtalkPersonDeliveryAvailable: true,
+      },
+      {
+        subjectType: 'user',
+        subjectId: 'user_2',
+        label: 'Zhao Ming',
+        subtitle: 'zhao@example.com',
+        isActive: true,
+        dingtalkBound: false,
+        dingtalkGrantEnabled: false,
+        dingtalkPersonDeliveryAvailable: false,
+      },
+      {
+        subjectType: 'member-group',
+        subjectId: 'group_1',
+        label: 'Sales Team',
+        subtitle: '3 members',
+        isActive: true,
+        dingtalkBound: null,
+        dingtalkGrantEnabled: null,
+        dingtalkPersonDeliveryAvailable: null,
+      },
     ],
     total: 3,
     limit: 8,
@@ -1865,8 +1892,12 @@ describe('MetaAutomationManager', () => {
 
     const suggestion = container.querySelector('[data-automation-person-suggestion="user:user_1"]') as HTMLButtonElement
     expect(suggestion).toBeTruthy()
+    expect(suggestion.textContent).toContain('DingTalk direct message ready; form authorization enabled')
     suggestion.click()
     await flushPromises()
+
+    const selectedRecipient = container.querySelector('[data-automation-person-recipient="user_1"]') as HTMLElement
+    expect(selectedRecipient.textContent).toContain('DingTalk direct message ready; form authorization enabled')
 
     searchInput.value = 'sales'
     searchInput.dispatchEvent(new Event('input', { bubbles: true }))
@@ -1874,8 +1905,12 @@ describe('MetaAutomationManager', () => {
 
     const groupSuggestion = container.querySelector('[data-automation-person-suggestion="member-group:group_1"]') as HTMLButtonElement
     expect(groupSuggestion).toBeTruthy()
+    expect(groupSuggestion.textContent).toContain('Member group members are checked individually for DingTalk delivery')
     groupSuggestion.click()
     await flushPromises()
+
+    const selectedGroup = container.querySelector('[data-automation-person-member-group="group_1"]') as HTMLElement
+    expect(selectedGroup.textContent).toContain('Member group members are checked individually for DingTalk delivery')
 
     const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
     expect(userIdsInput.value).toBe('user_1')
@@ -1914,6 +1949,9 @@ describe('MetaAutomationManager', () => {
           subtitle: 'inactive@example.com',
           isActive: false,
           accessLevel: 'read',
+          dingtalkBound: false,
+          dingtalkGrantEnabled: false,
+          dingtalkPersonDeliveryAvailable: false,
         },
         {
           subjectType: 'member-group',
@@ -1922,6 +1960,9 @@ describe('MetaAutomationManager', () => {
           subtitle: '3 members',
           isActive: true,
           accessLevel: 'write',
+          dingtalkBound: null,
+          dingtalkGrantEnabled: null,
+          dingtalkPersonDeliveryAvailable: null,
         },
         {
           subjectType: 'role',
@@ -1957,6 +1998,7 @@ describe('MetaAutomationManager', () => {
     expect(inactiveSuggestion.disabled).toBe(true)
     expect(inactiveSuggestion.textContent).toContain('User')
     expect(inactiveSuggestion.textContent).toContain('Access: read')
+    expect(inactiveSuggestion.textContent).toContain('No DingTalk delivery link; person message will skip until linked')
     expect(inactiveSuggestion.textContent).toContain('Inactive users cannot be added')
     expect(container.querySelector('[data-automation-person-suggestion="user:role_admin"]')).toBeNull()
     expect(container.textContent).not.toContain('Admins')
@@ -1971,6 +2013,7 @@ describe('MetaAutomationManager', () => {
     expect(groupSuggestion.disabled).toBe(false)
     expect(groupSuggestion.textContent).toContain('Member group')
     expect(groupSuggestion.textContent).toContain('Access: write')
+    expect(groupSuggestion.textContent).toContain('Member group members are checked individually for DingTalk delivery')
     groupSuggestion.click()
     await flushPromises()
 

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -103,9 +103,36 @@ function mockClient() {
     })),
     listFormShareCandidates: vi.fn(async () => ({
       items: [
-        { subjectType: 'user', subjectId: 'user_1', label: 'Lin Lan', subtitle: 'lin@example.com', isActive: true },
-        { subjectType: 'user', subjectId: 'user_2', label: 'Zhao Ming', subtitle: 'zhao@example.com', isActive: true },
-        { subjectType: 'member-group', subjectId: 'group_1', label: 'Sales Team', subtitle: '3 members', isActive: true },
+        {
+          subjectType: 'user',
+          subjectId: 'user_1',
+          label: 'Lin Lan',
+          subtitle: 'lin@example.com',
+          isActive: true,
+          dingtalkBound: true,
+          dingtalkGrantEnabled: true,
+          dingtalkPersonDeliveryAvailable: true,
+        },
+        {
+          subjectType: 'user',
+          subjectId: 'user_2',
+          label: 'Zhao Ming',
+          subtitle: 'zhao@example.com',
+          isActive: true,
+          dingtalkBound: false,
+          dingtalkGrantEnabled: false,
+          dingtalkPersonDeliveryAvailable: false,
+        },
+        {
+          subjectType: 'member-group',
+          subjectId: 'group_1',
+          label: 'Sales Team',
+          subtitle: '3 members',
+          isActive: true,
+          dingtalkBound: null,
+          dingtalkGrantEnabled: null,
+          dingtalkPersonDeliveryAvailable: null,
+        },
       ],
       total: 3,
       limit: 8,
@@ -1894,8 +1921,12 @@ describe('MetaAutomationRuleEditor', () => {
 
     const suggestion = container.querySelector('[data-person-recipient-suggestion="user:user_1"]') as HTMLButtonElement
     expect(suggestion).toBeTruthy()
+    expect(suggestion.textContent).toContain('DingTalk direct message ready; form authorization enabled')
     suggestion.click()
     await flushPromises()
+
+    const selectedRecipient = container.querySelector('[data-person-recipient="user_1"]') as HTMLElement
+    expect(selectedRecipient.textContent).toContain('DingTalk direct message ready; form authorization enabled')
 
     searchInput.value = 'sales'
     searchInput.dispatchEvent(new Event('input'))
@@ -1903,8 +1934,12 @@ describe('MetaAutomationRuleEditor', () => {
 
     const groupSuggestion = container.querySelector('[data-person-recipient-suggestion="member-group:group_1"]') as HTMLButtonElement
     expect(groupSuggestion).toBeTruthy()
+    expect(groupSuggestion.textContent).toContain('Member group members are checked individually for DingTalk delivery')
     groupSuggestion.click()
     await flushPromises()
+
+    const selectedGroup = container.querySelector('[data-person-member-group="group_1"]') as HTMLElement
+    expect(selectedGroup.textContent).toContain('Member group members are checked individually for DingTalk delivery')
 
     const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
     expect(userIdsInput.value).toBe('user_1')
@@ -1943,6 +1978,9 @@ describe('MetaAutomationRuleEditor', () => {
             subtitle: 'inactive@example.com',
             isActive: false,
             accessLevel: 'read',
+            dingtalkBound: false,
+            dingtalkGrantEnabled: false,
+            dingtalkPersonDeliveryAvailable: false,
           },
           {
             subjectType: 'member-group',
@@ -1951,6 +1989,9 @@ describe('MetaAutomationRuleEditor', () => {
             subtitle: '3 members',
             isActive: true,
             accessLevel: 'write',
+            dingtalkBound: null,
+            dingtalkGrantEnabled: null,
+            dingtalkPersonDeliveryAvailable: null,
           },
           {
             subjectType: 'role',
@@ -1989,6 +2030,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(inactiveSuggestion.disabled).toBe(true)
     expect(inactiveSuggestion.textContent).toContain('User')
     expect(inactiveSuggestion.textContent).toContain('Access: read')
+    expect(inactiveSuggestion.textContent).toContain('No DingTalk delivery link; person message will skip until linked')
     expect(inactiveSuggestion.textContent).toContain('Inactive users cannot be added')
     expect(container.querySelector('[data-person-recipient-suggestion="user:role_admin"]')).toBeNull()
     expect(container.textContent).not.toContain('Admins')
@@ -2003,6 +2045,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(groupSuggestion.disabled).toBe(false)
     expect(groupSuggestion.textContent).toContain('Member group')
     expect(groupSuggestion.textContent).toContain('Access: write')
+    expect(groupSuggestion.textContent).toContain('Member group members are checked individually for DingTalk delivery')
     groupSuggestion.click()
     await flushPromises()
 

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -27,6 +27,74 @@ describe('MultitableApiClient', () => {
     await expect(client.resolveComment('c1')).resolves.toBeUndefined()
   })
 
+  it('normalizes form share candidate DingTalk status fields', async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      expect(input).toBe('/api/multitable/sheets/sheet_1/form-share-candidates?q=lin&limit=8')
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          items: [
+            {
+              subjectType: 'user',
+              subjectId: 'user_1',
+              label: 'Lin Lan',
+              subtitle: 'lin@example.com',
+              isActive: true,
+              accessLevel: 'write',
+              dingtalkBound: true,
+              dingtalkGrantEnabled: false,
+              dingtalkPersonDeliveryAvailable: true,
+            },
+            {
+              subjectType: 'member-group',
+              subjectId: 'group_1',
+              label: 'Sales Team',
+              subtitle: '3 members',
+              isActive: true,
+              dingtalkBound: null,
+              dingtalkGrantEnabled: null,
+              dingtalkPersonDeliveryAvailable: null,
+            },
+          ],
+          total: 2,
+          limit: 8,
+          query: 'lin',
+        },
+      }), { status: 200 })
+    })
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(client.listFormShareCandidates('sheet_1', { q: 'lin', limit: 8 })).resolves.toEqual({
+      items: [
+        {
+          subjectType: 'user',
+          subjectId: 'user_1',
+          label: 'Lin Lan',
+          subtitle: 'lin@example.com',
+          isActive: true,
+          accessLevel: 'write',
+          dingtalkBound: true,
+          dingtalkGrantEnabled: false,
+          dingtalkPersonDeliveryAvailable: true,
+        },
+        {
+          subjectType: 'member-group',
+          subjectId: 'group_1',
+          label: 'Sales Team',
+          subtitle: '3 members',
+          isActive: true,
+          accessLevel: null,
+          dingtalkBound: null,
+          dingtalkGrantEnabled: null,
+          dingtalkPersonDeliveryAvailable: null,
+        },
+      ],
+      total: 2,
+      limit: 8,
+      query: 'lin',
+    })
+  })
+
   it('normalizes automation rule list responses from snake_case API rows', async () => {
     const fetchFn = vi.fn(async (input: string) => {
       expect(input).toBe('/api/multitable/sheets/sheet_1/automations')

--- a/docs/development/dingtalk-person-recipient-binding-warning-development-20260422.md
+++ b/docs/development/dingtalk-person-recipient-binding-warning-development-20260422.md
@@ -1,0 +1,50 @@
+# DingTalk Person Recipient Binding Warning Development - 2026-04-22
+
+## Goal
+
+Make the "Send DingTalk person message" recipient picker show whether a selected local user can actually receive DingTalk direct messages, and whether DingTalk form authorization is enabled.
+
+This keeps person-message recipients based on local users/member groups while making DingTalk delivery readiness visible before users save an automation rule.
+
+## Scope
+
+- `GET /api/multitable/sheets/:sheetId/form-share-candidates` now enriches user candidates with DingTalk status fields:
+  - `dingtalkBound`: true when the local user has a DingTalk external identity or an active linked DingTalk directory account.
+  - `dingtalkGrantEnabled`: true when the local user has an enabled DingTalk external auth grant.
+  - `dingtalkPersonDeliveryAvailable`: true when the local user has an active linked DingTalk directory account with an external DingTalk user ID, matching the person-message executor requirement.
+- Member-group candidates return the same DingTalk fields as `null`, because group delivery is evaluated per member at send time.
+- The generic `/permission-candidates` endpoint is not changed.
+
+## Frontend Behavior
+
+- Inline automation form and advanced rule editor both show DingTalk status on person-message search candidates.
+- The selected recipient chips preserve the same status after the user adds a candidate.
+- Inactive local users remain disabled.
+- Unsupported role candidates remain filtered out for DingTalk person-message recipients.
+- Binding and grant status is UI-only metadata; automation payloads still submit only local `userIds`, `memberGroupIds`, and dynamic recipient field paths.
+
+## User-Facing Labels
+
+- `DingTalk direct message ready; form authorization enabled`
+- `DingTalk direct message ready; form authorization not enabled`
+- `No DingTalk delivery link; person message will skip until linked`
+- `Not bound to DingTalk; person message may skip until linked`
+- `Member group members are checked individually for DingTalk delivery`
+
+## Files Changed
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-client.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Notes
+
+- Direct person delivery readiness intentionally follows the existing executor lookup: active DingTalk `directory_account_links` plus active `directory_accounts.external_user_id`.
+- A DingTalk OAuth identity alone marks `dingtalkBound` true, but `dingtalkPersonDeliveryAvailable` remains false until directory delivery linkage exists.
+- This slice does not block saves for unlinked users. Delivery history already records skipped users when the executor cannot resolve a DingTalk recipient.

--- a/docs/development/dingtalk-person-recipient-binding-warning-verification-20260422.md
+++ b/docs/development/dingtalk-person-recipient-binding-warning-verification-20260422.md
@@ -1,0 +1,55 @@
+# DingTalk Person Recipient Binding Warning Verification - 2026-04-22
+
+## Branch
+
+- `codex/dingtalk-person-recipient-binding-warning-20260422`
+- Base branch: `codex/dingtalk-person-recipient-candidate-status-20260422`
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed. `3` test files, `148` tests.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts --reporter=dot
+```
+
+Result: passed. `1` test file, `39` tests.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Existing Vite warnings remained:
+- `WorkflowDesigner.vue` is both dynamically and statically imported.
+- Several production chunks exceed the default `500 kB` warning threshold.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Covered Scenarios
+
+- Backend form-share candidate API returns DingTalk binding, grant, and direct-delivery readiness for user candidates.
+- Backend form-share candidate API returns `null` DingTalk status for member-group candidates.
+- Frontend API client preserves the new DingTalk status fields during normalization.
+- Inline automation form shows bound/authorized, unlinked, inactive, and member-group DingTalk recipient status.
+- Advanced rule editor shows the same candidate and selected-chip status.
+- Role candidates remain filtered out from DingTalk person recipient selection.
+- Saved automation payload remains unchanged: local user IDs and member-group IDs only.
+
+## Non-Blocking Observations
+
+- The backend integration file logs an existing mocked formula dependency warning in one unrelated test, but the suite passes.
+- Repository still has unrelated dirty `node_modules` files under plugins/tools. They were not touched or staged.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1846,6 +1846,9 @@ type MultitableSheetPermissionCandidate = {
   subtitle: string | null
   isActive: boolean
   accessLevel: MultitableSheetAccessLevel | null
+  dingtalkBound?: boolean | null
+  dingtalkGrantEnabled?: boolean | null
+  dingtalkPersonDeliveryAvailable?: boolean | null
 }
 
 const SHEET_READ_PERMISSION_CODES = new Set([
@@ -2176,6 +2179,95 @@ async function listSheetPermissionCandidates(
   )
 
   return candidates.filter((_candidate, index) => eligibility[index])
+}
+
+async function enrichFormShareCandidatesWithDingTalkStatus(
+  query: QueryFn,
+  candidates: MultitableSheetPermissionCandidate[],
+): Promise<MultitableSheetPermissionCandidate[]> {
+  const userIds = Array.from(new Set(
+    candidates
+      .filter((candidate) => candidate.subjectType === 'user')
+      .map((candidate) => candidate.subjectId.trim())
+      .filter((subjectId) => subjectId.length > 0),
+  ))
+  if (userIds.length === 0) {
+    return candidates.map((candidate) => candidate.subjectType === 'member-group'
+      ? {
+        ...candidate,
+        dingtalkBound: null,
+        dingtalkGrantEnabled: null,
+        dingtalkPersonDeliveryAvailable: null,
+      }
+      : candidate)
+  }
+
+  const [identityResult, deliveryResult, grantResult] = await Promise.all([
+    query(
+      `SELECT DISTINCT local_user_id
+       FROM user_external_identities
+       WHERE local_user_id = ANY($1::text[])
+         AND provider = $2`,
+      [userIds, 'dingtalk'],
+    ),
+    query(
+      `SELECT DISTINCT l.local_user_id
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE l.local_user_id = ANY($1::text[])
+         AND l.link_status = 'linked'
+         AND a.provider = $2
+         AND a.is_active = TRUE
+         AND COALESCE(a.external_user_id, '') <> ''`,
+      [userIds, 'dingtalk'],
+    ),
+    query(
+      `SELECT local_user_id, BOOL_OR(enabled) AS enabled
+       FROM user_external_auth_grants
+       WHERE local_user_id = ANY($1::text[])
+         AND provider = $2
+       GROUP BY local_user_id`,
+      [userIds, 'dingtalk'],
+    ),
+  ])
+
+  const identityUserIds = new Set(
+    (identityResult.rows as Array<{ local_user_id?: string | null }>)
+      .map((row) => (typeof row.local_user_id === 'string' ? row.local_user_id.trim() : ''))
+      .filter((localUserId) => localUserId.length > 0),
+  )
+  const deliveryUserIds = new Set(
+    (deliveryResult.rows as Array<{ local_user_id?: string | null }>)
+      .map((row) => (typeof row.local_user_id === 'string' ? row.local_user_id.trim() : ''))
+      .filter((localUserId) => localUserId.length > 0),
+  )
+  const grantEnabledByUserId = new Map(
+    (grantResult.rows as Array<{ local_user_id?: string | null; enabled?: boolean | null }>)
+      .map((row) => [
+        typeof row.local_user_id === 'string' ? row.local_user_id.trim() : '',
+        row.enabled === true,
+      ] as const)
+      .filter(([localUserId]) => localUserId.length > 0),
+  )
+
+  return candidates.map((candidate) => {
+    if (candidate.subjectType === 'member-group') {
+      return {
+        ...candidate,
+        dingtalkBound: null,
+        dingtalkGrantEnabled: null,
+        dingtalkPersonDeliveryAvailable: null,
+      }
+    }
+    if (candidate.subjectType !== 'user') return candidate
+    const dingtalkPersonDeliveryAvailable = deliveryUserIds.has(candidate.subjectId)
+    return {
+      ...candidate,
+      dingtalkBound: dingtalkPersonDeliveryAvailable || identityUserIds.has(candidate.subjectId),
+      dingtalkGrantEnabled: grantEnabledByUserId.get(candidate.subjectId) === true,
+      dingtalkPersonDeliveryAvailable,
+    }
+  })
 }
 
 async function loadSheetPermissionScopeMap(
@@ -5640,8 +5732,9 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageViews) return sendForbidden(res)
 
-      const items = (await listSheetPermissionCandidates(pool.query.bind(pool), sheetId, { q, limit }))
+      const candidates = (await listSheetPermissionCandidates(pool.query.bind(pool), sheetId, { q, limit }))
         .filter((candidate) => candidate.subjectType === 'user' || candidate.subjectType === 'member-group')
+      const items = await enrichFormShareCandidatesWithDingTalkStatus(pool.query.bind(pool), candidates)
       return res.json({ ok: true, data: { items, total: items.length, limit, query: q } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -1733,6 +1733,141 @@ describe('Multitable sheet-scoped permissions API', () => {
     })
   })
 
+  test('lists form-share candidates with DingTalk binding status for person recipients', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:write'],
+      userPermissionMap: {
+        user_linked: ['multitable:read'],
+        user_bound_only: ['multitable:read'],
+        user_unbound: ['multitable:read'],
+      },
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [] }
+        }
+        if (sql.includes('WITH user_candidates AS') && sql.includes('role_candidates AS')) {
+          expect(params).toEqual(['sheet_ops', '', '%', 20])
+          return {
+            rows: [
+              {
+                subject_type: 'user',
+                subject_id: 'user_linked',
+                user_name: 'Linked User',
+                user_email: 'linked@example.com',
+                user_is_active: true,
+                permission_codes: [],
+              },
+              {
+                subject_type: 'user',
+                subject_id: 'user_bound_only',
+                user_name: 'Bound Only',
+                user_email: 'bound@example.com',
+                user_is_active: true,
+                permission_codes: [],
+              },
+              {
+                subject_type: 'user',
+                subject_id: 'user_unbound',
+                user_name: 'Unbound User',
+                user_email: 'unbound@example.com',
+                user_is_active: true,
+                permission_codes: [],
+              },
+              {
+                subject_type: 'member-group',
+                subject_id: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+                group_name: 'North Region',
+                group_description: null,
+                member_count: 12,
+                user_is_active: true,
+                permission_codes: [],
+              },
+            ],
+          }
+        }
+        if (sql.includes('FROM user_external_identities')) {
+          expect(params).toEqual([['user_linked', 'user_bound_only', 'user_unbound'], 'dingtalk'])
+          return { rows: [{ local_user_id: 'user_bound_only' }] }
+        }
+        if (sql.includes('FROM directory_account_links l') && sql.includes('JOIN directory_accounts a')) {
+          expect(params).toEqual([['user_linked', 'user_bound_only', 'user_unbound'], 'dingtalk'])
+          return { rows: [{ local_user_id: 'user_linked' }] }
+        }
+        if (sql.includes('FROM user_external_auth_grants')) {
+          expect(params).toEqual([['user_linked', 'user_bound_only', 'user_unbound'], 'dingtalk'])
+          return {
+            rows: [
+              { local_user_id: 'user_linked', enabled: true },
+              { local_user_id: 'user_bound_only', enabled: false },
+            ],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/form-share-candidates')
+      .expect(200)
+
+    expect(response.body.data).toEqual({
+      items: [
+        {
+          subjectType: 'user',
+          subjectId: 'user_linked',
+          label: 'Linked User',
+          subtitle: 'linked@example.com',
+          isActive: true,
+          accessLevel: null,
+          dingtalkBound: true,
+          dingtalkGrantEnabled: true,
+          dingtalkPersonDeliveryAvailable: true,
+        },
+        {
+          subjectType: 'user',
+          subjectId: 'user_bound_only',
+          label: 'Bound Only',
+          subtitle: 'bound@example.com',
+          isActive: true,
+          accessLevel: null,
+          dingtalkBound: true,
+          dingtalkGrantEnabled: false,
+          dingtalkPersonDeliveryAvailable: false,
+        },
+        {
+          subjectType: 'user',
+          subjectId: 'user_unbound',
+          label: 'Unbound User',
+          subtitle: 'unbound@example.com',
+          isActive: true,
+          accessLevel: null,
+          dingtalkBound: false,
+          dingtalkGrantEnabled: false,
+          dingtalkPersonDeliveryAvailable: false,
+        },
+        {
+          subjectType: 'member-group',
+          subjectId: '3e9c4bc7-13c2-4d12-8b52-9f0d62045d3c',
+          label: 'North Region',
+          subtitle: '12 members',
+          isActive: true,
+          accessLevel: null,
+          dingtalkBound: null,
+          dingtalkGrantEnabled: null,
+          dingtalkPersonDeliveryAvailable: null,
+        },
+      ],
+      total: 4,
+      limit: 20,
+      query: '',
+    })
+  })
+
   test('sets sheet permission access levels through the authoring endpoint', async () => {
     const deleteCalls: Array<unknown[] | undefined> = []
     const insertCalls: Array<unknown[] | undefined> = []


### PR DESCRIPTION
## Summary
- Enrich form-share user candidates with DingTalk binding, authorization grant, and direct-message delivery readiness.
- Show the same status on DingTalk person-message candidate rows and selected recipient chips in both automation UIs.
- Keep automation payloads local-user/member-group based; status is UI-only guidance.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

Docs added under `docs/development/` for development and verification notes.