### PR TITLE
test(dingtalk): add P4 API smoke runner

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -66,6 +66,7 @@
 - [x] Add a user guide for table group binding, automation messages, public form links, and form access levels.
 - [x] Add troubleshooting notes for webhook signature failures, unbound users, missing grants, no-email users, and links that cannot be opened.
 - [x] Add a P4 remote-smoke evidence compiler that validates required checks and writes redacted `summary.json` / `summary.md` artifacts.
+- [x] Add a P4 API-only remote-smoke runner for table/form creation, group binding, `dingtalk_granted` setup, automation test-run, and delivery evidence bootstrap.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-1078-rebase-repair-development-20260423.md
+++ b/docs/development/dingtalk-p4-1078-rebase-repair-development-20260423.md
@@ -1,0 +1,47 @@
+# DingTalk P4 #1078 Rebase Repair Development - 2026-04-23
+
+## Context
+
+The DingTalk P4 substack readiness report identified `#1078` as the first dirty node:
+
+- `#1076` was repaired and now passes against `codex/dingtalk-person-delivery-skip-reasons-20260422`.
+- `#1078` targets `codex/dingtalk-p4-smoke-evidence-runner-20260422` but was still based on the pre-repair parent state.
+- GitHub reported `mergeStateStatus = DIRTY` for `#1078`.
+
+## Repair
+
+Rebased `codex/dingtalk-p4-api-smoke-runner-20260422` onto the updated parent:
+
+```bash
+git rebase origin/codex/dingtalk-p4-smoke-evidence-runner-20260422
+```
+
+Result:
+
+- skipped already-applied `docs(dingtalk): add P4 smoke runbook`
+- skipped already-applied `test(dingtalk): add P4 smoke evidence compiler`
+- replayed only `test(dingtalk): add P4 API smoke runner`
+- no manual conflicts
+
+The rebased PR diff is now limited to the API smoke runner slice plus this repair documentation.
+
+## Files In Scope
+
+Functional slice already present in `#1078`:
+
+- `scripts/ops/dingtalk-p4-remote-smoke.mjs`
+- `scripts/ops/dingtalk-p4-remote-smoke.test.mjs`
+- related evidence compiler/export packet updates
+- DingTalk P4 remote-smoke docs
+
+Repair docs added in this update:
+
+- `docs/development/dingtalk-p4-1078-rebase-repair-development-20260423.md`
+- `docs/development/dingtalk-p4-1078-rebase-repair-verification-20260423.md`
+- `output/delivery/dingtalk-p4-1078-rebase-repair-20260423/TEST_AND_VERIFICATION.md`
+
+## Non-Goals
+
+- Does not merge the DingTalk P4 stack.
+- Does not rebase downstream PRs `#1082` and later.
+- Does not run real DingTalk webhook delivery; this remains an operator/staging smoke step.

--- a/docs/development/dingtalk-p4-1078-rebase-repair-verification-20260423.md
+++ b/docs/development/dingtalk-p4-1078-rebase-repair-verification-20260423.md
@@ -1,0 +1,64 @@
+# DingTalk P4 #1078 Rebase Repair Verification - 2026-04-23
+
+## Local Targeted Tests
+
+```bash
+node --test \
+  scripts/ops/dingtalk-p4-remote-smoke.test.mjs \
+  scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs \
+  scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result:
+
+```text
+tests 12
+pass 12
+fail 0
+```
+
+## Diff Check
+
+```bash
+git diff --check origin/codex/dingtalk-p4-smoke-evidence-runner-20260422...HEAD
+```
+
+Result:
+
+```text
+EXIT 0
+```
+
+## Rebase Shape
+
+```bash
+git log --oneline origin/codex/dingtalk-p4-smoke-evidence-runner-20260422..HEAD
+```
+
+Result before adding these repair docs:
+
+```text
+458aa8294 test(dingtalk): add P4 API smoke runner
+```
+
+This confirms the earlier stack layers are no longer duplicated in `#1078` after rebase.
+
+## Expected Remote Check After Push
+
+After force-with-lease pushing the repaired branch:
+
+```bash
+node scripts/ops/check-pr-stack-readiness.mjs \
+  --root-base codex/dingtalk-person-delivery-skip-reasons-20260422 \
+  1076 1078
+```
+
+Expected result:
+
+```text
+PR stack readiness: PASS
+```
+
+## Residual Risk
+
+Updating `#1078` changes the base branch for `#1082`, so downstream PRs may need their own rebase pass before the full P4 stack is clean.

--- a/docs/development/dingtalk-p4-api-smoke-runner-development-20260422.md
+++ b/docs/development/dingtalk-p4-api-smoke-runner-development-20260422.md
@@ -1,0 +1,43 @@
+# DingTalk P4 API Smoke Runner Development
+
+- Date: 2026-04-22
+- Scope: P4 remote-smoke automation bootstrap
+- Branch: `codex/dingtalk-p4-api-smoke-runner-20260422`
+
+## What Changed
+
+- Added `scripts/ops/dingtalk-p4-remote-smoke.mjs`.
+- The runner creates a disposable base, sheet, text field, form view, and `dingtalk_granted` form-share allowlist.
+- The runner creates two sheet-scoped DingTalk group destinations, runs test-send, creates a group automation with `publicFormViewId`, test-runs the automation, and queries rule-level group delivery rows.
+- Optional `--person-user` creates and test-runs a DingTalk person automation, then queries rule-level person delivery rows.
+- The output is `evidence.json`, aligned with `compile-dingtalk-p4-smoke-evidence.mjs`.
+- Secrets are not printed or written: bearer tokens, DingTalk `access_token`, `sign`, `timestamp`, `SEC...`, JWTs, public form tokens, and password-like fields are redacted.
+
+## Boundary
+
+The runner is API-only. It does not replace these manual checks:
+
+- real DingTalk group receives the visible message
+- authorized DingTalk-bound user opens and submits the form from DingTalk
+- unauthorized DingTalk-bound user is blocked and inserts no record
+- no-email synced account is manually created and bound from the admin surface
+
+Those checks remain `pending` in `evidence.json` until an operator fills manual evidence and compiles with `--strict`.
+
+## Files
+
+- `scripts/ops/dingtalk-p4-remote-smoke.mjs`
+- `scripts/ops/dingtalk-p4-remote-smoke.test.mjs`
+- `scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`
+- `scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`
+- `scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
+- `scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Flow
+
+1. Provide `DINGTALK_P4_AUTH_TOKEN`, two group robot webhooks, and at least one allowed local user or member group on the staging host.
+2. Run `node scripts/ops/dingtalk-p4-remote-smoke.mjs --output-dir output/dingtalk-p4-remote-smoke/<run>`.
+3. Complete the manual DingTalk-client checks in the generated `evidence.json`.
+4. Run `node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input <evidence.json> --output-dir <run> --strict`.

--- a/docs/development/dingtalk-p4-api-smoke-runner-verification-20260422.md
+++ b/docs/development/dingtalk-p4-api-smoke-runner-verification-20260422.md
@@ -1,0 +1,37 @@
+# DingTalk P4 API Smoke Runner Verification
+
+- Date: 2026-04-22
+- Scope: local script tests and documentation packet coverage
+
+## Commands Run
+
+```bash
+node --check scripts/ops/dingtalk-p4-remote-smoke.mjs
+node --check scripts/ops/dingtalk-p4-remote-smoke.test.mjs
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs
+node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `dingtalk-p4-remote-smoke.test.mjs`: passed.
+- `compile-dingtalk-p4-smoke-evidence.test.mjs`: passed.
+- `export-dingtalk-staging-evidence-packet.test.mjs`: passed.
+- Syntax checks: passed.
+- `git diff --cached --check`: passed.
+
+## Coverage Notes
+
+- The fake API test covers base, sheet, field, form view, form-share, two group destinations, group test-send, group automation test-run, optional person automation test-run, and delivery history queries.
+- The runner output test asserts secrets are not printed or persisted, including bearer token, DingTalk `access_token`, `sign`, `timestamp`, `SEC...`, and public form token.
+- Missing admin token and malformed robot secret fail before any network request.
+- A no-person-recipient run keeps `delivery-history-group-person` as `pending`, matching the remote-smoke boundary.
+
+## Remaining Remote Validation
+
+- Run the API-only runner against the deployed 142/staging backend with real robot webhooks.
+- Complete manual DingTalk-client evidence for authorized submit, unauthorized denial, and no-email local user creation/binding.
+- Compile the final evidence with `--strict`.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -78,6 +78,36 @@ Expected generated files:
 
 The compiler requires every smoke check in this document to be `pass` when `--strict` is used. It redacts DingTalk webhook `access_token`, `SEC...` secrets, bearer/JWT tokens, passwords, and public form tokens before writing artifacts.
 
+## API-Only Smoke Runner
+
+Use the API-only runner to prepare the disposable test resources and collect backend evidence before the manual DingTalk-client checks. It creates a table, a form view, two group destinations, a `dingtalk_granted` form share, a group automation rule, and optional person-message rule when `--person-user` is supplied.
+
+Do not paste secrets into docs or chat. Supply them through secure shell env, a local password manager, or a temporary shell session on the staging host.
+
+```bash
+node scripts/ops/dingtalk-p4-remote-smoke.mjs \
+  --api-base "$DINGTALK_P4_API_BASE" \
+  --web-base "$DINGTALK_P4_WEB_BASE" \
+  --auth-token "$DINGTALK_P4_AUTH_TOKEN" \
+  --group-a-webhook "$DINGTALK_P4_GROUP_A_WEBHOOK" \
+  --group-b-webhook "$DINGTALK_P4_GROUP_B_WEBHOOK" \
+  --allowed-user "$DINGTALK_P4_ALLOWED_USER_ID" \
+  --person-user "$DINGTALK_P4_PERSON_USER_ID" \
+  --output-dir output/dingtalk-p4-remote-smoke/142-api
+```
+
+Expected output:
+
+- `evidence.json`
+
+The runner intentionally leaves these checks as `pending`:
+
+- authorized DingTalk-bound user opens and submits from the real DingTalk group message
+- unauthorized DingTalk-bound user is blocked and inserts no record
+- no-email DingTalk-synced account creation and binding
+
+If no `--person-user` is provided, person delivery evidence is also `pending`. Fill those manual results in `evidence.json`, then run the compiler with `--strict`.
+
 ## Smoke 1: Create table and public form
 
 Steps:

--- a/output/delivery/dingtalk-p4-1078-rebase-repair-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/dingtalk-p4-1078-rebase-repair-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,40 @@
+# Test And Verification - DingTalk P4 #1078 Rebase Repair
+
+Date: 2026-04-23
+
+## Summary
+
+Rebased `#1078` (`test(dingtalk): add P4 API smoke runner`) onto the repaired `#1076` parent branch.
+
+The rebase skipped already-applied parent commits and left `#1078` with only its API smoke runner slice plus repair documentation.
+
+## Verification
+
+```bash
+node --test \
+  scripts/ops/dingtalk-p4-remote-smoke.test.mjs \
+  scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs \
+  scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Passed: 12/12 tests.
+
+```bash
+git diff --check origin/codex/dingtalk-p4-smoke-evidence-runner-20260422...HEAD
+```
+
+Passed.
+
+## Next Check
+
+After pushing, run:
+
+```bash
+node scripts/ops/check-pr-stack-readiness.mjs \
+  --root-base codex/dingtalk-person-delivery-skip-reasons-20260422 \
+  1076 1078
+```
+
+Expected: `PASS`.
+
+Then re-run the full P4 substack readiness report to identify the next dirty downstream node.

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
@@ -198,6 +198,7 @@ function redactString(value) {
   return value
     .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
     .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
     .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
     .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
@@ -80,7 +80,7 @@ test('compile-dingtalk-p4-smoke-evidence compiles passing evidence and redacts s
         id,
         status: 'pass',
         evidence: {
-          notes: `${id} used https://oapi.dingtalk.com/robot/send?access_token=robot-secret and SECabcdefgh12345678`,
+          notes: `${id} used https://oapi.dingtalk.com/robot/send?access_token=robot-secret&timestamp=1690000000000&sign=robot-sign and SECabcdefgh12345678`,
           publicUrl: 'http://example.test/form?publicToken=pub_secret',
           authorization: 'Bearer abc.def.ghi',
           token: 'raw-token',
@@ -104,10 +104,14 @@ test('compile-dingtalk-p4-smoke-evidence compiles passing evidence and redacts s
 
     const redacted = readFileSync(path.join(outputDir, 'evidence.redacted.json'), 'utf8')
     assert.doesNotMatch(redacted, /robot-secret/)
+    assert.doesNotMatch(redacted, /1690000000000/)
+    assert.doesNotMatch(redacted, /robot-sign/)
     assert.doesNotMatch(redacted, /SECabcdefgh12345678/)
     assert.doesNotMatch(redacted, /pub_secret/)
     assert.doesNotMatch(redacted, /raw-token/)
     assert.match(redacted, /access_token=<redacted>/)
+    assert.match(redacted, /timestamp=<redacted>/)
+    assert.match(redacted, /sign=<redacted>/)
     assert.match(redacted, /SEC<redacted>/)
     assert.match(redacted, /publicToken=<redacted>/)
     assert.match(redacted, /"<redacted>"/)

--- a/scripts/ops/dingtalk-p4-remote-smoke.mjs
+++ b/scripts/ops/dingtalk-p4-remote-smoke.mjs
@@ -1,0 +1,771 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-remote-smoke'
+const DEFAULT_API_BASE = 'http://127.0.0.1:8900'
+
+const REQUIRED_CHECKS = [
+  {
+    id: 'create-table-form',
+    label: 'Create a table and form view',
+  },
+  {
+    id: 'bind-two-dingtalk-groups',
+    label: 'Bind at least two DingTalk groups',
+  },
+  {
+    id: 'set-form-dingtalk-granted',
+    label: 'Set the form to dingtalk_granted',
+  },
+  {
+    id: 'send-group-message-form-link',
+    label: 'Send a DingTalk group message with a form link',
+  },
+  {
+    id: 'authorized-user-submit',
+    label: 'Verify an authorized user can open and submit',
+  },
+  {
+    id: 'unauthorized-user-denied',
+    label: 'Verify an unauthorized user cannot submit and no record is inserted',
+  },
+  {
+    id: 'delivery-history-group-person',
+    label: 'Verify group and person delivery history',
+  },
+  {
+    id: 'no-email-user-create-bind',
+    label: 'Create and bind a no-email DingTalk-synced local user',
+  },
+]
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-p4-remote-smoke.mjs [options]
+
+Runs the API-addressable part of the DingTalk P4 remote smoke against a deployed
+backend. It creates a disposable table/form, binds two DingTalk group robot
+destinations, sets the form to dingtalk_granted, runs group automation, queries
+delivery history, and writes evidence.json.
+
+It does not prove real DingTalk client identity switching. The authorized-user,
+unauthorized-user, and no-email account checks stay pending until an operator
+fills them from manual evidence.
+
+Required inputs:
+  --auth-token <token>             Bearer token for an admin/table owner
+  --group-a-webhook <url>          DingTalk group A robot webhook
+  --group-b-webhook <url>          DingTalk group B robot webhook
+  --allowed-user <id>              Local user allowed to fill; repeatable
+  --allowed-member-group <id>      Allowed local member group; repeatable
+                                  Provide at least one allowed user or group.
+
+Options:
+  --api-base <url>                 Backend API base, default ${DEFAULT_API_BASE}
+  --web-base <url>                 Public app base for evidence notes
+  --group-a-secret <secret>        Optional DingTalk group A SEC... secret
+  --group-b-secret <secret>        Optional DingTalk group B SEC... secret
+  --person-user <id>               Optional local user for person-message smoke; repeatable
+  --output-dir <dir>               Output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
+  --timeout-ms <ms>                Per-request timeout, default 15000
+  --skip-health                    Skip GET /health
+  --skip-test-send                 Create group destinations but skip group test-send
+  --skip-automation-test-run       Create automation rules but skip test-run
+  --help                           Show this help
+
+Environment fallbacks:
+  DINGTALK_P4_API_BASE, API_BASE
+  DINGTALK_P4_WEB_BASE, WEB_BASE, PUBLIC_APP_URL
+  DINGTALK_P4_AUTH_TOKEN, ADMIN_TOKEN, AUTH_TOKEN
+  DINGTALK_P4_GROUP_A_WEBHOOK, DINGTALK_GROUP_A_WEBHOOK
+  DINGTALK_P4_GROUP_B_WEBHOOK, DINGTALK_GROUP_B_WEBHOOK
+  DINGTALK_P4_GROUP_A_SECRET, DINGTALK_GROUP_A_SECRET
+  DINGTALK_P4_GROUP_B_SECRET, DINGTALK_GROUP_B_SECRET
+  DINGTALK_P4_ALLOWED_USER_IDS, DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS
+  DINGTALK_P4_PERSON_USER_IDS
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function envValue(...names) {
+  for (const name of names) {
+    const value = process.env[name]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function splitList(value) {
+  if (!value) return []
+  return Array.from(new Set(
+    String(value)
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  ))
+}
+
+function appendList(list, value) {
+  const values = splitList(value)
+  for (const item of values) {
+    if (!list.includes(item)) list.push(item)
+  }
+}
+
+function parseArgs(argv) {
+  const opts = {
+    apiBase: envValue('DINGTALK_P4_API_BASE', 'API_BASE') || DEFAULT_API_BASE,
+    webBase: envValue('DINGTALK_P4_WEB_BASE', 'WEB_BASE', 'PUBLIC_APP_URL'),
+    authToken: envValue('DINGTALK_P4_AUTH_TOKEN', 'ADMIN_TOKEN', 'AUTH_TOKEN'),
+    groupAWebhook: envValue('DINGTALK_P4_GROUP_A_WEBHOOK', 'DINGTALK_GROUP_A_WEBHOOK'),
+    groupBWebhook: envValue('DINGTALK_P4_GROUP_B_WEBHOOK', 'DINGTALK_GROUP_B_WEBHOOK'),
+    groupASecret: envValue('DINGTALK_P4_GROUP_A_SECRET', 'DINGTALK_GROUP_A_SECRET'),
+    groupBSecret: envValue('DINGTALK_P4_GROUP_B_SECRET', 'DINGTALK_GROUP_B_SECRET'),
+    allowedUserIds: splitList(envValue('DINGTALK_P4_ALLOWED_USER_IDS', 'DINGTALK_P4_ALLOWED_USER_ID')),
+    allowedMemberGroupIds: splitList(envValue('DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS', 'DINGTALK_P4_ALLOWED_MEMBER_GROUP_ID')),
+    personUserIds: splitList(envValue('DINGTALK_P4_PERSON_USER_IDS', 'DINGTALK_P4_PERSON_USER_ID')),
+    outputDir: null,
+    timeoutMs: 15_000,
+    skipHealth: false,
+    skipTestSend: false,
+    skipAutomationTestRun: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--api-base':
+        opts.apiBase = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--web-base':
+        opts.webBase = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--auth-token':
+        opts.authToken = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--group-a-webhook':
+        opts.groupAWebhook = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--group-b-webhook':
+        opts.groupBWebhook = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--group-a-secret':
+        opts.groupASecret = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--group-b-secret':
+        opts.groupBSecret = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--allowed-user':
+        appendList(opts.allowedUserIds, readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--allowed-member-group':
+        appendList(opts.allowedMemberGroupIds, readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--person-user':
+        appendList(opts.personUserIds, readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--timeout-ms':
+        opts.timeoutMs = Number.parseInt(readRequiredValue(argv, i, arg), 10)
+        i += 1
+        break
+      case '--skip-health':
+        opts.skipHealth = true
+        break
+      case '--skip-test-send':
+        opts.skipTestSend = true
+        break
+      case '--skip-automation-test-run':
+        opts.skipAutomationTestRun = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  opts.apiBase = normalizeBaseUrl(opts.apiBase, '--api-base')
+  if (opts.webBase) opts.webBase = normalizeBaseUrl(opts.webBase, '--web-base')
+
+  return opts
+}
+
+function normalizeBaseUrl(value, label) {
+  try {
+    const url = new URL(value)
+    url.pathname = url.pathname.replace(/\/+$/, '')
+    url.search = ''
+    url.hash = ''
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    throw new Error(`${label} must be a valid URL`)
+  }
+}
+
+function validateWebhookUrl(value, label) {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error('must use http or https')
+    }
+    return url.toString()
+  } catch (error) {
+    throw new Error(`${label} must be a valid http(s) URL: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function validateSecret(value, label) {
+  const secret = typeof value === 'string' ? value.trim() : ''
+  if (!secret) return ''
+  if (!/^SEC[A-Za-z0-9+/=_-]{8,}$/.test(secret)) {
+    throw new Error(`${label} must look like a DingTalk SEC... robot secret`)
+  }
+  return secret
+}
+
+function validateOptions(opts) {
+  if (!opts.authToken) throw new Error('--auth-token or DINGTALK_P4_AUTH_TOKEN is required')
+  opts.groupAWebhook = validateWebhookUrl(opts.groupAWebhook, '--group-a-webhook')
+  opts.groupBWebhook = validateWebhookUrl(opts.groupBWebhook, '--group-b-webhook')
+  opts.groupASecret = validateSecret(opts.groupASecret, '--group-a-secret')
+  opts.groupBSecret = validateSecret(opts.groupBSecret, '--group-b-secret')
+  if (opts.allowedUserIds.length === 0 && opts.allowedMemberGroupIds.length === 0) {
+    throw new Error('at least one --allowed-user or --allowed-member-group is required for dingtalk_granted')
+  }
+  if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs < 1_000 || opts.timeoutMs > 120_000) {
+    throw new Error('--timeout-ms must be an integer between 1000 and 120000')
+  }
+}
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function makeRunId() {
+  return `dingtalk-p4-api-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}`
+}
+
+function redactString(value) {
+  return String(value)
+    .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function shouldFullyRedactKey(key) {
+  const normalized = String(key).toLowerCase().replace(/[^a-z0-9]/g, '')
+  if (!normalized) return false
+  if (normalized.includes('webhookurl') || normalized === 'url' || normalized.endsWith('link')) return false
+  return normalized.includes('secret')
+    || normalized.includes('password')
+    || normalized.includes('authorization')
+    || normalized.includes('bearer')
+    || normalized.includes('jwt')
+    || normalized.endsWith('token')
+    || normalized.includes('accesstoken')
+    || normalized.includes('refreshtoken')
+}
+
+function sanitizeValue(value, key = '') {
+  if (value === null || value === undefined) return value
+  if (typeof value === 'string') {
+    if (key && shouldFullyRedactKey(key)) return '<redacted>'
+    return redactString(value)
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.map((item) => sanitizeValue(item))
+  if (typeof value === 'object') {
+    const next = {}
+    for (const [entryKey, entryValue] of Object.entries(value)) {
+      next[entryKey] = sanitizeValue(entryValue, entryKey)
+    }
+    return next
+  }
+  return value
+}
+
+function createEvidence(opts, runId) {
+  const checks = REQUIRED_CHECKS.map((check) => ({
+    id: check.id,
+    label: check.label,
+    status: 'pending',
+    evidence: {
+      notes: 'Not executed by API runner.',
+    },
+  }))
+
+  return {
+    runId,
+    executedAt: nowIso(),
+    runner: {
+      tool: 'dingtalk-p4-remote-smoke',
+      mode: 'api-only',
+      notes: 'API runner output must be completed with manual DingTalk-client evidence before strict release sign-off.',
+    },
+    environment: {
+      apiBase: opts.apiBase,
+      webBase: opts.webBase || '',
+    },
+    checks,
+    artifacts: [],
+  }
+}
+
+function setCheck(evidence, id, status, data) {
+  const check = evidence.checks.find((entry) => entry.id === id)
+  if (!check) throw new Error(`Unknown check id: ${id}`)
+  check.status = status
+  check.evidence = sanitizeValue(data)
+}
+
+function pendingManualChecks(evidence) {
+  setCheck(evidence, 'authorized-user-submit', 'pending', {
+    notes: 'Manual DingTalk-client validation required: open the group message as an allowed DingTalk-bound local user, sign in if prompted, submit, and verify a record was inserted.',
+  })
+  setCheck(evidence, 'unauthorized-user-denied', 'pending', {
+    notes: 'Manual DingTalk-client validation required: open the same form as a DingTalk-bound user outside the allowlist and verify access or submit is blocked with no record insert.',
+  })
+  setCheck(evidence, 'no-email-user-create-bind', 'pending', {
+    notes: 'Manual admin validation required: create and bind a synced DingTalk account without email, confirm the onboarding packet is shown only in the result panel.',
+  })
+}
+
+function encodePath(value) {
+  return encodeURIComponent(String(value))
+}
+
+function isObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function unwrapData(payload) {
+  if (isObject(payload) && payload.ok === false) {
+    const message = isObject(payload.error) && typeof payload.error.message === 'string'
+      ? payload.error.message
+      : 'API returned ok:false'
+    throw new Error(message)
+  }
+  return isObject(payload) && Object.prototype.hasOwnProperty.call(payload, 'data') ? payload.data : payload
+}
+
+function requireEntity(payload, key) {
+  const data = unwrapData(payload)
+  if (isObject(data) && isObject(data[key])) return data[key]
+  if (isObject(data) && typeof data.id === 'string') return data
+  throw new Error(`API response did not include ${key}.id`)
+}
+
+function requireId(entity, label) {
+  if (!isObject(entity) || typeof entity.id !== 'string' || !entity.id.trim()) {
+    throw new Error(`${label} response did not include id`)
+  }
+  return entity.id.trim()
+}
+
+function getDeliveries(payload) {
+  const data = unwrapData(payload)
+  if (isObject(data) && Array.isArray(data.deliveries)) return data.deliveries
+  if (Array.isArray(data)) return data
+  return []
+}
+
+function getExecutionStatus(execution) {
+  if (!isObject(execution)) return 'unknown'
+  return typeof execution.status === 'string' ? execution.status : 'unknown'
+}
+
+function assertSuccessfulExecution(execution, label) {
+  const status = getExecutionStatus(execution)
+  if (status !== 'success') {
+    const error = isObject(execution) && typeof execution.error === 'string' ? `: ${execution.error}` : ''
+    throw new Error(`${label} test-run status was ${status}${error}`)
+  }
+  const failedSteps = Array.isArray(execution.steps)
+    ? execution.steps.filter((step) => isObject(step) && step.status !== 'success')
+    : []
+  if (failedSteps.length > 0) {
+    throw new Error(`${label} test-run had failed steps: ${JSON.stringify(sanitizeValue(failedSteps))}`)
+  }
+}
+
+function compactError(error) {
+  return redactString(error instanceof Error ? error.message : String(error))
+}
+
+async function requestJson(opts, route, options = {}) {
+  const method = options.method ?? 'GET'
+  const expected = options.expected ?? [200]
+  const url = new URL(route, opts.apiBase)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), opts.timeoutMs)
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Accept: 'application/json',
+        ...(options.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+        Authorization: `Bearer ${opts.authToken}`,
+      },
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      signal: controller.signal,
+    })
+    const text = await response.text()
+    const parsed = text ? JSON.parse(text) : null
+    if (!expected.includes(response.status)) {
+      throw new Error(`${method} ${url.pathname} failed with ${response.status}: ${JSON.stringify(sanitizeValue(parsed ?? text)).slice(0, 600)}`)
+    }
+    return parsed
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`${method} ${url.pathname} returned non-JSON response`)
+    }
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error(`${method} ${url.pathname} timed out after ${opts.timeoutMs}ms`)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function writeEvidence(outputDir, evidence) {
+  mkdirSync(outputDir, { recursive: true })
+  const evidencePath = path.join(outputDir, 'evidence.json')
+  writeFileSync(evidencePath, `${JSON.stringify(sanitizeValue(evidence), null, 2)}\n`, 'utf8')
+  return evidencePath
+}
+
+async function runSmoke(opts, evidence) {
+  if (!opts.skipHealth) {
+    await requestJson(opts, '/health', { expected: [200, 204] })
+    evidence.artifacts.push({ kind: 'api-health', status: 'pass', path: '/health' })
+  }
+
+  const stamp = evidence.runId.replace(/[^A-Za-z0-9_-]/g, '-')
+  const base = requireEntity(await requestJson(opts, '/api/multitable/bases', {
+    method: 'POST',
+    expected: [200, 201],
+    body: {
+      name: `DingTalk P4 Remote Smoke ${stamp}`,
+      icon: 'ding',
+      color: '#0EA5E9',
+    },
+  }), 'base')
+  const baseId = requireId(base, 'base')
+
+  const sheet = requireEntity(await requestJson(opts, '/api/multitable/sheets', {
+    method: 'POST',
+    expected: [200, 201],
+    body: {
+      baseId,
+      name: `DingTalk P4 Smoke ${stamp}`,
+      description: 'Disposable sheet created by scripts/ops/dingtalk-p4-remote-smoke.mjs',
+      seed: true,
+    },
+  }), 'sheet')
+  const sheetId = requireId(sheet, 'sheet')
+
+  const field = requireEntity(await requestJson(opts, '/api/multitable/fields', {
+    method: 'POST',
+    expected: [200, 201],
+    body: {
+      sheetId,
+      name: `P4 Smoke Notes ${stamp.slice(-8)}`,
+      type: 'string',
+    },
+  }), 'field')
+  const fieldId = requireId(field, 'field')
+
+  const formView = requireEntity(await requestJson(opts, '/api/multitable/views', {
+    method: 'POST',
+    expected: [200, 201],
+    body: {
+      sheetId,
+      name: 'DingTalk P4 Protected Form',
+      type: 'form',
+      config: {
+        publicForm: {
+          enabled: true,
+          accessMode: 'dingtalk_granted',
+        },
+      },
+    },
+  }), 'view')
+  const formViewId = requireId(formView, 'form view')
+
+  setCheck(evidence, 'create-table-form', 'pass', {
+    notes: 'Created disposable base, sheet, field, and form view through API.',
+    baseId,
+    sheetId,
+    fieldId,
+    formViewId,
+  })
+
+  const formShare = unwrapData(await requestJson(
+    opts,
+    `/api/multitable/sheets/${encodePath(sheetId)}/views/${encodePath(formViewId)}/form-share`,
+    {
+      method: 'PATCH',
+      expected: [200],
+      body: {
+        enabled: true,
+        accessMode: 'dingtalk_granted',
+        allowedUserIds: opts.allowedUserIds,
+        allowedMemberGroupIds: opts.allowedMemberGroupIds,
+      },
+    },
+  ))
+  const accessMode = isObject(formShare) && typeof formShare.accessMode === 'string'
+    ? formShare.accessMode
+    : 'unknown'
+  if (accessMode !== 'dingtalk_granted') {
+    throw new Error(`form share accessMode was ${accessMode}, expected dingtalk_granted`)
+  }
+  setCheck(evidence, 'set-form-dingtalk-granted', 'pass', {
+    notes: 'Form share was enabled with local allowlist-based DingTalk access.',
+    sheetId,
+    formViewId,
+    accessMode,
+    formShareStatus: isObject(formShare) ? formShare.status : undefined,
+    allowedUserCount: opts.allowedUserIds.length,
+    allowedMemberGroupCount: opts.allowedMemberGroupIds.length,
+  })
+
+  const destinations = []
+  for (const group of [
+    { key: 'A', webhookUrl: opts.groupAWebhook, secret: opts.groupASecret },
+    { key: 'B', webhookUrl: opts.groupBWebhook, secret: opts.groupBSecret },
+  ]) {
+    const body = {
+      name: `P4 Smoke Group ${group.key} ${stamp.slice(-8)}`,
+      webhookUrl: group.webhookUrl,
+      enabled: true,
+      sheetId,
+    }
+    if (group.secret) body.secret = group.secret
+    const destination = requireEntity(await requestJson(opts, '/api/multitable/dingtalk-groups', {
+      method: 'POST',
+      expected: [200, 201],
+      body,
+    }), 'destination')
+    destinations.push({
+      key: group.key,
+      id: requireId(destination, `DingTalk group ${group.key}`),
+      name: isObject(destination) && typeof destination.name === 'string' ? destination.name : `P4 Smoke Group ${group.key}`,
+    })
+  }
+
+  const manualDeliveryCounts = {}
+  if (!opts.skipTestSend) {
+    for (const destination of destinations) {
+      await requestJson(
+        opts,
+        `/api/multitable/dingtalk-groups/${encodePath(destination.id)}/test-send?sheetId=${encodeURIComponent(sheetId)}`,
+        {
+          method: 'POST',
+          expected: [200, 204],
+          body: {
+            subject: `P4 smoke ${destination.key}`,
+            content: `P4 DingTalk group destination test-send for ${sheetId}.`,
+          },
+        },
+      )
+      const deliveries = getDeliveries(await requestJson(
+        opts,
+        `/api/multitable/dingtalk-groups/${encodePath(destination.id)}/deliveries?sheetId=${encodeURIComponent(sheetId)}&limit=20`,
+      ))
+      manualDeliveryCounts[destination.id] = deliveries.length
+      if (deliveries.length === 0) {
+        throw new Error(`DingTalk group ${destination.key} test-send produced no delivery rows`)
+      }
+    }
+  }
+
+  setCheck(evidence, 'bind-two-dingtalk-groups', opts.skipTestSend ? 'pending' : 'pass', {
+    notes: opts.skipTestSend
+      ? 'Created two DingTalk group destinations, but --skip-test-send left smoke evidence pending.'
+      : 'Created two DingTalk group destinations and verified test-send delivery rows.',
+    sheetId,
+    destinationIds: destinations.map((destination) => destination.id),
+    manualTestDeliveryCounts: manualDeliveryCounts,
+  })
+
+  const groupRule = requireEntity(await requestJson(
+    opts,
+    `/api/multitable/sheets/${encodePath(sheetId)}/automations`,
+    {
+      method: 'POST',
+      expected: [200, 201],
+      body: {
+        name: 'DingTalk P4 group form-link smoke',
+        enabled: true,
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationIds: destinations.map((destination) => destination.id),
+          titleTemplate: 'DingTalk P4 protected form smoke',
+          bodyTemplate: 'Open the protected form link from DingTalk. Only allowlisted local users or member groups should be able to submit.',
+          publicFormViewId: formViewId,
+        },
+      },
+    },
+  ), 'rule')
+  const groupRuleId = requireId(groupRule, 'group automation rule')
+
+  let groupRuleDeliveryCount = 0
+  if (!opts.skipAutomationTestRun) {
+    const execution = await requestJson(
+      opts,
+      `/api/multitable/sheets/${encodePath(sheetId)}/automations/${encodePath(groupRuleId)}/test`,
+      { method: 'POST', expected: [200] },
+    )
+    assertSuccessfulExecution(execution, 'group automation')
+    const ruleDeliveries = getDeliveries(await requestJson(
+      opts,
+      `/api/multitable/sheets/${encodePath(sheetId)}/automations/${encodePath(groupRuleId)}/dingtalk-group-deliveries?limit=20`,
+    ))
+    groupRuleDeliveryCount = ruleDeliveries.length
+    if (ruleDeliveries.length < destinations.length) {
+      throw new Error(`group automation delivery rows ${ruleDeliveries.length} < destination count ${destinations.length}`)
+    }
+  }
+
+  setCheck(evidence, 'send-group-message-form-link', opts.skipAutomationTestRun ? 'pending' : 'pass', {
+    notes: opts.skipAutomationTestRun
+      ? 'Created the DingTalk group automation rule, but --skip-automation-test-run left actual send evidence pending.'
+      : 'Created and test-ran a DingTalk group automation rule with the protected form view link.',
+    sheetId,
+    formViewId,
+    groupRuleId,
+    destinationIds: destinations.map((destination) => destination.id),
+    groupRuleDeliveryCount,
+  })
+
+  let personRuleId = ''
+  let personRuleDeliveryCount = 0
+  if (opts.personUserIds.length > 0) {
+    const personRule = requireEntity(await requestJson(
+      opts,
+      `/api/multitable/sheets/${encodePath(sheetId)}/automations`,
+      {
+        method: 'POST',
+        expected: [200, 201],
+        body: {
+          name: 'DingTalk P4 person delivery smoke',
+          enabled: true,
+          triggerType: 'record.created',
+          triggerConfig: {},
+          actionType: 'send_dingtalk_person_message',
+          actionConfig: {
+            userIds: opts.personUserIds,
+            titleTemplate: 'DingTalk P4 person delivery smoke',
+            bodyTemplate: 'Person delivery smoke for P4 evidence. This validates delivery history rows for bound or skipped recipients.',
+            publicFormViewId: formViewId,
+          },
+        },
+      },
+    ), 'rule')
+    personRuleId = requireId(personRule, 'person automation rule')
+
+    if (!opts.skipAutomationTestRun) {
+      const execution = await requestJson(
+        opts,
+        `/api/multitable/sheets/${encodePath(sheetId)}/automations/${encodePath(personRuleId)}/test`,
+        { method: 'POST', expected: [200] },
+      )
+      assertSuccessfulExecution(execution, 'person automation')
+      const personDeliveries = getDeliveries(await requestJson(
+        opts,
+        `/api/multitable/sheets/${encodePath(sheetId)}/automations/${encodePath(personRuleId)}/dingtalk-person-deliveries?limit=20`,
+      ))
+      personRuleDeliveryCount = personDeliveries.length
+      if (personDeliveries.length === 0) {
+        throw new Error('person automation test-run produced no delivery rows')
+      }
+    }
+  }
+
+  const hasPersonEvidence = opts.personUserIds.length > 0 && !opts.skipAutomationTestRun && personRuleDeliveryCount > 0
+  const hasGroupEvidence = !opts.skipAutomationTestRun && groupRuleDeliveryCount >= destinations.length
+  setCheck(evidence, 'delivery-history-group-person', hasGroupEvidence && hasPersonEvidence ? 'pass' : 'pending', {
+    notes: hasGroupEvidence && hasPersonEvidence
+      ? 'Verified rule-level group and person delivery rows from API test-runs.'
+      : 'Group delivery was queried by the API runner; person delivery remains pending unless --person-user is provided and automation test-run is enabled.',
+    sheetId,
+    groupRuleId,
+    groupRuleDeliveryCount,
+    personRuleId: personRuleId || undefined,
+    personRuleDeliveryCount,
+    personUserCount: opts.personUserIds.length,
+  })
+
+  pendingManualChecks(evidence)
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  validateOptions(opts)
+  const runId = makeRunId()
+  const outputDir = opts.outputDir ?? path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, runId)
+  const evidence = createEvidence(opts, runId)
+
+  let exitCode = 0
+  try {
+    await runSmoke(opts, evidence)
+  } catch (error) {
+    exitCode = 1
+    evidence.error = compactError(error)
+    console.error(`[dingtalk-p4-remote-smoke] ERROR: ${evidence.error}`)
+    const firstPending = evidence.checks.find((check) => check.status === 'pending')
+    if (firstPending) {
+      setCheck(evidence, firstPending.id, 'fail', {
+        notes: 'API runner stopped at this check.',
+        error: compactError(error),
+      })
+    }
+  } finally {
+    const evidencePath = writeEvidence(outputDir, evidence)
+    const relativeEvidencePath = path.relative(process.cwd(), evidencePath).replaceAll('\\', '/')
+    console.log(`Wrote ${relativeEvidencePath}`)
+    console.log(`Compile after manual updates: node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input ${relativeEvidencePath} --output-dir ${path.relative(process.cwd(), outputDir).replaceAll('\\', '/')} --strict`)
+  }
+
+  if (exitCode !== 0) process.exit(exitCode)
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error(`[dingtalk-p4-remote-smoke] ERROR: ${compactError(error)}`)
+  process.exit(1)
+}

--- a/scripts/ops/dingtalk-p4-remote-smoke.test.mjs
+++ b/scripts/ops/dingtalk-p4-remote-smoke.test.mjs
@@ -1,0 +1,406 @@
+import assert from 'node:assert/strict'
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import http from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-remote-smoke.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-remote-smoke-'))
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = ''
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      raw += chunk
+    })
+    req.on('end', () => {
+      if (!raw) {
+        resolve(null)
+        return
+      }
+      try {
+        resolve(JSON.parse(raw))
+      } catch (error) {
+        reject(error)
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+function sendJson(res, status, body) {
+  res.statusCode = status
+  if (body === undefined) {
+    res.end()
+    return
+  }
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+function createFakeApiServer() {
+  const requests = []
+  let groupCount = 0
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+      const body = await readRequestBody(req)
+      requests.push({
+        method: req.method,
+        pathname: url.pathname,
+        search: url.search,
+        headers: req.headers,
+        body,
+      })
+
+      if (req.method === 'GET' && url.pathname === '/health') {
+        sendJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/bases') {
+        sendJson(res, 201, { ok: true, data: { base: { id: 'base_1', name: body.name } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/sheets') {
+        assert.equal(body.baseId, 'base_1')
+        sendJson(res, 200, { ok: true, data: { sheet: { id: 'sheet_1', baseId: 'base_1', seeded: true } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/fields') {
+        assert.equal(body.sheetId, 'sheet_1')
+        assert.equal(body.type, 'string')
+        sendJson(res, 201, { ok: true, data: { field: { id: 'field_1', name: body.name } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/views') {
+        assert.equal(body.sheetId, 'sheet_1')
+        assert.equal(body.type, 'form')
+        sendJson(res, 201, {
+          ok: true,
+          data: {
+            view: {
+              id: 'view_form_1',
+              sheetId: 'sheet_1',
+              type: 'form',
+              config: body.config,
+            },
+          },
+        })
+        return
+      }
+
+      if (req.method === 'PATCH' && url.pathname === '/api/multitable/sheets/sheet_1/views/view_form_1/form-share') {
+        assert.equal(body.enabled, true)
+        assert.equal(body.accessMode, 'dingtalk_granted')
+        assert.deepEqual(body.allowedUserIds, ['user_authorized'])
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            enabled: true,
+            status: 'active',
+            accessMode: 'dingtalk_granted',
+            publicToken: 'public_token_should_not_leak',
+            allowedUserIds: ['user_authorized'],
+          },
+        })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/dingtalk-groups') {
+        groupCount += 1
+        assert.equal(body.sheetId, 'sheet_1')
+        assert.equal(body.enabled, true)
+        assert.match(body.webhookUrl, /access_token=robot-secret-/)
+        if (body.secret) assert.match(body.secret, /^SEC/)
+        sendJson(res, 201, {
+          ok: true,
+          data: {
+            id: `dt_group_${groupCount}`,
+            name: body.name,
+            enabled: true,
+            sheetId: 'sheet_1',
+          },
+        })
+        return
+      }
+
+      const testSendMatch = url.pathname.match(/^\/api\/multitable\/dingtalk-groups\/(dt_group_[12])\/test-send$/)
+      if (req.method === 'POST' && testSendMatch) {
+        assert.equal(url.searchParams.get('sheetId'), 'sheet_1')
+        assert.match(body.subject, /P4 smoke/)
+        sendJson(res, 204)
+        return
+      }
+
+      const manualDeliveriesMatch = url.pathname.match(/^\/api\/multitable\/dingtalk-groups\/(dt_group_[12])\/deliveries$/)
+      if (req.method === 'GET' && manualDeliveriesMatch) {
+        assert.equal(url.searchParams.get('sheetId'), 'sheet_1')
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [
+              {
+                id: `delivery_${manualDeliveriesMatch[1]}`,
+                destinationId: manualDeliveriesMatch[1],
+                sourceType: 'manual_test',
+                status: 'success',
+              },
+            ],
+          },
+        })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/sheets/sheet_1/automations') {
+        assert.equal(body.triggerType, 'record.created')
+        if (body.actionType === 'send_dingtalk_group_message') {
+          assert.deepEqual(body.actionConfig.destinationIds, ['dt_group_1', 'dt_group_2'])
+          assert.equal(body.actionConfig.publicFormViewId, 'view_form_1')
+          sendJson(res, 200, { ok: true, data: { rule: { id: 'rule_group_1', actionType: body.actionType } } })
+          return
+        }
+        if (body.actionType === 'send_dingtalk_person_message') {
+          assert.deepEqual(body.actionConfig.userIds, ['user_person_bound'])
+          assert.equal(body.actionConfig.publicFormViewId, 'view_form_1')
+          sendJson(res, 200, { ok: true, data: { rule: { id: 'rule_person_1', actionType: body.actionType } } })
+          return
+        }
+      }
+
+      const testRunMatch = url.pathname.match(/^\/api\/multitable\/sheets\/sheet_1\/automations\/(rule_group_1|rule_person_1)\/test$/)
+      if (req.method === 'POST' && testRunMatch) {
+        const actionType = testRunMatch[1] === 'rule_group_1'
+          ? 'send_dingtalk_group_message'
+          : 'send_dingtalk_person_message'
+        sendJson(res, 200, {
+          id: `exec_${testRunMatch[1]}`,
+          ruleId: testRunMatch[1],
+          triggeredBy: 'manual_test',
+          status: 'success',
+          steps: [{ actionType, status: 'success' }],
+        })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/api/multitable/sheets/sheet_1/automations/rule_group_1/dingtalk-group-deliveries') {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [
+              { id: 'rule_group_delivery_1', destinationId: 'dt_group_1', status: 'success' },
+              { id: 'rule_group_delivery_2', destinationId: 'dt_group_2', status: 'success' },
+            ],
+          },
+        })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/api/multitable/sheets/sheet_1/automations/rule_person_1/dingtalk-person-deliveries') {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [
+              { id: 'rule_person_delivery_1', userId: 'user_person_bound', status: 'success' },
+            ],
+          },
+        })
+        return
+      }
+
+      sendJson(res, 404, { ok: false, error: { message: `unexpected route ${req.method} ${url.pathname}` } })
+    } catch (error) {
+      sendJson(res, 500, { ok: false, error: { message: error instanceof Error ? error.message : String(error) } })
+    }
+  })
+
+  return {
+    requests,
+    async listen() {
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+      const address = server.address()
+      return `http://127.0.0.1:${address.port}`
+    },
+    async close() {
+      await new Promise((resolve) => server.close(resolve))
+    },
+  }
+}
+
+function runScript(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('close', (code) => resolve({ code, stdout, stderr }))
+  })
+}
+
+test('dingtalk-p4-remote-smoke runs API chain, writes pending manual gates, and redacts secrets', async () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'smoke')
+  const fakeApi = createFakeApiServer()
+
+  try {
+    const apiBase = await fakeApi.listen()
+    const result = await runScript([
+      '--api-base',
+      apiBase,
+      '--web-base',
+      'https://metasheet.example.test',
+      '--auth-token',
+      'secret-admin-token',
+      '--group-a-webhook',
+      'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a&timestamp=1690000000000&sign=abc-sign-a',
+      '--group-b-webhook',
+      'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b&timestamp=1690000000001&sign=abc-sign-b',
+      '--group-a-secret',
+      'SECabcdefghijklmnop12345678',
+      '--allowed-user',
+      'user_authorized',
+      '--person-user',
+      'user_person_bound',
+      '--output-dir',
+      outputDir,
+    ])
+
+    assert.equal(result.code, 0, result.stderr || result.stdout)
+    assert.match(result.stdout, /Wrote .*evidence\.json/)
+    assert.doesNotMatch(result.stdout, /secret-admin-token/)
+    assert.doesNotMatch(result.stdout, /robot-secret-a/)
+    assert.doesNotMatch(result.stdout, /SECabcdefghijklmnop12345678/)
+    assert.equal(existsSync(path.join(outputDir, 'evidence.json')), true)
+
+    const evidenceText = readFileSync(path.join(outputDir, 'evidence.json'), 'utf8')
+    assert.doesNotMatch(evidenceText, /secret-admin-token/)
+    assert.doesNotMatch(evidenceText, /robot-secret-a/)
+    assert.doesNotMatch(evidenceText, /robot-secret-b/)
+    assert.doesNotMatch(evidenceText, /abc-sign-a/)
+    assert.doesNotMatch(evidenceText, /1690000000000/)
+    assert.doesNotMatch(evidenceText, /SECabcdefghijklmnop12345678/)
+    assert.doesNotMatch(evidenceText, /public_token_should_not_leak/)
+
+    const evidence = JSON.parse(evidenceText)
+    const byId = new Map(evidence.checks.map((check) => [check.id, check]))
+    assert.equal(byId.get('create-table-form').status, 'pass')
+    assert.equal(byId.get('bind-two-dingtalk-groups').status, 'pass')
+    assert.equal(byId.get('set-form-dingtalk-granted').status, 'pass')
+    assert.equal(byId.get('send-group-message-form-link').status, 'pass')
+    assert.equal(byId.get('delivery-history-group-person').status, 'pass')
+    assert.equal(byId.get('authorized-user-submit').status, 'pending')
+    assert.equal(byId.get('unauthorized-user-denied').status, 'pending')
+    assert.equal(byId.get('no-email-user-create-bind').status, 'pending')
+    assert.equal(byId.get('send-group-message-form-link').evidence.groupRuleDeliveryCount, 2)
+    assert.equal(byId.get('delivery-history-group-person').evidence.personRuleDeliveryCount, 1)
+
+    assert.equal(fakeApi.requests.every((request) => request.headers.authorization === 'Bearer secret-admin-token'), true)
+    assert.equal(fakeApi.requests.some((request) => request.pathname.endsWith('/dingtalk-person-deliveries')), true)
+  } finally {
+    await fakeApi.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-remote-smoke keeps delivery history pending without person recipients', async () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'smoke')
+  const fakeApi = createFakeApiServer()
+
+  try {
+    const apiBase = await fakeApi.listen()
+    const result = await runScript([
+      '--api-base',
+      apiBase,
+      '--auth-token',
+      'secret-admin-token',
+      '--group-a-webhook',
+      'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
+      '--group-b-webhook',
+      'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+      '--allowed-user',
+      'user_authorized',
+      '--output-dir',
+      outputDir,
+    ])
+
+    assert.equal(result.code, 0, result.stderr || result.stdout)
+    const evidence = JSON.parse(readFileSync(path.join(outputDir, 'evidence.json'), 'utf8'))
+    const deliveryCheck = evidence.checks.find((check) => check.id === 'delivery-history-group-person')
+    assert.equal(deliveryCheck.status, 'pending')
+    assert.equal(deliveryCheck.evidence.groupRuleDeliveryCount, 2)
+    assert.equal(deliveryCheck.evidence.personUserCount, 0)
+    assert.equal(fakeApi.requests.some((request) => request.pathname.endsWith('/dingtalk-person-deliveries')), false)
+  } finally {
+    await fakeApi.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-remote-smoke rejects missing auth token before making requests', () => {
+  const result = spawnSync(process.execPath, [
+    scriptPath,
+    '--api-base',
+    'http://127.0.0.1:9',
+    '--group-a-webhook',
+    'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
+    '--group-b-webhook',
+    'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+    '--allowed-user',
+    'user_authorized',
+  ], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /--auth-token/)
+  assert.doesNotMatch(result.stderr, /robot-secret-a/)
+})
+
+test('dingtalk-p4-remote-smoke rejects malformed DingTalk robot secrets', () => {
+  const result = spawnSync(process.execPath, [
+    scriptPath,
+    '--api-base',
+    'http://127.0.0.1:9',
+    '--auth-token',
+    'secret-admin-token',
+    '--group-a-webhook',
+    'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
+    '--group-b-webhook',
+    'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+    '--group-a-secret',
+    'not-a-secret',
+    '--allowed-user',
+    'user_authorized',
+  ], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /--group-a-secret/)
+  assert.doesNotMatch(result.stderr, /secret-admin-token/)
+})

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -81,6 +81,11 @@ const requiredPacketFiles = [
     kind: 'script',
     description: 'compiles redacted P4 remote-smoke evidence summaries from operator-provided results',
   },
+  {
+    path: 'scripts/ops/dingtalk-p4-remote-smoke.mjs',
+    kind: 'script',
+    description: 'runs the API-only part of P4 remote smoke and writes bootstrap evidence for manual completion',
+  },
 ]
 
 function printHelp() {
@@ -214,8 +219,10 @@ ${evidenceLines}
 4. Deploy a pinned tag with \`DEPLOY_IMAGE_TAG=<tag> bash scripts/ops/deploy-dingtalk-staging.sh\`.
 5. Execute \`docs/development/dingtalk-staging-execution-checklist-20260408.md\`.
 6. Execute \`docs/dingtalk-remote-smoke-checklist-20260422.md\` for P4 DingTalk form/group/person coverage.
-7. Compile smoke evidence with \`node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input <evidence.json> --output-dir <evidence-dir> --strict\`.
-8. Re-export this packet with \`--include-output <evidence-dir>\` after smoke evidence exists.
+7. Optionally bootstrap API-addressable evidence with \`node scripts/ops/dingtalk-p4-remote-smoke.mjs --output-dir <evidence-dir>\`.
+8. Complete the manual DingTalk-client checks in \`evidence.json\`.
+9. Compile smoke evidence with \`node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input <evidence.json> --output-dir <evidence-dir> --strict\`.
+10. Re-export this packet with \`--include-output <evidence-dir>\` after smoke evidence exists.
 
 ## Non-Goals
 

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -40,6 +40,10 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       existsSync(path.join(outputDir, 'scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs')),
       true,
     )
+    assert.equal(
+      existsSync(path.join(outputDir, 'scripts/ops/dingtalk-p4-remote-smoke.mjs')),
+      true,
+    )
     assert.equal(existsSync(path.join(outputDir, 'scripts/ops/deploy-dingtalk-staging.sh')), true)
     assert.equal(existsSync(path.join(outputDir, 'docker/app.staging.env.example')), true)
 
@@ -58,10 +62,15 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       manifest.files.some((file) => file.path === 'scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs'),
       true,
     )
+    assert.equal(
+      manifest.files.some((file) => file.path === 'scripts/ops/dingtalk-p4-remote-smoke.mjs'),
+      true,
+    )
 
     const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
     assert.match(readme, /DingTalk Staging Evidence Packet/)
     assert.match(readme, /docs\/dingtalk-remote-smoke-checklist-20260422\.md/)
+    assert.match(readme, /dingtalk-p4-remote-smoke\.mjs/)
     assert.match(readme, /compile-dingtalk-p4-smoke-evidence\.mjs/)
     assert.match(readme, /No runtime evidence directory was included/)
     assert.match(readme, /Does not store secrets/)


### PR DESCRIPTION
## Summary

- Add `scripts/ops/dingtalk-p4-remote-smoke.mjs` to bootstrap the API-addressable P4 remote-smoke flow: disposable table/form creation, `dingtalk_granted` form share, two DingTalk group destinations, group automation test-run, optional person-message test-run, and evidence output.
- Keep real DingTalk-client checks pending in generated evidence until an operator verifies authorized submit, unauthorized denial, and no-email account creation/binding.
- Extend evidence redaction for DingTalk webhook `sign` and `timestamp`, and include the runner in the staging evidence packet.
- Update the P4 checklist/TODO plus development and verification notes.

## Verification

- `node --check scripts/ops/dingtalk-p4-remote-smoke.mjs`
- `node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `git diff --cached --check`

## Notes

- This PR is stacked on #1076 / `codex/dingtalk-p4-smoke-evidence-runner-20260422`.
- Existing unrelated dirty `node_modules` files in the worktree were not staged or modified by this commit.