### PR TITLE
test(dingtalk): guard P4 packet stale markers

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -76,6 +76,7 @@
 - [x] Add a P4 smoke session env template initializer for secure one-command staging setup.
 - [x] Add P4 smoke session finalization so completed manual evidence reruns strict compile and refreshes the session summary.
 - [x] Add a P4 final-pass packet gate so release evidence export rejects unfinished, failed, stale-schema, or partially compiled sessions.
+- [x] Clear generated packet markers before gated export validation so failed reruns cannot leave a stale passing `manifest.json` or `README.md`.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-packet-stale-output-guard-development-20260423.md
+++ b/docs/development/dingtalk-p4-packet-stale-output-guard-development-20260423.md
@@ -1,0 +1,35 @@
+# DingTalk P4 Packet Stale Output Guard Development
+
+- Date: 2026-04-23
+- Scope: staging evidence packet failed-rerun safety
+- Branch: `codex/dingtalk-p4-packet-stale-output-guard-20260423`
+
+## What Changed
+
+- The packet exporter now removes its generated `manifest.json` and `README.md` markers immediately after parsing `--output-dir` and before validating included evidence.
+- A gated rerun that fails validation no longer leaves an older passing manifest or README in the same output directory.
+- The `--require-dingtalk-p4-pass` empty-include check now runs after marker cleanup, so misuse of the final gate also clears stale generated markers for that output directory.
+- Added a regression test that first writes a valid gated packet, then reruns the exporter against the same `--output-dir` with an invalid P4 session and verifies the old markers are gone.
+
+## Why
+
+The final-pass packet gate prevents bad evidence from being copied, but a failed rerun against an existing output directory could still leave an older successful `manifest.json` or `README.md`. Operators might read those files and mistake stale evidence for the latest failed run. Clearing generated markers before validation makes failed reruns visibly incomplete.
+
+## Files
+
+- `scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
+- `scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Impact
+
+Use the same final export command:
+
+```bash
+node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \
+  --include-output output/dingtalk-p4-remote-smoke-session/142-session \
+  --require-dingtalk-p4-pass \
+  --output-dir artifacts/dingtalk-staging-evidence-packet/142-final
+```
+
+If validation fails, treat the output directory as not publishable until the command succeeds and writes a fresh `manifest.json`.

--- a/docs/development/dingtalk-p4-packet-stale-output-guard-verification-20260423.md
+++ b/docs/development/dingtalk-p4-packet-stale-output-guard-verification-20260423.md
@@ -1,0 +1,30 @@
+# DingTalk P4 Packet Stale Output Guard Verification
+
+- Date: 2026-04-23
+- Scope: packet exporter failed-rerun safety
+
+## Commands Run
+
+```bash
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs`: passed.
+- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`: passed.
+- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`: passed, 12/12 tests.
+- `git diff --cached --check`: passed.
+
+## Coverage Notes
+
+- Existing ungated and gated export paths remain covered.
+- New regression coverage verifies successful gated and ungated exports followed by a failed gated rerun against the same output directory remove stale `manifest.json` and `README.md`.
+- Existing final-pass failure coverage still verifies bad sessions are rejected before copying new evidence.
+
+## Remaining Remote Validation
+
+- Export a real final packet from the 142/staging P4 session only after `--finalize` passes.

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { cpSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 const DEFAULT_OUTPUT_DIR = 'artifacts/dingtalk-staging-evidence-packet'
@@ -168,10 +168,6 @@ function parseArgs(argv) {
     }
   }
 
-  if (opts.requireDingTalkP4Pass && opts.includeOutputDirs.length === 0) {
-    throw new Error('--require-dingtalk-p4-pass requires at least one --include-output session directory')
-  }
-
   return opts
 }
 
@@ -290,6 +286,12 @@ function validateEvidenceDir(sourceDir, opts) {
   return opts.requireDingTalkP4Pass ? validateDingTalkP4FinalPass(sourceDir) : null
 }
 
+function clearGeneratedPacketMarkers(outputDir) {
+  for (const file of ['manifest.json', 'README.md']) {
+    rmSync(path.join(outputDir, file), { force: true })
+  }
+}
+
 function copyEvidenceDir(sourceDir, outputDir, index, dingtalkP4FinalStatus) {
   const destinationName = `${String(index + 1).padStart(2, '0')}-${sanitizeEvidenceName(sourceDir)}`
   const destination = path.join(outputDir, 'evidence', destinationName)
@@ -365,6 +367,10 @@ ${gateLine}
 async function main() {
   try {
     const opts = parseArgs(process.argv.slice(2))
+    clearGeneratedPacketMarkers(opts.outputDir)
+    if (opts.requireDingTalkP4Pass && opts.includeOutputDirs.length === 0) {
+      throw new Error('--require-dingtalk-p4-pass requires at least one --include-output session directory')
+    }
     const evidenceValidations = opts.includeOutputDirs.map((dir) => validateEvidenceDir(dir, opts))
     mkdirSync(opts.outputDir, { recursive: true })
 

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -364,6 +364,99 @@ test('export-dingtalk-staging-evidence-packet prevalidates all required P4 evide
   }
 })
 
+test('export-dingtalk-staging-evidence-packet clears stale packet markers before gated validation failure', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const validEvidenceDir = path.join(tmpDir, '142-session-valid')
+  const invalidEvidenceDir = path.join(tmpDir, '142-session-invalid')
+
+  try {
+    writeDingTalkP4Session(validEvidenceDir)
+    const initialResult = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', validEvidenceDir, '--require-dingtalk-p4-pass'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(initialResult.status, 0, initialResult.stderr)
+    assert.equal(existsSync(path.join(outputDir, 'manifest.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'README.md')), true)
+
+    writeDingTalkP4Session(invalidEvidenceDir, {
+      sessionSummary: {
+        sessionPhase: 'bootstrap',
+        overallStatus: 'manual_pending',
+        finalStrictStatus: 'not_run',
+      },
+    })
+    const failedResult = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', invalidEvidenceDir, '--require-dingtalk-p4-pass'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(failedResult.status, 1)
+    assert.match(failedResult.stderr, /included DingTalk P4 session is not final pass/)
+    assert.equal(existsSync(path.join(outputDir, 'manifest.json')), false)
+    assert.equal(existsSync(path.join(outputDir, 'README.md')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet clears ungated packet markers before gated validation failure', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const legacyEvidenceDir = path.join(tmpDir, 'legacy-smoke-output')
+  const invalidEvidenceDir = path.join(tmpDir, '142-session-invalid')
+
+  try {
+    mkdirSync(legacyEvidenceDir, { recursive: true })
+    writeFileSync(path.join(legacyEvidenceDir, 'summary.json'), JSON.stringify({ ok: true }), 'utf8')
+    const initialResult = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', legacyEvidenceDir],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(initialResult.status, 0, initialResult.stderr)
+    assert.equal(existsSync(path.join(outputDir, 'manifest.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'README.md')), true)
+
+    writeDingTalkP4Session(invalidEvidenceDir, {
+      sessionSummary: {
+        sessionPhase: 'bootstrap',
+        overallStatus: 'manual_pending',
+        finalStrictStatus: 'not_run',
+      },
+    })
+    const failedResult = spawnSync(
+      process.execPath,
+      [scriptPath, '--output-dir', outputDir, '--include-output', invalidEvidenceDir, '--require-dingtalk-p4-pass'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(failedResult.status, 1)
+    assert.match(failedResult.stderr, /included DingTalk P4 session is not final pass/)
+    assert.equal(existsSync(path.join(outputDir, 'manifest.json')), false)
+    assert.equal(existsSync(path.join(outputDir, 'README.md')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('export-dingtalk-staging-evidence-packet requires included evidence for final gate', () => {
   const tmpDir = makeTmpDir()
 


### PR DESCRIPTION
Stacked on #1093.

## Summary
- Clear generated packet markers (`manifest.json`, `README.md`) before included-evidence validation.
- Prevent a failed gated rerun against an existing `--output-dir` from leaving stale passing packet markers.
- Keep the cleanup narrowly scoped to generated marker files instead of deleting the whole output directory.
- Add regression coverage for both gated-success -> gated-failure and ungated-success -> gated-failure reruns.
- Add development and verification notes for this slice.

## Verification
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs` (12/12)
- `git diff --cached --check`