### PR TITLE
feat(approval): support parallel join-any

### DIFF
--- a/docs/development/approval-wp1-parallel-any-development-20260423.md
+++ b/docs/development/approval-wp1-parallel-any-development-20260423.md
@@ -1,0 +1,57 @@
+# Approval WP1 Parallel Join-Any Development - 2026-04-23
+
+## Scope
+
+This change closes the first deferred follow-up from the WP1 parallel gateway delivery: `joinMode='any'`.
+
+Before this change the type and template-validation layers accepted `joinMode='any'`, but runtime execution rejected it:
+
+- initial parallel fork path threw for non-`all`;
+- post-approve parallel branch advancement threw for non-`all`.
+
+## Runtime Semantics
+
+`joinMode='any'` means first branch to reach the configured `joinNodeKey` wins.
+
+Implemented behavior:
+
+- Parallel fan-out still creates active assignments for all pending branch frontiers when no branch reaches the join immediately.
+- If a branch reaches the join during initial fan-out through only cc / auto-approval work, that branch wins immediately and no sibling approval assignments are created.
+- Initial fan-out join-any preserves any cc / auto-approval events accumulated before the parallel node.
+- If an active branch reaches the join after an approval action, the executor advances past the join immediately instead of waiting for sibling branches.
+- The service cancels sibling branch assignments before inserting post-join assignments.
+- The instance metadata key `parallelBranchStates` is stripped after leaving the parallel region.
+
+Deferred behavior remains unchanged:
+
+- return-to-node while inside an active parallel region is still rejected with `APPROVAL_RETURN_IN_PARALLEL_UNSUPPORTED`;
+- nested parallel remains rejected by template validation;
+- overlapping approvers across branches remain rejected.
+
+## Service-Layer Cancellation
+
+The executor is pure and does not mutate assignments. `ApprovalProductService.dispatchAction()` now handles join-any sibling cancellation after it receives a post-join resolution from `resolveAfterApproveInParallel()`.
+
+Cancellation rules:
+
+- only applies when the current instance is in a parallel region;
+- only applies when `parallelState.joinMode === 'any'`;
+- only applies when the resolution leaves the parallel fork node;
+- marks active sibling branch assignments inactive before new post-join assignments are inserted;
+- annotates cancelled assignment metadata with `parallelCancelledBy`, `parallelCancelledAt`, `parallelJoinMode`, and `parallelNodeKey`;
+- emits a `sign` audit row with `parallelAutoCancelled=true`.
+
+This mirrors existing approval-node `approvalMode='any'` first-wins cancellation without changing assignment uniqueness constraints.
+
+## Files
+
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/tests/unit/approval-graph-executor.test.ts`
+- `packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts`
+
+## Non-Goals
+
+- No database migration.
+- No OpenAPI schema change; `joinMode='any'` was already part of the contract.
+- No frontend UI change; the post-join DTO returns to linear state just like join-all.

--- a/docs/development/approval-wp1-parallel-any-verification-20260423.md
+++ b/docs/development/approval-wp1-parallel-any-verification-20260423.md
@@ -1,0 +1,119 @@
+# Approval WP1 Parallel Join-Any Verification - 2026-04-23
+
+## Commands Run
+
+Unit test:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       12 passed (12)
+Exit        0
+```
+
+Backend typecheck:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result:
+
+```text
+Exit 0
+```
+
+Frontend typecheck:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result:
+
+```text
+Exit 0
+```
+
+WP1 parallel integration:
+
+```bash
+DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/approval-wp1-parallel-gateway.api.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       4 passed (4)
+Exit        0
+```
+
+Adjacent approval regression:
+
+```bash
+DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/approval-wp1-any-mode.api.test.ts \
+  --reporter=dot
+
+DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/approval-pack1a-lifecycle.api.test.ts \
+  --reporter=dot
+
+DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/approval-wp2-source-filter.api.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+approval-wp1-any-mode.api.test.ts      1 passed (1), 1 test
+approval-pack1a-lifecycle.api.test.ts  1 passed (1), 3 tests
+approval-wp2-source-filter.api.test.ts 1 passed (1), 7 tests
+Total adjacent regression              3 files, 11 tests
+Exit        0
+```
+
+Diff hygiene:
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+Exit 0
+```
+
+## Scenarios Covered
+
+- Executor accepts a `joinMode='any'` parallel state and advances past the join after one branch reaches the join.
+- Executor preserves pre-parallel CC events when a join-any branch auto-completes during initial fan-out.
+- HTTP create/publish creates a join-any parallel approval with two active branches.
+- First branch approval advances to the post-join `finance_review` node.
+- Sibling branch assignment is cancelled before post-join assignment insertion.
+- Cancelled sibling assignment metadata records the winning actor and parallel node.
+- Late sibling approver receives `403` because their assignment is no longer active.
+- Post-join approver completes the instance.
+- `parallelBranchStates` is removed from instance metadata after leaving the parallel region.
+- Approval audit metadata records `parallelJoinMode='any'` and cancelled assignees.
+- A `sign` audit row records branch auto-cancellation for timeline consumers.
+
+## Verification Notes
+
+One attempted verification ran multiple approval integration files in the same Vitest invocation against the same local Postgres database. That caused a DDL/bootstrap deadlock in `ensureApprovalSchemaReady()`.
+
+The stable pattern for these live-DB approval integration tests is one integration file per command against the shared local database. Single-file runs are green and are the results recorded above.

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -422,12 +422,10 @@ export class ApprovalGraphExecutor {
    *     if the branch moved to another approval node in the same branch OR
    *     reached the join node while siblings remain pending. The route layer
    *     persists the updated `parallelState` into `metadata.parallelBranchStates`.
-   *   - A post-join resolution (`resolveFromNode(joinNodeKey)`) once every
-   *     branch has reported complete under `joinMode='all'`. In that case
-   *     `parallelState` carries the final archived state map.
-   *
-   * The `joinMode='any'` path is reserved for a future wave and currently
-   * throws; see the dev MD follow-up list.
+   *   - A post-join resolution (`resolveFromNode(joinNodeKey)`) once the
+   *     join condition is met. `joinMode='all'` waits for every branch;
+   *     `joinMode='any'` advances as soon as this branch reaches the join.
+   *     In both cases `parallelState` carries the final archived state map.
    */
   resolveAfterApproveInParallel(
     branchNodeKey: string,
@@ -438,9 +436,6 @@ export class ApprovalGraphExecutor {
     )
     if (!branch) {
       throw new Error(`Parallel branch with current node ${branchNodeKey} not found in state`)
-    }
-    if (currentState.joinMode !== 'all') {
-      throw new Error(`Parallel joinMode '${currentState.joinMode}' is not supported in v1`)
     }
     const aggregateMode = this.getApprovalMode(branchNodeKey)
 
@@ -490,8 +485,9 @@ export class ApprovalGraphExecutor {
       branches: updatedBranches,
     }
     const allComplete = Object.values(updatedState.branches).every((entry) => entry.complete)
+    const joinSatisfied = currentState.joinMode === 'any' || allComplete
 
-    if (!allComplete) {
+    if (!joinSatisfied) {
       // Still waiting on siblings; keep the instance pending with fewer active branches.
       const pendingBranches = Object.values(updatedState.branches).filter((entry) => !entry.complete)
       return {
@@ -509,7 +505,9 @@ export class ApprovalGraphExecutor {
       }
     }
 
-    // All branches complete — advance past the join node.
+    // Join condition satisfied — advance past the join node. For join-any the
+    // route layer cancels sibling branch assignments before inserting the
+    // post-join assignments returned here.
     const postJoin = this.resolveFromNode(currentState.joinNodeKey, {
       aggregateMode,
       aggregateComplete: true,
@@ -698,13 +696,10 @@ export class ApprovalGraphExecutor {
         if (!parallelConfig) {
           throw new Error(`Parallel node ${node.key} has invalid config`)
         }
-        if (parallelConfig.joinMode !== 'all') {
-          throw new Error(`Parallel joinMode '${parallelConfig.joinMode}' is not supported in v1`)
-        }
 
         const branchStates: Record<string, ParallelBranchState> = {}
         const branchAssignments: ApprovalGraphAssignment[] = []
-        let allBranchesAutoComplete = true
+        const branchAdvances: Array<{ edgeKey: string; advance: BranchAdvance }> = []
 
         for (const edgeKey of parallelConfig.branches) {
           const branchStartNode = this.targetForEdge(edgeKey)
@@ -715,9 +710,35 @@ export class ApprovalGraphExecutor {
             { fromNodeKey: branchStartNode, includeStartNode: true },
             parallelConfig.joinNodeKey,
           )
+          branchAdvances.push({ edgeKey, advance })
+        }
+
+        const anyAutoCompleteWinner = parallelConfig.joinMode === 'any'
+          ? branchAdvances.find((entry) => entry.advance.kind === 'reached-join')
+          : undefined
+        if (anyAutoCompleteWinner) {
+          // A branch with only cc / auto-approval work reached the join
+          // immediately. Under join-any that branch wins before sibling
+          // approval assignments are created.
+          const postJoin = this.resolveFromNode(parallelConfig.joinNodeKey, context)
+          return {
+            ...postJoin,
+            ccEvents: [
+              ...ccEvents,
+              ...anyAutoCompleteWinner.advance.ccEvents,
+              ...postJoin.ccEvents,
+            ],
+            autoApprovalEvents: [
+              ...autoApprovalEvents,
+              ...anyAutoCompleteWinner.advance.autoApprovalEvents,
+              ...postJoin.autoApprovalEvents,
+            ],
+          }
+        }
+
+        for (const { edgeKey, advance } of branchAdvances) {
           ccEvents.push(...advance.ccEvents)
           autoApprovalEvents.push(...advance.autoApprovalEvents)
-
           if (advance.kind === 'pending-approval') {
             branchStates[edgeKey] = {
               edgeKey,
@@ -725,7 +746,6 @@ export class ApprovalGraphExecutor {
               complete: false,
             }
             branchAssignments.push(...advance.assignments)
-            allBranchesAutoComplete = false
           } else {
             branchStates[edgeKey] = {
               edgeKey,
@@ -735,6 +755,7 @@ export class ApprovalGraphExecutor {
           }
         }
 
+        const allBranchesAutoComplete = Object.values(branchStates).every((entry) => entry.complete)
         if (allBranchesAutoComplete) {
           // Every branch fast-forwarded through auto-approvals / cc to the join
           // node. Continue walking past the join node directly.

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1502,6 +1502,7 @@ export class ApprovalProductService {
       //                    (aggregateCancelledBy/aggregateCancelledAt metadata) + one 'sign' record.
       //   'single' / default: exactly one assignee expected; blanket-deactivate all active rows.
       let aggregateCancelledAssigneeIds: string[] = []
+      let parallelCancelledAssigneeIds: string[] = []
       if (approvalMode === 'all') {
         await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
         const remainingAssignments = currentNodeAssignments.length - actorAssignments.length
@@ -1575,6 +1576,47 @@ export class ApprovalProductService {
         ? executor.resolveAfterApproveInParallel(actorBranchNodeKey, parallelState)
         : executor.resolveAfterApprove(currentNodeKey)
 
+      const parallelAnyWinner =
+        isInParallelRegion
+        && parallelState?.joinMode === 'any'
+        && resolution.currentNodeKey !== parallelState.parallelNodeKey
+      if (parallelAnyWinner && parallelState) {
+        const pendingSiblingNodeKeys = new Set(
+          Object.values(parallelState.branches)
+            .filter((entry) => !entry.complete && entry.currentNodeKey && entry.currentNodeKey !== currentNodeKey)
+            .map((entry) => entry.currentNodeKey as string),
+        )
+        const siblingAssignments = assignments.rows.filter((assignment) =>
+          assignment.is_active
+          && assignment.node_key
+          && pendingSiblingNodeKeys.has(assignment.node_key))
+        parallelCancelledAssigneeIds = Array.from(
+          new Set(siblingAssignments.map((assignment) => assignment.assignee_id)),
+        )
+        if (siblingAssignments.length > 0) {
+          await client.query(
+            `UPDATE approval_assignments
+             SET is_active = FALSE,
+                 metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+                   'parallelCancelledBy', $3::text,
+                   'parallelCancelledAt', now()::text,
+                   'parallelJoinMode', 'any',
+                   'parallelNodeKey', $4::text
+                 ),
+                 updated_at = now()
+             WHERE instance_id = $1
+               AND is_active = TRUE
+               AND id = ANY($2::uuid[])`,
+            [
+              id,
+              siblingAssignments.map((assignment) => assignment.id),
+              actor.userId,
+              parallelState.parallelNodeKey,
+            ],
+          )
+        }
+      }
+
       // Manage parallel branch state in `approval_instances.metadata`:
       //   - If the resolution's `currentNodeKey` equals a parallel fork node
       //     (either the same one we were already inside, or a brand-new
@@ -1633,6 +1675,10 @@ export class ApprovalProductService {
         approveRecordMetadata.parallelNodeKey = parallelState?.parallelNodeKey
         approveRecordMetadata.parallelBranchComplete =
           resolution.currentNodeKey !== parallelState?.parallelNodeKey
+        if (parallelAnyWinner) {
+          approveRecordMetadata.parallelJoinMode = 'any'
+          approveRecordMetadata.parallelCancelledAssignees = parallelCancelledAssigneeIds
+        }
       }
       if (approvalMode === 'any' && aggregateCancelledAssigneeIds.length > 0) {
         approveRecordMetadata.aggregateCancelled = aggregateCancelledAssigneeIds
@@ -1666,6 +1712,26 @@ export class ApprovalProductService {
             aggregateMode: 'any',
             aggregateCancelledBy: actor.userId,
             cancelledAssignees: aggregateCancelledAssigneeIds,
+          },
+        })
+      }
+      if (parallelAnyWinner && parallelCancelledAssigneeIds.length > 0) {
+        await this.insertApprovalRecord(client, id, {
+          action: 'sign',
+          actorId: 'system',
+          actorName: 'System',
+          comment: null,
+          fromStatus: instance.status,
+          toStatus: resolution.status,
+          fromVersion: instance.version,
+          toVersion: nextVersion,
+          metadata: {
+            nodeKey: currentNodeKey,
+            parallelAutoCancelled: true,
+            parallelJoinMode: 'any',
+            parallelNodeKey: parallelState?.parallelNodeKey,
+            parallelCancelledBy: actor.userId,
+            cancelledAssignees: parallelCancelledAssigneeIds,
           },
         })
       }

--- a/packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts
@@ -84,7 +84,7 @@ function buildFormSchema() {
  * Branch B: compliance-review (single approver, user compliance-1)
  * Shared join: finance-review (single approver, user finance-1)
  */
-function buildParallelGatewayGraph() {
+function buildParallelGatewayGraph(joinMode: 'all' | 'any' = 'all') {
   return {
     nodes: [
       { key: 'start', type: 'start', config: {} },
@@ -93,7 +93,7 @@ function buildParallelGatewayGraph() {
         type: 'parallel',
         config: {
           branches: ['edge-fork-legal', 'edge-fork-compliance'],
-          joinMode: 'all',
+          joinMode,
           joinNodeKey: 'finance_review',
         },
       },
@@ -333,6 +333,155 @@ describeIfDatabase('Approval Wave 2 WP1 parallel-gateway (并行分支) API', ()
       nodeKey: 'finance_review',
       nextNodeKey: null,
       aggregateComplete: true,
+    })
+  })
+
+  it('joins after the first completed branch and cancels sibling branches (joinMode=any)', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-parallel-any')
+    const requesterToken = await authToken(baseUrl, 'requester-parallel-any')
+    const legalToken = await authToken(baseUrl, 'legal-1')
+    const complianceToken = await authToken(baseUrl, 'compliance-1')
+    const financeToken = await authToken(baseUrl, 'finance-1')
+
+    const templateKey = `approval-wp1-parallel-any-${Date.now()}`
+
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Parallel Gateway Any Template',
+        description: 'WP1 parallel-gateway join-any integration',
+        formSchema: buildFormSchema(),
+        approvalGraph: buildParallelGatewayGraph('any'),
+      },
+    })
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status).toBe(200)
+
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: {
+        templateId: template.id,
+        formData: { reason: 'parallel-gateway join-any request' },
+      },
+    })
+    expect(createResponse.status).toBe(201)
+    const createdApproval = await createResponse.json() as {
+      id: string
+      status: string
+      currentNodeKey: string | null
+      currentNodeKeys?: string[] | null
+      assignments: Array<{ assigneeId: string; isActive: boolean; nodeKey?: string | null }>
+    }
+    createdApprovalIds.add(createdApproval.id)
+    expect(createdApproval.status).toBe('pending')
+    expect(createdApproval.currentNodeKey).toBe('parallel_fork')
+    expect([...(createdApproval.currentNodeKeys || [])].sort()).toEqual([
+      'compliance_review',
+      'legal_review',
+    ])
+
+    const legalApproveResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, legalToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'legal wins join-any' },
+    })
+    expect(legalApproveResponse.status).toBe(200)
+    const afterLegal = await legalApproveResponse.json() as {
+      status: string
+      currentNodeKey: string | null
+      currentNodeKeys?: string[] | null
+      assignments: Array<{ assigneeId: string; isActive: boolean; nodeKey?: string | null; metadata?: JsonRecord }>
+    }
+    expect(afterLegal.status).toBe('pending')
+    expect(afterLegal.currentNodeKey).toBe('finance_review')
+    expect(afterLegal.currentNodeKeys).toBeFalsy()
+    expect(
+      afterLegal.assignments
+        .filter((a) => a.isActive)
+        .map((a) => ({ assigneeId: a.assigneeId, nodeKey: a.nodeKey })),
+    ).toEqual([
+      { assigneeId: 'finance-1', nodeKey: 'finance_review' },
+    ])
+
+    const pool = poolManager.get()
+    const assignmentResult = await pool.query<ApprovalAssignmentRow>(
+      `SELECT assignee_id, node_key, is_active, metadata
+       FROM approval_assignments
+       WHERE instance_id = $1
+       ORDER BY created_at ASC`,
+      [createdApproval.id],
+    )
+    const complianceAssignment = assignmentResult.rows.find((row) => row.assignee_id === 'compliance-1')
+    expect(complianceAssignment?.is_active).toBe(false)
+    expect(complianceAssignment?.metadata).toMatchObject({
+      parallelCancelledBy: 'legal-1',
+      parallelJoinMode: 'any',
+      parallelNodeKey: 'parallel_fork',
+    })
+
+    const instanceResult = await pool.query<ApprovalInstanceRow>(
+      `SELECT status, current_node_key, metadata FROM approval_instances WHERE id = $1`,
+      [createdApproval.id],
+    )
+    expect(instanceResult.rows[0]?.current_node_key).toBe('finance_review')
+    expect((instanceResult.rows[0]?.metadata as JsonRecord | undefined)?.parallelBranchStates).toBeUndefined()
+
+    const complianceApproveResponse = await jsonRequest(
+      baseUrl,
+      `/api/approvals/${createdApproval.id}/actions`,
+      complianceToken,
+      {
+        method: 'POST',
+        body: { action: 'approve', comment: 'too late' },
+      },
+    )
+    expect(complianceApproveResponse.status).toBe(403)
+
+    const financeApproveResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, financeToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'finance ok' },
+    })
+    expect(financeApproveResponse.status).toBe(200)
+    const afterFinance = await financeApproveResponse.json() as {
+      status: string
+      currentNodeKey: string | null
+      assignments: Array<{ assigneeId: string; isActive: boolean }>
+    }
+    expect(afterFinance.status).toBe('approved')
+    expect(afterFinance.currentNodeKey).toBeNull()
+    expect(afterFinance.assignments.filter((a) => a.isActive)).toHaveLength(0)
+
+    const recordsResult = await pool.query<ApprovalRecordRow>(
+      `SELECT action, actor_id, to_status, metadata
+       FROM approval_records
+       WHERE instance_id = $1
+       ORDER BY to_version ASC, created_at ASC`,
+      [createdApproval.id],
+    )
+    const legalApproveRecord = recordsResult.rows.find((row) => row.action === 'approve' && row.actor_id === 'legal-1')
+    expect(legalApproveRecord?.metadata).toMatchObject({
+      nodeKey: 'legal_review',
+      nextNodeKey: 'finance_review',
+      parallelNodeKey: 'parallel_fork',
+      parallelBranchComplete: true,
+      parallelJoinMode: 'any',
+      parallelCancelledAssignees: ['compliance-1'],
+    })
+    const cancellationRecord = recordsResult.rows.find((row) =>
+      row.action === 'sign' && row.metadata.parallelAutoCancelled === true)
+    expect(cancellationRecord?.metadata).toMatchObject({
+      nodeKey: 'legal_review',
+      parallelJoinMode: 'any',
+      parallelNodeKey: 'parallel_fork',
+      parallelCancelledBy: 'legal-1',
+      cancelledAssignees: ['compliance-1'],
     })
   })
 

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -407,6 +407,160 @@ describe('ApprovalGraphExecutor', () => {
       },
     ])
   })
+
+  it('advances past the join when one joinMode=any branch reaches the join', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'parallel_fork',
+          type: 'parallel',
+          config: {
+            branches: ['edge-fork-a', 'edge-fork-b'],
+            joinMode: 'any',
+            joinNodeKey: 'finance-review',
+          },
+        },
+        {
+          key: 'legal-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['legal-1'] },
+        },
+        {
+          key: 'compliance-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['compliance-1'] },
+        },
+        {
+          key: 'finance-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['finance-1'] },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+        { key: 'edge-fork-a', source: 'parallel_fork', target: 'legal-review' },
+        { key: 'edge-fork-b', source: 'parallel_fork', target: 'compliance-review' },
+        { key: 'edge-a-join', source: 'legal-review', target: 'finance-review' },
+        { key: 'edge-b-join', source: 'compliance-review', target: 'finance-review' },
+        { key: 'edge-finance-end', source: 'finance-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const initial = executor.resolveInitialState()
+
+    expect(initial.currentNodeKey).toBe('parallel_fork')
+    expect(initial.parallelState!.joinMode).toBe('any')
+    expect([...(initial.currentNodeKeys || [])].sort()).toEqual([
+      'compliance-review',
+      'legal-review',
+    ])
+
+    const afterLegal = executor.resolveAfterApproveInParallel('legal-review', initial.parallelState!)
+    expect(afterLegal.status).toBe('pending')
+    expect(afterLegal.currentNodeKey).toBe('finance-review')
+    expect(afterLegal.currentNodeKeys).toBeUndefined()
+    expect(afterLegal.parallelState!.branches['edge-fork-a']).toEqual({
+      edgeKey: 'edge-fork-a',
+      currentNodeKey: null,
+      complete: true,
+    })
+    expect(afterLegal.parallelState!.branches['edge-fork-b']).toEqual({
+      edgeKey: 'edge-fork-b',
+      currentNodeKey: 'compliance-review',
+      complete: false,
+    })
+    expect(afterLegal.assignments).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'finance-1',
+        nodeKey: 'finance-review',
+        sourceStep: 3,
+      },
+    ])
+  })
+
+  it('preserves pre-parallel events when a joinMode=any branch auto-completes during fanout', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'notify-before-fork', type: 'cc', config: { targetType: 'role', targetIds: ['ops'] } },
+        {
+          key: 'parallel_fork',
+          type: 'parallel',
+          config: {
+            branches: ['edge-fork-auto', 'edge-fork-pending'],
+            joinMode: 'any',
+            joinNodeKey: 'finance-review',
+          },
+        },
+        {
+          key: 'auto-review',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: [],
+            approvalMode: 'all',
+            emptyAssigneePolicy: 'auto-approve',
+          },
+        },
+        {
+          key: 'compliance-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['compliance-1'] },
+        },
+        {
+          key: 'finance-review',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['finance-1'] },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-notify', source: 'start', target: 'notify-before-fork' },
+        { key: 'edge-notify-fork', source: 'notify-before-fork', target: 'parallel_fork' },
+        { key: 'edge-fork-auto', source: 'parallel_fork', target: 'auto-review' },
+        { key: 'edge-fork-pending', source: 'parallel_fork', target: 'compliance-review' },
+        { key: 'edge-auto-join', source: 'auto-review', target: 'finance-review' },
+        { key: 'edge-pending-join', source: 'compliance-review', target: 'finance-review' },
+        { key: 'edge-finance-end', source: 'finance-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const initial = executor.resolveInitialState()
+
+    expect(initial.status).toBe('pending')
+    expect(initial.currentNodeKey).toBe('finance-review')
+    expect(initial.parallelState).toBeUndefined()
+    expect(initial.assignments).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'finance-1',
+        nodeKey: 'finance-review',
+        sourceStep: 3,
+      },
+    ])
+    expect(initial.ccEvents).toEqual([
+      {
+        nodeKey: 'notify-before-fork',
+        targetType: 'role',
+        targetId: 'ops',
+      },
+    ])
+    expect(initial.autoApprovalEvents).toEqual([
+      {
+        nodeKey: 'auto-review',
+        sourceStep: 1,
+        approvalMode: 'all',
+        reason: 'empty-assignee',
+      },
+    ])
+  })
 })
 
 describe('validateApprovalFormData', () => {


### PR DESCRIPTION
## Summary

Enables runtime support for approval parallel gateway `joinMode='any'`.

What changed:
- `ApprovalGraphExecutor` accepts `joinMode='any'` during initial fan-out and post-approval branch advancement.
- First branch to reach the join advances into the post-join node.
- Initial fan-out handles an auto-completing winning branch and preserves pre-parallel cc / auto events.
- `ApprovalProductService.dispatchAction()` cancels still-active sibling branch assignments before inserting post-join assignments.
- Cancellation metadata is stored on inactive sibling assignments and a system `sign` audit row.
- Added focused executor and HTTP integration coverage.

Non-goals:
- No DB migration.
- No OpenAPI/schema change; `joinMode='any'` was already accepted by contract.
- No frontend UI change.
- Return-to-node inside an active parallel region remains unsupported.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts --reporter=dot` -> 12/12 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` -> exit 0
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` -> exit 0
- `DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-wp1-parallel-gateway.api.test.ts --reporter=dot` -> 4/4 passed
- Single-file adjacent regression against local Postgres:
  - `approval-wp1-any-mode.api.test.ts` -> 1/1 passed
  - `approval-pack1a-lifecycle.api.test.ts` -> 3/3 passed
  - `approval-wp2-source-filter.api.test.ts` -> 7/7 passed
- `git diff --check` -> exit 0

## Notes

A multi-file Vitest integration invocation against the shared local Postgres database can deadlock in `ensureApprovalSchemaReady()` due fixture DDL/bootstrap concurrency. The same files pass when run one file per command; this is documented in the verification MD.
