### PR TITLE
fix(web): install pinia in app bootstrap

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -2,6 +2,7 @@
  * Vue Application Entry Point
  */
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import { createRouter, createWebHistory } from 'vue-router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
@@ -143,6 +144,7 @@ router.beforeEach(async (to, _from, next) => {
 async function bootstrap(): Promise<void> {
   const app = createApp(App)
   app.use(ElementPlus)
+  app.use(createPinia())
   app.use(router)
 
   await router.isReady()

--- a/apps/web/tests/main-pinia-bootstrap.spec.ts
+++ b/apps/web/tests/main-pinia-bootstrap.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('web bootstrap Pinia runtime wiring', () => {
+  it('installs Pinia before the router mounts route components', () => {
+    const source = readFileSync(resolve(__dirname, '../src/main.ts'), 'utf8')
+
+    expect(source).toContain("import { createPinia } from 'pinia'")
+    expect(source).toContain('app.use(createPinia())')
+
+    const piniaIndex = source.indexOf('app.use(createPinia())')
+    const routerIndex = source.indexOf('app.use(router)')
+    expect(piniaIndex).toBeGreaterThan(-1)
+    expect(routerIndex).toBeGreaterThan(-1)
+    expect(piniaIndex).toBeLessThan(routerIndex)
+  })
+})


### PR DESCRIPTION
## Summary
- Install Pinia in the Vue app bootstrap before router components mount.
- Add a bootstrap regression test so ApprovalCenter/other Pinia-backed route chunks cannot regress to a blank page from missing active Pinia.

## Why
Staging click validation for Approval Center loaded the route chunk successfully but the page body stayed blank. Browser console showed `Cannot read properties of undefined (reading '_s')`, which is Pinia's missing active app instance path.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/main-pinia-bootstrap.spec.ts tests/approvalCenterSourceFilter.spec.ts --reporter=dot` -> 5/5 passed
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` -> passed
- `pnpm --filter @metasheet/web build` -> passed
- `git diff --check` -> passed
