### PR TITLE
test(dingtalk): guide P4 no-email admin evidence

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -86,6 +86,7 @@
 - [x] Add a P4 unauthorized denial evidence contract so pass evidence must prove submit blocking and zero record insert.
 - [x] Add a P4 remote-smoke TODO exporter so status runs generate an executable checklist for remaining evidence.
 - [x] Auto-refresh P4 smoke status and remote TODO reports from the session bootstrap/finalize commands.
+- [x] Add a P4 no-email admin evidence helper so manual-admin proof uses concrete artifact names and structured result fields.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-p4-no-email-admin-evidence-helper-development-20260423.md
+++ b/docs/development/dingtalk-p4-no-email-admin-evidence-helper-development-20260423.md
@@ -1,0 +1,20 @@
+# DingTalk P4 No-email Admin Evidence Helper Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-no-email-admin-evidence-helper-20260423`
+- Scope: local P4 manual-admin evidence guidance for no-email DingTalk user creation and binding.
+
+## Changes
+
+- Added concrete suggested artifacts for `no-email-user-create-bind`:
+  - `artifacts/no-email-user-create-bind/admin-create-bind-result.png`
+  - `artifacts/no-email-user-create-bind/account-linked-after-refresh.png`
+  - `artifacts/no-email-user-create-bind/temp-password-redacted-note.txt`
+- Added a structured `adminEvidence` helper object to generated evidence templates and API runner workspaces.
+- Updated manual evidence checklists with no-email admin instructions and artifact names.
+- Updated `dingtalk-p4-smoke-status` so generated TODO recorder commands use `manual-admin` and a concrete no-email artifact path.
+- Updated remote smoke docs and feature TODO.
+
+## Rationale
+
+`no-email-user-create-bind` is the only required `manual-admin` P4 evidence item. Making its artifact names and result fields explicit reduces ambiguity during the final 142/staging remote smoke and helps prevent temporary passwords from entering release evidence.

--- a/docs/development/dingtalk-p4-no-email-admin-evidence-helper-verification-20260423.md
+++ b/docs/development/dingtalk-p4-no-email-admin-evidence-helper-verification-20260423.md
@@ -1,0 +1,33 @@
+# DingTalk P4 No-email Admin Evidence Helper Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-no-email-admin-evidence-helper-20260423`
+
+## Commands
+
+```bash
+node --check scripts/ops/dingtalk-p4-remote-smoke.mjs
+node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+node --check scripts/ops/dingtalk-p4-smoke-status.mjs
+node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs
+node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs
+node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs
+git diff --check
+```
+
+## Expected Results
+
+- API runner workspaces include no-email suggested artifact names and structured `adminEvidence` fields.
+- Manual evidence kits include the same no-email admin instructions.
+- Status TODO output suggests a concrete `manual-admin` recorder command for `no-email-user-create-bind`.
+- Existing recorder validation still passes.
+
+## Actual Results
+
+- Syntax checks passed for the API runner, evidence compiler, and smoke status reporter.
+- `node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs` passed 4 tests with 0 failures.
+- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs` passed 13 tests with 0 failures.
+- `node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs` passed 9 tests with 0 failures.
+- `node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs` passed 14 tests with 0 failures.
+- `git diff --check` passed.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -210,6 +210,22 @@ node scripts/ops/dingtalk-p4-evidence-record.mjs \
   --blocked-reason "Visible error showed the user is not in the allowlist."
 ```
 
+For `no-email-user-create-bind`, capture the admin result panel and refreshed account row without exposing the temporary password:
+
+```bash
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --check-id no-email-user-create-bind \
+  --status pass \
+  --source manual-admin \
+  --operator qa-admin \
+  --summary "Admin created and bound a no-email DingTalk-synced local user; temporary password is redacted." \
+  --artifact artifacts/no-email-user-create-bind/admin-create-bind-result.png \
+  --artifact artifacts/no-email-user-create-bind/account-linked-after-refresh.png
+```
+
+The generated `evidence.json` also includes a `adminEvidence` helper object for this check. Fill `emailWasBlank`, `createdLocalUserId`, `boundDingTalkExternalId`, and `accountLinkedAfterRefresh` before final strict compile when that information is available.
+
 ```bash
 node scripts/ops/dingtalk-p4-smoke-session.mjs \
   --finalize output/dingtalk-p4-remote-smoke-session/142-session
@@ -432,6 +448,12 @@ Expected:
 - onboarding packet is shown
 - temporary password is shown only in the admin result panel
 - the account list refreshes and shows the local link
+
+Evidence:
+
+- `artifacts/no-email-user-create-bind/admin-create-bind-result.png`
+- `artifacts/no-email-user-create-bind/account-linked-after-refresh.png`
+- optional `artifacts/no-email-user-create-bind/temp-password-redacted-note.txt` confirming the temporary password was not copied into evidence
 
 ## Pass criteria
 

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
@@ -107,6 +107,11 @@ const MANUAL_EVIDENCE_REQUIREMENTS = [
     id: 'no-email-user-create-bind',
     source: 'manual-admin',
     label: 'no-email DingTalk-synced account creation and binding',
+    suggestedArtifacts: [
+      'artifacts/no-email-user-create-bind/admin-create-bind-result.png',
+      'artifacts/no-email-user-create-bind/account-linked-after-refresh.png',
+      'artifacts/no-email-user-create-bind/temp-password-redacted-note.txt',
+    ],
   },
 ]
 const MANUAL_EVIDENCE_BY_ID = new Map(MANUAL_EVIDENCE_REQUIREMENTS.map((requirement) => [requirement.id, requirement]))
@@ -219,6 +224,18 @@ function makeTemplateEvidence(checkId) {
       summary: '',
       artifacts: [],
       instructions: `Required when status is pass: ${manualRequirement.label}; include real DingTalk-client/admin evidence, not API bootstrap output.`,
+      suggestedArtifacts: manualRequirement.suggestedArtifacts ?? [],
+      ...(checkId === 'no-email-user-create-bind'
+        ? {
+            adminEvidence: {
+              emailWasBlank: null,
+              createdLocalUserId: '',
+              boundDingTalkExternalId: '',
+              accountLinkedAfterRefresh: null,
+              temporaryPasswordRedacted: true,
+            },
+          }
+        : {}),
     }
   }
 
@@ -262,7 +279,10 @@ function artifactDirForCheck(checkId) {
 
 function renderManualEvidenceChecklist() {
   const rows = MANUAL_EVIDENCE_REQUIREMENTS.map((requirement) => {
-    return `| \`${requirement.id}\` | \`${requirement.source}\` | ${requirement.label} | \`${artifactDirForCheck(requirement.id)}/\` |`
+    const suggested = Array.isArray(requirement.suggestedArtifacts) && requirement.suggestedArtifacts.length
+      ? requirement.suggestedArtifacts.map((artifact) => `\`${artifact}\``).join('<br>')
+      : `\`${artifactDirForCheck(requirement.id)}/\``
+    return `| \`${requirement.id}\` | \`${requirement.source}\` | ${requirement.label} | ${suggested} |`
   })
 
   return `# DingTalk P4 Manual Evidence Kit
@@ -271,9 +291,16 @@ Use this kit after running \`scripts/ops/dingtalk-p4-remote-smoke.mjs\` or after
 
 ## Required Manual Evidence
 
-| Check ID | Required Source | What It Proves | Suggested Artifact Folder |
+| Check ID | Required Source | What It Proves | Suggested Artifacts |
 | --- | --- | --- | --- |
 ${rows.join('\n')}
+
+## No-email Admin Evidence
+
+- Create a local user from a synced DingTalk account while leaving email empty.
+- Capture the create-and-bind result panel without exposing the temporary password.
+- Capture the refreshed account row showing the local user link.
+- Record \`evidence.adminEvidence.emailWasBlank: true\`, \`createdLocalUserId\`, \`boundDingTalkExternalId\`, and \`accountLinkedAfterRefresh: true\` when updating \`evidence.json\`.
 
 ## Fill Rules
 

--- a/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+++ b/scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
@@ -141,6 +141,7 @@ test('compile-dingtalk-p4-smoke-evidence writes an editable template', () => {
     assert.equal(template.checks.find((check) => check.id === 'authorized-user-submit').evidence.performedAt, '')
     assert.deepEqual(template.checks.find((check) => check.id === 'authorized-user-submit').evidence.artifacts, [])
     assert.equal(template.checks.find((check) => check.id === 'no-email-user-create-bind').evidence.source, 'manual-admin')
+    assert.equal(template.checks.find((check) => check.id === 'no-email-user-create-bind').evidence.adminEvidence.temporaryPasswordRedacted, true)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }
@@ -170,6 +171,8 @@ test('compile-dingtalk-p4-smoke-evidence writes a manual evidence kit', () => {
     const checklist = readFileSync(path.join(kitDir, 'manual-evidence-checklist.md'), 'utf8')
     assert.match(checklist, /manual-client/)
     assert.match(checklist, /manual-admin/)
+    assert.match(checklist, /admin-create-bind-result\.png/)
+    assert.match(checklist, /temporary password/)
     assert.match(checklist, /Do not paste DingTalk robot full webhook URLs/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })

--- a/scripts/ops/dingtalk-p4-remote-smoke.mjs
+++ b/scripts/ops/dingtalk-p4-remote-smoke.mjs
@@ -60,6 +60,11 @@ const MANUAL_EVIDENCE_REQUIREMENTS = [
     id: 'no-email-user-create-bind',
     source: 'manual-admin',
     label: 'no-email DingTalk-synced account creation and binding',
+    suggestedArtifacts: [
+      'artifacts/no-email-user-create-bind/admin-create-bind-result.png',
+      'artifacts/no-email-user-create-bind/account-linked-after-refresh.png',
+      'artifacts/no-email-user-create-bind/temp-password-redacted-note.txt',
+    ],
   },
 ]
 const MANUAL_EVIDENCE_BY_ID = new Map(MANUAL_EVIDENCE_REQUIREMENTS.map((requirement) => [requirement.id, requirement]))
@@ -356,6 +361,18 @@ function makeManualEvidenceSkeleton(checkId, notes, extra = {}) {
     artifacts: [],
     notes,
     instructions: `Required before strict pass: ${requirement.label}; place evidence files under ${artifactDirForCheck(checkId)}/ and reference them with relative paths.`,
+    suggestedArtifacts: requirement.suggestedArtifacts ?? [],
+    ...(checkId === 'no-email-user-create-bind'
+      ? {
+          adminEvidence: {
+            emailWasBlank: null,
+            createdLocalUserId: '',
+            boundDingTalkExternalId: '',
+            accountLinkedAfterRefresh: null,
+            temporaryPasswordRedacted: true,
+          },
+        }
+      : {}),
     ...extra,
   }
 }
@@ -508,7 +525,10 @@ async function requestJson(opts, route, options = {}) {
 
 function renderManualEvidenceChecklist() {
   const rows = MANUAL_EVIDENCE_REQUIREMENTS.map((requirement) => {
-    return `| \`${requirement.id}\` | \`${requirement.source}\` | ${requirement.label} | \`${artifactDirForCheck(requirement.id)}/\` |`
+    const suggested = Array.isArray(requirement.suggestedArtifacts) && requirement.suggestedArtifacts.length
+      ? requirement.suggestedArtifacts.map((artifact) => `\`${artifact}\``).join('<br>')
+      : `\`${artifactDirForCheck(requirement.id)}/\``
+    return `| \`${requirement.id}\` | \`${requirement.source}\` | ${requirement.label} | ${suggested} |`
   })
 
   return `# DingTalk P4 Manual Evidence Checklist
@@ -518,9 +538,16 @@ The API runner has prepared backend resources and bootstrap evidence. Fill the
 manual checks below from real DingTalk-client or administrator actions before
 running strict compile.
 
-| Check ID | Required Source | What It Proves | Artifact Folder |
+| Check ID | Required Source | What It Proves | Suggested Artifacts |
 | --- | --- | --- | --- |
 ${rows.join('\n')}
+
+## No-email Admin Evidence
+
+- Use the admin directory sync page to create a local user from a synced DingTalk account with the email field left blank.
+- Capture the create-and-bind result panel without exposing the temporary password.
+- Capture the refreshed account row showing the local user link.
+- Record \`evidence.adminEvidence.emailWasBlank: true\`, \`createdLocalUserId\`, \`boundDingTalkExternalId\`, and \`accountLinkedAfterRefresh: true\` when updating \`evidence.json\`.
 
 ## Fill Rules
 

--- a/scripts/ops/dingtalk-p4-remote-smoke.test.mjs
+++ b/scripts/ops/dingtalk-p4-remote-smoke.test.mjs
@@ -323,12 +323,23 @@ test('dingtalk-p4-remote-smoke runs API chain, writes pending manual gates, and 
     assert.equal(byId.get('send-group-message-form-link').evidence.apiBootstrap.groupRuleDeliveryCount, 2)
     assert.equal(byId.get('authorized-user-submit').evidence.source, 'manual-client')
     assert.equal(byId.get('no-email-user-create-bind').evidence.source, 'manual-admin')
+    assert.deepEqual(
+      byId.get('no-email-user-create-bind').evidence.suggestedArtifacts,
+      [
+        'artifacts/no-email-user-create-bind/admin-create-bind-result.png',
+        'artifacts/no-email-user-create-bind/account-linked-after-refresh.png',
+        'artifacts/no-email-user-create-bind/temp-password-redacted-note.txt',
+      ],
+    )
+    assert.equal(byId.get('no-email-user-create-bind').evidence.adminEvidence.temporaryPasswordRedacted, true)
     assert.equal(byId.get('delivery-history-group-person').evidence.personRuleDeliveryCount, 1)
 
     const checklist = readFileSync(path.join(outputDir, 'manual-evidence-checklist.md'), 'utf8')
     assert.match(checklist, /manual-client/)
     assert.match(checklist, /manual-admin/)
     assert.match(checklist, /artifacts\/authorized-user-submit/)
+    assert.match(checklist, /admin-create-bind-result\.png/)
+    assert.match(checklist, /temporary password/)
 
     assert.equal(fakeApi.requests.every((request) => request.headers.authorization === 'Bearer secret-admin-token'), true)
     assert.equal(fakeApi.requests.some((request) => request.pathname.endsWith('/dingtalk-person-deliveries')), true)

--- a/scripts/ops/dingtalk-p4-smoke-status.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-status.mjs
@@ -388,6 +388,12 @@ function manualSourceForCheck(check) {
 
 function evidenceRecordCommandForCheck(opts, check) {
   if (!opts.sessionDir || !check.manual) return ''
+  const artifactRef = check.id === 'no-email-user-create-bind'
+    ? 'artifacts/no-email-user-create-bind/admin-create-bind-result.png'
+    : `artifacts/${check.id}/<file>`
+  const summary = check.id === 'no-email-user-create-bind'
+    ? '"Admin created and bound a no-email DingTalk-synced local user; temporary password is redacted."'
+    : '"<summary>"'
   const args = [
     'node scripts/ops/dingtalk-p4-evidence-record.mjs',
     '--session-dir',
@@ -401,9 +407,9 @@ function evidenceRecordCommandForCheck(opts, check) {
     '--operator',
     '<operator>',
     '--summary',
-    '"<summary>"',
+    summary,
     '--artifact',
-    `artifacts/${check.id}/<file>`,
+    artifactRef,
   ]
   if (check.id === 'unauthorized-user-denied') {
     args.push(

--- a/scripts/ops/dingtalk-p4-smoke-status.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-status.test.mjs
@@ -195,6 +195,43 @@ test('dingtalk-p4-smoke-status writes an executable remote smoke TODO report', (
   }
 })
 
+test('dingtalk-p4-smoke-status suggests a concrete no-email admin evidence command', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+
+  try {
+    writeSession(sessionDir, {
+      sessionPhase: 'bootstrap',
+      sessionOverallStatus: 'manual_pending',
+      finalStrictStatus: 'not_run',
+      steps: [
+        { id: 'preflight', status: 'pass', exitCode: 0 },
+        { id: 'api-runner', status: 'pass', exitCode: 0 },
+        { id: 'compile', status: 'pass', exitCode: 0 },
+      ],
+      checkOverrides: {
+        'no-email-user-create-bind': {
+          status: 'pending',
+        },
+      },
+    })
+
+    const result = runScript(['--session-dir', sessionDir])
+
+    assert.equal(result.status, 0, result.stderr)
+    const todoText = readFileSync(path.join(sessionDir, 'smoke-todo.md'), 'utf8')
+    assert.match(todoText, /--source manual-admin/)
+    assert.match(todoText, /admin-create-bind-result\.png/)
+    assert.match(todoText, /temporary password is redacted/)
+    const summary = JSON.parse(readFileSync(path.join(sessionDir, 'smoke-status.json'), 'utf8'))
+    const noEmailTodo = summary.remoteSmokeTodos.items.find((item) => item.id === 'no-email-user-create-bind')
+    assert.match(noEmailTodo.evidenceRecordCommand, /manual-admin/)
+    assert.match(noEmailTodo.evidenceRecordCommand, /admin-create-bind-result\.png/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('dingtalk-p4-smoke-status reports handoff pending after final strict pass', () => {
   const tmpDir = makeTmpDir()
   const sessionDir = path.join(tmpDir, '142-session')


### PR DESCRIPTION
## Summary
- Add concrete suggested artifact names for `no-email-user-create-bind` in generated API runner workspaces and manual evidence kits.
- Add a structured `adminEvidence` helper object for the no-email manual-admin check.
- Update `dingtalk-p4-smoke-status` TODO output to suggest a concrete `manual-admin` recorder command and artifact path.
- Update remote smoke docs, feature TODO, and development/verification notes.

## Verification
- `node --check scripts/ops/dingtalk-p4-remote-smoke.mjs`
- `node --check scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-status.mjs`
- `node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs` passed 4 tests.
- `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs` passed 13 tests.
- `node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs` passed 9 tests.
- `node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs` passed 14 tests.
- `git diff --check` passed.

Stacked on #1106.