### PR TITLE
feat(approval): add WP1 parallel gateway

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -108,7 +108,14 @@ function mockApproval(index: number): UnifiedApprovalDTO {
   const status = statuses[index % statuses.length]
   // Surface an any-mode fixture on a stable slot so dev-mode always exercises the UI branch.
   const isAnyModeFixture = index % 5 === 1
-  const baseAssignmentNodeKey = isAnyModeFixture ? 'approval_any' : 'approval_1'
+  // Surface a parallel-gateway fixture on a stable slot so dev-mode always
+  // exercises the `currentNodeKeys` → "并行中" UI path. Parallel wins over
+  // any-mode on that slot because the any-mode badge already renders on many
+  // other indices.
+  const isParallelFixture = index % 7 === 3
+  const baseAssignmentNodeKey = isParallelFixture
+    ? 'parallel_fork'
+    : isAnyModeFixture ? 'approval_any' : 'approval_1'
   return {
     id: `apv_${index}`,
     sourceSystem: 'platform',
@@ -128,8 +135,32 @@ function mockApproval(index: number): UnifiedApprovalDTO {
     requestNo: `AP-${String(100000 + index)}`,
     formSnapshot: { fld_reason: '出差报销', fld_amount: 5000, fld_type: 'reimbursement' },
     currentNodeKey: status === 'pending' ? baseAssignmentNodeKey : null,
+    ...(status === 'pending' && isParallelFixture
+      ? { currentNodeKeys: ['legal_review', 'compliance_review'] as string[] }
+      : {}),
     assignments: status === 'pending'
-      ? (isAnyModeFixture
+      ? (isParallelFixture
+        ? [
+          {
+            id: `asgn_${index}_legal`,
+            type: 'approval',
+            assigneeId: 'user_legal',
+            sourceStep: 1,
+            nodeKey: 'legal_review',
+            isActive: true,
+            metadata: {},
+          },
+          {
+            id: `asgn_${index}_compliance`,
+            type: 'approval',
+            assigneeId: 'user_compliance',
+            sourceStep: 1,
+            nodeKey: 'compliance_review',
+            isActive: true,
+            metadata: {},
+          },
+        ]
+        : isAnyModeFixture
         ? [
           {
             id: `asgn_${index}_a`,

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -7,9 +7,10 @@ export const APPROVAL_PRODUCT_PERMISSIONS = [
 
 export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[number]
 
-export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'end'
+export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
 export type ApprovalMode = 'single' | 'all' | 'any'
+export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
 export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
@@ -29,7 +30,12 @@ export interface ApprovalNode {
   key: string
   type: ApprovalNodeType
   name?: string
-  config: ApprovalNodeConfig | ConditionNodeConfig | CcNodeConfig | Record<string, never>
+  config:
+    | ApprovalNodeConfig
+    | ConditionNodeConfig
+    | CcNodeConfig
+    | ParallelNodeConfig
+    | Record<string, never>
 }
 
 export interface ApprovalNodeConfig {
@@ -59,6 +65,12 @@ export interface ConditionRule {
 export interface CcNodeConfig {
   targetType: ApprovalAssigneeType
   targetIds: string[]
+}
+
+export interface ParallelNodeConfig {
+  branches: string[]
+  joinMode: ParallelJoinMode
+  joinNodeKey: string
 }
 
 export interface ApprovalEdge {
@@ -148,6 +160,11 @@ export interface UnifiedApprovalDTO {
   requestNo?: string | null
   formSnapshot?: Record<string, unknown> | null
   currentNodeKey?: string | null
+  /**
+   * Parallel gateway (并行分支) — surfaced only when the instance is inside
+   * a parallel region (length ≥ 2). Absent on linear state.
+   */
+  currentNodeKeys?: string[] | null
   assignments: ApprovalAssignmentDTO[]
   createdAt: string
   updatedAt: string

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -13,6 +13,15 @@
       >
         {{ statusLabel(approval.status) }}
       </el-tag>
+      <el-tag
+        v-if="approval && isInParallelRegion"
+        type="warning"
+        size="large"
+        class="approval-detail__parallel-badge"
+        effect="light"
+      >
+        并行中 · {{ parallelBranchNodeKeys.map(nodeLabel).join(' / ') }}
+      </el-tag>
     </header>
 
     <el-alert
@@ -75,56 +84,115 @@
         <!-- Right: history timeline -->
         <div class="approval-detail__timeline">
           <h2>审批流程</h2>
-          <el-timeline v-if="store.history.length">
-            <el-timeline-item
-              v-for="item in store.history"
-              :key="item.id"
-              :type="timelineItemType(item.action, item.toStatus)"
-              :icon="timelineIcon(item.action, item.metadata)"
-              :hollow="item.toStatus === 'pending'"
-              size="large"
-              :timestamp="item.occurredAt ? formatDate(item.occurredAt) : '-'"
-              placement="top"
-            >
-              <div class="approval-detail__timeline-content">
-                <div class="approval-detail__timeline-header">
-                  <strong>{{ item.metadata?.autoApproved ? '系统自动审批' : (item.actorName ?? '系统') }}</strong>
-                  <el-tag :type="timelineActionTagType(item.action, item.metadata)" size="small">
-                    {{ actionLabel(item.action, item.metadata) }}
-                  </el-tag>
-                </div>
-                <p v-if="item.comment" class="approval-detail__timeline-comment">
-                  {{ item.comment }}
-                </p>
-                <div v-if="hasTimelineMetadata(item.metadata)" class="approval-detail__timeline-meta">
-                  <span v-if="item.metadata?.autoApproved" class="approval-detail__meta-badge approval-detail__meta-badge--auto">
-                    自动审批
+          <template v-if="store.history.length">
+            <!-- Parallel gateway (并行分支): cluster history entries under
+                 each branch's approval-node key so reviewers can trace
+                 per-branch decisions without re-reading the full timeline. -->
+            <template v-if="isInParallelRegion && timelineBranchGroups.length">
+              <div
+                v-for="group in timelineBranchGroups"
+                :key="group.key"
+                class="approval-detail__timeline-group"
+              >
+                <div class="approval-detail__timeline-group-header">
+                  <span class="approval-detail__timeline-group-label">
+                    {{ group.label }}
                   </span>
-                  <span v-if="item.metadata?.approvalMode" class="approval-detail__meta-badge">
-                    审批模式: {{ approvalModeLabel(item.metadata.approvalMode as string) }}
-                  </span>
-                  <span v-if="item.metadata?.aggregateComplete && item.metadata?.approvalMode === 'all'" class="approval-detail__meta-badge approval-detail__meta-badge--complete">
-                    会签完成
-                  </span>
-                  <span v-if="item.metadata?.aggregateComplete && item.metadata?.approvalMode === 'any'" class="approval-detail__meta-badge approval-detail__meta-badge--complete">
-                    或签完成
-                  </span>
-                  <span v-if="cancelledAssigneesLabel(item.metadata)" class="approval-detail__meta-badge approval-detail__meta-badge--cancelled">
-                    {{ cancelledAssigneesLabel(item.metadata) }}
-                  </span>
-                  <span v-if="item.action === 'sign' && item.metadata?.autoCancelled" class="approval-detail__meta-badge approval-detail__meta-badge--cancelled">
-                    （已被 {{ item.metadata?.aggregateCancelledBy || '发起人' }} 的决定覆盖）
-                  </span>
-                  <span v-if="item.action === 'return' && item.metadata?.targetNodeKey" class="approval-detail__meta-badge approval-detail__meta-badge--return">
-                    退回至: {{ nodeLabel(item.metadata.targetNodeKey as string) }}
-                  </span>
-                  <span v-if="item.metadata?.nodeKey" class="approval-detail__meta-badge">
-                    节点: {{ item.metadata.nodeKey }}
+                  <span class="approval-detail__timeline-group-count">
+                    {{ group.items.length }} 条
                   </span>
                 </div>
+                <el-timeline>
+                  <el-timeline-item
+                    v-for="item in group.items"
+                    :key="item.id"
+                    :type="timelineItemType(item.action, item.toStatus)"
+                    :icon="timelineIcon(item.action, item.metadata)"
+                    :hollow="item.toStatus === 'pending'"
+                    size="large"
+                    :timestamp="item.occurredAt ? formatDate(item.occurredAt) : '-'"
+                    placement="top"
+                  >
+                    <div class="approval-detail__timeline-content">
+                      <div class="approval-detail__timeline-header">
+                        <strong>{{ item.metadata?.autoApproved ? '系统自动审批' : (item.actorName ?? '系统') }}</strong>
+                        <el-tag :type="timelineActionTagType(item.action, item.metadata)" size="small">
+                          {{ actionLabel(item.action, item.metadata) }}
+                        </el-tag>
+                      </div>
+                      <p v-if="item.comment" class="approval-detail__timeline-comment">
+                        {{ item.comment }}
+                      </p>
+                      <div v-if="hasTimelineMetadata(item.metadata)" class="approval-detail__timeline-meta">
+                        <span v-if="item.metadata?.autoApproved" class="approval-detail__meta-badge approval-detail__meta-badge--auto">自动审批</span>
+                        <span v-if="item.metadata?.approvalMode" class="approval-detail__meta-badge">
+                          审批模式: {{ approvalModeLabel(item.metadata.approvalMode as string) }}
+                        </span>
+                        <span v-if="item.metadata?.aggregateComplete && item.metadata?.approvalMode === 'all'" class="approval-detail__meta-badge approval-detail__meta-badge--complete">会签完成</span>
+                        <span v-if="item.metadata?.aggregateComplete && item.metadata?.approvalMode === 'any'" class="approval-detail__meta-badge approval-detail__meta-badge--complete">或签完成</span>
+                        <span v-if="cancelledAssigneesLabel(item.metadata)" class="approval-detail__meta-badge approval-detail__meta-badge--cancelled">
+                          {{ cancelledAssigneesLabel(item.metadata) }}
+                        </span>
+                        <span v-if="item.action === 'sign' && item.metadata?.autoCancelled" class="approval-detail__meta-badge approval-detail__meta-badge--cancelled">
+                          （已被 {{ item.metadata?.aggregateCancelledBy || '发起人' }} 的决定覆盖）
+                        </span>
+                        <span v-if="item.action === 'return' && item.metadata?.targetNodeKey" class="approval-detail__meta-badge approval-detail__meta-badge--return">
+                          退回至: {{ nodeLabel(item.metadata.targetNodeKey as string) }}
+                        </span>
+                        <span v-if="item.metadata?.nodeKey" class="approval-detail__meta-badge">
+                          节点: {{ item.metadata.nodeKey }}
+                        </span>
+                      </div>
+                    </div>
+                  </el-timeline-item>
+                </el-timeline>
               </div>
-            </el-timeline-item>
-          </el-timeline>
+            </template>
+            <el-timeline v-else>
+              <el-timeline-item
+                v-for="item in store.history"
+                :key="item.id"
+                :type="timelineItemType(item.action, item.toStatus)"
+                :icon="timelineIcon(item.action, item.metadata)"
+                :hollow="item.toStatus === 'pending'"
+                size="large"
+                :timestamp="item.occurredAt ? formatDate(item.occurredAt) : '-'"
+                placement="top"
+              >
+                <div class="approval-detail__timeline-content">
+                  <div class="approval-detail__timeline-header">
+                    <strong>{{ item.metadata?.autoApproved ? '系统自动审批' : (item.actorName ?? '系统') }}</strong>
+                    <el-tag :type="timelineActionTagType(item.action, item.metadata)" size="small">
+                      {{ actionLabel(item.action, item.metadata) }}
+                    </el-tag>
+                  </div>
+                  <p v-if="item.comment" class="approval-detail__timeline-comment">
+                    {{ item.comment }}
+                  </p>
+                  <div v-if="hasTimelineMetadata(item.metadata)" class="approval-detail__timeline-meta">
+                    <span v-if="item.metadata?.autoApproved" class="approval-detail__meta-badge approval-detail__meta-badge--auto">自动审批</span>
+                    <span v-if="item.metadata?.approvalMode" class="approval-detail__meta-badge">
+                      审批模式: {{ approvalModeLabel(item.metadata.approvalMode as string) }}
+                    </span>
+                    <span v-if="item.metadata?.aggregateComplete && item.metadata?.approvalMode === 'all'" class="approval-detail__meta-badge approval-detail__meta-badge--complete">会签完成</span>
+                    <span v-if="item.metadata?.aggregateComplete && item.metadata?.approvalMode === 'any'" class="approval-detail__meta-badge approval-detail__meta-badge--complete">或签完成</span>
+                    <span v-if="cancelledAssigneesLabel(item.metadata)" class="approval-detail__meta-badge approval-detail__meta-badge--cancelled">
+                      {{ cancelledAssigneesLabel(item.metadata) }}
+                    </span>
+                    <span v-if="item.action === 'sign' && item.metadata?.autoCancelled" class="approval-detail__meta-badge approval-detail__meta-badge--cancelled">
+                      （已被 {{ item.metadata?.aggregateCancelledBy || '发起人' }} 的决定覆盖）
+                    </span>
+                    <span v-if="item.action === 'return' && item.metadata?.targetNodeKey" class="approval-detail__meta-badge approval-detail__meta-badge--return">
+                      退回至: {{ nodeLabel(item.metadata.targetNodeKey as string) }}
+                    </span>
+                    <span v-if="item.metadata?.nodeKey" class="approval-detail__meta-badge">
+                      节点: {{ item.metadata.nodeKey }}
+                    </span>
+                  </div>
+                </div>
+              </el-timeline-item>
+            </el-timeline>
+          </template>
           <el-empty v-else description="暂无审批历史" :image-size="80" />
         </div>
       </div>
@@ -343,6 +411,49 @@ const approval = computed(() => store.activeApproval)
 const isRequester = computed(() => {
   // Simple heuristic: mock current user as 'user_1'
   return approval.value?.requester?.id === 'user_1'
+})
+
+// Parallel gateway (并行分支) — the instance is inside a parallel region when
+// the backend surfaces `currentNodeKeys` with at least two entries. Templates
+// with a single-branch fallback or any other shape leave the field absent, so
+// existing linear-flow rendering is untouched.
+const parallelBranchNodeKeys = computed<string[]>(() => {
+  const nodeKeys = approval.value?.currentNodeKeys
+  return Array.isArray(nodeKeys) ? nodeKeys : []
+})
+const isInParallelRegion = computed(() => parallelBranchNodeKeys.value.length >= 2)
+
+interface TimelineGroup {
+  key: string
+  label: string
+  items: typeof store.history
+}
+
+// Group the history timeline by the approval-node key each entry targets so a
+// reviewer can scan each branch's decisions without interleaving. Entries
+// that lack a `metadata.nodeKey` (e.g. the 'created' row or cc broadcasts
+// from before the parallel fork) land in an "其他" group rendered last. The
+// group order follows first-seen order in the timeline, so branches appear
+// in the order the backend recorded them.
+const timelineBranchGroups = computed<TimelineGroup[]>(() => {
+  if (!isInParallelRegion.value) return []
+  const buckets = new Map<string, TimelineGroup>()
+  const order: string[] = []
+  const OTHER_KEY = '__other'
+  for (const item of store.history) {
+    const nodeKey = typeof item.metadata?.nodeKey === 'string' ? item.metadata.nodeKey : null
+    const bucketKey = nodeKey && parallelBranchNodeKeys.value.includes(nodeKey) ? nodeKey : OTHER_KEY
+    if (!buckets.has(bucketKey)) {
+      order.push(bucketKey)
+      buckets.set(bucketKey, {
+        key: bucketKey,
+        label: bucketKey === OTHER_KEY ? '其他' : nodeLabel(bucketKey),
+        items: [],
+      })
+    }
+    buckets.get(bucketKey)!.items.push(item)
+  }
+  return order.map((key) => buckets.get(key)!)
 })
 
 const actionDialogVisible = ref(false)
@@ -743,6 +854,39 @@ onMounted(async () => {
 .approval-detail__meta-badge--return {
   background: #fff7e6;
   color: #fa8c16;
+}
+
+.approval-detail__parallel-badge {
+  margin-left: 8px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+}
+
+.approval-detail__timeline-group {
+  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  background: var(--el-fill-color-blank, #fff);
+}
+
+.approval-detail__timeline-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px dashed var(--el-border-color-lighter, #ebedf0);
+}
+
+.approval-detail__timeline-group-label {
+  font-weight: 600;
+  color: var(--el-text-color-primary, #303133);
+}
+
+.approval-detail__timeline-group-count {
+  font-size: 12px;
+  color: var(--el-text-color-secondary, #606266);
 }
 
 .approval-detail__actions {

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -199,6 +199,7 @@ function nodeTypeLabel(type: ApprovalNodeType) {
     approval: '审批',
     cc: '抄送',
     condition: '条件',
+    parallel: '并行',
     end: '结束',
   }
   return map[type] ?? type
@@ -210,6 +211,7 @@ function nodeTimelineType(type: ApprovalNodeType): string {
     approval: 'warning',
     cc: 'success',
     condition: 'danger',
+    parallel: 'warning',
     end: 'info',
   }
   return map[type] ?? 'info'
@@ -221,6 +223,7 @@ function nodeTimelineIcon(type: ApprovalNodeType) {
     approval: UserFilled,
     cc: Message,
     condition: QuestionFilled,
+    parallel: QuestionFilled,
     end: CircleCheckFilled,
   }
   return map[type] ?? undefined
@@ -232,6 +235,7 @@ function nodeTagType(type: ApprovalNodeType): string {
     approval: 'warning',
     cc: 'success',
     condition: 'danger',
+    parallel: 'warning',
     end: 'info',
   }
   return map[type] ?? ''

--- a/docs/development/approval-wp1-parallel-gateway-development-20260422.md
+++ b/docs/development/approval-wp1-parallel-gateway-development-20260422.md
@@ -1,0 +1,241 @@
+# Approval Wave 2 WP1 — 并行分支 (Parallel Gateway) Development Notes
+
+> Date: 2026-04-22
+> Branch: `codex/approval-wp1-parallel-gateway-20260422`
+> Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/wp1-parallel`
+> Base: `origin/main @ 27a9b9de1`
+> Scope: Close the Wave 2 WP1 flow-control trilogy by shipping end-to-end
+> support for the `parallel` ApprovalNodeType (会签 + 或签 already delivered
+> in Pack 1A and PR #1015 respectively).
+
+## Chosen approach
+
+**Approach A (additive / non-breaking)** — `ApprovalGraphResolution` gains
+an optional `currentNodeKeys?: string[]` and an optional
+`parallelState?: ParallelInstanceState`. Legacy consumers keep
+`currentNodeKey` unchanged. When `currentNodeKeys.length >= 2` the caller
+knows the instance is inside a parallel region.
+
+Why not Approach B: any-mode (#1015) and Pack 1A both read
+`currentNodeKey` directly from the resolution; replacing the field would
+force a cascade of audit-row / assignment-metadata changes on those
+already-shipped flows. Additive keeps Pack 1A and or-mode behavior
+byte-for-byte unchanged.
+
+## Data model delta
+
+`packages/core-backend/src/types/approval-product.ts`:
+
+- `ApprovalNodeType` now includes `'parallel'` (union addition).
+- New `ParallelJoinMode = 'all' | 'any'`.
+- New `ParallelNodeConfig { branches: string[]; joinMode; joinNodeKey }`.
+  `joinNodeKey` is **required** — the walker uses it as the terminal
+  signal per branch, and validation enforces that every branch edge's
+  downstream path reaches it.
+- `UnifiedApprovalDTO` gains `currentNodeKeys?: string[] | null`.
+
+`packages/core-backend/src/services/approval-bridge-types.ts` mirrors
+`currentNodeKeys` onto the bridge DTO (for parity with the product DTO).
+
+`packages/core-backend/src/services/ApprovalGraphExecutor.ts`:
+
+- New exports `ParallelBranchState` and `ParallelInstanceState`
+  describe the per-instance branch map persisted in
+  `approval_instances.metadata.parallelBranchStates`.
+- `ApprovalGraphResolution.currentNodeKeys` and
+  `ApprovalGraphResolution.parallelState` are both optional.
+
+**No new DB columns.** The parallel branch-state map lives entirely in
+the pre-existing `approval_instances.metadata` JSONB column, keyed by
+`parallelBranchStates`. This avoids a migration and side-steps index
+churn on `approval_assignments` (see "Storage & lookup rules" below).
+
+## Engine semantics
+
+### Walk path
+
+`resolveFromNode` now recognises `type: 'parallel'`:
+
+1. For each branch edgeKey, call a shared `resolveBranchAdvance` helper
+   that walks until it either hits a pending approval (returns that
+   branch's frontier + assignments) or the join node (branch already
+   auto-complete via cc / auto-approve chain).
+2. Aggregate per-branch assignments / cc events / auto-approval events.
+3. If *every* branch auto-completed, recurse past the join node
+   (`resolveFromNode(joinNodeKey)`).
+4. Otherwise return a resolution whose `currentNodeKey` is the parallel
+   fork node, `currentNodeKeys` lists pending branch frontiers,
+   `assignments` carries the flattened per-branch pending assignments,
+   and `parallelState` carries the initial branch-state map.
+
+### Post-approve path
+
+- Linear state: `resolveAfterApprove(currentNodeKey)` unchanged.
+- Parallel state: new `resolveAfterApproveInParallel(branchNodeKey,
+  state)` walks the actor's branch one "advance step":
+  - Branch reaches another approval before the join → return a
+    pending resolution with `currentNodeKey = parallelNodeKey` and the
+    sibling frontiers preserved in `currentNodeKeys`; `parallelState`
+    carries the updated map.
+  - Branch reaches the join → mark this branch complete. If siblings
+    still pending, return pending resolution; otherwise recurse past
+    the join (`resolveFromNode(joinNodeKey)`) and return a linear
+    resolution.
+
+### Storage & lookup rules
+
+- `instance.current_node_key = parallelNodeKey` while the parallel
+  region is open (per advisor Option α — keeps the parallel "address"
+  stable and lets the dispatch route derive the actor's branch from
+  their active assignment's `node_key`).
+- `instance.metadata.parallelBranchStates` persists
+  `{ parallelNodeKey, joinNodeKey, joinMode, branches: { [edgeKey]: { currentNodeKey, complete } } }`.
+- The route reads that back, picks the actor's branch node by matching
+  an active assignment whose `node_key` is one of the pending branch
+  frontiers, and passes the derived `branchNodeKey` into
+  `resolveAfterApproveInParallel`.
+- Once all branches report complete, the metadata key is stripped with
+  `jsonb - 'parallelBranchStates'` so subsequent actions run the linear
+  path.
+
+### Return-to-node
+
+`resolveReturnToNode` and `listVisitedApprovalNodeKeysUntil` are **not**
+taught how to jump into or out of a parallel branch. The dispatch route
+rejects `action: 'return'` while the instance is in a parallel region
+with `APPROVAL_RETURN_IN_PARALLEL_UNSUPPORTED` (409). The linear walker
+in `listVisitedApprovalNodeKeysUntil` still skips over a `parallel`
+fork by jumping to its `joinNodeKey`, which keeps the post-join return
+target set stable.
+
+### Single-mode in a parallel branch
+
+When the actor's branch is a default / single-mode approval node inside
+a parallel region, `deactivateAllActiveAssignments` would nuke sibling
+branches too. The route now scopes to
+`deactivateActorAssignmentsAtNode(branchNodeKey, …)` while inside a
+parallel region; linear state keeps the legacy blanket deactivation.
+
+## Template-level validation
+
+`normalizeApprovalGraph` grew a parallel post-pass:
+
+- Every `branches` edgeKey must exist and must originate from the
+  parallel node.
+- `joinNodeKey` must reference a real node.
+- Each branch's forward-reachable approval assignees are collected
+  and **rejected if any assignee appears in two branches** — the
+  `approval_assignments (instance_id, assignment_type, assignee_id)
+  WHERE is_active=TRUE` unique index cannot represent the same user
+  active in two branches at once (v1 limitation; see follow-ups).
+- Nested parallel inside a branch is rejected.
+
+The dev MD (you are reading) records this as a deliberate v1
+trade-off. Integration test
+`approval-wp1-parallel-gateway.api.test.ts` exercises the rejection.
+
+## Route wiring (ApprovalProductService)
+
+- `createApproval` copies `initial.parallelState` into the new
+  instance's `metadata.parallelBranchStates` when the initial
+  resolution lands inside a parallel region.
+- `dispatchAction`:
+  - Reads parallel state from `instance.metadata` at the start of the
+    transaction.
+  - Derives `actorBranchNodeKey` by scanning the actor's active
+    assignments for one whose `node_key` matches a pending branch
+    frontier.
+  - Rejects `return` under parallel state with a typed error.
+  - Keeps `revoke` unchanged (revokes the whole instance regardless).
+  - Under parallel state with single-mode, deactivates only the
+    actor's branch-node assignment instead of blanket-deactivating.
+  - Selects `resolveAfterApproveInParallel` vs `resolveAfterApprove`
+    based on `isInParallelRegion && actorBranchNodeKey`.
+  - Updates `metadata.parallelBranchStates` (persist / refresh / strip)
+    based on whether the resolution keeps us in, enters, or leaves a
+    parallel region.
+  - Adds `parallelNodeKey` and `parallelBranchComplete` markers to the
+    approve-audit metadata for timeline UI.
+
+## OpenAPI
+
+`packages/openapi/src/base.yml`:
+
+- `ApprovalNode.type` enum gains `parallel`.
+- New `ApprovalParallelNodeConfig` schema documents `branches`,
+  `joinMode`, `joinNodeKey`.
+- `UnifiedApprovalDTO.currentNodeKeys` documented as the parallel
+  frontier (length ≥ 2 signals parallel state).
+
+## Frontend
+
+- `apps/web/src/types/approval.ts` mirrors the new types, node type,
+  and DTO field.
+- `apps/web/src/views/approval/ApprovalDetailView.vue` renders a
+  `并行中 · {labels}` badge in the header when `currentNodeKeys.length
+  >= 2`, and switches the history timeline to a branch-grouped layout
+  — one boxed section per branch approval node, plus an `其他` bucket
+  for pre-fork (`created`, cc broadcasts). Linear-state rendering
+  (`el-timeline` without groups) is used when the instance is not in
+  a parallel region, so Pack 1A / or-mode detail views are unchanged.
+- `apps/web/src/approvals/api.ts` mock factory grew a parallel
+  fixture slot (`index % 7 === 3`) with two active branch
+  assignments and a populated `currentNodeKeys` so dev mode exercises
+  the UI branch without backend changes.
+
+## Tests
+
+- `packages/core-backend/tests/unit/approval-graph-executor.test.ts`
+  gains two parallel cases: fork produces per-branch assignments +
+  parallelState; fork-then-approve keeps instance pending with
+  updated branch state, then join-all advances to the post-join
+  frontier.
+- `packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts`:
+  - Template creation + publish + instance creation shows two active
+    branches and `currentNodeKeys`.
+  - First branch approval keeps instance pending, second closes.
+  - Post-join `finance-review` completes the instance.
+  - Audit records carry `parallelNodeKey` + `parallelBranchComplete`.
+  - Return inside parallel → 409
+    `APPROVAL_RETURN_IN_PARALLEL_UNSUPPORTED`.
+  - Template validation rejects duplicate approver across branches
+    with 400 `VALIDATION_ERROR`.
+
+## Follow-ups (deferred)
+
+1. `joinMode: 'any'` (first-branch-wins join) — executor currently
+   throws. Needs sibling-branch cancellation audit trail similar to
+   or-mode.
+2. Return-to-node targeting an approval inside a closed parallel
+   branch — requires the walker to pick a specific branch sub-region
+   and replay it; the route currently rejects all returns while
+   parallel is active.
+3. Nested parallel (a branch whose internal sub-graph contains
+   another parallel node) — rejected in template validation; would
+   need recursive `parallelBranchStates` (tree instead of flat map).
+4. Overlapping approvers across branches — blocked by template
+   validation; could be unblocked by relaxing the unique index or by
+   promoting each active assignment to carry a branch discriminator.
+5. Any-mode (或签) inside a parallel branch whose sibling approvers
+   also race — deactivation logic needs to be scoped to branch +
+   actor, not just actor. Currently handled correctly via
+   `deactivateActorAssignmentsAtNode(branchNodeKey, …)` so any-mode +
+   parallel combination works, but there are no integration tests for
+   that combo yet. Add a regression test in the next wave.
+6. `RuntimePolicy.revokeBeforeNodeKeys` and parallel state —
+   `instance.current_node_key` equals `parallelNodeKey` while
+   parallel is active. Templates listing only branch-approval nodes
+   in `revokeBeforeNodeKeys` will **block** revoke during the
+   parallel region; template authors must include the parallel fork
+   node key (or `finance_review` post-join) explicitly. Not
+   automatically re-written by the service — revisit in a later wave
+   if authoring ergonomics bite.
+
+## Non-goals
+
+- No DB schema change — all parallel state fits inside
+  `approval_instances.metadata` JSONB.
+- No changes to Pack 1A (`all` mode) or or-mode (`any` mode)
+  semantics. Their integration tests pass unchanged on this branch.
+- No visual flow diagram — existing timeline already separates per-
+  `nodeKey` entries, which is sufficient for a minimum viable render.

--- a/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
+++ b/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
@@ -181,3 +181,34 @@ Results:
 The OpenAPI contract gate checks for a clean committed dist after running the
 build; it is rerun after this fix commit is created so `git diff --quiet` can
 observe the regenerated files as baseline.
+
+Post-commit commands rerun:
+
+```bash
+./scripts/ops/attendance-run-gate-contract-case.sh openapi
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-parallel-gateway.api.test.ts --reporter=dot
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-any-mode.api.test.ts \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot
+```
+
+Post-commit results:
+
+- OpenAPI contract gate: passed.
+- WP1 parallel integration: 3/3 passed.
+- Pack 1A + or-mode regression: 4/4 passed.
+- WP2 source filter regression: 7/7 passed.
+
+Note: one local attempt to run all four integration files in the same Vitest
+process hit a PostgreSQL DDL deadlock in shared fixture setup. The split
+commands above are the stable pattern already used for this family of tests;
+CI runs these jobs in a clean database context.

--- a/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
+++ b/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
@@ -212,3 +212,48 @@ Note: one local attempt to run all four integration files in the same Vitest
 process hit a PostgreSQL DDL deadlock in shared fixture setup. The split
 commands above are the stable pattern already used for this family of tests;
 CI runs these jobs in a clean database context.
+
+## Final main rebase — 2026-04-23
+
+After #1079 and #1080 were merged, PR #1081 became `BEHIND`. The branch was
+rebased onto `origin/main@2aa78e8680eb9f2e71e52e226de710886acb0ded` before
+final merge instead of bypassing the stale-branch gate.
+
+Rebased head stack:
+
+```text
+ecba58023 docs(approval): record WP1 CI follow-up verification
+ada6f3977 fix(approval): publish parallel node contract artifacts
+f5a3cf631 docs(approval): record WP1 parallel rebase verification
+3ae85fcee feat(approval): ship WP1 parallel gateway (并行分支) with join-all semantics
+```
+
+Commands rerun after final rebase:
+
+```bash
+./scripts/ops/attendance-run-gate-contract-case.sh openapi
+pnpm type-check
+git diff --check
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-parallel-gateway.api.test.ts --reporter=dot
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-any-mode.api.test.ts \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts --reporter=dot
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot
+```
+
+Final rebase results:
+
+- OpenAPI contract gate: passed.
+- Workspace type-check: passed.
+- `git diff --check`: passed.
+- WP1 parallel integration: 3/3 passed.
+- Pack 1A + or-mode regression: 4/4 passed.
+- WP2 source filter regression: 7/7 passed.

--- a/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
+++ b/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
@@ -144,3 +144,40 @@ Results:
 - `git diff --check`: passed.
 
 Note: the full-unit count is one higher than the original delivery summary because `origin/main` now includes the #1077 WP2 source filter regression test.
+
+## CI follow-up verification — 2026-04-23
+
+PR #1081 first CI run exposed two packaging gaps that were not covered by the
+focused local commands:
+
+- `pnpm type-check` runs web type checking and caught `TemplateDetailView.vue`
+  maps that were typed as `Record<ApprovalNodeType, ...>` but did not include
+  the new `parallel` node type.
+- `contracts (openapi)` caught generated dist drift after
+  `packages/openapi/src/base.yml` added the parallel schema fields.
+
+Fixes applied:
+
+- Added `parallel` label / timeline / icon / tag entries to
+  `apps/web/src/views/approval/TemplateDetailView.vue`.
+- Rebuilt and committed `packages/openapi/dist/openapi.json`,
+  `packages/openapi/dist/openapi.yaml`, and
+  `packages/openapi/dist/combined.openapi.yml`.
+
+Commands rerun:
+
+```bash
+pnpm exec tsx packages/openapi/tools/build.ts
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Results:
+
+- OpenAPI build: completed and regenerated the expected dist files.
+- Frontend `vue-tsc -b --noEmit`: passed.
+- Backend TypeScript: passed with zero diagnostics.
+
+The OpenAPI contract gate checks for a clean committed dist after running the
+build; it is rerun after this fix commit is created so `git diff --quiet` can
+observe the regenerated files as baseline.

--- a/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
+++ b/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
@@ -1,0 +1,109 @@
+# Approval WP1 Parallel Gateway — Verification Log
+
+> Date: 2026-04-22
+> Branch: `codex/approval-wp1-parallel-gateway-20260422`
+> Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/wp1-parallel`
+> Base: `origin/main @ 27a9b9de1`
+
+## Command log (all green)
+
+```text
+# Baseline before any changes (sanity that pack1a + any-mode + wp2 src-filter are green on this branch)
+$ DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-any-mode.api.test.ts \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts \
+    tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot
+  Test Files  3 passed (3)
+  Tests       8 passed (8)
+  Duration    3.64s
+
+# Backend TypeScript (both after data-model edits and after dispatch wiring; the second is recorded here)
+$ pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+  (no output — clean)
+
+# Web TypeScript
+$ pnpm --filter @metasheet/web exec vue-tsc --noEmit
+  (no output — clean)
+
+# New parallel gateway integration test
+$ DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-parallel-gateway.api.test.ts --reporter=dot
+  Test Files  1 passed (1)
+  Tests       3 passed (3)
+  Duration    2.53s
+
+# Regression (still green)
+$ DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-any-mode.api.test.ts \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts \
+    tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot
+  Test Files  3 passed (3)
+  Tests       8 passed (8)
+  Duration    2.60s
+
+# Combined integration sweep (parallel + regression)
+$ DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-parallel-gateway.api.test.ts \
+    tests/integration/approval-wp1-any-mode.api.test.ts \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts \
+    tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot
+  Test Files  4 passed (4)
+  Tests       11 passed (11)
+  Duration    2.64s
+
+# Executor unit tests (existing + 2 new parallel cases)
+$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts --reporter=dot
+  Test Files  1 passed (1)
+  Tests       10 passed (10)
+
+# Full core-backend unit suite
+$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
+  Test Files  123 passed (123)
+  Tests       1590 passed (1590)
+```
+
+## Scenarios verified
+
+| ID | Scenario | Entry point | Expected | Actual |
+|----|----------|-------------|----------|--------|
+| V1 | Template with parallel fork + join-all creates cleanly | `POST /api/approval-templates` | 201 | 201 |
+| V2 | Publish of template with parallel nodes | `POST /api/approval-templates/:id/publish` | 200 | 200 |
+| V3 | Create approval fans into two branches | `POST /api/approvals` | `currentNodeKey=parallel_fork`, `currentNodeKeys=[legal_review,compliance_review]`, two active assignments | Matches |
+| V4 | First branch approver → instance stays pending with the other branch active | `POST /api/approvals/:id/actions` (legal-1 approves) | `status=pending`, `currentNodeKey=parallel_fork`, `currentNodeKeys=[compliance_review]` | Matches |
+| V5 | Second branch approver → join-all triggers; instance advances past join | `POST /api/approvals/:id/actions` (compliance-1 approves) | `status=pending`, `currentNodeKey=finance_review`, `currentNodeKeys` absent | Matches |
+| V6 | Post-join approver completes the instance | `POST /api/approvals/:id/actions` (finance-1 approves) | `status=approved`, `currentNodeKey=null` | Matches |
+| V7 | Metadata strips `parallelBranchStates` once the region closes | SQL inspection | key absent | Matches |
+| V8 | Return during parallel state | `POST /api/approvals/:id/actions` with `action=return` | 409 `APPROVAL_RETURN_IN_PARALLEL_UNSUPPORTED` | Matches |
+| V9 | Duplicate approver across branches at template-creation time | `POST /api/approval-templates` | 400 `VALIDATION_ERROR` with "duplicate approver" | Matches |
+| V10 | Pack 1A 会签 lifecycle unchanged | existing suite | 3/3 green | Matches |
+| V11 | 或签 (any-mode) unchanged | existing suite | 1/1 green | Matches |
+| V12 | WP2 sourceSystem filter unchanged | existing suite | 4/4 green | Matches |
+
+## Baseline references
+
+- Pack 1A: `packages/core-backend/tests/integration/approval-pack1a-lifecycle.api.test.ts`
+- 或签 (any-mode): `packages/core-backend/tests/integration/approval-wp1-any-mode.api.test.ts`
+- WP2 sourceSystem filter: `packages/core-backend/tests/integration/approval-wp2-source-filter.api.test.ts`
+
+## Non-goals confirmed
+
+- No DB migration introduced — parallel branch state is carried in
+  pre-existing `approval_instances.metadata` JSONB.
+- Pack 1A + or-mode integration suites pass unchanged on this branch;
+  their test files are untouched.
+- `listVisitedApprovalNodeKeysUntil` behavior on linear graphs is
+  unchanged — only added a pass-through for parallel fork nodes so the
+  walker can skip over them when computing return targets for a
+  linearly-visited approval ahead of a later parallel region.
+
+## Open follow-ups (documented in development MD)
+
+- `joinMode: 'any'` first-branch-wins join.
+- Return-to-node targeting a node inside a closed branch.
+- Nested parallel regions.
+- Branch-overlapping approvers (requires assignment-index rethink).
+- Regression test combining 或签 aggregation inside a parallel branch.

--- a/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
+++ b/docs/development/approval-wp1-parallel-gateway-verification-20260422.md
@@ -107,3 +107,40 @@ $ pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=do
 - Nested parallel regions.
 - Branch-overlapping approvers (requires assignment-index rethink).
 - Regression test combining 或签 aggregation inside a parallel branch.
+## Rebase verification — 2026-04-22
+
+Rebased from the original delivery baseline onto `origin/main@d547d89fcfcfded72f2e78a16320111d6def4f54`.
+
+Rebased head:
+
+```text
+a452b3517 feat(approval): ship WP1 parallel gateway (并行分支) with join-all semantics
+```
+
+Commands rerun after rebase:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp1-parallel-gateway.api.test.ts \
+    tests/integration/approval-wp1-any-mode.api.test.ts \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts \
+    tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
+
+git diff --check
+```
+
+Results:
+
+- Backend TypeScript: passed with zero diagnostics.
+- Frontend `vue-tsc`: passed.
+- Integration regression: 4 files passed, 14/14 tests passed.
+- Backend full unit suite: 123 files passed, 1591/1591 tests passed.
+- `git diff --check`: passed.
+
+Note: the full-unit count is one higher than the original delivery summary because `origin/main` now includes the #1077 WP2 source filter regression test.

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -7,6 +7,7 @@ import type {
   ConditionRule,
   FormField,
   FormSchema,
+  ParallelNodeConfig,
   RuntimeGraph,
 } from '../types/approval-product'
 
@@ -30,9 +31,52 @@ export interface ApprovalGraphAutoApprovalEvent {
   reason: 'empty-assignee'
 }
 
+/**
+ * Per-branch runtime state tracked in `approval_instances.metadata.parallelBranchStates`
+ * while an instance is inside a parallel-gateway region.
+ *
+ * The executor is stateless — the route service passes the current map in and
+ * receives an updated map back on each resolution.
+ */
+export interface ParallelBranchState {
+  edgeKey: string
+  /** Current frontier inside this branch. `null` once the branch has reached the join node. */
+  currentNodeKey: string | null
+  complete: boolean
+}
+
+export interface ParallelInstanceState {
+  parallelNodeKey: string
+  joinNodeKey: string
+  joinMode: 'all' | 'any'
+  branches: Record<string, ParallelBranchState>
+}
+
+type BranchAdvance =
+  | {
+      kind: 'pending-approval'
+      approvalNodeKey: string
+      assignments: ApprovalGraphAssignment[]
+      ccEvents: ApprovalCcEvent[]
+      autoApprovalEvents: ApprovalGraphAutoApprovalEvent[]
+    }
+  | {
+      kind: 'reached-join'
+      ccEvents: ApprovalCcEvent[]
+      autoApprovalEvents: ApprovalGraphAutoApprovalEvent[]
+    }
+
 export interface ApprovalGraphResolution {
   status: 'pending' | 'approved'
   currentNodeKey: string | null
+  /**
+   * Parallel gateway frontier. For non-parallel state this is either omitted
+   * or equals `[currentNodeKey]`. When the resolution lands the instance
+   * inside a parallel region, every still-pending branch's current approval
+   * node is listed here; consumers can use length ≥ 2 as the "in parallel"
+   * signal without peeking into metadata.
+   */
+  currentNodeKeys?: string[]
   currentStep: number | null
   totalSteps: number
   assignments: ApprovalGraphAssignment[]
@@ -51,6 +95,13 @@ export interface ApprovalGraphResolution {
    * `false` from the other entry points that do not represent an aggregation completion event.
    */
   aggregateComplete: boolean
+  /**
+   * When the resolution enters a parallel region, carries the initial branch
+   * state map the route should persist to `metadata.parallelBranchStates`.
+   * When the resolution leaves a parallel region (join-all complete), carries
+   * the final state map so the caller can archive it before clearing metadata.
+   */
+  parallelState?: ParallelInstanceState
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -71,6 +122,15 @@ function isConditionBranch(value: unknown): value is ConditionBranch {
 
 function isNonEmptyStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === 'string' && entry.trim().length > 0)
+}
+
+function isParallelNodeConfig(config: unknown): config is ParallelNodeConfig {
+  return isRecord(config)
+    && isNonEmptyStringArray(config.branches)
+    && (config.branches as string[]).length >= 2
+    && typeof config.joinNodeKey === 'string'
+    && config.joinNodeKey.trim().length > 0
+    && (config.joinMode === 'all' || config.joinMode === 'any')
 }
 
 function looksLikeComparableDateString(value: string): boolean {
@@ -353,6 +413,115 @@ export class ApprovalGraphExecutor {
     return this.resolveFromNode(next, completionContext)
   }
 
+  /**
+   * Advances a single branch inside a parallel-gateway region after one of its
+   * approval nodes has finished aggregating (会签 last approver, 或签 first
+   * approver, or single-approver completion). Returns either:
+   *
+   *   - `{ status: 'pending', currentNodeKey: parallelNodeKey, parallelState }`
+   *     if the branch moved to another approval node in the same branch OR
+   *     reached the join node while siblings remain pending. The route layer
+   *     persists the updated `parallelState` into `metadata.parallelBranchStates`.
+   *   - A post-join resolution (`resolveFromNode(joinNodeKey)`) once every
+   *     branch has reported complete under `joinMode='all'`. In that case
+   *     `parallelState` carries the final archived state map.
+   *
+   * The `joinMode='any'` path is reserved for a future wave and currently
+   * throws; see the dev MD follow-up list.
+   */
+  resolveAfterApproveInParallel(
+    branchNodeKey: string,
+    currentState: ParallelInstanceState,
+  ): ApprovalGraphResolution {
+    const branch = Object.values(currentState.branches).find(
+      (entry) => entry.currentNodeKey === branchNodeKey,
+    )
+    if (!branch) {
+      throw new Error(`Parallel branch with current node ${branchNodeKey} not found in state`)
+    }
+    if (currentState.joinMode !== 'all') {
+      throw new Error(`Parallel joinMode '${currentState.joinMode}' is not supported in v1`)
+    }
+    const aggregateMode = this.getApprovalMode(branchNodeKey)
+
+    // Walk the branch forward one "advance step" — stop either at the next
+    // pending approval node (still inside the branch) or at the join node.
+    const advance = this.resolveBranchAdvance(branchNodeKey, currentState.joinNodeKey)
+    const updatedBranches: Record<string, ParallelBranchState> = { ...currentState.branches }
+    const branchEntryKey = Object.keys(currentState.branches).find(
+      (key) => currentState.branches[key].currentNodeKey === branchNodeKey,
+    )!
+
+    if (advance.kind === 'pending-approval') {
+      updatedBranches[branchEntryKey] = {
+        edgeKey: branch.edgeKey,
+        currentNodeKey: advance.approvalNodeKey,
+        complete: false,
+      }
+      const updatedState: ParallelInstanceState = {
+        ...currentState,
+        branches: updatedBranches,
+      }
+      const pendingBranches = Object.values(updatedState.branches).filter((entry) => !entry.complete)
+      return {
+        status: 'pending',
+        currentNodeKey: currentState.parallelNodeKey,
+        currentNodeKeys: pendingBranches.map((entry) => entry.currentNodeKey!).filter((key): key is string => Boolean(key)),
+        currentStep: this.stepIndexForNode(advance.approvalNodeKey) || this.totalSteps,
+        totalSteps: this.totalSteps,
+        assignments: advance.assignments,
+        ccEvents: advance.ccEvents,
+        autoApprovalEvents: advance.autoApprovalEvents,
+        aggregateMode,
+        aggregateComplete: true,
+        parallelState: updatedState,
+      }
+    }
+
+    // Branch reached the join node. Mark it complete and decide whether the
+    // parallel region as a whole can advance.
+    updatedBranches[branchEntryKey] = {
+      edgeKey: branch.edgeKey,
+      currentNodeKey: null,
+      complete: true,
+    }
+    const updatedState: ParallelInstanceState = {
+      ...currentState,
+      branches: updatedBranches,
+    }
+    const allComplete = Object.values(updatedState.branches).every((entry) => entry.complete)
+
+    if (!allComplete) {
+      // Still waiting on siblings; keep the instance pending with fewer active branches.
+      const pendingBranches = Object.values(updatedState.branches).filter((entry) => !entry.complete)
+      return {
+        status: 'pending',
+        currentNodeKey: currentState.parallelNodeKey,
+        currentNodeKeys: pendingBranches.map((entry) => entry.currentNodeKey!).filter((key): key is string => Boolean(key)),
+        currentStep: this.stepIndexForNode(pendingBranches[0]?.currentNodeKey ?? '') || this.totalSteps,
+        totalSteps: this.totalSteps,
+        assignments: [],
+        ccEvents: advance.ccEvents,
+        autoApprovalEvents: advance.autoApprovalEvents,
+        aggregateMode,
+        aggregateComplete: true,
+        parallelState: updatedState,
+      }
+    }
+
+    // All branches complete — advance past the join node.
+    const postJoin = this.resolveFromNode(currentState.joinNodeKey, {
+      aggregateMode,
+      aggregateComplete: true,
+    })
+    return {
+      ...postJoin,
+      ccEvents: [...advance.ccEvents, ...postJoin.ccEvents],
+      autoApprovalEvents: [...advance.autoApprovalEvents, ...postJoin.autoApprovalEvents],
+      parallelState: updatedState,
+    }
+  }
+
   getApprovalMode(nodeKey: string): ApprovalMode {
     return normalizeApprovalMode(this.getApprovalNodeConfig(nodeKey).approvalMode)
   }
@@ -410,6 +579,19 @@ export class ApprovalGraphExecutor {
           return approvalTrail
         }
         nextNodeKey = this.firstTargetForNode(node.key)
+        continue
+      }
+
+      if (node.type === 'parallel') {
+        // Return-to-node inside a parallel region is deferred to a follow-up
+        // wave; the caller (dispatch route) rejects `return` when the
+        // instance is in parallel state before reaching here. The linear
+        // walker skips over the parallel fork and resumes at the join node.
+        const parallelConfig = isParallelNodeConfig(node.config) ? node.config : null
+        if (!parallelConfig) {
+          throw new Error(`Parallel node ${node.key} has invalid config`)
+        }
+        nextNodeKey = parallelConfig.joinNodeKey
         continue
       }
 
@@ -511,6 +693,81 @@ export class ApprovalGraphExecutor {
         }
       }
 
+      if (node.type === 'parallel') {
+        const parallelConfig = isParallelNodeConfig(node.config) ? node.config : null
+        if (!parallelConfig) {
+          throw new Error(`Parallel node ${node.key} has invalid config`)
+        }
+        if (parallelConfig.joinMode !== 'all') {
+          throw new Error(`Parallel joinMode '${parallelConfig.joinMode}' is not supported in v1`)
+        }
+
+        const branchStates: Record<string, ParallelBranchState> = {}
+        const branchAssignments: ApprovalGraphAssignment[] = []
+        let allBranchesAutoComplete = true
+
+        for (const edgeKey of parallelConfig.branches) {
+          const branchStartNode = this.targetForEdge(edgeKey)
+          if (!branchStartNode) {
+            throw new Error(`Parallel branch edge ${edgeKey} has no target`)
+          }
+          const advance = this.resolveBranchAdvance(
+            { fromNodeKey: branchStartNode, includeStartNode: true },
+            parallelConfig.joinNodeKey,
+          )
+          ccEvents.push(...advance.ccEvents)
+          autoApprovalEvents.push(...advance.autoApprovalEvents)
+
+          if (advance.kind === 'pending-approval') {
+            branchStates[edgeKey] = {
+              edgeKey,
+              currentNodeKey: advance.approvalNodeKey,
+              complete: false,
+            }
+            branchAssignments.push(...advance.assignments)
+            allBranchesAutoComplete = false
+          } else {
+            branchStates[edgeKey] = {
+              edgeKey,
+              currentNodeKey: null,
+              complete: true,
+            }
+          }
+        }
+
+        if (allBranchesAutoComplete) {
+          // Every branch fast-forwarded through auto-approvals / cc to the join
+          // node. Continue walking past the join node directly.
+          const postJoin = this.resolveFromNode(parallelConfig.joinNodeKey, context)
+          return {
+            ...postJoin,
+            ccEvents: [...ccEvents, ...postJoin.ccEvents],
+            autoApprovalEvents: [...autoApprovalEvents, ...postJoin.autoApprovalEvents],
+          }
+        }
+
+        const pendingBranches = Object.values(branchStates).filter((entry) => !entry.complete)
+        const firstBranchFrontier = pendingBranches[0]?.currentNodeKey ?? parallelConfig.joinNodeKey
+        return {
+          status: 'pending',
+          currentNodeKey: node.key,
+          currentNodeKeys: pendingBranches.map((entry) => entry.currentNodeKey!).filter((key): key is string => Boolean(key)),
+          currentStep: this.stepIndexForNode(firstBranchFrontier) || this.totalSteps,
+          totalSteps: this.totalSteps,
+          assignments: branchAssignments,
+          ccEvents,
+          autoApprovalEvents,
+          aggregateMode: context.aggregateMode,
+          aggregateComplete: context.aggregateComplete,
+          parallelState: {
+            parallelNodeKey: node.key,
+            joinNodeKey: parallelConfig.joinNodeKey,
+            joinMode: parallelConfig.joinMode,
+            branches: branchStates,
+          },
+        }
+      }
+
       if (node.type === 'end') {
         return {
           status: 'approved',
@@ -569,6 +826,126 @@ export class ApprovalGraphExecutor {
   private firstTargetForNode(nodeKey: string): string | null {
     const edge = this.outgoingEdges.get(nodeKey)?.[0]
     return edge?.target || null
+  }
+
+  /**
+   * Walks a single parallel branch until it either hits the next pending
+   * approval node (branch still active) or reaches the join node (branch
+   * complete for join-all purposes). CC and auto-approval events encountered
+   * in between are collected for the caller to persist.
+   *
+   * The `from` argument has two shapes so both fan-out (from the parallel
+   * node into a branch-start via edge traversal) and post-approval advance
+   * (from the approver's own branch-local approval node) can share this
+   * walker.
+   *   - `{ fromNodeKey, includeStartNode: true }`: the walker starts ON
+   *     `fromNodeKey` — used by the fan-out path where the edge target is
+   *     the branch's first business node.
+   *   - `fromNodeKey` as a string (equivalent to `includeStartNode: false`):
+   *     the walker starts on the node AFTER `fromNodeKey` — used by the
+   *     post-approval advance path where the caller already processed the
+   *     branch's current approval.
+   */
+  private resolveBranchAdvance(
+    from: string | { fromNodeKey: string; includeStartNode: boolean },
+    joinNodeKey: string,
+  ): BranchAdvance {
+    const ccEvents: ApprovalCcEvent[] = []
+    const autoApprovalEvents: ApprovalGraphAutoApprovalEvent[] = []
+    const visited = new Set<string>()
+
+    const startNodeKey = typeof from === 'string' ? from : from.fromNodeKey
+    const includeStart = typeof from === 'string' ? false : from.includeStartNode
+    let currentKey: string | null = includeStart ? startNodeKey : this.firstTargetForNode(startNodeKey)
+
+    while (currentKey) {
+      if (visited.has(currentKey)) {
+        throw new Error(`Parallel branch contains a cycle near ${currentKey}`)
+      }
+      visited.add(currentKey)
+
+      if (currentKey === joinNodeKey) {
+        return { kind: 'reached-join', ccEvents, autoApprovalEvents }
+      }
+
+      const node = this.nodeMap.get(currentKey)
+      if (!node) {
+        throw new Error(`Runtime graph references unknown node ${currentKey}`)
+      }
+
+      if (node.type === 'condition') {
+        currentKey = this.resolveConditionTarget(node)
+        continue
+      }
+
+      if (node.type === 'cc') {
+        const ccConfig = node.config as unknown as Record<string, unknown>
+        const targetIds = ccConfig.targetIds
+        const targetType = ccConfig.targetType
+        if (!isNonEmptyStringArray(targetIds) || (targetType !== 'user' && targetType !== 'role')) {
+          throw new Error(`CC node ${node.key} has invalid config`)
+        }
+        for (const targetId of targetIds) {
+          ccEvents.push({
+            nodeKey: node.key,
+            targetType,
+            targetId,
+          })
+        }
+        currentKey = this.firstTargetForNode(node.key)
+        continue
+      }
+
+      if (node.type === 'approval') {
+        const approvalConfig = isApprovalNodeConfig(node.config) ? node.config : null
+        if (!approvalConfig) {
+          throw new Error(`Approval node ${node.key} has invalid config`)
+        }
+        const sourceStep = this.stepIndexForNode(node.key)
+        const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode)
+        if (approvalConfig.assigneeIds.length === 0) {
+          if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
+            autoApprovalEvents.push({
+              nodeKey: node.key,
+              sourceStep,
+              approvalMode,
+              reason: 'empty-assignee',
+            })
+            currentKey = this.firstTargetForNode(node.key)
+            continue
+          }
+          throw new Error(`Approval node ${node.key} has no assignees`)
+        }
+        return {
+          kind: 'pending-approval',
+          approvalNodeKey: node.key,
+          assignments: approvalConfig.assigneeIds.map((assigneeId) => ({
+            assignmentType: approvalConfig.assigneeType,
+            assigneeId,
+            nodeKey: node.key,
+            sourceStep,
+          })),
+          ccEvents,
+          autoApprovalEvents,
+        }
+      }
+
+      if (node.type === 'parallel') {
+        throw new Error(`Nested parallel nodes are not supported in v1 (at ${node.key})`)
+      }
+
+      if (node.type === 'end') {
+        throw new Error(`Parallel branch terminated at an end node before reaching join ${joinNodeKey}`)
+      }
+
+      if (node.type === 'start') {
+        throw new Error(`Parallel branch walker unexpectedly hit start node ${node.key}`)
+      }
+
+      throw new Error(`Unsupported node type ${node.type}`)
+    }
+
+    throw new Error(`Parallel branch starting from ${startNodeKey} did not reach join ${joinNodeKey}`)
   }
 
   private targetForEdge(edgeKey: string): string | null {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -19,6 +19,7 @@ import type {
 import {
   ApprovalGraphExecutor,
   type ApprovalGraphAutoApprovalEvent,
+  type ParallelInstanceState,
   validateApprovalFormData,
 } from './ApprovalGraphExecutor'
 import type {
@@ -147,9 +148,10 @@ const FORM_FIELD_TYPES = new Set([
   'attachment',
 ])
 
-const APPROVAL_NODE_TYPES = new Set(['start', 'approval', 'cc', 'condition', 'end'])
+const APPROVAL_NODE_TYPES = new Set(['start', 'approval', 'cc', 'condition', 'parallel', 'end'])
 const CONDITION_OPERATORS = new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'isEmpty'])
 const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any'])
+const PARALLEL_JOIN_MODES = new Set(['all', 'any'])
 const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve'])
 
 function toNullableRecord(value: unknown): Record<string, unknown> | null {
@@ -343,6 +345,33 @@ function normalizeApprovalGraph(value: unknown, context: ValidationContext): App
           targetIds: node.config.targetIds.map((entry) => entry.trim()),
         }
         break
+      case 'parallel':
+        if (!Array.isArray(node.config.branches)
+          || node.config.branches.some((entry) => !isNonEmptyString(entry))
+          || node.config.branches.length < 2) {
+          failValidation(
+            context,
+            `approvalGraph.nodes[${index}].config.branches must list at least two edgeKeys`,
+          )
+        }
+        if (!isNonEmptyString(node.config.joinNodeKey)) {
+          failValidation(
+            context,
+            `approvalGraph.nodes[${index}].config.joinNodeKey is required`,
+          )
+        }
+        if (typeof node.config.joinMode !== 'string' || !PARALLEL_JOIN_MODES.has(node.config.joinMode)) {
+          failValidation(
+            context,
+            `approvalGraph.nodes[${index}].config.joinMode must be 'all' or 'any'`,
+          )
+        }
+        normalizedNode.config = {
+          branches: (node.config.branches as string[]).map((entry) => entry.trim()),
+          joinMode: node.config.joinMode,
+          joinNodeKey: (node.config.joinNodeKey as string).trim(),
+        }
+        break
       case 'condition':
         if (!Array.isArray(node.config.branches)) {
           failValidation(context, `approvalGraph.nodes[${index}].config.branches must be an array`)
@@ -410,7 +439,119 @@ function normalizeApprovalGraph(value: unknown, context: ValidationContext): App
     failValidation(context, 'approvalGraph edges must reference known nodes')
   }
 
+  // Parallel-gateway structural validation: referenced edges and join node must
+  // exist; branches must not share approval-node assignees (v1 limitation — the
+  // approval_assignments.active-unique index cannot represent the same user
+  // being active in two branches at once). Nested parallel is rejected too.
+  const edgeMap = new Map(edges.map((edge) => [edge.key, edge]))
+  const nodeByKey = new Map(nodes.map((node) => [node.key, node]))
+  for (const node of nodes) {
+    if (node.type !== 'parallel') continue
+    const parallelConfig = node.config as { branches: string[]; joinNodeKey: string }
+    for (const branchEdgeKey of parallelConfig.branches) {
+      const edge = edgeMap.get(branchEdgeKey)
+      if (!edge || edge.source !== node.key) {
+        failValidation(
+          context,
+          `approvalGraph parallel node ${node.key} references unknown branch edge ${branchEdgeKey}`,
+        )
+      }
+    }
+    const joinNode = nodeByKey.get(parallelConfig.joinNodeKey)
+    if (!joinNode) {
+      failValidation(
+        context,
+        `approvalGraph parallel node ${node.key} references unknown join node ${parallelConfig.joinNodeKey}`,
+      )
+    }
+
+    // Collect the approval-node assignees reachable from each branch start up to
+    // the join node. Reject duplicate assigneeIds across branches because the
+    // active-assignment unique index cannot hold two active rows for the same
+    // user at once. Nested parallel is explicitly rejected in v1.
+    const assigneesPerBranch: Array<Set<string>> = []
+    for (const branchEdgeKey of parallelConfig.branches) {
+      const edge = edgeMap.get(branchEdgeKey)!
+      const branchAssignees = collectBranchAssignees(
+        edge.target,
+        parallelConfig.joinNodeKey,
+        nodeByKey,
+        edges,
+        context,
+      )
+      assigneesPerBranch.push(branchAssignees)
+    }
+    const seen = new Set<string>()
+    for (const branchAssignees of assigneesPerBranch) {
+      for (const assignee of branchAssignees) {
+        if (seen.has(assignee)) {
+          failValidation(
+            context,
+            `approvalGraph parallel node ${node.key} has duplicate approver '${assignee}' across branches`,
+          )
+        }
+        seen.add(assignee)
+      }
+    }
+  }
+
   return { nodes, edges }
+}
+
+function collectBranchAssignees(
+  startNodeKey: string,
+  joinNodeKey: string,
+  nodeByKey: Map<string, ApprovalGraph['nodes'][number]>,
+  edges: ApprovalGraph['edges'],
+  context: ValidationContext,
+): Set<string> {
+  const assignees = new Set<string>()
+  const outgoing = new Map<string, ApprovalGraph['edges']>()
+  for (const edge of edges) {
+    const existing = outgoing.get(edge.source) || []
+    existing.push(edge)
+    outgoing.set(edge.source, existing)
+  }
+
+  const visited = new Set<string>()
+  let currentKey: string | null = startNodeKey
+  while (currentKey) {
+    if (currentKey === joinNodeKey) return assignees
+    if (visited.has(currentKey)) {
+      failValidation(context, `approvalGraph parallel branch contains a cycle near ${currentKey}`)
+    }
+    visited.add(currentKey)
+    const node = nodeByKey.get(currentKey)
+    if (!node) {
+      failValidation(context, `approvalGraph parallel branch references unknown node ${currentKey}`)
+    }
+    if (node.type === 'parallel') {
+      failValidation(context, `approvalGraph parallel branch cannot contain nested parallel node ${node.key}`)
+    }
+    if (node.type === 'end') {
+      failValidation(
+        context,
+        `approvalGraph parallel branch must reach join before end (at ${node.key})`,
+      )
+    }
+    if (node.type === 'approval') {
+      const approvalConfig = node.config as { assigneeIds?: string[] }
+      for (const assignee of approvalConfig.assigneeIds ?? []) {
+        assignees.add(assignee)
+      }
+    }
+    // Walk the first outgoing edge — condition nodes aren't explored for every
+    // branch here (the form-data isn't available at template validation
+    // time), so duplicate detection is conservative across the statically
+    // reachable first-edge path. Condition branches inside parallel remain
+    // legal at runtime; this check only flags obvious overlaps.
+    const nextEdge = outgoing.get(currentKey)?.[0]
+    currentKey = nextEdge?.target ?? null
+  }
+  failValidation(
+    context,
+    `approvalGraph parallel branch starting near ${startNodeKey} never reaches join ${joinNodeKey}`,
+  )
 }
 
 function asApprovalGraph(value: Record<string, unknown>): ApprovalGraph {
@@ -458,6 +599,18 @@ function toUnifiedApprovalDTO(
   row: ApprovalInstanceRow,
   assignments: ApprovalAssignmentDTO[],
 ): UnifiedApprovalDTO {
+  // Surface `currentNodeKeys` when the instance is inside a parallel region so
+  // consumers (frontend timeline, callers checking `.length > 1`) can detect
+  // parallel state without peeking at metadata. When there's no parallel
+  // state, we leave the field undefined; callers continue to use
+  // `currentNodeKey` unchanged.
+  const parallelState = readParallelBranchStates(row.metadata)
+  const currentNodeKeys = parallelState
+    ? Object.values(parallelState.branches)
+        .filter((entry) => !entry.complete && entry.currentNodeKey)
+        .map((entry) => entry.currentNodeKey as string)
+    : undefined
+
   return {
     id: row.id,
     sourceSystem: row.source_system,
@@ -477,6 +630,7 @@ function toUnifiedApprovalDTO(
     requestNo: row.request_no,
     formSnapshot: toNullableRecord(row.form_snapshot),
     currentNodeKey: row.current_node_key,
+    ...(currentNodeKeys ? { currentNodeKeys } : {}),
     assignments,
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
@@ -579,6 +733,55 @@ function buildRuntimeGraph(approvalGraph: ApprovalGraph, policy: RuntimePolicy):
       ...(policy.revokeBeforeNodeKeys ? { revokeBeforeNodeKeys: [...policy.revokeBeforeNodeKeys] } : {}),
     },
   })
+}
+
+function buildPersistableParallelState(state: ParallelInstanceState): Record<string, unknown> {
+  return {
+    parallelNodeKey: state.parallelNodeKey,
+    joinNodeKey: state.joinNodeKey,
+    joinMode: state.joinMode,
+    branches: Object.fromEntries(
+      Object.entries(state.branches).map(([edgeKey, entry]) => [
+        edgeKey,
+        {
+          edgeKey: entry.edgeKey,
+          currentNodeKey: entry.currentNodeKey,
+          complete: entry.complete,
+        },
+      ]),
+    ),
+  }
+}
+
+function readParallelBranchStates(metadata: unknown): ParallelInstanceState | null {
+  if (!isRecord(metadata)) return null
+  const states = (metadata as { parallelBranchStates?: unknown }).parallelBranchStates
+  if (!isRecord(states)) return null
+  if (typeof states.parallelNodeKey !== 'string'
+    || typeof states.joinNodeKey !== 'string'
+    || (states.joinMode !== 'all' && states.joinMode !== 'any')
+    || !isRecord(states.branches)) {
+    return null
+  }
+  const branches: Record<string, ParallelInstanceState['branches'][string]> = {}
+  for (const [edgeKey, entryRaw] of Object.entries(states.branches)) {
+    if (!isRecord(entryRaw)) return null
+    const entry = entryRaw as { edgeKey?: unknown; currentNodeKey?: unknown; complete?: unknown }
+    if (typeof entry.edgeKey !== 'string') return null
+    if (entry.currentNodeKey !== null && typeof entry.currentNodeKey !== 'string') return null
+    if (typeof entry.complete !== 'boolean') return null
+    branches[edgeKey] = {
+      edgeKey: entry.edgeKey,
+      currentNodeKey: entry.currentNodeKey as string | null,
+      complete: entry.complete,
+    }
+  }
+  return {
+    parallelNodeKey: states.parallelNodeKey as string,
+    joinNodeKey: states.joinNodeKey as string,
+    joinMode: states.joinMode as 'all' | 'any',
+    branches,
+  }
 }
 
 export class ApprovalProductService {
@@ -925,6 +1128,11 @@ export class ApprovalProductService {
       permissions: actor.permissions || [],
     }
 
+    const instanceMetadata: Record<string, unknown> = { templateKey: bundle.template.key }
+    if (initial.parallelState) {
+      instanceMetadata.parallelBranchStates = buildPersistableParallelState(initial.parallelState)
+    }
+
     let client: ApprovalDbClient | null = null
     try {
       client = await pool.connect()
@@ -951,7 +1159,7 @@ export class ApprovalProductService {
           JSON.stringify(requesterSnapshot),
           JSON.stringify({ templateId: bundle.template.id, templateKey: bundle.template.key }),
           JSON.stringify({ rejectCommentRequired: true, allowRevoke: runtimeGraph.policy.allowRevoke, sourceOfTruth: 'platform' }),
-          JSON.stringify({ templateKey: bundle.template.key }),
+          JSON.stringify(instanceMetadata),
           initial.currentStep ?? 0,
           initial.totalSteps,
           bundle.template.id,
@@ -1036,9 +1244,35 @@ export class ApprovalProductService {
 
       const runtimeGraph = asRuntimeGraph(runtime.runtime_graph)
       const executor = new ApprovalGraphExecutor(runtimeGraph, toNullableRecord(instance.form_snapshot) || {})
-      const currentNodeKey = instance.current_node_key
+      const storedCurrentNodeKey = instance.current_node_key
       const actorRoles = actor.roles || []
       const actorName = actor.userName || actor.userId
+      const parallelState = readParallelBranchStates(instance.metadata)
+      const isInParallelRegion = Boolean(parallelState && storedCurrentNodeKey === parallelState.parallelNodeKey)
+
+      // Resolve the actor's effective branch node. In single-linear state this
+      // is `instance.current_node_key`. In a parallel region the actor's
+      // decision applies to *their* branch's current approval node, which
+      // is the `node_key` of one of their still-active assignments matching
+      // a pending branch frontier in `parallelBranchStates`.
+      let currentNodeKey: string | null = storedCurrentNodeKey
+      let actorBranchNodeKey: string | null = null
+      if (isInParallelRegion && parallelState) {
+        const pendingBranchNodeKeys = new Set(
+          Object.values(parallelState.branches)
+            .filter((entry) => !entry.complete && entry.currentNodeKey)
+            .map((entry) => entry.currentNodeKey as string),
+        )
+        const candidate = assignments.rows.find((assignment) => {
+          if (!assignmentMatchesActor(assignment, actor.userId, actorRoles)) return false
+          return assignment.node_key ? pendingBranchNodeKeys.has(assignment.node_key) : false
+        })
+        if (candidate?.node_key) {
+          actorBranchNodeKey = candidate.node_key
+          currentNodeKey = candidate.node_key
+        }
+      }
+
       const currentNodeAssignments = currentNodeKey
         ? assignments.rows.filter((assignment) => assignment.node_key === currentNodeKey)
         : []
@@ -1131,6 +1365,7 @@ export class ApprovalProductService {
                version = $2,
                current_node_key = NULL,
                current_step = total_steps,
+               metadata = COALESCE(metadata, '{}'::jsonb) - 'parallelBranchStates',
                updated_at = now()
            WHERE id = $1`,
           [id, nextVersion],
@@ -1167,6 +1402,16 @@ export class ApprovalProductService {
       }
 
       if (request.action === 'return') {
+        if (isInParallelRegion) {
+          // Return-to-node inside a parallel region is deferred to a
+          // follow-up wave; the route rejects with a typed error so clients
+          // can surface a specific message. See follow-ups in the dev MD.
+          throw new ServiceError(
+            'Return is not supported while the approval is in a parallel branch',
+            409,
+            'APPROVAL_RETURN_IN_PARALLEL_UNSUPPORTED',
+          )
+        }
         const targetNodeKey = request.targetNodeKey?.trim()
         if (!targetNodeKey) {
           throw new ServiceError('targetNodeKey is required for return', 400, 'VALIDATION_ERROR')
@@ -1230,6 +1475,7 @@ export class ApprovalProductService {
                version = $2,
                current_node_key = NULL,
                current_step = total_steps,
+               metadata = COALESCE(metadata, '{}'::jsonb) - 'parallelBranchStates',
                updated_at = now()
            WHERE id = $1`,
           [id, nextVersion],
@@ -1314,10 +1560,50 @@ export class ApprovalProductService {
           )
         }
       } else {
-        await this.deactivateAllActiveAssignments(client, id)
+        // Single-approver mode. In parallel state the blanket
+        // `deactivateAllActiveAssignments` would cancel sibling branches'
+        // pending assignments as well, so scope the deactivation to the
+        // actor's own branch node. Linear state keeps the legacy behavior.
+        if (isInParallelRegion) {
+          await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
+        } else {
+          await this.deactivateAllActiveAssignments(client, id)
+        }
       }
 
-      const resolution = executor.resolveAfterApprove(currentNodeKey)
+      const resolution = isInParallelRegion && parallelState && actorBranchNodeKey
+        ? executor.resolveAfterApproveInParallel(actorBranchNodeKey, parallelState)
+        : executor.resolveAfterApprove(currentNodeKey)
+
+      // Manage parallel branch state in `approval_instances.metadata`:
+      //   - If the resolution's `currentNodeKey` equals a parallel fork node
+      //     (either the same one we were already inside, or a brand-new
+      //     parallel region reached after a linear stage), persist / refresh
+      //     `parallelBranchStates` so subsequent dispatches can re-derive
+      //     branch nodes.
+      //   - Otherwise, strip any prior `parallelBranchStates` so the
+      //     instance returns to linear semantics.
+      const resolutionEntersParallel =
+        resolution.parallelState !== undefined
+        && resolution.currentNodeKey === resolution.parallelState.parallelNodeKey
+      if (resolutionEntersParallel && resolution.parallelState) {
+        await client.query(
+          `UPDATE approval_instances
+           SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('parallelBranchStates', $2::jsonb),
+               updated_at = now()
+           WHERE id = $1`,
+          [id, JSON.stringify(buildPersistableParallelState(resolution.parallelState))],
+        )
+      } else if (isInParallelRegion) {
+        await client.query(
+          `UPDATE approval_instances
+           SET metadata = COALESCE(metadata, '{}'::jsonb) - 'parallelBranchStates',
+               updated_at = now()
+           WHERE id = $1`,
+          [id],
+        )
+      }
+
       await client.query(
         `UPDATE approval_instances
          SET status = $2,
@@ -1342,6 +1628,11 @@ export class ApprovalProductService {
         nextNodeKey: resolution.currentNodeKey,
         approvalMode,
         aggregateComplete: true,
+      }
+      if (isInParallelRegion) {
+        approveRecordMetadata.parallelNodeKey = parallelState?.parallelNodeKey
+        approveRecordMetadata.parallelBranchComplete =
+          resolution.currentNodeKey !== parallelState?.parallelNodeKey
       }
       if (approvalMode === 'any' && aggregateCancelledAssigneeIds.length > 0) {
         approveRecordMetadata.aggregateCancelled = aggregateCancelledAssigneeIds

--- a/packages/core-backend/src/services/approval-bridge-types.ts
+++ b/packages/core-backend/src/services/approval-bridge-types.ts
@@ -29,6 +29,12 @@ export interface UnifiedApprovalDTO {
   requestNo?: string | null
   formSnapshot?: Record<string, unknown> | null
   currentNodeKey?: string | null
+  /**
+   * Parallel gateway (并行分支) — populated only when the instance is in a
+   * parallel region (length ≥ 2). Absent on linear state; callers that don't
+   * care about parallelism keep using `currentNodeKey` unchanged.
+   */
+  currentNodeKeys?: string[] | null
   assignments: ApprovalAssignmentDTO[]
   createdAt: string
   updatedAt: string

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -7,9 +7,10 @@ export const APPROVAL_PRODUCT_PERMISSIONS = [
 
 export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[number]
 
-export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'end'
+export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
 export type ApprovalMode = 'single' | 'all' | 'any'
+export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
 export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
@@ -29,7 +30,12 @@ export interface ApprovalNode {
   key: string
   type: ApprovalNodeType
   name?: string
-  config: ApprovalNodeConfig | ConditionNodeConfig | CcNodeConfig | Record<string, never>
+  config:
+    | ApprovalNodeConfig
+    | ConditionNodeConfig
+    | CcNodeConfig
+    | ParallelNodeConfig
+    | Record<string, never>
 }
 
 export interface ApprovalNodeConfig {
@@ -59,6 +65,18 @@ export interface ConditionRule {
 export interface CcNodeConfig {
   targetType: ApprovalAssigneeType
   targetIds: string[]
+}
+
+/**
+ * Parallel gateway (并行分支) — fans into N branches from `branches` (edgeKeys)
+ * and re-joins at `joinNodeKey`. `joinMode === 'all'` ("和") waits for every
+ * branch to reach the join node before advancing. `'any'` is reserved for
+ * a future wave and is not wired into the executor in v1.
+ */
+export interface ParallelNodeConfig {
+  branches: string[]
+  joinMode: ParallelJoinMode
+  joinNodeKey: string
 }
 
 export interface ApprovalEdge {
@@ -148,6 +166,13 @@ export interface UnifiedApprovalDTO {
   requestNo?: string | null
   formSnapshot?: Record<string, unknown> | null
   currentNodeKey?: string | null
+  /**
+   * Parallel gateway (并行分支) — populated only when the instance is in
+   * parallel state (length ≥ 2). For non-parallel state this equals
+   * `[currentNodeKey]` or is omitted. Callers that don't care about
+   * parallelism can keep using `currentNodeKey` unchanged.
+   */
+  currentNodeKeys?: string[] | null
   assignments: ApprovalAssignmentDTO[]
   createdAt: string
   updatedAt: string

--- a/packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts
@@ -1,0 +1,475 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+type JsonRecord = Record<string, unknown>
+
+type ApprovalAssignmentRow = {
+  assignee_id: string
+  node_key: string | null
+  is_active: boolean
+  metadata: JsonRecord | null
+}
+
+type ApprovalInstanceRow = {
+  status: string
+  current_node_key: string | null
+  metadata: JsonRecord | null
+}
+
+type ApprovalRecordRow = {
+  action: string
+  actor_id: string | null
+  to_status: string
+  metadata: JsonRecord
+}
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: {
+    method?: string
+    body?: unknown
+  } = {},
+) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+  return response
+}
+
+function buildFormSchema() {
+  return {
+    fields: [
+      {
+        id: 'reason',
+        type: 'text',
+        label: '事由',
+        required: true,
+      },
+    ],
+  }
+}
+
+/**
+ * Two parallel branches join at a finance-review node before reaching end.
+ * Branch A: legal-review (single approver, user legal-1)
+ * Branch B: compliance-review (single approver, user compliance-1)
+ * Shared join: finance-review (single approver, user finance-1)
+ */
+function buildParallelGatewayGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'parallel_fork',
+        type: 'parallel',
+        config: {
+          branches: ['edge-fork-legal', 'edge-fork-compliance'],
+          joinMode: 'all',
+          joinNodeKey: 'finance_review',
+        },
+      },
+      {
+        key: 'legal_review',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['legal-1'] },
+      },
+      {
+        key: 'compliance_review',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['compliance-1'] },
+      },
+      {
+        key: 'finance_review',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['finance-1'] },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+      { key: 'edge-fork-legal', source: 'parallel_fork', target: 'legal_review' },
+      { key: 'edge-fork-compliance', source: 'parallel_fork', target: 'compliance_review' },
+      { key: 'edge-legal-join', source: 'legal_review', target: 'finance_review' },
+      { key: 'edge-compliance-join', source: 'compliance_review', target: 'finance_review' },
+      { key: 'edge-finance-end', source: 'finance_review', target: 'end' },
+    ],
+  }
+}
+
+describeIfDatabase('Approval Wave 2 WP1 parallel-gateway (并行分支) API', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+
+  beforeAll(async () => {
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+
+    await ensureApprovalSchemaReady()
+
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [],
+    })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool.query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+    } catch {
+      // Ignore cleanup failures — the top-level describe restart clears everything on rerun.
+    }
+
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  it('forks two branches and joins only after all branches complete (joinMode=all)', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-parallel')
+    const requesterToken = await authToken(baseUrl, 'requester-parallel')
+    const legalToken = await authToken(baseUrl, 'legal-1')
+    const complianceToken = await authToken(baseUrl, 'compliance-1')
+    const financeToken = await authToken(baseUrl, 'finance-1')
+
+    const templateKey = `approval-wp1-parallel-${Date.now()}`
+
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Parallel Gateway Template',
+        description: 'WP1 parallel-gateway integration',
+        formSchema: buildFormSchema(),
+        approvalGraph: buildParallelGatewayGraph(),
+      },
+    })
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status).toBe(200)
+
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: {
+        templateId: template.id,
+        formData: { reason: 'parallel-gateway request' },
+      },
+    })
+    expect(createResponse.status).toBe(201)
+    const createdApproval = await createResponse.json() as {
+      id: string
+      status: string
+      currentNodeKey: string | null
+      currentNodeKeys?: string[] | null
+      assignments: Array<{ assigneeId: string; isActive: boolean; nodeKey?: string | null }>
+    }
+    createdApprovalIds.add(createdApproval.id)
+    expect(createdApproval.status).toBe('pending')
+    expect(createdApproval.currentNodeKey).toBe('parallel_fork')
+    expect(createdApproval.currentNodeKeys).toBeDefined()
+    expect([...(createdApproval.currentNodeKeys || [])].sort()).toEqual([
+      'compliance_review',
+      'legal_review',
+    ])
+
+    const activeAssignees = createdApproval.assignments
+      .filter((a) => a.isActive)
+      .map((a) => ({ assigneeId: a.assigneeId, nodeKey: a.nodeKey }))
+      .sort((a, b) => a.assigneeId.localeCompare(b.assigneeId))
+    expect(activeAssignees).toEqual([
+      { assigneeId: 'compliance-1', nodeKey: 'compliance_review' },
+      { assigneeId: 'legal-1', nodeKey: 'legal_review' },
+    ])
+
+    // First branch (legal) approves — the instance stays pending in parallel state
+    // with the second branch still active.
+    const legalApproveResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, legalToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'legal ok' },
+    })
+    expect(legalApproveResponse.status).toBe(200)
+    const afterLegal = await legalApproveResponse.json() as {
+      status: string
+      currentNodeKey: string | null
+      currentNodeKeys?: string[] | null
+      assignments: Array<{ assigneeId: string; isActive: boolean; nodeKey?: string | null }>
+    }
+    expect(afterLegal.status).toBe('pending')
+    expect(afterLegal.currentNodeKey).toBe('parallel_fork')
+    expect(afterLegal.currentNodeKeys).toEqual(['compliance_review'])
+    expect(
+      afterLegal.assignments
+        .filter((a) => a.isActive)
+        .map((a) => ({ assigneeId: a.assigneeId, nodeKey: a.nodeKey })),
+    ).toEqual([
+      { assigneeId: 'compliance-1', nodeKey: 'compliance_review' },
+    ])
+
+    // Second branch (compliance) approves — join-all triggers, advance past
+    // the join node to finance-review.
+    const complianceApproveResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, complianceToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'compliance ok' },
+    })
+    expect(complianceApproveResponse.status).toBe(200)
+    const afterCompliance = await complianceApproveResponse.json() as {
+      status: string
+      currentNodeKey: string | null
+      currentNodeKeys?: string[] | null
+      assignments: Array<{ assigneeId: string; isActive: boolean; nodeKey?: string | null }>
+    }
+    expect(afterCompliance.status).toBe('pending')
+    expect(afterCompliance.currentNodeKey).toBe('finance_review')
+    expect(afterCompliance.currentNodeKeys).toBeFalsy()
+    expect(
+      afterCompliance.assignments
+        .filter((a) => a.isActive)
+        .map((a) => ({ assigneeId: a.assigneeId, nodeKey: a.nodeKey })),
+    ).toEqual([
+      { assigneeId: 'finance-1', nodeKey: 'finance_review' },
+    ])
+
+    // Sanity: metadata no longer carries parallelBranchStates once the region closes.
+    const pool = poolManager.get()
+    const instanceResult = await pool.query<ApprovalInstanceRow>(
+      `SELECT status, current_node_key, metadata FROM approval_instances WHERE id = $1`,
+      [createdApproval.id],
+    )
+    expect(instanceResult.rows[0]?.current_node_key).toBe('finance_review')
+    expect((instanceResult.rows[0]?.metadata as JsonRecord | undefined)?.parallelBranchStates).toBeUndefined()
+
+    // Post-join approval completes the whole instance.
+    const financeApproveResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, financeToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'finance ok' },
+    })
+    expect(financeApproveResponse.status).toBe(200)
+    const afterFinance = await financeApproveResponse.json() as {
+      status: string
+      currentNodeKey: string | null
+      assignments: Array<{ assigneeId: string; isActive: boolean }>
+    }
+    expect(afterFinance.status).toBe('approved')
+    expect(afterFinance.currentNodeKey).toBeNull()
+    expect(afterFinance.assignments.filter((a) => a.isActive)).toHaveLength(0)
+
+    // Audit trail: two branch approvals, then join-close approval.
+    const approveRecordsResult = await pool.query<ApprovalRecordRow>(
+      `SELECT action, actor_id, to_status, metadata
+       FROM approval_records
+       WHERE instance_id = $1 AND action = 'approve'
+       ORDER BY to_version ASC, created_at ASC`,
+      [createdApproval.id],
+    )
+    expect(approveRecordsResult.rows).toHaveLength(3)
+    expect(approveRecordsResult.rows[0]?.actor_id).toBe('legal-1')
+    expect(approveRecordsResult.rows[0]?.metadata).toMatchObject({
+      nodeKey: 'legal_review',
+      parallelNodeKey: 'parallel_fork',
+      parallelBranchComplete: false,
+    })
+    expect(approveRecordsResult.rows[1]?.actor_id).toBe('compliance-1')
+    expect(approveRecordsResult.rows[1]?.metadata).toMatchObject({
+      nodeKey: 'compliance_review',
+      parallelNodeKey: 'parallel_fork',
+      parallelBranchComplete: true,
+      nextNodeKey: 'finance_review',
+    })
+    expect(approveRecordsResult.rows[2]?.actor_id).toBe('finance-1')
+    expect(approveRecordsResult.rows[2]?.metadata).toMatchObject({
+      nodeKey: 'finance_review',
+      nextNodeKey: null,
+      aggregateComplete: true,
+    })
+  })
+
+  it('rejects return while the instance is in a parallel branch with a typed error', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-parallel-return')
+    const requesterToken = await authToken(baseUrl, 'requester-parallel-return')
+    const legalToken = await authToken(baseUrl, 'legal-2')
+    const templateKey = `approval-wp1-parallel-return-${Date.now()}`
+
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Parallel Gateway Return-Reject Template',
+        description: 'return during parallel should be rejected',
+        formSchema: buildFormSchema(),
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'parallel_fork_2',
+              type: 'parallel',
+              config: {
+                branches: ['edge-fork-legal-2', 'edge-fork-compliance-2'],
+                joinMode: 'all',
+                joinNodeKey: 'finance_review_2',
+              },
+            },
+            {
+              key: 'legal_review_2',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['legal-2'] },
+            },
+            {
+              key: 'compliance_review_2',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['compliance-2'] },
+            },
+            {
+              key: 'finance_review_2',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['finance-2'] },
+            },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'edge-start-fork-2', source: 'start', target: 'parallel_fork_2' },
+            { key: 'edge-fork-legal-2', source: 'parallel_fork_2', target: 'legal_review_2' },
+            { key: 'edge-fork-compliance-2', source: 'parallel_fork_2', target: 'compliance_review_2' },
+            { key: 'edge-legal-join-2', source: 'legal_review_2', target: 'finance_review_2' },
+            { key: 'edge-compliance-join-2', source: 'compliance_review_2', target: 'finance_review_2' },
+            { key: 'edge-finance-end-2', source: 'finance_review_2', target: 'end' },
+          ],
+        },
+      },
+    })
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status).toBe(200)
+
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId: template.id, formData: { reason: 'return should fail' } },
+    })
+    expect(createResponse.status).toBe(201)
+    const createdApproval = await createResponse.json() as { id: string }
+    createdApprovalIds.add(createdApproval.id)
+
+    const returnResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, legalToken, {
+      method: 'POST',
+      body: { action: 'return', comment: 'not valid', targetNodeKey: 'start' },
+    })
+    expect(returnResponse.status).toBe(409)
+    const errorPayload = await returnResponse.json() as { error?: { code?: string } }
+    expect(errorPayload.error?.code).toBe('APPROVAL_RETURN_IN_PARALLEL_UNSUPPORTED')
+  })
+
+  it('rejects templates whose parallel branches share an approver', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-parallel-dup')
+    const templateKey = `approval-wp1-parallel-dup-${Date.now()}`
+
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Parallel Gateway Duplicate Approver Template',
+        description: 'duplicate approver across branches must be rejected',
+        formSchema: buildFormSchema(),
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'parallel_fork_dup',
+              type: 'parallel',
+              config: {
+                branches: ['edge-fork-a-dup', 'edge-fork-b-dup'],
+                joinMode: 'all',
+                joinNodeKey: 'finance_review_dup',
+              },
+            },
+            {
+              key: 'branch_a_dup',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['shared-approver'] },
+            },
+            {
+              key: 'branch_b_dup',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['shared-approver'] },
+            },
+            {
+              key: 'finance_review_dup',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['finance-dup'] },
+            },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'edge-start-fork-dup', source: 'start', target: 'parallel_fork_dup' },
+            { key: 'edge-fork-a-dup', source: 'parallel_fork_dup', target: 'branch_a_dup' },
+            { key: 'edge-fork-b-dup', source: 'parallel_fork_dup', target: 'branch_b_dup' },
+            { key: 'edge-a-join-dup', source: 'branch_a_dup', target: 'finance_review_dup' },
+            { key: 'edge-b-join-dup', source: 'branch_b_dup', target: 'finance_review_dup' },
+            { key: 'edge-finance-end-dup', source: 'finance_review_dup', target: 'end' },
+          ],
+        },
+      },
+    })
+    expect(templateResponse.status).toBe(400)
+    const errorPayload = await templateResponse.json() as { error?: { code?: string; message?: string } }
+    expect(errorPayload.error?.code).toBe('VALIDATION_ERROR')
+    expect(errorPayload.error?.message || '').toMatch(/duplicate approver/i)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -262,6 +262,151 @@ describe('ApprovalGraphExecutor', () => {
       'finance-review',
     ])
   })
+
+  it('forks a parallel gateway into per-branch assignments and emits a parallelState', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'parallel_fork',
+          type: 'parallel',
+          config: {
+            branches: ['edge-fork-a', 'edge-fork-b'],
+            joinMode: 'all',
+            joinNodeKey: 'finance-review',
+          },
+        },
+        {
+          key: 'legal-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['legal-1'] },
+        },
+        {
+          key: 'compliance-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['compliance-1'] },
+        },
+        {
+          key: 'finance-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['finance-1'] },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+        { key: 'edge-fork-a', source: 'parallel_fork', target: 'legal-review' },
+        { key: 'edge-fork-b', source: 'parallel_fork', target: 'compliance-review' },
+        { key: 'edge-a-join', source: 'legal-review', target: 'finance-review' },
+        { key: 'edge-b-join', source: 'compliance-review', target: 'finance-review' },
+        { key: 'edge-finance-end', source: 'finance-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const initial = executor.resolveInitialState()
+
+    expect(initial.status).toBe('pending')
+    expect(initial.currentNodeKey).toBe('parallel_fork')
+    expect([...(initial.currentNodeKeys || [])].sort()).toEqual([
+      'compliance-review',
+      'legal-review',
+    ])
+    expect(initial.assignments.map((a) => ({ assigneeId: a.assigneeId, nodeKey: a.nodeKey })).sort((x, y) => x.assigneeId.localeCompare(y.assigneeId))).toEqual([
+      { assigneeId: 'compliance-1', nodeKey: 'compliance-review' },
+      { assigneeId: 'legal-1', nodeKey: 'legal-review' },
+    ])
+    expect(initial.parallelState).toBeDefined()
+    expect(initial.parallelState!.parallelNodeKey).toBe('parallel_fork')
+    expect(initial.parallelState!.joinNodeKey).toBe('finance-review')
+    expect(initial.parallelState!.joinMode).toBe('all')
+    const branchStates = initial.parallelState!.branches
+    expect(branchStates['edge-fork-a']).toEqual({
+      edgeKey: 'edge-fork-a',
+      currentNodeKey: 'legal-review',
+      complete: false,
+    })
+    expect(branchStates['edge-fork-b']).toEqual({
+      edgeKey: 'edge-fork-b',
+      currentNodeKey: 'compliance-review',
+      complete: false,
+    })
+  })
+
+  it('keeps the instance pending when one parallel branch approves and the other is still active', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'parallel_fork',
+          type: 'parallel',
+          config: {
+            branches: ['edge-fork-a', 'edge-fork-b'],
+            joinMode: 'all',
+            joinNodeKey: 'finance-review',
+          },
+        },
+        {
+          key: 'legal-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['legal-1'] },
+        },
+        {
+          key: 'compliance-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['compliance-1'] },
+        },
+        {
+          key: 'finance-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['finance-1'] },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+        { key: 'edge-fork-a', source: 'parallel_fork', target: 'legal-review' },
+        { key: 'edge-fork-b', source: 'parallel_fork', target: 'compliance-review' },
+        { key: 'edge-a-join', source: 'legal-review', target: 'finance-review' },
+        { key: 'edge-b-join', source: 'compliance-review', target: 'finance-review' },
+        { key: 'edge-finance-end', source: 'finance-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const initial = executor.resolveInitialState()
+
+    const afterLegal = executor.resolveAfterApproveInParallel('legal-review', initial.parallelState!)
+    expect(afterLegal.status).toBe('pending')
+    expect(afterLegal.currentNodeKey).toBe('parallel_fork')
+    expect(afterLegal.currentNodeKeys).toEqual(['compliance-review'])
+    expect(afterLegal.assignments).toEqual([])
+    expect(afterLegal.parallelState!.branches['edge-fork-a']).toEqual({
+      edgeKey: 'edge-fork-a',
+      currentNodeKey: null,
+      complete: true,
+    })
+    expect(afterLegal.parallelState!.branches['edge-fork-b']).toEqual({
+      edgeKey: 'edge-fork-b',
+      currentNodeKey: 'compliance-review',
+      complete: false,
+    })
+
+    const afterCompliance = executor.resolveAfterApproveInParallel('compliance-review', afterLegal.parallelState!)
+    expect(afterCompliance.status).toBe('pending')
+    expect(afterCompliance.currentNodeKey).toBe('finance-review')
+    expect(afterCompliance.currentNodeKeys).toBeUndefined()
+    expect(afterCompliance.assignments).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'finance-1',
+        nodeKey: 'finance-review',
+        sourceStep: 3,
+      },
+    ])
+  })
 })
 
 describe('validateApprovalFormData', () => {

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2322,6 +2322,41 @@ components:
       required:
         - targetType
         - targetIds
+    ApprovalParallelNodeConfig:
+      type: object
+      description: |
+        Parallel gateway (并行分支) — fans into the listed branch edges and
+        re-joins at `joinNodeKey`. v1 only ships `joinMode: all` (会签 on
+        the join); `any` is reserved for a future wave.
+      properties:
+        branches:
+          type: array
+          minItems: 2
+          items:
+            type: string
+          description: |
+            Outgoing edgeKeys, one per branch. Each edge's downstream path
+            must reach `joinNodeKey` before any `end` or loop, and must not
+            share approver assignees with any other branch.
+        joinMode:
+          type: string
+          enum:
+            - all
+            - any
+          description: |
+            Join policy at `joinNodeKey`. `all` waits for every branch to
+            report complete before advancing. `any` (future) would advance
+            on the first branch to complete.
+        joinNodeKey:
+          type: string
+          description: |
+            The approval / cc node every branch converges onto. Required —
+            lets the runtime short-circuit walker without structural
+            inference.
+      required:
+        - branches
+        - joinMode
+        - joinNodeKey
     ApprovalNode:
       type: object
       properties:
@@ -2334,6 +2369,7 @@ components:
             - approval
             - cc
             - condition
+            - parallel
             - end
         name:
           type: string
@@ -2561,6 +2597,17 @@ components:
         currentNodeKey:
           type: string
           nullable: true
+        currentNodeKeys:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: |
+            Parallel gateway (并行分支) runtime frontier. Present only when
+            the instance is inside a parallel region with ≥ 2 still-pending
+            branches. Each entry is the current approval node key for one
+            branch. When absent or length < 2, use `currentNodeKey`
+            unchanged for the linear / non-parallel flow.
         assignments:
           type: array
           items:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3365,6 +3365,37 @@
           "targetIds"
         ]
       },
+      "ApprovalParallelNodeConfig": {
+        "type": "object",
+        "description": "Parallel gateway (并行分支) — fans into the listed branch edges and\nre-joins at `joinNodeKey`. v1 only ships `joinMode: all` (会签 on\nthe join); `any` is reserved for a future wave.\n",
+        "properties": {
+          "branches": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "string"
+            },
+            "description": "Outgoing edgeKeys, one per branch. Each edge's downstream path\nmust reach `joinNodeKey` before any `end` or loop, and must not\nshare approver assignees with any other branch.\n"
+          },
+          "joinMode": {
+            "type": "string",
+            "enum": [
+              "all",
+              "any"
+            ],
+            "description": "Join policy at `joinNodeKey`. `all` waits for every branch to\nreport complete before advancing. `any` (future) would advance\non the first branch to complete.\n"
+          },
+          "joinNodeKey": {
+            "type": "string",
+            "description": "The approval / cc node every branch converges onto. Required —\nlets the runtime short-circuit walker without structural\ninference.\n"
+          }
+        },
+        "required": [
+          "branches",
+          "joinMode",
+          "joinNodeKey"
+        ]
+      },
       "ApprovalNode": {
         "type": "object",
         "properties": {
@@ -3378,6 +3409,7 @@
               "approval",
               "cc",
               "condition",
+              "parallel",
               "end"
             ]
           },
@@ -3703,6 +3735,14 @@
           "currentNodeKey": {
             "type": "string",
             "nullable": true
+          },
+          "currentNodeKeys": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "Parallel gateway (并行分支) runtime frontier. Present only when\nthe instance is inside a parallel region with ≥ 2 still-pending\nbranches. Each entry is the current approval node key for one\nbranch. When absent or length < 2, use `currentNodeKey`\nunchanged for the linear / non-parallel flow.\n"
           },
           "assignments": {
             "type": "array",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2322,6 +2322,41 @@ components:
       required:
         - targetType
         - targetIds
+    ApprovalParallelNodeConfig:
+      type: object
+      description: |
+        Parallel gateway (并行分支) — fans into the listed branch edges and
+        re-joins at `joinNodeKey`. v1 only ships `joinMode: all` (会签 on
+        the join); `any` is reserved for a future wave.
+      properties:
+        branches:
+          type: array
+          minItems: 2
+          items:
+            type: string
+          description: |
+            Outgoing edgeKeys, one per branch. Each edge's downstream path
+            must reach `joinNodeKey` before any `end` or loop, and must not
+            share approver assignees with any other branch.
+        joinMode:
+          type: string
+          enum:
+            - all
+            - any
+          description: |
+            Join policy at `joinNodeKey`. `all` waits for every branch to
+            report complete before advancing. `any` (future) would advance
+            on the first branch to complete.
+        joinNodeKey:
+          type: string
+          description: |
+            The approval / cc node every branch converges onto. Required —
+            lets the runtime short-circuit walker without structural
+            inference.
+      required:
+        - branches
+        - joinMode
+        - joinNodeKey
     ApprovalNode:
       type: object
       properties:
@@ -2334,6 +2369,7 @@ components:
             - approval
             - cc
             - condition
+            - parallel
             - end
         name:
           type: string
@@ -2561,6 +2597,17 @@ components:
         currentNodeKey:
           type: string
           nullable: true
+        currentNodeKeys:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: |
+            Parallel gateway (并行分支) runtime frontier. Present only when
+            the instance is inside a parallel region with ≥ 2 still-pending
+            branches. Each entry is the current approval node key for one
+            branch. When absent or length < 2, use `currentNodeKey`
+            unchanged for the linear / non-parallel flow.
         assignments:
           type: array
           items:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2215,6 +2215,36 @@ components:
           items:
             type: string
       required: [targetType, targetIds]
+    ApprovalParallelNodeConfig:
+      type: object
+      description: |
+        Parallel gateway (并行分支) — fans into the listed branch edges and
+        re-joins at `joinNodeKey`. v1 only ships `joinMode: all` (会签 on
+        the join); `any` is reserved for a future wave.
+      properties:
+        branches:
+          type: array
+          minItems: 2
+          items:
+            type: string
+          description: |
+            Outgoing edgeKeys, one per branch. Each edge's downstream path
+            must reach `joinNodeKey` before any `end` or loop, and must not
+            share approver assignees with any other branch.
+        joinMode:
+          type: string
+          enum: [all, any]
+          description: |
+            Join policy at `joinNodeKey`. `all` waits for every branch to
+            report complete before advancing. `any` (future) would advance
+            on the first branch to complete.
+        joinNodeKey:
+          type: string
+          description: |
+            The approval / cc node every branch converges onto. Required —
+            lets the runtime short-circuit walker without structural
+            inference.
+      required: [branches, joinMode, joinNodeKey]
     ApprovalNode:
       type: object
       properties:
@@ -2222,7 +2252,7 @@ components:
           type: string
         type:
           type: string
-          enum: [start, approval, cc, condition, end]
+          enum: [start, approval, cc, condition, parallel, end]
         name:
           type: string
         config:
@@ -2417,6 +2447,17 @@ components:
         currentNodeKey:
           type: string
           nullable: true
+        currentNodeKeys:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: |
+            Parallel gateway (并行分支) runtime frontier. Present only when
+            the instance is inside a parallel region with ≥ 2 still-pending
+            branches. Each entry is the current approval node key for one
+            branch. When absent or length < 2, use `currentNodeKey`
+            unchanged for the linear / non-parallel flow.
         assignments:
           type: array
           items:


### PR DESCRIPTION
## Summary
- Add `parallel` approval graph nodes with join-all semantics.
- Preserve legacy `currentNodeKey` while adding `currentNodeKeys`/parallel state for multi-branch execution.
- Add backend, OpenAPI, frontend type/API, and approval detail UI support.
- Add unit and integration coverage for fork/join-all, branch approval, return guard, and duplicate approver validation.

## Rebase
- Rebased onto `origin/main@d547d89fcfcfded72f2e78a16320111d6def4f54`.
- Rebased head: `4400127c5`.

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-wp1-parallel-gateway.api.test.ts tests/integration/approval-wp1-any-mode.api.test.ts tests/integration/approval-pack1a-lifecycle.api.test.ts tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot` -> 14/14 passed
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot` -> 123 files, 1591/1591 passed
- `git diff --check`

## Notes
- `joinMode=any`, nested parallel, and return-into-closed-branch are documented follow-ups.
- Full-unit count is one above the original delivery summary because main now includes the #1077 WP2 source filter regression test.