### PR TITLE
test(dingtalk): scan P4 manual artifacts for secrets

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -82,6 +82,7 @@
 - [x] Add a P4 smoke status reporter that summarizes remaining evidence gaps, finalization state, and release handoff readiness.
 - [x] Add an offline P4 session-to-handoff chain test so the local tooling contract stays verified without real DingTalk credentials.
 - [x] Add a P4 evidence recorder CLI so operators can safely update manual checks without hand-editing `evidence.json`.
+- [x] Add a P4 strict artifact secret scan so finalization catches raw secret-like text artifacts before packet handoff.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-strict-artifact-secret-scan-development-20260423.md
+++ b/docs/development/dingtalk-p4-strict-artifact-secret-scan-development-20260423.md
@@ -1,0 +1,18 @@
+# DingTalk P4 Strict Artifact Secret Scan Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-artifact-secret-scan-20260423`
+- Scope: local P4 evidence compiler hardening.
+
+## Changes
+
+- Added secret-like text scanning to `compile-dingtalk-p4-smoke-evidence.mjs` for referenced local manual artifact files.
+- The scan runs after the existing strict artifact path, file, and non-empty checks.
+- Small likely-text artifacts are scanned for DingTalk robot webhooks, `access_token` params, bearer tokens, `SEC...` secrets, JWTs, client secret assignments, and public form tokens.
+- Findings are reported as `manualEvidenceIssues` with `code: "artifact_secret_detected"`.
+- The issue records the artifact path and pattern name, but never stores the matched secret preview.
+- Updated the remote smoke checklist and P4 TODO so operators know strict compile catches raw secret-like text artifacts before final handoff.
+
+## Rationale
+
+The final packet validator already scans exported packets, and the evidence recorder scans artifacts it writes. This change catches the same class of mistakes earlier when an operator manually edits `workspace/evidence.json` or places artifacts directly before `--finalize`.

--- a/docs/development/dingtalk-p4-strict-artifact-secret-scan-verification-20260423.md
+++ b/docs/development/dingtalk-p4-strict-artifact-secret-scan-verification-20260423.md
@@ -1,0 +1,28 @@
+# DingTalk P4 Strict Artifact Secret Scan Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-artifact-secret-scan-20260423`
+
+## Commands
+
+```bash
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --check scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs
+node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs
+node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+git diff --check
+```
+
+## Expected Results
+
+- Passing evidence with clean artifacts still compiles successfully.
+- Strict compile rejects local manual text artifacts containing DingTalk robot webhook tokens or `SEC...` secrets.
+- `summary.json` and stderr must not contain raw secret values from artifact content.
+- Session finalization and offline handoff remain green with clean artifacts.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -106,6 +106,7 @@ Strict artifact refs are self-contained by default:
 - Use relative paths only.
 - Put each file under `artifacts/<check-id>/` next to the input `evidence.json`.
 - The referenced path must exist, be a file, and be non-empty.
+- Small text artifact files are scanned for common raw secret shapes during strict compile.
 - External URL refs are rejected unless `--allow-external-artifact-refs` is passed. Prefer local files for release evidence because URL-only proof can be edited or become unavailable.
 
 Example check evidence:

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
@@ -50,6 +50,37 @@ const REQUIRED_CHECKS = [
 
 const CHECK_ID_SET = new Set(REQUIRED_CHECKS.map((check) => check.id))
 const VALID_STATUSES = new Set(['pass', 'fail', 'skipped', 'pending'])
+const MAX_SECRET_SCAN_BYTES = 2 * 1024 * 1024
+const SECRET_PATTERNS = [
+  {
+    name: 'dingtalk_robot_webhook',
+    regex: /https:\/\/oapi\.dingtalk\.com\/robot\/send\?[^\s"'`<>]*access_token=(?!<redacted>|\$|%24|\(\?)[^\s&"'`<>]{8,}/i,
+  },
+  {
+    name: 'access_token_param',
+    regex: /(?:^|[?&])access_token=(?!<redacted>|\$|%24|replace-me|\(\?)[A-Za-z0-9._~+/=-]{16,}/i,
+  },
+  {
+    name: 'bearer_token',
+    regex: /\bBearer\s+(?!<redacted>|\$|\{)[A-Za-z0-9._~+/=-]{20,}/i,
+  },
+  {
+    name: 'dingtalk_sec_secret',
+    regex: /\bSEC(?=[A-Za-z0-9+/=-]{12,}\b)(?=[A-Za-z0-9+/=-]*\d)[A-Za-z0-9+/=-]{12,}\b/,
+  },
+  {
+    name: 'jwt',
+    regex: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  },
+  {
+    name: 'dingtalk_secret_assignment',
+    regex: /\b(?:DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET|client_secret)\s*=\s*(?!<redacted>|replace-me|\$|\s|$)[^\s&"'`<>]{8,}/i,
+  },
+  {
+    name: 'public_form_token',
+    regex: /\bpublicToken=(?!<redacted>|\$)[A-Za-z0-9._~+/=-]{12,}/i,
+  },
+]
 const API_BOOTSTRAP_CHECK_IDS = new Set([
   'create-table-form',
   'bind-two-dingtalk-groups',
@@ -440,6 +471,30 @@ function isAbsoluteArtifactPath(value) {
   return path.isAbsolute(value) || path.win32.isAbsolute(value) || value.replaceAll('\\', '/').startsWith('//')
 }
 
+function isLikelyText(buffer) {
+  return !buffer.includes(0)
+}
+
+function scanArtifactFileForSecrets(checkId, artifactRef, file) {
+  const stats = statSync(file)
+  if (!stats.isFile() || stats.size <= 0 || stats.size > MAX_SECRET_SCAN_BYTES) return []
+  const buffer = readFileSync(file)
+  if (!isLikelyText(buffer)) return []
+  const content = buffer.toString('utf8')
+  const issues = []
+  for (const pattern of SECRET_PATTERNS) {
+    if (pattern.regex.test(content)) {
+      issues.push(artifactIssue(
+        checkId,
+        'artifact_secret_detected',
+        `${checkId} artifact file contains secret-like value (${pattern.name})`,
+        artifactRef,
+      ))
+    }
+  }
+  return issues
+}
+
 function validateManualArtifactRefs(checkId, evidence, evidenceDir, opts) {
   const issues = []
   const refs = collectArtifactRefs(evidence)
@@ -492,7 +547,9 @@ function validateManualArtifactRefs(checkId, evidence, evidenceDir, opts) {
     }
     if (stat.size <= 0) {
       issues.push(artifactIssue(checkId, 'artifact_ref_empty', `${checkId} artifact file is empty`, trimmed))
+      continue
     }
+    issues.push(...scanArtifactFileForSecrets(checkId, normalizedRef, fullPath))
   }
   return issues
 }

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
@@ -334,6 +334,42 @@ test('compile-dingtalk-p4-smoke-evidence strict mode rejects empty manual artifa
   }
 })
 
+test('compile-dingtalk-p4-smoke-evidence strict mode rejects secret-like manual artifact files', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+  const artifactRef = manualArtifactRefForCheck('authorized-user-submit')
+  const rawWebhook = 'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-token-0123456789'
+  const rawSecret = 'SECabcdefghijklmnop12345678'
+
+  try {
+    writeEvidence(evidencePath)
+    writeFileSync(path.join(tmpDir, artifactRef), `${rawWebhook}\n${rawSecret}\n`, 'utf8')
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /artifact_secret_detected/)
+    assert.doesNotMatch(result.stderr, /robot-secret-token/)
+    assert.doesNotMatch(result.stderr, /SECabcdefghijklmnop12345678/)
+    const summaryText = readFileSync(path.join(outputDir, 'summary.json'), 'utf8')
+    assert.doesNotMatch(summaryText, /robot-secret-token/)
+    assert.doesNotMatch(summaryText, /SECabcdefghijklmnop12345678/)
+    const summary = JSON.parse(summaryText)
+    assert.equal(summary.overallStatus, 'fail')
+    assert.equal(summary.manualEvidenceIssues.some((issue) => (
+      issue.id === 'authorized-user-submit'
+        && issue.code === 'artifact_secret_detected'
+        && issue.artifactRef === artifactRef
+    )), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('compile-dingtalk-p4-smoke-evidence strict mode rejects external artifacts unless explicitly allowed', () => {
   const tmpDir = makeTmpDir()
   const evidencePath = path.join(tmpDir, 'evidence.json')


### PR DESCRIPTION
Stacked on #1100.

## Summary
- Add strict compile scanning for small text manual artifact files referenced by P4 evidence.
- Report secret-like artifact content as `manualEvidenceIssues` with `artifact_secret_detected` before final handoff.
- Keep findings limited to artifact path and pattern name; do not store matched secret previews.
- Update remote smoke checklist, TODO, and development/verification notes.

## Verification
- `node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`
- `node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-session.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs`
- `node --check scripts/ops/dingtalk-p4-offline-handoff.test.mjs`
- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs` (12/12)
- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs` (6/6)
- `node --test scripts/ops/dingtalk-p4-offline-handoff.test.mjs` (1/1)
- `node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs` (11/11)
- `node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs` (8/8)
- `node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs` (7/7)
- `git diff --check`