### PR TITLE
test(spreadsheets): cover legacy cell version UI wiring

### DIFF
--- a/apps/web/tests/grid-view-cell-version-wiring.spec.ts
+++ b/apps/web/tests/grid-view-cell-version-wiring.spec.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import GridView from '../src/views/GridView.vue'
+
+const apiFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+function createJsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  }
+}
+
+function createGridCellsPayload(version: number, value = 'before') {
+  return {
+    ok: true,
+    data: {
+      sheet: {
+        id: 'sheet-1',
+        spreadsheet_id: 'ss-1',
+        row_count: 2,
+        column_count: 2,
+      },
+      cells: [
+        {
+          row_index: 0,
+          column_index: 0,
+          value: { value },
+          formula: null,
+          version,
+        },
+      ],
+    },
+  }
+}
+
+async function flushUi(cycles = 8): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button'))
+    .find((candidate) => candidate.textContent?.includes(label))
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${label}`)
+  }
+  return button
+}
+
+function setFormulaBar(container: HTMLElement, value: string): void {
+  const input = container.querySelector('.formula-input')
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error('Formula input not found')
+  }
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  input.dispatchEvent(new Event('blur', { bubbles: true }))
+}
+
+function getPutCellsBody() {
+  const call = apiFetchMock.mock.calls.find(([url, init]) => (
+    String(url) === '/api/spreadsheets/ss-1/sheets/sheet-1/cells' &&
+    (init as RequestInit | undefined)?.method === 'PUT'
+  ))
+  if (!call) throw new Error('PUT /cells call not found')
+  return JSON.parse(String((call[1] as RequestInit).body))
+}
+
+describe('GridView legacy cell version wiring', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+  const originalAlert = globalThis.alert
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    vi.spyOn(globalThis, 'alert').mockImplementation(() => undefined)
+    localStorage.clear()
+    localStorage.setItem('gridSpreadsheetId', 'ss-1')
+    localStorage.setItem('gridSheetId', 'sheet-1')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    container?.remove()
+    app = null
+    container = null
+    localStorage.clear()
+    vi.restoreAllMocks()
+    globalThis.alert = originalAlert
+  })
+
+  it('sends expectedVersion when saving a changed server-backed cell', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse(createGridCellsPayload(3)))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          cells: [
+            { row_index: 0, column_index: 0, value: { value: 'after' }, formula: null, version: 4 },
+          ],
+        },
+      }))
+
+    app = createApp(GridView)
+    app.mount(container!)
+    await flushUi()
+
+    setFormulaBar(container!, 'after')
+    findButton(container!, '保存').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(getPutCellsBody()).toEqual({
+      cells: [
+        { row: 0, col: 0, value: 'after', expectedVersion: 3 },
+      ],
+    })
+    expect(container!.textContent).toContain('已保存')
+    expect(globalThis.alert).toHaveBeenCalledWith('保存成功！')
+  })
+
+  it('surfaces VERSION_CONFLICT and does not mark the grid as saved', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse(createGridCellsPayload(1)))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: false,
+        error: {
+          code: 'VERSION_CONFLICT',
+          row: 0,
+          col: 0,
+          serverVersion: 2,
+          expectedVersion: 1,
+        },
+      }, 409))
+
+    app = createApp(GridView)
+    app.mount(container!)
+    await flushUi()
+
+    setFormulaBar(container!, 'stale')
+    findButton(container!, '保存').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(getPutCellsBody()).toEqual({
+      cells: [
+        { row: 0, col: 0, value: 'stale', expectedVersion: 1 },
+      ],
+    })
+    expect(container!.textContent).toContain('单元格 A1 已被其他会话更新')
+    expect(container!.textContent).not.toContain('已保存')
+    expect(globalThis.alert).toHaveBeenCalledWith('单元格 A1 已被其他会话更新，请刷新后重试。（服务器版本：2，本地版本：1）')
+  })
+})

--- a/apps/web/tests/spreadsheet-detail-cell-version-wiring.spec.ts
+++ b/apps/web/tests/spreadsheet-detail-cell-version-wiring.spec.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import SpreadsheetDetailView from '../src/views/SpreadsheetDetailView.vue'
+
+const apiFetchMock = vi.hoisted(() => vi.fn())
+const routerPushMock = vi.hoisted(() => vi.fn())
+const routeParams = vi.hoisted(() => ({ id: 'ss-1' }))
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: routeParams }),
+  useRouter: () => ({ push: routerPushMock }),
+}))
+
+function createJsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  }
+}
+
+function createSpreadsheetPayload(sheetIds = ['sheet-1']) {
+  return {
+    ok: true,
+    data: {
+      id: 'ss-1',
+      name: 'Legacy Sheet',
+      sheets: sheetIds.map((id, index) => ({
+        id,
+        name: `Sheet ${index + 1}`,
+      })),
+    },
+  }
+}
+
+function createCellsPayload(cells: unknown[]) {
+  return {
+    ok: true,
+    data: {
+      sheet: {
+        id: 'sheet-1',
+        spreadsheet_id: 'ss-1',
+        row_count: 100,
+        column_count: 26,
+      },
+      cells,
+    },
+  }
+}
+
+function deferredResponse() {
+  let resolve!: (value: unknown) => void
+  const promise = new Promise((next) => {
+    resolve = next
+  })
+  return {
+    promise,
+    resolve,
+  }
+}
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button'))
+    .find((candidate) => candidate.textContent?.includes(label))
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${label}`)
+  }
+  return button
+}
+
+function setInput(input: HTMLInputElement | HTMLSelectElement, value: string): void {
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+function getPutCellsBody(sheetId = 'sheet-1') {
+  const call = apiFetchMock.mock.calls.find(([url, init]) => (
+    String(url) === `/api/spreadsheets/ss-1/sheets/${sheetId}/cells` &&
+    (init as RequestInit | undefined)?.method === 'PUT'
+  ))
+  if (!call) throw new Error('PUT /cells call not found')
+  const body = (call[1] as RequestInit).body
+  return JSON.parse(String(body))
+}
+
+describe('SpreadsheetDetailView legacy cell version wiring', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    routerPushMock.mockReset()
+    routeParams.id = 'ss-1'
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    container?.remove()
+    app = null
+    container = null
+  })
+
+  it('loads cell versions and sends expectedVersion on update', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse(createSpreadsheetPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createCellsPayload([
+        { row_index: 0, column_index: 0, value: { value: 'before' }, formula: null, version: 3 },
+      ])))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          cells: [
+            { row_index: 0, column_index: 0, value: { value: 'after' }, formula: null, version: 4 },
+          ],
+        },
+      }))
+
+    app = createApp(SpreadsheetDetailView)
+    app.mount(container!)
+    await flushUi()
+
+    const inputs = container!.querySelectorAll('input')
+    setInput(inputs[2] as HTMLInputElement, 'after')
+    findButton(container!, 'Update').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(getPutCellsBody()).toEqual({
+      cells: [
+        { row: 0, col: 0, value: 'after', expectedVersion: 3 },
+      ],
+    })
+    expect(container!.textContent).toContain('Cell updated.')
+  })
+
+  it('surfaces VERSION_CONFLICT without marking the update as successful', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse(createSpreadsheetPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createCellsPayload([
+        { row_index: 0, column_index: 0, value: { value: 'before' }, formula: null, version: 1 },
+      ])))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: false,
+        error: {
+          code: 'VERSION_CONFLICT',
+          row: 0,
+          col: 0,
+          serverVersion: 2,
+          expectedVersion: 1,
+        },
+      }, 409))
+
+    app = createApp(SpreadsheetDetailView)
+    app.mount(container!)
+    await flushUi()
+
+    const inputs = container!.querySelectorAll('input')
+    setInput(inputs[2] as HTMLInputElement, 'stale')
+    findButton(container!, 'Update').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(getPutCellsBody()).toEqual({
+      cells: [
+        { row: 0, col: 0, value: 'stale', expectedVersion: 1 },
+      ],
+    })
+    expect(container!.textContent).toContain('Cell A1 was changed by another session')
+    expect(container!.textContent).not.toContain('Cell updated.')
+  })
+
+  it('does not reuse stale expectedVersion after switching sheets while cell versions are loading', async () => {
+    const sheet2Cells = deferredResponse()
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse(createSpreadsheetPayload(['sheet-1', 'sheet-2'])))
+      .mockResolvedValueOnce(createJsonResponse(createCellsPayload([
+        { row_index: 0, column_index: 0, value: { value: 'sheet-1' }, formula: null, version: 9 },
+      ])))
+      .mockImplementationOnce(() => sheet2Cells.promise)
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          cells: [
+            { row_index: 0, column_index: 0, value: { value: 'sheet-2-new' }, formula: null, version: 1 },
+          ],
+        },
+      }))
+
+    app = createApp(SpreadsheetDetailView)
+    app.mount(container!)
+    await flushUi()
+
+    const sheet2 = Array.from(container!.querySelectorAll('.spreadsheet-detail__sheet'))
+      .find((candidate) => candidate.textContent?.includes('sheet-2'))
+    expect(sheet2).toBeTruthy()
+    sheet2!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(1)
+
+    const inputs = container!.querySelectorAll('input')
+    setInput(inputs[2] as HTMLInputElement, 'sheet-2-new')
+    findButton(container!, 'Update').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(getPutCellsBody('sheet-2')).toEqual({
+      cells: [
+        { row: 0, col: 0, value: 'sheet-2-new' },
+      ],
+    })
+
+    sheet2Cells.resolve(createJsonResponse(createCellsPayload([
+      { row_index: 0, column_index: 0, value: { value: 'sheet-2' }, formula: null, version: 5 },
+    ])))
+    await flushUi()
+  })
+})

--- a/docs/development/legacy-cells-ui-wiring-tests-development-20260423.md
+++ b/docs/development/legacy-cells-ui-wiring-tests-development-20260423.md
@@ -1,0 +1,48 @@
+# Legacy Cells UI Version Wiring Tests Development - 2026-04-23
+
+## Context
+
+PR #1042 added backend optimistic locking for the legacy spreadsheet cells PUT API.
+PR #1092 wired the frontend helper and two legacy cell editors to send `expectedVersion`.
+PR #1096 added a live/staging API conflict smoke test.
+
+This follow-up closes the remaining test gap: view-level UI interactions must prove that the saved payload includes the server-loaded cell version and that a 409 conflict is not presented as a successful save.
+
+## Scope
+
+Added two focused frontend specs:
+
+- `apps/web/tests/spreadsheet-detail-cell-version-wiring.spec.ts`
+- `apps/web/tests/grid-view-cell-version-wiring.spec.ts`
+
+No runtime code was changed.
+
+## SpreadsheetDetailView Coverage
+
+The new spec mounts `SpreadsheetDetailView` with mocked `apiFetch` and `vue-router`.
+
+Covered behavior:
+
+- Initial cell load records `version` from `/cells`.
+- Updating A1 sends `{ row, col, value, expectedVersion }` to the legacy cells PUT endpoint.
+- A backend `VERSION_CONFLICT` response renders the conflict copy and does not render the success copy.
+- Switching sheets while the new sheet's cells are still loading does not reuse the previous sheet's cached `expectedVersion`.
+
+The sheet-switch case is load-bearing because it protects the stale-cache failure mode where sheet A's version could accidentally be sent with sheet B's first write.
+
+## GridView Coverage
+
+The new spec mounts `GridView` with mocked `apiFetch` and local storage sheet selection.
+
+Covered behavior:
+
+- Loading a server-backed cell stores its version.
+- Editing through the formula input and clicking `保存` sends `expectedVersion`.
+- A backend `VERSION_CONFLICT` response shows conflict copy, triggers the conflict alert, and does not mark the grid as saved.
+
+## Design Notes
+
+- Tests use real component event flow instead of calling helper functions directly.
+- API is mocked at the boundary so assertions stay focused on frontend contract shape.
+- The tests intentionally assert the PUT request body rather than implementation internals.
+- This is test-only; it does not alter the optimistic-locking behavior already shipped by PR #1092.

--- a/docs/development/legacy-cells-ui-wiring-tests-verification-20260423.md
+++ b/docs/development/legacy-cells-ui-wiring-tests-verification-20260423.md
@@ -1,0 +1,63 @@
+# Legacy Cells UI Version Wiring Tests Verification - 2026-04-23
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/spreadsheet-detail-cell-version-wiring.spec.ts \
+  tests/grid-view-cell-version-wiring.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       5 passed (5)
+```
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/spreadsheet-cell-versioning.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       4 passed (4)
+```
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result:
+
+```text
+EXIT 0
+```
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+EXIT 0
+```
+
+## Verified Behaviors
+
+- `SpreadsheetDetailView` sends `expectedVersion` from loaded cell metadata.
+- `SpreadsheetDetailView` displays a 409 conflict and does not display success copy.
+- `SpreadsheetDetailView` does not send a stale version after switching sheets before the new sheet load finishes.
+- `GridView` sends `expectedVersion` from loaded cell metadata when saving through the formula input.
+- `GridView` displays conflict copy and alert on 409, without marking the save as successful.
+
+## Residual Risk
+
+- These are frontend unit/component tests with mocked API responses; the live API conflict path is covered separately by the PR #1096 smoke script.
+- Browser-level interaction across the deployed UI remains an optional staging click check, not a blocker for this test-only follow-up.

--- a/output/delivery/legacy-cells-ui-wiring-tests-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/legacy-cells-ui-wiring-tests-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,55 @@
+# Test And Verification - Legacy Cells UI Version Wiring
+
+Date: 2026-04-23
+
+## Summary
+
+Added view-level frontend coverage for the legacy spreadsheet cells optimistic-locking flow.
+
+This verifies that the two legacy editors wired in PR #1092 actually send `expectedVersion` from real UI interactions and do not show success after a backend `VERSION_CONFLICT`.
+
+## Files
+
+- `apps/web/tests/spreadsheet-detail-cell-version-wiring.spec.ts`
+- `apps/web/tests/grid-view-cell-version-wiring.spec.ts`
+- `docs/development/legacy-cells-ui-wiring-tests-development-20260423.md`
+- `docs/development/legacy-cells-ui-wiring-tests-verification-20260423.md`
+
+## Verification
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/spreadsheet-detail-cell-version-wiring.spec.ts \
+  tests/grid-view-cell-version-wiring.spec.ts \
+  --reporter=dot
+```
+
+Passed: 5/5 tests.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/spreadsheet-cell-versioning.spec.ts \
+  --reporter=dot
+```
+
+Passed: 4/4 tests.
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Passed.
+
+```bash
+git diff --check
+```
+
+Passed.
+
+## Conclusion
+
+The frontend optimistic-locking contract is now covered at both helper level and view wiring level:
+
+- Helper tests validate version cache and payload construction.
+- New view tests validate real component save flows.
+- Live/staging API smoke from PR #1096 validates backend conflict behavior against the deployed service.


### PR DESCRIPTION
## Summary
- Add view-level tests proving SpreadsheetDetailView sends legacy cell `expectedVersion` from loaded metadata.
- Add GridView wiring tests for formula-bar save payloads and `VERSION_CONFLICT` handling.
- Add development and verification docs for the test-only follow-up.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/spreadsheet-detail-cell-version-wiring.spec.ts tests/grid-view-cell-version-wiring.spec.ts --reporter=dot` → 5/5 passed
- `pnpm --filter @metasheet/web exec vitest run tests/spreadsheet-cell-versioning.spec.ts --reporter=dot` → 4/4 passed
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` → passed
- `git diff --check` → passed

## Notes
Test-only follow-up for PR #1092 and PR #1096. No runtime code changes.