### PR TITLE
test(dingtalk): add P4 smoke evidence compiler

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -28,25 +28,25 @@
 
 ## P1: DingTalk Group Standard Workflow
 
-- [ ] Backend: verify table-scoped DingTalk group destinations support multiple groups per table.
-- [ ] Backend: verify create, update, delete, list, test-send, and delivery history routes enforce automation/write permissions.
-- [ ] Backend: verify webhook URLs and robot secrets are redacted in responses, logs, and delivery diagnostics.
-- [ ] Frontend: expose DingTalk group binding in the table integration or existing API token manager surface.
-- [ ] Frontend: let users add, edit, delete, and test-send DingTalk group robot destinations.
-- [ ] Frontend: show that group binding does not import DingTalk group members and does not grant form fill permission by itself.
-- [ ] Automation UI: let users choose a bound DingTalk group for `send_dingtalk_group_message`.
-- [ ] Automation UI: let users include public form and internal processing links in group messages.
-- [ ] Runtime: confirm a group message link opens the form and permission checks still gate access.
+- [x] Backend: verify table-scoped DingTalk group destinations support multiple groups per table.
+- [x] Backend: verify create, update, delete, list, test-send, and delivery history routes enforce automation/write permissions.
+- [x] Backend: verify webhook URLs and robot secrets are redacted in responses, logs, and delivery diagnostics.
+- [x] Frontend: expose DingTalk group binding in the table integration or existing API token manager surface.
+- [x] Frontend: let users add, edit, delete, and test-send DingTalk group robot destinations.
+- [x] Frontend: show that group binding does not import DingTalk group members and does not grant form fill permission by itself.
+- [x] Automation UI: let users choose a bound DingTalk group for `send_dingtalk_group_message`.
+- [x] Automation UI: let users include public form and internal processing links in group messages.
+- [x] Runtime: confirm a group message link opens the form and permission checks still gate access.
 
 ## P2: Form Access And Assigned Fillers
 
-- [ ] Form share UI: support `public`, `dingtalk`, and `dingtalk_granted` access modes.
-- [ ] Form share UI: allow table owners to choose allowed local users and member groups for DingTalk-protected modes.
-- [ ] Form share UI: explain that only selected local users/member groups can fill when allowlists are configured.
-- [ ] Backend: keep `dingtalk_granted` submit guard before record insert.
-- [ ] Backend: reject inactive allowed users and invalid member groups when saving form access settings.
-- [ ] Automation UI: display the selected form access level before saving a DingTalk action.
-- [ ] Runtime copy: show clear errors for auth required, DingTalk binding required, grant required, and not in allowlist.
+- [x] Form share UI: support `public`, `dingtalk`, and `dingtalk_granted` access modes.
+- [x] Form share UI: allow table owners to choose allowed local users and member groups for DingTalk-protected modes.
+- [x] Form share UI: explain that only selected local users/member groups can fill when allowlists are configured.
+- [x] Backend: keep `dingtalk_granted` submit guard before record insert.
+- [x] Backend: reject inactive allowed users and invalid member groups when saving form access settings.
+- [x] Automation UI: display the selected form access level before saving a DingTalk action.
+- [x] Runtime copy: show clear errors for auth required, DingTalk binding required, grant required, and not in allowlist.
 
 ## P3: DingTalk Person Messaging And User Sync
 
@@ -65,6 +65,7 @@
 - [x] Add an administrator guide for DingTalk app credentials, group robot binding, directory sync, and no-email user creation.
 - [x] Add a user guide for table group binding, automation messages, public form links, and form access levels.
 - [x] Add troubleshooting notes for webhook signature failures, unbound users, missing grants, no-email users, and links that cannot be opened.
+- [x] Add a P4 remote-smoke evidence compiler that validates required checks and writes redacted `summary.json` / `summary.md` artifacts.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-smoke-evidence-runner-development-20260422.md
+++ b/docs/development/dingtalk-p4-smoke-evidence-runner-development-20260422.md
@@ -1,0 +1,28 @@
+# DingTalk P4 Smoke Evidence Runner Development - 2026-04-22
+
+## Goal
+
+Continue the DingTalk plan after the P4 documentation/runbook slice by making remote smoke results machine-checkable without pretending that remote execution has already happened.
+
+## Changes
+
+- Added `scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`.
+  - Writes an editable evidence template with all required P4 checks.
+  - Compiles operator-filled evidence into `summary.json`, `summary.md`, and `evidence.redacted.json`.
+  - Supports `--strict` so missing, pending, skipped, or failed required checks return non-zero.
+  - Redacts DingTalk robot `access_token`, `SEC...` secrets, bearer/JWT tokens, passwords, and public form tokens.
+- Added `scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`.
+- Updated `docs/dingtalk-remote-smoke-checklist-20260422.md` with the evidence compiler workflow.
+- Updated `scripts/ops/export-dingtalk-staging-evidence-packet.mjs` so the staging handoff packet includes the evidence compiler.
+- Added an explicit backend integration test proving form-share save rejects unknown allowed member groups.
+- Updated `docs/development/dingtalk-feature-plan-and-todo-20260422.md` to reflect completed P1/P2 implementation coverage and the new P4 evidence compiler, while keeping actual remote smoke execution unchecked.
+
+## Non-Goals
+
+- No real DingTalk webhook or work-notification call was executed in this slice.
+- No remote authorized/unauthorized user session was simulated.
+- No admin token or DingTalk secret was generated or recorded.
+
+## Expected Effect
+
+When the remote smoke is executed, operators can now produce a standardized, redacted evidence directory and use `--strict` to fail the run unless every required P4 check is marked `pass`.

--- a/docs/development/dingtalk-p4-smoke-evidence-runner-verification-20260422.md
+++ b/docs/development/dingtalk-p4-smoke-evidence-runner-verification-20260422.md
@@ -1,0 +1,55 @@
+# DingTalk P4 Smoke Evidence Runner Verification - 2026-04-22
+
+## Branch
+
+- `codex/dingtalk-p4-smoke-evidence-runner-20260422`
+- Base branch: `codex/dingtalk-docs-smoke-runbook-20260422`
+
+## Verification Commands
+
+```bash
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+```
+
+Result: passed.
+
+```bash
+node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+```
+
+Result: passed. 4 tests passed.
+
+```bash
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result: passed. 4 tests passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false
+```
+
+Result: passed. 1 file passed, 19 tests passed.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-form-share-manager.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed. 3 files passed, 110 tests passed.
+
+```bash
+rg -n "compile-dingtalk-p4-smoke-evidence|P4 remote-smoke evidence compiler|Unknown allowed member groups|Remote smoke: create a table and form view" docs/dingtalk-remote-smoke-checklist-20260422.md docs/development/dingtalk-feature-plan-and-todo-20260422.md docs/development/dingtalk-p4-smoke-evidence-runner-development-20260422.md scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs scripts/ops/export-dingtalk-staging-evidence-packet.mjs packages/core-backend/tests/integration/public-form-flow.test.ts
+```
+
+Result: passed.
+
+```bash
+git diff --check -- scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs docs/dingtalk-remote-smoke-checklist-20260422.md docs/development/dingtalk-feature-plan-and-todo-20260422.md docs/development/dingtalk-p4-smoke-evidence-runner-development-20260422.md docs/development/dingtalk-p4-smoke-evidence-runner-verification-20260422.md packages/core-backend/tests/integration/public-form-flow.test.ts
+```
+
+Result: passed.
+
+## Notes
+
+- Actual P4 remote smoke execution remains pending and is intentionally left unchecked in the TODO.
+- The repository still has unrelated dirty `node_modules` files under plugins/tools. They are not part of this slice.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -50,6 +50,34 @@ Do not capture or paste:
 - temporary passwords
 - admin tokens
 
+## Evidence compiler
+
+Use the evidence compiler after the manual smoke is executed. It does not call DingTalk or staging; it validates the operator-provided result file, redacts secrets, and writes a reusable evidence summary.
+
+Create a template:
+
+```bash
+node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \
+  --init-template output/dingtalk-p4-remote-smoke/evidence.json
+```
+
+After filling the template with results, compile it:
+
+```bash
+node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \
+  --input output/dingtalk-p4-remote-smoke/evidence.json \
+  --output-dir output/dingtalk-p4-remote-smoke/20260422 \
+  --strict
+```
+
+Expected generated files:
+
+- `summary.json`
+- `summary.md`
+- `evidence.redacted.json`
+
+The compiler requires every smoke check in this document to be `pass` when `--strict` is used. It redacts DingTalk webhook `access_token`, `SEC...` secrets, bearer/JWT tokens, passwords, and public form tokens before writing artifacts.
+
 ## Smoke 1: Create table and public form
 
 Steps:

--- a/packages/core-backend/tests/integration/public-form-flow.test.ts
+++ b/packages/core-backend/tests/integration/public-form-flow.test.ts
@@ -553,6 +553,50 @@ describe('Public form flow', () => {
     })
   })
 
+  test('form share config rejects unknown allowed member groups', async () => {
+    const storedConfig = {
+      publicForm: {
+        enabled: true,
+        publicToken: VALID_TOKEN,
+        accessMode: 'dingtalk',
+      },
+    }
+    const { app } = await createApp({
+      user: { id: 'admin_1', perms: ['multitable:write'] },
+      queryHandler: async (sql) => {
+        if (sql.includes('SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1')) {
+          return {
+            rows: [{
+              id: TEST_VIEW_ID,
+              sheet_id: TEST_SHEET_ID,
+              name: 'Public Form View',
+              type: 'form',
+              filter_info: {},
+              sort_info: {},
+              group_info: {},
+              hidden_field_ids: [],
+              config: storedConfig,
+            }],
+          }
+        }
+        if (sql.includes('SELECT id::text AS id FROM platform_member_groups WHERE id::text = ANY')) {
+          return { rows: [] }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const patchResponse = await request(app)
+      .patch(`/api/multitable/sheets/${TEST_SHEET_ID}/views/${TEST_VIEW_ID}/form-share`)
+      .send({ allowedMemberGroupIds: ['group_missing'] })
+      .expect(400)
+
+    expect(patchResponse.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'Unknown allowed member groups: group_missing',
+    })
+  })
+
   test('rate limit exceeded -> 429 with Retry-After header', async () => {
     const { app } = await createApp({
       queryHandler: buildQueryHandler(VALID_TOKEN),

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-remote-smoke'
+
+const REQUIRED_CHECKS = [
+  {
+    id: 'create-table-form',
+    label: 'Create a table and form view',
+    todo: 'Remote smoke: create a table and form view',
+  },
+  {
+    id: 'bind-two-dingtalk-groups',
+    label: 'Bind at least two DingTalk groups',
+    todo: 'Remote smoke: bind at least two DingTalk groups to the table',
+  },
+  {
+    id: 'set-form-dingtalk-granted',
+    label: 'Set the form to dingtalk_granted',
+    todo: 'Remote smoke: set the form to `dingtalk_granted`',
+  },
+  {
+    id: 'send-group-message-form-link',
+    label: 'Send a DingTalk group message with a form link',
+    todo: 'Remote smoke: send a group message with a form link',
+  },
+  {
+    id: 'authorized-user-submit',
+    label: 'Verify an authorized user can open and submit',
+    todo: 'Remote smoke: verify an authorized user can open and submit',
+  },
+  {
+    id: 'unauthorized-user-denied',
+    label: 'Verify an unauthorized user cannot submit and no record is inserted',
+    todo: 'Remote smoke: verify an unauthorized user cannot submit and no record is inserted',
+  },
+  {
+    id: 'delivery-history-group-person',
+    label: 'Verify group and person delivery history',
+    todo: 'Remote smoke: verify delivery history records group and person sends',
+  },
+  {
+    id: 'no-email-user-create-bind',
+    label: 'Create and bind a no-email DingTalk-synced local user',
+    todo: 'Checklist: no-email account creation and binding',
+  },
+]
+
+const CHECK_ID_SET = new Set(REQUIRED_CHECKS.map((check) => check.id))
+const VALID_STATUSES = new Set(['pass', 'fail', 'skipped', 'pending'])
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs [options]
+
+Compiles a manually executed DingTalk P4 remote-smoke evidence JSON file into
+redacted summary artifacts. It does not call DingTalk or staging.
+
+Options:
+  --input <file>           Evidence JSON to compile
+  --output-dir <dir>       Output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
+  --init-template <file>   Write an editable evidence template and exit
+  --strict                 Exit non-zero unless all required checks pass
+  --help                   Show this help
+
+Examples:
+  node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \\
+    --init-template output/dingtalk-p4-remote-smoke/evidence.json
+
+  node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \\
+    --input output/dingtalk-p4-remote-smoke/evidence.json \\
+    --output-dir output/dingtalk-p4-remote-smoke/20260422 \\
+    --strict
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function parseArgs(argv) {
+  const opts = {
+    input: null,
+    outputDir: null,
+    initTemplate: null,
+    strict: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--input':
+        opts.input = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--init-template':
+        opts.initTemplate = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--strict':
+        opts.strict = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (opts.initTemplate && opts.input) {
+    throw new Error('--init-template cannot be combined with --input')
+  }
+
+  return opts
+}
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function makeRunId() {
+  return `dingtalk-p4-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}`
+}
+
+function makeTemplate() {
+  return {
+    runId: makeRunId(),
+    executedAt: null,
+    environment: {
+      apiBase: '',
+      webBase: '',
+      branch: '',
+      commit: '',
+      operator: '',
+    },
+    notes: 'Fill this file after executing docs/dingtalk-remote-smoke-checklist-20260422.md. Do not paste DingTalk webhook tokens, SEC secrets, bearer tokens, passwords, or admin tokens.',
+    checks: REQUIRED_CHECKS.map((check) => ({
+      id: check.id,
+      label: check.label,
+      status: 'pending',
+      evidence: {
+        notes: '',
+      },
+    })),
+    artifacts: [],
+  }
+}
+
+function writeTemplate(file) {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(makeTemplate(), null, 2)}\n`, 'utf8')
+  console.log(`Wrote ${path.relative(process.cwd(), file)}`)
+}
+
+function parseEvidence(file) {
+  if (!existsSync(file)) {
+    throw new Error(`input evidence file does not exist: ${file}`)
+  }
+
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch (error) {
+    throw new Error(`failed to parse evidence JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function sanitizeName(value) {
+  const raw = typeof value === 'string' && value.trim() ? value.trim() : makeRunId()
+  return raw.replace(/[^A-Za-z0-9._-]/g, '-').replace(/^-+|-+$/g, '') || makeRunId()
+}
+
+function shouldFullyRedactKey(key) {
+  const normalized = String(key).toLowerCase().replace(/[^a-z0-9]/g, '')
+  if (!normalized) return false
+  if (normalized.includes('webhookurl') || normalized === 'url' || normalized.endsWith('link')) return false
+  return normalized.includes('secret')
+    || normalized.includes('password')
+    || normalized.includes('authorization')
+    || normalized.includes('bearer')
+    || normalized.includes('jwt')
+    || normalized.endsWith('token')
+    || normalized.includes('accesstoken')
+    || normalized.includes('refreshtoken')
+}
+
+function redactString(value) {
+  return value
+    .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function sanitizeValue(value, key = '') {
+  if (value === null || value === undefined) return value
+  if (typeof value === 'string') {
+    if (key && shouldFullyRedactKey(key)) return '<redacted>'
+    return redactString(value)
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.map((item) => sanitizeValue(item))
+  if (typeof value === 'object') {
+    const next = {}
+    for (const [entryKey, entryValue] of Object.entries(value)) {
+      next[entryKey] = sanitizeValue(entryValue, entryKey)
+    }
+    return next
+  }
+  return value
+}
+
+function normalizeStatus(value) {
+  const status = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  return VALID_STATUSES.has(status) ? status : 'pending'
+}
+
+function normalizeChecks(evidence) {
+  if (!Array.isArray(evidence?.checks)) {
+    throw new Error('evidence.checks must be an array')
+  }
+
+  const seen = new Set()
+  const duplicates = []
+  const checks = evidence.checks.map((check, index) => {
+    if (!check || typeof check !== 'object' || Array.isArray(check)) {
+      throw new Error(`evidence.checks[${index}] must be an object`)
+    }
+    const id = typeof check.id === 'string' ? check.id.trim() : ''
+    if (!id) throw new Error(`evidence.checks[${index}].id is required`)
+    if (seen.has(id)) duplicates.push(id)
+    seen.add(id)
+    return {
+      ...check,
+      id,
+      status: normalizeStatus(check.status),
+      required: CHECK_ID_SET.has(id),
+    }
+  })
+
+  if (duplicates.length > 0) {
+    throw new Error(`duplicate check ids: ${Array.from(new Set(duplicates)).join(', ')}`)
+  }
+
+  return checks
+}
+
+function buildSummary(evidence, inputFile, outputDir) {
+  const checks = normalizeChecks(evidence)
+  const byId = new Map(checks.map((check) => [check.id, check]))
+  const requiredRows = REQUIRED_CHECKS.map((required) => {
+    const check = byId.get(required.id)
+    const status = check ? normalizeStatus(check.status) : 'missing'
+    return {
+      ...required,
+      status,
+      evidence: check?.evidence ?? null,
+      notes: check?.notes ?? null,
+    }
+  })
+  const missingRequiredChecks = requiredRows.filter((check) => check.status === 'missing').map((check) => check.id)
+  const requiredChecksNotPassed = requiredRows
+    .filter((check) => check.status !== 'pass')
+    .map((check) => ({ id: check.id, status: check.status }))
+  const failedChecks = checks.filter((check) => check.status === 'fail').map((check) => check.id)
+  const unknownChecks = checks.filter((check) => !CHECK_ID_SET.has(check.id)).map((check) => check.id)
+  const overallStatus = requiredChecksNotPassed.length === 0 && failedChecks.length === 0 ? 'pass' : 'fail'
+  const sanitizedEvidence = sanitizeValue(evidence)
+
+  return {
+    tool: 'compile-dingtalk-p4-smoke-evidence',
+    generatedAt: nowIso(),
+    source: path.relative(process.cwd(), inputFile).replaceAll('\\', '/'),
+    outputDir: path.relative(process.cwd(), outputDir).replaceAll('\\', '/'),
+    overallStatus,
+    totals: {
+      totalChecks: checks.length,
+      requiredChecks: REQUIRED_CHECKS.length,
+      passedChecks: checks.filter((check) => check.status === 'pass').length,
+      failedChecks: checks.filter((check) => check.status === 'fail').length,
+      skippedChecks: checks.filter((check) => check.status === 'skipped').length,
+      pendingChecks: checks.filter((check) => check.status === 'pending').length,
+      missingRequiredChecks: missingRequiredChecks.length,
+      unknownChecks: unknownChecks.length,
+    },
+    requiredChecks: sanitizeValue(requiredRows),
+    missingRequiredChecks,
+    requiredChecksNotPassed,
+    failedChecks,
+    unknownChecks,
+    sanitizedEvidence,
+  }
+}
+
+function markdownEscape(value) {
+  return String(value ?? '')
+    .replaceAll('|', '\\|')
+    .replaceAll('\n', '<br>')
+}
+
+function compactEvidence(value) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return redactString(value)
+  if (typeof value === 'object') {
+    const preferred = value.summary ?? value.notes ?? value.path ?? value.url
+    if (typeof preferred === 'string') return redactString(preferred)
+    const json = JSON.stringify(sanitizeValue(value))
+    return json.length > 180 ? `${json.slice(0, 177)}...` : json
+  }
+  return String(value)
+}
+
+function renderMarkdown(summary) {
+  const requiredLines = summary.requiredChecks.map((check) => {
+    const evidence = compactEvidence(check.evidence ?? check.notes)
+    return `| \`${markdownEscape(check.id)}\` | ${markdownEscape(check.label)} | ${markdownEscape(check.status)} | ${markdownEscape(evidence)} |`
+  })
+  const unknownLines = summary.unknownChecks.length
+    ? summary.unknownChecks.map((id) => `- \`${id}\``).join('\n')
+    : '- None'
+  const failures = summary.requiredChecksNotPassed.length
+    ? summary.requiredChecksNotPassed.map((check) => `- \`${check.id}\`: ${check.status}`).join('\n')
+    : '- None'
+
+  return `# DingTalk P4 Remote Smoke Evidence Summary
+
+Generated at: ${summary.generatedAt}
+
+Source: \`${summary.source}\`
+
+Overall status: **${summary.overallStatus}**
+
+## Required Checks
+
+| ID | Required Check | Status | Evidence |
+| --- | --- | --- | --- |
+${requiredLines.join('\n')}
+
+## Required Checks Not Passed
+
+${failures}
+
+## Unknown Optional Checks
+
+${unknownLines}
+
+## Notes
+
+- This summary is generated from operator-provided evidence after executing \`docs/dingtalk-remote-smoke-checklist-20260422.md\`.
+- DingTalk webhook access tokens, SEC secrets, bearer tokens, JWTs, passwords, and public form tokens are redacted before writing artifacts.
+- A \`pass\` summary means the evidence file declares all required checks passed; it does not independently call DingTalk or staging.
+`
+}
+
+function compileEvidence(opts) {
+  if (!opts.input) {
+    throw new Error('--input is required unless --init-template is used')
+  }
+
+  const evidence = parseEvidence(opts.input)
+  const runId = sanitizeName(evidence?.runId)
+  const outputDir = opts.outputDir ?? path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, runId)
+  mkdirSync(outputDir, { recursive: true })
+
+  const summary = buildSummary(evidence, opts.input, outputDir)
+  const summaryJsonPath = path.join(outputDir, 'summary.json')
+  const summaryMdPath = path.join(outputDir, 'summary.md')
+  const redactedEvidencePath = path.join(outputDir, 'evidence.redacted.json')
+
+  writeFileSync(redactedEvidencePath, `${JSON.stringify(summary.sanitizedEvidence, null, 2)}\n`, 'utf8')
+  writeFileSync(summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+  writeFileSync(summaryMdPath, renderMarkdown(summary), 'utf8')
+
+  console.log(`Wrote ${path.relative(process.cwd(), redactedEvidencePath)}`)
+  console.log(`Wrote ${path.relative(process.cwd(), summaryJsonPath)}`)
+  console.log(`Wrote ${path.relative(process.cwd(), summaryMdPath)}`)
+
+  if (opts.strict && summary.overallStatus !== 'pass') {
+    throw new Error(`DingTalk P4 smoke evidence did not pass: ${summary.requiredChecksNotPassed.map((check) => `${check.id}:${check.status}`).join(', ')}`)
+  }
+
+  return summary
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2))
+  if (opts.initTemplate) {
+    writeTemplate(opts.initTemplate)
+  } else {
+    compileEvidence(opts)
+  }
+} catch (error) {
+  console.error(`[compile-dingtalk-p4-smoke-evidence] ERROR: ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(1)
+}

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'compile-dingtalk-p4-smoke-evidence.mjs')
+
+const requiredIds = [
+  'create-table-form',
+  'bind-two-dingtalk-groups',
+  'set-form-dingtalk-granted',
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'delivery-history-group-person',
+  'no-email-user-create-bind',
+]
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-smoke-evidence-'))
+}
+
+function writeEvidence(file, overrides = {}) {
+  const evidence = {
+    runId: 'remote-20260422',
+    executedAt: '2026-04-22T15:00:00.000Z',
+    environment: {
+      apiBase: 'http://142.171.239.56:8900',
+      webBase: 'http://142.171.239.56:8081',
+      branch: 'codex/dingtalk-docs-smoke-runbook-20260422',
+      commit: '83eed2a50',
+      operator: 'qa',
+    },
+    checks: requiredIds.map((id) => ({
+      id,
+      status: 'pass',
+      evidence: {
+        notes: `${id} ok`,
+      },
+    })),
+    artifacts: [],
+    ...overrides,
+  }
+  writeFileSync(file, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8')
+  return evidence
+}
+
+test('compile-dingtalk-p4-smoke-evidence writes an editable template', () => {
+  const tmpDir = makeTmpDir()
+  const templatePath = path.join(tmpDir, 'evidence.json')
+
+  try {
+    const result = spawnSync(process.execPath, [scriptPath, '--init-template', templatePath], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    const template = JSON.parse(readFileSync(templatePath, 'utf8'))
+    assert.equal(template.checks.length, requiredIds.length)
+    assert.deepEqual(template.checks.map((check) => check.id), requiredIds)
+    assert.equal(template.checks.every((check) => check.status === 'pending'), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence compiles passing evidence and redacts secrets', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+
+  try {
+    writeEvidence(evidencePath, {
+      checks: requiredIds.map((id) => ({
+        id,
+        status: 'pass',
+        evidence: {
+          notes: `${id} used https://oapi.dingtalk.com/robot/send?access_token=robot-secret and SECabcdefgh12345678`,
+          publicUrl: 'http://example.test/form?publicToken=pub_secret',
+          authorization: 'Bearer abc.def.ghi',
+          token: 'raw-token',
+        },
+      })),
+    })
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(existsSync(path.join(outputDir, 'summary.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'summary.md')), true)
+    assert.equal(existsSync(path.join(outputDir, 'evidence.redacted.json')), true)
+
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'pass')
+    assert.equal(summary.requiredChecksNotPassed.length, 0)
+
+    const redacted = readFileSync(path.join(outputDir, 'evidence.redacted.json'), 'utf8')
+    assert.doesNotMatch(redacted, /robot-secret/)
+    assert.doesNotMatch(redacted, /SECabcdefgh12345678/)
+    assert.doesNotMatch(redacted, /pub_secret/)
+    assert.doesNotMatch(redacted, /raw-token/)
+    assert.match(redacted, /access_token=<redacted>/)
+    assert.match(redacted, /SEC<redacted>/)
+    assert.match(redacted, /publicToken=<redacted>/)
+    assert.match(redacted, /"<redacted>"/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence strict mode fails when required checks are not passed', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+
+  try {
+    writeEvidence(evidencePath, {
+      checks: [
+        ...requiredIds.slice(0, -1).map((id) => ({ id, status: 'pass', evidence: { notes: `${id} ok` } })),
+        { id: requiredIds.at(-1), status: 'fail', evidence: { notes: 'no-email path failed' } },
+      ],
+    })
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /no-email-user-create-bind:fail/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'fail')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence rejects duplicate check ids', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+
+  try {
+    writeEvidence(evidencePath, {
+      checks: [
+        { id: 'create-table-form', status: 'pass' },
+        { id: 'create-table-form', status: 'pass' },
+      ],
+    })
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /duplicate check ids: create-table-form/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -76,6 +76,11 @@ const requiredPacketFiles = [
     kind: 'script',
     description: 'validates env, resolves image tag, runs docker compose, and checks backend health',
   },
+  {
+    path: 'scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs',
+    kind: 'script',
+    description: 'compiles redacted P4 remote-smoke evidence summaries from operator-provided results',
+  },
 ]
 
 function printHelp() {
@@ -209,7 +214,8 @@ ${evidenceLines}
 4. Deploy a pinned tag with \`DEPLOY_IMAGE_TAG=<tag> bash scripts/ops/deploy-dingtalk-staging.sh\`.
 5. Execute \`docs/development/dingtalk-staging-execution-checklist-20260408.md\`.
 6. Execute \`docs/dingtalk-remote-smoke-checklist-20260422.md\` for P4 DingTalk form/group/person coverage.
-7. Re-export this packet with \`--include-output <evidence-dir>\` after smoke evidence exists.
+7. Compile smoke evidence with \`node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input <evidence.json> --output-dir <evidence-dir> --strict\`.
+8. Re-export this packet with \`--include-output <evidence-dir>\` after smoke evidence exists.
 
 ## Non-Goals
 

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -36,6 +36,10 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       existsSync(path.join(outputDir, 'docs/dingtalk-remote-smoke-checklist-20260422.md')),
       true,
     )
+    assert.equal(
+      existsSync(path.join(outputDir, 'scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs')),
+      true,
+    )
     assert.equal(existsSync(path.join(outputDir, 'scripts/ops/deploy-dingtalk-staging.sh')), true)
     assert.equal(existsSync(path.join(outputDir, 'docker/app.staging.env.example')), true)
 
@@ -50,10 +54,15 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       manifest.files.some((file) => file.path === 'docs/dingtalk-remote-smoke-checklist-20260422.md'),
       true,
     )
+    assert.equal(
+      manifest.files.some((file) => file.path === 'scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs'),
+      true,
+    )
 
     const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
     assert.match(readme, /DingTalk Staging Evidence Packet/)
     assert.match(readme, /docs\/dingtalk-remote-smoke-checklist-20260422\.md/)
+    assert.match(readme, /compile-dingtalk-p4-smoke-evidence\.mjs/)
     assert.match(readme, /No runtime evidence directory was included/)
     assert.match(readme, /Does not store secrets/)
   } finally {


### PR DESCRIPTION
## Summary
- add `compile-dingtalk-p4-smoke-evidence.mjs` to create templates and compile operator-filled P4 remote-smoke evidence into redacted `summary.json`, `summary.md`, and `evidence.redacted.json`
- include the compiler in the DingTalk staging evidence packet and document the workflow in the remote smoke checklist
- add explicit backend coverage for rejecting unknown form-share allowed member groups
- update the DingTalk plan/TODO to mark already-covered P1/P2 work complete while keeping actual remote smoke execution unchecked

## Verification
- `node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`
- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-form-share-manager.spec.ts tests/multitable-automation-manager.spec.ts --watch=false`
- `rg -n "compile-dingtalk-p4-smoke-evidence|P4 remote-smoke evidence compiler|Unknown allowed member groups|Remote smoke: create a table and form view" docs/dingtalk-remote-smoke-checklist-20260422.md docs/development/dingtalk-feature-plan-and-todo-20260422.md docs/development/dingtalk-p4-smoke-evidence-runner-development-20260422.md scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs scripts/ops/export-dingtalk-staging-evidence-packet.mjs packages/core-backend/tests/integration/public-form-flow.test.ts`
- `git diff --cached --check`

## Notes
- this PR does not execute real remote DingTalk smoke; it standardizes required evidence and strict pass/fail validation for that execution
- unrelated dirty local `node_modules` files were not staged