### PR TITLE
feat(spreadsheets): send expectedVersion from legacy cells UI

### DIFF
--- a/apps/web/src/utils/spreadsheetCellVersions.ts
+++ b/apps/web/src/utils/spreadsheetCellVersions.ts
@@ -1,0 +1,97 @@
+export type CellVersionMap = Record<string, number>
+
+export interface SpreadsheetServerCell {
+  row_index: number
+  column_index: number
+  version?: number | null
+}
+
+export interface SpreadsheetCellPatch {
+  row: number
+  col: number
+  value?: string | null
+  formula?: string
+  dataType?: string
+  expectedVersion?: number
+}
+
+export interface CellVersionConflictPayload {
+  code?: string
+  message?: string
+  row?: number
+  col?: number
+  serverVersion?: number
+  expectedVersion?: number
+}
+
+export function cellVersionKey(row: number, col: number): string {
+  return `${row}:${col}`
+}
+
+export function formatCellReference(row: number, col: number): string {
+  let label = ''
+  let index = col
+  while (index >= 0) {
+    label = String.fromCharCode(65 + (index % 26)) + label
+    index = Math.floor(index / 26) - 1
+  }
+  return `${label}${row + 1}`
+}
+
+export function buildCellVersionMap(cells: readonly SpreadsheetServerCell[]): CellVersionMap {
+  return mergeCellVersionMap({}, cells)
+}
+
+export function mergeCellVersionMap(
+  current: CellVersionMap,
+  cells: readonly SpreadsheetServerCell[],
+): CellVersionMap {
+  const next: CellVersionMap = { ...current }
+  for (const cell of cells) {
+    if (typeof cell.version !== 'number') continue
+    if (!Number.isInteger(cell.row_index) || !Number.isInteger(cell.column_index)) continue
+    next[cellVersionKey(cell.row_index, cell.column_index)] = cell.version
+  }
+  return next
+}
+
+export function withExpectedCellVersions<T extends { row: number; col: number }>(
+  cells: readonly T[],
+  versions: CellVersionMap,
+): Array<T & { expectedVersion?: number }> {
+  return cells.map((cell) => {
+    const expectedVersion = versions[cellVersionKey(cell.row, cell.col)]
+    if (typeof expectedVersion !== 'number') {
+      return { ...cell }
+    }
+    return { ...cell, expectedVersion }
+  })
+}
+
+export function isCellVersionConflict(error: unknown): error is CellVersionConflictPayload {
+  return Boolean(error && typeof error === 'object' && (error as CellVersionConflictPayload).code === 'VERSION_CONFLICT')
+}
+
+export function formatCellVersionConflict(
+  error: CellVersionConflictPayload,
+  options: { locale?: 'en' | 'zh-CN' } = {},
+): string {
+  const row = typeof error.row === 'number' ? error.row : undefined
+  const col = typeof error.col === 'number' ? error.col : undefined
+  const cell = row !== undefined && col !== undefined ? formatCellReference(row, col) : undefined
+  const serverVersion = typeof error.serverVersion === 'number' ? error.serverVersion : undefined
+  const expectedVersion = typeof error.expectedVersion === 'number' ? error.expectedVersion : undefined
+  const versionHint = serverVersion !== undefined && expectedVersion !== undefined
+    ? options.locale === 'zh-CN'
+      ? `服务器版本：${serverVersion}，本地版本：${expectedVersion}`
+      : `server version: ${serverVersion}, expected: ${expectedVersion}`
+    : undefined
+
+  if (options.locale === 'zh-CN') {
+    const target = cell ? `单元格 ${cell}` : '单元格'
+    return `${target} 已被其他会话更新，请刷新后重试。${versionHint ? `（${versionHint}）` : ''}`
+  }
+
+  const target = cell ? `Cell ${cell}` : 'The cell'
+  return `${target} was changed by another session. Refresh before retrying.${versionHint ? ` (${versionHint})` : ''}`
+}

--- a/apps/web/src/views/GridView.vue
+++ b/apps/web/src/views/GridView.vue
@@ -261,6 +261,16 @@
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue'
 import { formulaEngine } from '../utils/formulaEngine'
 import { apiFetch } from '../utils/api'
+import {
+  buildCellVersionMap,
+  formatCellVersionConflict,
+  isCellVersionConflict,
+  mergeCellVersionMap,
+  withExpectedCellVersions,
+  type CellVersionMap,
+  type SpreadsheetCellPatch,
+  type SpreadsheetServerCell,
+} from '../utils/spreadsheetCellVersions'
 import ContextMenu from '../components/ContextMenu.vue'
 import type { MenuItem } from '../components/ContextMenu.vue'
 
@@ -289,9 +299,7 @@ interface ServerSheet {
   column_count: number
 }
 
-interface ServerCell {
-  row_index: number
-  column_index: number
+interface ServerCell extends SpreadsheetServerCell {
   value: unknown
   formula: string | null
 }
@@ -318,6 +326,7 @@ const lastSaved = ref('')
 const saveNotice = ref('')
 const lastSyncedData = ref<string[][] | null>(null)
 const lastSyncedSize = ref<{ rows: number; cols: number } | null>(null)
+const cellVersions = ref<CellVersionMap>({})
 const gridSpreadsheetId = ref<string | null>(null)
 const gridSheetId = ref<string | null>(null)
 
@@ -363,6 +372,7 @@ const rowHeights = ref<Record<number, number>>({})
 
 // 初始化数据
 function initData() {
+  cellVersions.value = {}
   data.value = Array(rows.value).fill(null).map(() =>
     Array(cols.value).fill('')
   )
@@ -616,6 +626,7 @@ function normalizeCellValue(value: unknown): string {
 }
 
 function applyServerCells(cells: ServerCell[], sizeHint?: { rows: number; cols: number }) {
+  cellVersions.value = buildCellVersionMap(cells)
   let maxRow = DEFAULT_ROWS - 1
   let maxCol = DEFAULT_COLS - 1
 
@@ -673,6 +684,7 @@ function loadGridDataFromStorage(): string[][] | null {
 }
 
 function applyLocalData(savedData: string[][], sizeHint?: { rows: number; cols: number }) {
+  cellVersions.value = {}
   const dataRows = savedData.length
   const dataCols = savedData[0]?.length ?? DEFAULT_COLS
   const targetRows = Math.max(sizeHint?.rows ?? DEFAULT_ROWS, dataRows)
@@ -711,6 +723,7 @@ function storeGridIds(spreadsheetId: string, sheetId: string) {
 function clearGridIds() {
   gridSpreadsheetId.value = null
   gridSheetId.value = null
+  cellVersions.value = {}
   localStorage.removeItem(GRID_SPREADSHEET_ID_KEY)
   localStorage.removeItem(GRID_SHEET_ID_KEY)
 }
@@ -809,6 +822,7 @@ async function loadCellsFromServer(
     }
     rows.value = resolvedSize.rows
     cols.value = resolvedSize.cols
+    cellVersions.value = {}
     data.value = buildEmptyData(rows.value, cols.value)
     recalculateAll()
     snapshotSyncedState()
@@ -819,8 +833,8 @@ async function loadCellsFromServer(
   }
 }
 
-function buildChangedCellPayload(): Array<{ row: number; col: number; value?: string | null; formula?: string }> {
-  const cells: Array<{ row: number; col: number; value?: string | null; formula?: string }> = []
+function buildChangedCellPayload(): SpreadsheetCellPatch[] {
+  const cells: SpreadsheetCellPatch[] = []
   for (let r = 0; r < rows.value; r++) {
     for (let c = 0; c < cols.value; c++) {
       const raw = data.value[r]?.[c] ?? ''
@@ -838,7 +852,7 @@ function buildChangedCellPayload(): Array<{ row: number; col: number; value?: st
       }
     }
   }
-  return cells
+  return withExpectedCellVersions(cells, cellVersions.value)
 }
 
 // 保存数据
@@ -870,6 +884,8 @@ async function saveData() {
     const payload = await response.json().catch(() => null)
 
     if (response.ok && payload?.ok) {
+      const updatedCells = Array.isArray(payload.data?.cells) ? payload.data.cells as ServerCell[] : []
+      cellVersions.value = mergeCellVersionMap(cellVersions.value, updatedCells)
       lastSaved.value = new Date().toLocaleTimeString()
       snapshotSyncedState()
       saveNotice.value = '已保存'
@@ -890,6 +906,12 @@ async function saveData() {
 
       alert('保存成功！')
     } else {
+      if (response.status === 409 && isCellVersionConflict(payload?.error)) {
+        const message = formatCellVersionConflict(payload.error, { locale: 'zh-CN' })
+        saveNotice.value = message
+        alert(message)
+        return
+      }
       throw new Error(payload?.error?.message || '保存失败')
     }
   } catch (error) {
@@ -1176,6 +1198,7 @@ watch(autoSaveEnabled, (enabled) => {
 async function loadSavedData() {
   lastSyncedData.value = null
   lastSyncedSize.value = null
+  cellVersions.value = {}
   const sizeHint = loadGridSizeFromStorage()
   const localData = loadGridDataFromStorage()
 

--- a/apps/web/src/views/SpreadsheetDetailView.vue
+++ b/apps/web/src/views/SpreadsheetDetailView.vue
@@ -77,6 +77,16 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { apiFetch } from '../utils/api'
+import {
+  buildCellVersionMap,
+  formatCellVersionConflict,
+  isCellVersionConflict,
+  mergeCellVersionMap,
+  withExpectedCellVersions,
+  type CellVersionMap,
+  type SpreadsheetCellPatch,
+  type SpreadsheetServerCell,
+} from '../utils/spreadsheetCellVersions'
 
 interface SheetItem {
   id: string
@@ -87,6 +97,11 @@ interface SpreadsheetDetail {
   id: string
   name: string
   sheets: SheetItem[]
+}
+
+interface ServerCell extends SpreadsheetServerCell {
+  value: unknown
+  formula: string | null
 }
 
 const route = useRoute()
@@ -104,11 +119,19 @@ const cellType = ref<string>('')
 const statusMessage = ref('')
 const statusKind = ref<'success' | 'error'>('success')
 const lastResponse = ref('')
+const cellVersions = ref<CellVersionMap>({})
 
 const spreadsheetId = computed(() => route.params.id as string)
 
-function selectSheet(id: string) {
+async function selectSheet(id: string) {
   selectedSheetId.value = id
+  statusMessage.value = ''
+  try {
+    await fetchSelectedSheetCells()
+  } catch (error) {
+    statusKind.value = 'error'
+    statusMessage.value = error instanceof Error ? error.message : 'Failed to load sheet cells'
+  }
 }
 
 function goBack() {
@@ -118,6 +141,7 @@ function goBack() {
 async function fetchSpreadsheet() {
   if (!spreadsheetId.value) return
   loading.value = true
+  statusMessage.value = ''
   try {
     const response = await apiFetch(`/api/spreadsheets/${spreadsheetId.value}`)
     const payload = await response.json().catch(() => null)
@@ -125,8 +149,14 @@ async function fetchSpreadsheet() {
       throw new Error(payload?.error?.message || 'Failed to load spreadsheet')
     }
     spreadsheet.value = payload.data
-    if (!selectedSheetId.value && spreadsheet.value?.sheets?.length) {
-      selectedSheetId.value = spreadsheet.value.sheets[0].id
+    const sheetIds = new Set(spreadsheet.value?.sheets?.map((sheet) => sheet.id) ?? [])
+    if (!selectedSheetId.value || !sheetIds.has(selectedSheetId.value)) {
+      selectedSheetId.value = spreadsheet.value?.sheets?.[0]?.id ?? ''
+    }
+    if (selectedSheetId.value) {
+      await fetchSelectedSheetCells()
+    } else {
+      cellVersions.value = {}
     }
   } catch (error) {
     statusKind.value = 'error'
@@ -134,6 +164,26 @@ async function fetchSpreadsheet() {
   } finally {
     loading.value = false
   }
+}
+
+async function fetchSelectedSheetCells() {
+  if (!spreadsheetId.value || !selectedSheetId.value) {
+    cellVersions.value = {}
+    return
+  }
+
+  const sheetId = selectedSheetId.value
+  cellVersions.value = {}
+  const response = await apiFetch(`/api/spreadsheets/${spreadsheetId.value}/sheets/${sheetId}/cells`)
+  const payload = await response.json().catch(() => null)
+  if (!response.ok || !payload?.ok) {
+    throw new Error(payload?.error?.message || 'Failed to load sheet cells')
+  }
+
+  if (selectedSheetId.value !== sheetId) return
+  const cells = Array.isArray(payload.data?.cells) ? payload.data.cells as ServerCell[] : []
+  cellVersions.value = buildCellVersionMap(cells)
+  lastResponse.value = JSON.stringify(payload.data, null, 2)
 }
 
 async function updateCell() {
@@ -145,22 +195,29 @@ async function updateCell() {
   updating.value = true
   statusMessage.value = ''
   try {
+    const cell: SpreadsheetCellPatch = {
+      row: cellRow.value,
+      col: cellCol.value,
+      value: cellValue.value || null,
+      formula: cellFormula.value || undefined,
+      dataType: cellType.value || undefined
+    }
+    const cells = withExpectedCellVersions([cell], cellVersions.value)
     const response = await apiFetch(`/api/spreadsheets/${spreadsheetId.value}/sheets/${selectedSheetId.value}/cells`, {
       method: 'PUT',
       body: JSON.stringify({
-        cells: [{
-          row: cellRow.value,
-          col: cellCol.value,
-          value: cellValue.value || null,
-          formula: cellFormula.value || undefined,
-          dataType: cellType.value || undefined
-        }]
+        cells
       })
     })
     const payload = await response.json().catch(() => null)
     if (!response.ok || !payload?.ok) {
+      if (response.status === 409 && isCellVersionConflict(payload?.error)) {
+        throw new Error(formatCellVersionConflict(payload.error))
+      }
       throw new Error(payload?.error?.message || 'Failed to update cell')
     }
+    const updatedCells = Array.isArray(payload.data?.cells) ? payload.data.cells as ServerCell[] : []
+    cellVersions.value = mergeCellVersionMap(cellVersions.value, updatedCells)
     statusKind.value = 'success'
     statusMessage.value = 'Cell updated.'
     lastResponse.value = JSON.stringify(payload.data, null, 2)

--- a/apps/web/tests/spreadsheet-cell-versioning.spec.ts
+++ b/apps/web/tests/spreadsheet-cell-versioning.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCellVersionMap,
+  cellVersionKey,
+  formatCellReference,
+  formatCellVersionConflict,
+  isCellVersionConflict,
+  mergeCellVersionMap,
+  withExpectedCellVersions,
+} from '../src/utils/spreadsheetCellVersions'
+
+describe('spreadsheet legacy cell versioning helpers', () => {
+  it('indexes server cell versions by row and column', () => {
+    expect(buildCellVersionMap([
+      { row_index: 0, column_index: 0, version: 1 },
+      { row_index: 4, column_index: 27, version: 9 },
+      { row_index: 2, column_index: 3, version: null },
+    ])).toEqual({
+      [cellVersionKey(0, 0)]: 1,
+      [cellVersionKey(4, 27)]: 9,
+    })
+  })
+
+  it('adds expectedVersion only for cells with a known server version', () => {
+    const patches = withExpectedCellVersions([
+      { row: 0, col: 0, value: 'A1' },
+      { row: 1, col: 0, value: 'A2' },
+      { row: 2, col: 0, formula: '=A1+A2', value: null },
+    ], {
+      [cellVersionKey(0, 0)]: 3,
+      [cellVersionKey(2, 0)]: 7,
+    })
+
+    expect(patches).toEqual([
+      { row: 0, col: 0, value: 'A1', expectedVersion: 3 },
+      { row: 1, col: 0, value: 'A2' },
+      { row: 2, col: 0, formula: '=A1+A2', value: null, expectedVersion: 7 },
+    ])
+  })
+
+  it('merges returned update versions without dropping untouched cells', () => {
+    expect(mergeCellVersionMap({
+      [cellVersionKey(0, 0)]: 1,
+      [cellVersionKey(0, 1)]: 2,
+    }, [
+      { row_index: 0, column_index: 0, version: 2 },
+      { row_index: 3, column_index: 2, version: 1 },
+    ])).toEqual({
+      [cellVersionKey(0, 0)]: 2,
+      [cellVersionKey(0, 1)]: 2,
+      [cellVersionKey(3, 2)]: 1,
+    })
+  })
+
+  it('formats A1 references and version conflict messages', () => {
+    expect(formatCellReference(0, 0)).toBe('A1')
+    expect(formatCellReference(4, 27)).toBe('AB5')
+    expect(isCellVersionConflict({ code: 'VERSION_CONFLICT' })).toBe(true)
+    expect(formatCellVersionConflict({
+      code: 'VERSION_CONFLICT',
+      row: 4,
+      col: 27,
+      serverVersion: 9,
+      expectedVersion: 7,
+    })).toBe('Cell AB5 was changed by another session. Refresh before retrying. (server version: 9, expected: 7)')
+    expect(formatCellVersionConflict({
+      code: 'VERSION_CONFLICT',
+      row: 0,
+      col: 0,
+      serverVersion: 2,
+      expectedVersion: 1,
+    }, { locale: 'zh-CN' })).toBe('单元格 A1 已被其他会话更新，请刷新后重试。（服务器版本：2，本地版本：1）')
+  })
+})

--- a/docs/development/legacy-cells-expected-version-frontend-development-20260423.md
+++ b/docs/development/legacy-cells-expected-version-frontend-development-20260423.md
@@ -1,0 +1,77 @@
+# Legacy Cells Expected Version Frontend Development - 2026-04-23
+
+## Context
+
+Backend PR #1042 added optimistic locking to the legacy spreadsheet cells PUT route:
+
+- Existing cells accept `expectedVersion`.
+- Mismatches return `409 VERSION_CONFLICT` with `serverVersion` and `expectedVersion`.
+- Missing `expectedVersion` preserves last-write-wins compatibility for old clients.
+
+This follow-up wires the frontend opt-in path so legacy spreadsheet UIs use the new backend seam when the server has already returned a cell version.
+
+## Scope
+
+Included:
+
+- `GridView.vue` sends `expectedVersion` for changed cells with known server versions.
+- `SpreadsheetDetailView.vue` loads sheet cell versions and sends `expectedVersion` for the manual update form.
+- Shared helper module for cell version maps, conflict formatting, and payload enrichment.
+- Focused frontend unit coverage for the helper behavior.
+
+Not included:
+
+- Full collaborative editing for legacy spreadsheets.
+- Automatic conflict reconciliation.
+- Frontend GridView/SpreadsheetDetailView end-to-end browser automation.
+
+## Implementation
+
+### Shared Helper
+
+Added `apps/web/src/utils/spreadsheetCellVersions.ts`:
+
+- `buildCellVersionMap(cells)` indexes backend rows by `row:col`.
+- `mergeCellVersionMap(current, cells)` updates cached versions from successful PUT responses.
+- `withExpectedCellVersions(cells, versions)` adds `expectedVersion` only when the version is known.
+- `formatCellVersionConflict(error, locale)` turns the backend `VERSION_CONFLICT` payload into user-facing copy.
+
+The helper intentionally omits `expectedVersion` for unknown/new cells so old and first-write flows keep the backend's LWW compatibility.
+
+### GridView
+
+`apps/web/src/views/GridView.vue` now keeps a `cellVersions` cache:
+
+- Server load populates the cache from GET `/cells`.
+- Empty/fallback/local loads clear the cache.
+- Save payloads are built from changed cells, then enriched with `expectedVersion` when available.
+- Successful PUT responses merge returned cell versions before snapshotting the synced state.
+- `409 VERSION_CONFLICT` is handled explicitly and does not snapshot local edits.
+
+### SpreadsheetDetailView
+
+`apps/web/src/views/SpreadsheetDetailView.vue` now:
+
+- Loads selected sheet cells after spreadsheet load and sheet switching.
+- Clears the selected-sheet version cache before async cell loading so a fast edit cannot reuse another sheet's stale version.
+- Ignores stale cell-load responses if the selected sheet changes while the request is in flight.
+- Tracks `row_index`/`column_index` versions for the selected sheet.
+- Sends `expectedVersion` for the update form when available.
+- Merges successful PUT response versions.
+- Surfaces `409 VERSION_CONFLICT` with refresh/retry guidance.
+
+## Design Notes
+
+- Version cache is client-side state only; it is rebuilt from backend GET responses.
+- Unknown versions are treated as old-client compatibility, not as version `0`.
+- Conflict handling is deliberately conservative: the frontend preserves the user's local edit and asks for refresh rather than overwriting with server data.
+- The new helper is pure TypeScript so it can be tested without mounting the legacy views.
+
+## Changed Files
+
+- `apps/web/src/utils/spreadsheetCellVersions.ts`
+- `apps/web/src/views/GridView.vue`
+- `apps/web/src/views/SpreadsheetDetailView.vue`
+- `apps/web/tests/spreadsheet-cell-versioning.spec.ts`
+- `docs/development/legacy-cells-expected-version-frontend-development-20260423.md`
+- `docs/development/legacy-cells-expected-version-frontend-verification-20260423.md`

--- a/docs/development/legacy-cells-expected-version-frontend-verification-20260423.md
+++ b/docs/development/legacy-cells-expected-version-frontend-verification-20260423.md
@@ -1,0 +1,96 @@
+# Legacy Cells Expected Version Frontend Verification - 2026-04-23
+
+## Summary
+
+Result: PASS
+
+This verification covers the legacy spreadsheet frontend opt-in for backend cell optimistic locking from PR #1042.
+
+## Commands
+
+### Dependency Bootstrap
+
+```bash
+pnpm install --frozen-lockfile
+git restore -- plugins/ tools/cli/node_modules
+```
+
+Result: PASS
+
+Notes:
+
+- The new worktree did not have local dependencies.
+- `pnpm install` produced known plugin/CLI `node_modules` symlink noise.
+- Only those dependency-link paths were restored; business files were preserved.
+
+### Frontend Focused Unit Test
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/spreadsheet-cell-versioning.spec.ts --reporter=dot
+```
+
+Result: PASS
+
+Output:
+
+```text
+Test Files  1 passed (1)
+Tests       4 passed (4)
+```
+
+Note: Vitest printed `WebSocket server error: Port is already in use` during one focused frontend run, but the process exited 0 and all target assertions passed. No dev server was required for this test.
+
+Coverage:
+
+- Builds version cache from server cells.
+- Adds `expectedVersion` only for known cells.
+- Merges successful PUT response versions without dropping untouched cells.
+- Formats conflict messages from `VERSION_CONFLICT` payloads.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: PASS
+
+### Backend Regression For PR #1042 Contract
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/spreadsheets-cell-version.test.ts --reporter=dot
+```
+
+Result: PASS
+
+Output:
+
+```text
+Test Files  1 passed (1)
+Tests       7 passed (7)
+```
+
+### Whitespace Check
+
+```bash
+git diff --check
+```
+
+Result: PASS
+
+## Manual Verification Plan
+
+Recommended staging checks after merge:
+
+1. Open the same legacy spreadsheet in two browser sessions.
+2. Session A loads cells and edits `A1`, then saves.
+3. Session B, without refresh, edits the same `A1` and saves.
+4. Expected: Session B receives a `409 VERSION_CONFLICT` message and local edits are not marked synced.
+5. Refresh Session B, edit again, save.
+6. Expected: save succeeds and the version cache advances from the PUT response.
+
+## Limitations
+
+- No automatic merge UI is implemented for legacy spreadsheet cells.
+- Unknown/new cells still omit `expectedVersion` to preserve old-client compatibility.
+- This branch does not add browser automation for the two-session conflict flow.

--- a/output/delivery/legacy-cells-expected-version-frontend-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/legacy-cells-expected-version-frontend-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,41 @@
+# Legacy Cells Expected Version Frontend - Test And Verification
+
+Date: 2026-04-23
+
+## Result
+
+PASS
+
+## Delivered
+
+- `GridView.vue` now sends `expectedVersion` for changed legacy spreadsheet cells when the frontend has a known server version.
+- `SpreadsheetDetailView.vue` now preloads selected-sheet cell versions and sends `expectedVersion` from the manual cell update form.
+- Shared pure helper added for version-map creation, payload enrichment, response version merging, and conflict message formatting.
+- Conflict responses preserve local edits and tell the user to refresh/retry instead of snapshotting stale state.
+
+## Verified Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/spreadsheet-cell-versioning.spec.ts --reporter=dot
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/spreadsheets-cell-version.test.ts --reporter=dot
+git diff --check
+```
+
+## Verified Results
+
+- Frontend focused unit test: 1 file / 4 tests passed.
+- Frontend type check: passed.
+- Backend PR #1042 contract regression: 1 file / 7 tests passed.
+- Whitespace check: passed.
+
+## Staging Manual Check
+
+Use two browser sessions against one legacy spreadsheet:
+
+1. Session A and B load the same sheet.
+2. Session A updates `A1` and saves.
+3. Session B updates stale `A1` and saves without refresh.
+4. Expected: Session B gets `VERSION_CONFLICT`; local stale edit is not marked synced.
+5. Refresh Session B and save again.
+6. Expected: save succeeds with the latest returned cell version.


### PR DESCRIPTION
## Summary

- wire legacy GridView saves to include `expectedVersion` for cells with known backend versions
- wire SpreadsheetDetailView to preload selected-sheet cell versions and include `expectedVersion` in manual updates
- add shared frontend helpers and focused unit coverage for version maps, payload enrichment, version merging, and conflict copy
- document development and verification in `docs/development/*legacy-cells-expected-version-frontend*`

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/spreadsheet-cell-versioning.spec.ts --reporter=dot`
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/spreadsheets-cell-version.test.ts --reporter=dot`
- `git diff --check`

## Notes

- Unknown/new cells still omit `expectedVersion` to preserve old-client LWW compatibility.
- Conflict handling preserves local edits and asks the user to refresh/retry; no automatic merge UI is added.