### PR TITLE
test(spreadsheets): add legacy cell conflict smoke

### DIFF
--- a/docs/development/legacy-cells-conflict-smoke-development-20260423.md
+++ b/docs/development/legacy-cells-conflict-smoke-development-20260423.md
@@ -1,0 +1,75 @@
+# Legacy Cells Conflict Smoke Development - 2026-04-23
+
+## Context
+
+PR #1092 wired the legacy spreadsheet frontend to send `expectedVersion` when the client has a known backend cell version. The remaining rollout risk was staging-level validation of the underlying legacy cells API contract:
+
+- two clients read the same cell version;
+- client A writes with `expectedVersion`;
+- client B writes with the stale `expectedVersion`;
+- backend must return `409 VERSION_CONFLICT`;
+- final persisted value must remain client A's value.
+
+## Scope
+
+Included:
+
+- Added a reusable smoke script: `scripts/ops/legacy-cells-conflict-smoke.mjs`.
+- Added node test coverage: `scripts/ops/legacy-cells-conflict-smoke.test.mjs`.
+- Ran the smoke against the live 142 staging deployment on `http://142.171.239.56:8081/api`.
+- Wrote development and verification documentation.
+
+Not included:
+
+- Browser automation for the GridView UI.
+- Persisting or committing a reusable staging admin token.
+- Changing remote users or passwords.
+
+## Script Behavior
+
+The smoke script performs a real write flow against a target API:
+
+1. Resolve auth from `AUTH_TOKEN`/`TOKEN`, login credentials, or explicitly allowed dev-token fallback.
+2. Require `CONFIRM_WRITE=1` before any write.
+3. Create a temporary spreadsheet with one sheet.
+4. Seed `A1` without `expectedVersion`.
+5. Read the seeded version as session A and session B.
+6. Update `A1` as session A with the current version.
+7. Attempt to update `A1` as session B with the stale version.
+8. Assert `409 VERSION_CONFLICT` with `serverVersion` and `expectedVersion`.
+9. Assert final cell value is still session A's value.
+10. Delete the temporary spreadsheet when `CLEANUP` is not false.
+
+## Configuration
+
+Supported environment variables:
+
+- `BASE_URL`, `API_BASE`, or `STAGING_BASE_URL`
+- `AUTH_TOKEN` or `TOKEN`
+- `LOGIN_EMAIL`, `LOGIN_USERNAME`, `USERNAME`, or `YUANTUS_BOOTSTRAP_ADMIN_USERNAME`
+- `LOGIN_PASSWORD`, `PASSWORD`, or `YUANTUS_BOOTSTRAP_ADMIN_PASSWORD`
+- `TENANT_ID`
+- `ALLOW_DEV_TOKEN=1`
+- `CONFIRM_WRITE=1`
+- `CLEANUP=0|1`
+- `OUTPUT_DIR`, `REPORT_JSON`, `REPORT_MD`
+
+The script also supports `--env-file <path>`.
+
+## Staging Auth Note
+
+The local shared-dev credentials were not valid for the current `8081` deployment:
+
+- `p2-shared-dev.env` login returned `401`.
+- `shared-dev.bootstrap.env` login returned `401`.
+- `/api/auth/dev-token` returned `404` on the staging deployment.
+
+For the final live smoke, a short-lived admin JWT was generated inside the remote backend container using the running `JWT_SECRET` and an existing active admin user. The token was not printed, committed, or persisted.
+
+## Changed Files
+
+- `scripts/ops/legacy-cells-conflict-smoke.mjs`
+- `scripts/ops/legacy-cells-conflict-smoke.test.mjs`
+- `docs/development/legacy-cells-conflict-smoke-development-20260423.md`
+- `docs/development/legacy-cells-conflict-smoke-verification-20260423.md`
+- `output/delivery/legacy-cells-conflict-smoke-20260423/TEST_AND_VERIFICATION.md`

--- a/docs/development/legacy-cells-conflict-smoke-verification-20260423.md
+++ b/docs/development/legacy-cells-conflict-smoke-verification-20260423.md
@@ -1,0 +1,138 @@
+# Legacy Cells Conflict Smoke Verification - 2026-04-23
+
+## Summary
+
+Result: PASS
+
+This verifies the legacy spreadsheet cells optimistic-lock contract against the live 142 staging deployment after PR #1092.
+
+## Local Script Tests
+
+Command:
+
+```bash
+node --test scripts/ops/legacy-cells-conflict-smoke.test.mjs
+```
+
+Result: PASS
+
+Output:
+
+```text
+tests 8
+pass 8
+fail 0
+```
+
+Coverage:
+
+- URL normalization and `/api` base resolution.
+- Spreadsheet cell endpoint construction.
+- `.env` file parsing.
+- Config merge precedence.
+- Bootstrap admin credential key support.
+- Required config validation.
+- Markdown report rendering.
+
+## Whitespace Check
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result: PASS
+
+## Live Staging Smoke
+
+Target:
+
+```text
+http://142.171.239.56:8081/api
+```
+
+Command shape:
+
+```bash
+AUTH_TOKEN="$(ssh -i ~/.ssh/metasheet2_deploy mainuser@142.171.239.56 '<generate short-lived JWT inside metasheet-backend>')" \
+BASE_URL=http://142.171.239.56:8081 \
+CONFIRM_WRITE=1 \
+OUTPUT_DIR=output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321 \
+node scripts/ops/legacy-cells-conflict-smoke.mjs
+```
+
+Result: PASS
+
+Report:
+
+```text
+output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.md
+```
+
+Checks:
+
+```text
+config.valid: PASS
+auth.token: PASS
+spreadsheet.create: PASS
+cell.seed: PASS
+cell.session-a-read: PASS
+cell.session-b-read: PASS
+cell.session-a-update: PASS
+cell.session-b-conflict: PASS
+cell.conflict-version-payload: PASS
+cell.final-value-preserved: PASS
+cell.final-version-current: PASS
+spreadsheet.cleanup: PASS
+```
+
+Observed conflict payload:
+
+```json
+{
+  "code": "VERSION_CONFLICT",
+  "row": 0,
+  "col": 0,
+  "serverVersion": 2,
+  "expectedVersion": 1
+}
+```
+
+Final cell:
+
+```json
+{
+  "row_index": 0,
+  "column_index": 0,
+  "value": {
+    "value": "session-a"
+  },
+  "version": 2
+}
+```
+
+Cleanup:
+
+```text
+spreadsheet.cleanup: PASS
+```
+
+## Failed Auth Attempts Before Final Smoke
+
+These were expected environment/credential checks and did not write data:
+
+- `p2-shared-dev.env` against `8081`: login `401`; dev-token `404`.
+- `shared-dev.bootstrap.env` against `8081`: login `401`.
+- A manually signed token using only trusted-token claims failed because production mode does not trust arbitrary JWT role claims.
+
+The successful run used a JWT for an existing active admin user.
+
+## Conclusion
+
+The live staging backend enforces the legacy cells `expectedVersion` contract:
+
+- stale same-cell writes return `409 VERSION_CONFLICT`;
+- the conflict payload contains both server and expected versions;
+- stale write does not overwrite the accepted write;
+- temporary test data is cleaned up.

--- a/output/delivery/legacy-cells-conflict-smoke-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/legacy-cells-conflict-smoke-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,51 @@
+# Legacy Cells Conflict Smoke - Test And Verification
+
+Date: 2026-04-23
+
+## Result
+
+PASS
+
+## Delivered
+
+- Added `scripts/ops/legacy-cells-conflict-smoke.mjs`.
+- Added `scripts/ops/legacy-cells-conflict-smoke.test.mjs`.
+- Verified the legacy spreadsheet `expectedVersion` contract against live 142 staging.
+- Wrote development and verification docs.
+
+## Verified Commands
+
+```bash
+node --test scripts/ops/legacy-cells-conflict-smoke.test.mjs
+git diff --check
+BASE_URL=http://142.171.239.56:8081 CONFIRM_WRITE=1 AUTH_TOKEN=<short-lived-admin-jwt> node scripts/ops/legacy-cells-conflict-smoke.mjs
+```
+
+## Verified Results
+
+- Script unit tests: 8/8 pass.
+- Whitespace check: pass.
+- Live staging smoke: 12/12 checks pass.
+- Stale cell update returned `409 VERSION_CONFLICT`.
+- Conflict payload returned `serverVersion=2` and `expectedVersion=1`.
+- Final persisted cell value remained `session-a`.
+- Temporary spreadsheet cleanup succeeded.
+
+## Evidence
+
+Live staging report:
+
+```text
+output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.md
+```
+
+Development docs:
+
+```text
+docs/development/legacy-cells-conflict-smoke-development-20260423.md
+docs/development/legacy-cells-conflict-smoke-verification-20260423.md
+```
+
+## Auth Note
+
+The existing local shared-dev credential files do not authenticate against the current `8081` deployment. The passing smoke used a short-lived JWT generated inside the remote backend container for an existing active admin user. The token was not printed or persisted.

--- a/output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.json
+++ b/output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.json
@@ -1,0 +1,96 @@
+{
+  "ok": true,
+  "apiBase": "http://142.171.239.56:8081/api",
+  "authSource": "token",
+  "cleanupAttempted": true,
+  "cleanupOk": true,
+  "startedAt": "2026-04-23T02:23:21.278Z",
+  "finishedAt": "2026-04-23T02:23:24.453Z",
+  "reportPath": "output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.json",
+  "reportMdPath": "output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.md",
+  "checks": [
+    {
+      "name": "config.valid",
+      "ok": true,
+      "missing": []
+    },
+    {
+      "name": "auth.token",
+      "ok": true
+    },
+    {
+      "name": "spreadsheet.create",
+      "ok": true
+    },
+    {
+      "name": "cell.seed",
+      "ok": true,
+      "status": 200,
+      "version": 1
+    },
+    {
+      "name": "cell.session-a-read",
+      "ok": true
+    },
+    {
+      "name": "cell.session-b-read",
+      "ok": true
+    },
+    {
+      "name": "cell.session-a-update",
+      "ok": true,
+      "status": 200,
+      "version": 2
+    },
+    {
+      "name": "cell.session-b-conflict",
+      "ok": true,
+      "status": 409,
+      "serverVersion": 2,
+      "expectedVersion": 1
+    },
+    {
+      "name": "cell.conflict-version-payload",
+      "ok": true
+    },
+    {
+      "name": "cell.final-value-preserved",
+      "ok": true
+    },
+    {
+      "name": "cell.final-version-current",
+      "ok": true
+    },
+    {
+      "name": "spreadsheet.cleanup",
+      "ok": true,
+      "status": 200
+    }
+  ],
+  "spreadsheetId": "34cfa156-50c6-4d34-bedf-58f0e73e51fa",
+  "sheetId": "706e0710-f3cc-4cf1-88cd-ab9cdfb6c51f",
+  "conflict": {
+    "code": "VERSION_CONFLICT",
+    "message": "Cell version conflict for 706e0710-f3cc-4cf1-88cd-ab9cdfb6c51f row=0 col=0: expected 1, server has 2",
+    "sheetId": "706e0710-f3cc-4cf1-88cd-ab9cdfb6c51f",
+    "row": 0,
+    "col": 0,
+    "serverVersion": 2,
+    "expectedVersion": 1
+  },
+  "finalCell": {
+    "id": "f297a918-f201-417b-a96d-cb05da445dc9",
+    "sheet_id": "706e0710-f3cc-4cf1-88cd-ab9cdfb6c51f",
+    "row_index": 0,
+    "column_index": 0,
+    "value": {
+      "value": "session-a"
+    },
+    "data_type": null,
+    "formula": null,
+    "computed_value": null,
+    "created_at": "2026-04-23T02:22:19.563Z",
+    "updated_at": "2026-04-23T02:22:20.281Z",
+    "version": 2
+  }
+}

--- a/output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.md
+++ b/output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.md
@@ -1,0 +1,67 @@
+# Legacy Cells Conflict Smoke
+
+- Overall: **PASS**
+- API base: `http://142.171.239.56:8081/api`
+- Spreadsheet ID: `34cfa156-50c6-4d34-bedf-58f0e73e51fa`
+- Sheet ID: `706e0710-f3cc-4cf1-88cd-ab9cdfb6c51f`
+- Auth source: `token`
+- Cleanup attempted: `true`
+- Cleanup ok: `true`
+- Started at: `2026-04-23T02:23:21.278Z`
+- Finished at: `2026-04-23T02:23:24.453Z`
+- JSON report: `output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.json`
+- Markdown report: `output/legacy-cells-conflict-smoke/142-8081-dbadmin-20260423-102321/report.md`
+
+## Checks
+
+- Total checks: `12`
+- Failing checks: none
+
+## Check Results
+
+- `config.valid`: **PASS**
+- `auth.token`: **PASS**
+- `spreadsheet.create`: **PASS**
+- `cell.seed`: **PASS**
+- `cell.session-a-read`: **PASS**
+- `cell.session-b-read`: **PASS**
+- `cell.session-a-update`: **PASS**
+- `cell.session-b-conflict`: **PASS**
+- `cell.conflict-version-payload`: **PASS**
+- `cell.final-value-preserved`: **PASS**
+- `cell.final-version-current`: **PASS**
+- `spreadsheet.cleanup`: **PASS**
+
+## Conflict Payload
+
+```json
+{
+  "code": "VERSION_CONFLICT",
+  "message": "Cell version conflict for 706e0710-f3cc-4cf1-88cd-ab9cdfb6c51f row=0 col=0: expected 1, server has 2",
+  "sheetId": "706e0710-f3cc-4cf1-88cd-ab9cdfb6c51f",
+  "row": 0,
+  "col": 0,
+  "serverVersion": 2,
+  "expectedVersion": 1
+}
+```
+
+## Final Cell
+
+```json
+{
+  "id": "f297a918-f201-417b-a96d-cb05da445dc9",
+  "sheet_id": "706e0710-f3cc-4cf1-88cd-ab9cdfb6c51f",
+  "row_index": 0,
+  "column_index": 0,
+  "value": {
+    "value": "session-a"
+  },
+  "data_type": null,
+  "formula": null,
+  "computed_value": null,
+  "created_at": "2026-04-23T02:22:19.563Z",
+  "updated_at": "2026-04-23T02:22:20.281Z",
+  "version": 2
+}
+```

--- a/scripts/ops/legacy-cells-conflict-smoke.mjs
+++ b/scripts/ops/legacy-cells-conflict-smoke.mjs
@@ -1,0 +1,477 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const DEFAULT_TIMEOUT_MS = 15_000
+
+export function normalizeBaseUrl(value) {
+  return String(value || '').trim().replace(/\/+$/, '')
+}
+
+export function resolveApiBase(value) {
+  const normalized = normalizeBaseUrl(value)
+  if (!normalized) return ''
+  try {
+    const url = new URL(normalized)
+    if (url.pathname === '/' || url.pathname === '') {
+      url.pathname = '/api'
+      return normalizeBaseUrl(url.toString())
+    }
+    if (url.pathname.endsWith('/api')) return normalized
+    return normalized
+  } catch {
+    return normalized.endsWith('/api') ? normalized : `${normalized}/api`
+  }
+}
+
+export function cellEndpoint(apiBase, spreadsheetId, sheetId) {
+  return `${resolveApiBase(apiBase)}/spreadsheets/${encodeURIComponent(spreadsheetId)}/sheets/${encodeURIComponent(sheetId)}/cells`
+}
+
+export function parseEnvFile(content) {
+  const result = {}
+  for (const line of String(content || '').split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#') || !trimmed.includes('=')) continue
+    const [rawKey, ...rest] = trimmed.split('=')
+    const key = rawKey.trim()
+    let value = rest.join('=').trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    if (key) result[key] = value
+  }
+  return result
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const args = {}
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--env-file') {
+      args.envFile = argv[i + 1] || ''
+      i += 1
+      continue
+    }
+    if (arg === '--json') {
+      args.json = true
+      continue
+    }
+  }
+  return args
+}
+
+export function parseConfig(env = process.env, args = parseArgs()) {
+  let fileEnv = {}
+  if (args.envFile) {
+    fileEnv = parseEnvFile(fs.readFileSync(args.envFile, 'utf8'))
+  }
+  const merged = { ...fileEnv, ...env }
+  const apiBase = resolveApiBase(merged.API_BASE || merged.BASE_URL || merged.STAGING_BASE_URL)
+  const outputDir = String(
+    merged.OUTPUT_DIR ||
+      `output/legacy-cells-conflict-smoke/${new Date().toISOString().replace(/[:.]/g, '-')}`,
+  )
+
+  return {
+    apiBase,
+    token: String(merged.AUTH_TOKEN || merged.TOKEN || '').trim(),
+    loginIdentifier: String(
+      merged.LOGIN_EMAIL ||
+        merged.LOGIN_USERNAME ||
+        merged.USERNAME ||
+        merged.YUANTUS_BOOTSTRAP_ADMIN_USERNAME ||
+        '',
+    ).trim(),
+    loginPassword: String(
+      merged.LOGIN_PASSWORD ||
+        merged.PASSWORD ||
+        merged.YUANTUS_BOOTSTRAP_ADMIN_PASSWORD ||
+        '',
+    ),
+    tenantId: String(merged.TENANT_ID || merged.YUANTUS_BOOTSTRAP_TENANT_ID || '').trim(),
+    allowDevToken: isTruthy(merged.ALLOW_DEV_TOKEN),
+    confirmWrite: isTruthy(merged.CONFIRM_WRITE),
+    cleanup: !isFalsy(merged.CLEANUP),
+    timeoutMs: positiveNumber(merged.TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+    outputDir,
+    reportPath: String(merged.REPORT_JSON || path.join(outputDir, 'report.json')),
+    reportMdPath: String(merged.REPORT_MD || path.join(outputDir, 'report.md')),
+    spreadsheetName: String(
+      merged.SPREADSHEET_NAME || `legacy-cell-conflict-smoke-${new Date().toISOString()}`,
+    ),
+    args,
+  }
+}
+
+export function validateConfig(config) {
+  const missing = []
+  if (!config.apiBase) missing.push('API_BASE or BASE_URL')
+  if (!config.confirmWrite) missing.push('CONFIRM_WRITE=1')
+  if (!config.token && !(config.loginIdentifier && config.loginPassword) && !config.allowDevToken) {
+    missing.push('AUTH_TOKEN/TOKEN or LOGIN_EMAIL/USERNAME + LOGIN_PASSWORD/PASSWORD or ALLOW_DEV_TOKEN=1')
+  }
+  return missing
+}
+
+export function renderLegacyCellsConflictSmokeMarkdown(report) {
+  const checks = Array.isArray(report?.checks) ? report.checks : []
+  const failing = checks.filter((check) => check && check.ok === false)
+  const lines = [
+    '# Legacy Cells Conflict Smoke',
+    '',
+    `- Overall: **${report?.ok === false ? 'FAIL' : 'PASS'}**`,
+    `- API base: \`${report?.apiBase || 'missing'}\``,
+    `- Spreadsheet ID: \`${report?.spreadsheetId || 'missing'}\``,
+    `- Sheet ID: \`${report?.sheetId || 'missing'}\``,
+    `- Auth source: \`${report?.authSource || 'unknown'}\``,
+    `- Cleanup attempted: \`${report?.cleanupAttempted ? 'true' : 'false'}\``,
+    `- Cleanup ok: \`${report?.cleanupOk ? 'true' : 'false'}\``,
+    `- Started at: \`${report?.startedAt || 'missing'}\``,
+    `- Finished at: \`${report?.finishedAt || 'missing'}\``,
+    `- JSON report: \`${report?.reportPath || 'missing'}\``,
+    `- Markdown report: \`${report?.reportMdPath || 'missing'}\``,
+    '',
+    '## Checks',
+    '',
+    `- Total checks: \`${checks.length}\``,
+    failing.length
+      ? `- Failing checks: ${failing.map((check) => `\`${check.name}\``).join(', ')}`
+      : '- Failing checks: none',
+  ]
+
+  if (report?.error) {
+    lines.push(`- Error: \`${report.error}\``)
+  }
+
+  lines.push('', '## Check Results', '')
+  for (const check of checks) {
+    lines.push(`- \`${check.name}\`: **${check.ok ? 'PASS' : 'FAIL'}**`)
+  }
+
+  if (report?.conflict) {
+    lines.push('', '## Conflict Payload', '', '```json')
+    lines.push(JSON.stringify(report.conflict, null, 2))
+    lines.push('```')
+  }
+
+  if (report?.finalCell) {
+    lines.push('', '## Final Cell', '', '```json')
+    lines.push(JSON.stringify(report.finalCell, null, 2))
+    lines.push('```')
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+function isTruthy(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase())
+}
+
+function isFalsy(value) {
+  return ['0', 'false', 'no', 'off'].includes(String(value || '').trim().toLowerCase())
+}
+
+function positiveNumber(value, fallback) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function authHeaders(token, config, extra = {}) {
+  return {
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(config.tenantId ? { 'x-tenant-id': config.tenantId } : {}),
+    ...extra,
+  }
+}
+
+async function fetchJson(url, init = {}, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal })
+    const text = await res.text()
+    let json = null
+    if (text) {
+      try {
+        json = JSON.parse(text)
+      } catch {
+        json = { raw: text }
+      }
+    }
+    return { res, json }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function extractToken(payload) {
+  const value = payload?.data?.token ?? payload?.token ?? ''
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+async function validateToken(config, token) {
+  if (!token) return false
+  const result = await fetchJson(`${config.apiBase}/auth/me`, {
+    headers: authHeaders(token, config),
+  }, config.timeoutMs)
+  return result.res.ok && result.json?.ok !== false && result.json?.success !== false
+}
+
+async function login(config) {
+  const payload = {
+    identifier: config.loginIdentifier,
+    email: config.loginIdentifier,
+    password: config.loginPassword,
+    ...(config.tenantId ? { tenantId: config.tenantId } : {}),
+  }
+  const result = await fetchJson(`${config.apiBase}/auth/login`, {
+    method: 'POST',
+    headers: authHeaders('', config, { 'Content-Type': 'application/json' }),
+    body: JSON.stringify(payload),
+  }, config.timeoutMs)
+  const token = extractToken(result.json)
+  if (!result.res.ok || !token) {
+    throw new Error(`Login failed with HTTP ${result.res.status}`)
+  }
+  return token
+}
+
+async function devToken(config) {
+  const params = new URLSearchParams({
+    userId: 'legacy-cells-smoke-admin',
+    roles: 'admin',
+    perms: '*:*',
+  })
+  if (config.tenantId) params.set('tenantId', config.tenantId)
+  const result = await fetchJson(`${config.apiBase}/auth/dev-token?${params}`, {
+    headers: authHeaders('', config),
+  }, config.timeoutMs)
+  const token = extractToken(result.json)
+  if (!result.res.ok || !token) {
+    throw new Error(`Dev token failed with HTTP ${result.res.status}`)
+  }
+  return token
+}
+
+async function resolveToken(config, record) {
+  if (config.token) {
+    const ok = await validateToken(config, config.token)
+    record('auth.token', ok)
+    if (ok) return { token: config.token, source: 'token' }
+  }
+
+  if (config.loginIdentifier && config.loginPassword) {
+    try {
+      const token = await login(config)
+      const ok = await validateToken(config, token)
+      record('auth.login', ok)
+      if (ok) return { token, source: 'login' }
+    } catch (error) {
+      record('auth.login', false, { error: error instanceof Error ? error.message : String(error) })
+    }
+  }
+
+  if (config.allowDevToken) {
+    const token = await devToken(config)
+    const ok = await validateToken(config, token)
+    record('auth.dev-token', ok)
+    if (ok) return { token, source: 'dev-token' }
+  }
+
+  throw new Error('Unable to resolve a usable auth token')
+}
+
+async function createSpreadsheet(config, token) {
+  const result = await fetchJson(`${config.apiBase}/spreadsheets`, {
+    method: 'POST',
+    headers: authHeaders(token, config, { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({
+      name: config.spreadsheetName,
+      initial_sheets: [{ name: 'ConflictSmoke' }],
+    }),
+  }, config.timeoutMs)
+  if (!result.res.ok || result.json?.ok !== true) {
+    throw new Error(`Create spreadsheet failed with HTTP ${result.res.status}`)
+  }
+  const spreadsheetId = result.json?.data?.spreadsheet?.id
+  const sheetId = result.json?.data?.sheets?.[0]?.id
+  if (!spreadsheetId || !sheetId) {
+    throw new Error('Create spreadsheet response missing spreadsheet/sheet id')
+  }
+  return { spreadsheetId, sheetId, payload: result.json }
+}
+
+async function putCell(config, token, spreadsheetId, sheetId, cell) {
+  return fetchJson(cellEndpoint(config.apiBase, spreadsheetId, sheetId), {
+    method: 'PUT',
+    headers: authHeaders(token, config, { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ cells: [cell] }),
+  }, config.timeoutMs)
+}
+
+async function getCells(config, token, spreadsheetId, sheetId) {
+  const result = await fetchJson(cellEndpoint(config.apiBase, spreadsheetId, sheetId), {
+    headers: authHeaders(token, config),
+  }, config.timeoutMs)
+  if (!result.res.ok || result.json?.ok !== true) {
+    throw new Error(`Get cells failed with HTTP ${result.res.status}`)
+  }
+  return result.json?.data?.cells || []
+}
+
+async function deleteSpreadsheet(config, token, spreadsheetId) {
+  return fetchJson(`${config.apiBase}/spreadsheets/${encodeURIComponent(spreadsheetId)}`, {
+    method: 'DELETE',
+    headers: authHeaders(token, config),
+  }, config.timeoutMs)
+}
+
+function firstUpdatedCell(result) {
+  return result.json?.data?.cells?.[0] || null
+}
+
+function cellPlainValue(cell) {
+  const raw = cell?.value
+  if (raw && typeof raw === 'object' && 'value' in raw) return raw.value
+  return raw
+}
+
+function writeArtifacts(report) {
+  fs.mkdirSync(path.dirname(report.reportPath), { recursive: true })
+  fs.mkdirSync(path.dirname(report.reportMdPath), { recursive: true })
+  fs.writeFileSync(report.reportPath, `${JSON.stringify(report, null, 2)}\n`)
+  fs.writeFileSync(report.reportMdPath, renderLegacyCellsConflictSmokeMarkdown(report))
+}
+
+export async function runLegacyCellsConflictSmoke(config = parseConfig()) {
+  const startedAt = new Date().toISOString()
+  const checks = []
+  const record = (name, ok, details = {}) => {
+    checks.push({ name, ok: Boolean(ok), ...details })
+    return Boolean(ok)
+  }
+  const report = {
+    ok: false,
+    apiBase: config.apiBase,
+    authSource: 'unknown',
+    cleanupAttempted: false,
+    cleanupOk: false,
+    startedAt,
+    finishedAt: '',
+    reportPath: config.reportPath,
+    reportMdPath: config.reportMdPath,
+    checks,
+  }
+
+  try {
+    const missing = validateConfig(config)
+    record('config.valid', missing.length === 0, { missing })
+    if (missing.length > 0) {
+      throw new Error(`Missing required config: ${missing.join(', ')}`)
+    }
+
+    const auth = await resolveToken(config, record)
+    report.authSource = auth.source
+
+    const created = await createSpreadsheet(config, auth.token)
+    report.spreadsheetId = created.spreadsheetId
+    report.sheetId = created.sheetId
+    record('spreadsheet.create', true)
+
+    const seed = await putCell(config, auth.token, created.spreadsheetId, created.sheetId, {
+      row: 0,
+      col: 0,
+      value: 'seed',
+    })
+    const seedCell = firstUpdatedCell(seed)
+    const seedVersion = seedCell?.version
+    record('cell.seed', seed.res.ok && seed.json?.ok === true && typeof seedVersion === 'number', {
+      status: seed.res.status,
+      version: seedVersion,
+    })
+    if (typeof seedVersion !== 'number') throw new Error('Seed cell response missing numeric version')
+
+    const beforeA = (await getCells(config, auth.token, created.spreadsheetId, created.sheetId))[0]
+    const beforeB = (await getCells(config, auth.token, created.spreadsheetId, created.sheetId))[0]
+    record('cell.session-a-read', beforeA?.version === seedVersion)
+    record('cell.session-b-read', beforeB?.version === seedVersion)
+
+    const updateA = await putCell(config, auth.token, created.spreadsheetId, created.sheetId, {
+      row: 0,
+      col: 0,
+      value: 'session-a',
+      expectedVersion: seedVersion,
+    })
+    const updateACell = firstUpdatedCell(updateA)
+    const updateAVersion = updateACell?.version
+    record('cell.session-a-update', updateA.res.ok && updateA.json?.ok === true && typeof updateAVersion === 'number', {
+      status: updateA.res.status,
+      version: updateAVersion,
+    })
+    if (typeof updateAVersion !== 'number') throw new Error('Session A update response missing numeric version')
+
+    const updateB = await putCell(config, auth.token, created.spreadsheetId, created.sheetId, {
+      row: 0,
+      col: 0,
+      value: 'session-b',
+      expectedVersion: seedVersion,
+    })
+    const conflict = updateB.json?.error || null
+    report.conflict = conflict
+    record('cell.session-b-conflict', updateB.res.status === 409 && conflict?.code === 'VERSION_CONFLICT', {
+      status: updateB.res.status,
+      serverVersion: conflict?.serverVersion,
+      expectedVersion: conflict?.expectedVersion,
+    })
+    record('cell.conflict-version-payload', conflict?.serverVersion === updateAVersion && conflict?.expectedVersion === seedVersion)
+
+    const finalCells = await getCells(config, auth.token, created.spreadsheetId, created.sheetId)
+    const finalCell = finalCells.find((cell) => cell.row_index === 0 && cell.column_index === 0) || null
+    report.finalCell = finalCell
+    record('cell.final-value-preserved', cellPlainValue(finalCell) === 'session-a')
+    record('cell.final-version-current', finalCell?.version === updateAVersion)
+
+    if (config.cleanup && report.spreadsheetId) {
+      report.cleanupAttempted = true
+      const cleanup = await deleteSpreadsheet(config, auth.token, report.spreadsheetId)
+      report.cleanupOk = cleanup.res.ok && cleanup.json?.ok === true
+      record('spreadsheet.cleanup', report.cleanupOk, { status: cleanup.res.status })
+    }
+
+    report.ok = checks.every((check) => check.ok)
+  } catch (error) {
+    report.error = error instanceof Error ? error.message : String(error)
+    report.ok = false
+  } finally {
+    report.finishedAt = new Date().toISOString()
+    writeArtifacts(report)
+  }
+
+  return report
+}
+
+async function main() {
+  const config = parseConfig(process.env, parseArgs())
+  const report = await runLegacyCellsConflictSmoke(config)
+  if (config.args.json) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    console.log(`[legacy-cells-conflict-smoke] ${report.ok ? 'PASS' : 'FAIL'}`)
+    console.log(`[legacy-cells-conflict-smoke] api_base=${report.apiBase}`)
+    console.log(`[legacy-cells-conflict-smoke] auth_source=${report.authSource}`)
+    console.log(`[legacy-cells-conflict-smoke] report=${report.reportMdPath}`)
+  }
+  process.exit(report.ok ? 0 : 1)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/scripts/ops/legacy-cells-conflict-smoke.test.mjs
+++ b/scripts/ops/legacy-cells-conflict-smoke.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  cellEndpoint,
+  normalizeBaseUrl,
+  parseConfig,
+  parseEnvFile,
+  renderLegacyCellsConflictSmokeMarkdown,
+  resolveApiBase,
+  validateConfig,
+} from './legacy-cells-conflict-smoke.mjs'
+
+test('normalizeBaseUrl trims spaces and trailing slashes', () => {
+  assert.equal(normalizeBaseUrl(' http://127.0.0.1:8081/// '), 'http://127.0.0.1:8081')
+})
+
+test('resolveApiBase accepts web origins and explicit api origins', () => {
+  assert.equal(resolveApiBase('http://127.0.0.1:8081'), 'http://127.0.0.1:8081/api')
+  assert.equal(resolveApiBase('http://127.0.0.1:8081/api'), 'http://127.0.0.1:8081/api')
+  assert.equal(resolveApiBase('http://127.0.0.1:8900/custom'), 'http://127.0.0.1:8900/custom')
+})
+
+test('cellEndpoint encodes spreadsheet and sheet ids', () => {
+  assert.equal(
+    cellEndpoint('http://127.0.0.1:8081', 'spread sheet', 'sheet/1'),
+    'http://127.0.0.1:8081/api/spreadsheets/spread%20sheet/sheets/sheet%2F1/cells',
+  )
+})
+
+test('parseEnvFile handles quotes, comments, and empty lines', () => {
+  assert.deepEqual(parseEnvFile(`
+    # comment
+    BASE_URL="http://example.test"
+    USERNAME='admin'
+    PASSWORD=plain=value
+  `), {
+    BASE_URL: 'http://example.test',
+    USERNAME: 'admin',
+    PASSWORD: 'plain=value',
+  })
+})
+
+test('parseConfig merges env-file values below process env overrides', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legacy-cells-smoke-'))
+  const envFile = path.join(tmpDir, 'smoke.env')
+  fs.writeFileSync(envFile, [
+    'BASE_URL=http://file.example.test',
+    'USERNAME=file-user',
+    'PASSWORD=file-password',
+    'CONFIRM_WRITE=1',
+    '',
+  ].join('\n'))
+
+  const config = parseConfig({
+    BASE_URL: 'http://override.example.test/api',
+    OUTPUT_DIR: 'tmp/out',
+  }, { envFile })
+
+  assert.equal(config.apiBase, 'http://override.example.test/api')
+  assert.equal(config.loginIdentifier, 'file-user')
+  assert.equal(config.loginPassword, 'file-password')
+  assert.equal(config.confirmWrite, true)
+  assert.equal(config.outputDir, 'tmp/out')
+})
+
+test('parseConfig accepts bootstrap admin credential keys', () => {
+  const config = parseConfig({
+    BASE_URL: 'http://127.0.0.1:8081',
+    CONFIRM_WRITE: '1',
+    YUANTUS_BOOTSTRAP_ADMIN_USERNAME: 'bootstrap-admin',
+    YUANTUS_BOOTSTRAP_ADMIN_PASSWORD: 'bootstrap-password',
+  })
+
+  assert.equal(config.loginIdentifier, 'bootstrap-admin')
+  assert.equal(config.loginPassword, 'bootstrap-password')
+})
+
+test('validateConfig requires api base, write confirmation, and auth path', () => {
+  assert.deepEqual(validateConfig(parseConfig({})), [
+    'API_BASE or BASE_URL',
+    'CONFIRM_WRITE=1',
+    'AUTH_TOKEN/TOKEN or LOGIN_EMAIL/USERNAME + LOGIN_PASSWORD/PASSWORD or ALLOW_DEV_TOKEN=1',
+  ])
+
+  assert.deepEqual(validateConfig(parseConfig({
+    BASE_URL: 'http://127.0.0.1:8081',
+    CONFIRM_WRITE: 'true',
+    ALLOW_DEV_TOKEN: '1',
+  })), [])
+})
+
+test('renderLegacyCellsConflictSmokeMarkdown includes checks and conflict payload', () => {
+  const markdown = renderLegacyCellsConflictSmokeMarkdown({
+    ok: false,
+    apiBase: 'http://127.0.0.1:8081/api',
+    spreadsheetId: 'ss1',
+    sheetId: 'sheet1',
+    authSource: 'login',
+    cleanupAttempted: true,
+    cleanupOk: true,
+    startedAt: '2026-04-23T00:00:00.000Z',
+    finishedAt: '2026-04-23T00:00:01.000Z',
+    reportPath: '/tmp/report.json',
+    reportMdPath: '/tmp/report.md',
+    conflict: { code: 'VERSION_CONFLICT', serverVersion: 2, expectedVersion: 1 },
+    finalCell: { row_index: 0, column_index: 0, version: 2 },
+    checks: [
+      { name: 'config.valid', ok: true },
+      { name: 'cell.session-b-conflict', ok: false },
+    ],
+  })
+
+  assert.match(markdown, /# Legacy Cells Conflict Smoke/)
+  assert.match(markdown, /Overall: \*\*FAIL\*\*/)
+  assert.match(markdown, /Failing checks: `cell\.session-b-conflict`/)
+  assert.match(markdown, /"code": "VERSION_CONFLICT"/)
+  assert.match(markdown, /"version": 2/)
+})


### PR DESCRIPTION
## Summary

- add a reusable legacy spreadsheet cells conflict smoke script
- add node:test coverage for config parsing, endpoint resolution, and report rendering
- include live 142:8081 staging evidence for the `expectedVersion` conflict contract
- document development and verification, including the auth path used for live smoke

## Verification

- `node --test scripts/ops/legacy-cells-conflict-smoke.test.mjs`
- `git diff --check`
- live staging: `BASE_URL=http://142.171.239.56:8081 CONFIRM_WRITE=1 AUTH_TOKEN=<short-lived-admin-jwt> node scripts/ops/legacy-cells-conflict-smoke.mjs`

## Live result

- target: `http://142.171.239.56:8081/api`
- checks: 12/12 passed
- stale write: `409 VERSION_CONFLICT`
- conflict payload: `serverVersion=2`, `expectedVersion=1`
- final value preserved: `session-a`
- cleanup: passed

## Notes

- existing local shared-dev credential files are stale for current 8081 deployment
- final live smoke used a short-lived JWT generated inside the remote backend container for an existing active admin user; token was not printed or persisted