### PR TITLE
test(dingtalk): add P4 smoke session orchestrator

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -72,6 +72,7 @@
 - [x] Add a P4 manual evidence kit generator with required manual evidence fields and artifact folders.
 - [x] Add a P4 strict artifact gate so manual pass evidence must reference self-contained non-empty files under `artifacts/<check-id>/`.
 - [x] Make the P4 API-only runner output a complete smoke workspace with `evidence.json`, `manual-evidence-checklist.md`, and manual artifact folders.
+- [x] Add a P4 smoke session orchestrator that runs preflight, API workspace bootstrap, non-strict compile, and a redacted session summary.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-smoke-session-development-20260423.md
+++ b/docs/development/dingtalk-p4-smoke-session-development-20260423.md
@@ -1,0 +1,46 @@
+# DingTalk P4 Smoke Session Development
+
+- Date: 2026-04-23
+- Scope: P4 remote-smoke session orchestration
+- Branch: `codex/dingtalk-p4-smoke-session-20260423`
+
+## What Changed
+
+- Added `scripts/ops/dingtalk-p4-smoke-session.mjs`.
+- The session command runs:
+  - `dingtalk-p4-smoke-preflight.mjs`
+  - `dingtalk-p4-remote-smoke.mjs`
+  - `compile-dingtalk-p4-smoke-evidence.mjs` in non-strict mode
+- The session writes a structured output directory:
+  - `preflight/`
+  - `workspace/`
+  - `compiled/`
+  - `session-summary.json`
+  - `session-summary.md`
+- The session stops before the API runner if preflight fails.
+- The session exits successfully with `overallStatus: "manual_pending"` when preflight, API runner, and non-strict compile pass but manual DingTalk-client/admin checks remain.
+- The session uses env injection for child tools, so secrets do not need to be forwarded as child command-line args.
+- Added tests for successful fake-API orchestration and preflight failure short-circuiting.
+- Added the session script to the staging evidence packet export.
+
+## Why
+
+The P4 flow had reliable individual tools, but operators still had to run them in the right order and keep outputs aligned. The session orchestrator reduces remote-smoke execution to one command while preserving the hard boundary that real DingTalk-client/admin checks must still be completed manually.
+
+## Files
+
+- `scripts/ops/dingtalk-p4-smoke-session.mjs`
+- `scripts/ops/dingtalk-p4-smoke-session.test.mjs`
+- `scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
+- `scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Flow
+
+1. Store real staging/DingTalk inputs in a secure local env file.
+2. Run `node scripts/ops/dingtalk-p4-smoke-session.mjs --env-file <file> --output-dir <session-dir>`.
+3. If `session-summary.json` is `manual_pending`, complete `workspace/evidence.json`.
+4. Put proof files under `workspace/artifacts/<check-id>/`.
+5. Run strict compile against `workspace/evidence.json`.
+6. Export the evidence packet with `--include-output <session-dir>`.

--- a/docs/development/dingtalk-p4-smoke-session-verification-20260423.md
+++ b/docs/development/dingtalk-p4-smoke-session-verification-20260423.md
@@ -1,0 +1,36 @@
+# DingTalk P4 Smoke Session Verification
+
+- Date: 2026-04-23
+- Scope: P4 smoke session orchestration and evidence packet integration
+
+## Commands Run
+
+```bash
+node --check scripts/ops/dingtalk-p4-smoke-session.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`: passed.
+- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed.
+- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed, 2 tests.
+- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs`: passed.
+- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`: passed, 4 tests.
+- `git diff --cached --check`: passed after staging the smoke-session changes.
+
+## Coverage Notes
+
+- Successful fake-API coverage verifies preflight, API runner, non-strict compile, `session-summary.json`, and `manual_pending` status.
+- Failure coverage verifies preflight failure stops before workspace/bootstrap execution.
+- Evidence packet coverage verifies the new session script is copied and listed in the handoff README and manifest.
+
+## Remaining Remote Validation
+
+- Run the session command against 142/staging with real DingTalk group robots and allowlist inputs.
+- Complete generated manual evidence from real DingTalk clients/admin UI.
+- Run strict compile and export the final packet.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -124,6 +124,38 @@ Example check evidence:
 }
 ```
 
+## Session Orchestrator
+
+Use the session orchestrator for the normal 142/staging P4 run. It runs preflight, bootstraps the API-addressable smoke workspace, compiles a non-strict evidence summary, and writes a session report. It stops before the API runner when preflight fails.
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-session.mjs \
+  --env-file /secure/local/dingtalk-p4.env \
+  --output-dir output/dingtalk-p4-remote-smoke-session/142-session
+```
+
+Expected generated files:
+
+- `preflight/preflight-summary.json`
+- `preflight/preflight-summary.md`
+- `workspace/evidence.json`
+- `workspace/manual-evidence-checklist.md`
+- `workspace/artifacts/<check-id>/`
+- `compiled/summary.json`
+- `compiled/summary.md`
+- `compiled/evidence.redacted.json`
+- `session-summary.json`
+- `session-summary.md`
+
+Expected session status is usually `manual_pending` after the API runner succeeds, because the real DingTalk-client/admin checks still need operator proof. Fill `workspace/evidence.json`, place files in `workspace/artifacts/<check-id>/`, then run strict compile:
+
+```bash
+node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \
+  --input output/dingtalk-p4-remote-smoke-session/142-session/workspace/evidence.json \
+  --output-dir output/dingtalk-p4-remote-smoke-session/142-session/compiled \
+  --strict
+```
+
 ## Preflight Gate
 
 Before calling staging or DingTalk, run the preflight gate to check local tooling, required URLs, bearer token presence, DingTalk webhook format, optional `SEC...` secret format, allowlist inputs, and backend `/health`. It writes only redacted summaries.
@@ -146,7 +178,7 @@ Expected generated files:
 
 ## API-Only Smoke Runner
 
-Use the API-only runner to prepare the disposable test resources and collect backend evidence before the manual DingTalk-client checks. It creates a table, a form view, two group destinations, a `dingtalk_granted` form share, a group automation rule, and optional person-message rule when `--person-user` is supplied.
+Use the API-only runner directly when debugging the session's API step. It prepares the disposable test resources and collects backend evidence before the manual DingTalk-client checks. It creates a table, a form view, two group destinations, a `dingtalk_granted` form share, a group automation rule, and optional person-message rule when `--person-user` is supplied.
 
 Do not paste secrets into docs or chat. Supply them through secure shell env, a local password manager, or a temporary shell session on the staging host.
 

--- a/scripts/ops/dingtalk-p4-smoke-session.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-remote-smoke-session'
+const DEFAULT_API_BASE = 'http://127.0.0.1:8900'
+const MANUAL_CHECK_IDS = new Set([
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'no-email-user-create-bind',
+])
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-p4-smoke-session.mjs [options]
+
+Runs a DingTalk P4 smoke session in one operator command:
+  1. preflight input/tooling checks
+  2. API-only remote smoke workspace bootstrap
+  3. non-strict evidence compile for the generated workspace
+  4. session-summary.json / session-summary.md with remaining manual checks
+
+This script does not fill real DingTalk-client/admin evidence and does not run
+strict compile. After the session succeeds, place manual artifacts in the
+generated workspace and run compile-dingtalk-p4-smoke-evidence.mjs --strict.
+
+Options:
+  --env-file <file>                Optional KEY=VALUE file to read before env/CLI
+  --api-base <url>                 Backend API base, default ${DEFAULT_API_BASE}
+  --web-base <url>                 Public app base used by DingTalk message links
+  --auth-token <token>             Bearer token for admin/table owner
+  --group-a-webhook <url>          DingTalk group A robot webhook
+  --group-b-webhook <url>          DingTalk group B robot webhook
+  --group-a-secret <secret>        Optional DingTalk group A SEC... secret
+  --group-b-secret <secret>        Optional DingTalk group B SEC... secret
+  --allowed-user <id>              Local user allowed to fill; repeatable
+  --allowed-member-group <id>      Allowed local member group; repeatable
+  --person-user <id>               Optional local user for person smoke; repeatable
+  --output-dir <dir>               Session output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
+  --timeout-ms <ms>                Per-request timeout for child tools, default 15000
+  --skip-api                       Skip preflight GET /health only
+  --skip-health                    Skip runner GET /health only
+  --skip-test-send                 Forward to dingtalk-p4-remote-smoke.mjs
+  --skip-automation-test-run       Forward to dingtalk-p4-remote-smoke.mjs
+  --allow-external-artifact-refs   Forward to evidence compiler
+  --help                           Show this help
+
+Environment fallbacks:
+  DINGTALK_P4_API_BASE, API_BASE
+  DINGTALK_P4_WEB_BASE, WEB_BASE, PUBLIC_APP_URL
+  DINGTALK_P4_AUTH_TOKEN, ADMIN_TOKEN, AUTH_TOKEN
+  DINGTALK_P4_GROUP_A_WEBHOOK, DINGTALK_GROUP_A_WEBHOOK
+  DINGTALK_P4_GROUP_B_WEBHOOK, DINGTALK_GROUP_B_WEBHOOK
+  DINGTALK_P4_GROUP_A_SECRET, DINGTALK_GROUP_A_SECRET
+  DINGTALK_P4_GROUP_B_SECRET, DINGTALK_GROUP_B_SECRET
+  DINGTALK_P4_ALLOWED_USER_IDS, DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS
+  DINGTALK_P4_PERSON_USER_IDS
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function parseEnvFile(file) {
+  const resolved = path.resolve(process.cwd(), file)
+  if (!existsSync(resolved)) {
+    throw new Error(`--env-file does not exist: ${file}`)
+  }
+
+  const values = {}
+  const content = readFileSync(resolved, 'utf8')
+  for (const [index, rawLine] of content.split(/\r?\n/).entries()) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/)
+    if (!match) {
+      throw new Error(`invalid env line ${index + 1} in ${file}`)
+    }
+    const [, key, rawValue] = match
+    values[key] = unquoteEnvValue(rawValue.trim())
+  }
+  return values
+}
+
+function unquoteEnvValue(value) {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+function envValue(source, ...names) {
+  for (const name of names) {
+    const value = source[name]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function splitList(value) {
+  if (!value) return []
+  return Array.from(new Set(
+    String(value)
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  ))
+}
+
+function appendList(list, value) {
+  for (const entry of splitList(value)) {
+    if (!list.includes(entry)) list.push(entry)
+  }
+}
+
+function parseArgs(argv) {
+  let envFile = ''
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--env-file') {
+      envFile = readRequiredValue(argv, i, '--env-file')
+      break
+    }
+  }
+
+  const envFileValues = envFile ? parseEnvFile(envFile) : {}
+  const env = { ...envFileValues, ...process.env }
+  const opts = {
+    envFile,
+    apiBase: envValue(env, 'DINGTALK_P4_API_BASE', 'API_BASE') || DEFAULT_API_BASE,
+    webBase: envValue(env, 'DINGTALK_P4_WEB_BASE', 'WEB_BASE', 'PUBLIC_APP_URL'),
+    authToken: envValue(env, 'DINGTALK_P4_AUTH_TOKEN', 'ADMIN_TOKEN', 'AUTH_TOKEN'),
+    groupAWebhook: envValue(env, 'DINGTALK_P4_GROUP_A_WEBHOOK', 'DINGTALK_GROUP_A_WEBHOOK'),
+    groupBWebhook: envValue(env, 'DINGTALK_P4_GROUP_B_WEBHOOK', 'DINGTALK_GROUP_B_WEBHOOK'),
+    groupASecret: envValue(env, 'DINGTALK_P4_GROUP_A_SECRET', 'DINGTALK_GROUP_A_SECRET'),
+    groupBSecret: envValue(env, 'DINGTALK_P4_GROUP_B_SECRET', 'DINGTALK_GROUP_B_SECRET'),
+    allowedUserIds: splitList(envValue(env, 'DINGTALK_P4_ALLOWED_USER_IDS', 'DINGTALK_P4_ALLOWED_USER_ID')),
+    allowedMemberGroupIds: splitList(envValue(env, 'DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS', 'DINGTALK_P4_ALLOWED_MEMBER_GROUP_ID')),
+    personUserIds: splitList(envValue(env, 'DINGTALK_P4_PERSON_USER_IDS', 'DINGTALK_P4_PERSON_USER_ID')),
+    outputDir: null,
+    timeoutMs: 15_000,
+    skipApi: false,
+    skipHealth: false,
+    skipTestSend: false,
+    skipAutomationTestRun: false,
+    allowExternalArtifactRefs: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--env-file':
+        i += 1
+        break
+      case '--api-base':
+        opts.apiBase = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--web-base':
+        opts.webBase = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--auth-token':
+        opts.authToken = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--group-a-webhook':
+        opts.groupAWebhook = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--group-b-webhook':
+        opts.groupBWebhook = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--group-a-secret':
+        opts.groupASecret = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--group-b-secret':
+        opts.groupBSecret = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--allowed-user':
+        appendList(opts.allowedUserIds, readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--allowed-member-group':
+        appendList(opts.allowedMemberGroupIds, readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--person-user':
+        appendList(opts.personUserIds, readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--timeout-ms':
+        opts.timeoutMs = Number.parseInt(readRequiredValue(argv, i, arg), 10)
+        i += 1
+        break
+      case '--skip-api':
+        opts.skipApi = true
+        break
+      case '--skip-health':
+        opts.skipHealth = true
+        break
+      case '--skip-test-send':
+        opts.skipTestSend = true
+        break
+      case '--skip-automation-test-run':
+        opts.skipAutomationTestRun = true
+        break
+      case '--allow-external-artifact-refs':
+        opts.allowExternalArtifactRefs = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return opts
+}
+
+function makeRunId() {
+  return `dingtalk-p4-session-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}`
+}
+
+function redactString(value) {
+  return String(value)
+    .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function compactText(value) {
+  const redacted = redactString(value ?? '').trim()
+  if (!redacted) return ''
+  return redacted.length > 2000 ? `${redacted.slice(0, 1997)}...` : redacted
+}
+
+function relativePath(file) {
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function buildChildEnv(opts) {
+  return {
+    ...process.env,
+    DINGTALK_P4_API_BASE: opts.apiBase,
+    DINGTALK_P4_WEB_BASE: opts.webBase,
+    DINGTALK_P4_AUTH_TOKEN: opts.authToken,
+    DINGTALK_P4_GROUP_A_WEBHOOK: opts.groupAWebhook,
+    DINGTALK_P4_GROUP_B_WEBHOOK: opts.groupBWebhook,
+    DINGTALK_P4_GROUP_A_SECRET: opts.groupASecret,
+    DINGTALK_P4_GROUP_B_SECRET: opts.groupBSecret,
+    DINGTALK_P4_ALLOWED_USER_IDS: opts.allowedUserIds.join(','),
+    DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS: opts.allowedMemberGroupIds.join(','),
+    DINGTALK_P4_PERSON_USER_IDS: opts.personUserIds.join(','),
+  }
+}
+
+function runNodeStep(id, label, script, args, outputDir, env) {
+  mkdirSync(outputDir, { recursive: true })
+  const startedAt = new Date().toISOString()
+  const result = spawnSync(process.execPath, [script, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env,
+  })
+  const finishedAt = new Date().toISOString()
+  return {
+    id,
+    label,
+    status: result.status === 0 ? 'pass' : 'fail',
+    exitCode: result.status ?? 1,
+    outputDir: relativePath(outputDir),
+    startedAt,
+    finishedAt,
+    stdout: compactText(result.stdout),
+    stderr: compactText(result.stderr),
+  }
+}
+
+function readJsonIfExists(file) {
+  if (!existsSync(file)) return null
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function extractPendingManualChecks(evidencePath) {
+  const evidence = readJsonIfExists(evidencePath)
+  if (!Array.isArray(evidence?.checks)) return []
+  return evidence.checks
+    .filter((check) => check && check.status !== 'pass')
+    .map((check) => ({
+      id: check.id,
+      status: check.status ?? 'pending',
+      manual: MANUAL_CHECK_IDS.has(check.id),
+      source: typeof check.evidence?.source === 'string' ? check.evidence.source : '',
+    }))
+}
+
+function computeOverallStatus(steps, pendingChecks) {
+  if (steps.some((step) => step.status === 'fail')) return 'fail'
+  return pendingChecks.length > 0 ? 'manual_pending' : 'pass'
+}
+
+function renderMarkdown(summary) {
+  const rows = summary.steps.map((step) => {
+    const notes = step.stderr || step.stdout.split(/\r?\n/).filter(Boolean).at(-1) || ''
+    return `| \`${step.id}\` | ${step.label} | ${step.status} | ${step.exitCode} | ${notes.replaceAll('|', '\\|')} |`
+  })
+  const pending = summary.pendingChecks.length
+    ? summary.pendingChecks.map((check) => `- \`${check.id}\`: ${check.status}${check.manual ? ' (manual evidence required)' : ''}`).join('\n')
+    : '- None'
+  const commands = summary.nextCommands.map((command) => `- \`${command}\``).join('\n')
+
+  return `# DingTalk P4 Smoke Session Summary
+
+Generated at: ${summary.generatedAt}
+
+Overall status: **${summary.overallStatus}**
+
+Output directory: \`${summary.outputDir}\`
+
+## Steps
+
+| ID | Step | Status | Exit | Notes |
+| --- | --- | --- | --- | --- |
+${rows.join('\n')}
+
+## Pending Checks
+
+${pending}
+
+## Next Commands
+
+${commands}
+
+## Secret Handling
+
+- This summary redacts bearer tokens, DingTalk webhook tokens, signatures, timestamps, SEC secrets, JWTs, and public form tokens.
+- Do not paste raw credentials into \`evidence.json\`, Markdown reports, or chat.
+`
+}
+
+function writeSessionSummary(summary, outputDir) {
+  const jsonPath = path.join(outputDir, 'session-summary.json')
+  const mdPath = path.join(outputDir, 'session-summary.md')
+  writeFileSync(jsonPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+  writeFileSync(mdPath, `${renderMarkdown(summary)}\n`, 'utf8')
+  console.log(`Wrote ${relativePath(jsonPath)}`)
+  console.log(`Wrote ${relativePath(mdPath)}`)
+}
+
+function runSession(opts) {
+  if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs < 1_000 || opts.timeoutMs > 120_000) {
+    throw new Error('--timeout-ms must be an integer between 1000 and 120000')
+  }
+
+  const runId = makeRunId()
+  const outputDir = opts.outputDir ?? path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, runId)
+  const preflightDir = path.join(outputDir, 'preflight')
+  const workspaceDir = path.join(outputDir, 'workspace')
+  const compiledDir = path.join(outputDir, 'compiled')
+  const evidencePath = path.join(workspaceDir, 'evidence.json')
+  const env = buildChildEnv(opts)
+  const steps = []
+
+  mkdirSync(outputDir, { recursive: true })
+
+  const preflightArgs = [
+    'scripts/ops/dingtalk-p4-smoke-preflight.mjs',
+    '--output-dir',
+    preflightDir,
+    '--timeout-ms',
+    String(opts.timeoutMs),
+    ...(opts.skipApi ? ['--skip-api'] : []),
+  ]
+  steps.push(runNodeStep('preflight', 'Validate P4 smoke inputs and backend health', preflightArgs[0], preflightArgs.slice(1), preflightDir, env))
+
+  if (steps.at(-1).status === 'pass') {
+    const runnerArgs = [
+      'scripts/ops/dingtalk-p4-remote-smoke.mjs',
+      '--output-dir',
+      workspaceDir,
+      '--timeout-ms',
+      String(opts.timeoutMs),
+      ...(opts.skipHealth ? ['--skip-health'] : []),
+      ...(opts.skipTestSend ? ['--skip-test-send'] : []),
+      ...(opts.skipAutomationTestRun ? ['--skip-automation-test-run'] : []),
+    ]
+    steps.push(runNodeStep('api-runner', 'Bootstrap API-addressable P4 smoke workspace', runnerArgs[0], runnerArgs.slice(1), workspaceDir, env))
+  }
+
+  if (existsSync(evidencePath)) {
+    const compileArgs = [
+      'scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs',
+      '--input',
+      evidencePath,
+      '--output-dir',
+      compiledDir,
+      ...(opts.allowExternalArtifactRefs ? ['--allow-external-artifact-refs'] : []),
+    ]
+    steps.push(runNodeStep('compile', 'Compile non-strict evidence summary', compileArgs[0], compileArgs.slice(1), compiledDir, env))
+  }
+
+  const pendingChecks = extractPendingManualChecks(evidencePath)
+  const summary = {
+    tool: 'dingtalk-p4-smoke-session',
+    runId,
+    generatedAt: new Date().toISOString(),
+    outputDir: relativePath(outputDir),
+    preflightDir: relativePath(preflightDir),
+    workspaceDir: relativePath(workspaceDir),
+    compiledDir: relativePath(compiledDir),
+    overallStatus: computeOverallStatus(steps, pendingChecks),
+    steps,
+    pendingChecks,
+    nextCommands: [
+      `node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input ${relativePath(evidencePath)} --output-dir ${relativePath(compiledDir)} --strict`,
+      `node scripts/ops/export-dingtalk-staging-evidence-packet.mjs --include-output ${relativePath(outputDir)}`,
+    ],
+  }
+
+  writeSessionSummary(summary, outputDir)
+  return summary
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2))
+  const summary = runSession(opts)
+  if (summary.overallStatus === 'fail') process.exit(1)
+} catch (error) {
+  console.error(`[dingtalk-p4-smoke-session] ERROR: ${redactString(error instanceof Error ? error.message : String(error))}`)
+  process.exit(1)
+}

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict'
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import http from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-smoke-session.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-smoke-session-'))
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = ''
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      raw += chunk
+    })
+    req.on('end', () => {
+      if (!raw) {
+        resolve(null)
+        return
+      }
+      try {
+        resolve(JSON.parse(raw))
+      } catch (error) {
+        reject(error)
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+function sendJson(res, status, body) {
+  res.statusCode = status
+  if (body === undefined) {
+    res.end()
+    return
+  }
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+function createFakeApiServer() {
+  const requests = []
+  let groupCount = 0
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+      const body = await readRequestBody(req)
+      requests.push({
+        method: req.method,
+        pathname: url.pathname,
+        search: url.search,
+        headers: req.headers,
+        body,
+      })
+
+      if (req.method === 'GET' && url.pathname === '/health') {
+        sendJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/bases') {
+        sendJson(res, 201, { ok: true, data: { base: { id: 'base_1', name: body.name } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/sheets') {
+        sendJson(res, 200, { ok: true, data: { sheet: { id: 'sheet_1', baseId: body.baseId } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/fields') {
+        sendJson(res, 201, { ok: true, data: { field: { id: 'field_1', name: body.name } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/views') {
+        sendJson(res, 201, { ok: true, data: { view: { id: 'view_form_1', type: body.type } } })
+        return
+      }
+
+      if (req.method === 'PATCH' && url.pathname === '/api/multitable/sheets/sheet_1/views/view_form_1/form-share') {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            enabled: true,
+            status: 'active',
+            accessMode: 'dingtalk_granted',
+            publicToken: 'public_token_should_not_leak',
+          },
+        })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/dingtalk-groups') {
+        groupCount += 1
+        sendJson(res, 201, {
+          ok: true,
+          data: {
+            id: `dt_group_${groupCount}`,
+            name: body.name,
+            sheetId: body.sheetId,
+          },
+        })
+        return
+      }
+
+      const testSendMatch = url.pathname.match(/^\/api\/multitable\/dingtalk-groups\/(dt_group_[12])\/test-send$/)
+      if (req.method === 'POST' && testSendMatch) {
+        sendJson(res, 204)
+        return
+      }
+
+      const manualDeliveriesMatch = url.pathname.match(/^\/api\/multitable\/dingtalk-groups\/(dt_group_[12])\/deliveries$/)
+      if (req.method === 'GET' && manualDeliveriesMatch) {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [{ id: `delivery_${manualDeliveriesMatch[1]}`, status: 'success' }],
+          },
+        })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/sheets/sheet_1/automations') {
+        if (body.actionType === 'send_dingtalk_group_message') {
+          sendJson(res, 200, { ok: true, data: { rule: { id: 'rule_group_1' } } })
+          return
+        }
+        if (body.actionType === 'send_dingtalk_person_message') {
+          sendJson(res, 200, { ok: true, data: { rule: { id: 'rule_person_1' } } })
+          return
+        }
+      }
+
+      const testRunMatch = url.pathname.match(/^\/api\/multitable\/sheets\/sheet_1\/automations\/(rule_group_1|rule_person_1)\/test$/)
+      if (req.method === 'POST' && testRunMatch) {
+        sendJson(res, 200, {
+          id: `exec_${testRunMatch[1]}`,
+          status: 'success',
+          steps: [{ status: 'success' }],
+        })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/api/multitable/sheets/sheet_1/automations/rule_group_1/dingtalk-group-deliveries') {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [
+              { id: 'rule_group_delivery_1', destinationId: 'dt_group_1', status: 'success' },
+              { id: 'rule_group_delivery_2', destinationId: 'dt_group_2', status: 'success' },
+            ],
+          },
+        })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/api/multitable/sheets/sheet_1/automations/rule_person_1/dingtalk-person-deliveries') {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [{ id: 'rule_person_delivery_1', userId: 'user_person_bound', status: 'success' }],
+          },
+        })
+        return
+      }
+
+      sendJson(res, 404, { ok: false, error: { message: `unexpected route ${req.method} ${url.pathname}` } })
+    } catch (error) {
+      sendJson(res, 500, { ok: false, error: { message: error instanceof Error ? error.message : String(error) } })
+    }
+  })
+
+  return {
+    requests,
+    async listen() {
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+      const address = server.address()
+      return `http://127.0.0.1:${address.port}`
+    },
+    async close() {
+      await new Promise((resolve) => server.close(resolve))
+    },
+  }
+}
+
+function runScript(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('close', (code) => resolve({ status: code, stdout, stderr }))
+  })
+}
+
+test('dingtalk-p4-smoke-session runs preflight, API runner, and non-strict compile', async () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'session')
+  const envFile = path.join(tmpDir, 'p4.env')
+  const fakeApi = createFakeApiServer()
+
+  try {
+    const apiBase = await fakeApi.listen()
+    writeFileSync(envFile, [
+      `DINGTALK_P4_API_BASE=${apiBase}`,
+      'DINGTALK_P4_WEB_BASE=https://metasheet.example.test',
+      'DINGTALK_P4_AUTH_TOKEN=secret-admin-token',
+      'DINGTALK_P4_GROUP_A_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a&timestamp=1690000000000&sign=robot-sign-a',
+      'DINGTALK_P4_GROUP_B_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+      'DINGTALK_P4_GROUP_A_SECRET=SECabcdefghijklmnop12345678',
+      'DINGTALK_P4_ALLOWED_USER_IDS=user_authorized',
+      'DINGTALK_P4_PERSON_USER_IDS=user_person_bound',
+    ].join('\n'), 'utf8')
+
+    const result = await runScript([
+      '--env-file',
+      envFile,
+      '--output-dir',
+      outputDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.doesNotMatch(result.stdout, /secret-admin-token/)
+    assert.doesNotMatch(result.stdout, /robot-secret-a/)
+    assert.equal(existsSync(path.join(outputDir, 'preflight/preflight-summary.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'workspace/evidence.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'workspace/manual-evidence-checklist.md')), true)
+    assert.equal(existsSync(path.join(outputDir, 'compiled/summary.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'session-summary.json')), true)
+
+    const sessionSummaryText = readFileSync(path.join(outputDir, 'session-summary.json'), 'utf8')
+    assert.doesNotMatch(sessionSummaryText, /secret-admin-token/)
+    assert.doesNotMatch(sessionSummaryText, /robot-secret-a/)
+    assert.doesNotMatch(sessionSummaryText, /SECabcdefghijklmnop12345678/)
+    const sessionSummary = JSON.parse(sessionSummaryText)
+    assert.equal(sessionSummary.overallStatus, 'manual_pending')
+    assert.deepEqual(sessionSummary.steps.map((step) => step.id), ['preflight', 'api-runner', 'compile'])
+    assert.equal(sessionSummary.steps.every((step) => step.status === 'pass'), true)
+    assert.equal(sessionSummary.pendingChecks.some((check) => check.id === 'authorized-user-submit' && check.manual), true)
+    assert.equal(sessionSummary.pendingChecks.some((check) => check.id === 'send-group-message-form-link' && check.manual), true)
+
+    const compiledSummary = JSON.parse(readFileSync(path.join(outputDir, 'compiled/summary.json'), 'utf8'))
+    assert.equal(compiledSummary.overallStatus, 'fail')
+    assert.equal(compiledSummary.remoteClientStatus, 'fail')
+    assert.equal(fakeApi.requests.some((request) => request.pathname === '/health'), true)
+    assert.equal(fakeApi.requests.some((request) => request.pathname.endsWith('/dingtalk-person-deliveries')), true)
+  } finally {
+    await fakeApi.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-session stops after failed preflight', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'session')
+
+  try {
+    const result = spawnSync(process.execPath, [
+      scriptPath,
+      '--skip-api',
+      '--api-base',
+      'http://127.0.0.1:8900',
+      '--web-base',
+      'https://metasheet.example.test',
+      '--auth-token',
+      'secret-admin-token',
+      '--group-a-webhook',
+      'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
+      '--group-b-webhook',
+      'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+      '--output-dir',
+      outputDir,
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.doesNotMatch(result.stdout, /secret-admin-token/)
+    assert.equal(existsSync(path.join(outputDir, 'preflight/preflight-summary.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'workspace/evidence.json')), false)
+    assert.equal(existsSync(path.join(outputDir, 'compiled/summary.json')), false)
+
+    const sessionSummary = JSON.parse(readFileSync(path.join(outputDir, 'session-summary.json'), 'utf8'))
+    assert.equal(sessionSummary.overallStatus, 'fail')
+    assert.deepEqual(sessionSummary.steps.map((step) => step.id), ['preflight'])
+    assert.equal(sessionSummary.steps[0].status, 'fail')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -91,6 +91,11 @@ const requiredPacketFiles = [
     kind: 'script',
     description: 'validates P4 remote-smoke inputs and local tooling before calling staging or DingTalk',
   },
+  {
+    path: 'scripts/ops/dingtalk-p4-smoke-session.mjs',
+    kind: 'script',
+    description: 'orchestrates P4 preflight, API-only smoke workspace bootstrap, and non-strict evidence compile',
+  },
 ]
 
 function printHelp() {
@@ -224,11 +229,11 @@ ${evidenceLines}
 4. Deploy a pinned tag with \`DEPLOY_IMAGE_TAG=<tag> bash scripts/ops/deploy-dingtalk-staging.sh\`.
 5. Execute \`docs/development/dingtalk-staging-execution-checklist-20260408.md\`.
 6. Execute \`docs/dingtalk-remote-smoke-checklist-20260422.md\` for P4 DingTalk form/group/person coverage.
-7. Run the preflight gate with \`node scripts/ops/dingtalk-p4-smoke-preflight.mjs --output-dir <preflight-dir>\`.
-8. Optionally bootstrap API-addressable evidence with \`node scripts/ops/dingtalk-p4-remote-smoke.mjs --output-dir <evidence-dir>\`.
-9. Complete the manual DingTalk-client checks in \`evidence.json\`.
-10. Compile smoke evidence with \`node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input <evidence.json> --output-dir <evidence-dir> --strict\`.
-11. Re-export this packet with \`--include-output <evidence-dir>\` after smoke evidence exists.
+7. Run the session orchestrator with \`node scripts/ops/dingtalk-p4-smoke-session.mjs --output-dir <session-dir>\`.
+8. If needed, debug individual steps with \`dingtalk-p4-smoke-preflight.mjs\` and \`dingtalk-p4-remote-smoke.mjs\`.
+9. Complete the manual DingTalk-client checks in \`<session-dir>/workspace/evidence.json\`.
+10. Compile smoke evidence with \`node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input <session-dir>/workspace/evidence.json --output-dir <session-dir>/compiled --strict\`.
+11. Re-export this packet with \`--include-output <session-dir>\` after smoke evidence exists.
 
 ## Non-Goals
 

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -48,6 +48,10 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       existsSync(path.join(outputDir, 'scripts/ops/dingtalk-p4-smoke-preflight.mjs')),
       true,
     )
+    assert.equal(
+      existsSync(path.join(outputDir, 'scripts/ops/dingtalk-p4-smoke-session.mjs')),
+      true,
+    )
     assert.equal(existsSync(path.join(outputDir, 'scripts/ops/deploy-dingtalk-staging.sh')), true)
     assert.equal(existsSync(path.join(outputDir, 'docker/app.staging.env.example')), true)
 
@@ -74,12 +78,17 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       manifest.files.some((file) => file.path === 'scripts/ops/dingtalk-p4-smoke-preflight.mjs'),
       true,
     )
+    assert.equal(
+      manifest.files.some((file) => file.path === 'scripts/ops/dingtalk-p4-smoke-session.mjs'),
+      true,
+    )
 
     const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
     assert.match(readme, /DingTalk Staging Evidence Packet/)
     assert.match(readme, /docs\/dingtalk-remote-smoke-checklist-20260422\.md/)
     assert.match(readme, /dingtalk-p4-remote-smoke\.mjs/)
     assert.match(readme, /dingtalk-p4-smoke-preflight\.mjs/)
+    assert.match(readme, /dingtalk-p4-smoke-session\.mjs/)
     assert.match(readme, /compile-dingtalk-p4-smoke-evidence\.mjs/)
     assert.match(readme, /No runtime evidence directory was included/)
     assert.match(readme, /Does not store secrets/)


### PR DESCRIPTION
## Summary

- add `scripts/ops/dingtalk-p4-smoke-session.mjs` to orchestrate preflight, API-only smoke workspace bootstrap, and non-strict evidence compile
- write redacted `session-summary.json/md` with `manual_pending` status and remaining manual checks
- add fake-API tests for successful orchestration and preflight failure short-circuiting
- include the session script in the DingTalk staging evidence packet and update P4 smoke docs/TODO

## Verification

```bash
node --check scripts/ops/dingtalk-p4-smoke-session.mjs
node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs
node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
git diff --cached --check
```

Stacked on #1086.