### PR TITLE
feat(dingtalk): create bound users from account list

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -656,7 +656,7 @@
                 v-if="item.kind === 'pending_binding' && isManualAdmissionExpanded(item.account.id)"
                 class="directory-admin__button"
                 type="button"
-                :disabled="reviewProcessingAccountId === item.account.id || !canSubmitManualAdmission(item)"
+                :disabled="reviewProcessingAccountId === item.account.id || !canSubmitManualAdmission(item.account)"
                 @click="void createAndBindReviewUser(item)"
               >
                 {{ reviewProcessingAccountId === item.account.id ? '处理中...' : '创建用户并绑定' }}
@@ -1030,6 +1030,15 @@
                 {{ readBindingSearchLoading(account.id) ? '搜索中...' : '搜索本地用户' }}
               </button>
               <button
+                v-if="!account.localUser"
+                class="directory-admin__button directory-admin__button--secondary"
+                type="button"
+                :disabled="bindingAccountId === account.id"
+                @click="toggleManualAdmission(account)"
+              >
+                {{ isManualAdmissionExpanded(account.id) ? '收起手动创建' : '手动创建用户' }}
+              </button>
+              <button
                 class="directory-admin__button"
                 type="button"
                 :disabled="bindingAccountId === account.id || readBindingDraft(account).trim().length === 0"
@@ -1046,6 +1055,66 @@
               >
                 {{ unbindingAccountId === account.id ? '解绑中...' : '解除绑定' }}
               </button>
+            </div>
+
+            <div
+              v-if="!account.localUser && isManualAdmissionExpanded(account.id)"
+              class="directory-admin__review-admission"
+            >
+              <p class="directory-admin__hint">从当前钉钉同步成员创建本地用户并立即绑定。邮箱可为空，用户名或手机号可作为登录账号。</p>
+              <div class="directory-admin__form-grid">
+                <label class="directory-admin__field">
+                  <span>姓名</span>
+                  <input
+                    :value="readManualAdmissionDraft(account).name"
+                    class="directory-admin__input"
+                    type="text"
+                    placeholder="例如 李青"
+                    @input="onManualAdmissionDraftInput(account.id, 'name', $event)"
+                  />
+                </label>
+                <label class="directory-admin__field">
+                  <span>邮箱（可选）</span>
+                  <input
+                    :value="readManualAdmissionDraft(account).email"
+                    class="directory-admin__input"
+                    type="email"
+                    placeholder="例如 alpha@example.com"
+                    @input="onManualAdmissionDraftInput(account.id, 'email', $event)"
+                  />
+                </label>
+                <label class="directory-admin__field">
+                  <span>用户名（可选）</span>
+                  <input
+                    :value="readManualAdmissionDraft(account).username"
+                    class="directory-admin__input"
+                    type="text"
+                    placeholder="例如 liqing"
+                    @input="onManualAdmissionDraftInput(account.id, 'username', $event)"
+                  />
+                </label>
+                <label class="directory-admin__field">
+                  <span>手机号</span>
+                  <input
+                    :value="readManualAdmissionDraft(account).mobile"
+                    class="directory-admin__input"
+                    type="text"
+                    placeholder="可选：目录手机号会自动带入"
+                    @input="onManualAdmissionDraftInput(account.id, 'mobile', $event)"
+                  />
+                </label>
+              </div>
+              <p class="directory-admin__hint">姓名必填；邮箱、用户名、手机号至少填写一项。无邮箱用户会走临时密码 + 首登强制改密。</p>
+              <div class="directory-admin__actions">
+                <button
+                  class="directory-admin__button"
+                  type="button"
+                  :disabled="bindingAccountId === account.id || !canSubmitManualAdmission(account)"
+                  @click="void createAndBindAccountUser(account)"
+                >
+                  {{ bindingAccountId === account.id ? '处理中...' : '创建用户并绑定' }}
+                </button>
+              </div>
             </div>
 
             <p v-if="readBindingSearchError(account.id)" class="directory-admin__status directory-admin__status--error">
@@ -2241,8 +2310,8 @@ function onManualAdmissionDraftInput(accountId: string, field: keyof ManualAdmis
   }
 }
 
-function canSubmitManualAdmission(item: DirectoryReviewItem): boolean {
-  const draft = readManualAdmissionDraft(item.account)
+function canSubmitManualAdmission(account: DirectoryAccount): boolean {
+  const draft = readManualAdmissionDraft(account)
   return draft.name.trim().length > 0
     && (draft.email.trim().length > 0 || draft.username.trim().length > 0 || draft.mobile.trim().length > 0)
 }
@@ -3134,30 +3203,32 @@ async function backfillUserMobileAndBindReviewItem(item: DirectoryReviewItem) {
   }
 }
 
-async function createAndBindReviewUser(item: DirectoryReviewItem) {
-  const draft = readManualAdmissionDraft(item.account)
+async function createAndBindDirectoryAccountUser(account: DirectoryAccount, context: 'review' | 'account') {
+  const memberLabel = context === 'review' ? '待处理成员' : '目录成员'
+  const draft = readManualAdmissionDraft(account)
   const nextDraft: ManualAdmissionDraft = {
     name: draft.name.trim(),
     email: draft.email.trim(),
     username: draft.username.trim(),
     mobile: draft.mobile.trim(),
   }
-  manualAdmissionDrafts[item.account.id] = nextDraft
+  manualAdmissionDrafts[account.id] = nextDraft
   if (!nextDraft.name || (!nextDraft.email && !nextDraft.username && !nextDraft.mobile)) {
-    setStatus(`待处理成员 ${item.account.name} 的姓名必填，且邮箱、用户名、手机号至少填写一项`, 'error')
+    setStatus(`${memberLabel} ${account.name} 的姓名必填，且邮箱、用户名、手机号至少填写一项`, 'error')
     return
   }
 
-  reviewProcessingAccountId.value = item.account.id
+  if (context === 'review') reviewProcessingAccountId.value = account.id
+  else bindingAccountId.value = account.id
   try {
-    const response = await apiFetch(`/api/admin/directory/accounts/${encodeURIComponent(item.account.id)}/admit-user`, {
+    const response = await apiFetch(`/api/admin/directory/accounts/${encodeURIComponent(account.id)}/admit-user`, {
       method: 'POST',
       body: JSON.stringify({
         name: nextDraft.name,
         email: nextDraft.email || undefined,
         username: nextDraft.username || undefined,
         mobile: nextDraft.mobile || undefined,
-        enableDingTalkGrant: readGrantToggle(item.account.id),
+        enableDingTalkGrant: readGrantToggle(account.id),
       }),
     })
     const body = await readJson(response)
@@ -3171,18 +3242,18 @@ async function createAndBindReviewUser(item: DirectoryReviewItem) {
       ? data.onboarding as OnboardingPacket
       : null
 
-    updateBindingDraft(item.account.id, describeLocalUserIdentifier(createdUser))
-    selectedBindingUsers[item.account.id] = createdUser
-    clearBindingSearch(item.account.id)
-    delete mobileOverrideConfirmations[item.account.id]
-    delete mobileConflictHints[item.account.id]
-    delete manualAdmissionExpanded[item.account.id]
-    delete manualAdmissionDrafts[item.account.id]
+    updateBindingDraft(account.id, describeLocalUserIdentifier(createdUser))
+    selectedBindingUsers[account.id] = createdUser
+    clearBindingSearch(account.id)
+    delete mobileOverrideConfirmations[account.id]
+    delete mobileConflictHints[account.id]
+    delete manualAdmissionExpanded[account.id]
+    delete manualAdmissionDrafts[account.id]
     await refreshAfterReviewBindings()
     manualAdmissionResult.value = {
-      accountId: item.account.id,
-      accountName: item.account.name,
-      integrationId: item.account.integrationId,
+      accountId: account.id,
+      accountName: account.name,
+      integrationId: account.integrationId,
       userId: createdUser.id,
       userName: createdUser.name || nextDraft.name,
       email: createdUser.email || nextDraft.email || null,
@@ -3195,12 +3266,21 @@ async function createAndBindReviewUser(item: DirectoryReviewItem) {
       mobileBackfilled: nextDraft.mobile.length === 0 || (createdUser.mobile ?? '') === nextDraft.mobile,
       mobileBackfillError: '',
     }
-    setStatus(`待处理成员 ${item.account.name} 已创建本地用户并完成绑定`)
+    setStatus(`${memberLabel} ${account.name} 已创建本地用户并完成绑定`)
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '创建本地用户并绑定失败', 'error')
   } finally {
-    reviewProcessingAccountId.value = ''
+    if (context === 'review') reviewProcessingAccountId.value = ''
+    else bindingAccountId.value = ''
   }
+}
+
+async function createAndBindReviewUser(item: DirectoryReviewItem) {
+  await createAndBindDirectoryAccountUser(item.account, 'review')
+}
+
+async function createAndBindAccountUser(account: DirectoryAccount) {
+  await createAndBindDirectoryAccountUser(account, 'account')
 }
 
 async function retryBackfillUserMobileAndBindReviewItem(item: DirectoryReviewItem) {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -1041,6 +1041,123 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).not.toContain('https://example.com/invite/abc')
   })
 
+  it('creates and binds a no-email local user from the account list', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          id: 'account-list-no-email',
+          name: '王武',
+          email: null,
+          mobile: '13900008888',
+        })], { total: 1 }),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          user: {
+            id: 'user-created-list-no-email',
+            email: null,
+            username: 'wangwu',
+            name: '王武',
+            mobile: '13900008888',
+            role: 'user',
+            is_active: true,
+          },
+          temporaryPassword: 'Temp#888888',
+          onboarding: {
+            accountLabel: 'wangwu',
+            acceptInviteUrl: '',
+            inviteMessage: '账号：wangwu',
+          },
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          id: 'account-list-no-email',
+          name: '王武',
+          email: null,
+          mobile: '13900008888',
+          linkStatus: 'linked',
+          matchStrategy: 'manual_admin',
+          localUser: {
+            id: 'user-created-list-no-email',
+            email: null,
+            username: 'wangwu',
+            name: '王武',
+          },
+        })], { total: 1 }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const accountsSection = findAccountsSection(container!)
+    const accountCard = accountsSection.querySelector('.directory-admin__account') as HTMLElement
+    expect(accountCard).toBeTruthy()
+    const toggleButton = Array.from(accountCard.querySelectorAll('button')).find((button) => button.textContent?.includes('手动创建用户'))
+    expect(toggleButton).toBeTruthy()
+    toggleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    const usernameInput = Array.from(accountCard.querySelectorAll('input')).find((input) => input.getAttribute('placeholder') === '例如 liqing') as HTMLInputElement | undefined
+    expect(usernameInput).toBeTruthy()
+    usernameInput!.value = 'wangwu'
+    usernameInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    const createAndBindButton = Array.from(accountCard.querySelectorAll('button')).find((button) => button.textContent?.includes('创建用户并绑定'))
+    expect(createAndBindButton).toBeTruthy()
+    createAndBindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(12)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/account-list-no-email/admit-user',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: '王武',
+          username: 'wangwu',
+          mobile: '13900008888',
+          enableDingTalkGrant: true,
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('最近创建并绑定结果')
+    expect(container?.textContent).toContain('新用户临时密码：Temp#888888')
+    expect(container?.textContent).toContain('账号：wangwu')
+    expect(container?.textContent).toContain('目录成员 王武 已创建本地用户并完成绑定')
+  })
+
   it('focuses a reviewed account and quick-binds it from the accounts banner', async () => {
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({

--- a/docs/development/dingtalk-directory-account-list-admission-development-20260422.md
+++ b/docs/development/dingtalk-directory-account-list-admission-development-20260422.md
@@ -1,0 +1,41 @@
+# DingTalk Directory Account List Admission Development - 2026-04-22
+
+## Goal
+
+Let administrators create a local user directly from a synced DingTalk account in the member account list, then bind that new local user back to the DingTalk directory account.
+
+The backend `POST /api/admin/directory/accounts/:accountId/admit-user` route already supports no-email admission when a username or mobile number is provided. This slice exposes that standard path in the account list, not only in the pending review queue.
+
+## Scope
+
+- Added a `Manual create user` entry point to each unbound account in the `成员账号` list.
+- Reused the same admission fields as the pending review queue:
+  - Name
+  - Optional email
+  - Optional username
+  - Optional mobile
+- Kept no-email validation: name is required, and at least one of email, username, or mobile is required.
+- Reused the existing `admit-user` API call and result panel.
+- Preserved the existing quick bind flow for binding to an already existing local user.
+
+## Behavior
+
+- An unbound synced DingTalk account can be expanded in the account list.
+- If email is empty but username or mobile exists, the frontend submits the create-and-bind request without an empty email field.
+- The success result shows the local user, login account, temporary password, and onboarding message.
+- After success, integrations, pending review items, and account list are refreshed.
+
+## Files Changed
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/directoryManagementView.spec.ts`
+- `docs/development/dingtalk-directory-account-list-admission-development-20260422.md`
+- `docs/development/dingtalk-directory-account-list-admission-verification-20260422.md`
+
+## Backend Notes
+
+- No backend route changes were required.
+- Existing backend support is provided by:
+  - `packages/core-backend/src/routes/admin-directory.ts`
+  - `packages/core-backend/src/directory/directory-sync.ts`
+- Existing backend unit coverage already validates no-email manual admission and DingTalk binding behavior.

--- a/docs/development/dingtalk-directory-account-list-admission-verification-20260422.md
+++ b/docs/development/dingtalk-directory-account-list-admission-verification-20260422.md
@@ -1,0 +1,44 @@
+# DingTalk Directory Account List Admission Verification - 2026-04-22
+
+## Branch
+
+- `codex/dingtalk-directory-account-list-admission-20260422`
+- Base branch: `codex/dingtalk-person-recipient-binding-warning-20260422`
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --watch=false
+```
+
+Result: passed. `1` test file, `34` tests.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts --watch=false
+```
+
+Result: passed. `2` test files, `30` tests.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Vite emitted existing non-blocking warnings about `WorkflowDesigner.vue` being both dynamically and statically imported, plus large chunks after minification.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Covered Scenarios
+
+- Pending review queue manual admission still works.
+- No-email pending review admission still submits username/mobile without an empty email field.
+- Account list now offers manual create-and-bind for unbound DingTalk accounts.
+- Account-list no-email admission submits `name`, `username`, `mobile`, and `enableDingTalkGrant` without `email`.
+- Success result displays temporary password and onboarding copy.
+
+## Non-Blocking Observations
+
+- The repository still has unrelated dirty `node_modules` files under plugins/tools. They are not part of this slice.


### PR DESCRIPTION
## Summary
- add a manual create-and-bind entry point for unbound DingTalk directory accounts in the account list
- reuse the existing no-email manual admission API so username/mobile can create the local user and bind DingTalk identity
- add account-list coverage and development/verification docs

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`