### PR TITLE
docs(dingtalk): record P4 stack rebase repair

### DIFF
--- a/docs/development/dingtalk-p4-stack-rebase-repair-development-20260423.md
+++ b/docs/development/dingtalk-p4-stack-rebase-repair-development-20260423.md
@@ -1,0 +1,62 @@
+# DingTalk P4 Stack Rebase Repair Development - 2026-04-23
+
+## Scope
+
+This change records the operational repair of the DingTalk P4 stacked PR chain. It does not merge the DingTalk business stack into `main`; it only documents the branch rebase/push repair and the post-repair readiness evidence.
+
+## Stack Segment
+
+Root base:
+
+```text
+codex/dingtalk-person-delivery-skip-reasons-20260422
+```
+
+Validated PR order:
+
+```text
+#1076 -> #1078 -> #1082 -> #1083 -> #1085 -> #1086 -> #1087 -> #1089 -> #1090 -> #1093 -> #1094 -> #1095 -> #1097 -> #1099 -> #1100
+```
+
+## Repair Actions
+
+The dirty section started after #1076 because downstream branches still pointed at stale parent heads. Each child branch was rebased onto its updated parent and pushed with `--force-with-lease`.
+
+| PR | Branch | New Head |
+| --- | --- | --- |
+| #1078 | `codex/dingtalk-p4-api-smoke-runner-20260422` | `332e31ef8` |
+| #1082 | `codex/dingtalk-p4-smoke-preflight-20260422` | `239cd0c025` |
+| #1083 | `codex/dingtalk-p4-manual-evidence-kit-20260423` | `9740975e6` |
+| #1085 | `codex/dingtalk-p4-artifact-gate-20260423` | `187b144cb` |
+| #1086 | `codex/dingtalk-p4-smoke-workspace-20260423` | `171be76fa` |
+| #1087 | `codex/dingtalk-p4-smoke-session-20260423` | `3051e7ed7` |
+| #1089 | `codex/dingtalk-p4-smoke-session-env-template-20260423` | `bcea75cb5` |
+| #1090 | `codex/dingtalk-p4-smoke-session-finalize-20260423` | `1b72e6c41` |
+| #1093 | `codex/dingtalk-p4-evidence-packet-final-gate-20260423` | `0762c7959` |
+| #1094 | `codex/dingtalk-p4-packet-stale-output-guard-20260423` | `1a817c28e` |
+| #1095 | `codex/dingtalk-p4-packet-publish-check-20260423` | `dbc8529bc` |
+| #1097 | `codex/dingtalk-p4-final-handoff-command-20260423` | `fa7d4aa39` |
+| #1099 | `codex/dingtalk-p4-smoke-status-report-20260423` | `8567f6648` |
+| #1100 | `codex/dingtalk-p4-evidence-record-cli-20260423` | `5993bc714` |
+
+## Design Notes
+
+The repair preserves the original stack shape. No branch was retargeted to `main`, and no business diff was squashed into a different PR.
+
+`--force-with-lease` was used because every repaired branch is a PR branch whose history had to be restacked onto the updated parent. This is safer than a blind force push because it refuses to overwrite unexpected remote updates.
+
+The top-of-stack verification was run from #1100 after every downstream branch had been repaired. That gives coverage over all scripts added by the P4 evidence pipeline.
+
+## Artifacts
+
+Post-repair readiness report:
+
+```text
+output/pr-stack-readiness-dingtalk-p4-after-repair-20260423.md
+```
+
+Delivery verification summary:
+
+```text
+output/delivery/dingtalk-p4-stack-rebase-repair-20260423/TEST_AND_VERIFICATION.md
+```

--- a/docs/development/dingtalk-p4-stack-rebase-repair-verification-20260423.md
+++ b/docs/development/dingtalk-p4-stack-rebase-repair-verification-20260423.md
@@ -1,0 +1,71 @@
+# DingTalk P4 Stack Rebase Repair Verification - 2026-04-23
+
+## Summary
+
+The DingTalk P4 substack is clean after rebase repair. The stack readiness guard reports overall PASS and every PR in the validated range is `CLEAN`.
+
+## Commands Run
+
+Focused branch checks:
+
+```bash
+node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-preflight.test.mjs scripts/ops/dingtalk-p4-remote-smoke.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Top-of-stack checks:
+
+```bash
+node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
+git diff --check origin/codex/dingtalk-p4-smoke-status-report-20260423...HEAD
+```
+
+Stack readiness:
+
+```bash
+node scripts/ops/check-pr-stack-readiness.mjs --root-base codex/dingtalk-person-delivery-skip-reasons-20260422 --format markdown --output output/pr-stack-readiness-dingtalk-p4-after-repair-20260423.md 1076 1078 1082 1083 1085 1086 1087 1089 1090 1093 1094 1095 1097 1099 1100
+```
+
+Remote check rollup:
+
+```bash
+for pr in 1078 1082 1083 1085 1086 1087 1089 1090 1093 1094 1095 1097 1099 1100; do
+  gh pr checks "$pr"
+done
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| #1078 focused tests | 12/12 passed |
+| #1082 focused tests | 17/17 passed |
+| #1083 focused tests | 18/18 passed |
+| #1085 focused tests | 23/23 passed |
+| #1100 top-of-stack P4 ops tests | 71/71 passed |
+| `git diff --check` on top-of-stack diff | passed |
+| Stack readiness guard | overall PASS |
+| PR merge states | #1076 through #1100 all CLEAN |
+| PR `pr-validate` checks | #1078, #1082, #1083, #1085, #1086, #1087, #1089, #1090, #1093, #1094, #1095, #1097, #1099, #1100 all pass |
+
+## Readiness Report
+
+The generated report is tracked at:
+
+```text
+output/pr-stack-readiness-dingtalk-p4-after-repair-20260423.md
+```
+
+It reports:
+
+```text
+Overall: PASS
+```
+
+Every row in the P4 substack has the expected parent base and `CLEAN` merge state.
+
+## Residual Risk
+
+This repair only covers the P4 substack rooted at `codex/dingtalk-person-delivery-skip-reasons-20260422`. It does not imply that the larger DingTalk queue rooted at #1052 is ready to merge.
+
+The business PRs remain open. The next action is review/merge sequencing, not additional rebase work for this P4 segment.

--- a/output/delivery/dingtalk-p4-stack-rebase-repair-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/dingtalk-p4-stack-rebase-repair-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,38 @@
+# TEST AND VERIFICATION - DingTalk P4 Stack Rebase Repair
+
+Date: 2026-04-23
+
+## Outcome
+
+The DingTalk P4 stacked PR segment was repaired and verified. All repaired child branches were rebased onto their current parent branch and pushed with `--force-with-lease`.
+
+No DingTalk business PR was merged as part of this work.
+
+## Verified Stack
+
+```text
+#1076 -> #1078 -> #1082 -> #1083 -> #1085 -> #1086 -> #1087 -> #1089 -> #1090 -> #1093 -> #1094 -> #1095 -> #1097 -> #1099 -> #1100
+```
+
+## Evidence
+
+| Evidence | Result |
+| --- | --- |
+| Stack readiness report | `output/pr-stack-readiness-dingtalk-p4-after-repair-20260423.md` |
+| Stack readiness result | PASS |
+| GitHub merge state | all rows CLEAN |
+| GitHub checks | all repaired PRs have passing `pr-validate` |
+| Top-of-stack local tests | 71/71 passed |
+| Whitespace/diff check | passed |
+
+## Commands
+
+```bash
+node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
+git diff --check origin/codex/dingtalk-p4-smoke-status-report-20260423...HEAD
+node scripts/ops/check-pr-stack-readiness.mjs --root-base codex/dingtalk-person-delivery-skip-reasons-20260422 --format markdown --output output/pr-stack-readiness-dingtalk-p4-after-repair-20260423.md 1076 1078 1082 1083 1085 1086 1087 1089 1090 1093 1094 1095 1097 1099 1100
+```
+
+## Result
+
+The P4 substack is ready for normal review/merge sequencing. Larger DingTalk mainline readiness should still be evaluated separately because #1052 and neighboring non-P4 stack segments were not changed by this repair.

--- a/output/pr-stack-readiness-dingtalk-p4-after-repair-20260423.md
+++ b/output/pr-stack-readiness-dingtalk-p4-after-repair-20260423.md
@@ -1,0 +1,23 @@
+# PR Stack Readiness
+
+Overall: **PASS**
+
+Root base: `codex/dingtalk-person-delivery-skip-reasons-20260422`
+
+| Pos | PR | Status | Base | Expected Base | Head | Merge State | Reasons |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+1 | [#1076](https://github.com/zensgit/metasheet2/pull/1076) | PASS | `codex/dingtalk-person-delivery-skip-reasons-20260422` | `codex/dingtalk-person-delivery-skip-reasons-20260422` | `codex/dingtalk-p4-smoke-evidence-runner-20260422` | `CLEAN` | -
+2 | [#1078](https://github.com/zensgit/metasheet2/pull/1078) | PASS | `codex/dingtalk-p4-smoke-evidence-runner-20260422` | `codex/dingtalk-p4-smoke-evidence-runner-20260422` | `codex/dingtalk-p4-api-smoke-runner-20260422` | `CLEAN` | -
+3 | [#1082](https://github.com/zensgit/metasheet2/pull/1082) | PASS | `codex/dingtalk-p4-api-smoke-runner-20260422` | `codex/dingtalk-p4-api-smoke-runner-20260422` | `codex/dingtalk-p4-smoke-preflight-20260422` | `CLEAN` | -
+4 | [#1083](https://github.com/zensgit/metasheet2/pull/1083) | PASS | `codex/dingtalk-p4-smoke-preflight-20260422` | `codex/dingtalk-p4-smoke-preflight-20260422` | `codex/dingtalk-p4-manual-evidence-kit-20260423` | `CLEAN` | -
+5 | [#1085](https://github.com/zensgit/metasheet2/pull/1085) | PASS | `codex/dingtalk-p4-manual-evidence-kit-20260423` | `codex/dingtalk-p4-manual-evidence-kit-20260423` | `codex/dingtalk-p4-artifact-gate-20260423` | `CLEAN` | -
+6 | [#1086](https://github.com/zensgit/metasheet2/pull/1086) | PASS | `codex/dingtalk-p4-artifact-gate-20260423` | `codex/dingtalk-p4-artifact-gate-20260423` | `codex/dingtalk-p4-smoke-workspace-20260423` | `CLEAN` | -
+7 | [#1087](https://github.com/zensgit/metasheet2/pull/1087) | PASS | `codex/dingtalk-p4-smoke-workspace-20260423` | `codex/dingtalk-p4-smoke-workspace-20260423` | `codex/dingtalk-p4-smoke-session-20260423` | `CLEAN` | -
+8 | [#1089](https://github.com/zensgit/metasheet2/pull/1089) | PASS | `codex/dingtalk-p4-smoke-session-20260423` | `codex/dingtalk-p4-smoke-session-20260423` | `codex/dingtalk-p4-smoke-session-env-template-20260423` | `CLEAN` | -
+9 | [#1090](https://github.com/zensgit/metasheet2/pull/1090) | PASS | `codex/dingtalk-p4-smoke-session-env-template-20260423` | `codex/dingtalk-p4-smoke-session-env-template-20260423` | `codex/dingtalk-p4-smoke-session-finalize-20260423` | `CLEAN` | -
+10 | [#1093](https://github.com/zensgit/metasheet2/pull/1093) | PASS | `codex/dingtalk-p4-smoke-session-finalize-20260423` | `codex/dingtalk-p4-smoke-session-finalize-20260423` | `codex/dingtalk-p4-evidence-packet-final-gate-20260423` | `CLEAN` | -
+11 | [#1094](https://github.com/zensgit/metasheet2/pull/1094) | PASS | `codex/dingtalk-p4-evidence-packet-final-gate-20260423` | `codex/dingtalk-p4-evidence-packet-final-gate-20260423` | `codex/dingtalk-p4-packet-stale-output-guard-20260423` | `CLEAN` | -
+12 | [#1095](https://github.com/zensgit/metasheet2/pull/1095) | PASS | `codex/dingtalk-p4-packet-stale-output-guard-20260423` | `codex/dingtalk-p4-packet-stale-output-guard-20260423` | `codex/dingtalk-p4-packet-publish-check-20260423` | `CLEAN` | -
+13 | [#1097](https://github.com/zensgit/metasheet2/pull/1097) | PASS | `codex/dingtalk-p4-packet-publish-check-20260423` | `codex/dingtalk-p4-packet-publish-check-20260423` | `codex/dingtalk-p4-final-handoff-command-20260423` | `CLEAN` | -
+14 | [#1099](https://github.com/zensgit/metasheet2/pull/1099) | PASS | `codex/dingtalk-p4-final-handoff-command-20260423` | `codex/dingtalk-p4-final-handoff-command-20260423` | `codex/dingtalk-p4-smoke-status-report-20260423` | `CLEAN` | -
+15 | [#1100](https://github.com/zensgit/metasheet2/pull/1100) | PASS | `codex/dingtalk-p4-smoke-status-report-20260423` | `codex/dingtalk-p4-smoke-status-report-20260423` | `codex/dingtalk-p4-evidence-record-cli-20260423` | `CLEAN` | -


### PR DESCRIPTION
## Summary\n- document the DingTalk P4 stack rebase repair\n- include the post-repair stack readiness report\n- add a delivery TEST_AND_VERIFICATION summary\n\n## Verification\n- node --test top-of-stack DingTalk P4 ops tests: 71/71 passed\n- git diff --check passed\n- check-pr-stack-readiness overall PASS for #1076 -> #1100\n- gh pr checks pass for repaired PRs #1078/#1082/#1083/#1085/#1086/#1087/#1089/#1090/#1093/#1094/#1095/#1097/#1099/#1100\n\nThis PR is docs/evidence only. It does not merge or retarget the DingTalk business stack.