### PR TITLE
test(dingtalk): add P4 smoke status report

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -79,6 +79,8 @@
 - [x] Clear generated packet markers before gated export validation so failed reruns cannot leave a stale passing `manifest.json` or `README.md`.
 - [x] Add a P4 packet publish validator for final gated packet shape and common raw secret leakage checks.
 - [x] Add a one-command P4 final handoff wrapper that exports, validates, and summarizes a finalized session packet.
+- [x] Add a P4 smoke status reporter that summarizes remaining evidence gaps, finalization state, and release handoff readiness.
+- [x] Add an offline P4 session-to-handoff chain test so the local tooling contract stays verified without real DingTalk credentials.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-smoke-status-and-offline-handoff-development-20260423.md
+++ b/docs/development/dingtalk-p4-smoke-status-and-offline-handoff-development-20260423.md
@@ -1,0 +1,22 @@
+# DingTalk P4 Smoke Status And Offline Handoff Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-smoke-status-report-20260423`
+- Scope: local P4 remote-smoke tooling only; no DingTalk or staging calls are added by the status reporter.
+
+## Changes
+
+- Added `scripts/ops/dingtalk-p4-smoke-status.mjs`.
+- The status reporter reads `session-summary.json`, `workspace/evidence.json`, `compiled/summary.json`, optional `handoff-summary.json`, and optional `publish-check.json`.
+- It writes `smoke-status.json` / `smoke-status.md` with `manual_pending`, `finalize_pending`, `handoff_pending`, `release_ready`, or `fail`.
+- It reports required check gaps, manual evidence issues, finalization state, handoff publish status, and next commands without copying raw evidence payloads.
+- Added `--require-release-ready` for CI/operator gates that should fail unless the finalized session and handoff packet are ready.
+- Added the status command to `dingtalk-p4-smoke-session.mjs` next commands and to the exported DingTalk staging evidence packet.
+- Added `scripts/ops/dingtalk-p4-offline-handoff.test.mjs` to exercise session bootstrap, manual evidence completion, strict finalize, final handoff, and final status in one offline chain.
+
+## Guardrails
+
+- The status reporter does not call DingTalk, staging, Docker, or GitHub.
+- It does not create or infer admin tokens.
+- It redacts DingTalk robot access tokens, `SEC...` secrets, bearer tokens, JWTs, client secrets, public form tokens, and timestamp/sign query values from output strings.
+- Strict compile failures caused by missing manual evidence are surfaced as `manual_pending`, not as fake release readiness.

--- a/docs/development/dingtalk-p4-smoke-status-and-offline-handoff-verification-20260423.md
+++ b/docs/development/dingtalk-p4-smoke-status-and-offline-handoff-verification-20260423.md
@@ -1,0 +1,32 @@
+# DingTalk P4 Smoke Status And Offline Handoff Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-smoke-status-report-20260423`
+
+## Commands
+
+```bash
+node --check scripts/ops/dingtalk-p4-smoke-status.mjs
+node --check scripts/ops/dingtalk-p4-smoke-status.test.mjs
+node --check scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs
+node --test scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs
+node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-preflight.test.mjs
+git diff --check
+```
+
+## Expected Results
+
+- Status reporter tests cover manual-pending, handoff-pending, release-ready, failed operational step, strict manual evidence issue, and missing input cases.
+- Offline handoff test covers API-only bootstrap with a fake API, programmatic manual evidence completion, strict finalization, final handoff packet validation, and `--require-release-ready`.
+- Output summaries must not contain raw admin tokens, DingTalk robot access tokens, `SEC...` signing secrets, or public form tokens.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -159,6 +159,13 @@ Expected generated files:
 Expected session status is usually `manual_pending` after the API runner succeeds, because the real DingTalk-client/admin checks still need operator proof. Fill `workspace/evidence.json`, place files in `workspace/artifacts/<check-id>/`, then finalize the session:
 
 ```bash
+node scripts/ops/dingtalk-p4-smoke-status.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session
+```
+
+The status report writes `smoke-status.json` / `smoke-status.md` and shows whether the run is blocked, waiting for manual evidence, ready to finalize, waiting for handoff, or release-ready.
+
+```bash
 node scripts/ops/dingtalk-p4-smoke-session.mjs \
   --finalize output/dingtalk-p4-remote-smoke-session/142-session
 ```
@@ -171,6 +178,15 @@ After finalization passes, prefer the one-command final handoff wrapper. It expo
 node scripts/ops/dingtalk-p4-final-handoff.mjs \
   --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
   --output-dir artifacts/dingtalk-staging-evidence-packet/142-final
+```
+
+After final handoff, re-run status with the handoff summary when you need a single release-readiness gate:
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-status.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --handoff-summary artifacts/dingtalk-staging-evidence-packet/142-final/handoff-summary.json \
+  --require-release-ready
 ```
 
 If debugging the individual steps, export a handoff packet with the final-pass gate enabled:

--- a/scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+++ b/scripts/ops/dingtalk-p4-offline-handoff.test.mjs
@@ -1,0 +1,319 @@
+import assert from 'node:assert/strict'
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import http from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const sessionScript = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-smoke-session.mjs')
+const handoffScript = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-final-handoff.mjs')
+const statusScript = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-smoke-status.mjs')
+const manualClientIds = new Set([
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+])
+const manualAdminIds = new Set(['no-email-user-create-bind'])
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-offline-handoff-'))
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = ''
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      raw += chunk
+    })
+    req.on('end', () => {
+      if (!raw) {
+        resolve(null)
+        return
+      }
+      try {
+        resolve(JSON.parse(raw))
+      } catch (error) {
+        reject(error)
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+function sendJson(res, status, body) {
+  res.statusCode = status
+  if (body === undefined) {
+    res.end()
+    return
+  }
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+function createFakeApiServer() {
+  let groupCount = 0
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+      const body = await readRequestBody(req)
+
+      if (req.method === 'GET' && url.pathname === '/health') {
+        sendJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/bases') {
+        sendJson(res, 201, { ok: true, data: { base: { id: 'base_1', name: body.name } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/sheets') {
+        sendJson(res, 200, { ok: true, data: { sheet: { id: 'sheet_1', baseId: body.baseId } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/fields') {
+        sendJson(res, 201, { ok: true, data: { field: { id: 'field_1', name: body.name } } })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/views') {
+        sendJson(res, 201, { ok: true, data: { view: { id: 'view_form_1', type: body.type } } })
+        return
+      }
+
+      if (req.method === 'PATCH' && url.pathname === '/api/multitable/sheets/sheet_1/views/view_form_1/form-share') {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            enabled: true,
+            status: 'active',
+            accessMode: 'dingtalk_granted',
+            publicToken: 'public_token_should_not_leak',
+          },
+        })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/dingtalk-groups') {
+        groupCount += 1
+        sendJson(res, 201, {
+          ok: true,
+          data: {
+            id: `dt_group_${groupCount}`,
+            name: body.name,
+            sheetId: body.sheetId,
+          },
+        })
+        return
+      }
+
+      if (req.method === 'POST' && /^\/api\/multitable\/dingtalk-groups\/dt_group_[12]\/test-send$/.test(url.pathname)) {
+        sendJson(res, 204)
+        return
+      }
+
+      const manualDeliveriesMatch = url.pathname.match(/^\/api\/multitable\/dingtalk-groups\/(dt_group_[12])\/deliveries$/)
+      if (req.method === 'GET' && manualDeliveriesMatch) {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [{ id: `delivery_${manualDeliveriesMatch[1]}`, status: 'success' }],
+          },
+        })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/api/multitable/sheets/sheet_1/automations') {
+        if (body.actionType === 'send_dingtalk_group_message') {
+          sendJson(res, 200, { ok: true, data: { rule: { id: 'rule_group_1' } } })
+          return
+        }
+        if (body.actionType === 'send_dingtalk_person_message') {
+          sendJson(res, 200, { ok: true, data: { rule: { id: 'rule_person_1' } } })
+          return
+        }
+      }
+
+      const testRunMatch = url.pathname.match(/^\/api\/multitable\/sheets\/sheet_1\/automations\/(rule_group_1|rule_person_1)\/test$/)
+      if (req.method === 'POST' && testRunMatch) {
+        sendJson(res, 200, {
+          id: `exec_${testRunMatch[1]}`,
+          status: 'success',
+          steps: [{ status: 'success' }],
+        })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/api/multitable/sheets/sheet_1/automations/rule_group_1/dingtalk-group-deliveries') {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [
+              { id: 'rule_group_delivery_1', destinationId: 'dt_group_1', status: 'success' },
+              { id: 'rule_group_delivery_2', destinationId: 'dt_group_2', status: 'success' },
+            ],
+          },
+        })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/api/multitable/sheets/sheet_1/automations/rule_person_1/dingtalk-person-deliveries') {
+        sendJson(res, 200, {
+          ok: true,
+          data: {
+            deliveries: [{ id: 'rule_person_delivery_1', userId: 'user_person_bound', status: 'success' }],
+          },
+        })
+        return
+      }
+
+      sendJson(res, 404, { ok: false, error: { message: `unexpected route ${req.method} ${url.pathname}` } })
+    } catch (error) {
+      sendJson(res, 500, { ok: false, error: { message: error instanceof Error ? error.message : String(error) } })
+    }
+  })
+
+  return {
+    async listen() {
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+      const address = server.address()
+      return `http://127.0.0.1:${address.port}`
+    },
+    async close() {
+      await new Promise((resolve) => server.close(resolve))
+    },
+  }
+}
+
+function runAsyncScript(script, args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [script, ...args], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('close', (code) => resolve({ status: code, stdout, stderr }))
+  })
+}
+
+function runSyncScript(script, args) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+function fillManualEvidence(sessionDir) {
+  const evidencePath = path.join(sessionDir, 'workspace', 'evidence.json')
+  const evidence = JSON.parse(readFileSync(evidencePath, 'utf8'))
+  for (const check of evidence.checks) {
+    if (!manualClientIds.has(check.id) && !manualAdminIds.has(check.id)) continue
+    const artifactRef = `artifacts/${check.id}/evidence.txt`
+    const artifactPath = path.join(sessionDir, 'workspace', artifactRef)
+    mkdirSync(path.dirname(artifactPath), { recursive: true })
+    writeFileSync(artifactPath, `${check.id} offline manual proof\n`, 'utf8')
+    check.status = 'pass'
+    check.evidence = {
+      source: manualClientIds.has(check.id) ? 'manual-client' : 'manual-admin',
+      operator: 'qa',
+      performedAt: '2026-04-23T10:00:00.000Z',
+      summary: `${check.id} verified in offline handoff chain`,
+      artifacts: [artifactRef],
+    }
+  }
+  writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8')
+}
+
+function assertNoSecrets(value) {
+  assert.doesNotMatch(value, /secret-admin-token/)
+  assert.doesNotMatch(value, /robot-secret-a/)
+  assert.doesNotMatch(value, /robot-secret-b/)
+  assert.doesNotMatch(value, /SECabcdefghijklmnop12345678/)
+  assert.doesNotMatch(value, /public_token_should_not_leak/)
+}
+
+test('DingTalk P4 offline handoff chain reaches release-ready without leaking secrets', async () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const packetDir = path.join(tmpDir, 'packet')
+  const envFile = path.join(tmpDir, 'p4.env')
+  const fakeApi = createFakeApiServer()
+
+  try {
+    const apiBase = await fakeApi.listen()
+    writeFileSync(envFile, [
+      `DINGTALK_P4_API_BASE=${apiBase}`,
+      'DINGTALK_P4_WEB_BASE=https://metasheet.example.test',
+      'DINGTALK_P4_AUTH_TOKEN=secret-admin-token',
+      'DINGTALK_P4_GROUP_A_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a&timestamp=1690000000000&sign=robot-sign-a',
+      'DINGTALK_P4_GROUP_B_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+      'DINGTALK_P4_GROUP_A_SECRET=SECabcdefghijklmnop12345678',
+      'DINGTALK_P4_ALLOWED_USER_IDS=user_authorized',
+      'DINGTALK_P4_PERSON_USER_IDS=user_person_bound',
+    ].join('\n'), 'utf8')
+
+    const sessionResult = await runAsyncScript(sessionScript, [
+      '--env-file',
+      envFile,
+      '--output-dir',
+      sessionDir,
+    ])
+    assert.equal(sessionResult.status, 0, sessionResult.stderr || sessionResult.stdout)
+    assertNoSecrets(sessionResult.stdout)
+    assertNoSecrets(readFileSync(path.join(sessionDir, 'session-summary.json'), 'utf8'))
+
+    fillManualEvidence(sessionDir)
+
+    const finalizeResult = runSyncScript(sessionScript, ['--finalize', sessionDir])
+    assert.equal(finalizeResult.status, 0, finalizeResult.stderr || finalizeResult.stdout)
+    const finalizedSummary = JSON.parse(readFileSync(path.join(sessionDir, 'session-summary.json'), 'utf8'))
+    assert.equal(finalizedSummary.overallStatus, 'pass')
+    assert.equal(finalizedSummary.finalStrictStatus, 'pass')
+    assert.equal(finalizedSummary.nextCommands.some((command) => command.includes('dingtalk-p4-smoke-status.mjs')), true)
+
+    const handoffResult = runSyncScript(handoffScript, [
+      '--session-dir',
+      sessionDir,
+      '--output-dir',
+      packetDir,
+    ])
+    assert.equal(handoffResult.status, 0, handoffResult.stderr || handoffResult.stdout)
+    const handoffSummaryText = readFileSync(path.join(packetDir, 'handoff-summary.json'), 'utf8')
+    assertNoSecrets(handoffSummaryText)
+    const handoffSummary = JSON.parse(handoffSummaryText)
+    assert.equal(handoffSummary.status, 'pass')
+    assert.equal(handoffSummary.publishCheck.status, 'pass')
+    assert.equal(existsSync(path.join(packetDir, 'manifest.json')), true)
+
+    const statusResult = runSyncScript(statusScript, [
+      '--session-dir',
+      sessionDir,
+      '--handoff-summary',
+      path.join(packetDir, 'handoff-summary.json'),
+      '--require-release-ready',
+    ])
+    assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout)
+    const statusText = readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8')
+    assertNoSecrets(statusText)
+    const statusSummary = JSON.parse(statusText)
+    assert.equal(statusSummary.overallStatus, 'release_ready')
+    assert.equal(statusSummary.totals.gaps, 0)
+  } finally {
+    await fakeApi.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})

--- a/scripts/ops/dingtalk-p4-smoke-session.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.mjs
@@ -395,6 +395,14 @@ function finalHandoffCommand(outputDir) {
   ].join(' ')
 }
 
+function statusCommand(outputDir) {
+  return [
+    'node scripts/ops/dingtalk-p4-smoke-status.mjs',
+    '--session-dir',
+    relativePath(outputDir),
+  ].join(' ')
+}
+
 function finalizeCommand(outputDir, allowExternalArtifactRefs = false) {
   return [
     'node scripts/ops/dingtalk-p4-smoke-session.mjs',
@@ -552,6 +560,7 @@ function runSession(opts) {
     steps,
     pendingChecks,
     nextCommands: [
+      statusCommand(outputDir),
       finalizeCommand(outputDir, opts.allowExternalArtifactRefs),
       exportPacketCommand(outputDir),
     ],
@@ -628,8 +637,8 @@ function runFinalStrictCompile(opts) {
         }
       : null,
     nextCommands: strictPassed
-      ? [finalHandoffCommand(outputDir), exportPacketCommand(outputDir, true)]
-      : [finalizeCommand(outputDir, opts.allowExternalArtifactRefs), finalHandoffCommand(outputDir), exportPacketCommand(outputDir, true)],
+      ? [statusCommand(outputDir), finalHandoffCommand(outputDir), exportPacketCommand(outputDir, true)]
+      : [statusCommand(outputDir), finalizeCommand(outputDir, opts.allowExternalArtifactRefs), finalHandoffCommand(outputDir), exportPacketCommand(outputDir, true)],
   }
 
   writeSessionSummary(summary, outputDir)

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -362,6 +362,7 @@ test('dingtalk-p4-smoke-session runs preflight, API runner, and non-strict compi
     assert.equal(sessionSummary.steps.every((step) => step.status === 'pass'), true)
     assert.equal(sessionSummary.pendingChecks.some((check) => check.id === 'authorized-user-submit' && check.manual), true)
     assert.equal(sessionSummary.pendingChecks.some((check) => check.id === 'send-group-message-form-link' && check.manual), true)
+    assert.equal(sessionSummary.nextCommands.some((command) => command.includes('dingtalk-p4-smoke-status.mjs')), true)
     assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--finalize')), true)
 
     const compiledSummary = JSON.parse(readFileSync(path.join(outputDir, 'compiled/summary.json'), 'utf8'))
@@ -445,6 +446,7 @@ test('dingtalk-p4-smoke-session finalizes completed manual evidence with strict 
     assert.equal(sessionSummary.steps.at(-1).status, 'pass')
     assert.equal(sessionSummary.pendingChecks.length, 0)
     assert.equal(sessionSummary.finalStrictSummary.overallStatus, 'pass')
+    assert.equal(sessionSummary.nextCommands.some((command) => command.includes('dingtalk-p4-smoke-status.mjs')), true)
     assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--strict')), false)
     assert.equal(sessionSummary.nextCommands.some((command) => command.includes('dingtalk-p4-final-handoff.mjs')), true)
     assert.equal(sessionSummary.nextCommands.some((command) => command.includes('--require-dingtalk-p4-pass')), true)

--- a/scripts/ops/dingtalk-p4-smoke-status.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-status.mjs
@@ -1,0 +1,507 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-remote-smoke-status'
+
+const REQUIRED_CHECKS = [
+  {
+    id: 'create-table-form',
+    label: 'Create a table and form view',
+    todo: 'Remote smoke: create a table and form view',
+    manual: false,
+  },
+  {
+    id: 'bind-two-dingtalk-groups',
+    label: 'Bind at least two DingTalk groups',
+    todo: 'Remote smoke: bind at least two DingTalk groups to the table',
+    manual: false,
+  },
+  {
+    id: 'set-form-dingtalk-granted',
+    label: 'Set the form to dingtalk_granted',
+    todo: 'Remote smoke: set the form to `dingtalk_granted`',
+    manual: false,
+  },
+  {
+    id: 'send-group-message-form-link',
+    label: 'Send a DingTalk group message with a form link',
+    todo: 'Remote smoke: send a group message with a form link',
+    manual: true,
+  },
+  {
+    id: 'authorized-user-submit',
+    label: 'Verify an authorized user can open and submit',
+    todo: 'Remote smoke: verify an authorized user can open and submit',
+    manual: true,
+  },
+  {
+    id: 'unauthorized-user-denied',
+    label: 'Verify an unauthorized user cannot submit and no record is inserted',
+    todo: 'Remote smoke: verify an unauthorized user cannot submit and no record is inserted',
+    manual: true,
+  },
+  {
+    id: 'delivery-history-group-person',
+    label: 'Verify group and person delivery history',
+    todo: 'Remote smoke: verify delivery history records group and person sends',
+    manual: false,
+  },
+  {
+    id: 'no-email-user-create-bind',
+    label: 'Create and bind a no-email DingTalk-synced local user',
+    todo: 'Checklist: no-email account creation and binding',
+    manual: true,
+  },
+]
+
+const REQUIRED_CHECK_BY_ID = new Map(REQUIRED_CHECKS.map((check) => [check.id, check]))
+const VALID_STATUSES = new Set(['pass', 'fail', 'skipped', 'pending', 'missing'])
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-p4-smoke-status.mjs [options]
+
+Reads DingTalk P4 smoke session/evidence/handoff files and writes a redacted
+status report with remaining gaps and next commands. It does not call DingTalk
+or staging.
+
+Options:
+  --session-dir <dir>           DingTalk P4 smoke session directory
+  --session-summary <file>      Optional session-summary.json path
+  --evidence <file>             Optional workspace evidence.json path
+  --compiled-summary <file>     Optional compiled summary.json path
+  --handoff-summary <file>      Optional final handoff-summary.json path
+  --publish-check-json <file>   Optional publish-check.json path
+  --output-json <file>          Output status JSON, default <session-dir>/smoke-status.json
+  --output-md <file>            Output status Markdown, default <session-dir>/smoke-status.md
+  --require-release-ready       Exit non-zero unless overallStatus is release_ready
+  --help                        Show this help
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function makeRunId() {
+  return `dingtalk-p4-status-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}`
+}
+
+function parseArgs(argv) {
+  const opts = {
+    sessionDir: '',
+    sessionSummary: '',
+    evidence: '',
+    compiledSummary: '',
+    handoffSummary: '',
+    publishCheckJson: '',
+    outputJson: '',
+    outputMd: '',
+    requireReleaseReady: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--session-dir':
+        opts.sessionDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--session-summary':
+        opts.sessionSummary = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--evidence':
+        opts.evidence = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--compiled-summary':
+        opts.compiledSummary = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--handoff-summary':
+        opts.handoffSummary = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--publish-check-json':
+        opts.publishCheckJson = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--output-json':
+        opts.outputJson = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--output-md':
+        opts.outputMd = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--require-release-ready':
+        opts.requireReleaseReady = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (opts.sessionDir) {
+    opts.sessionSummary ||= path.join(opts.sessionDir, 'session-summary.json')
+    opts.evidence ||= path.join(opts.sessionDir, 'workspace', 'evidence.json')
+    opts.compiledSummary ||= path.join(opts.sessionDir, 'compiled', 'summary.json')
+    opts.outputJson ||= path.join(opts.sessionDir, 'smoke-status.json')
+    opts.outputMd ||= path.join(opts.sessionDir, 'smoke-status.md')
+  } else {
+    const outputRoot = path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, makeRunId())
+    opts.outputJson ||= path.join(outputRoot, 'smoke-status.json')
+    opts.outputMd ||= path.join(outputRoot, 'smoke-status.md')
+  }
+
+  if (!opts.sessionDir && !opts.sessionSummary && !opts.evidence && !opts.compiledSummary && !opts.handoffSummary && !opts.publishCheckJson) {
+    throw new Error('provide --session-dir or at least one input file')
+  }
+
+  return opts
+}
+
+function relativePath(file) {
+  if (!file) return ''
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function redactString(value) {
+  return String(value ?? '')
+    .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function sanitizeValue(value) {
+  if (value === null || value === undefined) return value
+  if (typeof value === 'string') return redactString(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.map((entry) => sanitizeValue(entry))
+  if (typeof value === 'object') {
+    const next = {}
+    for (const [key, entryValue] of Object.entries(value)) {
+      next[key] = sanitizeValue(entryValue)
+    }
+    return next
+  }
+  return value
+}
+
+function readJsonIfExists(file, label) {
+  if (!file || !existsSync(file)) return null
+  if (!statSync(file).isFile()) {
+    throw new Error(`${label} must be a file: ${relativePath(file)}`)
+  }
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function normalizeStatus(value) {
+  const status = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  return VALID_STATUSES.has(status) ? status : 'pending'
+}
+
+function checksFromEvidence(evidence) {
+  if (!Array.isArray(evidence?.checks)) return new Map()
+  return new Map(evidence.checks
+    .filter((check) => check && typeof check === 'object' && typeof check.id === 'string')
+    .map((check) => [check.id.trim(), check]))
+}
+
+function checksFromCompiled(compiledSummary) {
+  if (!Array.isArray(compiledSummary?.requiredChecks)) return new Map()
+  return new Map(compiledSummary.requiredChecks
+    .filter((check) => check && typeof check === 'object' && typeof check.id === 'string')
+    .map((check) => [check.id.trim(), check]))
+}
+
+function manualIssuesById(compiledSummary) {
+  const issues = new Map()
+  if (!Array.isArray(compiledSummary?.manualEvidenceIssues)) return issues
+  for (const issue of compiledSummary.manualEvidenceIssues) {
+    const id = typeof issue?.id === 'string' ? issue.id.trim() : ''
+    if (!id) continue
+    const list = issues.get(id) ?? []
+    list.push({
+      code: redactString(issue.code ?? 'manual_evidence_issue'),
+      message: redactString(issue.message ?? issue.code ?? 'manual evidence issue'),
+      artifactRef: issue.artifactRef ? redactString(issue.artifactRef) : undefined,
+    })
+    issues.set(id, list)
+  }
+  return issues
+}
+
+function buildRequiredChecks(evidence, compiledSummary) {
+  const evidenceChecks = checksFromEvidence(evidence)
+  const compiledChecks = checksFromCompiled(compiledSummary)
+  const issueMap = manualIssuesById(compiledSummary)
+
+  return REQUIRED_CHECKS.map((required) => {
+    const evidenceCheck = evidenceChecks.get(required.id)
+    const compiledCheck = compiledChecks.get(required.id)
+    const status = normalizeStatus(evidenceCheck?.status ?? compiledCheck?.status ?? 'missing')
+    const source = typeof evidenceCheck?.evidence?.source === 'string'
+      ? redactString(evidenceCheck.evidence.source)
+      : typeof compiledCheck?.evidence?.source === 'string'
+        ? redactString(compiledCheck.evidence.source)
+        : ''
+    const issues = issueMap.get(required.id) ?? []
+    return {
+      id: required.id,
+      label: required.label,
+      todo: required.todo,
+      manual: required.manual,
+      status,
+      source,
+      manualEvidenceIssueCount: issues.length,
+      issues,
+    }
+  })
+}
+
+function buildGaps(requiredChecks) {
+  const gaps = []
+  for (const check of requiredChecks) {
+    if (check.status !== 'pass') {
+      gaps.push({
+        id: check.id,
+        severity: check.status === 'fail' ? 'error' : 'required',
+        status: check.status,
+        nextAction: check.manual
+          ? `complete real DingTalk-client/admin evidence for ${check.id}`
+          : `complete API/bootstrap smoke check ${check.id}`,
+      })
+    }
+    for (const issue of check.issues) {
+      gaps.push({
+        id: check.id,
+        severity: 'required',
+        status: 'manual_evidence_issue',
+        code: issue.code,
+        nextAction: issue.message,
+      })
+    }
+  }
+  return gaps
+}
+
+function hasFailedSessionStep(sessionSummary) {
+  if (!Array.isArray(sessionSummary?.steps)) return false
+  return sessionSummary.steps.some((step) => {
+    if (!step || step.status !== 'fail') return false
+    return step.id !== 'strict-compile'
+  })
+}
+
+function hasFailedEvidence(requiredChecks, compiledSummary) {
+  if (requiredChecks.some((check) => check.status === 'fail')) return true
+  return Array.isArray(compiledSummary?.failedChecks) && compiledSummary.failedChecks.length > 0
+}
+
+function summarizeHandoff(handoffSummary, publishCheck) {
+  const handoffStatus = handoffSummary?.status ?? 'not_available'
+  const publishStatus = handoffSummary?.publishCheck?.status ?? publishCheck?.status ?? 'not_available'
+  const secretFindingCount = Array.isArray(handoffSummary?.publishCheck?.secretFindings)
+    ? handoffSummary.publishCheck.secretFindings.length
+    : Array.isArray(publishCheck?.secretFindings)
+      ? publishCheck.secretFindings.length
+      : 0
+  const failures = [
+    ...(Array.isArray(handoffSummary?.failures) ? handoffSummary.failures : []),
+    ...(Array.isArray(publishCheck?.failures) ? publishCheck.failures : []),
+  ].map((failure) => redactString(failure))
+
+  return {
+    status: handoffStatus,
+    publishStatus,
+    secretFindingCount,
+    failures,
+  }
+}
+
+function computeOverallStatus({ sessionSummary, compiledSummary, requiredChecks, gaps, handoff }) {
+  if (hasFailedSessionStep(sessionSummary) || hasFailedEvidence(requiredChecks, compiledSummary)) return 'fail'
+  if (gaps.length > 0) return 'manual_pending'
+  if (!sessionSummary || sessionSummary.sessionPhase !== 'finalize' || sessionSummary.finalStrictStatus !== 'pass') {
+    return 'finalize_pending'
+  }
+  if (handoff.status === 'not_available' && handoff.publishStatus === 'not_available') return 'handoff_pending'
+  if (handoff.status !== 'pass' || handoff.publishStatus !== 'pass') return 'fail'
+  return 'release_ready'
+}
+
+function sessionCommand(opts, command) {
+  if (!opts.sessionDir) return ''
+  return command.replaceAll('<session-dir>', relativePath(opts.sessionDir))
+}
+
+function buildNextCommands(overallStatus, opts) {
+  const commands = []
+  if (!opts.sessionDir) {
+    commands.push('node scripts/ops/dingtalk-p4-smoke-session.mjs --env-file <env-file> --output-dir <session-dir>')
+    return commands
+  }
+
+  if (overallStatus === 'manual_pending' || overallStatus === 'finalize_pending') {
+    commands.push(sessionCommand(opts, 'node scripts/ops/dingtalk-p4-smoke-session.mjs --finalize <session-dir>'))
+  }
+  if (overallStatus === 'handoff_pending' || overallStatus === 'finalize_pending') {
+    commands.push(sessionCommand(opts, 'node scripts/ops/dingtalk-p4-final-handoff.mjs --session-dir <session-dir>'))
+  }
+  if (overallStatus === 'fail') {
+    commands.push('inspect failed steps/checks in this status report before rerunning the relevant command')
+  }
+  if (overallStatus === 'release_ready') {
+    commands.push('review the final packet artifacts manually before sharing outside the release team')
+  }
+  return Array.from(new Set(commands.filter(Boolean)))
+}
+
+function buildSummary(opts) {
+  const sessionSummary = readJsonIfExists(opts.sessionSummary, 'session summary')
+  const evidence = readJsonIfExists(opts.evidence, 'evidence')
+  const compiledSummary = readJsonIfExists(opts.compiledSummary, 'compiled summary')
+  const handoffSummary = readJsonIfExists(opts.handoffSummary, 'handoff summary')
+  const publishCheck = readJsonIfExists(opts.publishCheckJson, 'publish check')
+
+  if (!sessionSummary && !evidence && !compiledSummary && !handoffSummary && !publishCheck) {
+    throw new Error('none of the provided input files exist')
+  }
+
+  const requiredChecks = buildRequiredChecks(evidence, compiledSummary)
+  const gaps = buildGaps(requiredChecks)
+  const handoff = summarizeHandoff(handoffSummary, publishCheck)
+  const overallStatus = computeOverallStatus({
+    sessionSummary,
+    compiledSummary,
+    requiredChecks,
+    gaps,
+    handoff,
+  })
+
+  return {
+    tool: 'dingtalk-p4-smoke-status',
+    generatedAt: new Date().toISOString(),
+    overallStatus,
+    sessionPhase: sessionSummary?.sessionPhase ?? 'not_available',
+    finalStrictStatus: sessionSummary?.finalStrictStatus ?? 'not_available',
+    apiBootstrapStatus: compiledSummary?.apiBootstrapStatus ?? 'not_available',
+    remoteClientStatus: compiledSummary?.remoteClientStatus ?? 'not_available',
+    inputs: {
+      sessionDir: relativePath(opts.sessionDir),
+      sessionSummary: opts.sessionSummary && existsSync(opts.sessionSummary) ? relativePath(opts.sessionSummary) : '',
+      evidence: opts.evidence && existsSync(opts.evidence) ? relativePath(opts.evidence) : '',
+      compiledSummary: opts.compiledSummary && existsSync(opts.compiledSummary) ? relativePath(opts.compiledSummary) : '',
+      handoffSummary: opts.handoffSummary && existsSync(opts.handoffSummary) ? relativePath(opts.handoffSummary) : '',
+      publishCheckJson: opts.publishCheckJson && existsSync(opts.publishCheckJson) ? relativePath(opts.publishCheckJson) : '',
+    },
+    totals: {
+      requiredChecks: REQUIRED_CHECKS.length,
+      passedChecks: requiredChecks.filter((check) => check.status === 'pass').length,
+      failedChecks: requiredChecks.filter((check) => check.status === 'fail').length,
+      pendingOrMissingChecks: requiredChecks.filter((check) => check.status !== 'pass' && check.status !== 'fail').length,
+      manualEvidenceIssues: requiredChecks.reduce((total, check) => total + check.manualEvidenceIssueCount, 0),
+      gaps: gaps.length,
+    },
+    requiredChecks,
+    gaps,
+    handoff,
+    nextCommands: [],
+  }
+}
+
+function markdownEscape(value) {
+  return redactString(value).replaceAll('|', '\\|').replaceAll('\n', '<br>')
+}
+
+function renderMarkdown(summary) {
+  const checkRows = summary.requiredChecks.map((check) => {
+    const issue = check.issues.length ? check.issues.map((entry) => entry.code).join(', ') : ''
+    return `| \`${markdownEscape(check.id)}\` | ${markdownEscape(check.status)} | ${check.manual ? 'yes' : 'no'} | ${markdownEscape(check.source)} | ${markdownEscape(issue)} |`
+  })
+  const gaps = summary.gaps.length
+    ? summary.gaps.map((gap) => `- \`${gap.id}\`: ${markdownEscape(gap.nextAction)} (${gap.status})`).join('\n')
+    : '- None'
+  const commands = summary.nextCommands.length
+    ? summary.nextCommands.map((command) => `- \`${markdownEscape(command)}\``).join('\n')
+    : '- None'
+
+  return `# DingTalk P4 Smoke Status
+
+Generated at: ${summary.generatedAt}
+
+Overall status: **${summary.overallStatus}**
+
+Session phase: **${summary.sessionPhase}**
+
+Final strict status: **${summary.finalStrictStatus}**
+
+API bootstrap status: **${summary.apiBootstrapStatus}**
+
+Remote client status: **${summary.remoteClientStatus}**
+
+Handoff status: **${summary.handoff.status}**
+
+Publish status: **${summary.handoff.publishStatus}**
+
+## Required Checks
+
+| Check | Status | Manual | Evidence Source | Issues |
+| --- | --- | --- | --- | --- |
+${checkRows.join('\n')}
+
+## Gaps
+
+${gaps}
+
+## Next Commands
+
+${commands}
+
+## Secret Handling
+
+- This report stores statuses, issue codes, and next actions only; it does not copy raw evidence payloads.
+- DingTalk webhook access tokens, SEC secrets, bearer tokens, JWTs, passwords, and public form tokens are redacted from strings before output.
+`
+}
+
+function writeSummary(summary, opts) {
+  mkdirSync(path.dirname(opts.outputJson), { recursive: true })
+  mkdirSync(path.dirname(opts.outputMd), { recursive: true })
+  writeFileSync(opts.outputJson, `${JSON.stringify(sanitizeValue(summary), null, 2)}\n`, 'utf8')
+  writeFileSync(opts.outputMd, renderMarkdown(summary), 'utf8')
+  console.log(`Wrote ${relativePath(opts.outputJson)}`)
+  console.log(`Wrote ${relativePath(opts.outputMd)}`)
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2))
+  const summary = buildSummary(opts)
+  summary.nextCommands = buildNextCommands(summary.overallStatus, opts)
+  writeSummary(summary, opts)
+  if (opts.requireReleaseReady && summary.overallStatus !== 'release_ready') {
+    process.exit(1)
+  }
+} catch (error) {
+  console.error(`[dingtalk-p4-smoke-status] ERROR: ${redactString(error instanceof Error ? error.message : String(error))}`)
+  process.exit(1)
+}

--- a/scripts/ops/dingtalk-p4-smoke-status.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-status.test.mjs
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-smoke-status.mjs')
+const requiredCheckIds = [
+  'create-table-form',
+  'bind-two-dingtalk-groups',
+  'set-form-dingtalk-granted',
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'delivery-history-group-person',
+  'no-email-user-create-bind',
+]
+const manualIds = new Set([
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'no-email-user-create-bind',
+])
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-smoke-status-'))
+}
+
+function writeJson(file, value) {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function makeEvidenceChecks(overrides = {}) {
+  return requiredCheckIds.map((id) => ({
+    id,
+    status: overrides[id]?.status ?? 'pass',
+    evidence: {
+      source: manualIds.has(id) ? 'manual-client' : 'api-bootstrap',
+      summary: `${id} ok`,
+      ...overrides[id]?.evidence,
+    },
+  }))
+}
+
+function writeSession(sessionDir, options = {}) {
+  const checkOverrides = options.checkOverrides ?? {}
+  const checks = makeEvidenceChecks(checkOverrides)
+  writeJson(path.join(sessionDir, 'workspace', 'evidence.json'), {
+    runId: 'remote-142',
+    checks,
+  })
+  const requiredChecks = checks.map((check) => ({
+    id: check.id,
+    status: check.status,
+    evidence: check.evidence,
+  }))
+  const notPassed = requiredChecks
+    .filter((check) => check.status !== 'pass')
+    .map((check) => ({ id: check.id, status: check.status }))
+
+  writeJson(path.join(sessionDir, 'compiled', 'summary.json'), {
+    tool: 'compile-dingtalk-p4-smoke-evidence',
+    overallStatus: notPassed.length === 0 && !options.manualEvidenceIssues?.length ? 'pass' : 'fail',
+    apiBootstrapStatus: 'pass',
+    remoteClientStatus: notPassed.length === 0 && !options.manualEvidenceIssues?.length ? 'pass' : 'fail',
+    totals: {
+      totalChecks: requiredCheckIds.length,
+      requiredChecks: requiredCheckIds.length,
+      passedChecks: requiredChecks.filter((check) => check.status === 'pass').length,
+      failedChecks: requiredChecks.filter((check) => check.status === 'fail').length,
+      skippedChecks: requiredChecks.filter((check) => check.status === 'skipped').length,
+      pendingChecks: requiredChecks.filter((check) => check.status === 'pending').length,
+      missingRequiredChecks: 0,
+      unknownChecks: 0,
+    },
+    requiredChecks,
+    missingRequiredChecks: [],
+    requiredChecksNotPassed: notPassed,
+    failedChecks: requiredChecks.filter((check) => check.status === 'fail').map((check) => check.id),
+    unknownChecks: [],
+    manualEvidenceIssues: options.manualEvidenceIssues ?? [],
+  })
+
+  writeJson(path.join(sessionDir, 'session-summary.json'), {
+    tool: 'dingtalk-p4-smoke-session',
+    runId: 'session-142',
+    sessionPhase: options.sessionPhase ?? 'finalize',
+    overallStatus: options.sessionOverallStatus ?? 'pass',
+    finalStrictStatus: options.finalStrictStatus ?? 'pass',
+    steps: options.steps ?? [
+      { id: 'preflight', status: 'pass', exitCode: 0 },
+      { id: 'api-runner', status: 'pass', exitCode: 0 },
+      { id: 'compile', status: 'pass', exitCode: 0 },
+      { id: 'strict-compile', status: options.finalStrictStatus === 'fail' ? 'fail' : 'pass', exitCode: options.finalStrictStatus === 'fail' ? 1 : 0 },
+    ],
+    pendingChecks: notPassed,
+  })
+}
+
+function runScript(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+test('dingtalk-p4-smoke-status reports manual pending gaps for bootstrap sessions', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeSession(sessionDir, {
+      sessionPhase: 'bootstrap',
+      sessionOverallStatus: 'manual_pending',
+      finalStrictStatus: 'not_run',
+      steps: [
+        { id: 'preflight', status: 'pass', exitCode: 0 },
+        { id: 'api-runner', status: 'pass', exitCode: 0 },
+        { id: 'compile', status: 'pass', exitCode: 0 },
+      ],
+      checkOverrides: {
+        'authorized-user-submit': {
+          status: 'pending',
+          evidence: {
+            summary: 'open https://oapi.dingtalk.com/robot/send?access_token=secret-token-should-hide',
+          },
+        },
+      },
+    })
+
+    const result = runScript(['--session-dir', sessionDir])
+
+    assert.equal(result.status, 0, result.stderr)
+    const summaryText = readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8')
+    assert.doesNotMatch(summaryText, /secret-token-should-hide/)
+    const summary = JSON.parse(summaryText)
+    assert.equal(summary.overallStatus, 'manual_pending')
+    assert.equal(summary.totals.gaps > 0, true)
+    assert.equal(summary.requiredChecks.find((check) => check.id === 'authorized-user-submit').status, 'pending')
+    assert.equal(summary.nextCommands.some((command) => command.includes('--finalize')), true)
+    assert.equal(existsSync(path.join(sessionDir, 'smoke-status.md')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-status reports handoff pending after final strict pass', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeSession(sessionDir)
+
+    const result = runScript(['--session-dir', sessionDir])
+
+    assert.equal(result.status, 0, result.stderr)
+    const summary = JSON.parse(readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'handoff_pending')
+    assert.equal(summary.totals.gaps, 0)
+    assert.equal(summary.nextCommands.some((command) => command.includes('dingtalk-p4-final-handoff.mjs')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-status reports release ready with passing handoff and publish check', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const packetDir = path.join(tmpDir, 'packet')
+  const handoffSummary = path.join(packetDir, 'handoff-summary.json')
+
+  try {
+    writeSession(sessionDir)
+    writeJson(handoffSummary, {
+      tool: 'dingtalk-p4-final-handoff',
+      status: 'pass',
+      publishCheck: {
+        status: 'pass',
+        secretFindings: [],
+      },
+      failures: [],
+    })
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--handoff-summary',
+      handoffSummary,
+      '--require-release-ready',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summary = JSON.parse(readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'release_ready')
+    assert.equal(summary.handoff.status, 'pass')
+    assert.equal(summary.handoff.publishStatus, 'pass')
+    assert.equal(summary.nextCommands.some((command) => command.includes('review the final packet')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-status require-release-ready fails before handoff is ready', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeSession(sessionDir)
+
+    const result = runScript(['--session-dir', sessionDir, '--require-release-ready'])
+
+    assert.equal(result.status, 1)
+    const summary = JSON.parse(readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'handoff_pending')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-status reports operational failures before gap states', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeJson(path.join(sessionDir, 'session-summary.json'), {
+      tool: 'dingtalk-p4-smoke-session',
+      sessionPhase: 'bootstrap',
+      overallStatus: 'fail',
+      finalStrictStatus: 'not_run',
+      steps: [
+        { id: 'preflight', status: 'fail', exitCode: 1 },
+      ],
+      pendingChecks: [],
+    })
+
+    const result = runScript(['--session-dir', sessionDir])
+
+    assert.equal(result.status, 0, result.stderr)
+    const summary = JSON.parse(readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'fail')
+    assert.equal(summary.nextCommands.some((command) => command.includes('inspect failed steps')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-status treats strict manual evidence issues as manual pending', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeSession(sessionDir, {
+      sessionOverallStatus: 'fail',
+      finalStrictStatus: 'fail',
+      manualEvidenceIssues: [
+        {
+          id: 'authorized-user-submit',
+          code: 'artifact_ref_missing',
+          message: 'authorized-user-submit artifact file does not exist: Bearer very-secret-admin-token-should-hide',
+        },
+      ],
+    })
+
+    const result = runScript(['--session-dir', sessionDir])
+
+    assert.equal(result.status, 0, result.stderr)
+    const summaryText = readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8')
+    assert.doesNotMatch(summaryText, /very-secret-admin-token-should-hide/)
+    const summary = JSON.parse(summaryText)
+    assert.equal(summary.overallStatus, 'manual_pending')
+    assert.equal(summary.requiredChecks.find((check) => check.id === 'authorized-user-submit').manualEvidenceIssueCount, 1)
+    assert.equal(summary.nextCommands.some((command) => command.includes('--finalize')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-status rejects missing inputs', () => {
+  const result = runScript([])
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /provide --session-dir or at least one input file/)
+})

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -107,6 +107,11 @@ const requiredPacketFiles = [
     description: 'orchestrates P4 preflight, API-only smoke workspace bootstrap, and non-strict evidence compile',
   },
   {
+    path: 'scripts/ops/dingtalk-p4-smoke-status.mjs',
+    kind: 'script',
+    description: 'summarizes a P4 smoke session, evidence gaps, finalization state, and handoff readiness',
+  },
+  {
     path: 'scripts/ops/dingtalk-p4-final-handoff.mjs',
     kind: 'script',
     description: 'exports a finalized P4 smoke session, validates the packet, and writes handoff summaries',
@@ -361,10 +366,12 @@ ${gateLine}
 6. Execute \`docs/dingtalk-remote-smoke-checklist-20260422.md\` for P4 DingTalk form/group/person coverage.
 7. Run the session orchestrator with \`node scripts/ops/dingtalk-p4-smoke-session.mjs --output-dir <session-dir>\`.
 8. If needed, debug individual steps with \`dingtalk-p4-smoke-preflight.mjs\` and \`dingtalk-p4-remote-smoke.mjs\`.
-9. Complete the manual DingTalk-client checks in \`<session-dir>/workspace/evidence.json\`.
-10. Finalize smoke evidence with \`node scripts/ops/dingtalk-p4-smoke-session.mjs --finalize <session-dir>\`.
-11. Run \`node scripts/ops/dingtalk-p4-final-handoff.mjs --session-dir <session-dir> --output-dir <packet-dir>\` after finalization passes.
-12. If debugging manually, re-export with \`--include-output <session-dir> --require-dingtalk-p4-pass\`, then validate with \`validate-dingtalk-staging-evidence-packet.mjs\`.
+9. Check remaining evidence gaps with \`node scripts/ops/dingtalk-p4-smoke-status.mjs --session-dir <session-dir>\`.
+10. Complete the manual DingTalk-client checks in \`<session-dir>/workspace/evidence.json\`.
+11. Finalize smoke evidence with \`node scripts/ops/dingtalk-p4-smoke-session.mjs --finalize <session-dir>\`.
+12. Re-run \`dingtalk-p4-smoke-status.mjs\` to confirm the status moved to \`handoff_pending\`.
+13. Run \`node scripts/ops/dingtalk-p4-final-handoff.mjs --session-dir <session-dir> --output-dir <packet-dir>\` after finalization passes.
+14. If debugging manually, re-export with \`--include-output <session-dir> --require-dingtalk-p4-pass\`, then validate with \`validate-dingtalk-staging-evidence-packet.mjs\`.
 
 ## Non-Goals
 

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -104,6 +104,10 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       true,
     )
     assert.equal(
+      existsSync(path.join(outputDir, 'scripts/ops/dingtalk-p4-smoke-status.mjs')),
+      true,
+    )
+    assert.equal(
       existsSync(path.join(outputDir, 'scripts/ops/dingtalk-p4-final-handoff.mjs')),
       true,
     )
@@ -143,6 +147,10 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
       true,
     )
     assert.equal(
+      manifest.files.some((file) => file.path === 'scripts/ops/dingtalk-p4-smoke-status.mjs'),
+      true,
+    )
+    assert.equal(
       manifest.files.some((file) => file.path === 'scripts/ops/dingtalk-p4-final-handoff.mjs'),
       true,
     )
@@ -157,6 +165,7 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
     assert.match(readme, /dingtalk-p4-remote-smoke\.mjs/)
     assert.match(readme, /dingtalk-p4-smoke-preflight\.mjs/)
     assert.match(readme, /dingtalk-p4-smoke-session\.mjs/)
+    assert.match(readme, /dingtalk-p4-smoke-status\.mjs/)
     assert.match(readme, /dingtalk-p4-final-handoff\.mjs/)
     assert.match(readme, /validate-dingtalk-staging-evidence-packet\.mjs/)
     assert.match(readme, /compile-dingtalk-p4-smoke-evidence\.mjs/)


### PR DESCRIPTION
Stacked on #1097.

## Summary
- Add `dingtalk-p4-smoke-status.mjs` to summarize P4 session/evidence gaps, finalization state, handoff status, and release readiness without calling DingTalk or staging.
- Add `--require-release-ready` for operator/CI gating after final handoff.
- Add the status command to smoke-session next commands and include it in exported staging evidence packets.
- Add an offline session-to-final-handoff chain test that runs fake API bootstrap, fills manual evidence, finalizes, handoffs, and confirms release-ready status without leaking secrets.
- Update remote smoke checklist, TODO, and development/verification notes.

## Verification
- `node --check scripts/ops/dingtalk-p4-smoke-status.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-status.test.mjs`
- `node --check scripts/ops/dingtalk-p4-offline-handoff.test.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`
- `node --check scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs` (7/7)
- `node --test scripts/ops/dingtalk-p4-offline-handoff.test.mjs` (1/1)
- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs` (6/6)
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs` (12/12)
- `node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs` (8/8)
- `node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs` (7/7)
- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs` (11/11)
- `node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs` (4/4)
- `node --test scripts/ops/dingtalk-p4-smoke-preflight.test.mjs` (4/4)
- `git diff --check`