### PR TITLE
test(dingtalk): require P4 unauthorized denial proof

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -83,6 +83,7 @@
 - [x] Add an offline P4 session-to-handoff chain test so the local tooling contract stays verified without real DingTalk credentials.
 - [x] Add a P4 evidence recorder CLI so operators can safely update manual checks without hand-editing `evidence.json`.
 - [x] Add a P4 strict artifact secret scan so finalization catches raw secret-like text artifacts before packet handoff.
+- [x] Add a P4 unauthorized denial evidence contract so pass evidence must prove submit blocking and zero record insert.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-unauthorized-denial-contract-development-20260423.md
+++ b/docs/development/dingtalk-p4-unauthorized-denial-contract-development-20260423.md
@@ -1,0 +1,25 @@
+# DingTalk P4 Unauthorized Denial Contract Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-unauthorized-denial-contract-20260423`
+- Scope: local P4 evidence contract hardening for the unauthorized-user remote smoke check.
+
+## Changes
+
+- Strengthened `compile-dingtalk-p4-smoke-evidence.mjs` strict checks for `unauthorized-user-denied`.
+- A pass now requires:
+  - `evidence.submitBlocked === true`
+  - `evidence.recordInsertDelta === 0`, or equal `beforeRecordCount` / `afterRecordCount`
+  - `evidence.blockedReason`, `evidence.errorSummary`, or `evidence.visibleErrorSummary`
+- Extended `dingtalk-p4-evidence-record.mjs` with:
+  - `--submit-blocked`
+  - `--record-insert-delta`
+  - `--before-record-count`
+  - `--after-record-count`
+  - `--blocked-reason`
+- Updated the offline handoff chain to record `unauthorized-user-denied` via the recorder with structured no-insert proof.
+- Updated remote smoke checklist and TODO guidance.
+
+## Rationale
+
+The checklist requires proving that an unauthorized DingTalk-bound user cannot submit and that no record is inserted. This contract prevents a generic screenshot or summary from being marked as pass without the no-insert evidence needed for release confidence.

--- a/docs/development/dingtalk-p4-unauthorized-denial-contract-verification-20260423.md
+++ b/docs/development/dingtalk-p4-unauthorized-denial-contract-verification-20260423.md
@@ -1,0 +1,35 @@
+# DingTalk P4 Unauthorized Denial Contract Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-unauthorized-denial-contract-20260423`
+
+## Commands
+
+```bash
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+node --check scripts/ops/dingtalk-p4-evidence-record.mjs
+node --check scripts/ops/dingtalk-p4-evidence-record.test.mjs
+node --check scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+node --check scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs
+node --test scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs
+node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+git diff --check
+```
+
+## Expected Results
+
+- Strict compile rejects `unauthorized-user-denied` pass evidence when `submitBlocked`, zero insert delta, or visible blocked reason is missing.
+- Recorder accepts `--record-insert-delta 0` and equal before/after count variants.
+- Recorder rejects incomplete unauthorized denial pass evidence before mutating `evidence.json`.
+- Offline handoff remains release-ready with structured unauthorized denial evidence.
+
+## Actual Results
+
+- Syntax checks passed for the updated evidence compiler, recorder, and P4 session/handoff tests.
+- `node --test` passed 56 tests with 0 failures across the P4 evidence compiler, recorder, offline handoff, smoke session, final handoff, smoke status, and staging packet validator suites.
+- `git diff --check` passed.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -181,6 +181,22 @@ node scripts/ops/dingtalk-p4-evidence-record.mjs \
 
 For pass evidence, put the referenced file under `workspace/artifacts/<check-id>/` before running the recorder. The recorder validates the relative path, non-empty local file, manual source, and obvious secret-like text before updating `workspace/evidence.json`.
 
+For `unauthorized-user-denied`, also record the structured no-insert proof:
+
+```bash
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --check-id unauthorized-user-denied \
+  --status pass \
+  --source manual-client \
+  --operator qa \
+  --summary "Unauthorized DingTalk-bound user was blocked and no record was inserted." \
+  --artifact artifacts/unauthorized-user-denied/unauthorized-denied.png \
+  --submit-blocked \
+  --record-insert-delta 0 \
+  --blocked-reason "Visible error showed the user is not in the allowlist."
+```
+
 ```bash
 node scripts/ops/dingtalk-p4-smoke-session.mjs \
   --finalize output/dingtalk-p4-remote-smoke-session/142-session

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
@@ -554,6 +554,49 @@ function validateManualArtifactRefs(checkId, evidence, evidenceDir, opts) {
   return issues
 }
 
+function finiteNumber(value) {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function hasZeroRecordInsertDelta(evidence) {
+  const delta = finiteNumber(evidence.recordInsertDelta)
+  if (delta !== null) return delta === 0
+  const before = finiteNumber(evidence.beforeRecordCount)
+  const after = finiteNumber(evidence.afterRecordCount)
+  return before !== null && after !== null && before === after
+}
+
+function validateUnauthorizedDeniedEvidence(evidence) {
+  const issues = []
+  if (evidence.submitBlocked !== true) {
+    issues.push({
+      id: 'unauthorized-user-denied',
+      code: 'submit_blocked_required',
+      message: 'unauthorized-user-denied pass evidence requires evidence.submitBlocked=true',
+    })
+  }
+  if (!hasZeroRecordInsertDelta(evidence)) {
+    issues.push({
+      id: 'unauthorized-user-denied',
+      code: 'record_insert_delta_zero_required',
+      message: 'unauthorized-user-denied pass evidence requires evidence.recordInsertDelta=0 or equal beforeRecordCount/afterRecordCount',
+    })
+  }
+  if (!isNonEmptyString(evidence.blockedReason) && !isNonEmptyString(evidence.errorSummary) && !isNonEmptyString(evidence.visibleErrorSummary)) {
+    issues.push({
+      id: 'unauthorized-user-denied',
+      code: 'blocked_reason_required',
+      message: 'unauthorized-user-denied pass evidence requires evidence.blockedReason, evidence.errorSummary, or evidence.visibleErrorSummary',
+    })
+  }
+  return issues
+}
+
 function validateManualEvidenceRequirements(checksById, evidenceDir, opts) {
   const issues = []
   for (const requirement of MANUAL_EVIDENCE_REQUIREMENTS) {
@@ -607,6 +650,9 @@ function validateManualEvidenceRequirements(checksById, evidenceDir, opts) {
         code: 'summary_required',
         message: `${requirement.id} requires evidence.summary, evidence.notes, or evidence.resultSummary`,
       })
+    }
+    if (requirement.id === 'unauthorized-user-denied') {
+      issues.push(...validateUnauthorizedDeniedEvidence(evidence))
     }
   }
   return issues

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
@@ -38,6 +38,13 @@ function makePassingEvidenceForCheck(id, extras = {}) {
       performedAt: '2026-04-22T15:00:00.000Z',
       summary: `${id} manual evidence ok`,
       artifacts: [manualArtifactRefForCheck(id)],
+      ...(id === 'unauthorized-user-denied'
+        ? {
+            submitBlocked: true,
+            recordInsertDelta: 0,
+            blockedReason: 'Visible form error showed the user is not in the DingTalk allowlist.',
+          }
+        : {}),
       ...extras,
     }
   }
@@ -447,6 +454,45 @@ test('compile-dingtalk-p4-smoke-evidence strict mode rejects pass checks without
     assert.equal(summary.remoteClientStatus, 'fail')
     assert.equal(summary.manualEvidenceIssues.some((issue) => issue.id === 'authorized-user-submit'), true)
     assert.equal(summary.manualEvidenceIssues.some((issue) => issue.id === 'send-group-message-form-link'), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('compile-dingtalk-p4-smoke-evidence strict mode requires structured unauthorized denial evidence', () => {
+  const tmpDir = makeTmpDir()
+  const evidencePath = path.join(tmpDir, 'evidence.json')
+  const outputDir = path.join(tmpDir, 'compiled')
+
+  try {
+    writeEvidence(evidencePath, {
+      checks: requiredIds.map((id) => ({
+        id,
+        status: 'pass',
+        evidence: makePassingEvidenceForCheck(id, id === 'unauthorized-user-denied'
+          ? {
+              submitBlocked: false,
+              recordInsertDelta: 1,
+              blockedReason: '',
+            }
+          : {}),
+      })),
+    })
+
+    const result = spawnSync(process.execPath, [scriptPath, '--input', evidencePath, '--output-dir', outputDir, '--strict'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /submit_blocked_required/)
+    assert.match(result.stderr, /record_insert_delta_zero_required/)
+    assert.match(result.stderr, /blocked_reason_required/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'fail')
+    assert.equal(summary.manualEvidenceIssues.some((issue) => issue.code === 'submit_blocked_required'), true)
+    assert.equal(summary.manualEvidenceIssues.some((issue) => issue.code === 'record_insert_delta_zero_required'), true)
+    assert.equal(summary.manualEvidenceIssues.some((issue) => issue.code === 'blocked_reason_required'), true)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }

--- a/scripts/ops/dingtalk-p4-evidence-record.mjs
+++ b/scripts/ops/dingtalk-p4-evidence-record.mjs
@@ -65,6 +65,11 @@ Options:
   --summary <text>           Human-readable result summary
   --notes <text>             Optional notes
   --artifact <path>          Relative artifact path; repeatable
+  --submit-blocked           Set evidence.submitBlocked=true for unauthorized-user-denied
+  --record-insert-delta <n>  Set evidence.recordInsertDelta
+  --before-record-count <n>  Set evidence.beforeRecordCount
+  --after-record-count <n>   Set evidence.afterRecordCount
+  --blocked-reason <text>    Set evidence.blockedReason
   --dry-run                  Validate and print the updated check without writing
   --help                     Show this help
 
@@ -100,6 +105,11 @@ function parseArgs(argv) {
     summary: '',
     notes: '',
     artifacts: [],
+    submitBlocked: false,
+    recordInsertDelta: null,
+    beforeRecordCount: null,
+    afterRecordCount: null,
+    blockedReason: '',
     dryRun: false,
   }
 
@@ -146,6 +156,25 @@ function parseArgs(argv) {
         opts.artifacts.push(readRequiredValue(argv, i, arg).trim())
         i += 1
         break
+      case '--submit-blocked':
+        opts.submitBlocked = true
+        break
+      case '--record-insert-delta':
+        opts.recordInsertDelta = readNumberValue(readRequiredValue(argv, i, arg), arg)
+        i += 1
+        break
+      case '--before-record-count':
+        opts.beforeRecordCount = readNumberValue(readRequiredValue(argv, i, arg), arg)
+        i += 1
+        break
+      case '--after-record-count':
+        opts.afterRecordCount = readNumberValue(readRequiredValue(argv, i, arg), arg)
+        i += 1
+        break
+      case '--blocked-reason':
+        opts.blockedReason = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
       case '--dry-run':
         opts.dryRun = true
         break
@@ -167,6 +196,12 @@ function parseArgs(argv) {
   if (!opts.status) throw new Error('--status is required')
   if (!VALID_STATUSES.has(opts.status)) throw new Error(`--status must be one of: ${Array.from(VALID_STATUSES).join(', ')}`)
   return opts
+}
+
+function readNumberValue(value, flag) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) throw new Error(`${flag} must be a finite number`)
+  return parsed
 }
 
 function relativePath(file) {
@@ -269,12 +304,31 @@ function validateManualPass(opts) {
   if (!isDateLike(opts.performedAt)) throw new Error('--performed-at must be a valid date')
 }
 
+function hasZeroRecordInsertDelta(opts) {
+  if (opts.recordInsertDelta !== null) return opts.recordInsertDelta === 0
+  return opts.beforeRecordCount !== null && opts.afterRecordCount !== null && opts.beforeRecordCount === opts.afterRecordCount
+}
+
+function validateUnauthorizedDeniedPass(opts) {
+  if (opts.checkId !== 'unauthorized-user-denied' || opts.status !== 'pass') return
+  if (opts.submitBlocked !== true) {
+    throw new Error('unauthorized-user-denied pass evidence requires --submit-blocked')
+  }
+  if (!hasZeroRecordInsertDelta(opts)) {
+    throw new Error('unauthorized-user-denied pass evidence requires --record-insert-delta 0 or equal --before-record-count/--after-record-count')
+  }
+  if (!opts.blockedReason) {
+    throw new Error('unauthorized-user-denied pass evidence requires --blocked-reason')
+  }
+}
+
 function validateInputs(opts) {
   for (const [label, value] of [
     ['--source', opts.source],
     ['--operator', opts.operator],
     ['--summary', opts.summary],
     ['--notes', opts.notes],
+    ['--blocked-reason', opts.blockedReason],
   ]) {
     assertNoSecretText(value, label)
   }
@@ -282,6 +336,7 @@ function validateInputs(opts) {
     throw new Error('--performed-at must be a valid date')
   }
   validateManualPass(opts)
+  validateUnauthorizedDeniedPass(opts)
 }
 
 function findCheck(evidence, checkId) {
@@ -298,6 +353,11 @@ function buildEvidencePayload(opts, artifactRefs) {
   if (opts.summary) payload.summary = opts.summary
   if (opts.notes) payload.notes = opts.notes
   if (artifactRefs.length > 0) payload.artifacts = artifactRefs
+  if (opts.submitBlocked) payload.submitBlocked = true
+  if (opts.recordInsertDelta !== null) payload.recordInsertDelta = opts.recordInsertDelta
+  if (opts.beforeRecordCount !== null) payload.beforeRecordCount = opts.beforeRecordCount
+  if (opts.afterRecordCount !== null) payload.afterRecordCount = opts.afterRecordCount
+  if (opts.blockedReason) payload.blockedReason = opts.blockedReason
   return payload
 }
 

--- a/scripts/ops/dingtalk-p4-evidence-record.test.mjs
+++ b/scripts/ops/dingtalk-p4-evidence-record.test.mjs
@@ -97,6 +97,50 @@ test('dingtalk-p4-evidence-record records passing manual client evidence', () =>
   }
 })
 
+test('dingtalk-p4-evidence-record records structured unauthorized denial evidence', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, 'session')
+
+  try {
+    const evidencePath = writeEvidence(sessionDir)
+    const artifactRef = writeArtifact(sessionDir, 'unauthorized-user-denied')
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--check-id',
+      'unauthorized-user-denied',
+      '--status',
+      'pass',
+      '--source',
+      'manual-client',
+      '--operator',
+      'qa',
+      '--performed-at',
+      '2026-04-23T10:00:00.000Z',
+      '--summary',
+      'Unauthorized DingTalk-bound user was blocked.',
+      '--artifact',
+      artifactRef,
+      '--submit-blocked',
+      '--record-insert-delta',
+      '0',
+      '--blocked-reason',
+      'Visible error showed the user is not in the allowlist.',
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const evidence = JSON.parse(readFileSync(evidencePath, 'utf8'))
+    const check = evidence.checks.find((entry) => entry.id === 'unauthorized-user-denied')
+    assert.equal(check.status, 'pass')
+    assert.equal(check.evidence.submitBlocked, true)
+    assert.equal(check.evidence.recordInsertDelta, 0)
+    assert.equal(check.evidence.blockedReason, 'Visible error showed the user is not in the allowlist.')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('dingtalk-p4-evidence-record supports dry-run without writing evidence', () => {
   const tmpDir = makeTmpDir()
   const sessionDir = path.join(tmpDir, 'session')
@@ -168,6 +212,82 @@ test('dingtalk-p4-evidence-record preserves existing evidence metadata', () => {
     assert.equal(updatedCheck.evidence.instructions, 'Keep this operator guidance.')
     assert.deepEqual(updatedCheck.evidence.apiBootstrap, { tableId: 'table_1' })
     assert.equal(updatedCheck.evidence.operator, 'qa')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-evidence-record rejects incomplete unauthorized denial evidence', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, 'session')
+
+  try {
+    writeEvidence(sessionDir)
+    const artifactRef = writeArtifact(sessionDir, 'unauthorized-user-denied')
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--check-id',
+      'unauthorized-user-denied',
+      '--status',
+      'pass',
+      '--source',
+      'manual-client',
+      '--operator',
+      'qa',
+      '--summary',
+      'Unauthorized DingTalk-bound user was blocked.',
+      '--artifact',
+      artifactRef,
+      '--record-insert-delta',
+      '1',
+    ])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /requires --submit-blocked/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-evidence-record accepts equal before and after record counts for unauthorized denial', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, 'session')
+
+  try {
+    const evidencePath = writeEvidence(sessionDir)
+    const artifactRef = writeArtifact(sessionDir, 'unauthorized-user-denied')
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--check-id',
+      'unauthorized-user-denied',
+      '--status',
+      'pass',
+      '--source',
+      'manual-client',
+      '--operator',
+      'qa',
+      '--summary',
+      'Unauthorized DingTalk-bound user was blocked.',
+      '--artifact',
+      artifactRef,
+      '--submit-blocked',
+      '--before-record-count',
+      '7',
+      '--after-record-count',
+      '7',
+      '--blocked-reason',
+      'Visible grant-required error.',
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const evidence = JSON.parse(readFileSync(evidencePath, 'utf8'))
+    const check = evidence.checks.find((entry) => entry.id === 'unauthorized-user-denied')
+    assert.equal(check.evidence.beforeRecordCount, 7)
+    assert.equal(check.evidence.afterRecordCount, 7)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }

--- a/scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+++ b/scripts/ops/dingtalk-p4-offline-handoff.test.mjs
@@ -244,6 +244,15 @@ function fillManualEvidence(sessionDir) {
       `${check.id} verified in offline handoff chain`,
       '--artifact',
       artifactRef,
+      ...(check.id === 'unauthorized-user-denied'
+        ? [
+            '--submit-blocked',
+            '--record-insert-delta',
+            '0',
+            '--blocked-reason',
+            'Visible error showed the user is not in the allowlist.',
+          ]
+        : []),
     ])
     assert.equal(result.status, 0, result.stderr || result.stdout)
   }

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -42,6 +42,13 @@ function makePassingEvidenceForCheck(id) {
       performedAt: '2026-04-22T15:00:00.000Z',
       summary: `${id} manual evidence ok`,
       artifacts: [manualArtifactRefForCheck(id)],
+      ...(id === 'unauthorized-user-denied'
+        ? {
+            submitBlocked: true,
+            recordInsertDelta: 0,
+            blockedReason: 'Visible error showed the user is not in the allowlist.',
+          }
+        : {}),
     }
   }
   return {


### PR DESCRIPTION
## Summary
- Require structured `unauthorized-user-denied` pass evidence in strict P4 compile: submit blocked, zero record insert delta or equal before/after counts, and a visible blocked reason.
- Extend `dingtalk-p4-evidence-record` with unauthorized denial proof flags and fail fast for incomplete pass evidence.
- Update offline handoff tests, remote smoke checklist, TODO, and development/verification docs.

## Verification
- `node --check` for updated evidence compiler, recorder, and P4 session/handoff tests.
- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/dingtalk-p4-evidence-record.test.mjs scripts/ops/dingtalk-p4-offline-handoff.test.mjs scripts/ops/dingtalk-p4-smoke-session.test.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs scripts/ops/dingtalk-p4-smoke-status.test.mjs` passed 56 tests.
- `git diff --check` passed.

Stacked on #1102.