### PR TITLE
test(dingtalk): add P4 strict artifact gate

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -70,6 +70,7 @@
 - [x] Add a P4 remote-smoke preflight gate for local tooling, env input, webhook format, and backend health readiness.
 - [x] Harden P4 evidence strict mode so real DingTalk-client/admin checks require per-check manual evidence metadata.
 - [x] Add a P4 manual evidence kit generator with required manual evidence fields and artifact folders.
+- [x] Add a P4 strict artifact gate so manual pass evidence must reference self-contained non-empty files under `artifacts/<check-id>/`.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-artifact-gate-development-20260423.md
+++ b/docs/development/dingtalk-p4-artifact-gate-development-20260423.md
@@ -1,0 +1,37 @@
+# DingTalk P4 Strict Artifact Gate Development
+
+- Date: 2026-04-23
+- Scope: P4 remote-smoke evidence compiler hardening
+- Branch: `codex/dingtalk-p4-artifact-gate-20260423`
+
+## What Changed
+
+- Added strict validation for manual DingTalk-client/admin artifact refs in `scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`.
+- A manual check marked `pass` must now reference at least one artifact that is:
+  - a relative path
+  - inside `artifacts/<check-id>/` next to the input `evidence.json`
+  - present on disk
+  - a file, not a directory
+  - non-empty
+- Added `--allow-external-artifact-refs` for controlled external evidence stores. Without this flag, URL refs fail strict mode with `artifact_ref_external_disallowed`.
+- Redacted artifact refs are included in `manualEvidenceIssues` so operators can fix the bundle without leaking tokens.
+- Updated tests to create real local artifact files for passing evidence and to cover missing, wrong-folder, absolute, traversal, empty, and external URL refs.
+- Updated the remote smoke checklist and P4 TODO to describe the self-contained evidence bundle rule.
+
+## Why
+
+The previous strict mode proved that manual metadata existed, but it did not prove that referenced screenshots or logs were actually included. This allowed an evidence file to pass with placeholder refs such as `screenshots/foo.png`. The new gate makes strict pass evidence reproducible and reviewable from the submitted bundle.
+
+## Files
+
+- `scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`
+- `scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Flow
+
+1. Generate a kit with `--init-kit`.
+2. Put screenshots, exported logs, or notes under the generated `artifacts/<check-id>/` folders.
+3. Fill per-check `evidence.artifacts` with those relative paths.
+4. Run strict compile. If the compiler reports `artifact_ref_*`, fix the bundle before treating the smoke as passed.

--- a/docs/development/dingtalk-p4-artifact-gate-verification-20260423.md
+++ b/docs/development/dingtalk-p4-artifact-gate-verification-20260423.md
@@ -1,0 +1,34 @@
+# DingTalk P4 Strict Artifact Gate Verification
+
+- Date: 2026-04-23
+- Scope: evidence compiler strict artifact validation
+
+## Commands Run
+
+```bash
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`: passed.
+- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`: passed, 11 tests.
+- `git diff --cached --check`: passed after staging the artifact-gate changes.
+
+## Coverage Notes
+
+- Passing evidence now creates real non-empty files under `artifacts/<check-id>/`.
+- Strict mode fails for missing artifact files with `artifact_ref_missing`.
+- Strict mode fails for wrong per-check folders with `artifact_ref_wrong_folder`.
+- Strict mode fails for absolute paths with `artifact_ref_not_relative`.
+- Strict mode fails for path traversal with `artifact_ref_path_traversal`.
+- Strict mode fails for empty files with `artifact_ref_empty`.
+- Strict mode fails for external URL refs unless `--allow-external-artifact-refs` is set.
+
+## Remaining Remote Validation
+
+- Run the 142/staging smoke with a generated evidence kit.
+- Capture real DingTalk-client/admin artifacts into the bundle.
+- Compile the completed evidence with `--strict`.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -101,6 +101,13 @@ Strict mode also requires real manual evidence metadata for the checks that only
 - `unauthorized-user-denied`: `source: "manual-client"`
 - `no-email-user-create-bind`: `source: "manual-admin"`
 
+Strict artifact refs are self-contained by default:
+
+- Use relative paths only.
+- Put each file under `artifacts/<check-id>/` next to the input `evidence.json`.
+- The referenced path must exist, be a file, and be non-empty.
+- External URL refs are rejected unless `--allow-external-artifact-refs` is passed. Prefer local files for release evidence because URL-only proof can be edited or become unavailable.
+
 Example check evidence:
 
 ```json
@@ -112,7 +119,7 @@ Example check evidence:
     "operator": "qa",
     "performedAt": "2026-04-22T15:00:00.000Z",
     "summary": "Allowed DingTalk-bound user opened the group link and submitted one record.",
-    "artifacts": ["screenshots/authorized-submit.png"]
+    "artifacts": ["artifacts/authorized-user-submit/authorized-submit.png"]
   }
 }
 ```

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-remote-smoke'
@@ -91,6 +91,8 @@ Options:
   --output-dir <dir>       Output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
   --init-template <file>   Write an editable evidence template and exit
   --init-kit <dir>         Write evidence.json plus manual evidence folders/checklist and exit
+  --allow-external-artifact-refs
+                           Allow URL artifact refs for manual evidence instead of requiring local files
   --strict                 Exit non-zero unless all required checks pass
   --help                   Show this help
 
@@ -122,6 +124,7 @@ function parseArgs(argv) {
     outputDir: null,
     initTemplate: null,
     initKit: null,
+    allowExternalArtifactRefs: false,
     strict: false,
   }
 
@@ -146,6 +149,9 @@ function parseArgs(argv) {
         break
       case '--strict':
         opts.strict = true
+        break
+      case '--allow-external-artifact-refs':
+        opts.allowExternalArtifactRefs = true
         break
       case '--help':
         printHelp()
@@ -242,7 +248,8 @@ ${rows.join('\n')}
 
 - Keep \`status: "pending"\` until the real DingTalk-client or admin action has been performed.
 - When setting one of the checks above to \`pass\`, fill \`evidence.operator\`, \`evidence.performedAt\`, \`evidence.summary\`, and \`evidence.artifacts\`.
-- Artifact refs should point to screenshots, exported logs, or notes captured during the real smoke run.
+- Artifact refs should point to non-empty files captured during the real smoke run. Put them under \`artifacts/<check-id>/\` next to \`evidence.json\`.
+- External URL artifact refs are rejected by default in strict mode. Use \`--allow-external-artifact-refs\` only when the artifact store is controlled and durable.
 - Do not paste DingTalk robot full webhook URLs, \`SEC...\` secrets, bearer tokens, admin tokens, public form tokens, temporary passwords, or raw cookies.
 
 ## Compile
@@ -380,15 +387,33 @@ function normalizeEvidenceSource(evidence) {
   return isNonEmptyString(source) ? source.trim() : ''
 }
 
-function hasArtifactRefs(evidence) {
-  if (!evidence || typeof evidence !== 'object' || Array.isArray(evidence)) return false
+function normalizeArtifactRefsFromValue(value) {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizeArtifactRefsFromValue(entry))
+  }
+  if (value === null || value === undefined) return []
+  if (typeof value === 'string') return [value]
+  if (value && typeof value === 'object') {
+    for (const key of ['path', 'file', 'url', 'href']) {
+      if (Object.hasOwn(value, key)) return [value[key]]
+    }
+  }
+  return [value]
+}
+
+function collectArtifactRefs(evidence) {
+  if (!evidence || typeof evidence !== 'object' || Array.isArray(evidence)) return []
   const artifactCandidates = [
     evidence.artifacts,
     evidence.artifactRefs,
     evidence.screenshots,
     evidence.files,
   ]
-  return artifactCandidates.some((candidate) => Array.isArray(candidate) && candidate.length > 0)
+  return artifactCandidates.flatMap((candidate) => normalizeArtifactRefsFromValue(candidate))
+}
+
+function hasArtifactRefs(evidence) {
+  return collectArtifactRefs(evidence).length > 0
 }
 
 function hasSummary(evidence) {
@@ -398,7 +423,81 @@ function hasSummary(evidence) {
     || isNonEmptyString(evidence.resultSummary)
 }
 
-function validateManualEvidenceRequirements(checksById) {
+function isExternalArtifactRef(value) {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value)
+}
+
+function artifactIssue(id, code, message, artifactRef) {
+  return {
+    id,
+    code,
+    message,
+    ...(typeof artifactRef === 'string' && artifactRef ? { artifactRef: redactString(artifactRef) } : {}),
+  }
+}
+
+function isAbsoluteArtifactPath(value) {
+  return path.isAbsolute(value) || path.win32.isAbsolute(value) || value.replaceAll('\\', '/').startsWith('//')
+}
+
+function validateManualArtifactRefs(checkId, evidence, evidenceDir, opts) {
+  const issues = []
+  const refs = collectArtifactRefs(evidence)
+  const expectedPrefix = `artifacts/${checkId}/`
+  const evidenceRoot = path.resolve(evidenceDir)
+  for (const ref of refs) {
+    if (!isNonEmptyString(ref)) {
+      issues.push(artifactIssue(checkId, 'artifact_ref_invalid', `${checkId} has an empty artifact reference`))
+      continue
+    }
+
+    const trimmed = ref.trim()
+    if (isExternalArtifactRef(trimmed)) {
+      if (!opts.allowExternalArtifactRefs) {
+        issues.push(artifactIssue(checkId, 'artifact_ref_external_disallowed', `${checkId} external artifact refs require --allow-external-artifact-refs`, trimmed))
+      }
+      continue
+    }
+
+    if (isAbsoluteArtifactPath(trimmed)) {
+      issues.push(artifactIssue(checkId, 'artifact_ref_not_relative', `${checkId} artifact refs must be relative paths`, trimmed))
+      continue
+    }
+
+    const normalizedInput = trimmed.replaceAll('\\', '/')
+    const rawSegments = normalizedInput.split('/').filter(Boolean)
+    const normalizedRef = path.posix.normalize(normalizedInput)
+    if (rawSegments.includes('..') || normalizedRef.startsWith('../') || normalizedRef === '..') {
+      issues.push(artifactIssue(checkId, 'artifact_ref_path_traversal', `${checkId} artifact refs cannot traverse outside the evidence directory`, trimmed))
+      continue
+    }
+    if (!normalizedRef.startsWith(expectedPrefix)) {
+      issues.push(artifactIssue(checkId, 'artifact_ref_wrong_folder', `${checkId} artifact refs must live under ${expectedPrefix}`, trimmed))
+      continue
+    }
+
+    const fullPath = path.resolve(evidenceDir, normalizedRef)
+    if (fullPath !== evidenceRoot && !fullPath.startsWith(`${evidenceRoot}${path.sep}`)) {
+      issues.push(artifactIssue(checkId, 'artifact_ref_path_traversal', `${checkId} artifact refs cannot traverse outside the evidence directory`, trimmed))
+      continue
+    }
+    if (!existsSync(fullPath)) {
+      issues.push(artifactIssue(checkId, 'artifact_ref_missing', `${checkId} artifact file does not exist`, trimmed))
+      continue
+    }
+    const stat = statSync(fullPath)
+    if (!stat.isFile()) {
+      issues.push(artifactIssue(checkId, 'artifact_ref_not_file', `${checkId} artifact ref must point to a file`, trimmed))
+      continue
+    }
+    if (stat.size <= 0) {
+      issues.push(artifactIssue(checkId, 'artifact_ref_empty', `${checkId} artifact file is empty`, trimmed))
+    }
+  }
+  return issues
+}
+
+function validateManualEvidenceRequirements(checksById, evidenceDir, opts) {
   const issues = []
   for (const requirement of MANUAL_EVIDENCE_REQUIREMENTS) {
     const check = checksById.get(requirement.id)
@@ -442,6 +541,8 @@ function validateManualEvidenceRequirements(checksById) {
         code: 'artifact_refs_required',
         message: `${requirement.id} requires per-check evidence.artifacts, evidence.artifactRefs, evidence.screenshots, or evidence.files`,
       })
+    } else {
+      issues.push(...validateManualArtifactRefs(requirement.id, evidence, evidenceDir, opts))
     }
     if (!hasSummary(evidence)) {
       issues.push({
@@ -454,7 +555,7 @@ function validateManualEvidenceRequirements(checksById) {
   return issues
 }
 
-function buildSummary(evidence, inputFile, outputDir) {
+function buildSummary(evidence, inputFile, outputDir, opts = {}) {
   const checks = normalizeChecks(evidence)
   const byId = new Map(checks.map((check) => [check.id, check]))
   const requiredRows = REQUIRED_CHECKS.map((required) => {
@@ -473,7 +574,7 @@ function buildSummary(evidence, inputFile, outputDir) {
     .map((check) => ({ id: check.id, status: check.status }))
   const failedChecks = checks.filter((check) => check.status === 'fail').map((check) => check.id)
   const unknownChecks = checks.filter((check) => !CHECK_ID_SET.has(check.id)).map((check) => check.id)
-  const manualEvidenceIssues = validateManualEvidenceRequirements(byId)
+  const manualEvidenceIssues = validateManualEvidenceRequirements(byId, path.dirname(inputFile), opts)
   const apiBootstrapRequired = requiredRows.filter((check) => API_BOOTSTRAP_CHECK_IDS.has(check.id))
   const apiBootstrapStatus = apiBootstrapRequired.every((check) => check.status === 'pass') ? 'pass' : 'fail'
   const remoteClientStatus = requiredChecksNotPassed.length === 0 && manualEvidenceIssues.length === 0 ? 'pass' : 'fail'
@@ -589,7 +690,9 @@ function compileEvidence(opts) {
   const outputDir = opts.outputDir ?? path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, runId)
   mkdirSync(outputDir, { recursive: true })
 
-  const summary = buildSummary(evidence, opts.input, outputDir)
+  const summary = buildSummary(evidence, opts.input, outputDir, {
+    allowExternalArtifactRefs: opts.allowExternalArtifactRefs,
+  })
   const summaryJsonPath = path.join(outputDir, 'summary.json')
   const summaryMdPath = path.join(outputDir, 'summary.md')
   const redactedEvidencePath = path.join(outputDir, 'evidence.redacted.json')

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
@@ -26,6 +26,10 @@ const manualClientIds = new Set([
 ])
 const manualAdminIds = new Set(['no-email-user-create-bind'])
 
+function manualArtifactRefForCheck(id) {
+  return `artifacts/${id}/evidence.txt`
+}
+
 function makePassingEvidenceForCheck(id, extras = {}) {
   if (manualClientIds.has(id) || manualAdminIds.has(id)) {
     return {
@@ -33,7 +37,7 @@ function makePassingEvidenceForCheck(id, extras = {}) {
       operator: 'qa',
       performedAt: '2026-04-22T15:00:00.000Z',
       summary: `${id} manual evidence ok`,
-      artifacts: [`screenshots/${id}.png`],
+      artifacts: [manualArtifactRefForCheck(id)],
       ...extras,
     }
   }
@@ -48,7 +52,44 @@ function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-smoke-evidence-'))
 }
 
-function writeEvidence(file, overrides = {}) {
+function collectArtifactRefsFromValue(value) {
+  if (Array.isArray(value)) return value.flatMap((entry) => collectArtifactRefsFromValue(entry))
+  if (typeof value === 'string') return [value]
+  if (value && typeof value === 'object') {
+    for (const key of ['path', 'file', 'url', 'href']) {
+      if (typeof value[key] === 'string') return [value[key]]
+    }
+  }
+  return []
+}
+
+function collectArtifactRefs(evidence) {
+  return [
+    evidence?.artifacts,
+    evidence?.artifactRefs,
+    evidence?.screenshots,
+    evidence?.files,
+  ].flatMap((candidate) => collectArtifactRefsFromValue(candidate))
+}
+
+function writeManualArtifactFiles(evidenceFile, evidence, options = {}) {
+  const evidenceDir = path.dirname(evidenceFile)
+  for (const check of evidence.checks ?? []) {
+    if (!manualClientIds.has(check.id) && !manualAdminIds.has(check.id)) continue
+    if (check.status !== 'pass') continue
+
+    for (const artifactRef of collectArtifactRefs(check.evidence)) {
+      if (/^[a-z][a-z0-9+.-]*:\/\//i.test(artifactRef)) continue
+      if (path.isAbsolute(artifactRef) || artifactRef.includes('..')) continue
+
+      const fullPath = path.join(evidenceDir, artifactRef)
+      mkdirSync(path.dirname(fullPath), { recursive: true })
+      writeFileSync(fullPath, options.emptyRefs?.has(artifactRef) ? '' : `${check.id} manual evidence\n`, 'utf8')
+    }
+  }
+}
+
+function writeEvidence(file, overrides = {}, options = {}) {
   const evidence = {
     runId: 'remote-20260422',
     executedAt: '2026-04-22T15:00:00.000Z',
@@ -68,6 +109,7 @@ function writeEvidence(file, overrides = {}) {
     ...overrides,
   }
   writeFileSync(file, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8')
+  if (options.createArtifacts !== false) writeManualArtifactFiles(file, evidence, options)
   return evidence
 }
 
@@ -176,6 +218,163 @@ test('compile-dingtalk-p4-smoke-evidence compiles passing evidence and redacts s
     assert.match(redacted, /SEC<redacted>/)
     assert.match(redacted, /publicToken=<redacted>/)
     assert.match(redacted, /"<redacted>"/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence strict mode rejects missing manual artifact files', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+
+  try {
+    writeEvidence(evidencePath, {}, { createArtifacts: false })
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /artifact_ref_missing/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'fail')
+    assert.equal(summary.manualEvidenceIssues.some((issue) => issue.code === 'artifact_ref_missing'), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence strict mode rejects wrong manual artifact folders', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+
+  try {
+    writeEvidence(evidencePath, {
+      checks: requiredIds.map((id) => ({
+        id,
+        status: 'pass',
+        evidence: makePassingEvidenceForCheck(id, id === 'authorized-user-submit'
+          ? { artifacts: ['artifacts/send-group-message-form-link/authorized-submit.txt'] }
+          : {}),
+      })),
+    })
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /artifact_ref_wrong_folder/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.manualEvidenceIssues.some((issue) => issue.id === 'authorized-user-submit' && issue.code === 'artifact_ref_wrong_folder'), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence strict mode rejects absolute and traversal artifact refs', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+  const absoluteArtifactPath = path.join(tmpDir, 'absolute-evidence.txt')
+
+  try {
+    writeFileSync(absoluteArtifactPath, 'absolute evidence\n', 'utf8')
+    writeEvidence(evidencePath, {
+      checks: requiredIds.map((id) => ({
+        id,
+        status: 'pass',
+        evidence: makePassingEvidenceForCheck(id, {
+          ...(id === 'send-group-message-form-link' ? { artifacts: [absoluteArtifactPath] } : {}),
+          ...(id === 'authorized-user-submit' ? { artifacts: ['../outside-evidence.txt'] } : {}),
+        }),
+      })),
+    })
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /artifact_ref_not_relative/)
+    assert.match(result.stderr, /artifact_ref_path_traversal/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.manualEvidenceIssues.some((issue) => issue.code === 'artifact_ref_not_relative'), true)
+    assert.equal(summary.manualEvidenceIssues.some((issue) => issue.code === 'artifact_ref_path_traversal'), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence strict mode rejects empty manual artifact files', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+  const emptyArtifactRef = manualArtifactRefForCheck('authorized-user-submit')
+
+  try {
+    writeEvidence(evidencePath, {}, { emptyRefs: new Set([emptyArtifactRef]) })
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /artifact_ref_empty/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.manualEvidenceIssues.some((issue) => issue.id === 'authorized-user-submit' && issue.code === 'artifact_ref_empty'), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence strict mode rejects external artifacts unless explicitly allowed', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+  const allowedOutputDir = path.join(tmpDir, 'compiled-allowed')
+
+  try {
+    writeEvidence(evidencePath, {
+      checks: requiredIds.map((id) => ({
+        id,
+        status: 'pass',
+        evidence: makePassingEvidenceForCheck(id, id === 'authorized-user-submit'
+          ? { artifacts: ['https://evidence.example.test/authorized-submit.png'] }
+          : {}),
+      })),
+    })
+
+    const blocked = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(blocked.status, 1)
+    assert.match(blocked.stderr, /artifact_ref_external_disallowed/)
+
+    const allowed = spawnSync(process.execPath, [
+      scriptPath,
+      '--input',
+      evidencePath,
+      '--output-dir',
+      allowedOutputDir,
+      '--strict',
+      '--allow-external-artifact-refs',
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(allowed.status, 0, allowed.stderr)
+    const summary = JSON.parse(readFileSync(path.join(allowedOutputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'pass')
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- tighten DingTalk P4 strict evidence compile so manual pass checks must reference self-contained non-empty local files under `artifacts/<check-id>/`
- add `--allow-external-artifact-refs` for explicitly permitted durable external evidence stores
- expand compiler tests for missing, wrong-folder, absolute, traversal, empty, and external artifact refs
- document the artifact bundle rule and add development/verification notes

## Verification

```bash
node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
git diff --cached --check
```

Stacked on #1083.