### PR TITLE
test(approval): skip repeated schema bootstrap DDL

### DIFF
--- a/docs/development/approval-schema-bootstrap-marker-development-20260423.md
+++ b/docs/development/approval-schema-bootstrap-marker-development-20260423.md
@@ -1,0 +1,46 @@
+# Approval Schema Bootstrap Marker Development - 2026-04-23
+
+## Scope
+
+This change hardens the approval integration-test schema bootstrap so multiple approval API test files can run in the same Vitest invocation against one shared local Postgres database.
+
+The previous helper already used `pg_advisory_xact_lock`, but the lock only serialized bootstrap callers. It did not prevent this sequence:
+
+1. Worker A acquires the lock, runs the full DDL bootstrap, commits, and starts its HTTP server.
+2. Worker B then acquires the lock and repeats the same DDL.
+3. Worker B's `ALTER TABLE` / index statements can conflict with worker A's live API queries, producing a Postgres deadlock.
+
+## Change
+
+`ensureApprovalSchemaReady()` now combines two guards:
+
+- `pg_advisory_xact_lock(hashtext('approval-schema-bootstrap'))` serializes concurrent bootstrap entry.
+- `approval_test_schema_bootstrap_state` stores a DB-persisted bootstrap version marker.
+
+Under the advisory lock, the helper now:
+
+1. Creates the marker table if missing.
+2. Reads `key='approval-schema-bootstrap'`.
+3. If the stored version is `20260423-once-per-db`, commits and returns without running DDL.
+4. Otherwise runs the full approval schema DDL.
+5. Upserts the marker version at the end of the same transaction.
+
+This makes the first worker perform the full bootstrap and makes later workers skip repeat DDL after the schema has already been materialized.
+
+## Files
+
+- `packages/core-backend/tests/helpers/approval-schema-bootstrap.ts`
+
+## Design Notes
+
+- The marker is DB-scoped rather than process memory, because Vitest file workers run independently.
+- The marker is versioned so future helper changes can intentionally force one new bootstrap pass by bumping `APPROVAL_SCHEMA_BOOTSTRAP_VERSION`.
+- The marker table is test-only and lives alongside the approval test schema in local/integration databases.
+- The marker is written only after all DDL succeeds, so a failed bootstrap does not poison later retries.
+
+## Non-Goals
+
+- No production migration.
+- No runtime service code change.
+- No attempt to suppress unrelated degraded-mode startup logs for absent BPMN/EventBus/Automation tables in the local test database.
+

--- a/docs/development/approval-schema-bootstrap-marker-verification-20260423.md
+++ b/docs/development/approval-schema-bootstrap-marker-verification-20260423.md
@@ -1,0 +1,114 @@
+# Approval Schema Bootstrap Marker Verification - 2026-04-23
+
+## Baseline Failure
+
+Before the marker change, this command reproduced the existing fixture race:
+
+```bash
+DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/approval-wp1-any-mode.api.test.ts \
+  tests/integration/approval-pack1a-lifecycle.api.test.ts \
+  tests/integration/approval-wp2-source-filter.api.test.ts \
+  tests/integration/approval-wp1-parallel-gateway.api.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 failed | 3 passed (4)
+Tests       14 passed (15)
+Failure     deadlock detected in ensureApprovalSchemaReady()
+Exit        1
+```
+
+Postgres detail:
+
+```text
+Process waits for AccessExclusiveLock on approval_assignments while another process waits for RowShareLock.
+```
+
+## Commands Run
+
+Backend typecheck:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result:
+
+```text
+Exit 0
+```
+
+Multi-file approval integration, first run after fix:
+
+```bash
+DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/approval-wp1-any-mode.api.test.ts \
+  tests/integration/approval-pack1a-lifecycle.api.test.ts \
+  tests/integration/approval-wp2-source-filter.api.test.ts \
+  tests/integration/approval-wp1-parallel-gateway.api.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests       15 passed (15)
+Exit        0
+```
+
+Multi-file approval integration, repeat run with marker present:
+
+```bash
+DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/approval-wp1-any-mode.api.test.ts \
+  tests/integration/approval-pack1a-lifecycle.api.test.ts \
+  tests/integration/approval-wp2-source-filter.api.test.ts \
+  tests/integration/approval-wp1-parallel-gateway.api.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests       15 passed (15)
+Exit        0
+```
+
+Marker check:
+
+```bash
+psql postgresql://chouhua@127.0.0.1:5432/postgres -Atqc \
+  "SELECT key || '=' || version FROM approval_test_schema_bootstrap_state WHERE key = 'approval-schema-bootstrap'"
+```
+
+Result:
+
+```text
+approval-schema-bootstrap=20260423-once-per-db
+```
+
+Diff hygiene:
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+Exit 0
+```
+
+## Notes
+
+The local test database still logs degraded-mode startup errors for unrelated missing BPMN/EventBus/Automation tables. Those messages pre-existed this change and did not fail the approval integration tests.
+

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -1,5 +1,8 @@
 import { poolManager } from '../../src/integration/db/connection-pool'
 
+const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260423-once-per-db'
+
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
  * materialized for the integration-test suite.
@@ -23,10 +26,17 @@ import { poolManager } from '../../src/integration/db/connection-pool'
  * race in `pg_class`, producing Postgres errors 42710 (duplicate_object) or
  * 23505 (unique violation on `pg_class`/`pg_constraint`).
  *
- * We serialize the entire DDL sequence with a session-scoped advisory lock
- * acquired inside a dedicated `pg.PoolClient` and released automatically on
- * `COMMIT` / `ROLLBACK` (that is what `pg_advisory_xact_lock` does — as
- * opposed to `pg_advisory_lock`, which would require an explicit unlock).
+ * We serialize the entire DDL sequence with a session-scoped advisory lock and
+ * a DB-persisted version marker. The advisory lock prevents concurrent
+ * bootstraps from interleaving, while the marker prevents worker B from running
+ * the same DDL after worker A has already committed and started its HTTP server.
+ * That second phase matters because otherwise worker B's repeat ALTER/INDEX
+ * statements can still deadlock with worker A's live API queries.
+ *
+ * The advisory lock is acquired inside a dedicated `pg.PoolClient` and released
+ * automatically on `COMMIT` / `ROLLBACK` (that is what
+ * `pg_advisory_xact_lock` does — as opposed to `pg_advisory_lock`, which would
+ * require an explicit unlock).
  *
  * The lock key is `hashtext('approval-schema-bootstrap')` — int4 up-cast by
  * Postgres to int8 for the one-arg form of `pg_advisory_xact_lock`.
@@ -44,7 +54,23 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
   const client = await pool.connect()
   try {
     await client.query('BEGIN')
-    await client.query(`SELECT pg_advisory_xact_lock(hashtext('approval-schema-bootstrap'))`)
+    await client.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [APPROVAL_SCHEMA_BOOTSTRAP_KEY])
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS approval_test_schema_bootstrap_state (
+        key TEXT PRIMARY KEY,
+        version TEXT NOT NULL,
+        completed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `)
+    const marker = await client.query<{ version: string }>(
+      `SELECT version FROM approval_test_schema_bootstrap_state WHERE key = $1`,
+      [APPROVAL_SCHEMA_BOOTSTRAP_KEY],
+    )
+    if (marker.rows[0]?.version === APPROVAL_SCHEMA_BOOTSTRAP_VERSION) {
+      await client.query('COMMIT')
+      return
+    }
 
     await client.query('CREATE EXTENSION IF NOT EXISTS pgcrypto')
 
@@ -249,6 +275,15 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_published_definitions_active_template ON approval_published_definitions(template_id) WHERE is_active = TRUE`)
 
     await client.query(`CREATE SEQUENCE IF NOT EXISTS approval_request_no_seq START WITH 100001 INCREMENT BY 1`)
+
+    await client.query(
+      `INSERT INTO approval_test_schema_bootstrap_state (key, version, completed_at)
+       VALUES ($1, $2, now())
+       ON CONFLICT (key)
+       DO UPDATE SET version = EXCLUDED.version,
+                     completed_at = EXCLUDED.completed_at`,
+      [APPROVAL_SCHEMA_BOOTSTRAP_KEY, APPROVAL_SCHEMA_BOOTSTRAP_VERSION],
+    )
 
     await client.query('COMMIT')
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes the approval integration-test DDL deadlock that occurs when multiple approval API test files run in one Vitest invocation against the same shared local Postgres database.

What changed:
- Keep the existing `pg_advisory_xact_lock(hashtext('approval-schema-bootstrap'))` serialization.
- Add a DB-persisted marker table `approval_test_schema_bootstrap_state`.
- Skip the full DDL body when marker version `20260423-once-per-db` is already present.
- Upsert the marker only after the full approval schema bootstrap succeeds.

Why this is needed:
- The advisory lock serialized bootstrap callers, but worker A could finish bootstrap and start its HTTP server before worker B repeated the same DDL.
- Worker B's repeated `ALTER TABLE` / index statements could then deadlock with worker A's live API queries.
- The marker makes the first worker materialize schema and later workers return without touching approval DDL.

## Verification

Baseline before fix:
- Multi-file approval integration command failed with `deadlock detected` in `ensureApprovalSchemaReady()`.
- Result was `1 failed | 3 passed`, `14/15` tests passed.

After fix:
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` -> exit 0
- Multi-file approval integration command -> `4 files / 15 tests passed`, exit 0
- Same multi-file command repeated with marker present -> `4 files / 15 tests passed`, exit 0
- Marker query -> `approval-schema-bootstrap=20260423-once-per-db`
- `git diff --check` -> exit 0

Command used:

```bash
DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres \
  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/approval-wp1-any-mode.api.test.ts \
  tests/integration/approval-pack1a-lifecycle.api.test.ts \
  tests/integration/approval-wp2-source-filter.api.test.ts \
  tests/integration/approval-wp1-parallel-gateway.api.test.ts \
  --reporter=dot
```

## Notes

This is test-only infrastructure. No production migration or runtime service code changes.
