### PR TITLE
fix(approval): handle unavailable PLM bridge

### DIFF
--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -108,6 +108,19 @@ function compareHistoryDescending(
   return String(right.id).localeCompare(String(left.id))
 }
 
+function isPlmBridgeUnavailableError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return error.message.includes('HTTP client not initialized')
+}
+
+function plmBridgeUnavailableError(): ServiceError {
+  return new ServiceError(
+    'PLM approval bridge is not configured',
+    503,
+    'PLM_APPROVAL_BRIDGE_UNAVAILABLE',
+  )
+}
+
 function toUnifiedDTO(
   row: ApprovalInstanceRow,
   assignments: ApprovalAssignmentRow[] = [],
@@ -518,15 +531,26 @@ export class ApprovalBridgeService {
     let totalCount: number | null = null
 
     for (let pageOffset = 0; pageOffset < requestedWindow; pageOffset += PLM_SYNC_UPSTREAM_PAGE_SIZE) {
-      const result = await plmAdapter.getApprovals({
-        status: options?.status,
-        productId: options?.productId,
-        requesterId: options?.requesterId,
-        limit: PLM_SYNC_UPSTREAM_PAGE_SIZE,
-        offset: pageOffset,
-      })
+      let result
+      try {
+        result = await plmAdapter.getApprovals({
+          status: options?.status,
+          productId: options?.productId,
+          requesterId: options?.requesterId,
+          limit: PLM_SYNC_UPSTREAM_PAGE_SIZE,
+          offset: pageOffset,
+        })
+      } catch (error) {
+        if (isPlmBridgeUnavailableError(error)) {
+          throw plmBridgeUnavailableError()
+        }
+        throw error
+      }
 
       if (result.error) {
+        if (isPlmBridgeUnavailableError(result.error)) {
+          throw plmBridgeUnavailableError()
+        }
         throw new ServiceError(
           'Failed to fetch PLM approvals',
           502,

--- a/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
@@ -746,6 +746,17 @@ describe('approval bridge routes', () => {
     expect(response.body.error.code).toBe('ASSIGNEE_FILTER_UNSUPPORTED')
   })
 
+  it('returns a controlled unavailable response when the PLM adapter is not connected', async () => {
+    const plmAdapter = createPlmAdapterMock()
+    plmAdapter.getApprovals.mockRejectedValueOnce(new Error('HTTP client not initialized'))
+
+    const response = await request(createApp(plmAdapter))
+      .get('/api/approvals?sourceSystem=plm')
+      .expect(503)
+
+    expect(response.body.error.code).toBe('PLM_APPROVAL_BRIDGE_UNAVAILABLE')
+  })
+
   it('lists platform approvals without requiring a PLM adapter', async () => {
     const response = await request(createApp())
       .get('/api/approvals')


### PR DESCRIPTION
## Summary
- Map an unconnected PLM adapter (`HTTP client not initialized`) to a controlled `503 PLM_APPROVAL_BRIDGE_UNAVAILABLE` response.
- Preserve existing successful PLM sync behavior and existing upstream-error handling.
- Add a route regression test for `GET /api/approvals?sourceSystem=plm` when the adapter object exists but is not connected.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approvals-bridge-routes.test.ts --reporter=dot` -> 21/21 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` -> passed
- `pnpm --filter @metasheet/core-backend build` -> passed
- `git diff --check` -> passed

## Staging context
142 currently has no live PLM HTTP client configured; before this fix, selecting the PLM source filter returned a generic 500. After merge/deploy, the same condition should return controlled 503 with `PLM_APPROVAL_BRIDGE_UNAVAILABLE`.
