### PR TITLE
test(ops): guard PR mainline merge target

### DIFF
--- a/docs/development/pr-mainline-base-guard-development-20260423.md
+++ b/docs/development/pr-mainline-base-guard-development-20260423.md
@@ -1,0 +1,68 @@
+# PR Mainline Base Guard Development - 2026-04-23
+
+## Context
+
+During the DingTalk P4 PR queue review, several PRs looked merge-ready because they were `CLEAN` and had passing `pr-validate` checks. A closer inspection showed they were stacked PRs whose `baseRefName` was another feature branch, not `main`.
+
+Two PRs were merged into their configured stack bases before that was detected:
+
+- `#1063` into `codex/dingtalk-person-granted-form-guard-20260422`
+- `#1075` into `codex/dingtalk-person-delivery-skip-reasons-20260422`
+
+No `main` branch commit was created by those merges. The local `origin/main` remained at `b25a6aea6` during the stack inspection.
+
+`#1076` was reopened after a failed mergeability attempt, rebased onto the updated stack base, force-with-lease pushed, and restored to `CLEAN` with `pr-validate` passing.
+
+## Change
+
+Added `scripts/ops/check-pr-mainline-readiness.mjs`.
+
+The tool checks one or more PRs before an administrator merge and fails if:
+
+- PR state is not `OPEN`
+- PR base is not the expected branch, defaulting to `main`
+- `mergeStateStatus` is not `CLEAN`
+- any required check is pending or failing
+
+It supports:
+
+- live GitHub checks via `gh pr view`
+- offline JSON input for deterministic testing
+- `text`, `markdown`, and `json` output
+- `--base <branch>` for intentional stack-base checks
+- `--output <path>` for saving evidence reports
+
+## Why This Shape
+
+The key failure mode was not CI, test coverage, or mergeability. It was target-branch ambiguity.
+
+The guard makes the intended merge target explicit. For normal mainline promotion the command should be:
+
+```bash
+node scripts/ops/check-pr-mainline-readiness.mjs <pr-number>
+```
+
+For an intentional stacked PR merge, the operator must state the stack base:
+
+```bash
+node scripts/ops/check-pr-mainline-readiness.mjs \
+  --base codex/dingtalk-person-delivery-skip-reasons-20260422 \
+  1076
+```
+
+That distinction prevents a stacked PR from being treated as a mainline-ready PR simply because it is `CLEAN`.
+
+## Files
+
+- `scripts/ops/check-pr-mainline-readiness.mjs`
+- `scripts/ops/check-pr-mainline-readiness.test.mjs`
+- `docs/development/pr-mainline-base-guard-development-20260423.md`
+- `docs/development/pr-mainline-base-guard-verification-20260423.md`
+- `output/delivery/pr-mainline-base-guard-20260423/TEST_AND_VERIFICATION.md`
+
+## Non-Goals
+
+- Does not replace branch protection.
+- Does not approve or merge PRs.
+- Does not flatten stacked PRs.
+- Does not decide whether a stacked PR should be promoted to `main`.

--- a/docs/development/pr-mainline-base-guard-verification-20260423.md
+++ b/docs/development/pr-mainline-base-guard-verification-20260423.md
@@ -1,0 +1,77 @@
+# PR Mainline Base Guard Verification - 2026-04-23
+
+## Local Unit Tests
+
+```bash
+node --test scripts/ops/check-pr-mainline-readiness.test.mjs
+```
+
+Result:
+
+```text
+tests 8
+pass 8
+fail 0
+```
+
+## Whitespace Check
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+EXIT 0
+```
+
+## Live GitHub Guard - Expected Failure For Stacked PRs
+
+```bash
+node scripts/ops/check-pr-mainline-readiness.mjs \
+  --format markdown \
+  --output output/pr-mainline-readiness-1063-1076-1099-20260423.md \
+  1063 1076 1099
+```
+
+Result:
+
+```text
+EXIT 1
+Overall: FAIL
+```
+
+Observed reasons:
+
+- `#1063` is merged and targets `codex/dingtalk-person-granted-form-guard-20260422`, not `main`.
+- `#1076` is open and clean, but targets `codex/dingtalk-person-delivery-skip-reasons-20260422`, not `main`.
+- `#1099` is open and clean, but targets `codex/dingtalk-p4-final-handoff-command-20260423`, not `main`.
+
+The generated evidence report is:
+
+- `output/pr-mainline-readiness-1063-1076-1099-20260423.md`
+
+## Live GitHub Guard - Expected Pass For Explicit Stack Base
+
+```bash
+node scripts/ops/check-pr-mainline-readiness.mjs \
+  --base codex/dingtalk-person-delivery-skip-reasons-20260422 \
+  1076
+```
+
+Result:
+
+```text
+EXIT 0
+PR mainline readiness: PASS
+```
+
+This confirms the tool can still support intentional stacked PR operations, but only when the operator explicitly names the stack base.
+
+## Stack State After Repair
+
+- `origin/main` remains on `b25a6aea6` at the time of this verification.
+- `#1063` and `#1075` are merged into their configured stack bases, not into `main`.
+- `#1076` is reopened, rebased onto its updated stack base, `CLEAN`, and passing `pr-validate`.
+- No top-of-stack DingTalk P4 flattening was attempted because the top branch diff against `main` spans 182 files and includes real DingTalk feature/runtime changes, not only P4 smoke tooling.

--- a/output/delivery/pr-mainline-base-guard-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/pr-mainline-base-guard-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,50 @@
+# Test And Verification - PR Mainline Base Guard
+
+Date: 2026-04-23
+
+## Summary
+
+Added a pre-merge guard for administrator PR promotion.
+
+The guard prevents stacked PRs from being mistaken for mainline-ready PRs by explicitly checking `baseRefName`, `state`, `mergeStateStatus`, and check-rollup results before merge.
+
+## Verification
+
+```bash
+node --test scripts/ops/check-pr-mainline-readiness.test.mjs
+```
+
+Passed: 8/8 tests.
+
+```bash
+git diff --check
+```
+
+Passed.
+
+```bash
+node scripts/ops/check-pr-mainline-readiness.mjs \
+  --format markdown \
+  --output output/pr-mainline-readiness-1063-1076-1099-20260423.md \
+  1063 1076 1099
+```
+
+Expected result: failed with `EXIT 1` because all three sampled PRs do not target `main`.
+
+```bash
+node scripts/ops/check-pr-mainline-readiness.mjs \
+  --base codex/dingtalk-person-delivery-skip-reasons-20260422 \
+  1076
+```
+
+Expected result: passed with `EXIT 0` because the intentional stack base was explicitly provided.
+
+## Operational Conclusion
+
+Do not batch-admin-merge PRs based only on `CLEAN` and green checks. First run:
+
+```bash
+node scripts/ops/check-pr-mainline-readiness.mjs <pr-number>
+```
+
+Only proceed with mainline admin merge when this guard passes with the default `main` base.

--- a/output/pr-mainline-readiness-1063-1076-1099-20260423.md
+++ b/output/pr-mainline-readiness-1063-1076-1099-20260423.md
@@ -1,0 +1,11 @@
+# PR Mainline Readiness
+
+Overall: **FAIL**
+
+Expected base: `main`
+
+| PR | Status | Base | Head | Merge State | Reasons |
+| --- | --- | --- | --- | --- | --- |
+[#1063](https://github.com/zensgit/metasheet2/pull/1063) | FAIL | `codex/dingtalk-person-granted-form-guard-20260422` | `codex/dingtalk-feature-plan-todo-20260422` | `UNKNOWN` | state is MERGED, expected OPEN<br>base is codex/dingtalk-person-granted-form-guard-20260422, expected main<br>mergeStateStatus is UNKNOWN, expected CLEAN
+[#1076](https://github.com/zensgit/metasheet2/pull/1076) | FAIL | `codex/dingtalk-person-delivery-skip-reasons-20260422` | `codex/dingtalk-p4-smoke-evidence-runner-20260422` | `CLEAN` | base is codex/dingtalk-person-delivery-skip-reasons-20260422, expected main
+[#1099](https://github.com/zensgit/metasheet2/pull/1099) | FAIL | `codex/dingtalk-p4-final-handoff-command-20260423` | `codex/dingtalk-p4-smoke-status-report-20260423` | `CLEAN` | base is codex/dingtalk-p4-final-handoff-command-20260423, expected main

--- a/scripts/ops/check-pr-mainline-readiness.mjs
+++ b/scripts/ops/check-pr-mainline-readiness.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const GH_PR_FIELDS = [
+  'number',
+  'title',
+  'state',
+  'baseRefName',
+  'headRefName',
+  'mergeStateStatus',
+  'reviewDecision',
+  'statusCheckRollup',
+  'url',
+].join(',')
+
+export function parseArgs(argv) {
+  const config = {
+    expectedBase: 'main',
+    format: 'text',
+    inputJson: null,
+    output: null,
+    prs: [],
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--base') {
+      config.expectedBase = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--format') {
+      config.format = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--input-json') {
+      config.inputJson = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--output') {
+      config.output = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      config.help = true
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`)
+    } else {
+      config.prs.push(arg)
+    }
+  }
+
+  if (!['json', 'markdown', 'text'].includes(config.format)) {
+    throw new Error('--format must be one of: text, markdown, json')
+  }
+
+  return config
+}
+
+function requireValue(argv, index, arg) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${arg} requires a value`)
+  }
+  return value
+}
+
+export function normalizePrList(value) {
+  if (Array.isArray(value)) return value
+  if (value && Array.isArray(value.prs)) return value.prs
+  if (value && Array.isArray(value.pullRequests)) return value.pullRequests
+  if (value && typeof value === 'object') return [value]
+  throw new Error('Input JSON must be a PR object or an array of PR objects')
+}
+
+export function evaluatePr(pr, options = {}) {
+  const expectedBase = options.expectedBase ?? 'main'
+  const reasons = []
+  const warnings = []
+  const checks = normalizeChecks(pr.statusCheckRollup)
+  const pendingChecks = checks.filter(isPendingCheck)
+  const failedChecks = checks.filter((check) => !isPendingCheck(check) && !isSuccessfulCheck(check))
+
+  if (pr.state !== 'OPEN') {
+    reasons.push(`state is ${pr.state ?? 'unknown'}, expected OPEN`)
+  }
+
+  if (pr.baseRefName !== expectedBase) {
+    reasons.push(`base is ${pr.baseRefName ?? 'unknown'}, expected ${expectedBase}`)
+  }
+
+  if (pr.mergeStateStatus && pr.mergeStateStatus !== 'CLEAN') {
+    reasons.push(`mergeStateStatus is ${pr.mergeStateStatus}, expected CLEAN`)
+  }
+
+  if (failedChecks.length > 0) {
+    reasons.push(`failing checks: ${failedChecks.map((check) => check.name).join(', ')}`)
+  }
+
+  if (pendingChecks.length > 0) {
+    reasons.push(`pending checks: ${pendingChecks.map((check) => check.name).join(', ')}`)
+  }
+
+  if (pr.reviewDecision && pr.reviewDecision !== 'APPROVED') {
+    warnings.push(`reviewDecision is ${pr.reviewDecision}`)
+  }
+
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    state: pr.state,
+    baseRefName: pr.baseRefName,
+    headRefName: pr.headRefName,
+    mergeStateStatus: pr.mergeStateStatus,
+    reviewDecision: pr.reviewDecision || '',
+    ok: reasons.length === 0,
+    reasons,
+    warnings,
+    checks,
+  }
+}
+
+function normalizeChecks(statusCheckRollup) {
+  if (!Array.isArray(statusCheckRollup)) return []
+  return statusCheckRollup.map((check) => ({
+    name: check.name ?? check.context ?? 'unknown-check',
+    conclusion: check.conclusion ?? check.state ?? '',
+    status: check.status ?? (check.conclusion || check.state ? 'COMPLETED' : ''),
+  }))
+}
+
+function isSuccessfulCheck(check) {
+  return ['SUCCESS', 'SKIPPED', 'NEUTRAL'].includes(String(check.conclusion).toUpperCase())
+}
+
+function isPendingCheck(check) {
+  return Boolean(check.status && check.status !== 'COMPLETED')
+}
+
+export function evaluatePrs(prs, options = {}) {
+  const results = prs.map((pr) => evaluatePr(pr, options))
+  return {
+    ok: results.every((result) => result.ok),
+    expectedBase: options.expectedBase ?? 'main',
+    checkedAt: new Date().toISOString(),
+    results,
+  }
+}
+
+export function renderText(summary) {
+  const lines = [
+    `PR mainline readiness: ${summary.ok ? 'PASS' : 'FAIL'}`,
+    `Expected base: ${summary.expectedBase}`,
+  ]
+
+  for (const result of summary.results) {
+    lines.push('')
+    lines.push(`#${result.number ?? '?'} ${result.title ?? ''}`.trim())
+    lines.push(`status: ${result.ok ? 'PASS' : 'FAIL'}`)
+    lines.push(`base: ${result.baseRefName ?? 'unknown'} -> expected ${summary.expectedBase}`)
+    lines.push(`head: ${result.headRefName ?? 'unknown'}`)
+    lines.push(`mergeStateStatus: ${result.mergeStateStatus ?? 'unknown'}`)
+    if (result.reasons.length > 0) {
+      lines.push(`reasons: ${result.reasons.join('; ')}`)
+    }
+    if (result.warnings.length > 0) {
+      lines.push(`warnings: ${result.warnings.join('; ')}`)
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+export function renderMarkdown(summary) {
+  const lines = [
+    '# PR Mainline Readiness',
+    '',
+    `Overall: **${summary.ok ? 'PASS' : 'FAIL'}**`,
+    '',
+    `Expected base: \`${summary.expectedBase}\``,
+    '',
+    '| PR | Status | Base | Head | Merge State | Reasons |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ]
+
+  for (const result of summary.results) {
+    const pr = result.url
+      ? `[#${result.number}](${result.url})`
+      : `#${result.number ?? '?'}`
+    const reasons = result.reasons.length > 0
+      ? result.reasons.map((reason) => escapePipe(reason)).join('<br>')
+      : '-'
+    lines.push([
+      pr,
+      result.ok ? 'PASS' : 'FAIL',
+      `\`${result.baseRefName ?? 'unknown'}\``,
+      `\`${result.headRefName ?? 'unknown'}\``,
+      `\`${result.mergeStateStatus ?? 'unknown'}\``,
+      reasons,
+    ].join(' | '))
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+function escapePipe(value) {
+  return String(value).replaceAll('|', '\\|')
+}
+
+export function readPrsFromJsonFile(filePath) {
+  return normalizePrList(JSON.parse(readFileSync(filePath, 'utf8')))
+}
+
+export function readPrFromGh(prNumber) {
+  const result = spawnSync('gh', [
+    'pr',
+    'view',
+    String(prNumber),
+    '--json',
+    GH_PR_FIELDS,
+  ], {
+    encoding: 'utf8',
+  })
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `gh pr view failed for ${prNumber}`)
+  }
+
+  return JSON.parse(result.stdout)
+}
+
+export function renderSummary(summary, format) {
+  if (format === 'json') return `${JSON.stringify(summary, null, 2)}\n`
+  if (format === 'markdown') return renderMarkdown(summary)
+  return renderText(summary)
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/ops/check-pr-mainline-readiness.mjs [options] <pr...>
+  node scripts/ops/check-pr-mainline-readiness.mjs --input-json pr.json
+
+Options:
+  --base <branch>       Expected base branch. Default: main
+  --format <format>     text, markdown, or json. Default: text
+  --input-json <path>   Read PR object or array from JSON instead of calling gh
+  --output <path>       Write rendered result to a file
+`)
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const config = parseArgs(argv)
+  if (config.help) {
+    printHelp()
+    return 0
+  }
+
+  const prs = config.inputJson
+    ? readPrsFromJsonFile(config.inputJson)
+    : config.prs.map((prNumber) => readPrFromGh(prNumber))
+
+  if (prs.length === 0) {
+    throw new Error('At least one PR number or --input-json is required')
+  }
+
+  const summary = evaluatePrs(prs, { expectedBase: config.expectedBase })
+  const rendered = renderSummary(summary, config.format)
+
+  if (config.output) {
+    mkdirSync(path.dirname(config.output), { recursive: true })
+    writeFileSync(config.output, rendered, 'utf8')
+  } else {
+    process.stdout.write(rendered)
+  }
+
+  return summary.ok ? 0 : 1
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exitCode = main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/scripts/ops/check-pr-mainline-readiness.test.mjs
+++ b/scripts/ops/check-pr-mainline-readiness.test.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  evaluatePrs,
+  main,
+  parseArgs,
+  readPrsFromJsonFile,
+  renderMarkdown,
+} from './check-pr-mainline-readiness.mjs'
+
+function openMainPr(overrides = {}) {
+  return {
+    number: 100,
+    title: 'test: safe main PR',
+    state: 'OPEN',
+    baseRefName: 'main',
+    headRefName: 'codex/safe',
+    mergeStateStatus: 'CLEAN',
+    reviewDecision: '',
+    statusCheckRollup: [
+      { name: 'pr-validate', conclusion: 'SUCCESS', status: 'COMPLETED' },
+      { name: 'optional-e2e', conclusion: 'SKIPPED', status: 'COMPLETED' },
+    ],
+    url: 'https://github.com/example/repo/pull/100',
+    ...overrides,
+  }
+}
+
+test('parseArgs accepts base, format, input, output, and PR numbers', () => {
+  assert.deepEqual(parseArgs([
+    '--base',
+    'release',
+    '--format',
+    'markdown',
+    '--input-json',
+    'prs.json',
+    '--output',
+    'out.md',
+    '123',
+  ]), {
+    expectedBase: 'release',
+    format: 'markdown',
+    inputJson: 'prs.json',
+    output: 'out.md',
+    prs: ['123'],
+  })
+})
+
+test('evaluatePrs passes a clean open PR targeting main', () => {
+  const summary = evaluatePrs([openMainPr()])
+
+  assert.equal(summary.ok, true)
+  assert.equal(summary.results[0].ok, true)
+  assert.deepEqual(summary.results[0].reasons, [])
+})
+
+test('evaluatePrs blocks stacked PRs that do not target main', () => {
+  const summary = evaluatePrs([
+    openMainPr({
+      number: 1063,
+      baseRefName: 'codex/dingtalk-person-granted-form-guard-20260422',
+      headRefName: 'codex/dingtalk-feature-plan-todo-20260422',
+    }),
+  ])
+
+  assert.equal(summary.ok, false)
+  assert.equal(summary.results[0].ok, false)
+  assert.deepEqual(summary.results[0].reasons, [
+    'base is codex/dingtalk-person-granted-form-guard-20260422, expected main',
+  ])
+})
+
+test('evaluatePrs blocks dirty merge state and failed checks', () => {
+  const summary = evaluatePrs([
+    openMainPr({
+      mergeStateStatus: 'DIRTY',
+      statusCheckRollup: [
+        { name: 'unit', conclusion: 'FAILURE', status: 'COMPLETED' },
+      ],
+    }),
+  ])
+
+  assert.equal(summary.ok, false)
+  assert.deepEqual(summary.results[0].reasons, [
+    'mergeStateStatus is DIRTY, expected CLEAN',
+    'failing checks: unit',
+  ])
+})
+
+test('evaluatePrs reports pending checks', () => {
+  const summary = evaluatePrs([
+    openMainPr({
+      statusCheckRollup: [
+        { name: 'unit', conclusion: '', status: 'IN_PROGRESS' },
+      ],
+    }),
+  ])
+
+  assert.equal(summary.ok, false)
+  assert.deepEqual(summary.results[0].reasons, [
+    'pending checks: unit',
+  ])
+})
+
+test('renderMarkdown summarizes failed stacked PRs', () => {
+  const summary = evaluatePrs([
+    openMainPr({
+      number: 1063,
+      baseRefName: 'codex/stack-base',
+      headRefName: 'codex/stack-head',
+    }),
+  ])
+
+  const markdown = renderMarkdown(summary)
+  assert.match(markdown, /Overall: \*\*FAIL\*\*/)
+  assert.match(markdown, /\[#1063\]\(https:\/\/github.com\/example\/repo\/pull\/100\)/)
+  assert.match(markdown, /base is codex\/stack-base, expected main/)
+})
+
+test('readPrsFromJsonFile accepts a single PR object', () => {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), 'pr-mainline-readiness-'))
+  const input = path.join(tmpDir, 'pr.json')
+
+  try {
+    writeFileSync(input, JSON.stringify(openMainPr()), 'utf8')
+    assert.equal(readPrsFromJsonFile(input).length, 1)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('main can render markdown from offline JSON and returns failure for stacked PRs', () => {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), 'pr-mainline-readiness-'))
+  const input = path.join(tmpDir, 'prs.json')
+  const output = path.join(tmpDir, 'report.md')
+
+  try {
+    writeFileSync(input, JSON.stringify([
+      openMainPr(),
+      openMainPr({ number: 101, baseRefName: 'codex/stack-base' }),
+    ]), 'utf8')
+
+    const exitCode = main([
+      '--input-json',
+      input,
+      '--format',
+      'markdown',
+      '--output',
+      output,
+    ])
+
+    assert.equal(exitCode, 1)
+    const report = readFileSync(output, 'utf8')
+    assert.match(report, /Overall: \*\*FAIL\*\*/)
+    assert.match(report, /#101/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- Add `scripts/ops/check-pr-mainline-readiness.mjs` to block admin mainline merges when a PR targets a stacked feature branch instead of `main`.
- Support live `gh pr view` checks plus offline JSON input for deterministic tests.
- Document the DingTalk P4 stack finding and the repaired #1076 state.

## Verification
- `node --test scripts/ops/check-pr-mainline-readiness.test.mjs` → 8/8 passed
- `git diff --check` → passed
- `node scripts/ops/check-pr-mainline-readiness.mjs --format markdown --output output/pr-mainline-readiness-1063-1076-1099-20260423.md 1063 1076 1099` → expected EXIT 1; all sampled PRs are not `main` based
- `node scripts/ops/check-pr-mainline-readiness.mjs --base codex/dingtalk-person-delivery-skip-reasons-20260422 1076` → expected EXIT 0

## Notes
No DingTalk runtime stack is flattened in this PR. This is an ops guard/tooling follow-up only.