### PR TITLE
test(dingtalk): add P4 smoke session env template

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -73,6 +73,7 @@
 - [x] Add a P4 strict artifact gate so manual pass evidence must reference self-contained non-empty files under `artifacts/<check-id>/`.
 - [x] Make the P4 API-only runner output a complete smoke workspace with `evidence.json`, `manual-evidence-checklist.md`, and manual artifact folders.
 - [x] Add a P4 smoke session orchestrator that runs preflight, API workspace bootstrap, non-strict compile, and a redacted session summary.
+- [x] Add a P4 smoke session env template initializer for secure one-command staging setup.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-smoke-session-env-template-development-20260423.md
+++ b/docs/development/dingtalk-p4-smoke-session-env-template-development-20260423.md
@@ -1,0 +1,35 @@
+# DingTalk P4 Smoke Session Env Template Development
+
+- Date: 2026-04-23
+- Scope: P4 smoke session operator setup
+- Branch: `codex/dingtalk-p4-smoke-session-env-template-20260423`
+
+## What Changed
+
+- Added `--init-env-template <file>` to `scripts/ops/dingtalk-p4-smoke-session.mjs`.
+- The initializer writes a safe local env template for:
+  - staging API and web base URLs
+  - admin/table-owner bearer token
+  - two DingTalk group robot webhook URLs
+  - optional `SEC...` robot signing secrets
+  - allowed local users and member groups
+  - optional person-message smoke recipients
+- The initializer exits after writing the template and does not run preflight, API smoke, or compile.
+- Updated the remote smoke checklist to start with template generation.
+
+## Why
+
+The session command reduced the smoke run to one command, but operators still needed to remember the exact env variable names. This change creates a reproducible, non-committed setup file so staging execution is less error-prone while keeping secrets out of docs and reports.
+
+## Files
+
+- `scripts/ops/dingtalk-p4-smoke-session.mjs`
+- `scripts/ops/dingtalk-p4-smoke-session.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Flow
+
+1. Run `node scripts/ops/dingtalk-p4-smoke-session.mjs --init-env-template <local-env-file>`.
+2. Fill the generated file locally or on the staging host.
+3. Run `node scripts/ops/dingtalk-p4-smoke-session.mjs --env-file <local-env-file> --output-dir <session-dir>`.

--- a/docs/development/dingtalk-p4-smoke-session-env-template-verification-20260423.md
+++ b/docs/development/dingtalk-p4-smoke-session-env-template-verification-20260423.md
@@ -1,0 +1,31 @@
+# DingTalk P4 Smoke Session Env Template Verification
+
+- Date: 2026-04-23
+- Scope: session env template initialization
+
+## Commands Run
+
+```bash
+node --check scripts/ops/dingtalk-p4-smoke-session.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`: passed.
+- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed.
+- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed, 3 tests.
+- `git diff --cached --check`: passed after staging the env-template changes.
+
+## Coverage Notes
+
+- The new test verifies `--init-env-template` writes all required env keys.
+- The new test verifies the initializer does not create a session summary.
+- Existing session tests continue to cover orchestration and preflight failure short-circuiting.
+
+## Remaining Remote Validation
+
+- Fill the generated env file with real 142/staging values.
+- Run the session command against staging.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -128,9 +128,18 @@ Example check evidence:
 
 Use the session orchestrator for the normal 142/staging P4 run. It runs preflight, bootstraps the API-addressable smoke workspace, compiles a non-strict evidence summary, and writes a session report. It stops before the API runner when preflight fails.
 
+Create a local env template first:
+
 ```bash
 node scripts/ops/dingtalk-p4-smoke-session.mjs \
-  --env-file /secure/local/dingtalk-p4.env \
+  --init-env-template output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env
+```
+
+Fill the generated file outside git with real staging and DingTalk robot inputs.
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-session.mjs \
+  --env-file output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env \
   --output-dir output/dingtalk-p4-remote-smoke-session/142-session
 ```
 

--- a/scripts/ops/dingtalk-p4-smoke-session.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.mjs
@@ -27,6 +27,7 @@ strict compile. After the session succeeds, place manual artifacts in the
 generated workspace and run compile-dingtalk-p4-smoke-evidence.mjs --strict.
 
 Options:
+  --init-env-template <file>       Write a safe editable env template and exit
   --env-file <file>                Optional KEY=VALUE file to read before env/CLI
   --api-base <url>                 Backend API base, default ${DEFAULT_API_BASE}
   --web-base <url>                 Public app base used by DingTalk message links
@@ -132,6 +133,7 @@ function parseArgs(argv) {
   const envFileValues = envFile ? parseEnvFile(envFile) : {}
   const env = { ...envFileValues, ...process.env }
   const opts = {
+    initEnvTemplate: null,
     envFile,
     apiBase: envValue(env, 'DINGTALK_P4_API_BASE', 'API_BASE') || DEFAULT_API_BASE,
     webBase: envValue(env, 'DINGTALK_P4_WEB_BASE', 'WEB_BASE', 'PUBLIC_APP_URL'),
@@ -156,6 +158,10 @@ function parseArgs(argv) {
     const arg = argv[i]
     switch (arg) {
       case '--env-file':
+        i += 1
+        break
+      case '--init-env-template':
+        opts.initEnvTemplate = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
         break
       case '--api-base':
@@ -231,6 +237,42 @@ function parseArgs(argv) {
   }
 
   return opts
+}
+
+function renderEnvTemplate() {
+  return `# DingTalk P4 smoke session env template
+# Fill this file locally or on the staging host. Do not commit it.
+# Run:
+#   node scripts/ops/dingtalk-p4-smoke-session.mjs --env-file <this-file> --output-dir output/dingtalk-p4-remote-smoke-session/<run>
+
+DINGTALK_P4_API_BASE=http://142.171.239.56:8900
+DINGTALK_P4_WEB_BASE=http://142.171.239.56:8081
+
+# Admin/table-owner bearer token. Keep private.
+DINGTALK_P4_AUTH_TOKEN=
+
+# DingTalk group robot webhooks. Full webhook URLs must stay private.
+DINGTALK_P4_GROUP_A_WEBHOOK=
+DINGTALK_P4_GROUP_B_WEBHOOK=
+
+# Optional SEC... robot signing secrets.
+DINGTALK_P4_GROUP_A_SECRET=
+DINGTALK_P4_GROUP_B_SECRET=
+
+# Local user IDs or member group IDs allowed to submit the dingtalk_granted form.
+# Use comma-separated values when there are multiple entries.
+DINGTALK_P4_ALLOWED_USER_IDS=
+DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS=
+
+# Optional local user IDs for direct DingTalk person-message delivery history.
+DINGTALK_P4_PERSON_USER_IDS=
+`
+}
+
+function writeEnvTemplate(file) {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, renderEnvTemplate(), 'utf8')
+  console.log(`Wrote ${relativePath(file)}`)
 }
 
 function makeRunId() {
@@ -443,8 +485,12 @@ function runSession(opts) {
 
 try {
   const opts = parseArgs(process.argv.slice(2))
-  const summary = runSession(opts)
-  if (summary.overallStatus === 'fail') process.exit(1)
+  if (opts.initEnvTemplate) {
+    writeEnvTemplate(opts.initEnvTemplate)
+  } else {
+    const summary = runSession(opts)
+    if (summary.overallStatus === 'fail') process.exit(1)
+  }
 } catch (error) {
   console.error(`[dingtalk-p4-smoke-session] ERROR: ${redactString(error instanceof Error ? error.message : String(error))}`)
   process.exit(1)

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -213,6 +213,34 @@ function runScript(args) {
   })
 }
 
+test('dingtalk-p4-smoke-session writes an editable env template', () => {
+  const tmpDir = makeTmpDir()
+  const envPath = path.join(tmpDir, 'dingtalk-p4.env')
+
+  try {
+    const result = spawnSync(process.execPath, [
+      scriptPath,
+      '--init-env-template',
+      envPath,
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Wrote .*dingtalk-p4\.env/)
+    const content = readFileSync(envPath, 'utf8')
+    assert.match(content, /DINGTALK_P4_API_BASE=/)
+    assert.match(content, /DINGTALK_P4_AUTH_TOKEN=/)
+    assert.match(content, /DINGTALK_P4_GROUP_A_WEBHOOK=/)
+    assert.match(content, /DINGTALK_P4_ALLOWED_USER_IDS=/)
+    assert.doesNotMatch(content, /secret-admin-token/)
+    assert.equal(existsSync(path.join(tmpDir, 'session-summary.json')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('dingtalk-p4-smoke-session runs preflight, API runner, and non-strict compile', async () => {
   const tmpDir = makeTmpDir()
   const outputDir = path.join(tmpDir, 'session')


### PR DESCRIPTION
## Summary

- add `--init-env-template <file>` to `dingtalk-p4-smoke-session.mjs`
- generate a safe editable env template for staging API/web bases, admin token, DingTalk robots, allowlists, and optional person recipients
- cover the initializer with a test and update the remote smoke checklist/TODO
- add development and verification notes

## Verification

```bash
node --check scripts/ops/dingtalk-p4-smoke-session.mjs
node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
git diff --cached --check
```

Stacked on #1087.