### PR TITLE
docs(dingtalk): add P4 smoke runbook

### DIFF
--- a/docs/development/dingtalk-docs-smoke-runbook-development-20260422.md
+++ b/docs/development/dingtalk-docs-smoke-runbook-development-20260422.md
@@ -1,0 +1,47 @@
+# DingTalk Docs Smoke Runbook Development - 2026-04-22
+
+## Goal
+
+Complete the P4 documentation slice from the DingTalk feature plan:
+
+- administrator guide for app credentials, group robot binding, directory sync, and no-email local user creation
+- user workflow guide for group binding, automation messages, public form links, and form access levels
+- troubleshooting notes for webhook signature failures, unbound users, missing grants, no-email users, and links that cannot be opened
+- remote smoke checklist for deployed environment validation
+
+## Changes
+
+- Updated `docs/dingtalk-admin-operations-guide-20260420.md` with:
+  - DingTalk directory account operation flow
+  - no-email local user creation and binding notes
+  - person delivery `success / failed / skipped` status meanings
+  - troubleshooting matrix
+- Updated `docs/dingtalk-capability-guide-20260420.md` with:
+  - account-list local user creation
+  - person delivery skipped status semantics
+- Updated `docs/dingtalk-synced-account-local-user-guide-20260420.md` with:
+  - manual admission from synced account list
+  - no-email create-and-bind behavior
+  - troubleshooting for no-created-user, duplicate identifier, pre-bind, and no-email invite cases
+- Added `docs/dingtalk-user-workflow-guide-20260422.md`.
+- Added `docs/dingtalk-remote-smoke-checklist-20260422.md`.
+- Updated `docs/development/dingtalk-feature-plan-and-todo-20260422.md` to reflect completed P3 work and P4 documentation coverage.
+- Updated `scripts/ops/export-dingtalk-staging-evidence-packet.mjs` so the exported handoff packet includes the new P4 user guide, account guide, remote smoke checklist, and current plan.
+
+## Non-Goals
+
+- No runtime code changes.
+- No API contract changes.
+- No database migration changes.
+- No live remote smoke execution in this slice; the new checklist is the operator-ready runbook for that execution.
+
+## Expected Effect
+
+Operators and table owners now have a single documented path for:
+
+- binding DingTalk groups to tables
+- creating automation messages
+- protecting form links with DingTalk and local allowlists
+- manually creating and binding no-email DingTalk-synced users
+- diagnosing skipped person deliveries
+- executing remote smoke without exposing DingTalk secrets or admin tokens

--- a/docs/development/dingtalk-docs-smoke-runbook-verification-20260422.md
+++ b/docs/development/dingtalk-docs-smoke-runbook-verification-20260422.md
@@ -1,0 +1,50 @@
+# DingTalk Docs Smoke Runbook Verification - 2026-04-22
+
+## Branch
+
+- `codex/dingtalk-docs-smoke-runbook-20260422`
+- Base branch: `codex/dingtalk-person-delivery-skip-reasons-20260422`
+
+## Verification Commands
+
+```bash
+rg -n "A0. Configure DingTalk directory accounts|Person delivery status meanings|Troubleshooting matrix|Manual admission from the synced account list|DingTalk User Workflow Guide|DingTalk Remote Smoke Checklist|Remote smoke checklist|DingTalk Admin Operations Guide|export-dingtalk-staging-evidence-packet" docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/dingtalk-synced-account-local-user-guide-20260420.md docs/dingtalk-user-workflow-guide-20260422.md docs/dingtalk-remote-smoke-checklist-20260422.md docs/development/dingtalk-feature-plan-and-todo-20260422.md scripts/ops/export-dingtalk-staging-evidence-packet.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result: passed. Matched the admin guide, synced-account guide, user workflow guide, remote smoke checklist, TODO file, and evidence packet script/test.
+
+```bash
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result: passed. 4 tests passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-person-delivery-service.test.ts tests/unit/directory-sync-bind-account.test.ts --watch=false
+```
+
+Result: passed. 2 files passed, 10 tests passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-form-share-manager.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed. 3 files passed, 110 tests passed.
+
+```bash
+git diff --check -- docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/dingtalk-synced-account-local-user-guide-20260420.md docs/dingtalk-user-workflow-guide-20260422.md docs/dingtalk-remote-smoke-checklist-20260422.md docs/development/dingtalk-feature-plan-and-todo-20260422.md docs/development/dingtalk-docs-smoke-runbook-development-20260422.md docs/development/dingtalk-docs-smoke-runbook-verification-20260422.md scripts/ops/export-dingtalk-staging-evidence-packet.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result: passed.
+
+## Covered Documentation Paths
+
+- Admin guide covers DingTalk directory setup, no-email local user creation, group robots, delivery status, and troubleshooting.
+- User guide covers table group binding, group/person automation, form access levels, allowlists, and end-user outcomes.
+- Remote smoke checklist covers table/form creation, two group bindings, `dingtalk_granted`, authorized submit, unauthorized denial, delivery history, and no-email admission.
+- Evidence packet exporter now includes the P4 user workflow guide, synced-account guide, remote smoke checklist, and current DingTalk TODO.
+- Feature TODO marks completed P3 work and P4 documentation tasks while leaving actual remote smoke execution pending.
+
+## Non-Blocking Observations
+
+- The repository still has unrelated dirty `node_modules` files under plugins/tools. They are not part of this slice.

--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -3,7 +3,7 @@
 - Date: 2026-04-22
 - Goal: table trigger -> DingTalk group/person message -> form fill or internal processing -> permission-safe completion
 - Delivery mode: small stacked PRs; each implementation PR must include development and verification notes
-- Current base: continue after the DingTalk validation and granted-form guard stack through PR #1062
+- Current base: continue after the DingTalk validation, directory admission, and person delivery history stack through PR #1073
 
 ## Guiding Decisions
 
@@ -50,21 +50,21 @@
 
 ## P3: DingTalk Person Messaging And User Sync
 
-- [ ] Backend: keep `send_dingtalk_person_message` support for static `userIds`.
-- [ ] Backend: keep `send_dingtalk_person_message` support for `memberGroupIds`.
-- [ ] Backend: keep dynamic recipient field paths for local users and member groups.
-- [ ] Frontend: expose person recipient picker for local users and member groups.
-- [ ] Frontend: warn when selected recipients are not bound to DingTalk.
-- [ ] Directory sync: show synced DingTalk accounts without matched local users.
-- [ ] Directory sync: support admin-triggered local user creation without email.
-- [ ] Directory sync: bind newly created local users to the DingTalk external identity.
-- [ ] Delivery history: record person send success, failure, and skipped-unbound reasons.
+- [x] Backend: keep `send_dingtalk_person_message` support for static `userIds`.
+- [x] Backend: keep `send_dingtalk_person_message` support for `memberGroupIds`.
+- [x] Backend: keep dynamic recipient field paths for local users and member groups.
+- [x] Frontend: expose person recipient picker for local users and member groups.
+- [x] Frontend: warn when selected recipients are not bound to DingTalk.
+- [x] Directory sync: show synced DingTalk accounts without matched local users.
+- [x] Directory sync: support admin-triggered local user creation without email.
+- [x] Directory sync: bind newly created local users to the DingTalk external identity.
+- [x] Delivery history: record person send success, failure, and skipped-unbound reasons.
 
 ## P4: Documentation And Remote Smoke
 
-- [ ] Add an administrator guide for DingTalk app credentials, group robot binding, directory sync, and no-email user creation.
-- [ ] Add a user guide for table group binding, automation messages, public form links, and form access levels.
-- [ ] Add troubleshooting notes for webhook signature failures, unbound users, missing grants, no-email users, and links that cannot be opened.
+- [x] Add an administrator guide for DingTalk app credentials, group robot binding, directory sync, and no-email user creation.
+- [x] Add a user guide for table group binding, automation messages, public form links, and form access levels.
+- [x] Add troubleshooting notes for webhook signature failures, unbound users, missing grants, no-email users, and links that cannot be opened.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.
@@ -72,6 +72,10 @@
 - [ ] Remote smoke: verify an authorized user can open and submit.
 - [ ] Remote smoke: verify an unauthorized user cannot submit and no record is inserted.
 - [ ] Remote smoke: verify delivery history records group and person sends.
+
+Remote smoke checklist:
+
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
 
 ## Suggested Parallel Lanes
 

--- a/docs/dingtalk-admin-operations-guide-20260420.md
+++ b/docs/dingtalk-admin-operations-guide-20260420.md
@@ -12,6 +12,7 @@ This guide explains the management-side UI flow for:
 - configuring table-triggered automation
 - configuring public form sharing
 - using protected public-form modes and allowlists
+- syncing DingTalk accounts and creating bound local users
 
 It does not cover end-user filling behavior beyond the links they receive.
 
@@ -20,6 +21,8 @@ It does not cover end-user filling behavior beyond the links they receive.
 - Send a table-triggered message to a DingTalk group: see [C. Configure a DingTalk group notification rule](#c-configure-a-dingtalk-group-notification-rule).
 - Send a form link that users can fill: see [D. Configure a public form](#d-configure-a-public-form).
 - Send to a DingTalk group while only selected local users or member groups can fill: see [E. Configure protected public-form allowlists](#e-configure-protected-public-form-allowlists) and [Scenario 2](#scenario-2-broadcast-to-a-group-but-only-selected-users-can-fill).
+- Create a local user from a synced DingTalk account without email: see [A0. Configure DingTalk directory accounts](#a0-configure-dingtalk-directory-accounts).
+- Diagnose unbound person recipients: see [G. Delivery history and troubleshooting](#g-delivery-history-and-troubleshooting).
 
 ## Before you start
 
@@ -27,8 +30,41 @@ You need all of the following:
 
 - access to the target table
 - permission to manage automation or form sharing on that table
+- DingTalk app credentials if you need sign-in, directory sync, or person work notifications
 - a DingTalk group robot webhook if you want group delivery
 - DingTalk-bound local users if you want person delivery or DingTalk-protected public forms
+
+## A0. Configure DingTalk directory accounts
+
+Management-side UI path:
+
+1. Open the admin directory management page.
+2. Configure or select a DingTalk directory integration.
+3. Run sync or wait for the configured schedule.
+4. Review synced accounts in the pending review queue or the member account list.
+5. For an unmatched account, either bind it to an existing local user or create a local user and bind it immediately.
+
+No-email local user creation:
+
+- name is required
+- at least one of email, username, or mobile is required
+- email may be empty
+- username or mobile can act as the login identifier
+- generated-password users are forced to change password at first sign-in
+- no-email users receive an onboarding packet in the admin result panel rather than an email invite
+
+Binding behavior:
+
+- manual creation writes a local `users` row
+- the new user is linked to the DingTalk directory account
+- the DingTalk grant is enabled by default unless the admin disables it
+- the account list refreshes after creation so operators can confirm the local link
+
+Important boundaries:
+
+- syncing a DingTalk account does not automatically authorize that raw DingTalk user to fill forms
+- form access still targets local users and local member groups
+- DingTalk department projection can help maintain local member groups, but DingTalk group robot bindings do not import group members
 
 ## A. Configure a DingTalk group destination
 
@@ -212,6 +248,33 @@ Use this when checking:
 - recipient is not bound to DingTalk
 - recipient selection is wrong
 - template or target link is wrong
+
+Person delivery status meanings:
+
+- `success`: the message was sent to a bound DingTalk user
+- `failed`: the DingTalk API/config/send path failed for a resolved recipient
+- `skipped`: the selected local user is inactive or does not have an active DingTalk binding
+
+Operational rule:
+
+- a skipped person recipient does not block messages to other bound recipients in the same action
+- if all recipients are skipped, the automation step is skipped and the delivery history shows the skipped users
+
+### Troubleshooting matrix
+
+| Symptom | Likely cause | Operator action |
+| --- | --- | --- |
+| DingTalk group test-send fails with webhook validation | webhook is not a standard DingTalk group robot URL or lacks `access_token` | copy the group robot webhook again from DingTalk robot settings |
+| DingTalk group test-send fails with signature error | robot uses signed mode but the saved secret is missing or not `SEC...` | edit the destination and set the current `SEC...` secret |
+| DingTalk group send returns non-zero `errcode` | DingTalk robot keyword/security policy or robot-side rule rejected the message | inspect delivery history `errorMessage` and `responseBody`, then adjust robot keyword/security settings or message template |
+| DingTalk group send returns HTTP non-2xx | DingTalk endpoint, network, or proxy rejected the request | inspect delivery history `httpStatus` and backend logs before retrying |
+| Person delivery shows `skipped` | local user is inactive or not bound to DingTalk | use the person delivery viewer `Skipped / unbound` filter, then bind the synced DingTalk account to the local user or create/bind from directory management |
+| Public form returns `DINGTALK_AUTH_REQUIRED` | visitor has not completed DingTalk sign-in | ask the user to reopen the link and sign in through DingTalk |
+| Public form returns `DINGTALK_BIND_REQUIRED` | DingTalk identity is not bound to a local user | bind or create the local user from directory management |
+| Public form returns `DINGTALK_GRANT_REQUIRED` | form requires `dingtalk_granted` but the local user has no enabled grant | enable the DingTalk grant for that local user |
+| Public form returns `DINGTALK_FORM_NOT_ALLOWED` | local user is outside the configured allowed users/member groups | update the form allowlist or add the user to an allowed local member group |
+| Internal processing link cannot open | notification delivery does not grant table/view permission | grant the required local table/view permission or use a public form link |
+| Delivery history cannot load | current user cannot manage automations or route failed | verify table automation permission and inspect backend logs |
 
 ## H. Common operating scenarios
 

--- a/docs/dingtalk-capability-guide-20260420.md
+++ b/docs/dingtalk-capability-guide-20260420.md
@@ -39,6 +39,7 @@ Supported:
 - syncing DingTalk departments and members into the directory mirror
 - review/bind/unbind governance
 - creating local users from synced members
+- creating and binding local users directly from the synced account list
 - auto-admission by department scope
 - excluding child departments from auto-admission
 - projecting DingTalk departments into `platform_member_groups`
@@ -79,6 +80,9 @@ Current model:
 - you choose local users
 - the system resolves their DingTalk bindings
 - unbound users cannot receive DingTalk person delivery
+- person delivery history records `success`, `failed`, and `skipped`
+- unbound or inactive local recipients are `skipped`; they do not block delivery to other bound recipients
+- operational troubleshooting lives in [DingTalk Admin Operations Guide](./dingtalk-admin-operations-guide-20260420.md)
 
 ### 5. Public forms and DingTalk-protected public forms
 

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -1,0 +1,189 @@
+# DingTalk Remote Smoke Checklist
+
+- Date: 2026-04-22
+- Scope: deployed environment validation
+- Audience: release owner, QA, implementation owner
+
+## Purpose
+
+Use this checklist after the stacked DingTalk PRs are deployed to a remote environment.
+
+The checklist proves the full product loop:
+
+- table trigger
+- DingTalk group/person message
+- form link or internal processing link
+- DingTalk identity gate
+- local user/member-group authorization
+- delivery history evidence
+
+## Preconditions
+
+- backend migrations have run
+- at least one admin can sign in
+- DingTalk app credentials are configured for sign-in and person work notifications
+- at least two DingTalk group robot webhooks are available for testing
+- at least two local users are available:
+  - one DingTalk-bound and authorized user
+  - one user that should be denied
+- at least one synced DingTalk account without a matched local user is available if no-email admission is being tested
+
+## Evidence to capture
+
+Capture:
+
+- environment URL
+- commit or image tag
+- table ID
+- form view ID
+- automation rule ID
+- DingTalk group destination IDs
+- screenshots of access mode and allowlist settings
+- delivery history rows for group and person sends
+- submit result for authorized user
+- blocked submit result for unauthorized user
+
+Do not capture or paste:
+
+- DingTalk robot full webhook URLs
+- DingTalk app secrets
+- temporary passwords
+- admin tokens
+
+## Smoke 1: Create table and public form
+
+Steps:
+
+1. Create a new table or choose a disposable test table.
+2. Add fields required by the test form.
+3. Create a form view.
+4. Enable public form sharing.
+5. Save the form with access mode `dingtalk_granted`.
+6. Add an allowlist containing the authorized local user or an allowed local member group.
+
+Expected:
+
+- form share manager shows `Authorized DingTalk users only`
+- local allowlist summary names the allowed local users/member groups
+- generated public form link is available
+
+## Smoke 2: Bind two DingTalk groups
+
+Steps:
+
+1. Open `API Tokens / Webhooks / DingTalk Groups`.
+2. Add DingTalk group destination A.
+3. Add DingTalk group destination B.
+4. Run `Test send` for both destinations.
+
+Expected:
+
+- both destinations are enabled
+- webhook URL is masked in the UI
+- secret is not displayed
+- test-send delivery history records success or a clear DingTalk error
+
+## Smoke 3: Send group message with form link
+
+Steps:
+
+1. Create an automation rule.
+2. Use action `Send DingTalk group message`.
+3. Select both DingTalk group destinations.
+4. Select the protected form view as the public form link.
+5. Save the rule.
+6. Trigger the rule by creating or updating a record.
+
+Expected:
+
+- DingTalk group message is received in both groups
+- message includes the form link
+- message includes access text showing DingTalk authorization and local allowlist scope
+- rule-level group delivery history records the send
+
+## Smoke 4: Authorized user can submit
+
+Steps:
+
+1. Open the DingTalk group message as the authorized DingTalk-bound user.
+2. Open the form link.
+3. Complete and submit the form.
+4. Check the table for the inserted record.
+
+Expected:
+
+- DingTalk sign-in succeeds if a session is not already active
+- form opens
+- submit succeeds
+- a new record is inserted
+
+## Smoke 5: Unauthorized user cannot submit
+
+Steps:
+
+1. Open the same form link as a DingTalk-bound user who is not authorized or not in the allowlist.
+2. Attempt to submit the form.
+3. Check the table for inserted records.
+
+Expected:
+
+- form access or submit is blocked
+- error copy explains the missing grant or allowlist access
+- no record is inserted
+
+## Smoke 6: Person delivery history records skipped users
+
+Steps:
+
+1. Create or edit an automation rule with action `Send DingTalk person message`.
+2. Select one bound local user and one unbound or inactive local user.
+3. Trigger the rule.
+4. Open person delivery history.
+
+Expected:
+
+- the bound local user receives the message
+- the unbound or inactive local user appears as `skipped`
+- skipped delivery reason explains that the DingTalk account is not linked or the user is inactive
+- skipped recipient does not block delivery to the bound recipient
+
+## Smoke 7: No-email DingTalk account creation and binding
+
+Steps:
+
+1. Open directory management.
+2. Find a synced DingTalk account without a matched local user.
+3. Expand manual creation from the member account list or pending review queue.
+4. Leave email empty.
+5. Enter name plus username or mobile.
+6. Submit create-and-bind.
+
+Expected:
+
+- local user is created
+- DingTalk account is linked to the local user
+- onboarding packet is shown
+- temporary password is shown only in the admin result panel
+- the account list refreshes and shows the local link
+
+## Pass criteria
+
+The remote smoke passes only when:
+
+- group destinations can be created and test-sent without leaking secrets
+- group automation sends a protected form link
+- authorized user can submit
+- unauthorized user cannot insert a record
+- group delivery history records group sends
+- person delivery history records `success`, `failed`, or `skipped`
+- no-email synced account can be manually created and bound when username or mobile is present
+
+## Failure handling
+
+If a smoke step fails:
+
+1. capture the exact step and timestamp
+2. capture the visible error message
+3. check backend logs for the route or delivery error
+4. do not retry by weakening the form access mode
+5. keep the DingTalk webhook and app secrets redacted in all reports

--- a/docs/dingtalk-synced-account-local-user-guide-20260420.md
+++ b/docs/dingtalk-synced-account-local-user-guide-20260420.md
@@ -70,7 +70,37 @@ Key references:
 - [directory-sync.ts](../packages/core-backend/src/directory/directory-sync.ts)
 - [DirectoryManagementView.vue](../apps/web/src/views/DirectoryManagementView.vue)
 
-### 2. Department-scoped auto-admission during sync
+### 2. Manual admission from the synced account list
+
+Supported.
+
+Admin flow:
+
+1. Open the directory management page.
+2. Open the synced member account list.
+3. Find an unmatched DingTalk account.
+4. Expand manual creation.
+5. Enter `name` and at least one identifier:
+   - `email`
+   - `username`
+   - `mobile`
+6. Submit `create user and bind`.
+
+Backend behavior:
+
+- calls the same `admit-user` route used by the review queue
+- allows email to be omitted when username or mobile is present
+- creates the local user
+- binds the new local user to the DingTalk external identity
+- returns the onboarding packet and temporary password when applicable
+
+Operational value:
+
+- admins can handle unmatched synced members directly from the account list
+- no separate user-management page is needed for the create-and-bind operation
+- the account list refreshes after success so the local link is visible immediately
+
+### 3. Department-scoped auto-admission during sync
 
 Supported.
 
@@ -95,7 +125,7 @@ Key references:
 - [directory-sync.ts](../packages/core-backend/src/directory/directory-sync.ts)
 - [DirectoryManagementView.vue](../apps/web/src/views/DirectoryManagementView.vue)
 
-### 3. What is created locally
+### 4. What is created locally
 
 When admission succeeds, the system creates or updates all of the following:
 
@@ -186,6 +216,51 @@ Evidence:
 
 - [auth.ts](../packages/core-backend/src/routes/auth.ts)
 - [ForcePasswordChangeView.vue](../apps/web/src/views/ForcePasswordChangeView.vue)
+
+## Troubleshooting
+
+### Sync completed but no local user was created
+
+Check:
+
+- the latest directory sync run record
+- whether the account is still waiting in the review queue
+- whether the account is outside the configured auto-admission department scope
+- whether alerts show a DingTalk permission or payload error
+
+Manual admission from the synced account list is the fallback when the account is valid but outside auto-admission scope.
+
+### The local identifier already exists
+
+Do not create a duplicate user.
+
+Recommended action:
+
+- bind the synced DingTalk account to the existing local user
+- verify the existing user is active
+- then enable the DingTalk grant if protected forms require `dingtalk_granted`
+
+### The synced account cannot be pre-bound
+
+Common cause:
+
+- the DingTalk sync payload does not contain a usable `openId` or `unionId`
+
+Recommended action:
+
+- verify DingTalk app permissions
+- re-run directory sync after permissions are fixed
+- retry manual admission or binding from the account list
+
+### No email invite was sent
+
+This is expected for no-email users.
+
+Use:
+
+- the onboarding packet
+- the generated temporary password
+- the forced password-change flow on first login
 
 ## What is not yet true on current `main`
 

--- a/docs/dingtalk-user-workflow-guide-20260422.md
+++ b/docs/dingtalk-user-workflow-guide-20260422.md
@@ -1,0 +1,172 @@
+# DingTalk User Workflow Guide
+
+- Date: 2026-04-22
+- Audience: table owners, automation authors, support users
+
+## Purpose
+
+This guide explains the operating workflow after DingTalk is configured by an administrator:
+
+- bind one table to one or more DingTalk group robot destinations
+- send DingTalk group or person messages from automation rules
+- include public form links or internal processing links
+- choose form access levels safely
+- understand what end users can and cannot do after clicking a DingTalk message
+
+## Core rule
+
+DingTalk is a sign-in and delivery channel.
+
+The system still authorizes:
+
+- local MetaSheet users
+- local MetaSheet member groups
+
+A DingTalk group message does not grant form-fill permission by itself.
+
+## Table owner workflow
+
+### 1. Bind DingTalk groups to a table
+
+1. Open the target table.
+2. Open `API Tokens / Webhooks / DingTalk Groups`.
+3. Add one destination per DingTalk group robot.
+4. Use `Test send` before using the destination in automation.
+
+Notes:
+
+- one table can bind multiple DingTalk groups
+- a destination belongs to the table where it was created
+- the destination stores the group robot webhook, not the DingTalk group roster
+- binding a group does not import group members
+
+### 2. Create a DingTalk group message automation
+
+1. Open automation management for the table.
+2. Create a rule with action `Send DingTalk group message`.
+3. Select one or more bound DingTalk group destinations.
+4. Write the title and body templates.
+5. Optionally select:
+   - a public form link for new submissions
+   - an internal processing link for local operators
+6. Check the access summary before saving.
+
+Use this for broad broadcast, such as asking a group to fill a form.
+
+### 3. Create a DingTalk person message automation
+
+1. Open automation management for the table.
+2. Create a rule with action `Send DingTalk person message`.
+3. Select local users or local member groups.
+4. Confirm recipient status warnings.
+5. Write the title and body templates.
+6. Optionally select a public form or internal processing link.
+
+Use this for exact handling requests.
+
+Delivery behavior:
+
+- bound and active local users receive the DingTalk person message
+- inactive or unbound local users are skipped
+- skipped recipients appear in person delivery history as `skipped`
+- skipped recipients do not block delivery to other bound recipients
+
+## Form access levels
+
+### Public
+
+Meaning:
+
+- anyone with the link can submit
+
+Use only when:
+
+- the form is intentionally open
+- no DingTalk identity check is required
+
+### DingTalk-bound
+
+Meaning:
+
+- the visitor must sign in through DingTalk
+- the DingTalk identity must be bound to a local user
+
+Use when:
+
+- you need DingTalk identity proof
+- all bound DingTalk local users may submit
+
+### DingTalk-authorized
+
+Meaning:
+
+- the visitor must sign in through DingTalk
+- the DingTalk identity must be bound to a local user
+- the local user must have an enabled DingTalk grant
+
+Use when:
+
+- only administrator-authorized DingTalk users should submit
+
+### Local allowlist
+
+For `DingTalk-bound` or `DingTalk-authorized` forms, table owners can add:
+
+- allowed local users
+- allowed local member groups
+
+If an allowlist exists, the visitor must pass both:
+
+- DingTalk access mode
+- local allowlist check
+
+This is the standard model for:
+
+- send a message to a large DingTalk group
+- allow only selected local users or member groups to fill
+
+## End-user flow
+
+### Opening a public form link
+
+The user clicks the DingTalk message link.
+
+Depending on access mode:
+
+- public forms open directly
+- DingTalk-bound forms require DingTalk sign-in and local binding
+- DingTalk-authorized forms also require an enabled DingTalk grant
+- allowlisted forms require the local user or one of their local member groups to be allowed
+
+### Opening an internal processing link
+
+The user clicks the DingTalk message link.
+
+The user must already have local permission to the table and view.
+
+Message delivery does not grant internal table access.
+
+## Common messages and actions
+
+| What the user sees | Meaning | Action |
+| --- | --- | --- |
+| Sign-in required | The form needs a DingTalk identity check | sign in through DingTalk |
+| DingTalk binding required | DingTalk identity is not bound to a local user | ask an admin to bind or create the local user from directory sync |
+| DingTalk grant required | The form requires administrator-enabled DingTalk access | ask an admin to enable the DingTalk grant |
+| Not in allowlist | The local user is not directly allowed and is not in an allowed member group | ask the table owner to update the form allowlist |
+| Internal link forbidden | The user lacks local table/view permission | ask the table owner to grant local access or use a public form |
+
+## Delivery history checks
+
+Table owners can inspect:
+
+- group delivery history for webhook delivery issues
+- person delivery history for recipient-level status
+
+Person delivery statuses:
+
+- `success`: sent
+- `failed`: send attempted but failed
+- `skipped`: local user was inactive or not bound to DingTalk
+
+Use skipped status to decide whether to bind a synced DingTalk account, enable a user, or remove the user from recipient selection.

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -27,6 +27,31 @@ const requiredPacketFiles = [
     description: 'DingTalk stack merge readiness context',
   },
   {
+    path: 'docs/dingtalk-admin-operations-guide-20260420.md',
+    kind: 'operations-guide',
+    description: 'admin procedures for DingTalk app setup, directory users, group robots, and troubleshooting',
+  },
+  {
+    path: 'docs/dingtalk-user-workflow-guide-20260422.md',
+    kind: 'user-guide',
+    description: 'table-owner workflow for DingTalk group/person notifications and protected form links',
+  },
+  {
+    path: 'docs/dingtalk-synced-account-local-user-guide-20260420.md',
+    kind: 'user-governance-guide',
+    description: 'manual and auto-admission paths for DingTalk-synced accounts, including no-email users',
+  },
+  {
+    path: 'docs/dingtalk-remote-smoke-checklist-20260422.md',
+    kind: 'checklist',
+    description: 'P4 remote smoke checklist for protected forms, multi-group sends, and DingTalk-bound users',
+  },
+  {
+    path: 'docs/development/dingtalk-feature-plan-and-todo-20260422.md',
+    kind: 'plan',
+    description: 'current DingTalk feature plan, TODO status, and remaining remote smoke tasks',
+  },
+  {
     path: 'docker/app.staging.env.example',
     kind: 'config-template',
     description: 'canonical staging env template; copy to docker/app.staging.env and fill secrets',
@@ -183,7 +208,8 @@ ${evidenceLines}
 3. Validate the env with \`bash scripts/ops/validate-env-file.sh docker/app.staging.env\`.
 4. Deploy a pinned tag with \`DEPLOY_IMAGE_TAG=<tag> bash scripts/ops/deploy-dingtalk-staging.sh\`.
 5. Execute \`docs/development/dingtalk-staging-execution-checklist-20260408.md\`.
-6. Re-export this packet with \`--include-output <evidence-dir>\` after smoke evidence exists.
+6. Execute \`docs/dingtalk-remote-smoke-checklist-20260422.md\` for P4 DingTalk form/group/person coverage.
+7. Re-export this packet with \`--include-output <evidence-dir>\` after smoke evidence exists.
 
 ## Non-Goals
 

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -31,6 +31,11 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       ),
       true,
     )
+    assert.equal(existsSync(path.join(outputDir, 'docs/dingtalk-user-workflow-guide-20260422.md')), true)
+    assert.equal(
+      existsSync(path.join(outputDir, 'docs/dingtalk-remote-smoke-checklist-20260422.md')),
+      true,
+    )
     assert.equal(existsSync(path.join(outputDir, 'scripts/ops/deploy-dingtalk-staging.sh')), true)
     assert.equal(existsSync(path.join(outputDir, 'docker/app.staging.env.example')), true)
 
@@ -41,9 +46,14 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       manifest.files.some((file) => file.path === 'scripts/ops/validate-env-file.sh'),
       true,
     )
+    assert.equal(
+      manifest.files.some((file) => file.path === 'docs/dingtalk-remote-smoke-checklist-20260422.md'),
+      true,
+    )
 
     const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
     assert.match(readme, /DingTalk Staging Evidence Packet/)
+    assert.match(readme, /docs\/dingtalk-remote-smoke-checklist-20260422\.md/)
     assert.match(readme, /No runtime evidence directory was included/)
     assert.match(readme, /Does not store secrets/)
   } finally {


### PR DESCRIPTION
## Summary
- add DingTalk admin/user docs for directory admission, no-email users, protected form links, and delivery status troubleshooting
- add the P4 remote smoke checklist covering multi-group send, `dingtalk_granted`, authorized/unauthorized submit, person delivery skipped states, and no-email account creation
- include the new DingTalk docs/checklist/TODO in the staging evidence packet exporter and cover it with the existing Node test

## Verification
- `rg -n "A0. Configure DingTalk directory accounts|Person delivery status meanings|Troubleshooting matrix|Manual admission from the synced account list|DingTalk User Workflow Guide|DingTalk Remote Smoke Checklist|Remote smoke checklist|DingTalk Admin Operations Guide|export-dingtalk-staging-evidence-packet" docs/dingtalk-admin-operations-guide-20260420.md docs/dingtalk-capability-guide-20260420.md docs/dingtalk-synced-account-local-user-guide-20260420.md docs/dingtalk-user-workflow-guide-20260422.md docs/dingtalk-remote-smoke-checklist-20260422.md docs/development/dingtalk-feature-plan-and-todo-20260422.md scripts/ops/export-dingtalk-staging-evidence-packet.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-person-delivery-service.test.ts tests/unit/directory-sync-bind-account.test.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-form-share-manager.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `git diff --cached --check`

## Notes
- actual remote smoke execution remains pending and is intentionally left unchecked in the TODO
- unrelated dirty `node_modules` files in the local worktree were not staged