### PR TITLE
test(dingtalk): add P4 final pass packet gate

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -75,6 +75,7 @@
 - [x] Add a P4 smoke session orchestrator that runs preflight, API workspace bootstrap, non-strict compile, and a redacted session summary.
 - [x] Add a P4 smoke session env template initializer for secure one-command staging setup.
 - [x] Add P4 smoke session finalization so completed manual evidence reruns strict compile and refreshes the session summary.
+- [x] Add a P4 final-pass packet gate so release evidence export rejects unfinished, failed, stale-schema, or partially compiled sessions.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-final-pass-packet-gate-development-20260423.md
+++ b/docs/development/dingtalk-p4-final-pass-packet-gate-development-20260423.md
@@ -1,0 +1,50 @@
+# DingTalk P4 Final-Pass Packet Gate Development
+
+- Date: 2026-04-23
+- Scope: staging evidence packet final-pass gating
+- Branch: `codex/dingtalk-p4-evidence-packet-final-gate-20260423`
+
+## What Changed
+
+- Added `--require-dingtalk-p4-pass` to `scripts/ops/export-dingtalk-staging-evidence-packet.mjs`.
+- When enabled, every `--include-output` directory must be a finalized passing DingTalk P4 smoke session; mixed legacy evidence directories are intentionally rejected under this flag.
+- The gate checks:
+  - `session-summary.json` exists and has `tool: "dingtalk-p4-smoke-session"`.
+  - `session-summary.json` has `sessionPhase: "finalize"`.
+  - `session-summary.json` has `overallStatus: "pass"`.
+  - `session-summary.json` has `finalStrictStatus: "pass"`.
+  - `session-summary.json` has no `pendingChecks`.
+  - `session-summary.json` includes a passing `strict-compile` step.
+  - `compiled/summary.json` exists and has `tool: "compile-dingtalk-p4-smoke-evidence"`.
+  - `compiled/summary.json` has `overallStatus: "pass"`.
+  - `compiled/summary.json` has `apiBootstrapStatus: "pass"`.
+  - `compiled/summary.json` has `remoteClientStatus: "pass"`.
+  - All eight required P4 checks exist and have `status: "pass"`.
+  - `compiled/summary.json` has empty arrays for `requiredChecksNotPassed`, `manualEvidenceIssues`, `failedChecks`, and `missingRequiredChecks`.
+  - `compiled/summary.json` totals show zero pending, failed, and missing checks.
+- The exporter validates all included output directories before copying packet files or writing `manifest.json`, so a failed gate does not create a partial new packet.
+- The manifest records `requireDingTalkP4Pass` and per-evidence `dingtalkP4FinalStatus`.
+- The packet README states whether the final-pass gate was enabled.
+- Finalized smoke sessions now recommend the packet export command with `--require-dingtalk-p4-pass`.
+- Updated the P4 smoke checklist and TODO with the final export command.
+
+## Why
+
+The session finalizer can prove that P4 evidence is complete, but the packet exporter previously copied any runtime directory. This gate prevents a release handoff packet from accidentally containing `manual_pending` or strict-failed DingTalk evidence.
+
+## Files
+
+- `scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
+- `scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
+- `scripts/ops/dingtalk-p4-smoke-session.mjs`
+- `scripts/ops/dingtalk-p4-smoke-session.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Flow
+
+1. Run the P4 smoke session.
+2. Fill real manual DingTalk-client/admin evidence.
+3. Run `node scripts/ops/dingtalk-p4-smoke-session.mjs --finalize <session-dir>`.
+4. Export the packet with `node scripts/ops/export-dingtalk-staging-evidence-packet.mjs --include-output <session-dir> --require-dingtalk-p4-pass`.
+5. Review raw included workspace/artifact files for tokens, webhooks, screenshots, or private data before publishing the packet.

--- a/docs/development/dingtalk-p4-final-pass-packet-gate-verification-20260423.md
+++ b/docs/development/dingtalk-p4-final-pass-packet-gate-verification-20260423.md
@@ -1,0 +1,40 @@
+# DingTalk P4 Final-Pass Packet Gate Verification
+
+- Date: 2026-04-23
+- Scope: packet exporter final-pass validation
+
+## Commands Run
+
+```bash
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs`: passed.
+- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`: passed.
+- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`: passed.
+- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed.
+- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`: passed, 10/10 tests.
+- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed, 6/6 tests.
+- `git diff --cached --check`: passed.
+
+## Coverage Notes
+
+- Existing packet export without the new gate remains compatible.
+- Gate success coverage verifies a finalized passing P4 session can be copied and records `dingtalkP4FinalStatus`.
+- Gate failure coverage verifies a `manual_pending` / non-final session is rejected.
+- Strict schema coverage verifies missing arrays, wrong compiler tool, API bootstrap failure, non-empty manual evidence issues, failed strict compile, pending session checks, and non-pass required checks are rejected.
+- Multi-include coverage verifies all included sessions are prevalidated before packet files or manifest are written.
+- Argument coverage verifies `--require-dingtalk-p4-pass` requires at least one `--include-output`.
+- Session finalize coverage verifies the generated final packet export command includes `--require-dingtalk-p4-pass`.
+
+## Remaining Remote Validation
+
+- Export a final packet from the real 142/staging session only after `--finalize` passes.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -165,6 +165,23 @@ node scripts/ops/dingtalk-p4-smoke-session.mjs \
 
 Finalizing reruns strict evidence compile, refreshes `session-summary.json` / `session-summary.md`, and returns non-zero until the manual evidence bundle is complete.
 
+After finalization passes, export a handoff packet with the final-pass gate enabled:
+
+```bash
+node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \
+  --include-output output/dingtalk-p4-remote-smoke-session/142-session \
+  --require-dingtalk-p4-pass \
+  --output-dir artifacts/dingtalk-staging-evidence-packet/142-final
+```
+
+The packet exporter rejects the included session unless the final pass is machine-verifiable:
+
+- `session-summary.json` must be from `dingtalk-p4-smoke-session`, have `sessionPhase: "finalize"`, `overallStatus: "pass"`, `finalStrictStatus: "pass"`, no `pendingChecks`, and a passing `strict-compile` step.
+- `compiled/summary.json` must be from `compile-dingtalk-p4-smoke-evidence`, have `overallStatus`, `apiBootstrapStatus`, and `remoteClientStatus` all set to `pass`.
+- All eight required checks must exist with `status: "pass"`.
+- `requiredChecksNotPassed`, `manualEvidenceIssues`, `failedChecks`, and `missingRequiredChecks` must be arrays and empty.
+- The exporter does not create secrets, but it copies raw included evidence. Review and redact raw workspace/artifact files before release handoff.
+
 ## Preflight Gate
 
 Before calling staging or DingTalk, run the preflight gate to check local tooling, required URLs, bearer token presence, DingTalk webhook format, optional `SEC...` secret format, allowlist inputs, and backend `/health`. It writes only redacted summaries.

--- a/scripts/ops/dingtalk-p4-smoke-session.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.mjs
@@ -378,8 +378,13 @@ function strictCompileCommand(evidencePath, compiledDir) {
   return `node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input ${relativePath(evidencePath)} --output-dir ${relativePath(compiledDir)} --strict`
 }
 
-function exportPacketCommand(outputDir) {
-  return `node scripts/ops/export-dingtalk-staging-evidence-packet.mjs --include-output ${relativePath(outputDir)}`
+function exportPacketCommand(outputDir, requireFinalPass = false) {
+  return [
+    'node scripts/ops/export-dingtalk-staging-evidence-packet.mjs',
+    '--include-output',
+    relativePath(outputDir),
+    ...(requireFinalPass ? ['--require-dingtalk-p4-pass'] : []),
+  ].join(' ')
 }
 
 function finalizeCommand(outputDir, allowExternalArtifactRefs = false) {
@@ -615,8 +620,8 @@ function runFinalStrictCompile(opts) {
         }
       : null,
     nextCommands: strictPassed
-      ? [exportPacketCommand(outputDir)]
-      : [finalizeCommand(outputDir, opts.allowExternalArtifactRefs), exportPacketCommand(outputDir)],
+      ? [exportPacketCommand(outputDir, true)]
+      : [finalizeCommand(outputDir, opts.allowExternalArtifactRefs), exportPacketCommand(outputDir, true)],
   }
 
   writeSessionSummary(summary, outputDir)

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -446,6 +446,7 @@ test('dingtalk-p4-smoke-session finalizes completed manual evidence with strict 
     assert.equal(sessionSummary.pendingChecks.length, 0)
     assert.equal(sessionSummary.finalStrictSummary.overallStatus, 'pass')
     assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--strict')), false)
+    assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--require-dingtalk-p4-pass')), true)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -1,9 +1,19 @@
 #!/usr/bin/env node
 
-import { cpSync, existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 const DEFAULT_OUTPUT_DIR = 'artifacts/dingtalk-staging-evidence-packet'
+const DINGTALK_P4_REQUIRED_CHECK_IDS = [
+  'create-table-form',
+  'bind-two-dingtalk-groups',
+  'set-form-dingtalk-granted',
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'delivery-history-group-person',
+  'no-email-user-create-bind',
+]
 
 const requiredPacketFiles = [
   {
@@ -104,14 +114,18 @@ function printHelp() {
 Exports the DingTalk/shared-dev staging operations packet into one artifact directory.
 
 Options:
-  --output-dir <dir>        Output directory, default ${DEFAULT_OUTPUT_DIR}
-  --include-output <dir>    Optional existing evidence directory to copy into evidence/
-  --help                    Show this help
+  --output-dir <dir>              Output directory, default ${DEFAULT_OUTPUT_DIR}
+  --include-output <dir>          Optional existing evidence directory to copy into evidence/
+  --require-dingtalk-p4-pass      Require every included output to be a finalized passing P4 session
+  --help                          Show this help
 
 Examples:
   node scripts/ops/export-dingtalk-staging-evidence-packet.mjs
   node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \\
     --include-output output/playwright/dingtalk-directory-staging-smoke/20260416-package-script
+  node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \\
+    --include-output output/dingtalk-p4-remote-smoke-session/142-session \\
+    --require-dingtalk-p4-pass
 `)
 }
 
@@ -127,6 +141,7 @@ function parseArgs(argv) {
   const opts = {
     outputDir: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR),
     includeOutputDirs: [],
+    requireDingTalkP4Pass: false,
   }
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -141,6 +156,9 @@ function parseArgs(argv) {
         opts.includeOutputDirs.push(path.resolve(process.cwd(), readRequiredValue(argv, i, arg)))
         i += 1
         break
+      case '--require-dingtalk-p4-pass':
+        opts.requireDingTalkP4Pass = true
+        break
       case '--help':
         printHelp()
         process.exit(0)
@@ -148,6 +166,10 @@ function parseArgs(argv) {
       default:
         throw new Error(`Unknown argument: ${arg}`)
     }
+  }
+
+  if (opts.requireDingTalkP4Pass && opts.includeOutputDirs.length === 0) {
+    throw new Error('--require-dingtalk-p4-pass requires at least one --include-output session directory')
   }
 
   return opts
@@ -176,11 +198,99 @@ function sanitizeEvidenceName(sourceDir) {
     .replace(/^-+|-+$/g, '') || 'evidence'
 }
 
-function copyEvidenceDir(sourceDir, outputDir, index) {
+function readJsonFile(file, label) {
+  if (!existsSync(file) || !statSync(file).isFile()) {
+    throw new Error(`${label} does not exist: ${file}`)
+  }
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function getArray(value, field, failures) {
+  if (!Array.isArray(value)) {
+    failures.push(`${field} is not an array`)
+    return []
+  }
+  return value
+}
+
+function requireEmptyArray(value, field, failures) {
+  const rows = getArray(value, field, failures)
+  if (rows.length > 0) failures.push(`${field} is not empty`)
+  return rows
+}
+
+function hasPassingCheck(requiredChecks, id) {
+  return requiredChecks.some((check) => check?.id === id && check.status === 'pass')
+}
+
+function validateDingTalkP4FinalPass(sourceDir) {
+  const sessionSummaryPath = path.join(sourceDir, 'session-summary.json')
+  const compiledSummaryPath = path.join(sourceDir, 'compiled', 'summary.json')
+  const sessionSummary = readJsonFile(sessionSummaryPath, 'session-summary.json')
+  const compiledSummary = readJsonFile(compiledSummaryPath, 'compiled/summary.json')
+  const failures = []
+
+  if (sessionSummary.tool !== 'dingtalk-p4-smoke-session') failures.push('session-summary.json tool is not dingtalk-p4-smoke-session')
+  if (sessionSummary.sessionPhase !== 'finalize') failures.push('session-summary.json sessionPhase is not finalize')
+  if (sessionSummary.overallStatus !== 'pass') failures.push('session-summary.json overallStatus is not pass')
+  if (sessionSummary.finalStrictStatus !== 'pass') failures.push('session-summary.json finalStrictStatus is not pass')
+  const sessionSteps = getArray(sessionSummary.steps, 'session-summary.json steps', failures)
+  const strictCompileStep = sessionSteps.find((step) => step?.id === 'strict-compile')
+  if (!strictCompileStep) {
+    failures.push('session-summary.json missing strict-compile step')
+  } else if (strictCompileStep.status !== 'pass') {
+    failures.push('session-summary.json strict-compile step is not pass')
+  }
+  requireEmptyArray(sessionSummary.pendingChecks, 'session-summary.json pendingChecks', failures)
+
+  if (compiledSummary.tool !== 'compile-dingtalk-p4-smoke-evidence') failures.push('compiled/summary.json tool is not compile-dingtalk-p4-smoke-evidence')
+  if (compiledSummary.overallStatus !== 'pass') failures.push('compiled/summary.json overallStatus is not pass')
+  if (compiledSummary.apiBootstrapStatus !== 'pass') failures.push('compiled/summary.json apiBootstrapStatus is not pass')
+  if (compiledSummary.remoteClientStatus !== 'pass') failures.push('compiled/summary.json remoteClientStatus is not pass')
+  if (compiledSummary.totals?.pendingChecks !== 0) failures.push('compiled/summary.json totals.pendingChecks is not 0')
+  if (compiledSummary.totals?.missingRequiredChecks !== 0) failures.push('compiled/summary.json totals.missingRequiredChecks is not 0')
+  if (compiledSummary.totals?.failedChecks !== 0) failures.push('compiled/summary.json totals.failedChecks is not 0')
+
+  const requiredChecks = getArray(compiledSummary.requiredChecks, 'compiled/summary.json requiredChecks', failures)
+  for (const id of DINGTALK_P4_REQUIRED_CHECK_IDS) {
+    if (!hasPassingCheck(requiredChecks, id)) {
+      failures.push(`compiled/summary.json required check ${id} is not pass`)
+    }
+  }
+  requireEmptyArray(compiledSummary.requiredChecksNotPassed, 'compiled/summary.json requiredChecksNotPassed', failures)
+  requireEmptyArray(compiledSummary.manualEvidenceIssues, 'compiled/summary.json manualEvidenceIssues', failures)
+  requireEmptyArray(compiledSummary.failedChecks, 'compiled/summary.json failedChecks', failures)
+  requireEmptyArray(compiledSummary.missingRequiredChecks, 'compiled/summary.json missingRequiredChecks', failures)
+
+  if (failures.length > 0) {
+    throw new Error(`included DingTalk P4 session is not final pass: ${path.relative(process.cwd(), sourceDir).replaceAll('\\', '/')} (${failures.join('; ')})`)
+  }
+
+  return {
+    status: 'pass',
+    sessionSummary: path.relative(sourceDir, sessionSummaryPath).replaceAll('\\', '/'),
+    compiledSummary: path.relative(sourceDir, compiledSummaryPath).replaceAll('\\', '/'),
+    sessionPhase: sessionSummary.sessionPhase,
+    finalStrictStatus: sessionSummary.finalStrictStatus,
+    compiledOverallStatus: compiledSummary.overallStatus,
+    apiBootstrapStatus: compiledSummary.apiBootstrapStatus,
+    remoteClientStatus: compiledSummary.remoteClientStatus,
+    requiredChecks: DINGTALK_P4_REQUIRED_CHECK_IDS.length,
+  }
+}
+
+function validateEvidenceDir(sourceDir, opts) {
   if (!existsSync(sourceDir) || !statSync(sourceDir).isDirectory()) {
     throw new Error(`--include-output must point to an existing directory: ${sourceDir}`)
   }
+  return opts.requireDingTalkP4Pass ? validateDingTalkP4FinalPass(sourceDir) : null
+}
 
+function copyEvidenceDir(sourceDir, outputDir, index, dingtalkP4FinalStatus) {
   const destinationName = `${String(index + 1).padStart(2, '0')}-${sanitizeEvidenceName(sourceDir)}`
   const destination = path.join(outputDir, 'evidence', destinationName)
   mkdirSync(path.dirname(destination), { recursive: true })
@@ -188,6 +298,7 @@ function copyEvidenceDir(sourceDir, outputDir, index) {
   return {
     source: path.relative(process.cwd(), sourceDir).replaceAll('\\', '/'),
     destination: path.relative(outputDir, destination).replaceAll('\\', '/'),
+    ...(dingtalkP4FinalStatus ? { dingtalkP4FinalStatus } : {}),
   }
 }
 
@@ -200,6 +311,9 @@ function renderReadme(manifest) {
   const evidenceLines = evidence.length
     ? evidence.map((entry) => `- \`${entry.destination}\` copied from \`${entry.source}\``).join('\n')
     : '- No runtime evidence directory was included. Re-run with `--include-output <dir>` after staging smoke.'
+  const gateLine = manifest.requireDingTalkP4Pass
+    ? '- DingTalk P4 final-pass gate was enabled; every included output was validated before copy.'
+    : '- DingTalk P4 final-pass gate was not enabled. Use `--require-dingtalk-p4-pass` for release evidence handoff.'
 
   return `# DingTalk Staging Evidence Packet
 
@@ -221,6 +335,10 @@ ${scripts.map(fileLine).join('\n')}
 
 ${evidenceLines}
 
+## Evidence Gates
+
+${gateLine}
+
 ## Recommended Order
 
 1. Read \`docs/development/dingtalk-staging-canary-deploy-20260408.md\`.
@@ -232,12 +350,12 @@ ${evidenceLines}
 7. Run the session orchestrator with \`node scripts/ops/dingtalk-p4-smoke-session.mjs --output-dir <session-dir>\`.
 8. If needed, debug individual steps with \`dingtalk-p4-smoke-preflight.mjs\` and \`dingtalk-p4-remote-smoke.mjs\`.
 9. Complete the manual DingTalk-client checks in \`<session-dir>/workspace/evidence.json\`.
-10. Compile smoke evidence with \`node scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs --input <session-dir>/workspace/evidence.json --output-dir <session-dir>/compiled --strict\`.
-11. Re-export this packet with \`--include-output <session-dir>\` after smoke evidence exists.
+10. Finalize smoke evidence with \`node scripts/ops/dingtalk-p4-smoke-session.mjs --finalize <session-dir>\`.
+11. Re-export this packet with \`--include-output <session-dir> --require-dingtalk-p4-pass\` after finalization passes.
 
 ## Non-Goals
 
-- Does not store secrets.
+- The exporter does not generate secrets; included evidence must be reviewed and redacted before release handoff.
 - Does not mutate \`docker/app.staging.env\`.
 - Does not run remote smoke tests.
 - Does not decide whether a staging result is production-ready.
@@ -247,6 +365,7 @@ ${evidenceLines}
 async function main() {
   try {
     const opts = parseArgs(process.argv.slice(2))
+    const evidenceValidations = opts.includeOutputDirs.map((dir) => validateEvidenceDir(dir, opts))
     mkdirSync(opts.outputDir, { recursive: true })
 
     const copiedFiles = requiredPacketFiles.map((entry) => {
@@ -259,7 +378,7 @@ async function main() {
     })
 
     const includedEvidence = opts.includeOutputDirs.map((dir, index) => {
-      const copied = copyEvidenceDir(dir, opts.outputDir, index)
+      const copied = copyEvidenceDir(dir, opts.outputDir, index, evidenceValidations[index])
       console.log(`Copied evidence ${copied.source}`)
       return copied
     })
@@ -268,6 +387,7 @@ async function main() {
       packet: 'dingtalk-staging-evidence-packet',
       generatedAt: new Date().toISOString(),
       repoRoot: process.cwd(),
+      requireDingTalkP4Pass: opts.requireDingTalkP4Pass,
       files: copiedFiles,
       includedEvidence,
     }

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -8,9 +8,60 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'export-dingtalk-staging-evidence-packet.mjs')
+const dingtalkP4RequiredCheckIds = [
+  'create-table-form',
+  'bind-two-dingtalk-groups',
+  'set-form-dingtalk-granted',
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'delivery-history-group-person',
+  'no-email-user-create-bind',
+]
 
 function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'dingtalk-staging-evidence-packet-'))
+}
+
+function writeDingTalkP4Session(dir, overrides = {}) {
+  mkdirSync(path.join(dir, 'compiled'), { recursive: true })
+  writeFileSync(path.join(dir, 'session-summary.json'), `${JSON.stringify({
+    tool: 'dingtalk-p4-smoke-session',
+    sessionPhase: 'finalize',
+    overallStatus: 'pass',
+    finalStrictStatus: 'pass',
+    steps: [
+      { id: 'preflight', status: 'pass', exitCode: 0 },
+      { id: 'api-runner', status: 'pass', exitCode: 0 },
+      { id: 'compile', status: 'pass', exitCode: 0 },
+      { id: 'strict-compile', status: 'pass', exitCode: 0 },
+    ],
+    pendingChecks: [],
+    ...overrides.sessionSummary,
+  }, null, 2)}\n`, 'utf8')
+  writeFileSync(path.join(dir, 'compiled', 'summary.json'), `${JSON.stringify({
+    tool: 'compile-dingtalk-p4-smoke-evidence',
+    overallStatus: 'pass',
+    apiBootstrapStatus: 'pass',
+    remoteClientStatus: 'pass',
+    totals: {
+      totalChecks: dingtalkP4RequiredCheckIds.length,
+      requiredChecks: dingtalkP4RequiredCheckIds.length,
+      passedChecks: dingtalkP4RequiredCheckIds.length,
+      failedChecks: 0,
+      skippedChecks: 0,
+      pendingChecks: 0,
+      missingRequiredChecks: 0,
+      unknownChecks: 0,
+    },
+    requiredChecks: dingtalkP4RequiredCheckIds.map((id) => ({ id, status: 'pass' })),
+    missingRequiredChecks: [],
+    requiredChecksNotPassed: [],
+    failedChecks: [],
+    unknownChecks: [],
+    manualEvidenceIssues: [],
+    ...overrides.compiledSummary,
+  }, null, 2)}\n`, 'utf8')
 }
 
 test('export-dingtalk-staging-evidence-packet copies required handoff files and writes manifest', () => {
@@ -57,6 +108,7 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
 
     const manifest = JSON.parse(readFileSync(path.join(outputDir, 'manifest.json'), 'utf8'))
     assert.equal(manifest.packet, 'dingtalk-staging-evidence-packet')
+    assert.equal(manifest.requireDingTalkP4Pass, false)
     assert.equal(manifest.includedEvidence.length, 0)
     assert.equal(
       manifest.files.some((file) => file.path === 'scripts/ops/validate-env-file.sh'),
@@ -91,7 +143,8 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
     assert.match(readme, /dingtalk-p4-smoke-session\.mjs/)
     assert.match(readme, /compile-dingtalk-p4-smoke-evidence\.mjs/)
     assert.match(readme, /No runtime evidence directory was included/)
-    assert.match(readme, /Does not store secrets/)
+    assert.match(readme, /DingTalk P4 final-pass gate was not enabled/)
+    assert.match(readme, /does not generate secrets/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }
@@ -123,6 +176,209 @@ test('export-dingtalk-staging-evidence-packet copies optional runtime evidence d
 
     const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
     assert.match(readme, /evidence\/01-smoke-output/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet accepts finalized DingTalk P4 pass evidence when required', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const evidenceDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeDingTalkP4Session(evidenceDir)
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', evidenceDir, '--require-dingtalk-p4-pass'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    const manifest = JSON.parse(readFileSync(path.join(outputDir, 'manifest.json'), 'utf8'))
+    assert.equal(manifest.requireDingTalkP4Pass, true)
+    assert.equal(manifest.includedEvidence.length, 1)
+    assert.equal(manifest.includedEvidence[0].dingtalkP4FinalStatus.status, 'pass')
+    assert.equal(manifest.includedEvidence[0].dingtalkP4FinalStatus.finalStrictStatus, 'pass')
+    assert.equal(manifest.includedEvidence[0].dingtalkP4FinalStatus.apiBootstrapStatus, 'pass')
+    assert.equal(manifest.includedEvidence[0].dingtalkP4FinalStatus.requiredChecks, 8)
+    assert.equal(existsSync(path.join(outputDir, 'evidence/01-142-session/session-summary.json')), true)
+
+    const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
+    assert.match(readme, /DingTalk P4 final-pass gate was enabled/)
+    assert.match(readme, /--require-dingtalk-p4-pass/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet rejects non-final DingTalk P4 evidence when required', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const evidenceDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeDingTalkP4Session(evidenceDir, {
+      sessionSummary: {
+        sessionPhase: 'bootstrap',
+        overallStatus: 'manual_pending',
+        finalStrictStatus: 'not_run',
+      },
+      compiledSummary: {
+        overallStatus: 'fail',
+        remoteClientStatus: 'fail',
+      },
+    })
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', evidenceDir, '--require-dingtalk-p4-pass'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /included DingTalk P4 session is not final pass/)
+    assert.match(result.stderr, /sessionPhase is not finalize/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet rejects incomplete DingTalk P4 final schema', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const evidenceDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeDingTalkP4Session(evidenceDir, {
+      compiledSummary: {
+        tool: undefined,
+        apiBootstrapStatus: 'fail',
+        requiredChecksNotPassed: undefined,
+        manualEvidenceIssues: [{ id: 'authorized-user-submit', code: 'artifact_refs_required' }],
+      },
+    })
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', evidenceDir, '--require-dingtalk-p4-pass'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /compiled\/summary\.json tool is not compile-dingtalk-p4-smoke-evidence/)
+    assert.match(result.stderr, /compiled\/summary\.json apiBootstrapStatus is not pass/)
+    assert.match(result.stderr, /compiled\/summary\.json requiredChecksNotPassed is not an array/)
+    assert.match(result.stderr, /compiled\/summary\.json manualEvidenceIssues is not empty/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet rejects failed strict compile step', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const evidenceDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeDingTalkP4Session(evidenceDir, {
+      sessionSummary: {
+        steps: [
+          { id: 'preflight', status: 'pass', exitCode: 0 },
+          { id: 'api-runner', status: 'pass', exitCode: 0 },
+          { id: 'compile', status: 'pass', exitCode: 0 },
+          { id: 'strict-compile', status: 'fail', exitCode: 1 },
+        ],
+        pendingChecks: [{ id: 'authorized-user-submit', status: 'pending', manual: true }],
+      },
+    })
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', evidenceDir, '--require-dingtalk-p4-pass'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /strict-compile step is not pass/)
+    assert.match(result.stderr, /session-summary\.json pendingChecks is not empty/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet prevalidates all required P4 evidence before writing packet', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const validEvidenceDir = path.join(tmpDir, '142-session-a')
+  const invalidEvidenceDir = path.join(tmpDir, '142-session-b')
+
+  try {
+    writeDingTalkP4Session(validEvidenceDir)
+    writeDingTalkP4Session(invalidEvidenceDir, {
+      compiledSummary: {
+        requiredChecks: dingtalkP4RequiredCheckIds.map((id) => ({
+          id,
+          status: id === 'authorized-user-submit' ? 'pending' : 'pass',
+        })),
+      },
+    })
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        '--output-dir',
+        outputDir,
+        '--include-output',
+        validEvidenceDir,
+        '--include-output',
+        invalidEvidenceDir,
+        '--require-dingtalk-p4-pass',
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /required check authorized-user-submit is not pass/)
+    assert.equal(existsSync(path.join(outputDir, 'manifest.json')), false)
+    assert.equal(existsSync(path.join(outputDir, 'evidence/01-142-session-a/session-summary.json')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet requires included evidence for final gate', () => {
+  const tmpDir = makeTmpDir()
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', path.join(tmpDir, 'packet'), '--require-dingtalk-p4-pass'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /--require-dingtalk-p4-pass requires at least one --include-output/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
Stacked on #1090.

## Summary
- Add `--require-dingtalk-p4-pass` to the staging evidence packet exporter.
- Require finalized DingTalk P4 session summaries, passing strict compile, all 8 required checks as `pass`, and empty failure/manual issue arrays before packet export.
- Prevalidate all included session directories before writing packet files or `manifest.json`.
- Update finalized session `nextCommands` to recommend packet export with the final-pass gate.
- Add development and verification notes for this slice.

## Verification
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs` (10/10)
- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs` (6/6)
- `git diff --cached --check`