### PR TITLE
test(dingtalk): add P4 manual evidence kit

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -69,6 +69,7 @@
 - [x] Add a P4 API-only remote-smoke runner for table/form creation, group binding, `dingtalk_granted` setup, automation test-run, and delivery evidence bootstrap.
 - [x] Add a P4 remote-smoke preflight gate for local tooling, env input, webhook format, and backend health readiness.
 - [x] Harden P4 evidence strict mode so real DingTalk-client/admin checks require per-check manual evidence metadata.
+- [x] Add a P4 manual evidence kit generator with required manual evidence fields and artifact folders.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-manual-evidence-kit-development-20260423.md
+++ b/docs/development/dingtalk-p4-manual-evidence-kit-development-20260423.md
@@ -1,0 +1,34 @@
+# DingTalk P4 Manual Evidence Kit Development
+
+- Date: 2026-04-23
+- Scope: P4 remote-smoke manual evidence capture
+- Branch: `codex/dingtalk-p4-manual-evidence-kit-20260423`
+
+## What Changed
+
+- Extended `scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs` with `--init-kit <dir>`.
+- The kit writes `evidence.json`, `manual-evidence-checklist.md`, and artifact folders for the checks that require real DingTalk-client or admin proof.
+- The standard `--init-template` JSON now includes the strict-mode manual evidence skeleton:
+  - `source: "manual-client"` for group-message visibility, authorized submit, and unauthorized denial.
+  - `source: "manual-admin"` for no-email local user creation and binding.
+  - empty `operator`, `performedAt`, `summary`, and `artifacts` fields that must be filled before strict pass.
+- API-bootstrap checks still default to `source: "api-bootstrap"`.
+- Updated the remote smoke checklist and P4 TODO with the new kit flow.
+
+## Why
+
+The previous strict-mode gate prevented incomplete manual evidence from passing, but the initialization path still produced a generic template. This change makes the required evidence shape explicit before the operator starts the real DingTalk smoke run.
+
+## Files
+
+- `scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`
+- `scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Flow
+
+1. Run `node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --init-kit output/dingtalk-p4-remote-smoke/<run>`.
+2. Place real screenshots/log excerpts in the generated `artifacts/<check-id>/` folders.
+3. Fill the matching per-check `evidence.operator`, `evidence.performedAt`, `evidence.summary`, and `evidence.artifacts`.
+4. Compile with `--strict` only after the manual DingTalk-client/admin checks have real evidence.

--- a/docs/development/dingtalk-p4-manual-evidence-kit-verification-20260423.md
+++ b/docs/development/dingtalk-p4-manual-evidence-kit-verification-20260423.md
@@ -1,0 +1,30 @@
+# DingTalk P4 Manual Evidence Kit Verification
+
+- Date: 2026-04-23
+- Scope: evidence compiler initialization and manual kit coverage
+
+## Commands Run
+
+```bash
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`: passed.
+- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`: passed, 6 tests.
+- `git diff --cached --check`: passed.
+
+## Coverage Notes
+
+- `--init-template` coverage verifies all required checks stay pending and include strict-mode source skeletons.
+- `--init-kit` coverage verifies `evidence.json`, `manual-evidence-checklist.md`, and required manual artifact folders are generated.
+- Existing strict-mode tests continue to verify that a pass without real manual metadata fails.
+
+## Remaining Remote Validation
+
+- Generate a kit for the actual 142/staging run.
+- Fill the generated evidence from real DingTalk-client/admin artifacts.
+- Compile final evidence with `--strict`.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -54,7 +54,23 @@ Do not capture or paste:
 
 Use the evidence compiler after the manual smoke is executed. It does not call DingTalk or staging; it validates the operator-provided result file, redacts secrets, and writes a reusable evidence summary.
 
-Create a template:
+Create a manual evidence kit when starting a full remote smoke run:
+
+```bash
+node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \
+  --init-kit output/dingtalk-p4-remote-smoke/142-manual-kit
+```
+
+Expected generated files:
+
+- `evidence.json`
+- `manual-evidence-checklist.md`
+- `artifacts/send-group-message-form-link/`
+- `artifacts/authorized-user-submit/`
+- `artifacts/unauthorized-user-denied/`
+- `artifacts/no-email-user-create-bind/`
+
+Create only the JSON template when you do not need artifact folders:
 
 ```bash
 node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
@@ -78,6 +78,7 @@ const MANUAL_EVIDENCE_REQUIREMENTS = [
     label: 'no-email DingTalk-synced account creation and binding',
   },
 ]
+const MANUAL_EVIDENCE_BY_ID = new Map(MANUAL_EVIDENCE_REQUIREMENTS.map((requirement) => [requirement.id, requirement]))
 
 function printHelp() {
   console.log(`Usage: node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs [options]
@@ -89,12 +90,16 @@ Options:
   --input <file>           Evidence JSON to compile
   --output-dir <dir>       Output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
   --init-template <file>   Write an editable evidence template and exit
+  --init-kit <dir>         Write evidence.json plus manual evidence folders/checklist and exit
   --strict                 Exit non-zero unless all required checks pass
   --help                   Show this help
 
 Examples:
   node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \\
     --init-template output/dingtalk-p4-remote-smoke/evidence.json
+
+  node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \\
+    --init-kit output/dingtalk-p4-remote-smoke/142-manual-kit
 
   node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \\
     --input output/dingtalk-p4-remote-smoke/evidence.json \\
@@ -116,6 +121,7 @@ function parseArgs(argv) {
     input: null,
     outputDir: null,
     initTemplate: null,
+    initKit: null,
     strict: false,
   }
 
@@ -134,6 +140,10 @@ function parseArgs(argv) {
         opts.initTemplate = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
         break
+      case '--init-kit':
+        opts.initKit = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
       case '--strict':
         opts.strict = true
         break
@@ -146,8 +156,9 @@ function parseArgs(argv) {
     }
   }
 
-  if (opts.initTemplate && opts.input) {
-    throw new Error('--init-template cannot be combined with --input')
+  const initModes = [opts.initTemplate, opts.initKit].filter(Boolean).length
+  if (initModes > 1 || (initModes > 0 && opts.input)) {
+    throw new Error('--init-template, --init-kit, and --input are mutually exclusive')
   }
 
   return opts
@@ -159,6 +170,25 @@ function nowIso() {
 
 function makeRunId() {
   return `dingtalk-p4-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}`
+}
+
+function makeTemplateEvidence(checkId) {
+  const manualRequirement = MANUAL_EVIDENCE_BY_ID.get(checkId)
+  if (manualRequirement) {
+    return {
+      source: manualRequirement.source,
+      operator: '',
+      performedAt: '',
+      summary: '',
+      artifacts: [],
+      instructions: `Required when status is pass: ${manualRequirement.label}; include real DingTalk-client/admin evidence, not API bootstrap output.`,
+    }
+  }
+
+  return {
+    source: API_BOOTSTRAP_CHECK_IDS.has(checkId) ? 'api-bootstrap' : '',
+    notes: '',
+  }
 }
 
 function makeTemplate() {
@@ -177,9 +207,7 @@ function makeTemplate() {
       id: check.id,
       label: check.label,
       status: 'pending',
-      evidence: {
-        notes: '',
-      },
+      evidence: makeTemplateEvidence(check.id),
     })),
     artifacts: [],
   }
@@ -189,6 +217,56 @@ function writeTemplate(file) {
   mkdirSync(path.dirname(file), { recursive: true })
   writeFileSync(file, `${JSON.stringify(makeTemplate(), null, 2)}\n`, 'utf8')
   console.log(`Wrote ${path.relative(process.cwd(), file)}`)
+}
+
+function artifactDirForCheck(checkId) {
+  return path.join('artifacts', checkId)
+}
+
+function renderManualEvidenceChecklist() {
+  const rows = MANUAL_EVIDENCE_REQUIREMENTS.map((requirement) => {
+    return `| \`${requirement.id}\` | \`${requirement.source}\` | ${requirement.label} | \`${artifactDirForCheck(requirement.id)}/\` |`
+  })
+
+  return `# DingTalk P4 Manual Evidence Kit
+
+Use this kit after running \`scripts/ops/dingtalk-p4-remote-smoke.mjs\` or after manually executing \`docs/dingtalk-remote-smoke-checklist-20260422.md\`.
+
+## Required Manual Evidence
+
+| Check ID | Required Source | What It Proves | Suggested Artifact Folder |
+| --- | --- | --- | --- |
+${rows.join('\n')}
+
+## Fill Rules
+
+- Keep \`status: "pending"\` until the real DingTalk-client or admin action has been performed.
+- When setting one of the checks above to \`pass\`, fill \`evidence.operator\`, \`evidence.performedAt\`, \`evidence.summary\`, and \`evidence.artifacts\`.
+- Artifact refs should point to screenshots, exported logs, or notes captured during the real smoke run.
+- Do not paste DingTalk robot full webhook URLs, \`SEC...\` secrets, bearer tokens, admin tokens, public form tokens, temporary passwords, or raw cookies.
+
+## Compile
+
+\`\`\`bash
+node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \\
+  --input evidence.json \\
+  --output-dir compiled \\
+  --strict
+\`\`\`
+`
+}
+
+function writeManualEvidenceKit(dir) {
+  mkdirSync(dir, { recursive: true })
+  const evidencePath = path.join(dir, 'evidence.json')
+  const checklistPath = path.join(dir, 'manual-evidence-checklist.md')
+  writeFileSync(evidencePath, `${JSON.stringify(makeTemplate(), null, 2)}\n`, 'utf8')
+  writeFileSync(checklistPath, renderManualEvidenceChecklist(), 'utf8')
+  for (const requirement of MANUAL_EVIDENCE_REQUIREMENTS) {
+    mkdirSync(path.join(dir, artifactDirForCheck(requirement.id)), { recursive: true })
+  }
+  console.log(`Wrote ${path.relative(process.cwd(), evidencePath)}`)
+  console.log(`Wrote ${path.relative(process.cwd(), checklistPath)}`)
 }
 
 function parseEvidence(file) {
@@ -537,6 +615,8 @@ try {
   const opts = parseArgs(process.argv.slice(2))
   if (opts.initTemplate) {
     writeTemplate(opts.initTemplate)
+  } else if (opts.initKit) {
+    writeManualEvidenceKit(opts.initKit)
   } else {
     compileEvidence(opts)
   }

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
@@ -86,6 +86,42 @@ test('compile-dingtalk-p4-smoke-evidence writes an editable template', () => {
     assert.equal(template.checks.length, requiredIds.length)
     assert.deepEqual(template.checks.map((check) => check.id), requiredIds)
     assert.equal(template.checks.every((check) => check.status === 'pending'), true)
+    assert.equal(template.checks.find((check) => check.id === 'create-table-form').evidence.source, 'api-bootstrap')
+    assert.equal(template.checks.find((check) => check.id === 'send-group-message-form-link').evidence.source, 'manual-client')
+    assert.equal(template.checks.find((check) => check.id === 'authorized-user-submit').evidence.operator, '')
+    assert.equal(template.checks.find((check) => check.id === 'authorized-user-submit').evidence.performedAt, '')
+    assert.deepEqual(template.checks.find((check) => check.id === 'authorized-user-submit').evidence.artifacts, [])
+    assert.equal(template.checks.find((check) => check.id === 'no-email-user-create-bind').evidence.source, 'manual-admin')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence writes a manual evidence kit', () => {
+  const tmpDir = makeTmpDir()
+  const kitDir = path.join(tmpDir, 'manual-kit')
+
+  try {
+    const result = spawnSync(process.execPath, [scriptPath, '--init-kit', kitDir], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(existsSync(path.join(kitDir, 'evidence.json')), true)
+    assert.equal(existsSync(path.join(kitDir, 'manual-evidence-checklist.md')), true)
+    assert.equal(existsSync(path.join(kitDir, 'artifacts/send-group-message-form-link')), true)
+    assert.equal(existsSync(path.join(kitDir, 'artifacts/authorized-user-submit')), true)
+    assert.equal(existsSync(path.join(kitDir, 'artifacts/unauthorized-user-denied')), true)
+    assert.equal(existsSync(path.join(kitDir, 'artifacts/no-email-user-create-bind')), true)
+
+    const template = JSON.parse(readFileSync(path.join(kitDir, 'evidence.json'), 'utf8'))
+    assert.equal(template.checks.find((check) => check.id === 'send-group-message-form-link').evidence.source, 'manual-client')
+    assert.equal(template.checks.find((check) => check.id === 'no-email-user-create-bind').evidence.source, 'manual-admin')
+    const checklist = readFileSync(path.join(kitDir, 'manual-evidence-checklist.md'), 'utf8')
+    assert.match(checklist, /manual-client/)
+    assert.match(checklist, /manual-admin/)
+    assert.match(checklist, /Do not paste DingTalk robot full webhook URLs/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- Extend `compile-dingtalk-p4-smoke-evidence.mjs` with `--init-kit <dir>` to generate an evidence JSON, manual evidence checklist, and per-check artifact folders.
- Update the plain `--init-template` JSON to include the strict-mode manual evidence skeleton for `manual-client` / `manual-admin` checks.
- Document the manual evidence kit flow in the P4 remote-smoke checklist and TODO.
- Add development and verification notes.

## Verification

- `node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`
- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`
- `git diff --cached --check`

## Notes

- This PR is stacked on #1082 / `codex/dingtalk-p4-smoke-preflight-20260422`.
- Existing unrelated dirty `node_modules` files in the worktree were not staged or modified by this commit.