### PR TITLE
test(dingtalk): add P4 final handoff command

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -78,6 +78,7 @@
 - [x] Add a P4 final-pass packet gate so release evidence export rejects unfinished, failed, stale-schema, or partially compiled sessions.
 - [x] Clear generated packet markers before gated export validation so failed reruns cannot leave a stale passing `manifest.json` or `README.md`.
 - [x] Add a P4 packet publish validator for final gated packet shape and common raw secret leakage checks.
+- [x] Add a one-command P4 final handoff wrapper that exports, validates, and summarizes a finalized session packet.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-final-handoff-command-development-20260423.md
+++ b/docs/development/dingtalk-p4-final-handoff-command-development-20260423.md
@@ -1,0 +1,53 @@
+# DingTalk P4 Final Handoff Command Development
+
+- Date: 2026-04-23
+- Scope: finalized P4 session packet export and publish validation wrapper
+- Branch: `codex/dingtalk-p4-final-handoff-command-20260423`
+
+## What Changed
+
+- Added `scripts/ops/dingtalk-p4-final-handoff.mjs`.
+- The command takes a finalized P4 `--session-dir` and:
+  - runs `export-dingtalk-staging-evidence-packet.mjs` with `--require-dingtalk-p4-pass`;
+  - runs `validate-dingtalk-staging-evidence-packet.mjs` with a publish-check JSON output;
+  - writes `handoff-summary.json` and `handoff-summary.md`.
+- The command exits non-zero when export or validation fails, but still writes a summary when `--output-dir` is known.
+- The command rejects overlapping session/output paths so packet export cannot recursively copy or pollute the source session.
+- The command clears stale `publish-check.json` and handoff summaries before each run, preventing failed reruns from reading an older passing publish check.
+- The command redacts child process output and strips raw `secretFindings.preview` values before writing summaries.
+- Added the final handoff script to generated DingTalk staging evidence packets.
+- Updated `dingtalk-p4-smoke-session.mjs` finalization next commands to recommend the handoff wrapper.
+- Updated the remote smoke checklist and P4 TODO.
+
+## Why
+
+The operator flow had separate commands for final packet export and publish validation. The wrapper reduces release-handoff mistakes after the real DingTalk client checks are complete by making the final local handoff repeatable and auditable.
+
+## Files
+
+- `scripts/ops/dingtalk-p4-final-handoff.mjs`
+- `scripts/ops/dingtalk-p4-final-handoff.test.mjs`
+- `scripts/ops/dingtalk-p4-smoke-session.mjs`
+- `scripts/ops/dingtalk-p4-smoke-session.test.mjs`
+- `scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
+- `scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-feature-plan-and-todo-20260422.md`
+
+## Operator Flow
+
+```bash
+node scripts/ops/dingtalk-p4-final-handoff.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --output-dir artifacts/dingtalk-staging-evidence-packet/142-final
+```
+
+Expected outputs:
+
+- `manifest.json`
+- `README.md`
+- `publish-check.json`
+- `handoff-summary.json`
+- `handoff-summary.md`
+
+Only publish the packet when `handoff-summary.json` has `status: "pass"`.

--- a/docs/development/dingtalk-p4-final-handoff-command-verification-20260423.md
+++ b/docs/development/dingtalk-p4-final-handoff-command-verification-20260423.md
@@ -1,0 +1,44 @@
+# DingTalk P4 Final Handoff Command Verification
+
+- Date: 2026-04-23
+- Scope: final handoff wrapper
+
+## Commands Run
+
+```bash
+node --check scripts/ops/dingtalk-p4-final-handoff.mjs
+node --check scripts/ops/dingtalk-p4-final-handoff.test.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+git diff --cached --check
+```
+
+## Results
+
+- `node --check scripts/ops/dingtalk-p4-final-handoff.mjs`: passed.
+- `node --check scripts/ops/dingtalk-p4-final-handoff.test.mjs`: passed.
+- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`: passed.
+- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed.
+- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs`: passed.
+- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`: passed.
+- `node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs`: passed, 8/8 tests.
+- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs`: passed, 6/6 tests.
+- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`: passed, 12/12 tests.
+- `git diff --cached --check`: passed.
+
+## Coverage Notes
+
+- Success coverage verifies the wrapper exports a packet, runs publish validation, and writes both JSON and Markdown summaries.
+- Failure coverage verifies an invalid finalized session causes export-gate failure and still writes a failed handoff summary.
+- Validator-failure coverage verifies raw secret findings fail validation without leaking raw previews into the handoff summary.
+- Stale-rerun coverage verifies old `publish-check.json` is cleared before a failed rerun.
+- Argument coverage verifies missing `--session-dir`, missing session directories, overlapping output/session paths, and unknown arguments fail.
+
+## Remaining Remote Validation
+
+- Run the wrapper against the real 142/staging finalized session after all DingTalk client/admin evidence is complete.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -165,7 +165,15 @@ node scripts/ops/dingtalk-p4-smoke-session.mjs \
 
 Finalizing reruns strict evidence compile, refreshes `session-summary.json` / `session-summary.md`, and returns non-zero until the manual evidence bundle is complete.
 
-After finalization passes, export a handoff packet with the final-pass gate enabled:
+After finalization passes, prefer the one-command final handoff wrapper. It exports the final gated packet, runs the publish validator, and writes `handoff-summary.json` / `handoff-summary.md`:
+
+```bash
+node scripts/ops/dingtalk-p4-final-handoff.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --output-dir artifacts/dingtalk-staging-evidence-packet/142-final
+```
+
+If debugging the individual steps, export a handoff packet with the final-pass gate enabled:
 
 ```bash
 node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \

--- a/scripts/ops/dingtalk-p4-final-handoff.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const DEFAULT_PACKET_ROOT = 'artifacts/dingtalk-staging-evidence-packet'
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-p4-final-handoff.mjs [options]
+
+Exports and validates a finalized DingTalk P4 smoke session in one local handoff command.
+
+Options:
+  --session-dir <dir>          Finalized DingTalk P4 smoke session directory (required)
+  --output-dir <dir>           Packet directory, default ${DEFAULT_PACKET_ROOT}/<session-name>-final
+  --publish-check-json <file>  Validator JSON output, default <output-dir>/publish-check.json
+  --summary-json <file>        Handoff JSON summary, default <output-dir>/handoff-summary.json
+  --summary-md <file>          Handoff Markdown summary, default <output-dir>/handoff-summary.md
+  --help                       Show this help
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function sanitizeName(value) {
+  return path
+    .basename(value)
+    .replace(/[^A-Za-z0-9._-]/g, '-')
+    .replace(/^-+|-+$/g, '') || 'session'
+}
+
+function parseArgs(argv) {
+  const opts = {
+    sessionDir: '',
+    outputDir: '',
+    publishCheckJson: '',
+    summaryJson: '',
+    summaryMd: '',
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--session-dir':
+        opts.sessionDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--publish-check-json':
+        opts.publishCheckJson = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--summary-json':
+        opts.summaryJson = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--summary-md':
+        opts.summaryMd = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!opts.sessionDir) throw new Error('--session-dir is required')
+  if (!opts.outputDir) {
+    opts.outputDir = path.resolve(process.cwd(), DEFAULT_PACKET_ROOT, `${sanitizeName(opts.sessionDir)}-final`)
+  }
+  opts.publishCheckJson ||= path.join(opts.outputDir, 'publish-check.json')
+  opts.summaryJson ||= path.join(opts.outputDir, 'handoff-summary.json')
+  opts.summaryMd ||= path.join(opts.outputDir, 'handoff-summary.md')
+  return opts
+}
+
+function relativePath(file) {
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function redactString(value) {
+  return String(value)
+    .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function readJsonIfExists(file) {
+  if (!existsSync(file) || !statSync(file).isFile()) return null
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function compactText(value) {
+  const text = redactString(value ?? '').trim()
+  if (!text) return ''
+  return text.length > 4000 ? `${text.slice(0, 3997)}...` : text
+}
+
+function runNodeStep(id, label, args) {
+  const startedAt = new Date().toISOString()
+  const result = spawnSync(process.execPath, args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  })
+  const finishedAt = new Date().toISOString()
+  return {
+    id,
+    label,
+    command: `node ${args.join(' ')}`,
+    status: result.status === 0 ? 'pass' : 'fail',
+    exitCode: result.status ?? 1,
+    startedAt,
+    finishedAt,
+    stdout: compactText(result.stdout),
+    stderr: compactText(result.stderr),
+  }
+}
+
+function validateSessionDir(sessionDir) {
+  if (!existsSync(sessionDir) || !statSync(sessionDir).isDirectory()) {
+    throw new Error(`--session-dir must point to an existing directory: ${relativePath(sessionDir)}`)
+  }
+}
+
+function pathsOverlap(left, right) {
+  const a = path.resolve(left)
+  const b = path.resolve(right)
+  return a === b || a.startsWith(`${b}${path.sep}`) || b.startsWith(`${a}${path.sep}`)
+}
+
+function validateOutputDir(opts) {
+  if (pathsOverlap(opts.outputDir, opts.sessionDir)) {
+    throw new Error('--output-dir must not be the session directory or overlap with it')
+  }
+}
+
+function clearGeneratedHandoffMarkers(opts) {
+  for (const file of [opts.publishCheckJson, opts.summaryJson, opts.summaryMd]) {
+    rmSync(file, { force: true })
+  }
+}
+
+function canWriteFailureSummary(opts) {
+  return !pathsOverlap(opts.outputDir, opts.sessionDir)
+}
+
+function sanitizePublishCheck(value) {
+  if (!value || typeof value !== 'object') return value
+  return {
+    ...value,
+    secretFindings: Array.isArray(value.secretFindings)
+      ? value.secretFindings.map((finding) => ({
+          ...finding,
+          preview: finding?.preview ? '<redacted>' : finding?.preview,
+        }))
+      : value.secretFindings,
+  }
+}
+
+function renderMarkdown(summary) {
+  const stepRows = summary.steps.map((step) => {
+    const notes = step.stderr || step.stdout.split(/\r?\n/).filter(Boolean).at(-1) || ''
+    return `| \`${step.id}\` | ${step.status} | ${step.exitCode} | ${notes.replaceAll('|', '\\|')} |`
+  })
+  const failures = summary.failures.length
+    ? summary.failures.map((failure) => `- ${failure}`).join('\n')
+    : '- None'
+  const publishStatus = summary.publishCheck?.status ?? 'not_available'
+
+  return `# DingTalk P4 Final Handoff Summary
+
+Generated at: ${summary.generatedAt}
+
+Overall status: **${summary.status}**
+
+Session directory: \`${summary.sessionDir}\`
+
+Packet directory: \`${summary.outputDir}\`
+
+Publish check status: **${publishStatus}**
+
+## Steps
+
+| Step | Status | Exit | Notes |
+| --- | --- | --- | --- |
+${stepRows.join('\n')}
+
+## Outputs
+
+- Packet manifest: \`${summary.outputs.manifest}\`
+- Packet README: \`${summary.outputs.readme}\`
+- Publish check JSON: \`${summary.outputs.publishCheckJson}\`
+- Handoff summary JSON: \`${summary.outputs.summaryJson}\`
+- Handoff summary Markdown: \`${summary.outputs.summaryMd}\`
+
+## Failures
+
+${failures}
+
+## Next Action
+
+${summary.status === 'pass'
+  ? '- Packet is ready for human release handoff review. Review raw artifacts once more before sharing externally.'
+  : '- Fix the failed step above, rerun this command, and do not publish the packet until this summary is pass.'}
+`
+}
+
+function writeSummary(summary, opts) {
+  mkdirSync(path.dirname(opts.summaryJson), { recursive: true })
+  mkdirSync(path.dirname(opts.summaryMd), { recursive: true })
+  writeFileSync(opts.summaryJson, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+  writeFileSync(opts.summaryMd, `${renderMarkdown(summary)}\n`, 'utf8')
+}
+
+function buildSummary(opts, steps) {
+  const publishCheck = sanitizePublishCheck(readJsonIfExists(opts.publishCheckJson))
+  const failures = []
+  for (const step of steps) {
+    if (step.status !== 'pass') failures.push(`${step.id} failed with exit code ${step.exitCode}`)
+  }
+  if (publishCheck && publishCheck.status !== 'pass') {
+    failures.push(...(Array.isArray(publishCheck.failures) ? publishCheck.failures : ['publish check failed']))
+  }
+
+  return {
+    tool: 'dingtalk-p4-final-handoff',
+    generatedAt: new Date().toISOString(),
+    status: steps.every((step) => step.status === 'pass') && publishCheck?.status === 'pass' ? 'pass' : 'fail',
+    sessionDir: relativePath(opts.sessionDir),
+    outputDir: relativePath(opts.outputDir),
+    steps,
+    publishCheck,
+    failures,
+    outputs: {
+      manifest: relativePath(path.join(opts.outputDir, 'manifest.json')),
+      readme: relativePath(path.join(opts.outputDir, 'README.md')),
+      publishCheckJson: relativePath(opts.publishCheckJson),
+      summaryJson: relativePath(opts.summaryJson),
+      summaryMd: relativePath(opts.summaryMd),
+    },
+  }
+}
+
+async function main() {
+  let opts
+  let steps = []
+  try {
+    opts = parseArgs(process.argv.slice(2))
+    validateSessionDir(opts.sessionDir)
+    validateOutputDir(opts)
+    clearGeneratedHandoffMarkers(opts)
+
+    const exportStep = runNodeStep('export-packet', 'Export final gated packet', [
+      'scripts/ops/export-dingtalk-staging-evidence-packet.mjs',
+      '--include-output',
+      relativePath(opts.sessionDir),
+      '--require-dingtalk-p4-pass',
+      '--output-dir',
+      relativePath(opts.outputDir),
+    ])
+    steps.push(exportStep)
+
+    if (exportStep.status === 'pass') {
+      const validateStep = runNodeStep('validate-packet', 'Validate packet publish readiness', [
+        'scripts/ops/validate-dingtalk-staging-evidence-packet.mjs',
+        '--packet-dir',
+        relativePath(opts.outputDir),
+        '--output-json',
+        relativePath(opts.publishCheckJson),
+      ])
+      steps.push(validateStep)
+    }
+
+    const summary = buildSummary(opts, steps)
+    writeSummary(summary, opts)
+    console.log(`Wrote ${relativePath(opts.summaryJson)}`)
+    console.log(`Wrote ${relativePath(opts.summaryMd)}`)
+    if (summary.status !== 'pass') process.exit(1)
+  } catch (error) {
+    if (opts && canWriteFailureSummary(opts)) {
+      const summary = buildSummary(opts, steps)
+      summary.status = 'fail'
+      summary.failures.push(error instanceof Error ? error.message : String(error))
+      writeSummary(summary, opts)
+      console.log(`Wrote ${relativePath(opts.summaryJson)}`)
+      console.log(`Wrote ${relativePath(opts.summaryMd)}`)
+    }
+    console.error(`[dingtalk-p4-final-handoff] ERROR: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+}
+
+await main()

--- a/scripts/ops/dingtalk-p4-final-handoff.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.test.mjs
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-final-handoff.mjs')
+const requiredCheckIds = [
+  'create-table-form',
+  'bind-two-dingtalk-groups',
+  'set-form-dingtalk-granted',
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'delivery-history-group-person',
+  'no-email-user-create-bind',
+]
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-final-handoff-'))
+}
+
+function writeJson(file, value) {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function writeFinalSession(sessionDir, overrides = {}) {
+  writeJson(path.join(sessionDir, 'workspace', 'evidence.json'), {
+    checks: requiredCheckIds.map((id) => ({ id, status: 'pass' })),
+  })
+  writeJson(path.join(sessionDir, 'session-summary.json'), {
+    tool: 'dingtalk-p4-smoke-session',
+    sessionPhase: 'finalize',
+    overallStatus: 'pass',
+    finalStrictStatus: 'pass',
+    steps: [
+      { id: 'preflight', status: 'pass', exitCode: 0 },
+      { id: 'api-runner', status: 'pass', exitCode: 0 },
+      { id: 'compile', status: 'pass', exitCode: 0 },
+      { id: 'strict-compile', status: 'pass', exitCode: 0 },
+    ],
+    pendingChecks: [],
+    ...overrides.sessionSummary,
+  })
+  writeJson(path.join(sessionDir, 'compiled', 'summary.json'), {
+    tool: 'compile-dingtalk-p4-smoke-evidence',
+    overallStatus: 'pass',
+    apiBootstrapStatus: 'pass',
+    remoteClientStatus: 'pass',
+    totals: {
+      totalChecks: requiredCheckIds.length,
+      requiredChecks: requiredCheckIds.length,
+      passedChecks: requiredCheckIds.length,
+      failedChecks: 0,
+      skippedChecks: 0,
+      pendingChecks: 0,
+      missingRequiredChecks: 0,
+      unknownChecks: 0,
+    },
+    requiredChecks: requiredCheckIds.map((id) => ({ id, status: 'pass' })),
+    missingRequiredChecks: [],
+    requiredChecksNotPassed: [],
+    failedChecks: [],
+    unknownChecks: [],
+    manualEvidenceIssues: [],
+    ...overrides.compiledSummary,
+  })
+}
+
+function runScript(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+test('dingtalk-p4-final-handoff exports, validates, and summarizes a final session', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    writeFinalSession(sessionDir)
+
+    const result = runScript(['--session-dir', sessionDir, '--output-dir', outputDir])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.equal(existsSync(path.join(outputDir, 'manifest.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'README.md')), true)
+    assert.equal(existsSync(path.join(outputDir, 'publish-check.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'handoff-summary.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'handoff-summary.md')), true)
+
+    const publishCheck = JSON.parse(readFileSync(path.join(outputDir, 'publish-check.json'), 'utf8'))
+    assert.equal(publishCheck.status, 'pass')
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'pass')
+    assert.deepEqual(summary.steps.map((step) => step.id), ['export-packet', 'validate-packet'])
+    assert.equal(summary.steps.every((step) => step.status === 'pass'), true)
+    assert.equal(summary.publishCheck.status, 'pass')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff fails and writes summary when export gate fails', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    writeFinalSession(sessionDir, {
+      sessionSummary: {
+        overallStatus: 'fail',
+        finalStrictStatus: 'fail',
+        steps: [
+          { id: 'preflight', status: 'pass', exitCode: 0 },
+          { id: 'api-runner', status: 'pass', exitCode: 0 },
+          { id: 'compile', status: 'pass', exitCode: 0 },
+          { id: 'strict-compile', status: 'fail', exitCode: 1 },
+        ],
+      },
+    })
+
+    const result = runScript(['--session-dir', sessionDir, '--output-dir', outputDir])
+
+    assert.equal(result.status, 1)
+    assert.equal(existsSync(path.join(outputDir, 'handoff-summary.json')), true)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'fail')
+    assert.deepEqual(summary.steps.map((step) => step.id), ['export-packet'])
+    assert.equal(summary.steps[0].status, 'fail')
+    assert.equal(summary.failures.some((failure) => failure.includes('export-packet failed')), true)
+    assert.equal(existsSync(path.join(outputDir, 'publish-check.json')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff fails validation without leaking secret previews into summary', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const outputDir = path.join(tmpDir, 'packet')
+  const rawWebhook = 'https://oapi.dingtalk.com/robot/send?access_token=0123456789abcdef0123456789abcdef'
+  const rawSecret = 'SECabcdefghijklmnop12345678'
+
+  try {
+    writeFinalSession(sessionDir)
+    const artifactDir = path.join(sessionDir, 'workspace', 'artifacts', 'send-group-message-form-link')
+    mkdirSync(artifactDir, { recursive: true })
+    writeFileSync(path.join(artifactDir, 'leaked.txt'), `${rawWebhook}\n${rawSecret}\n`, 'utf8')
+
+    const result = runScript(['--session-dir', sessionDir, '--output-dir', outputDir])
+
+    assert.equal(result.status, 1)
+    const summaryText = readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8')
+    assert.doesNotMatch(summaryText, /0123456789abcdef0123456789abcdef/)
+    assert.doesNotMatch(summaryText, /SECabcdefghijklmnop12345678/)
+    const summary = JSON.parse(summaryText)
+    assert.equal(summary.status, 'fail')
+    assert.deepEqual(summary.steps.map((step) => step.id), ['export-packet', 'validate-packet'])
+    assert.equal(summary.steps[1].status, 'fail')
+    assert.equal(summary.publishCheck.status, 'fail')
+    assert.equal(summary.publishCheck.secretFindings.some((finding) => finding.preview === '<redacted>'), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff clears stale publish check before failed rerun', () => {
+  const tmpDir = makeTmpDir()
+  const validSessionDir = path.join(tmpDir, '142-session-valid')
+  const invalidSessionDir = path.join(tmpDir, '142-session-invalid')
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    writeFinalSession(validSessionDir)
+    const firstResult = runScript(['--session-dir', validSessionDir, '--output-dir', outputDir])
+    assert.equal(firstResult.status, 0, firstResult.stderr || firstResult.stdout)
+    assert.equal(existsSync(path.join(outputDir, 'publish-check.json')), true)
+
+    writeFinalSession(invalidSessionDir, {
+      sessionSummary: {
+        overallStatus: 'fail',
+        finalStrictStatus: 'fail',
+        steps: [
+          { id: 'preflight', status: 'pass', exitCode: 0 },
+          { id: 'api-runner', status: 'pass', exitCode: 0 },
+          { id: 'compile', status: 'pass', exitCode: 0 },
+          { id: 'strict-compile', status: 'fail', exitCode: 1 },
+        ],
+      },
+    })
+    const secondResult = runScript(['--session-dir', invalidSessionDir, '--output-dir', outputDir])
+
+    assert.equal(secondResult.status, 1)
+    assert.equal(existsSync(path.join(outputDir, 'publish-check.json')), false)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'fail')
+    assert.equal(summary.publishCheck, null)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff requires session-dir', () => {
+  const result = runScript([])
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /--session-dir is required/)
+})
+
+test('dingtalk-p4-final-handoff rejects missing session directory and writes configured summary', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    const result = runScript(['--session-dir', path.join(tmpDir, 'missing'), '--output-dir', outputDir])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /--session-dir must point to an existing directory/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'fail')
+    assert.equal(summary.failures.some((failure) => failure.includes('--session-dir must point')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff rejects overlapping output and session paths', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const outputDir = path.join(sessionDir, 'packet')
+
+  try {
+    writeFinalSession(sessionDir)
+
+    const result = runScript(['--session-dir', sessionDir, '--output-dir', outputDir])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /--output-dir must not be the session directory or overlap with it/)
+    assert.equal(existsSync(path.join(outputDir, 'handoff-summary.json')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff rejects unknown arguments', () => {
+  const result = runScript(['--unknown'])
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Unknown argument: --unknown/)
+})

--- a/scripts/ops/dingtalk-p4-smoke-session.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.mjs
@@ -387,6 +387,14 @@ function exportPacketCommand(outputDir, requireFinalPass = false) {
   ].join(' ')
 }
 
+function finalHandoffCommand(outputDir) {
+  return [
+    'node scripts/ops/dingtalk-p4-final-handoff.mjs',
+    '--session-dir',
+    relativePath(outputDir),
+  ].join(' ')
+}
+
 function finalizeCommand(outputDir, allowExternalArtifactRefs = false) {
   return [
     'node scripts/ops/dingtalk-p4-smoke-session.mjs',
@@ -620,8 +628,8 @@ function runFinalStrictCompile(opts) {
         }
       : null,
     nextCommands: strictPassed
-      ? [exportPacketCommand(outputDir, true)]
-      : [finalizeCommand(outputDir, opts.allowExternalArtifactRefs), exportPacketCommand(outputDir, true)],
+      ? [finalHandoffCommand(outputDir), exportPacketCommand(outputDir, true)]
+      : [finalizeCommand(outputDir, opts.allowExternalArtifactRefs), finalHandoffCommand(outputDir), exportPacketCommand(outputDir, true)],
   }
 
   writeSessionSummary(summary, outputDir)

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -446,6 +446,7 @@ test('dingtalk-p4-smoke-session finalizes completed manual evidence with strict 
     assert.equal(sessionSummary.pendingChecks.length, 0)
     assert.equal(sessionSummary.finalStrictSummary.overallStatus, 'pass')
     assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--strict')), false)
+    assert.equal(sessionSummary.nextCommands.some((command) => command.includes('dingtalk-p4-final-handoff.mjs')), true)
     assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--require-dingtalk-p4-pass')), true)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -107,6 +107,11 @@ const requiredPacketFiles = [
     description: 'orchestrates P4 preflight, API-only smoke workspace bootstrap, and non-strict evidence compile',
   },
   {
+    path: 'scripts/ops/dingtalk-p4-final-handoff.mjs',
+    kind: 'script',
+    description: 'exports a finalized P4 smoke session, validates the packet, and writes handoff summaries',
+  },
+  {
     path: 'scripts/ops/validate-dingtalk-staging-evidence-packet.mjs',
     kind: 'script',
     description: 'validates final gated evidence packets and scans for secret-like raw evidence before handoff',
@@ -358,8 +363,8 @@ ${gateLine}
 8. If needed, debug individual steps with \`dingtalk-p4-smoke-preflight.mjs\` and \`dingtalk-p4-remote-smoke.mjs\`.
 9. Complete the manual DingTalk-client checks in \`<session-dir>/workspace/evidence.json\`.
 10. Finalize smoke evidence with \`node scripts/ops/dingtalk-p4-smoke-session.mjs --finalize <session-dir>\`.
-11. Re-export this packet with \`--include-output <session-dir> --require-dingtalk-p4-pass\` after finalization passes.
-12. Validate the release handoff with \`node scripts/ops/validate-dingtalk-staging-evidence-packet.mjs --packet-dir <packet-dir>\`.
+11. Run \`node scripts/ops/dingtalk-p4-final-handoff.mjs --session-dir <session-dir> --output-dir <packet-dir>\` after finalization passes.
+12. If debugging manually, re-export with \`--include-output <session-dir> --require-dingtalk-p4-pass\`, then validate with \`validate-dingtalk-staging-evidence-packet.mjs\`.
 
 ## Non-Goals
 

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -104,6 +104,10 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       true,
     )
     assert.equal(
+      existsSync(path.join(outputDir, 'scripts/ops/dingtalk-p4-final-handoff.mjs')),
+      true,
+    )
+    assert.equal(
       existsSync(path.join(outputDir, 'scripts/ops/validate-dingtalk-staging-evidence-packet.mjs')),
       true,
     )
@@ -139,6 +143,10 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       true,
     )
     assert.equal(
+      manifest.files.some((file) => file.path === 'scripts/ops/dingtalk-p4-final-handoff.mjs'),
+      true,
+    )
+    assert.equal(
       manifest.files.some((file) => file.path === 'scripts/ops/validate-dingtalk-staging-evidence-packet.mjs'),
       true,
     )
@@ -149,6 +157,7 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
     assert.match(readme, /dingtalk-p4-remote-smoke\.mjs/)
     assert.match(readme, /dingtalk-p4-smoke-preflight\.mjs/)
     assert.match(readme, /dingtalk-p4-smoke-session\.mjs/)
+    assert.match(readme, /dingtalk-p4-final-handoff\.mjs/)
     assert.match(readme, /validate-dingtalk-staging-evidence-packet\.mjs/)
     assert.match(readme, /compile-dingtalk-p4-smoke-evidence\.mjs/)
     assert.match(readme, /No runtime evidence directory was included/)


### PR DESCRIPTION
Stacked on #1095.

## Summary
- Add `dingtalk-p4-final-handoff.mjs` to export a finalized P4 session, run the packet publish validator, and write JSON/Markdown handoff summaries in one command.
- Include the final handoff command in exported DingTalk staging packets.
- Update smoke-session finalize next commands to recommend the handoff wrapper while retaining the manual gated export fallback.
- Guard against stale `publish-check.json`, overlapping session/output paths, and raw secret previews in generated summaries.
- Update the remote smoke checklist, TODO, and development/verification notes.

## Verification
- `node --check scripts/ops/dingtalk-p4-final-handoff.mjs`
- `node --check scripts/ops/dingtalk-p4-final-handoff.test.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs` (8/8)
- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs` (6/6)
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs` (12/12)
- `git diff --cached --check`