### PR TITLE
test(redis): add live leader lock smoke

### DIFF
--- a/docs/development/redis-runtime-live-smoke-development-20260423.md
+++ b/docs/development/redis-runtime-live-smoke-development-20260423.md
@@ -1,0 +1,37 @@
+# Redis Runtime Live Smoke Development - 2026-04-23
+
+## Scope
+
+This follow-up closes the remaining Redis runtime verification gap after the Redis wiring PR landed in `main`.
+
+The existing live smoke already covered:
+
+- `RedisTokenBucketStore`: Lua token consumption, TTL, and `SCRIPT FLUSH` / `NOSCRIPT` recovery.
+- `RedisCircuitBreakerStore`: Lua failure window, `CLOSED -> OPEN`, TTL, and `SCRIPT FLUSH` / `NOSCRIPT` recovery.
+
+This change adds the missing live coverage for:
+
+- `RedisLeaderLock`: real Redis `SET NX PX`, owner-scoped renew, owner-scoped release, and takeover after release.
+
+## Design
+
+The smoke test stays opt-in:
+
+- It runs only when `REDIS_URL` is set.
+- It is skipped by default in local and CI environments without Redis.
+- It uses a unique `ms2:*:<timestamp>:<random>:` prefix per test and deletes matching keys in `afterEach`.
+
+The new test does not introduce new runtime code. It only exercises the existing `RedisLeaderLock` seam against an actual Redis server, which is the behavior that the memory twin cannot fully prove.
+
+## Files
+
+- `packages/core-backend/tests/integration/redis-runtime-stores.integration.test.ts`
+
+## Verification Strategy
+
+Two levels are expected:
+
+- Default gate: no `REDIS_URL`; the live smoke file is discovered and skipped cleanly.
+- Manual/live gate: `REDIS_URL=redis://127.0.0.1:6379`; all Redis runtime store smoke tests run against real Redis.
+
+The live gate is intentionally not mandatory CI until the repo has a stable Redis service in CI.

--- a/docs/development/redis-runtime-live-smoke-verification-20260423.md
+++ b/docs/development/redis-runtime-live-smoke-verification-20260423.md
@@ -1,0 +1,74 @@
+# Redis Runtime Live Smoke Verification - 2026-04-23
+
+## Commands
+
+Default skip gate:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot
+```
+
+Live Redis gate:
+
+```bash
+docker run -d --name ms2-redis-smoke-20260423 -p 6379:6379 redis:7
+REDIS_URL=redis://127.0.0.1:6379 \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot
+docker rm -f ms2-redis-smoke-20260423
+```
+
+Typecheck:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Diff hygiene:
+
+```bash
+git diff --check
+```
+
+## Expected Result
+
+- Without `REDIS_URL`: 1 integration file is skipped.
+- With live Redis: 3 smoke tests pass:
+  - token bucket Lua + `SCRIPT FLUSH` recovery
+  - circuit breaker Lua + `SCRIPT FLUSH` recovery
+  - leader lock acquire/renew/release owner semantics
+
+## Notes
+
+This smoke remains an opt-in manual gate. It proves Redis server Lua and lock semantics without forcing every CI job to provision Redis.
+
+## Run Result - 2026-04-23
+
+Default skip gate:
+
+```text
+Test Files  1 skipped (1)
+Tests       3 skipped (3)
+Exit        0
+```
+
+Live Redis gate (`docker run redis:7`, `REDIS_URL=redis://127.0.0.1:6379`):
+
+```text
+Test Files  1 passed (1)
+Tests       3 passed (3)
+Exit        0
+```
+
+Typecheck:
+
+```text
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+Exit 0
+```
+
+Diff hygiene:
+
+```text
+git diff --check
+Exit 0
+```

--- a/packages/core-backend/tests/integration/redis-runtime-stores.integration.test.ts
+++ b/packages/core-backend/tests/integration/redis-runtime-stores.integration.test.ts
@@ -10,6 +10,10 @@ import {
   RedisTokenBucketStore,
   type RedisScriptClient,
 } from '../../src/integration/rate-limiting/redis-token-bucket-store'
+import {
+  RedisLeaderLock,
+  type RedisLeaderLockClient,
+} from '../../src/multitable/redis-leader-lock'
 
 const redisUrl = process.env.REDIS_URL
 const describeIfRedis = redisUrl ? describe : describe.skip
@@ -93,5 +97,27 @@ describeIfRedis('Redis runtime stores live smoke', () => {
     const afterFlush = await store.checkAndUpdate('svc-a', thresholds)
     expect(afterFlush.state).toBe(CircuitState.OPEN)
     expect(afterFlush.windowFailures).toBe(3)
+  })
+
+  it('executes owner-scoped leader lock operations against a real Redis server', async () => {
+    prefix = `ms2:leader:${Date.now()}:${Math.random().toString(16).slice(2)}:`
+    const lockKey = `${prefix}scheduler`
+    const lock = new RedisLeaderLock({
+      client: redis as unknown as RedisLeaderLockClient,
+    })
+
+    await expect(lock.acquire(lockKey, 'node-a', 5_000)).resolves.toBe(true)
+    await expect(lock.acquire(lockKey, 'node-b', 5_000)).resolves.toBe(false)
+    await expect(lock.isHeldBy(lockKey, 'node-a')).resolves.toBe(true)
+
+    await expect(lock.renew(lockKey, 'node-b', 5_000)).resolves.toBe(false)
+    await expect(lock.renew(lockKey, 'node-a', 5_000)).resolves.toBe(true)
+
+    await expect(lock.release(lockKey, 'node-b')).resolves.toBe(false)
+    await expect(lock.isHeldBy(lockKey, 'node-a')).resolves.toBe(true)
+
+    await expect(lock.release(lockKey, 'node-a')).resolves.toBe(true)
+    await expect(lock.acquire(lockKey, 'node-b', 5_000)).resolves.toBe(true)
+    await expect(lock.isHeldBy(lockKey, 'node-b')).resolves.toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Extends the opt-in Redis runtime live smoke with RedisLeaderLock coverage.
- Verifies real Redis SET NX PX acquire, owner-scoped renew, owner-scoped release, and takeover after release.
- Adds development and verification MDs with default skip and live Redis run results.

## Verification

- DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-wp1-parallel-gateway.api.test.ts tests/integration/approval-wp1-any-mode.api.test.ts tests/integration/approval-pack1a-lifecycle.api.test.ts tests/integration/approval-wp2-source-filter.api.test.ts --reporter=dot → 14/14 pass
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot → 3 skipped without REDIS_URL
- REDIS_URL=redis://127.0.0.1:6379 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/redis-runtime-stores.integration.test.ts --reporter=dot → 3/3 pass against redis:7
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false → pass
- git diff --check → pass