### PR TITLE
test(dingtalk): export P4 remote smoke todo report

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -84,6 +84,7 @@
 - [x] Add a P4 evidence recorder CLI so operators can safely update manual checks without hand-editing `evidence.json`.
 - [x] Add a P4 strict artifact secret scan so finalization catches raw secret-like text artifacts before packet handoff.
 - [x] Add a P4 unauthorized denial evidence contract so pass evidence must prove submit blocking and zero record insert.
+- [x] Add a P4 remote-smoke TODO exporter so status runs generate an executable checklist for remaining evidence.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-status-todo-export-development-20260423.md
+++ b/docs/development/dingtalk-p4-status-todo-export-development-20260423.md
@@ -1,0 +1,18 @@
+# DingTalk P4 Status TODO Export Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-status-todo-export-20260423`
+- Scope: local P4 remote-smoke operator tooling.
+
+## Changes
+
+- Extended `dingtalk-p4-smoke-status.mjs` to generate `smoke-todo.md` next to `smoke-status.json` and `smoke-status.md`.
+- Added `--output-todo-md` for custom TODO output paths.
+- Added `remoteSmokeTodos` to the status JSON with total, completed, remaining, and per-check item metadata.
+- Added per-check manual evidence recorder command templates in the TODO report.
+- Added unauthorized-user evidence recorder hints for `--submit-blocked`, `--record-insert-delta 0`, and `--blocked-reason`.
+- Updated the remote smoke checklist and feature TODO.
+
+## Rationale
+
+The remaining DingTalk target work is mostly real remote smoke execution, not new product code. The status TODO export makes the remaining work concrete for each staging session and reduces operator mistakes while collecting manual DingTalk evidence.

--- a/docs/development/dingtalk-p4-status-todo-export-verification-20260423.md
+++ b/docs/development/dingtalk-p4-status-todo-export-verification-20260423.md
@@ -1,0 +1,29 @@
+# DingTalk P4 Status TODO Export Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-status-todo-export-20260423`
+
+## Commands
+
+```bash
+node --check scripts/ops/dingtalk-p4-smoke-status.mjs
+node --check scripts/ops/dingtalk-p4-smoke-status.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs
+node --test scripts/ops/dingtalk-p4-offline-handoff.test.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+git diff --check
+```
+
+## Expected Results
+
+- Status runs write `smoke-todo.md` by default.
+- `--output-todo-md` writes the executable TODO report to a custom path.
+- The TODO report includes per-check completion state and recorder command templates.
+- Unauthorized-user TODO command includes the structured no-insert proof flags.
+- Secret-like strings remain redacted in status and TODO outputs.
+
+## Actual Results
+
+- Syntax checks passed for the status reporter and status reporter test file.
+- `node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs` passed 8 tests with 0 failures.
+- Adjacent handoff/packet regression passed 16 tests with 0 failures.
+- `git diff --check` passed.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -164,7 +164,17 @@ node scripts/ops/dingtalk-p4-smoke-status.mjs \
   --session-dir output/dingtalk-p4-remote-smoke-session/142-session
 ```
 
-The status report writes `smoke-status.json` / `smoke-status.md` and shows whether the run is blocked, waiting for manual evidence, ready to finalize, waiting for handoff, or release-ready.
+The status report writes `smoke-status.json`, `smoke-status.md`, and `smoke-todo.md`. It shows whether the run is blocked, waiting for manual evidence, ready to finalize, waiting for handoff, or release-ready.
+
+Use `smoke-todo.md` as the operator checklist for the remaining remote smoke evidence. It maps every required P4 check to a checked or unchecked item, includes per-check recorder command templates for manual DingTalk-client/admin evidence, and keeps secrets redacted.
+
+To write the TODO file to a custom path:
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-status.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --output-todo-md output/dingtalk-p4-remote-smoke-session/142-session/remote-smoke-todo.md
+```
 
 Use the evidence recorder instead of hand-editing JSON when adding one manual check at a time:
 

--- a/scripts/ops/dingtalk-p4-smoke-status.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-status.mjs
@@ -75,6 +75,7 @@ Options:
   --publish-check-json <file>   Optional publish-check.json path
   --output-json <file>          Output status JSON, default <session-dir>/smoke-status.json
   --output-md <file>            Output status Markdown, default <session-dir>/smoke-status.md
+  --output-todo-md <file>       Output executable TODO Markdown, default <session-dir>/smoke-todo.md
   --require-release-ready       Exit non-zero unless overallStatus is release_ready
   --help                        Show this help
 `)
@@ -102,6 +103,7 @@ function parseArgs(argv) {
     publishCheckJson: '',
     outputJson: '',
     outputMd: '',
+    outputTodoMd: '',
     requireReleaseReady: false,
   }
 
@@ -140,6 +142,10 @@ function parseArgs(argv) {
         opts.outputMd = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
         break
+      case '--output-todo-md':
+        opts.outputTodoMd = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
       case '--require-release-ready':
         opts.requireReleaseReady = true
         break
@@ -158,10 +164,12 @@ function parseArgs(argv) {
     opts.compiledSummary ||= path.join(opts.sessionDir, 'compiled', 'summary.json')
     opts.outputJson ||= path.join(opts.sessionDir, 'smoke-status.json')
     opts.outputMd ||= path.join(opts.sessionDir, 'smoke-status.md')
+    opts.outputTodoMd ||= path.join(opts.sessionDir, 'smoke-todo.md')
   } else {
     const outputRoot = path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, makeRunId())
     opts.outputJson ||= path.join(outputRoot, 'smoke-status.json')
     opts.outputMd ||= path.join(outputRoot, 'smoke-status.md')
+    opts.outputTodoMd ||= path.join(outputRoot, 'smoke-todo.md')
   }
 
   if (!opts.sessionDir && !opts.sessionSummary && !opts.evidence && !opts.compiledSummary && !opts.handoffSummary && !opts.publishCheckJson) {
@@ -374,6 +382,73 @@ function evidenceRecordCommand(opts) {
   ].join(' '))
 }
 
+function manualSourceForCheck(check) {
+  return check.id === 'no-email-user-create-bind' ? 'manual-admin' : 'manual-client'
+}
+
+function evidenceRecordCommandForCheck(opts, check) {
+  if (!opts.sessionDir || !check.manual) return ''
+  const args = [
+    'node scripts/ops/dingtalk-p4-evidence-record.mjs',
+    '--session-dir',
+    '<session-dir>',
+    '--check-id',
+    check.id,
+    '--status',
+    'pass',
+    '--source',
+    manualSourceForCheck(check),
+    '--operator',
+    '<operator>',
+    '--summary',
+    '"<summary>"',
+    '--artifact',
+    `artifacts/${check.id}/<file>`,
+  ]
+  if (check.id === 'unauthorized-user-denied') {
+    args.push(
+      '--submit-blocked',
+      '--record-insert-delta',
+      '0',
+      '--blocked-reason',
+      '"<visible denial reason>"',
+    )
+  }
+  return sessionCommand(opts, args.join(' '))
+}
+
+function buildRemoteSmokeTodos(requiredChecks, opts) {
+  const items = requiredChecks.map((check) => {
+    const completed = check.status === 'pass' && check.manualEvidenceIssueCount === 0
+    const firstIssue = check.issues[0]
+    const nextAction = completed
+      ? 'done'
+      : firstIssue?.message
+        ? firstIssue.message
+        : check.manual
+          ? `capture real DingTalk evidence and record ${check.id}`
+          : `rerun or inspect API/bootstrap evidence for ${check.id}`
+    return {
+      id: check.id,
+      label: check.label,
+      todo: check.todo,
+      status: check.status,
+      manual: check.manual,
+      completed,
+      issueCount: check.manualEvidenceIssueCount,
+      nextAction,
+      evidenceRecordCommand: completed ? '' : evidenceRecordCommandForCheck(opts, check),
+    }
+  })
+
+  return {
+    total: items.length,
+    completed: items.filter((item) => item.completed).length,
+    remaining: items.filter((item) => !item.completed).length,
+    items,
+  }
+}
+
 function buildNextCommands(overallStatus, opts) {
   const commands = []
   if (!opts.sessionDir) {
@@ -447,6 +522,7 @@ function buildSummary(opts) {
     },
     requiredChecks,
     gaps,
+    remoteSmokeTodos: buildRemoteSmokeTodos(requiredChecks, opts),
     handoff,
     nextCommands: [],
   }
@@ -460,6 +536,9 @@ function renderMarkdown(summary) {
   const checkRows = summary.requiredChecks.map((check) => {
     const issue = check.issues.length ? check.issues.map((entry) => entry.code).join(', ') : ''
     return `| \`${markdownEscape(check.id)}\` | ${markdownEscape(check.status)} | ${check.manual ? 'yes' : 'no'} | ${markdownEscape(check.source)} | ${markdownEscape(issue)} |`
+  })
+  const todoRows = summary.remoteSmokeTodos.items.map((item) => {
+    return `| ${item.completed ? 'done' : 'todo'} | \`${markdownEscape(item.id)}\` | ${markdownEscape(item.status)} | ${item.manual ? 'yes' : 'no'} | ${markdownEscape(item.todo)} |`
   })
   const gaps = summary.gaps.length
     ? summary.gaps.map((gap) => `- \`${gap.id}\`: ${markdownEscape(gap.nextAction)} (${gap.status})`).join('\n')
@@ -492,6 +571,14 @@ Publish status: **${summary.handoff.publishStatus}**
 | --- | --- | --- | --- | --- |
 ${checkRows.join('\n')}
 
+## Remote Smoke TODO
+
+Progress: **${summary.remoteSmokeTodos.completed}/${summary.remoteSmokeTodos.total}** complete, **${summary.remoteSmokeTodos.remaining}** remaining.
+
+| State | Check | Status | Manual | TODO |
+| --- | --- | --- | --- | --- |
+${todoRows.join('\n')}
+
 ## Gaps
 
 ${gaps}
@@ -507,13 +594,56 @@ ${commands}
 `
 }
 
+function renderTodoMarkdown(summary) {
+  const checklist = summary.remoteSmokeTodos.items.map((item) => {
+    const marker = item.completed ? 'x' : ' '
+    return `- [${marker}] \`${markdownEscape(item.id)}\` - ${markdownEscape(item.todo)}. Status: ${markdownEscape(item.status)}. Next: ${markdownEscape(item.nextAction)}.`
+  })
+  const commands = summary.remoteSmokeTodos.items
+    .filter((item) => !item.completed && item.evidenceRecordCommand)
+    .map((item) => `- \`${markdownEscape(item.evidenceRecordCommand)}\``)
+  const nextCommands = summary.nextCommands.length
+    ? summary.nextCommands.map((command) => `- \`${markdownEscape(command)}\``)
+    : ['- None']
+
+  return `# DingTalk P4 Remote Smoke TODO
+
+Generated at: ${summary.generatedAt}
+
+Overall status: **${summary.overallStatus}**
+
+Progress: **${summary.remoteSmokeTodos.completed}/${summary.remoteSmokeTodos.total}** complete, **${summary.remoteSmokeTodos.remaining}** remaining.
+
+## Checklist
+
+${checklist.join('\n')}
+
+## Evidence Recorder Commands
+
+${commands.length ? commands.join('\n') : '- None'}
+
+## Next Session Commands
+
+${nextCommands.join('\n')}
+
+## Notes
+
+- This TODO file is generated from \`smoke-status.json\` inputs and contains redacted command templates only.
+- Put manual artifacts under \`workspace/artifacts/<check-id>/\` before running an evidence recorder command.
+- Re-run \`dingtalk-p4-smoke-status.mjs\` after each evidence update to refresh this TODO file.
+`
+}
+
 function writeSummary(summary, opts) {
   mkdirSync(path.dirname(opts.outputJson), { recursive: true })
   mkdirSync(path.dirname(opts.outputMd), { recursive: true })
+  mkdirSync(path.dirname(opts.outputTodoMd), { recursive: true })
   writeFileSync(opts.outputJson, `${JSON.stringify(sanitizeValue(summary), null, 2)}\n`, 'utf8')
   writeFileSync(opts.outputMd, renderMarkdown(summary), 'utf8')
+  writeFileSync(opts.outputTodoMd, renderTodoMarkdown(summary), 'utf8')
   console.log(`Wrote ${relativePath(opts.outputJson)}`)
   console.log(`Wrote ${relativePath(opts.outputMd)}`)
+  console.log(`Wrote ${relativePath(opts.outputTodoMd)}`)
 }
 
 try {

--- a/scripts/ops/dingtalk-p4-smoke-status.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-status.test.mjs
@@ -141,9 +141,55 @@ test('dingtalk-p4-smoke-status reports manual pending gaps for bootstrap session
     assert.equal(summary.overallStatus, 'manual_pending')
     assert.equal(summary.totals.gaps > 0, true)
     assert.equal(summary.requiredChecks.find((check) => check.id === 'authorized-user-submit').status, 'pending')
+    assert.equal(summary.remoteSmokeTodos.remaining > 0, true)
+    assert.equal(summary.remoteSmokeTodos.items.find((item) => item.id === 'authorized-user-submit').completed, false)
     assert.equal(summary.nextCommands.some((command) => command.includes('dingtalk-p4-evidence-record.mjs')), true)
     assert.equal(summary.nextCommands.some((command) => command.includes('--finalize')), true)
     assert.equal(existsSync(path.join(sessionDir, 'smoke-status.md')), true)
+    assert.equal(existsSync(path.join(sessionDir, 'smoke-todo.md')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-status writes an executable remote smoke TODO report', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const todoMd = path.join(tmpDir, 'todo', 'remote-smoke-todo.md')
+
+  try {
+    writeSession(sessionDir, {
+      sessionPhase: 'bootstrap',
+      sessionOverallStatus: 'manual_pending',
+      finalStrictStatus: 'not_run',
+      steps: [
+        { id: 'preflight', status: 'pass', exitCode: 0 },
+        { id: 'api-runner', status: 'pass', exitCode: 0 },
+        { id: 'compile', status: 'pass', exitCode: 0 },
+      ],
+      checkOverrides: {
+        'unauthorized-user-denied': {
+          status: 'pending',
+          evidence: {
+            summary: 'blocked by Bearer very-secret-admin-token-should-hide',
+          },
+        },
+      },
+    })
+
+    const result = runScript(['--session-dir', sessionDir, '--output-todo-md', todoMd])
+
+    assert.equal(result.status, 0, result.stderr)
+    const todoText = readFileSync(todoMd, 'utf8')
+    assert.match(todoText, /DingTalk P4 Remote Smoke TODO/)
+    assert.match(todoText, /unauthorized-user-denied/)
+    assert.match(todoText, /--submit-blocked/)
+    assert.match(todoText, /--record-insert-delta/)
+    assert.doesNotMatch(todoText, /very-secret-admin-token-should-hide/)
+    const summary = JSON.parse(readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8'))
+    const unauthorizedTodo = summary.remoteSmokeTodos.items.find((item) => item.id === 'unauthorized-user-denied')
+    assert.equal(unauthorizedTodo.completed, false)
+    assert.match(unauthorizedTodo.evidenceRecordCommand, /--blocked-reason/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- Extend `dingtalk-p4-smoke-status` to generate `smoke-todo.md` alongside `smoke-status.json` and `smoke-status.md`.
- Add `remoteSmokeTodos` to status JSON and `--output-todo-md` for custom operator checklist output.
- Include per-check recorder command templates, including the unauthorized-user no-insert proof flags.
- Update the remote smoke checklist, feature TODO, and development/verification docs.

## Verification
- `node --check scripts/ops/dingtalk-p4-smoke-status.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-status.test.mjs`
- `node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs` passed 8 tests.
- `node --test scripts/ops/dingtalk-p4-offline-handoff.test.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs` passed 16 tests.
- `git diff --check` passed.

Stacked on #1104.