### PR TITLE
test(dingtalk): add P4 smoke session finalize

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -74,6 +74,7 @@
 - [x] Make the P4 API-only runner output a complete smoke workspace with `evidence.json`, `manual-evidence-checklist.md`, and manual artifact folders.
 - [x] Add a P4 smoke session orchestrator that runs preflight, API workspace bootstrap, non-strict compile, and a redacted session summary.
 - [x] Add a P4 smoke session env template initializer for secure one-command staging setup.
+- [x] Add P4 smoke session finalization so completed manual evidence reruns strict compile and refreshes the session summary.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-smoke-session-finalize-development-20260423.md
+++ b/docs/development/dingtalk-p4-smoke-session-finalize-development-20260423.md
@@ -1,0 +1,40 @@
+# DingTalk P4 Smoke Session Finalize Development
+
+- Date: 2026-04-23
+- Scope: P4 smoke session final strict compile
+- Branch: `codex/dingtalk-p4-smoke-session-finalize-20260423`
+
+## What Changed
+
+- Added `--finalize <session-dir>` to `scripts/ops/dingtalk-p4-smoke-session.mjs`.
+- Finalize mode reads `<session-dir>/workspace/evidence.json`, runs `compile-dingtalk-p4-smoke-evidence.mjs --strict`, and refreshes:
+  - `<session-dir>/compiled/summary.json`
+  - `<session-dir>/compiled/summary.md`
+  - `<session-dir>/compiled/evidence.redacted.json`
+  - `<session-dir>/session-summary.json`
+  - `<session-dir>/session-summary.md`
+- Existing session steps are preserved and a `strict-compile` step is appended.
+- Bootstrap summaries now recommend `--finalize <session-dir>` instead of a raw strict compiler command.
+- `session-summary` becomes `pass` only when strict compile passes.
+- If strict compile fails, `session-summary` becomes `fail`, includes final strict summary counts, and keeps the `--finalize` retry command in `nextCommands`.
+- Final summaries expose `sessionPhase`, `finalStrictStatus`, required checks not passed, and manual evidence issues.
+- Finalize mode rejects ambiguous `--output-dir` usage.
+- Updated the remote smoke checklist and P4 TODO to make `--finalize` the standard post-manual-evidence command.
+
+## Why
+
+After the session runner produced `manual_pending`, operators still had to remember the raw strict compile command and the session summary could remain stale. Finalize mode makes the same session CLI own the full lifecycle: bootstrap, manual pending, and final strict sign-off.
+
+## Files
+
+- `scripts/ops/dingtalk-p4-smoke-session.mjs`
+- `scripts/ops/dingtalk-p4-smoke-session.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Flow
+
+1. Run the session command and complete real DingTalk-client/admin evidence in `workspace/evidence.json`.
+2. Store local proof files under `workspace/artifacts/<check-id>/`.
+3. Run `node scripts/ops/dingtalk-p4-smoke-session.mjs --finalize <session-dir>`.
+4. Treat the run as complete only when `session-summary.json` reports `overallStatus: "pass"`.

--- a/docs/development/dingtalk-p4-smoke-session-finalize-verification-20260423.md
+++ b/docs/development/dingtalk-p4-smoke-session-finalize-verification-20260423.md
@@ -1,0 +1,31 @@
+# DingTalk P4 Smoke Session Finalize Verification
+
+- Date: 2026-04-23
+- Scope: session final strict compile and summary refresh
+
+## Commands Run
+
+```bash
+node --check scripts/ops/dingtalk-p4-smoke-session.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`: passed.
+- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed.
+- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed, 6 tests.
+- `git diff --cached --check`: passed after staging the finalize changes.
+
+## Coverage Notes
+
+- Finalize success coverage verifies strict compile passes, `session-summary` becomes `pass`, and `nextCommands` no longer includes the strict compile command.
+- Finalize failure coverage verifies missing manual artifacts fail strict compile, refresh `session-summary` to `fail`, and keep the `--finalize` retry command in `nextCommands`.
+- Finalize argument coverage verifies `--finalize` rejects ambiguous `--output-dir` usage.
+- Existing session coverage continues to verify env template generation, orchestration, and preflight short-circuiting.
+
+## Remaining Remote Validation
+
+- Run `--finalize` after real 142/staging DingTalk manual evidence has been filled.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -156,14 +156,14 @@ Expected generated files:
 - `session-summary.json`
 - `session-summary.md`
 
-Expected session status is usually `manual_pending` after the API runner succeeds, because the real DingTalk-client/admin checks still need operator proof. Fill `workspace/evidence.json`, place files in `workspace/artifacts/<check-id>/`, then run strict compile:
+Expected session status is usually `manual_pending` after the API runner succeeds, because the real DingTalk-client/admin checks still need operator proof. Fill `workspace/evidence.json`, place files in `workspace/artifacts/<check-id>/`, then finalize the session:
 
 ```bash
-node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs \
-  --input output/dingtalk-p4-remote-smoke-session/142-session/workspace/evidence.json \
-  --output-dir output/dingtalk-p4-remote-smoke-session/142-session/compiled \
-  --strict
+node scripts/ops/dingtalk-p4-smoke-session.mjs \
+  --finalize output/dingtalk-p4-remote-smoke-session/142-session
 ```
+
+Finalizing reruns strict evidence compile, refreshes `session-summary.json` / `session-summary.md`, and returns non-zero until the manual evidence bundle is complete.
 
 ## Preflight Gate
 

--- a/scripts/ops/dingtalk-p4-smoke-session.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.mjs
@@ -24,10 +24,11 @@ Runs a DingTalk P4 smoke session in one operator command:
 
 This script does not fill real DingTalk-client/admin evidence and does not run
 strict compile. After the session succeeds, place manual artifacts in the
-generated workspace and run compile-dingtalk-p4-smoke-evidence.mjs --strict.
+generated workspace and run --finalize <session-dir>.
 
 Options:
   --init-env-template <file>       Write a safe editable env template and exit
+  --finalize <session-dir>         Run strict compile for an existing session and refresh session summary
   --env-file <file>                Optional KEY=VALUE file to read before env/CLI
   --api-base <url>                 Backend API base, default ${DEFAULT_API_BASE}
   --web-base <url>                 Public app base used by DingTalk message links
@@ -134,6 +135,7 @@ function parseArgs(argv) {
   const env = { ...envFileValues, ...process.env }
   const opts = {
     initEnvTemplate: null,
+    finalizeDir: null,
     envFile,
     apiBase: envValue(env, 'DINGTALK_P4_API_BASE', 'API_BASE') || DEFAULT_API_BASE,
     webBase: envValue(env, 'DINGTALK_P4_WEB_BASE', 'WEB_BASE', 'PUBLIC_APP_URL'),
@@ -162,6 +164,10 @@ function parseArgs(argv) {
         break
       case '--init-env-template':
         opts.initEnvTemplate = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--finalize':
+        opts.finalizeDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
         break
       case '--api-base':
@@ -234,6 +240,13 @@ function parseArgs(argv) {
       default:
         throw new Error(`Unknown argument: ${arg}`)
     }
+  }
+
+  if (opts.initEnvTemplate && opts.finalizeDir) {
+    throw new Error('--init-env-template and --finalize are mutually exclusive')
+  }
+  if (opts.finalizeDir && opts.outputDir) {
+    throw new Error('--output-dir is not used with --finalize; pass the session directory to --finalize')
   }
 
   return opts
@@ -361,9 +374,57 @@ function computeOverallStatus(steps, pendingChecks) {
   return pendingChecks.length > 0 ? 'manual_pending' : 'pass'
 }
 
+function strictCompileCommand(evidencePath, compiledDir) {
+  return `node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input ${relativePath(evidencePath)} --output-dir ${relativePath(compiledDir)} --strict`
+}
+
+function exportPacketCommand(outputDir) {
+  return `node scripts/ops/export-dingtalk-staging-evidence-packet.mjs --include-output ${relativePath(outputDir)}`
+}
+
+function finalizeCommand(outputDir, allowExternalArtifactRefs = false) {
+  return [
+    'node scripts/ops/dingtalk-p4-smoke-session.mjs',
+    '--finalize',
+    relativePath(outputDir),
+    ...(allowExternalArtifactRefs ? ['--allow-external-artifact-refs'] : []),
+  ].join(' ')
+}
+
+function renderFinalStrictSummary(summary) {
+  const final = summary.finalStrictSummary
+  if (!final) return ''
+  const issues = Array.isArray(final.manualEvidenceIssues) && final.manualEvidenceIssues.length
+    ? final.manualEvidenceIssues.map((issue) => `- \`${issue.id}\`: ${issue.code}`).join('\n')
+    : '- None'
+  const notPassed = Array.isArray(final.requiredChecksNotPassed) && final.requiredChecksNotPassed.length
+    ? final.requiredChecksNotPassed.map((check) => `- \`${check.id}\`: ${check.status}`).join('\n')
+    : '- None'
+
+  return `
+## Final Strict Summary
+
+Final strict status: **${summary.finalStrictStatus}**
+
+API bootstrap status: **${final.apiBootstrapStatus ?? 'unknown'}**
+
+Remote client status: **${final.remoteClientStatus ?? 'unknown'}**
+
+Required checks not passed:
+
+${notPassed}
+
+Manual evidence issues:
+
+${issues}
+`
+}
+
 function renderMarkdown(summary) {
   const rows = summary.steps.map((step) => {
-    const notes = step.stderr || step.stdout.split(/\r?\n/).filter(Boolean).at(-1) || ''
+    const stdout = typeof step.stdout === 'string' ? step.stdout : ''
+    const stderr = typeof step.stderr === 'string' ? step.stderr : ''
+    const notes = stderr || stdout.split(/\r?\n/).filter(Boolean).at(-1) || ''
     return `| \`${step.id}\` | ${step.label} | ${step.status} | ${step.exitCode} | ${notes.replaceAll('|', '\\|')} |`
   })
   const pending = summary.pendingChecks.length
@@ -392,6 +453,8 @@ ${pending}
 ## Next Commands
 
 ${commands}
+
+${renderFinalStrictSummary(summary)}
 
 ## Secret Handling
 
@@ -471,12 +534,89 @@ function runSession(opts) {
     workspaceDir: relativePath(workspaceDir),
     compiledDir: relativePath(compiledDir),
     overallStatus: computeOverallStatus(steps, pendingChecks),
+    sessionPhase: 'bootstrap',
+    finalStrictStatus: 'not_run',
     steps,
     pendingChecks,
     nextCommands: [
-      `node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input ${relativePath(evidencePath)} --output-dir ${relativePath(compiledDir)} --strict`,
-      `node scripts/ops/export-dingtalk-staging-evidence-packet.mjs --include-output ${relativePath(outputDir)}`,
+      finalizeCommand(outputDir, opts.allowExternalArtifactRefs),
+      exportPacketCommand(outputDir),
     ],
+  }
+
+  writeSessionSummary(summary, outputDir)
+  return summary
+}
+
+function runFinalStrictCompile(opts) {
+  const outputDir = opts.finalizeDir
+  const preflightDir = path.join(outputDir, 'preflight')
+  const workspaceDir = path.join(outputDir, 'workspace')
+  const compiledDir = path.join(outputDir, 'compiled')
+  const evidencePath = path.join(workspaceDir, 'evidence.json')
+  const priorSummaryPath = path.join(outputDir, 'session-summary.json')
+
+  if (!existsSync(evidencePath)) {
+    throw new Error(`session workspace evidence does not exist: ${relativePath(evidencePath)}`)
+  }
+
+  const priorSummary = readJsonIfExists(priorSummaryPath)
+  const env = buildChildEnv(opts)
+  const strictCompileArgs = [
+    'scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs',
+    '--input',
+    evidencePath,
+    '--output-dir',
+    compiledDir,
+    '--strict',
+    ...(opts.allowExternalArtifactRefs ? ['--allow-external-artifact-refs'] : []),
+  ]
+  const strictStep = runNodeStep(
+    'strict-compile',
+    'Compile final strict P4 smoke evidence',
+    strictCompileArgs[0],
+    strictCompileArgs.slice(1),
+    compiledDir,
+    env,
+  )
+  const priorSteps = Array.isArray(priorSummary?.steps)
+    ? priorSummary.steps.filter((step) => step?.id !== 'strict-compile')
+    : []
+  const steps = [...priorSteps, strictStep]
+  const pendingChecks = extractPendingManualChecks(evidencePath)
+  const compiledSummary = readJsonIfExists(path.join(compiledDir, 'summary.json'))
+  const strictPassed = strictStep.status === 'pass' && compiledSummary?.overallStatus === 'pass'
+  const summary = {
+    tool: 'dingtalk-p4-smoke-session',
+    runId: priorSummary?.runId ?? makeRunId(),
+    generatedAt: new Date().toISOString(),
+    outputDir: relativePath(outputDir),
+    preflightDir: relativePath(preflightDir),
+    workspaceDir: relativePath(workspaceDir),
+    compiledDir: relativePath(compiledDir),
+    overallStatus: strictPassed ? 'pass' : 'fail',
+    sessionPhase: 'finalize',
+    finalStrictStatus: strictPassed ? 'pass' : 'fail',
+    steps,
+    pendingChecks,
+    finalStrictSummary: compiledSummary
+      ? {
+          overallStatus: compiledSummary.overallStatus,
+          apiBootstrapStatus: compiledSummary.apiBootstrapStatus,
+          remoteClientStatus: compiledSummary.remoteClientStatus,
+          requiredChecksNotPassed: compiledSummary.requiredChecksNotPassed ?? [],
+          manualEvidenceIssues: compiledSummary.manualEvidenceIssues ?? [],
+          manualEvidenceIssueCount: Array.isArray(compiledSummary.manualEvidenceIssues)
+            ? compiledSummary.manualEvidenceIssues.length
+            : 0,
+          requiredChecksNotPassedCount: Array.isArray(compiledSummary.requiredChecksNotPassed)
+            ? compiledSummary.requiredChecksNotPassed.length
+            : 0,
+        }
+      : null,
+    nextCommands: strictPassed
+      ? [exportPacketCommand(outputDir)]
+      : [finalizeCommand(outputDir, opts.allowExternalArtifactRefs), exportPacketCommand(outputDir)],
   }
 
   writeSessionSummary(summary, outputDir)
@@ -487,6 +627,9 @@ try {
   const opts = parseArgs(process.argv.slice(2))
   if (opts.initEnvTemplate) {
     writeEnvTemplate(opts.initEnvTemplate)
+  } else if (opts.finalizeDir) {
+    const summary = runFinalStrictCompile(opts)
+    if (summary.overallStatus !== 'pass') process.exit(1)
   } else {
     const summary = runSession(opts)
     if (summary.overallStatus === 'fail') process.exit(1)

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawn, spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import http from 'node:http'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -9,9 +9,83 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-smoke-session.mjs')
+const requiredIds = [
+  'create-table-form',
+  'bind-two-dingtalk-groups',
+  'set-form-dingtalk-granted',
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'delivery-history-group-person',
+  'no-email-user-create-bind',
+]
+const manualClientIds = new Set([
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+])
+const manualAdminIds = new Set(['no-email-user-create-bind'])
 
 function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-smoke-session-'))
+}
+
+function manualArtifactRefForCheck(id) {
+  return `artifacts/${id}/evidence.txt`
+}
+
+function makePassingEvidenceForCheck(id) {
+  if (manualClientIds.has(id) || manualAdminIds.has(id)) {
+    return {
+      source: manualClientIds.has(id) ? 'manual-client' : 'manual-admin',
+      operator: 'qa',
+      performedAt: '2026-04-22T15:00:00.000Z',
+      summary: `${id} manual evidence ok`,
+      artifacts: [manualArtifactRefForCheck(id)],
+    }
+  }
+  return {
+    source: 'api-bootstrap',
+    notes: `${id} ok`,
+  }
+}
+
+function writeCompletedSession(sessionDir, options = {}) {
+  const workspaceDir = path.join(sessionDir, 'workspace')
+  mkdirSync(workspaceDir, { recursive: true })
+  const evidence = {
+    runId: 'remote-20260422',
+    executedAt: '2026-04-22T15:00:00.000Z',
+    environment: {
+      apiBase: 'http://142.171.239.56:8900',
+      webBase: 'http://142.171.239.56:8081',
+      operator: 'qa',
+    },
+    checks: requiredIds.map((id) => ({
+      id,
+      status: 'pass',
+      evidence: makePassingEvidenceForCheck(id),
+    })),
+    artifacts: [],
+  }
+  writeFileSync(path.join(workspaceDir, 'evidence.json'), `${JSON.stringify(evidence, null, 2)}\n`, 'utf8')
+  for (const id of [...manualClientIds, ...manualAdminIds]) {
+    const artifactRef = manualArtifactRefForCheck(id)
+    if (options.omitArtifactFor === id) continue
+    const artifactPath = path.join(workspaceDir, artifactRef)
+    mkdirSync(path.dirname(artifactPath), { recursive: true })
+    writeFileSync(artifactPath, `${id} evidence\n`, 'utf8')
+  }
+  writeFileSync(path.join(sessionDir, 'session-summary.json'), `${JSON.stringify({
+    tool: 'dingtalk-p4-smoke-session',
+    runId: 'existing-session',
+    generatedAt: '2026-04-22T15:00:00.000Z',
+    steps: [
+      { id: 'preflight', label: 'preflight', status: 'pass', exitCode: 0 },
+      { id: 'api-runner', label: 'api runner', status: 'pass', exitCode: 0 },
+      { id: 'compile', label: 'compile', status: 'pass', exitCode: 0 },
+    ],
+  }, null, 2)}\n`, 'utf8')
 }
 
 function readRequestBody(req) {
@@ -282,10 +356,13 @@ test('dingtalk-p4-smoke-session runs preflight, API runner, and non-strict compi
     assert.doesNotMatch(sessionSummaryText, /SECabcdefghijklmnop12345678/)
     const sessionSummary = JSON.parse(sessionSummaryText)
     assert.equal(sessionSummary.overallStatus, 'manual_pending')
+    assert.equal(sessionSummary.sessionPhase, 'bootstrap')
+    assert.equal(sessionSummary.finalStrictStatus, 'not_run')
     assert.deepEqual(sessionSummary.steps.map((step) => step.id), ['preflight', 'api-runner', 'compile'])
     assert.equal(sessionSummary.steps.every((step) => step.status === 'pass'), true)
     assert.equal(sessionSummary.pendingChecks.some((check) => check.id === 'authorized-user-submit' && check.manual), true)
     assert.equal(sessionSummary.pendingChecks.some((check) => check.id === 'send-group-message-form-link' && check.manual), true)
+    assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--finalize')), true)
 
     const compiledSummary = JSON.parse(readFileSync(path.join(outputDir, 'compiled/summary.json'), 'utf8'))
     assert.equal(compiledSummary.overallStatus, 'fail')
@@ -336,4 +413,88 @@ test('dingtalk-p4-smoke-session stops after failed preflight', () => {
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }
+})
+
+test('dingtalk-p4-smoke-session finalizes completed manual evidence with strict compile', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'session')
+
+  try {
+    writeCompletedSession(outputDir)
+
+    const result = spawnSync(process.execPath, [
+      scriptPath,
+      '--finalize',
+      outputDir,
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.equal(existsSync(path.join(outputDir, 'compiled/summary.json')), true)
+    const compiledSummary = JSON.parse(readFileSync(path.join(outputDir, 'compiled/summary.json'), 'utf8'))
+    assert.equal(compiledSummary.overallStatus, 'pass')
+
+    const sessionSummary = JSON.parse(readFileSync(path.join(outputDir, 'session-summary.json'), 'utf8'))
+    assert.equal(sessionSummary.runId, 'existing-session')
+    assert.equal(sessionSummary.overallStatus, 'pass')
+    assert.equal(sessionSummary.sessionPhase, 'finalize')
+    assert.equal(sessionSummary.finalStrictStatus, 'pass')
+    assert.deepEqual(sessionSummary.steps.map((step) => step.id), ['preflight', 'api-runner', 'compile', 'strict-compile'])
+    assert.equal(sessionSummary.steps.at(-1).status, 'pass')
+    assert.equal(sessionSummary.pendingChecks.length, 0)
+    assert.equal(sessionSummary.finalStrictSummary.overallStatus, 'pass')
+    assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--strict')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-session finalize fails when strict evidence is incomplete', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'session')
+
+  try {
+    writeCompletedSession(outputDir, { omitArtifactFor: 'authorized-user-submit' })
+
+    const result = spawnSync(process.execPath, [
+      scriptPath,
+      '--finalize',
+      outputDir,
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stdout, /session-summary\.json/)
+    const sessionSummary = JSON.parse(readFileSync(path.join(outputDir, 'session-summary.json'), 'utf8'))
+    assert.equal(sessionSummary.overallStatus, 'fail')
+    assert.equal(sessionSummary.sessionPhase, 'finalize')
+    assert.equal(sessionSummary.finalStrictStatus, 'fail')
+    assert.equal(sessionSummary.steps.at(-1).id, 'strict-compile')
+    assert.equal(sessionSummary.steps.at(-1).status, 'fail')
+    assert.equal(sessionSummary.finalStrictSummary.overallStatus, 'fail')
+    assert.equal(sessionSummary.finalStrictSummary.manualEvidenceIssueCount > 0, true)
+    assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--finalize')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-session rejects finalize output-dir ambiguity', () => {
+  const result = spawnSync(process.execPath, [
+    scriptPath,
+    '--finalize',
+    'output/session',
+    '--output-dir',
+    'output/other',
+  ], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /--output-dir is not used with --finalize/)
 })


### PR DESCRIPTION
## Summary

- add `--finalize <session-dir>` to rerun strict compile against a completed P4 smoke session workspace
- refresh `session-summary.json/md` with `sessionPhase`, `finalStrictStatus`, final strict issue counts, and blocking issue lists
- make bootstrap summaries recommend `--finalize` instead of a raw strict compiler command
- cover finalize pass, finalize failure, and ambiguous finalize arguments in tests
- update checklist, TODO, and development/verification notes

## Verification

```bash
node --check scripts/ops/dingtalk-p4-smoke-session.mjs
node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
git diff --cached --check
```

Stacked on #1089.