### PR TITLE
feat(after-sales): verify installer provisioning seam

### DIFF
--- a/docs/development/after-sales-m1-installer-provisioning-development-20260422.md
+++ b/docs/development/after-sales-m1-installer-provisioning-development-20260422.md
@@ -1,0 +1,180 @@
+# After-Sales M1 — Installer C-min Through multitable/provisioning.ts (Development)
+
+> Document type: Development record
+> Date: 2026-04-22
+> Scope: Roadmap §5.2 (after-sales C-min) M1
+> Related: `docs/development/multitable-service-extraction-roadmap-20260407.md`
+> Worktree: `.worktrees/after-sales-m1`
+> Branch: `codex/after-sales-m1-installer-provisioning-20260422`
+> Baseline commit: `27a9b9de1`
+
+## 1. Background and recon finding
+
+The task brief expected to "replace the direct/fake provisioning path in the
+after-sales installer with a production adapter that calls
+`multitable/provisioning.ts`." Reconnaissance against baseline `27a9b9de1`
+found that this wiring is **already in place** — M0 Path A landed it:
+
+1. `plugins/plugin-after-sales/lib/installer.cjs#runInstall` resolves
+   `context.api.multitable.provisioning` (lines 224–232 and 466–475).
+2. When present, the installer calls
+   `provisioning.ensureObject({ projectId, descriptor })` for every blueprint
+   object whose `backing === 'multitable'` (or whose
+   `provisioning.multitable === true` for hybrid types).
+3. The production context binds the seam in `packages/core-backend/src/index.ts`
+   (lines 357–414) and the plugin-scoped wrapper in
+   `createPluginScopedMultitableApi` (same file, lines 1090–1183) wires
+   `ensureObjectInScope`, which delegates to
+   `multitable/provisioning.ts#ensureObject`.
+4. `plugins/plugin-after-sales/lib/blueprint.cjs` enriches the
+   `installedAsset` descriptor with a field list that already contains the
+   C-min minimum floor (`assetCode` required + `serialNo` optional) as its
+   first two entries, plus five additional C-full business fields (`model`,
+   `location`, `installedAt`, `warrantyUntil`, `status`).
+5. The existing end-to-end integration test
+   `packages/core-backend/tests/integration/after-sales-plugin.install.test.ts`
+   already exercises the whole install path against real Postgres and locks
+   in the full 7-field descriptor for installedAsset.
+
+This is consistent with the roadmap §5.2 acceptance criteria for M1:
+
+> - after-sales installer 不直接访问 `meta_*`
+> - `runInstall()` 真实建出 `installedAsset` 对应 sheet 和字段
+> - 现有 installer unit tests 继续通过
+> - 新增 1-2 个 integration tests 验证 provisioning helper 与真实 DB 契约
+
+The first three criteria are already satisfied at baseline. M1 is therefore
+scoped down to **adding a seam-level integration test** that proves the
+provisioning helper contract directly against real Postgres, plus these dev
+and verification notes.
+
+## 2. Why the blueprint is not trimmed to 2 fields
+
+The roadmap §5.2 says "推荐的最小持久字段集" = **recommended minimum floor**,
+not a hard cap. The five extra `installedAsset` fields
+(`model`, `location`, `installedAt`, `warrantyUntil`, `status`) are real
+business fields that map to the template's grid view and to the plugin's
+runtime admin. They are not placeholders (`id`, `created_at`, `updated_at`)
+or scaffolding. Trimming them would:
+
+1. Break `after-sales-plugin.install.test.ts`, which asserts all 7 fields.
+2. Delete real functionality already landed under the blueprint enrichment path.
+3. Exceed the M1 scope by reworking blueprint + end-to-end tests that belong
+   to subsequent C-full slices.
+
+We therefore leave `plugin-after-sales/lib/blueprint.cjs` untouched. The M1
+acceptance criterion ("installer builds a real installedAsset sheet + fields
+through provisioning.ts") is satisfied because the C-min floor (`assetCode`
+required + `serialNo` optional) is already the first two fields of the
+descriptor and gets persisted by `ensureFields` in the same code path as the
+rest.
+
+## 3. Adapter shape (unchanged from baseline)
+
+```
+installer.cjs::runInstall
+  ├─ loads blueprint (with enriched field list)
+  └─ for each object where backing === 'multitable':
+       provisioning = context.api.multitable.provisioning
+       → provisioning.ensureObject({ projectId, descriptor })
+           ├─ production: packages/core-backend/src/index.ts
+           │    calls multitable/provisioning.ts#ensureObject
+           │    inside a pooled transaction
+           │    (ensureLegacyBase → ensureSheet → ensureFields)
+           └─ unit tests: inject a vi.fn() fake adapter
+```
+
+The production adapter:
+
+1. Opens a transaction on the core pool.
+2. Calls `ensureLegacyBase(query)` — idempotent `meta_bases` insert.
+3. Calls `ensureSheet({ query, baseId, sheetId, name, description })`.
+4. Calls `ensureFields({ query, sheetId, fields })`.
+5. Claims plugin scope via `claimPluginObjectScope` (adds the registry row
+   that protects this sheet from cross-plugin writes).
+
+Plugins never touch `meta_*` SQL directly — that invariant is enforced by
+`createPluginScopedMultitableApi` in core-backend `index.ts`.
+
+## 4. Field spec actually persisted for installedAsset
+
+From `blueprint.cjs#enrichObjectDescriptor` (`installedAsset` branch):
+
+| Field ID        | Name            | Type   | Required | C-min? |
+|-----------------|-----------------|--------|----------|--------|
+| `assetCode`     | Asset Code      | string | ✓        | ✓      |
+| `serialNo`      | Serial No       | string |          | ✓      |
+| `model`         | Model           | string |          | C-full |
+| `location`      | Location        | string |          | C-full |
+| `installedAt`   | Installed At    | date   |          | C-full |
+| `warrantyUntil` | Warranty Until  | date   |          | C-full |
+| `status`        | Status          | select | ✓        | C-full |
+
+The new integration test asserts the first two rows (the C-min floor) land
+in `meta_fields` with correct `type` via the direct seam call. The existing
+end-to-end test (`after-sales-plugin.install.test.ts`) continues to assert
+all 7.
+
+## 5. New integration test outline
+
+File:
+`packages/core-backend/tests/integration/after-sales-installer-provisioning.api.test.ts`
+
+Harness:
+
+- `beforeAll`: opens a real `pg.Pool` from `DATABASE_URL`, then calls a
+  local `ensureMultitableSeamSchema(pool)` helper that creates only the
+  tables this suite exercises (`meta_bases`, `meta_sheets`, `meta_fields`,
+  `plugin_after_sales_template_installs`). This keeps the suite independent
+  from the full migration graph (which at baseline has an unrelated blocker
+  around `views.id` vs `kanban_configs.view_id` uuid/text mismatch in
+  `20250924120000_create_views_view_states.ts`). The schema definitions are
+  exact mirrors of the source migrations — no drift.
+- `beforeEach`: deletes rows from the seam tables for the dedicated test
+  tenant (`tenant_m1_installer_it`).
+- `afterAll`: cleans up and ends the pool.
+
+Three cases:
+
+1. **Direct seam path (primitives)** — calls `ensureLegacyBase` →
+   `ensureSheet` → `ensureFields` with the C-min descriptor and asserts:
+   - `meta_bases` contains `base_legacy`.
+   - `meta_sheets` row has `id=SHEET_ID, name='Installed Asset', base_id='base_legacy'`.
+   - `meta_fields` contains the 2 rows in the expected order.
+
+2. **Aggregate path (ensureObject)** — invokes
+   `provisioning.ensureObject({ projectId, descriptor })` with a minimal
+   2-field `installedAsset` descriptor. Asserts the same row layout plus
+   that the return value's `fields[*].name` matches expectation.
+
+3. **End-to-end through the plugin installer** — builds a minimal plugin
+   context with `api.database` backed by real Postgres and
+   `api.multitable.provisioning.ensureObject` backed by a spy that forwards
+   to the real `provisioning.ensureObject`. Runs
+   `installer.runInstall({ blueprint: { objects: [installedAsset C-min] }, mode: 'enable' })`
+   and asserts:
+   - install result reports `status='installed'`, `projectId=${TENANT}:after-sales`,
+     `createdObjects=['installedAsset']`.
+   - the spy was called exactly once with the C-min descriptor.
+   - `meta_fields` contains the 2 expected rows.
+
+Case 3 is the direct M1 acceptance for "runInstall() 真实建出 installedAsset
+对应 sheet 和字段" — it proves the plugin installer genuinely routes its
+installedAsset provisioning through `multitable/provisioning.ts` against
+real Postgres rather than a fake.
+
+## 6. Out of scope for M1 (C-full follow-ups)
+
+- installedAsset views (the `installedAsset-grid` view definition stays in
+  `blueprint.cjs` but is still covered only by the end-to-end install test).
+- Blueprint-driven records for installedAsset.
+- installedAsset attachments.
+- Other after-sales objects (ticket, customer, serviceRecord, partItem,
+  followUp) — all still covered by the existing end-to-end test.
+- Automation / notification / approval wiring around installedAsset.
+
+## 7. Files changed
+
+- `packages/core-backend/tests/integration/after-sales-installer-provisioning.api.test.ts` (new)
+- `docs/development/after-sales-m1-installer-provisioning-development-20260422.md` (this file)
+- `docs/development/after-sales-m1-installer-provisioning-verification-20260422.md`

--- a/docs/development/after-sales-m1-installer-provisioning-verification-20260422.md
+++ b/docs/development/after-sales-m1-installer-provisioning-verification-20260422.md
@@ -1,0 +1,108 @@
+# After-Sales M1 — Installer C-min Through multitable/provisioning.ts (Verification)
+
+> Document type: Verification record
+> Date: 2026-04-22
+> Worktree: `.worktrees/after-sales-m1`
+> Branch: `codex/after-sales-m1-installer-provisioning-20260422`
+> Baseline commit: `27a9b9de1`
+> Postgres: `postgresql://chouhua@127.0.0.1:5432/postgres`
+
+## 1. Baseline confirmation
+
+```
+$ git log --oneline -3
+27a9b9de1 feat(approval): add sourceSystem filter for unified inbox
+b2c3545e5 refactor(multitable): absorb route helpers into M0 modules
+213062cb7 test(approval): serialize approval schema bootstrap
+```
+
+HEAD matches the expected baseline `27a9b9de1`.
+
+## 2. Commands and results
+
+All commands run from `.worktrees/after-sales-m1`.
+
+### 2.1 Type check
+
+```
+$ pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+$ echo $?
+0
+```
+
+Result: **pass** (exit 0, no diagnostics printed).
+
+### 2.2 Installer unit tests + M0 provisioning unit tests
+
+```
+$ pnpm --filter @metasheet/core-backend exec vitest run \
+    tests/unit/after-sales-installer.test.ts \
+    tests/unit/multitable-provisioning.test.ts --reporter=dot
+
+ ✓ tests/unit/multitable-provisioning.test.ts  (7 tests) 3ms
+ ✓ tests/unit/after-sales-installer.test.ts  (41 tests) 14ms
+
+ Test Files  2 passed (2)
+      Tests  48 passed (48)
+```
+
+Result: **48 passed / 0 failed** (same as baseline).
+
+### 2.3 New integration test (production adapter + real Postgres)
+
+```
+$ DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+  PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec \
+    vitest --config vitest.integration.config.ts run \
+    tests/integration/after-sales-installer-provisioning.api.test.ts \
+    --reporter=dot
+
+ ✓ tests/integration/after-sales-installer-provisioning.api.test.ts  (3 tests) 42ms
+
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+```
+
+Result: **3 passed / 0 failed**.
+
+Breakdown:
+
+- provisions installedAsset sheet via ensureLegacyBase + ensureSheet + ensureFields (C-min direct seam)
+- provisions installedAsset via ensureObject with the C-min minimum descriptor
+- routes the after-sales installer runInstall through the multitable provisioning seam for installedAsset C-min
+
+## 3. Scope deviations
+
+None. M1 delivered exactly the narrow delta the roadmap §5.2 calls for:
+
+- No changes to `plugins/plugin-after-sales/lib/installer.cjs` (already wired
+  through `context.api.multitable.provisioning` at baseline).
+- No changes to `plugins/plugin-after-sales/lib/blueprint.cjs` (C-min floor
+  `assetCode` + `serialNo` already present; extra fields belong to C-full and
+  are intentionally preserved — see development MD §2 for the rationale).
+- No changes to `packages/core-backend/src/multitable/provisioning.ts` or to
+  the production context in `packages/core-backend/src/index.ts`.
+- One new integration test file + two MDs.
+
+## 4. Known pre-existing infrastructure note
+
+`pnpm --filter @metasheet/core-backend run migrate` fails during
+`20250924120000_create_views_view_states.ts` on the `kanban_configs.view_id`
+foreign key against `views.id` (uuid vs text mismatch). This failure is
+pre-existing on the baseline commit and unrelated to M1. To keep the new
+integration test resilient and narrowly scoped to the seam, it provisions
+only the four tables it actually touches (`meta_bases`, `meta_sheets`,
+`meta_fields`, `plugin_after_sales_template_installs`) with schema
+definitions that mirror the source migrations. The end-to-end test
+`after-sales-plugin.install.test.ts` still relies on the full migration
+stack and is therefore not run as part of M1 verification.
+
+## 5. Summary
+
+- Baseline `27a9b9de1` confirmed.
+- `tsc --noEmit`: pass.
+- Installer unit tests: 41/41 pass.
+- M0 provisioning unit tests: 7/7 pass.
+- New integration test: 3/3 pass.
+- No scope deviations.

--- a/docs/development/after-sales-m1-installer-provisioning-verification-20260422.md
+++ b/docs/development/after-sales-m1-installer-provisioning-verification-20260422.md
@@ -106,3 +106,35 @@ stack and is therefore not run as part of M1 verification.
 - M0 provisioning unit tests: 7/7 pass.
 - New integration test: 3/3 pass.
 - No scope deviations.
+## Rebase verification — 2026-04-22
+
+Rebased from the original delivery baseline onto `origin/main@d547d89fcfcfded72f2e78a16320111d6def4f54`.
+
+Rebased head:
+
+```text
+ad1ecb76d feat(after-sales): wire installer C-min through multitable/provisioning.ts
+```
+
+Commands rerun after rebase:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/after-sales-installer-provisioning.api.test.ts --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/after-sales-installer.test.ts \
+  tests/unit/multitable-provisioning.test.ts --reporter=dot
+
+git diff --check
+```
+
+Results:
+
+- TypeScript: passed with zero diagnostics.
+- New integration: `after-sales-installer-provisioning.api.test.ts` 3/3 passed.
+- Focused unit regression: `after-sales-installer.test.ts` + `multitable-provisioning.test.ts` 48/48 passed.
+- `git diff --check`: passed.

--- a/docs/development/after-sales-m1-installer-provisioning-verification-20260422.md
+++ b/docs/development/after-sales-m1-installer-provisioning-verification-20260422.md
@@ -138,3 +138,33 @@ Results:
 - New integration: `after-sales-installer-provisioning.api.test.ts` 3/3 passed.
 - Focused unit regression: `after-sales-installer.test.ts` + `multitable-provisioning.test.ts` 48/48 passed.
 - `git diff --check`: passed.
+
+## CI guard verification — 2026-04-23
+
+After PR #1079 first CI run, the generic `Plugin System Tests / test (18.x)`
+job failed because it runs the broader Vitest sweep without `DATABASE_URL`.
+The M1 real-DB integration test is intentionally external-dependency-backed,
+so it now uses `describe.skip` when `DATABASE_URL` is absent. The explicit
+integration command remains unchanged and still exercises the real
+PostgreSQL-backed seam when `DATABASE_URL` is provided.
+
+Commands rerun:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/integration/after-sales-installer-provisioning.api.test.ts --reporter=dot
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/after-sales-installer-provisioning.api.test.ts --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+git diff --check
+```
+
+Results:
+
+- No-DB default Vitest path: 1 file skipped, 3 tests skipped, exit 0.
+- Real-DB integration path: 3/3 passed.
+- TypeScript: passed with zero diagnostics.
+- `git diff --check`: passed.

--- a/packages/core-backend/tests/integration/after-sales-installer-provisioning.api.test.ts
+++ b/packages/core-backend/tests/integration/after-sales-installer-provisioning.api.test.ts
@@ -57,6 +57,7 @@ const OBJECT_ID = 'installedAsset'
 const SHEET_ID = getObjectSheetId(PROJECT_ID, OBJECT_ID)
 const ASSET_CODE_FIELD_ID = getObjectFieldId(PROJECT_ID, OBJECT_ID, 'assetCode')
 const SERIAL_NO_FIELD_ID = getObjectFieldId(PROJECT_ID, OBJECT_ID, 'serialNo')
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
 const require = createRequire(import.meta.url)
 
@@ -147,7 +148,7 @@ async function ensureMultitableSeamSchema(pool: Pool): Promise<void> {
   `)
 }
 
-describe('after-sales installer C-min contract against real multitable seam', () => {
+describeIfDatabase('after-sales installer C-min contract against real multitable seam', () => {
   let pool: Pool | undefined
   let schemaReady = false
 
@@ -159,12 +160,6 @@ describe('after-sales installer C-min contract against real multitable seam', ()
 
   beforeAll(async () => {
     const databaseUrl = process.env.DATABASE_URL?.trim()
-    if (!databaseUrl) {
-      throw new Error(
-        'DATABASE_URL is required for after-sales installer provisioning integration tests',
-      )
-    }
-
     pool = new Pool({ connectionString: databaseUrl })
     await ensureMultitableSeamSchema(pool)
     schemaReady = true

--- a/packages/core-backend/tests/integration/after-sales-installer-provisioning.api.test.ts
+++ b/packages/core-backend/tests/integration/after-sales-installer-provisioning.api.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Integration test: after-sales installer C-min contract with
+ * multitable/provisioning.ts.
+ *
+ * Purpose
+ * -------
+ * M1 of the multitable-service-extraction roadmap (§5.2) requires that the
+ * after-sales installer's C-min path for `installedAsset` land through the
+ * backend provisioning seam (ensureLegacyBase / ensureSheet / ensureFields).
+ *
+ * The existing end-to-end integration test (after-sales-plugin.install.test.ts)
+ * covers the full blueprint (7 installedAsset fields + all other objects). That
+ * test is deliberately kept unchanged because the 5 extra installedAsset fields
+ * beyond the C-min floor (model / location / installedAt / warrantyUntil /
+ * status) are real business fields that belong to C-full, not placeholder
+ * scaffolding.
+ *
+ * What this test adds is the narrow seam-level contract check the roadmap
+ * §5.2 acceptance criteria specifically calls out:
+ *
+ *   "新增 1-2 个 integration tests 验证 provisioning helper 与真实 DB 契约"
+ *
+ * We exercise the production provisioning helpers directly against a real
+ * Postgres database and assert that the installedAsset C-min minimum field
+ * set (assetCode required + serialNo optional) is persisted through the
+ * seam - no plugin-side meta_* SQL access required. This is the contract
+ * the after-sales installer relies on when it calls
+ * `context.api.multitable.provisioning.ensureObject` in production.
+ *
+ * Scope (strict M1 C-min)
+ * -----------------------
+ * - Only installedAsset sheet + 2 fields are exercised here.
+ * - Views, records, attachments, automations, notifications are out of scope.
+ * - Other after-sales objects (ticket, customer, serviceRecord, etc.) are
+ *   covered by the existing end-to-end test.
+ */
+
+import { createRequire } from 'module'
+import { Pool } from 'pg'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_BASE_ID,
+  ensureFields,
+  ensureLegacyBase,
+  ensureObject,
+  ensureSheet,
+  getObjectFieldId,
+  getObjectSheetId,
+  type MultitableProvisioningQueryFn,
+} from '../../src/multitable/provisioning'
+
+const TENANT_ID = 'tenant_m1_installer_it'
+const APP_ID = 'after-sales'
+const PROJECT_ID = `${TENANT_ID}:${APP_ID}`
+const OBJECT_ID = 'installedAsset'
+const SHEET_ID = getObjectSheetId(PROJECT_ID, OBJECT_ID)
+const ASSET_CODE_FIELD_ID = getObjectFieldId(PROJECT_ID, OBJECT_ID, 'assetCode')
+const SERIAL_NO_FIELD_ID = getObjectFieldId(PROJECT_ID, OBJECT_ID, 'serialNo')
+
+const require = createRequire(import.meta.url)
+
+function createRealQuery(pool: Pool): MultitableProvisioningQueryFn {
+  return async (sql, params) => {
+    const result = await pool.query(sql, params as unknown[] | undefined)
+    return {
+      rows: Array.isArray(result.rows) ? result.rows : [],
+      rowCount: typeof result.rowCount === 'number' ? result.rowCount : undefined,
+    }
+  }
+}
+
+/**
+ * Provision exactly the multitable tables that the provisioning seam touches.
+ * We do not invoke the full migration stack here because this suite only needs
+ * meta_bases / meta_sheets / meta_fields, and the full migration stack depends
+ * on a dozen unrelated tables (approvals, kanban_configs, etc.) that would
+ * widen the test surface beyond the M1 scope. The schema definitions mirror
+ * zzz20251231_create_meta_schema.ts and zzzz20260318110000_add_multitable_bases_and_permissions.ts.
+ */
+async function ensureMultitableSeamSchema(pool: Pool): Promise<void> {
+  await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_bases (
+      id text PRIMARY KEY,
+      name text NOT NULL,
+      icon text,
+      color text,
+      owner_id text,
+      workspace_id text,
+      created_at timestamptz DEFAULT now() NOT NULL,
+      updated_at timestamptz DEFAULT now() NOT NULL,
+      deleted_at timestamptz
+    )
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_sheets (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      base_id text REFERENCES meta_bases(id) ON DELETE SET NULL,
+      name text NOT NULL,
+      description text,
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now(),
+      deleted_at timestamptz
+    )
+  `)
+  // Some earlier test runs may have created meta_sheets without base_id; add it idempotently.
+  await pool.query(`
+    ALTER TABLE meta_sheets ADD COLUMN IF NOT EXISTS base_id text
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_fields (
+      id text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      sheet_id text NOT NULL REFERENCES meta_sheets(id) ON DELETE CASCADE,
+      name text NOT NULL,
+      type text NOT NULL,
+      property jsonb DEFAULT '{}'::jsonb,
+      "order" integer NOT NULL DEFAULT 0,
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now()
+    )
+  `)
+  // Ledger table the installer writes to on successful install.
+  // Mirrors zzzz20260407140000_create_plugin_after_sales_template_installs.ts.
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS plugin_after_sales_template_installs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      tenant_id text NOT NULL,
+      app_id text NOT NULL,
+      project_id text NOT NULL,
+      template_id text NOT NULL,
+      template_version text NOT NULL,
+      mode text NOT NULL CHECK (mode IN ('enable', 'reinstall')),
+      status text NOT NULL CHECK (status IN ('installed', 'partial', 'failed')),
+      created_objects_json jsonb NOT NULL DEFAULT '[]'::jsonb,
+      created_views_json jsonb NOT NULL DEFAULT '[]'::jsonb,
+      warnings_json jsonb NOT NULL DEFAULT '[]'::jsonb,
+      display_name text NOT NULL DEFAULT '',
+      config_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+      last_install_at timestamptz NOT NULL DEFAULT now(),
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `)
+  await pool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_plugin_after_sales_template_installs_tenant_app
+    ON plugin_after_sales_template_installs(tenant_id, app_id)
+  `)
+}
+
+describe('after-sales installer C-min contract against real multitable seam', () => {
+  let pool: Pool | undefined
+  let schemaReady = false
+
+  async function cleanupArtifacts() {
+    if (!pool || !schemaReady) return
+    await pool.query('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID])
+    await pool.query('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID])
+  }
+
+  beforeAll(async () => {
+    const databaseUrl = process.env.DATABASE_URL?.trim()
+    if (!databaseUrl) {
+      throw new Error(
+        'DATABASE_URL is required for after-sales installer provisioning integration tests',
+      )
+    }
+
+    pool = new Pool({ connectionString: databaseUrl })
+    await ensureMultitableSeamSchema(pool)
+    schemaReady = true
+    await cleanupArtifacts()
+  })
+
+  afterAll(async () => {
+    if (pool) {
+      await cleanupArtifacts()
+      await pool.end()
+    }
+  })
+
+  beforeEach(async () => {
+    await cleanupArtifacts()
+  })
+
+  it('provisions installedAsset sheet via ensureLegacyBase + ensureSheet + ensureFields (C-min direct seam)', async () => {
+    if (!pool) throw new Error('pool not initialised')
+    const query = createRealQuery(pool)
+
+    const baseId = await ensureLegacyBase(query)
+    expect(baseId).toBe(DEFAULT_BASE_ID)
+
+    const sheet = await ensureSheet({
+      query,
+      baseId,
+      sheetId: SHEET_ID,
+      name: 'Installed Asset',
+      description: null,
+    })
+    expect(sheet).toMatchObject({
+      id: SHEET_ID,
+      baseId,
+      name: 'Installed Asset',
+    })
+
+    const fields = await ensureFields({
+      query,
+      sheetId: SHEET_ID,
+      fields: [
+        {
+          id: ASSET_CODE_FIELD_ID,
+          name: 'Asset Code',
+          type: 'string',
+        },
+        {
+          id: SERIAL_NO_FIELD_ID,
+          name: 'Serial No',
+          type: 'string',
+        },
+      ],
+    })
+    expect(fields).toHaveLength(2)
+    expect(fields.map((f) => ({ id: f.id, name: f.name, type: f.type }))).toEqual([
+      { id: ASSET_CODE_FIELD_ID, name: 'Asset Code', type: 'string' },
+      { id: SERIAL_NO_FIELD_ID, name: 'Serial No', type: 'string' },
+    ])
+
+    const sheetRow = await pool.query<{ id: string; name: string; base_id: string }>(
+      `SELECT id, name, base_id FROM meta_sheets WHERE id = $1`,
+      [SHEET_ID],
+    )
+    expect(sheetRow.rows).toEqual([
+      { id: SHEET_ID, name: 'Installed Asset', base_id: DEFAULT_BASE_ID },
+    ])
+
+    const fieldRows = await pool.query<{ id: string; name: string; type: string }>(
+      `SELECT id, name, type
+       FROM meta_fields
+       WHERE sheet_id = $1
+       ORDER BY "order" ASC, id ASC`,
+      [SHEET_ID],
+    )
+    const rowById = new Map(fieldRows.rows.map((r) => [r.id, r]))
+    expect(rowById.get(ASSET_CODE_FIELD_ID)).toEqual({
+      id: ASSET_CODE_FIELD_ID,
+      name: 'Asset Code',
+      type: 'string',
+    })
+    expect(rowById.get(SERIAL_NO_FIELD_ID)).toEqual({
+      id: SERIAL_NO_FIELD_ID,
+      name: 'Serial No',
+      type: 'string',
+    })
+    expect(fieldRows.rows).toHaveLength(2)
+  })
+
+  it('provisions installedAsset via ensureObject with the C-min minimum descriptor', async () => {
+    if (!pool) throw new Error('pool not initialised')
+    const query = createRealQuery(pool)
+
+    const result = await ensureObject({
+      query,
+      projectId: PROJECT_ID,
+      descriptor: {
+        id: OBJECT_ID,
+        name: 'Installed Asset',
+        fields: [
+          {
+            id: 'assetCode',
+            name: 'Asset Code',
+            type: 'string',
+          },
+          {
+            id: 'serialNo',
+            name: 'Serial No',
+            type: 'string',
+          },
+        ],
+      },
+    })
+
+    expect(result.baseId).toBe(DEFAULT_BASE_ID)
+    expect(result.sheet.id).toBe(SHEET_ID)
+    expect(result.sheet.name).toBe('Installed Asset')
+    expect(result.fields.map((f) => f.name)).toEqual(['Asset Code', 'Serial No'])
+
+    const sheetRow = await pool.query<{ id: string; name: string }>(
+      `SELECT id, name FROM meta_sheets WHERE id = $1`,
+      [SHEET_ID],
+    )
+    expect(sheetRow.rows).toEqual([{ id: SHEET_ID, name: 'Installed Asset' }])
+
+    const fieldRows = await pool.query<{ name: string; type: string }>(
+      `SELECT name, type
+       FROM meta_fields
+       WHERE sheet_id = $1
+       ORDER BY "order" ASC, id ASC`,
+      [SHEET_ID],
+    )
+    expect(fieldRows.rows).toEqual([
+      { name: 'Asset Code', type: 'string' },
+      { name: 'Serial No', type: 'string' },
+    ])
+  })
+
+  it('routes the after-sales installer runInstall through the multitable provisioning seam for installedAsset C-min', async () => {
+    if (!pool) throw new Error('pool not initialised')
+    const query = createRealQuery(pool)
+
+    // Plugin consumes the production seam exclusively via
+    // context.api.multitable.provisioning. This test calls the installer's
+    // runInstall with a minimal context that exposes only that seam, proving
+    // the plugin does not reach into meta_* directly.
+    const ensureObjectCalls: Array<{ projectId: string; descriptor: unknown }> = []
+    const provisioning = {
+      ensureObject: async (input: {
+        projectId: string
+        descriptor: { id: string; name: string; fields?: unknown[] }
+      }) => {
+        ensureObjectCalls.push({ projectId: input.projectId, descriptor: input.descriptor })
+        return ensureObject({
+          query,
+          projectId: input.projectId,
+          descriptor: input.descriptor as Parameters<typeof ensureObject>[0]['descriptor'],
+        })
+      },
+    }
+
+    const fakeDatabase = {
+      async query(sql: string, params: unknown[] = []) {
+        const result = await pool!.query(sql, params)
+        return result.rows
+      },
+    }
+
+    const blueprint = {
+      id: 'after-sales-default',
+      version: '0.1.0',
+      appId: APP_ID,
+      objects: [
+        {
+          id: OBJECT_ID,
+          name: 'Installed Asset',
+          backing: 'multitable' as const,
+          fields: [
+            { id: 'assetCode', name: 'Asset Code', type: 'string' as const, required: true },
+            { id: 'serialNo', name: 'Serial No', type: 'string' as const, required: false },
+          ],
+        },
+      ],
+    }
+
+    // Ensure ledger is clean for this specific (tenant, app)
+    await pool.query(
+      `DELETE FROM plugin_after_sales_template_installs WHERE tenant_id = $1 AND app_id = $2`,
+      [TENANT_ID, APP_ID],
+    )
+
+    const installer = require('../../../../plugins/plugin-after-sales/lib/installer.cjs') as {
+      runInstall: (input: unknown) => Promise<{
+        projectId: string
+        status: string
+        createdObjects: string[]
+      }>
+    }
+
+    try {
+      const result = await installer.runInstall({
+        context: {
+          api: {
+            database: fakeDatabase,
+            multitable: { provisioning },
+          },
+        },
+        tenantId: TENANT_ID,
+        blueprint,
+        mode: 'enable',
+      })
+
+      expect(result.status).toBe('installed')
+      expect(result.projectId).toBe(PROJECT_ID)
+      expect(result.createdObjects).toEqual([OBJECT_ID])
+      expect(ensureObjectCalls).toHaveLength(1)
+      expect(ensureObjectCalls[0]?.projectId).toBe(PROJECT_ID)
+
+      const fieldRows = await pool.query<{ name: string; type: string }>(
+        `SELECT name, type
+         FROM meta_fields
+         WHERE sheet_id = $1
+         ORDER BY "order" ASC, id ASC`,
+        [SHEET_ID],
+      )
+      expect(fieldRows.rows).toEqual([
+        { name: 'Asset Code', type: 'string' },
+        { name: 'Serial No', type: 'string' },
+      ])
+    } finally {
+      await pool.query(
+        `DELETE FROM plugin_after_sales_template_installs WHERE tenant_id = $1 AND app_id = $2`,
+        [TENANT_ID, APP_ID],
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Add integration coverage for the after-sales installer consuming `context.api.multitable.provisioning`.
- Cover direct provisioning, aggregated `ensureObject`, and installer `runInstall` paths.
- Document the M1 seam decision and verification record.

## Rebase
- Rebased onto `origin/main@d547d89fcfcfded72f2e78a16320111d6def4f54`.
- Rebased head: `8a3211f4c`.

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-installer-provisioning.api.test.ts --reporter=dot` -> 3/3 passed
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/after-sales-installer.test.ts tests/unit/multitable-provisioning.test.ts --reporter=dot` -> 48/48 passed
- `git diff --check`

## Notes
- Pure additive test/docs PR; no runtime source change.
- Full migration-stack type mismatch remains documented as pre-existing and outside this PR.